### PR TITLE
PdfImagePlugin: call JpegImagePlugin._save instead of FileImage

### DIFF
--- a/PIL/PdfImagePlugin.py
+++ b/PIL/PdfImagePlugin.py
@@ -149,7 +149,7 @@ def _save(im, fp, filename):
             im.putdata(data)
         ImageFile._save(im, op, [("hex", (0,0)+im.size, 0, im.mode)])
     elif filter == "/DCTDecode":
-        ImageFile._save(im, op, [("jpeg", (0,0)+im.size, 0, im.mode)])
+        Image.SAVE["JPEG"](im, op, filename)
     elif filter == "/FlateDecode":
         ImageFile._save(im, op, [("zip", (0,0)+im.size, 0, im.mode)])
     elif filter == "/RunLengthDecode":


### PR DESCRIPTION
This way all the im.encoderconfig is set the same way. This would also fix #215
