### PR TITLE
Added clean/build to tox to make it behave like travis

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,7 @@ envlist = py26, py27, py32, py33
 
 [testenv]
 commands =
+    {envpython} setup.py clean
+    {envpython} setup.py build_ext --inplace
     {envpython} selftest.py
     {envpython} Tests/run.py --installed


### PR DESCRIPTION
If you run tox without the lines added by this patch (clean/build), the tests fail, also this make travis and tox work in the same way.

This is the error thrown running `tox -e py27` inside a fresh clone

```
GLOB sdist-make: /home/freyes/Projects/pillow.git/setup.py
py27 recreate: /home/freyes/Projects/pillow.git/.tox/py27
py27 sdist-inst: /home/freyes/Projects/pillow.git/.tox/dist/Pillow-2.1.0.zip
py27 runtests: commands[0]
Traceback (most recent call last):
  File "selftest.py", line 11, in <module>
    from PIL import Image, ImageDraw, ImageFilter, ImageMath
  File "/home/freyes/Projects/pillow.git/PIL/ImageMath.py", line 19, in <module>
    from PIL import _imagingmath
ImportError: cannot import name _imagingmath
ERROR: InvocationError: '/home/freyes/Projects/pillow.git/.tox/py27/bin/python selftest.py'
________________________________________________________________________________ summary _________________________________________________________________________________
ERROR:   py27: commands failed
```
