### PR TITLE
Automatically discover homebrew include/ and lib/ paths on OSX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -169,6 +169,12 @@ class pil_build_ext(build_ext):
             # freetype2 ships with X11
             _add_directory(library_dirs, "/usr/X11/lib")
             _add_directory(include_dirs, "/usr/X11/include")
+            # if brew is installed, use its lib and include directories
+            import commands
+            status, homebrew = commands.getstatusoutput('brew --prefix')
+            if status == 0:
+                _add_directory(library_dirs, os.path.join(homebrew, 'lib'))
+                _add_directory(include_dirs, os.path.join(homebrew, 'include'))
 
         elif sys.platform.startswith("linux"):
             for platform_ in (plat.processor(), plat.architecture()[0]):


### PR DESCRIPTION
This change allows Pillow to discover installed libs on OSX when using the homebrew package manager outside of `/usr/local/`.

It relies on the commands module, which goes away in Python 3.  If it seems like a good change to add, I can switch the code over to subprocess.
