### PR TITLE
Save the transparency header by default for PNGs

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -229,5 +229,9 @@ def test_trns_rgb():
     im = Image.open(file)
     assert_equal(im.info["transparency"], (248, 248, 248))
 
+    # check saving transparency by default
+    im = roundtrip(im)
+    assert_equal(im.info["transparency"], (248, 248, 248))
+
     im = roundtrip(im, transparency=(0, 1, 2))
     assert_equal(im.info["transparency"], (0, 1, 2))


### PR DESCRIPTION
This is a change in the default behavior.

For PNG files in modes L, P, RGB, prior behavior is to only save the transparency header if it's passed in in the encoder info. If the image is not in one of these modes, an error is raised. 

New behavior is to first look in eocoder info, and then the self.info dict for a transparency value. If the user specifies a transparency in encoder info, enforce the mode restrictions, if not, then just don't write the transparency if it's an invalid mode for transparency. 

This was mentioned as an issue in #423
