### PR TITLE
Fix AttributeError: class Image has no attribute 'DEBUG'

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -539,7 +539,7 @@ class Image:
         try:
             self.fp.close()
         except Exception as msg:
-            if Image.DEBUG:
+            if DEBUG:
                 print ("Error closing: %s" % msg)
 
         # Instead of simply setting to None, we're setting up a


### PR DESCRIPTION
For example:

```
======================================================================
ERROR: test_blur (test_file_libtiff.TestFileLibTiff)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\Build\Pillow\Pillow-git\Tests\test_file_libtiff.py", line 263, in test_blur
    im.close()
  File "D:\Build\Pillow\Pillow-git\PIL\Image.py", line 542, in close
    if Image.DEBUG:
AttributeError: class Image has no attribute 'DEBUG'
```
