### PR TITLE
Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,9 @@ to::
 
 	from PIL import Image
 
-Note that if your code imports _imaging, that will also be hosted in the PIL namespace. The preferred method of importing _imaging is::
+Note that if your code imports _imaging, that will also be hosted in
+the PIL namespace. The preferred, future proof method of importing the
+private _imaging module is::
 
     from PIL import Image
 	_imaging = Image.core
@@ -103,7 +105,7 @@ Current platform support for Pillow. Binary distributions are contributed for ea
 Installation
 ------------
 
-If there is a binary package for your system, that is the preferred way of obtaining Pillow. 
+If there is a binary package for your system, that is the preferred way of obtaining Pillow. [[UNDONE: Binary links]]
 
 Building from Source
 +++++++++


### PR DESCRIPTION
Work in progress for comments -- don't merge yet. 

There are a few things missing from the readme that can affect people who are just trying out Pillow for the first time. 

1) There's no installation instructions, and the PIL ones are out dated.
2) There's no complete list of dependencies, since we've added a few
3) The change in the import statements is the lone incompatibility that I'm aware of, but it's a big one. 

I'm going to continue to work on this, including testing out the distro specific information and merging more of the old PIL 1.1.7 documentation. 
