### PR TITLE
TST: fix TypeError: string argument expected, got 'bytes' on Py3

### DIFF
--- a/Tests/test_file_webp_metadata.py
+++ b/Tests/test_file_webp_metadata.py
@@ -9,10 +9,6 @@ try:
 except:
     skip('webp support not installed')
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 
 def test_read_exif_metadata():
@@ -40,7 +36,7 @@ def test_write_exif_metadata():
     image = Image.open(file_path)
     expected_exif = image.info['exif']
 
-    buffer = StringIO()
+    buffer = BytesIO()
 
     image.save(buffer, "webp", exif=expected_exif)
 
@@ -73,7 +69,7 @@ def test_write_icc_metadata():
     image = Image.open(file_path)
     expected_icc_profile = image.info['icc_profile']
 
-    buffer = StringIO()
+    buffer = BytesIO()
 
     image.save(buffer, "webp", icc_profile=expected_icc_profile)
 


### PR DESCRIPTION
Fixes two test errors on Python 3:

```
Tests\test_file_webp_metadata.py:45: image.save(buffer, "webp", exif=expected_exif) failed:
Traceback (most recent call last):
  File "Tests\test_file_webp_metadata.py", line 45, in test_write_exif_metadata
    image.save(buffer, "webp", exif=expected_exif)
  File "PIL\Image.py", line 1441, in save
    save_handler(self, fp, filename)
  File "PIL\WebPImagePlugin.py", line 70, in _save
    fp.write(data)
TypeError: string argument expected, got 'bytes'
```

```
Tests\test_file_webp_metadata.py:78: image.save(buffer, "webp", icc_profile=expected_icc_profile) failed:
Traceback (most recent call last):
  File "Tests\test_file_webp_metadata.py", line 78, in test_write_icc_metadata
    image.save(buffer, "webp", icc_profile=expected_icc_profile)
  File "PIL\Image.py", line 1441, in save
    save_handler(self, fp, filename)
  File "PIL\WebPImagePlugin.py", line 70, in _save
    fp.write(data)
TypeError: string argument expected, got 'bytes'
```
