### PR TITLE
Issue #697.  On MSVC 2012 builds <unistd.h> is not required.

### DIFF
--- a/libImaging/TiffDecode.h
+++ b/libImaging/TiffDecode.h
@@ -13,10 +13,11 @@
 #include <tiff.h>
 #endif
 
-#ifndef _UNISTD_H
-#include <unistd.h>
+#ifndef _MSC_VER
+	#ifndef _UNISTD_H
+	#include <unistd.h>
+	#endif
 #endif
-
 
 #ifndef min
 #define min(x,y) (( x > y ) ? y : x )


### PR DESCRIPTION
I made the conservative choice and only removed the #include <unistd.h> for Windows.  It can probably be removed entirely but didn't have a testing platform with another compiler.

Issue #697
