### PR TITLE
FIX: fix error for setup.py for Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -210,7 +210,9 @@ class pil_build_ext(build_ext):
             # if Homebrew is installed, use its lib and include directories
             import subprocess
             try:
-                prefix = subprocess.check_output(['brew', '--prefix']).strip()
+                prefix = subprocess.check_output(
+                    ['brew', '--prefix']
+                ).strip().decode('latin1')
             except:
                 # Homebrew not installed
                 prefix = None


### PR DESCRIPTION
The subprocess command in Python 3 returns a bytes object.  If the homebrew
subprocess check returns a not-empty result, then setup crashes trying to
combine the bytes with the string constants with and error like "TypeError:
Can't mix strings and bytes in path components."
