### PR TITLE
Updated EXIF tags to the 2.3 standard and fixed spelling error.

### DIFF
--- a/PIL/ExifTags.py
+++ b/PIL/ExifTags.py
@@ -124,7 +124,7 @@ TAGS = {
 }
 
 ##
-# Maps EXIF GSP tags to tag names.
+# Maps EXIF GPS tags to tag names.
 
 GPSTAGS = {
     0: "GPSVersionID",
@@ -153,5 +153,10 @@ GPSTAGS = {
     23: "GPSDestBearingRef",
     24: "GPSDestBearing",
     25: "GPSDestDistanceRef",
-    26: "GPSDestDistance"
+    26: "GPSDestDistance",
+    27: "GPSProcessingMethod",
+    28: "GPSAreaInformation",
+    29: "GPSDateStamp",
+    30: "GPSDifferential",
+    31: "GPSHPositioningError",
 }


### PR DESCRIPTION
Updated EXIF tags to the 2.3 standard and fixed spelling error in the comments.  

EXIF 2.3 standard is listed here: http://www.cipa.jp/english/hyoujunka/kikaku/pdf/DC-008-2010_E.pdf.
