### PR TITLE
BUG: Fix webp encode errors on win-amd64

### DIFF
--- a/_webp.c
+++ b/_webp.c
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include "py3.h"
 #include <webp/encode.h>
@@ -16,7 +17,7 @@ PyObject* WebPEncode_wrapper(PyObject* self, PyObject* args)
     Py_ssize_t size;
     size_t ret_size;
 
-    if (!PyArg_ParseTuple(args, "s#iifs",(char**)&rgb, &size, &width, &height, &quality_factor, &mode)) {
+    if (!PyArg_ParseTuple(args, "s#nifs",(char**)&rgb, &size, &width, &height, &quality_factor, &mode)) {
         Py_RETURN_NONE;
     }
 


### PR DESCRIPTION
This PR fixes two webp related test failures on win-amd64 (below). The uninitialized variable `size` of type  `Py_ssize_t`  should not be parsed as `int`.

```
<snip>
running test_file_webp ...
Tests\test_file_webp.py:43: lena("RGB").save(temp_file) failed:
Traceback (most recent call last):
  File "Tests\test_file_webp.py", line 43, in test_write_rgb
    lena("RGB").save(temp_file)
  File ".\PIL\Image.py", line 1465, in save
    save_handler(self, fp, filename)
  File ".\PIL\WebPImagePlugin.py", line 52, in _save
    fp.write(data)
TypeError: 'NoneType' does not support the buffer interface
Tests\test_file_webp.py:79: pil_image.save(temp_file) failed:
Traceback (most recent call last):
  File "Tests\test_file_webp.py", line 79, in test_write_rgba
    pil_image.save(temp_file)
  File ".\PIL\Image.py", line 1465, in save
    save_handler(self, fp, filename)
  File ".\PIL\WebPImagePlugin.py", line 52, in _save
    fp.write(data)
TypeError: 'NoneType' does not support the buffer interface
<snip>
```
