### PR TITLE
setup: look in multiarch paths in GNU platforms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -238,6 +238,9 @@ class pil_build_ext(build_ext):
             # work ;-)
             self.add_multiarch_paths()
 
+        elif sys.platform.startswith("gnu"):
+            self.add_multiarch_paths()
+
         elif sys.platform.startswith("netbsd"):
                     _add_directory(library_dirs, "/usr/pkg/lib")
                     _add_directory(include_dirs, "/usr/pkg/include")


### PR DESCRIPTION
Just like it is done as "kludge" in linux, add the multiarch library paths for GNU platforms (e.g. GNU/kFreeBSD and GNU/Hurd) so additional libraries in multiarch paths can be found (enabling extra image formats).
