### PR TITLE
Add proper shebangs to all Python scripts

### DIFF
--- a/Scripts/enhancer.py
+++ b/Scripts/enhancer.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 #
 # The Python Imaging Library
 # $Id$

--- a/Scripts/explode.py
+++ b/Scripts/explode.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 #
 # The Python Imaging Library
 # $Id$

--- a/Scripts/gifmaker.py
+++ b/Scripts/gifmaker.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 #
 # The Python Imaging Library
 # $Id$

--- a/Scripts/painter.py
+++ b/Scripts/painter.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 #
 # The Python Imaging Library
 # $Id$

--- a/Scripts/pilconvert.py
+++ b/Scripts/pilconvert.py
@@ -1,4 +1,4 @@
-#! /usr/local/bin/python
+#!/usr/bin/env python
 #
 # The Python Imaging Library.
 # $Id$

--- a/Scripts/pilfile.py
+++ b/Scripts/pilfile.py
@@ -1,4 +1,4 @@
-#! /usr/local/bin/python
+#!/usr/bin/env python
 #
 # The Python Imaging Library.
 # $Id$

--- a/Scripts/pilprint.py
+++ b/Scripts/pilprint.py
@@ -1,4 +1,4 @@
-#! /usr/local/bin/python
+#!/usr/bin/env python
 #
 # The Python Imaging Library.
 # $Id$

--- a/Scripts/player.py
+++ b/Scripts/player.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 #
 # The Python Imaging Library
 # $Id$

--- a/Scripts/thresholder.py
+++ b/Scripts/thresholder.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 #
 # The Python Imaging Library
 # $Id$

--- a/Scripts/viewer.py
+++ b/Scripts/viewer.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 #
 # The Python Imaging Library
 # $Id$


### PR DESCRIPTION
Currently, some of the scripts don't have a shebang at all, some others have it pointing towards `/usr/local/bin/python`. With this patch, all shebangs use `/usr/bin/env python` consistently.
