### PR TITLE
Fix for ZeroDivisionError in ImageOps.fit for image.size == (1,1)

### DIFF
--- a/PIL/ImageOps.py
+++ b/PIL/ImageOps.py
@@ -274,7 +274,7 @@ def fit(image, size, method=Image.NEAREST, bleed=0.0, centering=(0.5, 0.5)):
     # kevin@cazabon.com
     # http://www.cazabon.com
 
-    # No cropping/fit possible
+    # No cropping/fit possible. Prevents ZeroDivisionError @ liveAreaAspectRatio
     if image.size == (1,1):
         return image
 

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -37,6 +37,7 @@ def test_sanity():
 
     ImageOps.fit(lena("L"), (128, 128))
     ImageOps.fit(lena("RGB"), (128, 128))
+    ImageOps.fit(lena("RGB").resize((1,1)), (35,35))
 
     ImageOps.flip(lena("L"))
     ImageOps.flip(lena("RGB"))


### PR DESCRIPTION
Title says it all I guess ;-)
