### PR TITLE
More detailed error messages from Image.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist
 .tox
 *.so
 docs/_build
+
+# Vim cruft
+.*.swp

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1965,7 +1965,7 @@ def fromarray(obj, mode=None):
     else:
         ndmax = 4
     if ndim > ndmax:
-        raise ValueError("Too many dimensions.")
+        raise ValueError("Too many dimensions: %d > %d." % (ndim, ndmax))
 
     size = shape[1], shape[0]
     if strides is not None:
@@ -2018,7 +2018,7 @@ def open(fp, mode="r"):
     """
 
     if mode != "r":
-        raise ValueError("bad mode")
+        raise ValueError("bad mode %r" % mode)
 
     if isPath(fp):
         filename = fp
@@ -2054,7 +2054,8 @@ def open(fp, mode="r"):
                 #traceback.print_exc()
                 pass
 
-    raise IOError("cannot identify image file")
+    raise IOError("cannot identify image file %r"
+                  % (filename if filename else fp))
 
 #
 # Image processing.


### PR DESCRIPTION
This patch improves some of the error messages in `Image.py`. In particular, `Image.open` reports which image it was trying to open, which can be useful if you have a lot of images to load and a few are corrupted.
