### PR TITLE
fix typo in command to install prerequisites with hombrew

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,7 +149,7 @@ The easiest way to install the prerequisites is to use homebrew: http://mxcl.git
 
 ::
 
-$ brew install libtiff lbjpeg webp littlecms
+$ brew install libtiff libjpeg webp littlecms
 
 If you've built your own python, then you should be able to install Pillow using 
 


### PR DESCRIPTION
This pull request fixes a typo in the command to install the prerequisites with homebrew found in the readme. It's a little speed bump while trying to get up and running:

```
$ brew install libtiff lbjpeg webp littlecms
Error: No available formula for lbjpeg
```
