### PR TITLE
Import helper so unittest2 is imported for Py2.6

### DIFF
--- a/Tests/test_pyroma.py
+++ b/Tests/test_pyroma.py
@@ -1,4 +1,4 @@
-import unittest
+from helper import *
 
 try:
     import pyroma


### PR DESCRIPTION
If pyroma isn't installed, the test should be skipped. 

`unittest` doesn't have skip on Py2.6. 

The fix is to import helper, which imports the correct `unittest2` for 2.6.

 (re: #743)
