### PR TITLE
Include uses FreeType 2 header file

### DIFF
--- a/_imagingft.c
+++ b/_imagingft.c
@@ -59,7 +59,7 @@ struct {
     const char* message;
 } ft_errors[] =
 
-#include <freetype/fterrors.h>
+#include <freetype2/fterrors.h>
 
 /* -------------------------------------------------------------------- */
 /* font objects */


### PR DESCRIPTION
- http://www.freetype.org/freetype2/docs/tutorial/step1.html
  "Starting with FreeType 2.1.6, the old header file inclusion
  scheme is no longer supported."
