### PR TITLE
Better fix for ZeroDivisionError in ImageOps.fit for image.size height is 1

### DIFF
--- a/PIL/ImageOps.py
+++ b/PIL/ImageOps.py
@@ -275,10 +275,6 @@ def fit(image, size, method=Image.NEAREST, bleed=0.0, centering=(0.5, 0.5)):
     # kevin@cazabon.com
     # http://www.cazabon.com
 
-    # No cropping/fit possible. Prevents ZeroDivisionError @ liveAreaAspectRatio
-    if image.size == (1,1):
-        return image
-
     # ensure inputs are valid
     if not isinstance(centering, list):
         centering = [centering[0], centering[1]]
@@ -300,10 +296,12 @@ def fit(image, size, method=Image.NEAREST, bleed=0.0, centering=(0.5, 0.5)):
         int((float(bleed) * float(image.size[1])) + 0.5)
         )
 
-    liveArea = (
-        bleedPixels[0], bleedPixels[1], image.size[0] - bleedPixels[0] - 1,
-        image.size[1] - bleedPixels[1] - 1
-        )
+    liveArea = (0, 0, image.size[0], image.size[1])
+    if bleed > 0.0:
+        liveArea = (
+            bleedPixels[0], bleedPixels[1], image.size[0] - bleedPixels[0] - 1,
+            image.size[1] - bleedPixels[1] - 1
+            )
 
     liveSize = (liveArea[2] - liveArea[0], liveArea[3] - liveArea[1])
 

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -37,7 +37,6 @@ def test_sanity():
 
     ImageOps.fit(lena("L"), (128, 128))
     ImageOps.fit(lena("RGB"), (128, 128))
-    ImageOps.fit(lena("RGB").resize((1,1)), (35,35))
 
     ImageOps.flip(lena("L"))
     ImageOps.flip(lena("RGB"))
@@ -58,6 +57,17 @@ def test_sanity():
     ImageOps.solarize(lena("RGB"))
 
     success()
+
+def test_1pxfit():
+    # Division by zero in equalize if image is 1 pixel high
+    newimg = ImageOps.fit(lena("RGB").resize((1,1)), (35,35))
+    assert_equal(newimg.size,(35,35))
+    
+    newimg = ImageOps.fit(lena("RGB").resize((1,100)), (35,35))
+    assert_equal(newimg.size,(35,35))
+
+    newimg = ImageOps.fit(lena("RGB").resize((100,1)), (35,35))
+    assert_equal(newimg.size,(35,35))
 
 def test_pil163():
     # Division by zero in equalize if < 255 pixels in image (@PIL163)


### PR DESCRIPTION
pterk's earlier fix (https://github.com/python-imaging/Pillow/pull/255) does not really solve the problem - which is a ZeroDivisionError if the height of the image is 1px (regardless of width). I've disable the -1 size reduction when calculating the liveArea dimensions - this allows fit(..) to be applied to any image size.
