### PR TITLE
Handle 32bit compiled python on 64bit architecture

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ class pil_build_ext(build_ext):
             _add_directory(include_dirs, "/usr/X11/include")
 
         elif sys.platform.startswith("linux"):
-            for platform_ in (plat.processor(), plat.architecture()[0]):
+            for platform_ in (plat.architecture()[0], plat.processor()):
 
                 if not platform_:
                     continue


### PR DESCRIPTION
platforma.processor() will return x86_64 on a 64 bit linux system;
however, this it wrong for 32 bit compiled python. By looking at
platform.architecture() first it correctly notes the 32bit
compile.
