### PR TITLE
fix compiling with FreeType 2.5.1

### DIFF
--- a/_imagingft.c
+++ b/_imagingft.c
@@ -59,7 +59,11 @@ struct {
     const char* message;
 } ft_errors[] =
 
+#if defined(USE_FREETYPE_2_1)
+#include FT_ERRORS_H
+#else
 #include <freetype/fterrors.h>
+#endif
 
 /* -------------------------------------------------------------------- */
 /* font objects */


### PR DESCRIPTION
Excerpt from FT 2.5.1 change log:

> - The header  file layout  has been changed.   After installation,
>     all files are now located in `<prefix>/include/freetype2'.
>   
>     Applications  that  use   (a)  `freetype-config'  or  FreeType's
>   `pkg-config' file to get the include directory for the compiler,
>     and (b) the documented way for header inclusion like
>   
>   ```
>   #include <ft2build.h>
>   #include FT_FREETYPE_H
>   ...
>   ```
>   
>     don’t need any change to the source code.
