### PR TITLE
Move custom path of JPEG_ROOT, TIFF_ROOT, etc. before system.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,18 @@ class pil_build_ext(build_ext):
         _add_directory(include_dirs, "libImaging")
 
         #
+        # add configured kits
+
+        for root in (TCL_ROOT, JPEG_ROOT, TCL_ROOT, TIFF_ROOT, ZLIB_ROOT,
+                     FREETYPE_ROOT, LCMS_ROOT):
+            if isinstance(root, type(())):
+                lib_root, include_root = root
+            else:
+                lib_root = include_root = root
+            _add_directory(library_dirs, lib_root)
+            _add_directory(include_dirs, include_root)
+
+        #
         # add platform directories
 
         if sys.platform == "cygwin":
@@ -164,18 +176,6 @@ class pil_build_ext(build_ext):
                     break
             else:
                 TCL_ROOT = None
-
-        #
-        # add configured kits
-
-        for root in (TCL_ROOT, JPEG_ROOT, TCL_ROOT, TIFF_ROOT, ZLIB_ROOT,
-                     FREETYPE_ROOT, LCMS_ROOT):
-            if isinstance(root, type(())):
-                lib_root, include_root = root
-            else:
-                lib_root = include_root = root
-            _add_directory(library_dirs, lib_root)
-            _add_directory(include_dirs, include_root)
 
         #
         # add standard directories


### PR DESCRIPTION
Currently `setup.py` setups path of 

``` python
TCL_ROOT = None
JPEG_ROOT = None
ZLIB_ROOT = None
TIFF_ROOT = None
FREETYPE_ROOT = None
LCMS_ROOT = None
```

using system env variables and then this variables from `setup.py`.
This pull fix it. 
`setup.py` at first insert custom variables and then appends system in look up path.
