### PR TITLE
PixelAccess should use Unsigned ints

### DIFF
--- a/Tests/test_image_getpixel.py
+++ b/Tests/test_image_getpixel.py
@@ -42,10 +42,6 @@ def test_signedness():
         check(mode, 2**15+1)
         check(mode, 2**16-1)
 
-    check("I", 2**31-1)
-    check("I", 2**31)
-    check("I", 2**31+1)
-    check("I", 2**32-1)
                 
 
 

--- a/_imaging.c
+++ b/_imaging.c
@@ -464,7 +464,7 @@ getpixel(Imaging im, ImagingAccess access, int x, int y)
     union {
       UINT8 b[4];
       UINT16 h;
-      UINT32 i;
+      INT32 i;
       FLOAT32 f;
     } pixel;
 

--- a/libImaging/Access.c
+++ b/libImaging/Access.c
@@ -125,11 +125,11 @@ static void
 get_pixel_32L(Imaging im, int x, int y, void* color)
 {
     UINT8* in = (UINT8*) &im->image[y][x*4];
-    UINT32* out = color;
+    INT32* out = color;
 #ifdef WORDS_BIGENDIAN
     out[0] = in[0] + (in[1]<<8) + (in[2]<<16) + (in[3]<<24);
 #else
-    out[0] = *(UINT32*) in;
+    out[0] = *(INT32*) in;
 #endif
 }
 
@@ -137,9 +137,9 @@ static void
 get_pixel_32B(Imaging im, int x, int y, void* color)
 {
     UINT8* in = (UINT8*) &im->image[y][x*4];
-    UINT32* out = color;
+    INT32* out = color;
 #ifdef WORDS_BIGENDIAN
-    out[0] = *(UINT32*) in;
+    out[0] = *(INT32*) in;
 #else
     out[0] = in[3] + (in[2]<<8) + (in[1]<<16) + (in[0]<<24);
 #endif


### PR DESCRIPTION
Fixes #452, The Pixel access object should use unsigned ints when dealing with unsigned formats. 
