### PR TITLE
fixing save of transparency palette png-images

### DIFF
--- a/PIL/PngImagePlugin.py
+++ b/PIL/PngImagePlugin.py
@@ -70,7 +70,7 @@ _MODES = {
 }
 
 
-_simple_palette = re.compile(b'^\xff+\x00+$')
+_simple_palette = re.compile(b'^\xff+\x00\xff*$')
 
 # --------------------------------------------------------------------
 # Support classes.  Suitable for PNG and related formats like MNG etc.


### PR DESCRIPTION
this time everything is correct. see: https://github.com/python-imaging/Pillow/pull/149#discussion-diff-3473481

Every other test (even the complicated screwed up images) finished just fine with the current master 2.0.0. Will test it again on 64bit linux in the next days.
