### PR TITLE
Fix 10.9 Mavericks install issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -174,8 +174,7 @@ class pil_build_ext(build_ext):
             # darwin ports installation directories
             _add_directory(library_dirs, "/opt/local/lib")
             _add_directory(include_dirs, "/opt/local/include")
-            # xquartz installation directories
-            _add_directory(library_dirs, "/opt/X11/lib")
+            # Mavericks has X11 include files here
             _add_directory(include_dirs, "/opt/X11/include")
             # freetype2 ships with X11
             _add_directory(library_dirs, "/usr/X11/lib")


### PR DESCRIPTION
On a clean Mac 10.9 Mavericks install with XQuartz as the X11 system, Pillow fails to build with the following error:

cc -fno-strict-aliasing -fno-common -dynamic -g -Os -pipe -fno-common -fno-strict-aliasing -fwrapv -mno-fused-madd -DENABLE_DTRACE -DMACOSX -DNDEBUG -Wall -Wstrict-prototypes -Wshorten-64-to-32 -DNDEBUG -g -fwrapv -Os -Wall -Wstrict-prototypes -DENABLE_DTRACE -arch x86_64 -arch i386 -pipe -IlibImaging -I/System/Library/Frameworks/Python.framework/Versions/2.7/include -I/usr/local/include -I/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c _imagingtk.c -o build/temp.macosx-10.9-intel-2.7/_imagingtk.o -framework Tcl -framework Tk

clang: warning: -framework Tcl: 'linker' input unused

clang: warning: -framework Tk: 'linker' input unused

clang: warning: argument unused during compilation: '-mno-fused-madd'

In file included from _imagingtk.c:19:

/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk/usr/include/tk.h:78:11: fatal error: 'X11/Xlib.h' file not found
# include <X11/Xlib.h>

```
            ^
```

1 error generated.

error: command 'cc' failed with exit status 1

The fix is to include /opt/X11/include and /opt/X11/lib which is where the files are now located in 10.9 Mavericks installs
