### PR TITLE
Add files to the MANIFEST which were missing from the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,8 +6,12 @@ exclude SHIP
 exclude SHIP.bat
 include *.rst
 include *.c
-recursive-exclude Tests *
-recursive-include docs *.txt
+include *.h
+include selftest.py tox.ini
+recursive-include Scripts *.py README
+graft Images
+recursive-include docs *.txt *.html *.rst *.css *.py README CHANGES CONTENTS Makefile make.bat
 recursive-include libImaging *.c *.h
 recursive-include Tk *.c *.txt
-recursive-include Sane *.c *.txt
+recursive-include Sane *.c *.txt CHANGES README *.py
+


### PR DESCRIPTION
Matthias Klose pointed out that many of the files included in the Imaging-1.1.7 source zip were missing from the Pillow-1.7.8 zip. This adds those files to the MANIFEST.in.
