### PR TITLE
Adjust Homebrew freetype detection logic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -205,25 +205,31 @@ class pil_build_ext(build_ext):
             # darwin ports installation directories
             _add_directory(library_dirs, "/opt/local/lib")
             _add_directory(include_dirs, "/opt/local/include")
-            
-            # if homebrew is installed, use its lib and include directories
+
+            # if Homebrew is installed, use its lib and include directories
             import subprocess
             try:
-                prefix = subprocess.check_output(['brew', '--prefix'])
-                if prefix:
-                    prefix = prefix.strip()
-                    _add_directory(library_dirs, os.path.join(prefix, 'lib'))
-                    _add_directory(include_dirs, os.path.join(prefix, 'include'))
-                    
-                    # freetype2 is a key-only brew under opt/
-                    _add_directory(library_dirs, os.path.join(prefix, 'opt', 'freetype', 'lib'))
-                    _add_directory(include_dirs, os.path.join(prefix, 'opt', 'freetype', 'include'))
+                prefix = subprocess.check_output(['brew', '--prefix']).strip()
             except:
-                pass # homebrew not installed
-            
-            # freetype2 ships with X11 (after homebrew, so that homebrew freetype is preferred)
-            _add_directory(library_dirs, "/usr/X11/lib")
-            _add_directory(include_dirs, "/usr/X11/include")
+                # Homebrew not installed
+                prefix = None
+
+            ft_prefix = None
+
+            if prefix:
+                # add Homebrew's include and lib directories
+                _add_directory(library_dirs, os.path.join(prefix, 'lib'))
+                _add_directory(include_dirs, os.path.join(prefix, 'include'))
+                ft_prefix = os.path.join(prefix, 'opt', 'freetype')
+
+            if ft_prefix and os.path.isdir(ft_prefix):
+                # freetype might not be linked into Homebrew's prefix
+                _add_directory(library_dirs, os.path.join(ft_prefix, 'lib'))
+                _add_directory(include_dirs, os.path.join(ft_prefix, 'include'))
+            else:
+                # fall back to freetype from XQuartz if Homebrew's freetype is missing
+                _add_directory(library_dirs, "/usr/X11/lib")
+                _add_directory(include_dirs, "/usr/X11/include")
 
         elif sys.platform.startswith("linux"):
             arch_tp = (plat.processor(), plat.architecture()[0])


### PR DESCRIPTION
XQuartz ships an older freetype that still has a top-level "ft2build.h"
header file. Homebrew's freetype is newer and does not have this file,
it only has "freetype2/ft2build.h".

setup.py finds the header in XQuartz first, but Homebrew's compiler
wrappers intentionally strip out the XQuartz include paths during the
build unless the package depends on it explicitly.

We want to prefer Homebrew's freetype anyway, so if it's installed,
let's not even bother to search the XQuartz paths.

Fixes #653
