### PR TITLE
BUG: Windows image viewer unable to open image

### DIFF
--- a/PIL/ImageShow.py
+++ b/PIL/ImageShow.py
@@ -98,7 +98,8 @@ if sys.platform == "win32":
     class WindowsViewer(Viewer):
         format = "BMP"
         def get_command(self, file, **options):
-            return "start /wait %s && del /f %s" % (file, file)
+            return ("start /wait %s && ping -n 2 127.0.0.1 >NUL "
+                    "&& del /f %s" % (file, file))
 
     register(WindowsViewer)
 


### PR DESCRIPTION
The issue was reported several times during the past years.
The temporary bitmap file is deleted before the image viewer is started. The workaround is to wait some time before deleting the file.
http://stackoverflow.com/questions/4607633/image-format-to-save-in-python
http://stackoverflow.com/questions/7715501/pil-image-show-doesnt-work-on-windows-7
