### PR TITLE
Closes #397. Fixed Viewer.show to return properly.

### DIFF
--- a/PIL/ImageShow.py
+++ b/PIL/ImageShow.py
@@ -65,7 +65,7 @@ class Viewer:
         if base != image.mode and image.mode != "1":
             image = image.convert(base)
 
-        self.show_image(image, **options)
+        return self.show_image(image, **options)
 
     # hook methods
 


### PR DESCRIPTION
Viewer.show did not return a value, however ImageShow.show expected
Viewer.show to return a non-falsey value if successful. Therefor ImageShow.show
would continue to call multiple viewers.
