### PR TITLE
Fix a bug in quantize() causing crashes.

### DIFF
--- a/libImaging/Quant.c
+++ b/libImaging/Quant.c
@@ -914,7 +914,7 @@ map_image_pixels_from_median_box(
    unsigned long bestdist,bestmatch,dist;
    unsigned long initialdist;
    HashTable h2;
-   int pixelVal;
+   unsigned long pixelVal;
 
    h2=hashtable_new(unshifted_pixel_hash,unshifted_pixel_cmp);
    for (i=0;i<nPixels;i++) {


### PR DESCRIPTION
From German Bravo's Image-SIG post:
http://mail.python.org/pipermail/image-sig/2012-June/007047.html

"I found a nasty bug in PIL's quantize(), in Quant.c,
map_image_pixels_from_median_box(), the `int pixelVal;` definition
must be `unsigned long pixelVal;` instead... This was making PIL crash
under certain circumstances in my system (64 bit Mac OS X Lion 10.7.4
using llvm-gcc4.2)."

This bug has been causing issues in downstream libraries such as Colorific on OS X. https://github.com/99designs/colorific/issues/3
