### PR TITLE
TiffDecode.h build error on Windows with MSVS

### DIFF
--- a/libImaging/TiffDecode.h
+++ b/libImaging/TiffDecode.h
@@ -14,7 +14,12 @@
 #endif
 
 #ifndef _UNISTD_H
-#include <unistd.h>
+	#if defined(_MSC_VER)
+		#include <io.h>
+		#define _UNISTD_H
+	#else
+		#include <unistd.h>
+	#endif	
 #endif
 
 


### PR DESCRIPTION
To build Pillow in Windows with MSVC I had to include io.h instead of unistd.h.  unistd.h should work for mingw builds.  How this change effects other platforms is unknown.  The change was requested in Issue #672  (https://github.com/python-pillow/Pillow/issues/672)
