### PR TITLE
Include and library path fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,10 @@ _LIB_IMAGING = (
 
 
 def _add_directory(path, dir, where=None):
-    if dir and os.path.isdir(dir) and dir not in path:
+    if dir is None:
+        return
+    dir = os.path.realpath(dir)
+    if os.path.isdir(dir) and dir not in path:
         if where is None:
             path.append(dir)
         else:


### PR DESCRIPTION
Right now Pillow will pick up a Python install from `/usr/local`, `/sw`, etc and try to use their headers/link to them over the Python interpreter that is running `setup.py` (this obviously will create a broken install, in a best case scenario). This is easily resolved by correctly prioritizing the include and library paths. In particular, the ordering should be
1. user specified paths
2. prefix path
3. platform paths
4. standard paths
