### PR TITLE
issue 329: setup.py: better support for C_INCLUDE_PATH, LD_RUN_PATH, etc...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -203,10 +203,15 @@ class pil_build_ext(build_ext):
         # FIXME: check /opt/stuff directories here?
 
         # include, rpath, if set as environment variables:
-        if os.environ.get('C_INCLUDE_PATH'):
-            _add_directory(include_dirs, os.environ.get('C_INCLUDE_PATH'))
-        if os.environ.get('LD_RUN_PATH'):
-            _add_directory(library_dirs, os.environ.get('LD_RUN_PATH'))
+        for k in 'C_INCLUDE_PATH INCLUDE'.split():
+            if k in os.environ:
+                for d in os.environ[k].split(os.path.pathsep):
+                    _add_directory(include_dirs, d)
+
+        for k in 'LD_RUN_PATH LIBRARY_PATH LIB'.split():
+            if k in os.environ:
+                for d in os.environ[k].split(os.path.pathsep):
+                    _add_directory(library_dirs, d)
 
         prefix = sysconfig.get_config_var("prefix")
         if prefix:


### PR DESCRIPTION
Fix to support colon separated path list, and also support INCLUDE and LIB
environment variable used by MSVC.
