### PR TITLE
Added the ``named`` method to a Tiffs tag getter.

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -216,10 +216,29 @@ class ImageFileDirectory(collections.MutableMapping):
         self.reset()
 
     def reset(self):
+        #: Tags is an incomplete dictionary of the tags of the image.
+        #: For a complete dictionary, use teh as_dict method.
         self.tags = {}
         self.tagdata = {}
         self.tagtype = {} # added 2008-06-05 by Florian Hoech
         self.next = None
+
+    def __str__(self):
+        return str(self.as_dict())
+
+    def as_dict(self):
+        """Return a dictionary of the image's tags."""
+        return dict(self.items())
+
+    def named(self):
+        """Returns the complete tag dictionary, with named tags where posible."""
+        from . import TiffTags
+        result = {}
+        for tag_code, value in self.items():
+            tag_name = TiffTags.TAGS.get(tag_code, tag_code)
+            result[tag_name] = value
+        return result
+
 
     # dictionary API
 


### PR DESCRIPTION
I was loading a Tiff file which has some GeoTiff metadata and was being caught out by using the `im.tag.tags` public dictionary. This doesn't fix the issue, but makes the solution much more obvious to users (without breaking backwards compatibility or reducing performance):

```
>>> import PIL.Image
>>> im = PIL.Image.open('aklqaa.pyf1c10.subset.tif')

>>> print im.tag.tags
{256: (48,), 257: (71,), 258: (32,), 259: (1,), 262: (1,), 273: (258, 8322), 339: (3,), 278: (42,), 284: (1,)}

>>> print im.tag

{256: (48,), 257: (71,), 258: (32,), 259: (1,), 262: (1,), 33922: (0.0, 0.0, 0.0, -1.875, 88.75, 0.0), 33550: (3.75, 2.5, 0.0), 273: (258, 8322), 339: (3,), 277: (1,), 278: (42,), 279: (8064, 5568), 284: (1,)}

>>> print im.tag.named()
{'PlanarConfiguration': (1,), 'BitsPerSample': (32,), 'ImageLength': (71,), 'Compression': (1,), 'SampleFormat': (3,), 33922: (0.0, 0.0, 0.0, -1.875, 88.75, 0.0), 33550: (3.75, 2.5, 0.0), 'PhotometricInterpretation': (1,), 'RowsPerStrip': (42,), 'ImageWidth': (48,), 'SamplesPerPixel': (1,), 'StripOffsets': (258, 8322), 'StripByteCounts': (8064, 5568)}
```
