### PR TITLE
Fix warning: function declaration isn't a prototype

### DIFF
--- a/_webp.c
+++ b/_webp.c
@@ -87,7 +87,7 @@ PyInit__webp(void) {
 }
 #else
 PyMODINIT_FUNC
-init_webp()
+init_webp(void)
 {
     Py_InitModule("_webp", webpMethods);
 }


### PR DESCRIPTION
Fix an additional warning
