### PR TITLE
Fix rendered characters have been chipped for some TrueType fonts

### DIFF
--- a/_imagingft.c
+++ b/_imagingft.c
@@ -282,7 +282,7 @@ font_render(FontObject* self, PyObject* args)
 {
     int i, x, y;
     Imaging im;
-    int index, error, ascender;
+    int index, error, ascender, descender;
     int load_flags;
     unsigned char *source;
     FT_ULong ch;
@@ -332,6 +332,7 @@ font_render(FontObject* self, PyObject* args)
             int xx, x0, x1;
             source = (unsigned char*) glyph->bitmap.buffer;
             ascender = PIXEL(self->face->size->metrics.ascender);
+            descender = PIXEL(self->face->size->metrics.descender);
             xx = x + glyph->bitmap_left;
             x0 = 0;
             x1 = glyph->bitmap.width;
@@ -340,7 +341,7 @@ font_render(FontObject* self, PyObject* args)
             if (xx + x1 > im->xsize)
                 x1 = im->xsize - xx;
             for (y = 0; y < glyph->bitmap.rows; y++) {
-                int yy = y + ascender - glyph->bitmap_top;
+                int yy = y + ascender + descender - glyph->bitmap_top;
                 if (yy >= 0 && yy < im->ysize) {
                     /* blend this glyph into the buffer */
                     unsigned char *target = im->image8[yy] + xx;
@@ -361,6 +362,7 @@ font_render(FontObject* self, PyObject* args)
             int xx, x0, x1;
             source = (unsigned char*) glyph->bitmap.buffer;
             ascender = PIXEL(self->face->size->metrics.ascender);
+            descender = PIXEL(self->face->size->metrics.descender);
             xx = x + glyph->bitmap_left;
             x0 = 0;
             x1 = glyph->bitmap.width;
@@ -369,7 +371,7 @@ font_render(FontObject* self, PyObject* args)
             if (xx + x1 > im->xsize)
                 x1 = im->xsize - xx;
             for (y = 0; y < glyph->bitmap.rows; y++) {
-                int yy = y + ascender - glyph->bitmap_top;
+                int yy = y + ascender + descender - glyph->bitmap_top;
                 if (yy >= 0 && yy < im->ysize) {
                     /* blend this glyph into the buffer */
                     int i;


### PR DESCRIPTION
ImageFont ignores descender value of TrueType fonts (uses ascender only),
then some fonts which use descender is chipped on rendering.
![chipped_descenders-ipafont-gothic](https://f.cloud.github.com/assets/748828/113674/eee8934c-6b6c-11e2-8ffd-d3525ecc90c2.png)

This fix is already reported to PIL at http://hg.effbot.org/pil-2009-raclette/issue/13/chipped-characters-have-been-rendered
