### PR TITLE
BLD: Fix msvc build error C1189: "No Target Architecture"

### DIFF
--- a/_imagingcms.c
+++ b/_imagingcms.c
@@ -29,6 +29,7 @@ http://www.cazabon.com\n\
 #include "py3.h"
 
 #ifdef WIN32
+#include <windows.h>
 #include <windef.h>
 #include <wingdi.h>
 #endif


### PR DESCRIPTION
Fixes the following compiler error on Windows when building with msvc10 and SDK 7.1 for 64 bit:

```
_imagingcms.c
X:\WinSDK71\include\winnt.h(135) : fatal error C1189: #error :  "No Target Architecture"
error: command '"C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\BIN\amd64\cl.exe"' failed with exit status 2
```
