### PR TITLE
fixed crash loading broken color profile from file-like object

### DIFF
--- a/_imagingcms.c
+++ b/_imagingcms.c
@@ -134,8 +134,10 @@ cms_profile_fromstring(PyObject* self, PyObject* args)
     cmsErrorAction(LCMS_ERROR_IGNORE);
 
     hProfile = cmsOpenProfileFromMem(pProfile, nProfile);
-    if (!hProfile)
+    if (!hProfile) {
         PyErr_SetString(PyExc_IOError, "cannot open profile from string");
+        return NULL;
+    }
 
     return cms_profile_new(hProfile);
 }


### PR DESCRIPTION
Somebody forgot some brackets and a return long time ago.
Python interpreter freezes and crashes to the OS without this fix.
