### PR TITLE
Don't cover PyPy jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ notifications:
   irc: "chat.freenode.net#pil"
 
 python:
+  - "pypy"
   - 2.6
   - 2.7
   - 3.2
   - 3.3
   - 3.4
-  - "pypy"
 
 install:
   - "sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-qt4 ghostscript libffi-dev cmake"


### PR DESCRIPTION
PyPy builds are intermittently segfaulting and failing when running with coverage, but pass when running without coverage. 

Further, the PyPy builds are much (x5.8) slower with coverage, whereas CPython builds take about the same with or without.

See #640 for more details. I've reported these issues to PyPy: https://bugs.pypy.org/issue1768

In the meantime, let's run the PyPy builds without coverage so we have some confidence in the tests on PyPy and don't ignore failures.
