### PR TITLE
be more tolerant of tag read failures

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -47,6 +47,7 @@ from PIL import Image, ImageFile
 from PIL import ImagePalette
 from PIL import _binary
 
+import warnings
 import array, sys
 import collections
 import itertools
@@ -398,8 +399,7 @@ class ImageFileDirectory(collections.MutableMapping):
                 data = ifd[8:8+size]
 
             if len(data) != size:
-                if Image.DEBUG:
-                    print("- expecting to read %d bytes but only got %d. skipping tag %s" % (size, len(data), tag))
+                warnings.warn("Possibly corrupt EXIF data.  Expecting to read %d bytes but only got %d. Skipping tag %s" % (size, len(data), tag))
                 continue
 
             self.tagdata[tag] = typ, data


### PR DESCRIPTION
I am running into this issue on a file with a non-conforming MakerNote field that has a pointer to outside the EXIF block.  For what it's worth, both libexif and exiv2 are more tolerant of this case by just printing an error.  It seems that this situation can be very common as discussed here: http://www.exiv2.org/makernote.html
