### PR TITLE
More Unistd removal

### DIFF
--- a/libImaging/TiffDecode.h
+++ b/libImaging/TiffDecode.h
@@ -38,11 +38,10 @@ extern int ImagingLibTiffEncodeInit(ImagingCodecState state, char *filename, int
 extern int ImagingLibTiffSetField(ImagingCodecState state, ttag_t tag, ...);
 
 
-#if defined(_MSC_VER) && (_MSC_VER == 1310)
-/* VS2003/py2.4 can't use varargs. Skipping trace for now.*/
-#define TRACE(args)
-#else
-
+/* 
+   Trace debugging
+   legacy, don't enable for python 3.x, unicode issues. 
+*/
 
 /*
 #define VA_ARGS(...)	__VA_ARGS__
@@ -50,9 +49,6 @@ extern int ImagingLibTiffSetField(ImagingCodecState state, ttag_t tag, ...);
 */
 
 #define TRACE(args)
-
-#endif /* _MSC_VER */
-
 
 
 #endif


### PR DESCRIPTION
- Removing the unistd.h #include for all platforms, not just windows.
- Removing cruft for windows python 2.4
- Includes #698
