### PR TITLE
Add respective paths for C_INCLUDE_PATH, LD_RUN_PATH (rpath) to build if...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog (Pillow)
 2.2.0 (2013-10-01)
 ------------------
 
+- Add respective paths for C_INCLUDE_PATH, LD_RUN_PATH (rpath) to build
+  if specified as environment variables.
+  [seanupton]
+
 - Fix Issue #312 + gif optimize improvement
   [d-schmidt]
 

--- a/setup.py
+++ b/setup.py
@@ -196,6 +196,12 @@ class pil_build_ext(build_ext):
         _add_directory(library_dirs, "/usr/local/lib")
         # FIXME: check /opt/stuff directories here?
 
+        # include, rpath, if set as environment variables:
+        if os.environ.get('C_INCLUDE_PATH'):
+            _add_directory(include_dirs, os.environ.get('C_INCLUDE_PATH'))
+        if os.environ.get('LD_RUN_PATH'):
+            _add_directory(library_dirs, os.environ.get('LD_RUN_PATH'))
+
         prefix = sysconfig.get_config_var("prefix")
         if prefix:
             _add_directory(library_dirs, os.path.join(prefix, "lib"))


### PR DESCRIPTION
... specified as environment variables.

Note: https://github.com/collective/buildout.python needs this to build correctly on Linux where intent is to use the libjpeg provided in that buildout.
