### PR TITLE
Add tempfile for test output

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -126,7 +126,7 @@ def test_g4_write():
     file = "Tests/images/lena_g4_500.tif"
     orig = Image.open(file)
 
-    out = "temp.tif"
+    out = tempfile("temp.tif")
     rot = orig.transpose(Image.ROTATE_90)
     assert_equal(rot.size,(500,500))
     rot.save(out)


### PR DESCRIPTION
For consistency - all files created by tests should be created in a temporary folder.
(This prevents the creation of the temporary file in the installdir, which is where the tests are run when building the fedora package - such files otherwise easily sneak into the package).
