### PR TITLE
create a palette before converting transparent L-mode to RGBA

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -713,6 +713,16 @@ class Image:
         if dither is None:
             dither = FLOYDSTEINBERG
 
+        # fake a P-mode image, otherwise the transparency will get lost as there is
+        # currently no other way to convert transparency into an RGBA image
+        if self.mode == "L" and mode == "RGBA" and "transparency" in self.info:
+            from PIL import ImagePalette
+            self.mode = "P"
+            bytePalette = bytes([i//3 for i in range(768)])
+            self.palette = ImagePalette.raw("RGB", bytePalette)
+            self.palette.dirty = 1
+            self.load()
+
         try:
             im = self.im.convert(mode, dither)
         except ValueError:


### PR DESCRIPTION
fixes #154

If you load a L-mode image with transparency and want to save it as L or P-mode image you can maintain the transparency by adding it to the save() method as parameter.
This this doesn't work if you convert said image to RGBA and try to save it as PNG.

Converting to RGBA only includes alphas set in a palette so we have to create a palette and add alphas even for an greyscale image. Another solution would be rewriting the color conversion parts to accept and use a transparency value.
