### PR TITLE
DOC: Remove support for importing from the standard namespace

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,8 @@ Changelog (Pillow)
 - Add Python 3 support. (Pillow >= 2.0.0 supports Python 2.6, 2.7, 3.2, 3.3. Pillow < 2.0.0 supports Python 2.4, 2.5, 2.6, 2.7.)
   [fluggo]
 
+- Remove support for importing from the standard namespace.
+
 - Add PyPy support (experimental, please see: https://github.com/python-imaging/Pillow/issues/67)
 
 - Add WebP support.


### PR DESCRIPTION
This should also be mentioned in the release announcements because it will probably break many outdated tutorials.
