### PR TITLE
Added docs for previously-undocumented ExifTags module.

### DIFF
--- a/docs/reference/ExifTags.rst
+++ b/docs/reference/ExifTags.rst
@@ -1,0 +1,26 @@
+.. py:module:: PIL.ExifTags
+.. py:currentmodule:: PIL.ExifTags
+
+:py:mod:`ExifTags` Module
+==========================
+
+The :py:mod:`ExifTags` module exposes two dictionaries which
+provide constants and clear-text names for various well-known EXIF tags.
+
+.. py:class:: PIL.ExifTags.TAGS
+
+    The TAG dictionary maps 16-bit integer EXIF tag enumerations to
+    descriptive string names.  For instance:
+
+        >>> from PIL.ExifTags import TAGS
+        >>> TAGS[0x010e]
+        'ImageDescription'
+
+.. py:class:: PIL.ExifTags.GPSTAGS
+
+    The GPSTAGS dictionary maps 8-bit integer EXIF gps enumerations to
+    descriptive string names.  For instance:
+
+        >>> from PIL.ExifTags import GPSTAGS
+        >>> GPSTAGS[20]
+        'GPSDestLatitude'

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -4,6 +4,7 @@ Reference
 .. toctree::
    :maxdepth: 2
 
+   ExifTags
    Image
    ImageChops
    ImageColor


### PR DESCRIPTION
In looking into matplotlib exif support ticket https://github.com/matplotlib/matplotlib/issues/2314 I discovered that the ExifTags module in Pillow was undocumented, so I created a simple doc file for it.
