### PR TITLE
Run slow pypy first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ notifications:
   irc: "chat.freenode.net#pil"
 
 python:
+  - "pypy"
   - 2.6
   - 2.7
   - 3.2
   - 3.3
-  - "pypy"
 
 install:
   - "sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-qt4 ghostscript libffi-dev cmake"


### PR DESCRIPTION
It's always the slowest and we should give it a head start so we're not waiting for it to finish at the end. It means we're making the most use of our parallel job-runners for the quicker jobs.

See also #632.
