### PR TITLE
Match real palette format in ImagePalette.save()

### DIFF
--- a/PIL/ImagePalette.py
+++ b/PIL/ImagePalette.py
@@ -101,7 +101,7 @@ class ImagePalette:
         fp.write("# Mode: %s\n" % self.mode)
         for i in range(256):
             fp.write("%d" % i)
-            for j in range(i*3, i*3+3):
+            for j in range(i*len(self.mode), (i+1)*len(self.mode)):
                 try:
                     fp.write(" %d" % self.palette[j])
                 except IndexError:


### PR DESCRIPTION
The codes assumed that palette data was splitted into 3 parts in an array in the following sequence: 
[r(0), r(1) .. r(255), g(0), g(1), ... , g(255), b(0), b(1), ... ,b(255) ]. But the real format of this array was [r(0),g(0),b(0),r(1),g(1),b(1),...].
I rewrote the save() method to match the format de facto.
