### PR TITLE
Fix build issues in virtualenv on python3.3 and Ubuntu raring

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -211,7 +211,7 @@ class pil_build_ext(build_ext):
                 platinclude_path =\
                     platinclude_path.replace(prefix, sys.real_prefix)
 
-            _add_directory(include_dirs, platinclude_path)
+                _add_directory(include_dirs, platinclude_path)
 
         #
         # locate tkinter libraries


### PR DESCRIPTION
As mentioned in #292, Pillow doesn't build on python3.3 and Ubuntu raring. libImaging fails with 
`/usr/include/python3.3m/Python.h:8:22: fatal error: pyconfig.h: No such file or directory`

In Python 3.3 platform-specific and general includes can be split in two folders. These can be determined with `syscofig` or `distutils.sysconfig`. Unfortunatelly, virtualenv has a bug, which prevents usage of the appropriate `sysconfig` methods (the returned paths are not global but virtualenv-specific). See https://github.com/pypa/virtualenv/issues/458 .

The proposed patch deals with both issues. 
