### PR TITLE
Add directories for documentation build

### DIFF
--- a/docs/_build/.gitignore
+++ b/docs/_build/.gitignore
@@ -1,0 +1,1 @@
+# Empty file, to make the directory available in the repository

--- a/docs/_static/.gitignore
+++ b/docs/_static/.gitignore
@@ -1,0 +1,1 @@
+# Empty file, to make the directory available in the repository

--- a/docs/_templates/.gitignore
+++ b/docs/_templates/.gitignore
@@ -1,0 +1,1 @@
+# Empty file, to make the directory available in the repository


### PR DESCRIPTION
This fixes

```
WARNING: html_static_path entry '[...]/pillow/docs/_static' does not exist
```

when building documentation. The directories _build, _static and _templates are automatically created by sphinx-apidoc.
