### PR TITLE
PPC platform specific library files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -235,6 +235,9 @@ class pil_build_ext(build_ext):
                 elif platform_ in ["i386", "i686", "32bit"]:
                     _add_directory(library_dirs, "/usr/lib/i386-linux-gnu")
                     break
+                elif platform_ in ["ppc"]:
+                    _add_directory(library_dirs, "/usr/lib/powerpc-linux-gnu")
+                    break
             else:
                 raise ValueError(
                     "Unable to identify Linux platform: `%s`" % platform_)


### PR DESCRIPTION
Required to build on modern PPC linux (Ubuntu 12.04) with system packages for dependencies. 

Yay for setting up an old PPC mini as a test machine. 
