### PR TITLE
BUG: PIL Image array interface has the wrong size for YCbCr

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -198,7 +198,7 @@ _MODE_CONV = {
     "RGBX": ('|u1', 4),
     "RGBA": ('|u1', 4),
     "CMYK": ('|u1', 4),
-    "YCbCr": ('|u1', 4),
+    "YCbCr": ('|u1', 3),
 }
 
 def _conv_type_shape(im):


### PR DESCRIPTION
Reported at http://python.6.n6.nabble.com/PIL-Image-array-interface-has-the-wrong-size-for-YCbCr-td2103100.html
Patch at https://bitbucket.org/effbot/pil-2009-raclette/commits/e4a3b2e608b5a71cf23c0393d0d7bd4dd7900d7d
