### PR TITLE
Fix ImageColor.getcolor

### DIFF
--- a/PIL/ImageColor.py
+++ b/PIL/ImageColor.py
@@ -117,17 +117,18 @@ def getcolor(color, mode):
     :return: ``(red, green, blue)``
     """
     # same as getrgb, but converts the result to the given mode
-    color = getrgb(color)
-    if mode == "RGB":
-        return color
-    if mode == "RGBA":
-        if len(color) == 3:
-          color = (color + (255,))
-        r, g, b, a = color
-        return r, g, b, a
+    color, alpha = getrgb(color), 255
+    if len(color) == 4:
+        color, alpha = color[0:3], color[3]
+
     if Image.getmodebase(mode) == "L":
         r, g, b = color
-        return (r*299 + g*587 + b*114)//1000
+        color = (r*299 + g*587 + b*114)//1000
+        if mode[-1] == 'A':
+            return (color, alpha)
+    else:
+        if mode[-1] == 'A':
+            return color + (alpha,)
     return color
 
 colormap = {

--- a/Tests/test_imagecolor.py
+++ b/Tests/test_imagecolor.py
@@ -26,9 +26,25 @@ for color in list(ImageColor.colormap.keys()):
 
 assert_equal((0, 0, 0), ImageColor.getcolor("black", "RGB"))
 assert_equal((255, 255, 255), ImageColor.getcolor("white", "RGB"))
+assert_equal((0, 255, 115), ImageColor.getcolor("rgba(0, 255, 115, 33)", "RGB"))
+Image.new("RGB", (1, 1), "white")
+
+assert_equal((0, 0, 0, 255), ImageColor.getcolor("black", "RGBA"))
+assert_equal((255, 255, 255, 255), ImageColor.getcolor("white", "RGBA"))
+assert_equal((0, 255, 115, 33), ImageColor.getcolor("rgba(0, 255, 115, 33)", "RGBA"))
+Image.new("RGBA", (1, 1), "white")
 
 assert_equal(0, ImageColor.getcolor("black", "L"))
 assert_equal(255, ImageColor.getcolor("white", "L"))
+assert_equal(162, ImageColor.getcolor("rgba(0, 255, 115, 33)", "L"))
+Image.new("L", (1, 1), "white")
 
 assert_equal(0, ImageColor.getcolor("black", "1"))
 assert_equal(255, ImageColor.getcolor("white", "1"))
+assert_equal(162, ImageColor.getcolor("rgba(0, 255, 115, 33)", "1"))
+Image.new("1", (1, 1), "white")
+
+assert_equal((0, 255), ImageColor.getcolor("black", "LA"))
+assert_equal((255, 255), ImageColor.getcolor("white", "LA"))
+assert_equal((162, 33), ImageColor.getcolor("rgba(0, 255, 115, 33)", "LA"))
+Image.new("LA", (1, 1), "white")


### PR DESCRIPTION
This fixes `ImageColor.getcolor` function when color is `rgba` and mode is `RGB`. And when mode is `LA` and color is any value including `RGBA`.
