### PR TITLE
Py3 fixes

### DIFF
--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -2,7 +2,6 @@ from tester import *
 
 from PIL import Image
 import struct
-import math
 
 try:
     import site
@@ -70,8 +69,8 @@ def test_3d_array():
 def _test_img_equals_nparray(img, np):
     assert_equal(img.size, np.shape[0:2])
     px = img.load()
-    for x in range(0, img.size[0], math.floor(img.size[0]/10)):
-        for y in range(0, img.size[1], math.floor(img.size[1]/10)):
+    for x in range(0, img.size[0], int(img.size[0]/10)):
+        for y in range(0, img.size[1], int(img.size[1]/10)):
             assert_deep_equal(px[x,y], np[y,x])
 
 


### PR DESCRIPTION
s/xrange/range/. Convert to int. 

Makes it work on Python3. Apparently Travis doesn't check numpy on Py3. 
