### PR TITLE
BUG: AttributeError: 'function' object has no attribute 'im_func' on Py3.

### DIFF
--- a/PIL/WebPImagePlugin.py
+++ b/PIL/WebPImagePlugin.py
@@ -40,7 +40,10 @@ class WebPImageFile(ImageFile.ImageFile):
 
     def _getexif(self):
         from PIL.JpegImagePlugin import JpegImageFile
-        return JpegImageFile._getexif.im_func(self)
+        try:
+            return JpegImageFile._getexif.im_func(self)
+        except AttributeError:
+            return JpegImageFile._getexif(self)
 
 
 def _save(im, fp, filename):


### PR DESCRIPTION
Needs review. 
Fixes one test error on Python 3:

```
Tests\test_file_webp_metadata.py:22: exif = image._getexif() failed:
Traceback (most recent call last):
  File "Tests\test_file_webp_metadata.py", line 22, in test_read_exif_metadata
    exif = image._getexif()
  File "PIL\WebPImagePlugin.py", line 43, in _getexif
    return JpegImageFile._getexif.im_func(self)
AttributeError: 'function' object has no attribute 'im_func'
```
