### PR TITLE
Fix build failure when compiler.include_dirs refers to nonexistent directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -405,7 +405,12 @@ class pil_build_ext(build_ext):
 
             # Find the best version
             for directory in self.compiler.include_dirs:
-                for name in os.listdir(directory):
+                try:
+                    listdir = os.listdir(directory)
+                except Exception:  
+                    # WindowsError, FileNotFoundError
+                    continue
+                for name in listdir:
                     if name.startswith('openjpeg-') and \
                         os.path.isfile(os.path.join(directory, name,
                                                     'openjpeg.h')):


### PR DESCRIPTION
On my Windows system, Pillow fails to build on Python 2.x with the following error:

```
running build_ext
error: [Error 3] The system cannot find the path specified: 'X:\\Python27-x64\\PC/*.*'
```

The directory `'X:\Python27-x64\PC` listed in `compiler.include_dirs` is nonexistent.
