### PR TITLE
Allow saving to JPEG with an explicit qtables value

### DIFF
--- a/PIL/JpegImagePlugin.py
+++ b/PIL/JpegImagePlugin.py
@@ -498,7 +498,7 @@ def _save(im, fp, filename):
     else:
         if subsampling in presets:
             subsampling = presets[subsampling].get('subsampling', -1)
-        if qtables in presets:
+        if isStringType(qtables) and qtables in presets:
             qtables = presets[qtables].get('quantization')
 
     if subsampling == "4:4:4":

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -230,6 +230,13 @@ def test_quality_keep():
     assert_no_exception(lambda: im.save(f, quality='keep'))
 
 
+def test_qtables():
+    im = Image.open("Images/lena.jpg")
+    qtables = im.quantization
+    f = tempfile('temp.jpg')
+    assert_no_exception(lambda: im.save(f, qtables=qtables, subsampling=0))
+
+
 def test_junk_jpeg_header():
     # https://github.com/python-imaging/Pillow/issues/630
     filename = "Tests/images/junk_jpeg_header.jpg"


### PR DESCRIPTION
Currently, a `TypeError` is thrown when trying to save a JPEG with an explicit qtables value. From looking at the code, calls like this are OK:

``` python

im.save("/tmp/image.jpg", qtables="web_low", subsampling="web_high")
im.save("/tmp/image.jpg", qtables="web_low", subsampling="4:1:1")
im.save("/tmp/image.jpg", qtables="keep", subsampling="4:1:1")
```

I'd like to be able to specify exact qtables and subsampling values, so I've attached some code that will allow this.

Additionally the `qtables`, and `subsampling` parameters are undocumented, as is the `"keep"` value for the `quality` parameter. I'd be happy to add this documentation—I assume that should be added to the `JPEG` section of the appendix?
