### PR TITLE
test_file_tiff: skip JPEG-in-TIFF tests if libjpeg is not available

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -43,6 +43,10 @@ def test_mac_tiff():
 def test_gimp_tiff():
     # Read TIFF JPEG images from GIMP [@PIL168]
 
+    codecs = dir(Image.core)
+    if "jpeg_decoder" not in codecs:
+        skip("jpeg support not available")
+
     file = "Tests/images/pil168.tif"
     im = Image.open(file)
 


### PR DESCRIPTION
The improvement of tiff-related test code shown that one of the tiff tests relies on jpeg support as well. This commit fixes it to be skipped when jpeg is disabled.
