### PR TITLE
Added IGNORE_DECODING_ERRORS flag to ImageFile allowing corrupted images to load

### DIFF
--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -37,6 +37,7 @@ MAXBLOCK = 65536
 SAFEBLOCK = 1024*1024
 
 LOAD_TRUNCATED_IMAGES = False
+IGNORE_DECODING_ERRORS = False
 
 ERRORS = {
     -1: "image buffer overrun error",
@@ -228,7 +229,7 @@ class ImageFile(Image.Image):
 
         self.fp = None # might be shared
 
-        if (not LOAD_TRUNCATED_IMAGES or t == 0) and not self.map and e < 0:
+        if not IGNORE_DECODING_ERRORS and (not LOAD_TRUNCATED_IMAGES or t == 0) and not self.map and e < 0:
             # still raised if decoder fails to return anything
             raise_ioerror(e)
 


### PR DESCRIPTION
Since commit 33bf5d9d37d377c43ac38be497b1e9cdd1d34832 PIL is no longer able to load [this image](http://s.glbimg.com/jo/g1/f/original/2013/07/30/dsc0337_c_1.jpg) even after setting `ImageFile.LOAD_TRUNCATED_IMAGES = True` because of the `t == 0` check that was introduced then.

Because I'm not sure about what use cases @d-schmidt had in mind when the size check was added, I've introduced a new flag called IGNORE_DECODING_ERRORS that if True will never raise IOError. This should make everyone happy.
