### PR TITLE
Fix failing test when ghostscript is not installed.

### DIFF
--- a/PIL/EpsImagePlugin.py
+++ b/PIL/EpsImagePlugin.py
@@ -50,6 +50,21 @@ if sys.platform.startswith('win'):
     else:
         gs_windows_binary = False
 
+def has_ghostscript():
+    if gs_windows_binary:
+        return True
+    if not sys.platform.startswith('win'):
+        import subprocess
+        try:
+            gs = subprocess.Popen(['gs','--version'], stdout=subprocess.PIPE)
+            gs.stdout.read()
+            return True
+        except OSError:
+            # no ghostscript
+            pass
+    return False
+   
+
 def Ghostscript(tile, size, fp, scale=1):
     """Render an image using Ghostscript"""
 

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -4,18 +4,8 @@ from PIL import Image, EpsImagePlugin
 import sys
 import io
 
-if not EpsImagePlugin.gs_windows_binary:
-    # already checked. Not there.
+if not EpsImagePlugin.has_ghostscript():
     skip()
-
-if not sys.platform.startswith('win'):
-    import subprocess
-    try:
-        gs = subprocess.Popen(['gs','--version'], stdout=subprocess.PIPE)
-        gs.stdout.read()
-    except OSError:
-        # no ghostscript
-        skip()
 
 #Our two EPS test files (they are identical except for their bounding boxes)
 file1 = "Tests/images/zero_bb.eps"

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -2,6 +2,7 @@ from tester import *
 
 from PIL import Image
 from PIL import ImageFile
+from PIL import EpsImagePlugin
 
 codecs = dir(Image.core)
 
@@ -46,8 +47,9 @@ def test_parser():
     assert_image_equal(*roundtrip("TGA"))
     assert_image_equal(*roundtrip("PCX"))
 
-    im1, im2 = roundtrip("EPS")
-    assert_image_similar(im1, im2.convert('L'),20) # EPS comes back in RGB      
+    if EpsImagePlugin.has_ghostscript():
+        im1, im2 = roundtrip("EPS")
+        assert_image_similar(im1, im2.convert('L'),20) # EPS comes back in RGB      
     
     if "jpeg_encoder" in codecs:
         im1, im2 = roundtrip("JPEG") # lossy compression


### PR DESCRIPTION
- Hoisted the ghostscript detection into the EpsImagePlugin file from test_file_eps.py .
- Using it in test_imagefile.py 
