### PR TITLE
move test_adobe_deflate_tiff to libtiff test file

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -87,3 +87,11 @@ def test_g4_write():
 
     assert_false(orig.tobytes() == reread.tobytes())
 
+def test_adobe_deflate_tiff():
+    file = "Tests/images/tiff_adobe_deflate.tif"
+    im = Image.open(file)
+
+    assert_equal(im.mode, "RGB")
+    assert_equal(im.size, (278, 374))
+    assert_equal(im.tile[0][:3], ('tiff_adobe_deflate', (0, 0, 278, 374), 0))
+    assert_no_exception(lambda: im.load())

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -71,12 +71,3 @@ def test_xyres_tiff():
     im.tag.tags[Y_RESOLUTION] = (72,)
     im._setup()
     assert_equal(im.info['dpi'], (72., 72.))
-
-def test_adobe_deflate_tiff():
-    file = "Tests/images/tiff_adobe_deflate.tif"
-    im = Image.open(file)
-
-    assert_equal(im.mode, "RGB")
-    assert_equal(im.size, (278, 374))
-    assert_equal(im.tile[0][:3], ('tiff_adobe_deflate', (0, 0, 278, 374), 0))
-    assert_no_exception(lambda: im.load())


### PR DESCRIPTION
move test_adobe_deflate_tiff to test_file_libtiff.py
test should be skipped if libtiff isn't available 
