### PR TITLE
Correctly quote file names for WindowsViewer command

### DIFF
--- a/PIL/ImageShow.py
+++ b/PIL/ImageShow.py
@@ -103,8 +103,9 @@ if sys.platform == "win32":
     class WindowsViewer(Viewer):
         format = "BMP"
         def get_command(self, file, **options):
-            return ("start /wait %s && ping -n 2 127.0.0.1 >NUL "
-                    "&& del /f %s" % (quote(file), quote(file)))
+            return ('start "Pillow" /WAIT "%s" '
+                    '&& ping -n 2 127.0.0.1 >NUL '
+                    '&& del /f "%s"' % (file, file))
 
     register(WindowsViewer)
 


### PR DESCRIPTION
See https://github.com/python-imaging/Pillow/pull/398#issuecomment-31432940.

The first quoted string passed to the `start` command is the window title.
