### PR TITLE
Removed empty line

### DIFF
--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -105,7 +105,6 @@ Create JPEG thumbnails
             except IOError:
                 print("cannot create thumbnail for", infile)
 
-
 It is important to note that the library doesn’t decode or load the raster data
 unless it really has to. When you open a file, the file header is read to
 determine the file format and extract things like mode, size, and other


### PR DESCRIPTION
It seems that this empty line is what makes this code in the tutorial not highlighted 

http://pillow.readthedocs.org/en/latest/handbook/tutorial.html#a-sequence-iterator-class
