### PR TITLE
Fix test_imagedraw failures

### DIFF
--- a/libImaging/Imaging.h
+++ b/libImaging/Imaging.h
@@ -20,7 +20,7 @@ extern "C" {
 
 
 #ifndef M_PI
-#define	M_PI	3.14159265359
+#define	M_PI	3.1415926535897932384626433832795
 #endif
 
 


### PR DESCRIPTION
Msvc builds fail several imagedraw tests, apparently due to imprecise definition of `M_PI`:

```
running test_imagedraw ...
=== error 1
FF.FF.FF....FF.......
======================================================================
FAIL: test_arc1 (__main__.TestImageDraw)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "Tests\test_imagedraw.py", line 63, in test_arc1
    self.helper_arc(BBOX1)
  File "Tests\test_imagedraw.py", line 60, in helper_arc
    im, Image.open("Tests/images/imagedraw_arc.png"))
  File "D:\Build\Pillow\Pillow-git\Tests\helper.py", line 95, in assert_image_equal
    msg or "got different content")
AssertionError: got different content

======================================================================
FAIL: test_arc2 (__main__.TestImageDraw)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "Tests\test_imagedraw.py", line 66, in test_arc2
    self.helper_arc(BBOX2)
  File "Tests\test_imagedraw.py", line 60, in helper_arc
    im, Image.open("Tests/images/imagedraw_arc.png"))
  File "D:\Build\Pillow\Pillow-git\Tests\helper.py", line 95, in assert_image_equal
    msg or "got different content")
AssertionError: got different content

======================================================================
FAIL: test_chord1 (__main__.TestImageDraw)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "Tests\test_imagedraw.py", line 96, in test_chord1
    self.helper_chord(BBOX1)
  File "Tests\test_imagedraw.py", line 93, in helper_chord
    im, Image.open("Tests/images/imagedraw_chord.png"))
  File "D:\Build\Pillow\Pillow-git\Tests\helper.py", line 95, in assert_image_equal
    msg or "got different content")
AssertionError: got different content

======================================================================
FAIL: test_chord2 (__main__.TestImageDraw)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "Tests\test_imagedraw.py", line 99, in test_chord2
    self.helper_chord(BBOX2)
  File "Tests\test_imagedraw.py", line 93, in helper_chord
    im, Image.open("Tests/images/imagedraw_chord.png"))
  File "D:\Build\Pillow\Pillow-git\Tests\helper.py", line 95, in assert_image_equal
    msg or "got different content")
AssertionError: got different content

======================================================================
FAIL: test_ellipse1 (__main__.TestImageDraw)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "Tests\test_imagedraw.py", line 115, in test_ellipse1
    self.helper_ellipse(BBOX1)
  File "Tests\test_imagedraw.py", line 112, in helper_ellipse
    im, Image.open("Tests/images/imagedraw_ellipse.png"))
  File "D:\Build\Pillow\Pillow-git\Tests\helper.py", line 95, in assert_image_equal
    msg or "got different content")
AssertionError: got different content

======================================================================
FAIL: test_ellipse2 (__main__.TestImageDraw)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "Tests\test_imagedraw.py", line 118, in test_ellipse2
    self.helper_ellipse(BBOX2)
  File "Tests\test_imagedraw.py", line 112, in helper_ellipse
    im, Image.open("Tests/images/imagedraw_ellipse.png"))
  File "D:\Build\Pillow\Pillow-git\Tests\helper.py", line 95, in assert_image_equal
    msg or "got different content")
AssertionError: got different content

======================================================================
FAIL: test_pieslice1 (__main__.TestImageDraw)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "Tests\test_imagedraw.py", line 153, in test_pieslice1
    self.helper_pieslice(BBOX1)
  File "Tests\test_imagedraw.py", line 150, in helper_pieslice
    im, Image.open("Tests/images/imagedraw_pieslice.png"))
  File "D:\Build\Pillow\Pillow-git\Tests\helper.py", line 95, in assert_image_equal
    msg or "got different content")
AssertionError: got different content

======================================================================
FAIL: test_pieslice2 (__main__.TestImageDraw)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "Tests\test_imagedraw.py", line 156, in test_pieslice2
    self.helper_pieslice(BBOX2)
  File "Tests\test_imagedraw.py", line 150, in helper_pieslice
    im, Image.open("Tests/images/imagedraw_pieslice.png"))
  File "D:\Build\Pillow\Pillow-git\Tests\helper.py", line 95, in assert_image_equal
    msg or "got different content")
AssertionError: got different content

----------------------------------------------------------------------
Ran 21 tests in 0.083s

FAILED (failures=8)
```
