### PR TITLE
Fix 12-year-old FIXME

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -30,6 +30,7 @@ from PIL import VERSION, PILLOW_VERSION, _plugins
 
 import warnings
 
+
 class _imaging_not_installed:
     # module placeholder
     def __getattr__(self, id):
@@ -52,7 +53,7 @@ try:
     # directly; import Image and use the Image.core variable instead.
     from PIL import _imaging as core
     if PILLOW_VERSION != getattr(core, 'PILLOW_VERSION', None):
-         raise ImportError("The _imaging extension was built for another "
+        raise ImportError("The _imaging extension was built for another "
                             " version of Pillow or PIL")
 
 except ImportError as v:
@@ -91,10 +92,13 @@ except ImportError:
     builtins = __builtin__
 
 from PIL import ImageMode
-from PIL._binary import i8, o8
-from PIL._util import isPath, isStringType, deferred_error
+from PIL._binary import i8
+from PIL._util import isPath
+from PIL._util import isStringType
+from PIL._util import deferred_error
 
-import os, sys
+import os
+import sys
 
 # type stuff
 import collections
@@ -104,9 +108,10 @@ import numbers
 USE_CFFI_ACCESS = hasattr(sys, 'pypy_version_info')
 try:
     import cffi
-    HAS_CFFI=True
+    HAS_CFFI = True
 except:
-    HAS_CFFI=False
+    HAS_CFFI = False
+
 
 def isImageType(t):
     """
@@ -148,16 +153,16 @@ MESH = 4
 # resampling filters
 NONE = 0
 NEAREST = 0
-ANTIALIAS = 1 # 3-lobed lanczos
+ANTIALIAS = 1  # 3-lobed lanczos
 LINEAR = BILINEAR = 2
 CUBIC = BICUBIC = 3
 
 # dithers
 NONE = 0
 NEAREST = 0
-ORDERED = 1 # Not yet implemented
-RASTERIZE = 2 # Not yet implemented
-FLOYDSTEINBERG = 3 # default
+ORDERED = 1  # Not yet implemented
+RASTERIZE = 2  # Not yet implemented
+FLOYDSTEINBERG = 3  # default
 
 # palettes/quantizers
 WEB = 0
@@ -222,7 +227,7 @@ else:
 
 _MODE_CONV = {
     # official modes
-    "1": ('|b1', None), # broken
+    "1": ('|b1', None),  # broken
     "L": ('|u1', None),
     "I": (_ENDIAN + 'i4', None),
     "F": (_ENDIAN + 'f4', None),
@@ -232,8 +237,8 @@ _MODE_CONV = {
     "RGBA": ('|u1', 4),
     "CMYK": ('|u1', 4),
     "YCbCr": ('|u1', 3),
-    "LAB": ('|u1', 3), # UNDONE - unsigned |u1i1i1
-	# I;16 == I;16L, and I;32 == I;32L
+    "LAB": ('|u1', 3),  # UNDONE - unsigned |u1i1i1
+    # I;16 == I;16L, and I;32 == I;32L
     "I;16": ('<u2', None),
     "I;16B": ('>u2', None),
     "I;16L": ('<u2', None),
@@ -247,6 +252,7 @@ _MODE_CONV = {
     "I;32BS": ('>i4', None),
     "I;32LS": ('<i4', None),
 }
+
 
 def _conv_type_shape(im):
     shape = im.size[1], im.size[0]
@@ -368,8 +374,8 @@ def init():
     for plugin in _plugins:
         try:
             if DEBUG:
-                print ("Importing %s"%plugin)
-            __import__("PIL.%s"%plugin, globals(), locals(), [])
+                print ("Importing %s" % plugin)
+            __import__("PIL.%s" % plugin, globals(), locals(), [])
         except ImportError:
             if DEBUG:
                 print("Image: failed to import", end=' ')
@@ -378,6 +384,7 @@ def init():
     if OPEN or SAVE:
         _initialized = 2
         return 1
+
 
 # --------------------------------------------------------------------
 # Codec factories (used by tobytes/frombytes and ImageFile.load)
@@ -397,6 +404,7 @@ def _getdecoder(mode, decoder_name, args, extra=()):
         return decoder(mode, *args + extra)
     except AttributeError:
         raise IOError("decoder %s not available" % decoder_name)
+
 
 def _getencoder(mode, encoder_name, args, extra=()):
 
@@ -421,30 +429,36 @@ def _getencoder(mode, encoder_name, args, extra=()):
 def coerce_e(value):
     return value if isinstance(value, _E) else _E(value)
 
+
 class _E:
     def __init__(self, data):
         self.data = data
+
     def __add__(self, other):
         return _E((self.data, "__add__", coerce_e(other).data))
+
     def __mul__(self, other):
         return _E((self.data, "__mul__", coerce_e(other).data))
+
 
 def _getscaleoffset(expr):
     stub = ["stub"]
     data = expr(_E(stub)).data
     try:
-        (a, b, c) = data # simplified syntax
+        (a, b, c) = data  # simplified syntax
         if (a is stub and b == "__mul__" and isinstance(c, numbers.Number)):
             return c, 0.0
         if (a is stub and b == "__add__" and isinstance(c, numbers.Number)):
             return 1.0, c
-    except TypeError: pass
+    except TypeError:
+        pass
     try:
-        ((a, b, c), d, e) = data # full syntax
+        ((a, b, c), d, e) = data  # full syntax
         if (a is stub and b == "__mul__" and isinstance(c, numbers.Number) and
             d == "__add__" and isinstance(e, numbers.Number)):
             return c, e
-    except TypeError: pass
+    except TypeError:
+        pass
     raise ValueError("illegal expression")
 
 
@@ -495,11 +509,12 @@ class Image:
                 new.info[k] = v
         return new
 
-    _makeself = _new # compatibility
+    _makeself = _new  # compatibility
 
     # Context Manager Support
     def __enter__(self):
         return self
+
     def __exit__(self, *args):
         self.close()
 
@@ -518,13 +533,12 @@ class Image:
             self.fp.close()
         except Exception as msg:
             if Image.DEBUG:
-                print ("Error closing: %s" %msg)
+                print ("Error closing: %s" % msg)
 
         # Instead of simply setting to None, we're setting up a
         # deferred error that will better explain that the core image
         # object is gone.
         self.im = deferred_error(ValueError("Operation on closed image"))
-
 
     def _copy(self):
         self.load()
@@ -533,7 +547,8 @@ class Image:
         self.readonly = 0
 
     def _dump(self, file=None, format=None):
-        import tempfile, os
+        import os
+        import tempfile
         suffix = ''
         if format:
             suffix = '.'+format
@@ -591,7 +606,7 @@ class Image:
         e = _getencoder(self.mode, encoder_name, args)
         e.setimage(self.im)
 
-        bufsize = max(65536, self.size[0] * 4) # see RawEncode.c
+        bufsize = max(65536, self.size[0] * 4)  # see RawEncode.c
 
         data = []
         while True:
@@ -663,7 +678,9 @@ class Image:
 
         .. deprecated:: 2.0
         """
-        warnings.warn('fromstring() is deprecated. Please call frombytes() instead.', DeprecationWarning)
+        warnings.warn(
+            'fromstring() is deprecated. Please call frombytes() instead.',
+            DeprecationWarning)
         return self.frombytes(*args, **kw)
 
     def load(self):
@@ -779,30 +796,29 @@ class Image:
                 # Use transparent conversion to promote from transparent
                 # color to an alpha channel.
                 return self._new(self.im.convert_transparent(
-                                           mode, self.info['transparency']))
+                    mode, self.info['transparency']))
             elif self.mode in ('L', 'RGB', 'P') and mode in ('L', 'RGB', 'P'):
                 t = self.info['transparency']
                 if isinstance(t, bytes):
                     # Dragons. This can't be represented by a single color
-                    warnings.warn('Palette images with Transparency expressed '+
+                    warnings.warn('Palette images with Transparency expressed ' +
                                   ' in bytes should be converted to RGBA images')
                     delete_trns = True
                 else:
                     # get the new transparency color.
                     # use existing conversions
-                    trns_im = Image()._new(core.new(self.mode, (1,1)))
+                    trns_im = Image()._new(core.new(self.mode, (1, 1)))
                     if self.mode == 'P':
                         trns_im.putpalette(self.palette)
-                    trns_im.putpixel((0,0), t)
+                    trns_im.putpixel((0, 0), t)
 
-                    if mode in ('L','RGB'):
+                    if mode in ('L', 'RGB'):
                         trns_im = trns_im.convert(mode)
                     else:
                         # can't just retrieve the palette number, got to do it
                         # after quantization.
                         trns_im = trns_im.convert('RGB')
-                    trns = trns_im.getpixel((0,0))
-
+                    trns = trns_im.getpixel((0, 0))
 
         if mode == "P" and palette == ADAPTIVE:
             im = self.im.quantize(colors)
@@ -839,7 +855,7 @@ class Image:
 
         new_im = self._new(im)
         if delete_trns:
-            #crash fail if we leave a bytes transparency in an rgb/l mode.
+            # crash fail if we leave a bytes transparency in an rgb/l mode.
             del(new_im.info['transparency'])
         if trns is not None:
             if new_im.mode == 'P':
@@ -1019,7 +1035,7 @@ class Image:
             return out
         return self.im.getcolors(maxcolors)
 
-    def getdata(self, band = None):
+    def getdata(self, band=None):
         """
         Returns the contents of this image as a sequence object
         containing pixel values.  The sequence object is flattened, so
@@ -1040,7 +1056,7 @@ class Image:
         self.load()
         if band is not None:
             return self.im.getband(band)
-        return self.im # could be abused
+        return self.im  # could be abused
 
     def getextrema(self):
         """
@@ -1070,7 +1086,6 @@ class Image:
         self.load()
         return self.im.ptr
 
-
     def getpalette(self):
         """
         Returns the image palette as a list.
@@ -1086,8 +1101,7 @@ class Image:
             else:
                 return list(self.im.getpalette())
         except ValueError:
-            return None # no palette
-
+            return None  # no palette
 
     def getpixel(self, xy):
         """
@@ -1209,7 +1223,8 @@ class Image:
 
         if isImageType(box) and mask is None:
             # abbreviated paste(im, mask) syntax
-            mask = box; box = None
+            mask = box
+            box = None
 
         if box is None:
             # cover all of self
@@ -1315,7 +1330,7 @@ class Image:
                     # do things the hard way
                     im = self.im.convert(mode)
                     if im.mode not in ("LA", "RGBA"):
-                        raise ValueError # sanity check
+                        raise ValueError  # sanity check
                     self.im = im
                     self.pyaccess = None
                 self.mode = self.im.mode
@@ -1393,7 +1408,7 @@ class Image:
         self.mode = "P"
         self.palette = palette
         self.palette.mode = "RGB"
-        self.load() # install new palette
+        self.load()  # install new palette
 
     def putpixel(self, xy, value):
         """
@@ -1422,7 +1437,7 @@ class Image:
             self.load()
 
         if self.pyaccess:
-            return self.pyaccess.putpixel(xy,value)
+            return self.pyaccess.putpixel(xy, value)
         return self.im.putpixel(xy, value)
 
     def resize(self, size, resample=NEAREST):
@@ -1492,6 +1507,7 @@ class Image:
                  math.cos(angle), math.sin(angle), 0.0,
                 -math.sin(angle), math.cos(angle), 0.0
                  ]
+
             def transform(x, y, matrix=matrix):
                 (a, b, c, d, e, f) = matrix
                 return a*x + b*y + c, d*x + e*y + f
@@ -1579,13 +1595,13 @@ class Image:
                 try:
                     format = EXTENSION[ext]
                 except KeyError:
-                    raise KeyError(ext) # unknown extension
+                    raise KeyError(ext)  # unknown extension
 
         try:
             save_handler = SAVE[format.upper()]
         except KeyError:
             init()
-            save_handler = SAVE[format.upper()] # unknown format
+            save_handler = SAVE[format.upper()]  # unknown format
 
         if isPath(fp):
             fp = builtins.open(fp, "wb")
@@ -1682,8 +1698,9 @@ class Image:
         important than quality.
 
         Also note that this function modifies the :py:class:`~PIL.Image.Image`
-        object in place.  If you need to use the full resolution image as well, apply
-        this method to a :py:meth:`~PIL.Image.Image.copy` of the original image.
+        object in place.  If you need to use the full resolution image as well,
+        apply this method to a :py:meth:`~PIL.Image.Image.copy` of the original
+        image.
 
         :param size: Requested size.
         :param resample: Optional resampling filter.  This can be one
@@ -1696,8 +1713,12 @@ class Image:
 
         # preserve aspect ratio
         x, y = self.size
-        if x > size[0]: y = int(max(y * size[0] / x, 1)); x = int(size[0])
-        if y > size[1]: x = int(max(x * size[1] / y, 1)); y = int(size[1])
+        if x > size[0]:
+            y = int(max(y * size[0] / x, 1))
+            x = int(size[0])
+        if y > size[1]:
+            x = int(max(x * size[1] / y, 1))
+            y = int(size[1])
         size = x, y
 
         if size == self.size:
@@ -1712,7 +1733,7 @@ class Image:
         except ValueError:
             if resample != ANTIALIAS:
                 raise
-            im = self.resize(size, NEAREST) # fallback
+            im = self.resize(size, NEAREST)  # fallback
 
         self.im = im.im
         self.mode = im.mode
@@ -1748,7 +1769,9 @@ class Image:
         """
 
         if self.mode == 'RGBA':
-            return self.convert('RGBa').transform(size, method, data, resample, fill).convert('RGBA')
+            return self.convert('RGBa') \
+                .transform(size, method, data, resample, fill) \
+                .convert('RGBA')
 
         if isinstance(method, ImageTransformHandler):
             return method.transform(size, self, resample=resample, fill=fill)
@@ -1795,8 +1818,13 @@ class Image:
         elif method == QUAD:
             # quadrilateral warp.  data specifies the four corners
             # given as NW, SW, SE, and NE.
-            nw = data[0:2]; sw = data[2:4]; se = data[4:6]; ne = data[6:8]
-            x0, y0 = nw; As = 1.0 / w; At = 1.0 / h
+            nw = data[0:2]
+            sw = data[2:4]
+            se = data[4:6]
+            ne = data[6:8]
+            x0, y0 = nw
+            As = 1.0 / w
+            At = 1.0 / h
             data = (x0, (ne[0]-x0)*As, (sw[0]-x0)*At,
                     (se[0]-sw[0]-ne[0]+x0)*As*At,
                     y0, (ne[1]-y0)*As, (sw[1]-y0)*At,
@@ -1829,6 +1857,7 @@ class Image:
         self.load()
         im = self.im.transpose(method)
         return self._new(im)
+
 
 # --------------------------------------------------------------------
 # Lazy operations
@@ -1865,6 +1894,7 @@ class _ImageCrop(Image):
         # FIXME: future versions should optimize crop/paste
         # sequences!
 
+
 # --------------------------------------------------------------------
 # Abstract handlers.
 
@@ -1872,9 +1902,11 @@ class ImagePointHandler:
     # used as a mixin by point transforms (for use with im.point)
     pass
 
+
 class ImageTransformHandler:
     # used as a mixin by geometry transforms (for use with im.transform)
     pass
+
 
 # --------------------------------------------------------------------
 # Factories
@@ -1951,6 +1983,7 @@ def frombytes(mode, size, data, decoder_name="raw", *args):
     im.frombytes(data, decoder_name, args)
     return im
 
+
 def fromstring(*args, **kw):
     """Deprecated alias to frombytes.
 
@@ -2013,9 +2046,9 @@ def frombuffer(mode, size, data, decoder_name="raw", *args):
                     "  frombuffer(mode, size, data, 'raw', mode, 0, 1)",
                     RuntimeWarning, stacklevel=2
                 )
-            args = mode, 0, -1 # may change to (mode, 0, 1) post-1.1.6
+            args = mode, 0, -1  # may change to (mode, 0, 1) post-1.1.6
         if args[0] in _MAPMODES:
-            im = new(mode, (1,1))
+            im = new(mode, (1, 1))
             im = im._new(
                 core.map_buffer(data, size, decoder_name, None, 0, args)
                 )
@@ -2135,8 +2168,8 @@ def open(fp, mode="r"):
                 fp.seek(0)
                 return factory(fp, filename)
         except (SyntaxError, IndexError, TypeError):
-            #import traceback
-            #traceback.print_exc()
+            # import traceback
+            # traceback.print_exc()
             pass
 
     if init():
@@ -2148,12 +2181,13 @@ def open(fp, mode="r"):
                     fp.seek(0)
                     return factory(fp, filename)
             except (SyntaxError, IndexError, TypeError):
-                #import traceback
-                #traceback.print_exc()
+                # import traceback
+                # traceback.print_exc()
                 pass
 
     raise IOError("cannot identify image file %r"
                   % (filename if filename else fp))
+
 
 #
 # Image processing.
@@ -2253,6 +2287,7 @@ def merge(mode, bands):
         im.putband(bands[i].im, i)
     return bands[0]._new(im)
 
+
 # --------------------------------------------------------------------
 # Plugin registry
 
@@ -2310,6 +2345,7 @@ def register_extension(id, extension):
 def _show(image, **options):
     # override me, as necessary
     _showxv(image, **options)
+
 
 def _showxv(image, title=None, **options):
     from PIL import ImageShow


### PR DESCRIPTION
Comments in docs and code for Image.thumbnail(), dating back to PIL 1.1.3 from March 14, 2002:

> If omitted, it defaults to `PIL.Image.NEAREST` (this will be changed to `ANTIALIAS` in a future version).

```
# FIXME: the default resampling filter will be changed
        # to ANTIALIAS in future versions
```

It is now the future.

The resample parameter was added in PIL 1.1.2 (May 2001) and defaulted to ANTIALIAS. In 1.1.3 (March 2002) it was changed to NEAREST with the FIXME note.

No reason is given in the [PIL 1.1.3 release notes](http://effbot.org/zone/pil-changes-113.htm), but it looks like there were initially some problems with ANTIALIAS so they went with the safer option:

> (1.1.3c2 released)
> - ...
> - Fixed segmentation violation in ANTIALIAS filter (an internal buffer wasn’t properly allocated).
> 
> (1.1.3c1 released)
> - Added ANTIALIAS downsampling filter for high-quality “resize” and “thumbnail” operations. Also added filter option to the “thumbnail” operation; the default value is NEAREST, but this will most likely change in future versions.

PR also contains some pep8 and pyflakes cleanup.

TODO:
- [x] Update the docs
- [x] Should there be a note in the docs saying the default was NEAREST before version 2.5.0?
