### PR TITLE
More psd files handled

### DIFF
--- a/PIL/PsdImagePlugin.py
+++ b/PIL/PsdImagePlugin.py
@@ -28,7 +28,6 @@ MODES = {
     (2, 8): ("P", 1),
     (3, 8): ("RGB", 3),
     (4, 8): ("CMYK", 4),
-    (4, 16): ("CMYK", 4),
     (7, 8): ("L", 1), # FIXME: multilayer
     (8, 8): ("L", 1), # duotone
     (9, 8): ("LAB", 3)
@@ -58,7 +57,7 @@ class PsdImageFile(ImageFile.ImageFile):
     format_description = "Adobe Photoshop"
 
     def _open(self):
-
+        
         read = self.fp.read
 
         #

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,14 +5,9 @@ Changelog
 1.7.8 (Unreleased)
 ------------------
 
-- Manage more psd files:
-
-    - Added a psd mode (mode 4, 16 bits).
-      [thomasdesvenain]
-
-    - Fix opening psd files with RGBA layers when A mode is not of type 65535 but 3.
-      Fixes issue https://github.com/python-imaging/Pillow/issues/3
-      [thomasdesvenain]
+- Fix opening psd files with RGBA layers when A mode is not of type 65535 but 3.
+  Fixes issue https://github.com/python-imaging/Pillow/issues/3
+  [thomasdesvenain]
 
 
 1.7.7 (2012-04-04)


### PR DESCRIPTION
Fix opening psd files with RGBA layers when A mode is not of type 65535 …
but 3.
Fixes issue https://github.com/python-imaging/Pillow/issues/3
