### PR TITLE
Open BMP with header size 108 bytes

### DIFF
--- a/PIL/BmpImagePlugin.py
+++ b/PIL/BmpImagePlugin.py
@@ -82,7 +82,7 @@ class BmpImageFile(ImageFile.ImageFile):
             colors = 0
             direction = -1
 
-        elif len(s) in [40, 64]:
+        elif len(s) in [40, 64, 108]:
 
             # WIN 3.1 or OS/2 2.0 INFO
             bits = i16(s[14:])


### PR DESCRIPTION
PIL doesn't support
http://msdn.microsoft.com/en-us/library/windows/desktop/dd183380%28v=vs.85%29.aspx

This header is very similar to this one
http://msdn.microsoft.com/en-us/library/windows/desktop/dd183376%28v=vs.85%29.aspx

With given changes its possible to open and manipulate BMP file with
header size of 108 bytes.
