### PR TITLE
Fix msvc warning: 'inline' : macro redefinition

### DIFF
--- a/libImaging/ImPlatform.h
+++ b/libImaging/ImPlatform.h
@@ -17,12 +17,12 @@
 #error Sorry, this library requires ANSI header files.
 #endif
 
+#if !defined(PIL_USE_INLINE)
+#define inline 
+#else
 #if defined(_MSC_VER) && !defined(__GNUC__)
 #define inline __inline
 #endif
-
-#if !defined(PIL_USE_INLINE)
-#define inline 
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
Fixes msvc compiler warnings:

```
d:\build\pillow\pillow-git\libimaging\ImPlatform.h(25) : warning C4005: 'inline' : macro redefinition
        d:\build\pillow\pillow-git\libimaging\ImPlatform.h(21) : see previous definition of 'inline'
```
