### PR TITLE
Remove test that fails when numpy.int is 64 bit

### DIFF
--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -40,7 +40,6 @@ def test_numpy_to_image():
     assert_exception(TypeError, lambda: to_image(numpy.uint32))
     assert_exception(TypeError, lambda: to_image(numpy.uint64))
 
-    assert_image(to_image(numpy.int), "I", (10, 10))
     assert_image(to_image(numpy.int8), "I", (10, 10))
     assert_image(to_image(numpy.int16), "I;16", (10, 10))
     assert_image(to_image(numpy.int32), "I", (10, 10))


### PR DESCRIPTION
Fixes issue #75
