### PR TITLE
Remove ImagePalette._make_gamma_lut?

### DIFF
--- a/PIL/ImagePalette.py
+++ b/PIL/ImagePalette.py
@@ -134,13 +134,6 @@ def _make_linear_lut(black, white):
     return lut
 
 
-def _make_gamma_lut(exp, mode="RGB"):
-    lut = []
-    for i in range(256):
-        lut.append(int(((i / 255.0) ** exp) * 255.0 + 0.5))
-    return lut
-
-
 def new(mode, data):
     return Image.core.new_palette(mode, data)
 


### PR DESCRIPTION
`ImagePalette._make_gamma_lut()` is an internal factory class but isn't used anywhere in `PIL/*` or `Tests/*` code.

It's been in Pillow since the PIL fork, and was added in PIL 1.1.7. The `_make_linear_lut()` function was added at the same time and is still in use. Here's the relevant diff:
http://hg.effbot.org/pil-2009-raclette/commits/915c68a71749325ce110b697d2740c0977afea55

Shall we remove `_make_gamma_lut()`?

(Two commits in this PR: one to remove it, and one for flake8.)
