### PR TITLE
Fix saving EPS to open file objects on Python 2.x

### DIFF
--- a/PIL/EpsImagePlugin.py
+++ b/PIL/EpsImagePlugin.py
@@ -350,7 +350,9 @@ def _save(im, fp, filename, eps=1):
             pass
 
     base_fp = fp
-    fp = io.TextIOWrapper(NoCloseStream(fp), encoding='latin-1')
+    fp = NoCloseStream(fp)
+    if sys.version_info[0] > 2:
+        fp = io.TextIOWrapper(fp, encoding='latin-1')
 
     if eps:
         #


### PR DESCRIPTION
Fix issues #470 and #479.
Maybe @fluggo can review this PR and commit https://github.com/python-imaging/Pillow/commit/4f7d784a7137c4a0f7c75891a63c5f0cd9170dd0 for a better fix.
As mentioned before https://github.com/python-imaging/Pillow/issues/470#issuecomment-31677359, testing for EPS is spotty...
