### PR TITLE
Fix segfault when importing _imagingmorph

### DIFF
--- a/_imagingmorph.c
+++ b/_imagingmorph.c
@@ -267,9 +267,10 @@ setup_module(PyObject* m)
 
 static PyMethodDef functions[] = {
     /* Functions */
-    {"apply", (PyCFunction)apply, 1},
-    {"get_on_pixels", (PyCFunction)get_on_pixels, 1},
-    {"match", (PyCFunction)match, 1},
+    {"apply", (PyCFunction)apply, METH_VARARGS, NULL},
+    {"get_on_pixels", (PyCFunction)get_on_pixels, METH_VARARGS, NULL},
+    {"match", (PyCFunction)match, METH_VARARGS, NULL},
+    {NULL, NULL, 0, NULL}
 };
 
 #if PY_VERSION_HEX >= 0x03000000


### PR DESCRIPTION
Importing the _imagingmorph extension crashes (on Windows msvc builds).
The sentinel was missing. Also, it is probably better to use documented flags and to initialize the full PyMethodDef structure including ml_doc.
