### PR TITLE
Fix `support not installed` messages during selftest

### DIFF
--- a/selftest.py
+++ b/selftest.py
@@ -157,7 +157,7 @@ def testimage():
 
 def check_module(feature, module):
     try:
-        __import__("PIL." + module)
+        __import__(module)
     except ImportError:
         print("***", feature, "support not installed")
     else:


### PR DESCRIPTION
The extension modules are currently not installed in PIL but sys.path.
