### PR TITLE
Bug fix for encoding of b_whitespace - Similar to closed issue #272

### DIFF
--- a/PIL/PpmImagePlugin.py
+++ b/PIL/PpmImagePlugin.py
@@ -24,11 +24,14 @@ from PIL import Image, ImageFile
 #
 # --------------------------------------------------------------------
 
-import locale
-locale_lang,locale_enc = locale.getlocale()
-if locale_enc is None:
-    locale_lang,locale_enc = locale.getdefaultlocale()
-b_whitespace = string.whitespace.decode(locale_enc)
+b_whitespace = string.whitespace
+try:
+    import locale
+    locale_lang,locale_enc = locale.getlocale()
+    if locale_enc is None:
+        locale_lang,locale_enc = locale.getdefaultlocale() 
+    b_whitespace = b_whitespace.decode(locale_enc)
+except: pass
 b_whitespace = b_whitespace.encode('ascii','ignore')
 
 MODES = {


### PR DESCRIPTION
Hi,

Having recently changed from PIL to Pillow for creating images, I have been getting an error similar to that previously reported in Issue #272. Something like:

b_whitespace = string.whitespace.encode()
UnicodeDecodeError: 'ascii' codec can't decode byte 0xa0 in position 6: ordinal not in range(128)

In my case it was when I use Image.save() rather than Image.open(). 
I am using the Python API that is built into a commercial Finite Element Analysis package, so it is not a standard Python installation. The locale for this Python installation is ('English_United States', '1252').

I think that this error can easily be fixed by first decoding string.whitespace using the current locale and then encoding to ascii. It should also work in the other problem cases where the locale has been changed.

Cheers,
Michael
