### PR TITLE
fix UnboundLocalError: local variable 't' referenced before assignment

### DIFF
--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -229,7 +229,7 @@ class ImageFile(Image.Image):
 
         self.fp = None # might be shared
 
-        if (not LOAD_TRUNCATED_IMAGES or t == 0) and not self.map and e < 0:
+        if not self.map and (not LOAD_TRUNCATED_IMAGES or t == 0) and e < 0:
             # still raised if decoder fails to return anything
             raise_ioerror(e)
 


### PR DESCRIPTION
Variable `t` defined inside `if not self.map` block. That is why `not self.map` check required **before** `t == 0` check.
