### PR TITLE
Clean up preprocessor cruft for Windows

### DIFF
--- a/_imaging.c
+++ b/_imaging.c
@@ -3350,7 +3350,7 @@ extern PyObject* PyImaging_ZipEncoderNew(PyObject* self, PyObject* args);
 extern PyObject* PyImaging_LibTiffEncoderNew(PyObject* self, PyObject* args);
 
 /* Display support etc (in display.c) */
-#ifdef WIN32
+#ifdef _WIN32
 extern PyObject* PyImaging_CreateWindowWin32(PyObject* self, PyObject* args);
 extern PyObject* PyImaging_DisplayWin32(PyObject* self, PyObject* args);
 extern PyObject* PyImaging_DisplayModeWin32(PyObject* self, PyObject* args);
@@ -3423,14 +3423,14 @@ static PyMethodDef functions[] = {
 
     /* Memory mapping */
 #ifdef WITH_MAPPING
-#ifdef WIN32
+#ifdef _WIN32
     {"map", (PyCFunction)PyImaging_Mapper, 1},
 #endif
     {"map_buffer", (PyCFunction)PyImaging_MapBuffer, 1},
 #endif
 
     /* Display support */
-#ifdef WIN32
+#ifdef _WIN32
     {"display", (PyCFunction)PyImaging_DisplayWin32, 1},
     {"display_mode", (PyCFunction)PyImaging_DisplayModeWin32, 1},
     {"grabscreen", (PyCFunction)PyImaging_GrabScreenWin32, 1},

--- a/_imagingcms.c
+++ b/_imagingcms.c
@@ -28,12 +28,6 @@ http://www.cazabon.com\n\
 #include "Imaging.h"
 #include "py3.h"
 
-#ifdef WIN32
-#include <windows.h>
-#include <windef.h>
-#include <wingdi.h>
-#endif
-
 #define PYCMSVERSION "1.0.0 pil"
 
 /* version history */
@@ -450,7 +444,7 @@ cms_profile_is_intent_supported(CmsProfileObject *self, PyObject *args)
     return PyInt_FromLong(result != 0);
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 static PyObject *
 cms_get_display_profile_win32(PyObject* self, PyObject* args)
 {
@@ -496,7 +490,7 @@ static PyMethodDef pyCMSdll_methods[] = {
     {"createProfile", createProfile, 1},
 
     /* platform specific tools */
-#ifdef WIN32
+#ifdef _WIN32
     {"get_display_profile_win32", cms_get_display_profile_win32, 1},
 #endif
 

--- a/decode.c
+++ b/decode.c
@@ -433,9 +433,6 @@ PyImaging_TiffLzwDecoderNew(PyObject* self, PyObject* args)
 #include "TiffDecode.h"
 
 #include <string.h>
-#ifdef __WIN32__
-#define strcasecmp(s1, s2) stricmp(s1, s2)
-#endif
 
 PyObject*
 PyImaging_LibTiffDecoderNew(PyObject* self, PyObject* args)

--- a/display.c
+++ b/display.c
@@ -31,7 +31,7 @@
 /* -------------------------------------------------------------------- */
 /* Windows DIB support	*/
 
-#ifdef WIN32
+#ifdef _WIN32
 
 #include "ImDib.h"
 
@@ -864,4 +864,4 @@ error:
     return buffer;
 }
 
-#endif /* WIN32 */
+#endif /* _WIN32 */

--- a/encode.c
+++ b/encode.c
@@ -670,9 +670,6 @@ PyImaging_JpegEncoderNew(PyObject* self, PyObject* args)
 #include "TiffDecode.h"
 
 #include <string.h>
-#ifdef __WIN32__
-#define strcasecmp(s1, s2) stricmp(s1, s2)
-#endif
 
 PyObject*
 PyImaging_LibTiffEncoderNew(PyObject* self, PyObject* args)

--- a/libImaging/Dib.c
+++ b/libImaging/Dib.c
@@ -22,7 +22,7 @@
 
 #include "Imaging.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 
 #include "ImDib.h"
 
@@ -308,4 +308,4 @@ ImagingDeleteDIB(ImagingDIB dib)
     free(dib->info);
 }
 
-#endif /* WIN32 */
+#endif /* _WIN32 */

--- a/libImaging/ImDib.h
+++ b/libImaging/ImDib.h
@@ -10,20 +10,9 @@
  * See the README file for information on usage and redistribution.
  */
 
-#ifdef WIN32
+#ifdef _WIN32
 
-#if (defined(_MSC_VER) && _MSC_VER >= 1200) || (defined __GNUC__)
-/* already defined in basetsd.h */
-#undef INT8
-#undef UINT8
-#undef INT16
-#undef UINT16
-#undef INT32
-#undef INT64
-#undef UINT32
-#endif
-
-#include <windows.h>
+#include "ImPlatform.h"
 
 #if defined(__cplusplus)
 extern "C" {

--- a/libImaging/ImPlatform.h
+++ b/libImaging/ImPlatform.h
@@ -17,26 +17,21 @@
 #error Sorry, this library requires ANSI header files.
 #endif
 
-#if defined(_MSC_VER)
-#ifndef WIN32
-#define WIN32
-#endif
-/* VC++ 4.0 is a bit annoying when it comes to precision issues (like
-   claiming that "float a = 0.0;" would lead to loss of precision).  I
-   don't like to see warnings from my code, but since I still want to
-   keep it readable, I simply switch off a few warnings instead of adding
-   the tons of casts that VC++ seem to require.  This code is compiled
-   with numerous other compilers as well, so any real errors are likely
-   to be catched anyway. */
-#pragma warning(disable: 4244) /* conversion from 'float' to 'int' */
-#endif
-
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__GNUC__)
 #define inline __inline
 #endif
-#if !defined(USE_INLINE)
-#define inline
+
+#if !defined(PIL_USE_INLINE)
+#define inline 
 #endif
+
+#ifdef _WIN32
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#else
+/* For System that are not Windows, we'll need to define these. */
 
 #if SIZEOF_SHORT == 2
 #define	INT16 short
@@ -62,12 +57,16 @@
 #define	INT64 long
 #endif
 
-/* assume IEEE; tweak if necessary (patches are welcome) */
-#define	FLOAT32 float
-#define	FLOAT64 double
-
 #define	INT8  signed char
 #define	UINT8 unsigned char
 
 #define	UINT16 unsigned INT16
 #define	UINT32 unsigned INT32
+
+#endif
+
+/* assume IEEE; tweak if necessary (patches are welcome) */
+#define	FLOAT32 float
+#define	FLOAT64 double
+
+

--- a/libImaging/Incremental.c
+++ b/libImaging/Incremental.c
@@ -41,7 +41,6 @@
    two cases. */
 
 #ifdef _WIN32
-#include <windows.h>
 #include <process.h>
 #else
 #include <pthread.h>

--- a/map.c
+++ b/map.c
@@ -22,18 +22,6 @@
 
 #include "Imaging.h"
 
-#ifdef WIN32
-#define WIN32_LEAN_AND_MEAN
-#undef INT8
-#undef UINT8
-#undef INT16
-#undef UINT16
-#undef INT32
-#undef INT64
-#undef UINT32
-#include "windows.h"
-#endif
-
 #include "py3.h"
 
 /* compatibility wrappers (defined in _imaging.c) */
@@ -48,7 +36,7 @@ typedef struct {
     char* base;
     int   size;
     int   offset;
-#ifdef WIN32
+#ifdef _WIN32
     HANDLE hFile;
     HANDLE hMap;
 #endif
@@ -71,7 +59,7 @@ PyImaging_MapperNew(const char* filename, int readonly)
     mapper->base = NULL;
     mapper->size = mapper->offset = 0;
 
-#ifdef WIN32
+#ifdef _WIN32
     mapper->hFile = (HANDLE)-1;
     mapper->hMap  = (HANDLE)-1;
 
@@ -114,7 +102,7 @@ PyImaging_MapperNew(const char* filename, int readonly)
 static void
 mapping_dealloc(ImagingMapperObject* mapper)
 {
-#ifdef WIN32
+#ifdef _WIN32
     if (mapper->base != 0)
         UnmapViewOfFile(mapper->base);
     if (mapper->hMap != (HANDLE)-1)


### PR DESCRIPTION
1.  Renamed USE_INLINE to PIL_USE_INLINE to avoid conflicts with
   other headers/libraries.
2.  Replace `__WIN32__` and `WIN32` with `_WIN32`
3.  Don't define WIN32 when the compiler is MSVC but not on Windows
   Why would you even...
4.  Don't define strcasecmp if you're not even going to use it.
5.  Don't include Windows.h with undefs for compilers newer than 1998 everywhere.
6.  Don't surpress warnings for MSVC++ 4.0. People still using MSVC++ 4.0 deserve it.
7.  Don't include things that are already included in Windows.h
8.  Don't ignore USE_INLINE with MSVC

Addresses issue #642 and together with PR #643 fixes building on mingw-w64, and thus, issue #642

I have tested this with mingw-w64.

Anyone willing to test this with MSVC is more than welcome to.
