### PR TITLE
Invalid Tiff Prefix (Possible Corrupted Image), is there a good way to fix this ?

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -264,7 +264,7 @@ class ImageFileDirectory(collections.MutableMapping):
         if self.prefix == MM:
             self.i16, self.i32 = ib16, ib32
             self.o16, self.o32 = ob16, ob32
-        elif self.prefix in (II, '\xf5\xf5', ):
+        elif self.prefix in (II, '\xf5\xf5', '\xfb\xfb', '\xfe\xde', ):
             self.i16, self.i32 = il16, il32
             self.o16, self.o32 = ol16, ol32
         else:


### PR DESCRIPTION
Hi,
I have a portal running since 2011. This year we upgraded from PIL to Pillow. 

This upgrade broke our thumbnail generation for some Tiffs. The prefix validation was breaking our script.

After debugging I found that our prefix are different, I added those prefix to my fork. But I think the image is corrupted.

Is that correct ? Check the prefix values.

By the way, I will need this "hack". Is there a better place to handle this ? Please give me a hint.

ps: I created a PR  instead of a Issue to show diffs easily.

Thanks,
Paulo.
