### PR TITLE
Test image transforms

### DIFF
--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -41,7 +41,7 @@ def test_mesh():
                                  w,h,w,0))], # ul -> ccw around quad
                                Image.BILINEAR)
 
-    transformed.save('transformed.png')
+    #transformed.save('transformed.png')
 
     scaled = im.resize((w//2, h//2), Image.BILINEAR)
 


### PR DESCRIPTION
Some tests of the image transform operations, using real images and the crop/resize equivalents of the operations. 

The contains a test for #254, which fails pre-patch and succeeds later. 

A word of warning -- the test for issue #254 takes 256 megs of memory, and is not deterministic. It may fail if the bug is there, and it may succeed. (though, if we fail, then the bug is there) It relies on filling up enough memory that garbage is left. This is sized for small virtual machines. Actual workstations may not hit the bug. 
