### PR TITLE
travis_retry to avoid spurious pyroma installation failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ python:
 install:
   - "sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-qt4 ghostscript libffi-dev libjpeg-turbo-progs cmake imagemagick"
   - "pip install cffi"
-  - "pip install coveralls nose pyroma"
+  - "pip install coveralls nose"
+  - travis_retry pip install pyroma
   - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install unittest2; fi
 
   # webp


### PR DESCRIPTION
We've been seeing some occasional build failures due to `pip install pyroma` failing:

```
Downloading/unpacking pyroma
  Downloading pyroma-1.6.zip (360kB): 360kB downloaded
  Running setup.py (path:/home/travis/virtualenv/python3.2.5/build/pyroma/setup.py) egg_info for package pyroma

    no previously-included directories found matching 'pyroma/testdata/complete/*.egg'
Downloading/unpacking docopt>=0.6.1 (from coveralls)
  Downloading docopt-0.6.2.tar.gz
  Running setup.py (path:/home/travis/virtualenv/python3.2.5/build/docopt/setup.py) egg_info for package docopt

Downloading/unpacking coverage>=3.6 (from coveralls)
  Downloading coverage-3.7.1.tar.gz (284kB): 284kB downloaded
  Running setup.py (path:/home/travis/virtualenv/python3.2.5/build/coverage/setup.py) egg_info for package coverage

    warning: no previously-included files matching '*.pyc' found anywhere in distribution
Downloading/unpacking requests>=1.0.0 (from coveralls)
  Downloading requests-2.3.0-py2.py3-none-any.whl (452kB): 452kB downloaded
Downloading/unpacking PyYAML>=3.10 (from coveralls)
  Downloading PyYAML-3.11.tar.gz (248kB): 248kB downloaded
  Running setup.py (path:/home/travis/virtualenv/python3.2.5/build/PyYAML/setup.py) egg_info for package PyYAML

Requirement already satisfied (use --upgrade to upgrade): setuptools in /home/travis/virtualenv/python3.2.5/lib/python3.2/site-packages (from pyroma)
Downloading/unpacking docutils (from pyroma)
  Downloading docutils-0.11.tar.gz (1.6MB): 1.2MB downloaded
Cleaning up...
Exception:
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.2.5/lib/python3.2/site-packages/pip/basecommand.py", line 122, in main
    status = self.run(options, args)
  File "/home/travis/virtualenv/python3.2.5/lib/python3.2/site-packages/pip/commands/install.py", line 278, in run
    requirement_set.prepare_files(finder, force_root_egg_info=self.bundle, bundle=self.bundle)
  File "/home/travis/virtualenv/python3.2.5/lib/python3.2/site-packages/pip/req.py", line 1197, in prepare_files
    do_download,
  File "/home/travis/virtualenv/python3.2.5/lib/python3.2/site-packages/pip/req.py", line 1375, in unpack_url
    self.session,
  File "/home/travis/virtualenv/python3.2.5/lib/python3.2/site-packages/pip/download.py", line 572, in unpack_http_url
    download_hash = _download_url(resp, link, temp_location)
  File "/home/travis/virtualenv/python3.2.5/lib/python3.2/site-packages/pip/download.py", line 433, in _download_url
    for chunk in resp_read(4096):
  File "/home/travis/virtualenv/python3.2.5/lib/python3.2/site-packages/pip/download.py", line 421, in resp_read
    chunk_size, decode_content=False):
  File "/home/travis/virtualenv/python3.2.5/lib/python3.2/site-packages/pip/_vendor/requests/packages/urllib3/response.py", line 236, in stream
    data = self.read(amt=amt, decode_content=decode_content)
  File "/home/travis/virtualenv/python3.2.5/lib/python3.2/site-packages/pip/_vendor/requests/packages/urllib3/response.py", line 183, in read
    data = self._fp.read(amt)
  File "/opt/python/3.2.5/lib/python3.2/http/client.py", line 517, in read
    s = self.fp.read(amt)
  File "/opt/python/3.2.5/lib/python3.2/socket.py", line 287, in readinto
    return self._sock.recv_into(b)
  File "/opt/python/3.2.5/lib/python3.2/ssl.py", line 399, in recv_into
    return self.read(nbytes, buffer)
  File "/opt/python/3.2.5/lib/python3.2/ssl.py", line 293, in read
    v = self._sslobj.read(len, buffer)
socket.error: [Errno 104] Connection reset by peer

Storing debug log for failure in /home/travis/.pip/pip.log

The command "pip install coveralls nose pyroma" failed and exited with 2 during .
```

https://travis-ci.org/python-pillow/Pillow/jobs/29345217

The `travis_retry` function will retry a command up to three times:
http://blog.travis-ci.com/2013-05-20-network-timeouts-build-retries/

In action:

```
...
The command "pip install pyroma" failed. Retrying, 2 of 3.
...
```

https://travis-ci.org/hugovk/Pillow/jobs/29350671
