### PR TITLE
issue328: _imagingcms.c: include windef.h to fix build issue on MSVC

### DIFF
--- a/_imagingcms.c
+++ b/_imagingcms.c
@@ -33,6 +33,7 @@ http://www.cazabon.com\n\
 #endif
 
 #ifdef WIN32
+#include <windef.h>
 #include <wingdi.h>
 #endif
 


### PR DESCRIPTION
Pull request on issue 328.
