### PR TITLE
Add PyPy to the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ python:
 install: 
   - "sudo apt-get -qq install libfreetype6-dev liblcms2-dev libwebp-dev python-qt4 ghostscript libffi-dev"
   - "pip install cffi"
-  - "apt-get install python-tk"
+  - "sudo apt-get install python-tk"
 
 
 script:


### PR DESCRIPTION
See https://github.com/python-imaging/Pillow/issues/570

All that was needed was a "sudo apt-get install python-tk" in the .travis.yml.

But perhaps the install should only happen for the PyPy build, what do you think? 

And should PyPy be an allowed failure or would you prefer a normal build?
