### PR TITLE
Dump

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -505,8 +505,11 @@ class Image:
 
     def _dump(self, file=None, format=None):
         import tempfile, os
+        suffix = ''
+        if format:
+            suffix = '.'+format
         if not file:
-            f, file = tempfile.mkstemp(format or '')
+            f, file = tempfile.mkstemp(suffix)
             os.close(f)
             
         self.load()


### PR DESCRIPTION
- The suffix check isn't doing the right thing in _dump. (Thanks to April Chin @ Oracle for finding that)
- Make an actual suffix for the tempfile when passing in a format, in case whatever is reading it downstream is sensitive to extensions. 
