### PR TITLE
Quote filenames and title before using on command line

### DIFF
--- a/PIL/ImageShow.py
+++ b/PIL/ImageShow.py
@@ -17,6 +17,11 @@ from __future__ import print_function
 from PIL import Image
 import os, sys
 
+if(sys.version_info >= (3, 3)):
+    from shlex import quote
+else:
+    from pipes import quote
+
 _viewers = []
 
 def register(viewer, order=1):
@@ -99,7 +104,7 @@ if sys.platform == "win32":
         format = "BMP"
         def get_command(self, file, **options):
             return ("start /wait %s && ping -n 2 127.0.0.1 >NUL "
-                    "&& del /f %s" % (file, file))
+                    "&& del /f %s" % (quote(file), quote(file)))
 
     register(WindowsViewer)
 
@@ -111,7 +116,7 @@ elif sys.platform == "darwin":
             # on darwin open returns immediately resulting in the temp
             # file removal while app is opening
             command = "open -a /Applications/Preview.app"
-            command = "(%s %s; sleep 20; rm -f %s)&" % (command, file, file)
+            command = "(%s %s; sleep 20; rm -f %s)&" % (command, quote(file), quote(file))
             return command
 
     register(MacViewer)
@@ -134,7 +139,7 @@ else:
     class UnixViewer(Viewer):
         def show_file(self, file, **options):
             command, executable = self.get_command_ex(file, **options)
-            command = "(%s %s; rm -f %s)&" % (command, file, file)
+            command = "(%s %s; rm -f %s)&" % (command, quote(file), quote(file))
             os.system(command)
             return 1
 
@@ -154,8 +159,7 @@ else:
             # imagemagick's display command instead.
             command = executable = "xv"
             if title:
-                # FIXME: do full escaping
-                command = command + " -name \"%s\"" % title
+                command = command + " -name %s" % quote(title)
             return command, executable
 
     if which("xv"):


### PR DESCRIPTION
This commit quotes title and filename paramaters that are passed to the
command line when showing an image.
