### PR TITLE
Fix for #254

### DIFF
--- a/libImaging/Storage.c
+++ b/libImaging/Storage.c
@@ -36,6 +36,7 @@
 
 
 #include "Imaging.h"
+#include <string.h>
 
 
 int ImagingNewCount = 0;
@@ -333,6 +334,7 @@ ImagingNewBlock(const char *mode, int xsize, int ysize)
     im->block = (char *) malloc(bytes);
 
     if (im->block) {
+        memset(im->block, 0, bytes);
 
 	for (y = i = 0; y < im->ysize; y++) {
 	    im->image[y] = im->block + i;


### PR DESCRIPTION
Added a fix for issue #254, regarding a bug in image transformations resulting from uninitialized memory (especially noticeable on machines with limited physical memory available).
