### PR TITLE
restoring byte decode to utf-8 string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -587,7 +587,7 @@ setup(
     description='Python Imaging Library (Fork)',
     long_description=(
         _read('README.rst') + b'\n' +
-        _read('CHANGES.rst')),
+        _read('CHANGES.rst')).decode('utf-8'),
     author='Alex Clark (fork author)',
     author_email='aclark@aclark.net',
     url='http://python-imaging.github.io/',


### PR DESCRIPTION
Python 3.x builds are breaking OMMs due to 79603af5285289dc0c382be3510fe80e4484cd13. This restores the decode to a string. 
