### PR TITLE
Skip test_floodfill_border() on PyPy to avoid fatal error

### DIFF
--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -246,6 +246,11 @@ def test_floodfill():
 
 
 def test_floodfill_border():
+    # floodfill() is experimental
+    if hasattr(sys, 'pypy_version_info'):
+        # Causes fatal RPython error on PyPy
+        skip()
+
     # Arrange
     im = Image.new("RGB", (w, h))
     draw = ImageDraw.Draw(im)


### PR DESCRIPTION
`test_floodfill_border()` intermittently causes a fatal error on PyPy. 

```
RPython traceback:
  File "rpython_jit_metainterp_compile.c", line 20472, in send_loop_to_backend
  File "rpython_jit_backend_x86_assembler.c", line 1818, in Assembler386_assemble_loop
  File "rpython_jit_backend_x86_regalloc.c", line 293, in RegAlloc_prepare_loop
  File "rpython_jit_backend_x86_regalloc.c", line 909, in RegAlloc__prepare
  File "rpython_jit_backend_llsupport_regalloc.c", line 4706, in compute_vars_longevity
Fatal RPython error: AssertionError
/home/travis/build.sh: line 236:  7300 Aborted 
```

The tested `floodfill()` is commented as experimental so let's just skip this test on PyPy.
