### PR TITLE
chmod 644 ; remove env

### DIFF
--- a/test-installed.py
+++ b/test-installed.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import nose
 import os
 import sys


### PR DESCRIPTION
For consistency (with selftest.py at least), I think we should chmod 644 and remove /usr/bin/env python to force the user to decide which Python to run test-installed.py. with.
