### PR TITLE
More tests for Image.py

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -113,7 +113,7 @@ class TestImage(PillowTestCase):
     def test_alpha_composite(self):
         # http://stackoverflow.com/questions/3374878
         # Arrange
-        import ImageDraw
+        from PIL import ImageDraw
 
         expected_colors = sorted([
             (1122, (128, 127, 0, 255)),


### PR DESCRIPTION
- Add more tests for `Image`'s previously uncovered functions.
- Helps towards: Test coverage >= 80% #722.

---

About `test_alpha_composite()`:

`Image.alpha_composite()` was added in https://github.com/python-pillow/Pillow/pull/23.

The alpha composite test is based on this test mentioned in the original PR, but the test doesn't appear to have been committed: https://github.com/python-pillow/Pillow/pull/23#issuecomment-11081185.

At first, the only logical changes to the test was sorting the colour lists before comparison. However it failed. 

The images -- `im1`, `im2` and `im3` saved to png -- look valid with a visual check. There were subsequent changes to alpha compositing in https://github.com/python-pillow/Pillow/pull/29, https://github.com/python-pillow/Pillow/pull/156 and https://github.com/python-pillow/Pillow/pull/159, so I've modified the expected values to match the current implementation.
