### PR TITLE
Include zlib.h before Imaging.h

### DIFF
--- a/_imaging.c
+++ b/_imaging.c
@@ -74,6 +74,10 @@
 
 #include "Python.h"
 
+#ifdef HAVE_LIBZ
+#include "zlib.h"
+#endif
+
 #include "Imaging.h"
 
 #include "py3.h"
@@ -3415,7 +3419,6 @@ setup_module(PyObject* m) {
 #endif
 
 #ifdef HAVE_LIBZ
-#include "zlib.h"
   /* zip encoding strategies */
   PyModule_AddIntConstant(m, "DEFAULT_STRATEGY", Z_DEFAULT_STRATEGY);
   PyModule_AddIntConstant(m, "FILTERED", Z_FILTERED);


### PR DESCRIPTION
Fixes a msvc compile error because various types get redefined
