### PR TITLE
Tiff Tags

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -110,6 +110,10 @@ ICCPROFILE = 34675
 EXIFIFD = 34665
 XMP = 700
 
+# https://github.com/fiji/ImageJA/blob/master/src/main/java/ij/io/TiffDecoder.java
+IMAGEJ_META_DATA_BYTE_COUNTS = 50838
+IMAGEJ_META_DATA = 50839
+
 COMPRESSION_INFO = {
     # Compression => pil compression name
     1: "raw",

--- a/PIL/TiffTags.py
+++ b/PIL/TiffTags.py
@@ -186,6 +186,10 @@ TAGS = {
     50738: "AntiAliasStrength",
     50740: "DNGPrivateData",
     50741: "MakerNoteSafety",
+
+    #ImageJ
+    50838: "ImageJMetaDataByteCounts", # private tag registered with Adobe
+    50839: "ImageJMetaData", # private tag registered with Adobe
 }
 
 ##


### PR DESCRIPTION
Partial fix for issue #291.
Want to include fix for #290.

Includes recognizing the tags, and support for actually dealing with the referenced test file.  Works, but is not complete. 

Todo: 
- [ ] add test case
- [ ] add the ability to save tags in the tiff directory
