### PR TITLE
Remove unused tearDownModule()

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -5,22 +5,19 @@ from __future__ import print_function
 import sys
 import tempfile
 import os
-import glob
 
 if sys.version_info[:2] <= (2, 6):
     import unittest2 as unittest
 else:
     import unittest
 
-def tearDownModule():
-    #remove me later
-    pass
 
 class PillowTestCase(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
-        self.currentResult = None  # holds last result object passed to run method
+        # holds last result object passed to run method:
+        self.currentResult = None
 
     def run(self, result=None):
         self.currentResult = result  # remember result for use later
@@ -40,7 +37,7 @@ class PillowTestCase(unittest.TestCase):
             except OSError:
                 pass  # report?
         else:
-            print("=== orphaned temp file: %s" %path)
+            print("=== orphaned temp file: %s" % path)
 
     def assert_almost_equal(self, a, b, msg=None, eps=1e-6):
         self.assertLess(
@@ -134,7 +131,7 @@ class PillowTestCase(unittest.TestCase):
         if platform is not None:
             skip = sys.platform.startswith(platform)
         if travis is not None:
-            skip = skip and (travis == bool(os.environ.get('TRAVIS',False)))
+            skip = skip and (travis == bool(os.environ.get('TRAVIS', False)))
         if skip:
             self.skipTest(msg or "Known Bad Test")
 
@@ -142,8 +139,8 @@ class PillowTestCase(unittest.TestCase):
         assert template[:5] in ("temp.", "temp_")
         (fd, path) = tempfile.mkstemp(template[4:], template[:4])
         os.close(fd)
-        
-        self.addCleanup(self.delete_tempfile, path)      
+
+        self.addCleanup(self.delete_tempfile, path)
         return path
 
     def open_withImagemagick(self, f):
@@ -155,8 +152,8 @@ class PillowTestCase(unittest.TestCase):
             from PIL import Image
             return Image.open(outfile)
         raise IOError()
-    
-        
+
+
 # helpers
 
 import sys
@@ -210,17 +207,21 @@ def command_succeeds(cmd):
             return False
     return True
 
+
 def djpeg_available():
     return command_succeeds(['djpeg', '--help'])
+
 
 def cjpeg_available():
     return command_succeeds(['cjpeg', '--help'])
 
+
 def netpbm_available():
-    return command_succeeds(["ppmquant", "--help"]) and \
-           command_succeeds(["ppmtogif", "--help"])
+    return (command_succeeds(["ppmquant", "--help"]) and
+            command_succeeds(["ppmtogif", "--help"]))
+
 
 def imagemagick_available():
     return command_succeeds(['convert', '-version'])
-                            
+
 # End of file

--- a/Tests/test_000_sanity.py
+++ b/Tests/test_000_sanity.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 import PIL
 import PIL.Image

--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 import os

--- a/Tests/test_cffi.py
+++ b/Tests/test_cffi.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 try:
     import cffi

--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 import io

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image, EpsImagePlugin
 import io

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena, netpbm_available
+from helper import unittest, PillowTestCase, lena, netpbm_available
 
 from PIL import Image
 from PIL import GifImagePlugin

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena, py3
+from helper import unittest, PillowTestCase, lena, py3
 from helper import djpeg_available, cjpeg_available
 
 import random

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 from io import BytesIO

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena, py3
+from helper import unittest, PillowTestCase, lena, py3
 
 import os
 

--- a/Tests/test_file_libtiff_small.py
+++ b/Tests/test_file_libtiff_small.py
@@ -1,4 +1,4 @@
-from helper import unittest, tearDownModule
+from helper import unittest
 
 from PIL import Image
 

--- a/Tests/test_file_msp.py
+++ b/Tests/test_file_msp.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_file_palm.py
+++ b/Tests/test_file_palm.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena, imagemagick_available
+from helper import unittest, PillowTestCase, lena, imagemagick_available
 
 import os.path
 

--- a/Tests/test_file_pcx.py
+++ b/Tests/test_file_pcx.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 import os.path
 

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from io import BytesIO
 

--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 from PIL import SpiderImagePlugin

--- a/Tests/test_file_tar.py
+++ b/Tests/test_file_tar.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image, TarIO
 

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena, py3
+from helper import unittest, PillowTestCase, lena, py3
 
 from PIL import Image
 

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image, TiffImagePlugin, TiffTags
 

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_file_webp_alpha.py
+++ b/Tests/test_file_webp_alpha.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_file_webp_lossless.py
+++ b/Tests/test_file_webp_lossless.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_file_webp_metadata.py
+++ b/Tests/test_file_webp_metadata.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_file_xbm.py
+++ b/Tests/test_file_xbm.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_file_xpm.py
+++ b/Tests/test_file_xpm.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_font_bdf.py
+++ b/Tests/test_font_bdf.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import FontFile, BdfFontFile
 

--- a/Tests/test_font_pcf.py
+++ b/Tests/test_font_pcf.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image, FontFile, PcfFontFile
 from PIL import ImageFont, ImageDraw

--- a/Tests/test_format_lab.py
+++ b/Tests/test_format_lab.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_image_array.py
+++ b/Tests/test_image_array.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_image_copy.py
+++ b/Tests/test_image_copy.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_image_crop.py
+++ b/Tests/test_image_crop.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_image_draft.py
+++ b/Tests/test_image_draft.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, fromstring, tostring
+from helper import unittest, PillowTestCase, fromstring, tostring
 
 from PIL import Image
 

--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 from PIL import ImageFilter

--- a/Tests/test_image_frombytes.py
+++ b/Tests/test_image_frombytes.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_image_getbands.py
+++ b/Tests/test_image_getbands.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_image_getbbox.py
+++ b/Tests/test_image_getbbox.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_image_getcolors.py
+++ b/Tests/test_image_getcolors.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 
 class TestImageGetColors(PillowTestCase):

--- a/Tests/test_image_getdata.py
+++ b/Tests/test_image_getdata.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 
 class TestImageGetData(PillowTestCase):

--- a/Tests/test_image_getextrema.py
+++ b/Tests/test_image_getextrema.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 
 class TestImageGetExtrema(PillowTestCase):

--- a/Tests/test_image_getim.py
+++ b/Tests/test_image_getim.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena, py3
+from helper import unittest, PillowTestCase, lena, py3
 
 
 class TestImageGetIm(PillowTestCase):

--- a/Tests/test_image_getpalette.py
+++ b/Tests/test_image_getpalette.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 
 class TestImageGetPalette(PillowTestCase):

--- a/Tests/test_image_getpixel.py
+++ b/Tests/test_image_getpixel.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_image_getprojection.py
+++ b/Tests/test_image_getprojection.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_image_histogram.py
+++ b/Tests/test_image_histogram.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 
 class TestImageHistogram(PillowTestCase):

--- a/Tests/test_image_load.py
+++ b/Tests/test_image_load.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_image_mode.py
+++ b/Tests/test_image_mode.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_image_offset.py
+++ b/Tests/test_image_offset.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 
 class TestImageOffset(PillowTestCase):

--- a/Tests/test_image_point.py
+++ b/Tests/test_image_point.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 import sys
 

--- a/Tests/test_image_putalpha.py
+++ b/Tests/test_image_putalpha.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_image_putdata.py
+++ b/Tests/test_image_putdata.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 import sys
 

--- a/Tests/test_image_putpalette.py
+++ b/Tests/test_image_putpalette.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import ImagePalette
 

--- a/Tests/test_image_putpixel.py
+++ b/Tests/test_image_putpixel.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 
 class TestImageResize(PillowTestCase):

--- a/Tests/test_image_rotate.py
+++ b/Tests/test_image_rotate.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 
 class TestImageRotate(PillowTestCase):

--- a/Tests/test_image_split.py
+++ b/Tests/test_image_split.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 
 class TestImageThumbnail(PillowTestCase):

--- a/Tests/test_image_tobitmap.py
+++ b/Tests/test_image_tobitmap.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena, fromstring
+from helper import unittest, PillowTestCase, lena, fromstring
 
 
 class TestImageToBitmap(PillowTestCase):

--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_image_transpose.py
+++ b/Tests/test_image_transpose.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_imagechops.py
+++ b/Tests/test_imagechops.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 from PIL import ImageChops

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_imagecolor.py
+++ b/Tests/test_imagecolor.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 from PIL import ImageColor

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 from PIL import ImageColor

--- a/Tests/test_imageenhance.py
+++ b/Tests/test_imageenhance.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 from PIL import ImageEnhance

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena, fromstring, tostring
+from helper import unittest, PillowTestCase, lena, fromstring, tostring
 
 from io import BytesIO
 

--- a/Tests/test_imagefileio.py
+++ b/Tests/test_imagefileio.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena, tostring
+from helper import unittest, PillowTestCase, lena, tostring
 
 from PIL import Image
 from PIL import ImageFileIO

--- a/Tests/test_imagefilter.py
+++ b/Tests/test_imagefilter.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import ImageFilter
 

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 from PIL import ImageDraw

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 try:
     from PIL import ImageGrab

--- a/Tests/test_imagemath.py
+++ b/Tests/test_imagemath.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 from PIL import ImageMath

--- a/Tests/test_imagemode.py
+++ b/Tests/test_imagemode.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import ImageMode
 

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import ImageOps
 

--- a/Tests/test_imageops_usm.py
+++ b/Tests/test_imageops_usm.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 from PIL import ImageOps

--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import ImagePalette
 

--- a/Tests/test_imagepath.py
+++ b/Tests/test_imagepath.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import ImagePath
 

--- a/Tests/test_imageqt.py
+++ b/Tests/test_imageqt.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 try:
     from PIL import ImageQt

--- a/Tests/test_imagesequence.py
+++ b/Tests/test_imagesequence.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import ImageSequence
 

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 from PIL import ImageShow

--- a/Tests/test_imagestat.py
+++ b/Tests/test_imagestat.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 from PIL import ImageStat

--- a/Tests/test_imagetk.py
+++ b/Tests/test_imagetk.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 
 class TestImageTk(PillowTestCase):

--- a/Tests/test_imagetransform.py
+++ b/Tests/test_imagetransform.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 from PIL import ImageTransform

--- a/Tests/test_imagewin.py
+++ b/Tests/test_imagewin.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 from PIL import ImageWin

--- a/Tests/test_lib_image.py
+++ b/Tests/test_lib_image.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_lib_pack.py
+++ b/Tests/test_lib_pack.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, py3
+from helper import unittest, PillowTestCase, py3
 
 from PIL import Image
 

--- a/Tests/test_locale.py
+++ b/Tests/test_locale.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_mode_i16.py
+++ b/Tests/test_mode_i16.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule, lena
+from helper import unittest, PillowTestCase, lena
 
 from PIL import Image
 

--- a/Tests/test_olefileio.py
+++ b/Tests/test_olefileio.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 import datetime
 

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_shell_injection.py
+++ b/Tests/test_shell_injection.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, tearDownModule
+from helper import unittest, PillowTestCase
 from helper import djpeg_available, cjpeg_available, netpbm_available
 
 import sys


### PR DESCRIPTION
Test-helper `tearDownModule()` is no longer needed after #732 which stubbed it out.

This removes the stub and its import from test files.
