### PR TITLE
ENH: enable inline functions by default

### DIFF
--- a/libImaging/ImPlatform.h
+++ b/libImaging/ImPlatform.h
@@ -17,7 +17,7 @@
 #error Sorry, this library requires ANSI header files.
 #endif
 
-#if !defined(PIL_USE_INLINE)
+#if defined(PIL_NO_INLINE)
 #define inline 
 #else
 #if defined(_MSC_VER) && !defined(__GNUC__)


### PR DESCRIPTION
Is there a reason why C inline functions are disabled by default? On Windows all tests pass with this patch.
