### PR TITLE
Fixed variables misprint in ImageDraw tests

### DIFF
--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -123,7 +123,7 @@ class TestImageDraw(PillowTestCase):
         draw = ImageDraw.Draw(im)
 
         # Act
-        draw.line(points1, fill="yellow", width=2)
+        draw.line(points, fill="yellow", width=2)
         del draw
 
         # Assert
@@ -161,7 +161,7 @@ class TestImageDraw(PillowTestCase):
         draw = ImageDraw.Draw(im)
 
         # Act
-        draw.point(points1, fill="yellow")
+        draw.point(points, fill="yellow")
         del draw
 
         # Assert
@@ -180,7 +180,7 @@ class TestImageDraw(PillowTestCase):
         draw = ImageDraw.Draw(im)
 
         # Act
-        draw.polygon(points1, fill="red", outline="blue")
+        draw.polygon(points, fill="red", outline="blue")
         del draw
 
         # Assert


### PR DESCRIPTION
Some tests were using the global variables `points1` instead of the parameter `points`, therefore the involucred draw methods were not correctly tested with the two accepted parameter types (tuple and list).
