### PR TITLE
Test PyQt on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "pypy"
   - 2.6
   - 2.7
+  - "2.7_with_system_site_packages" # For PyQt4
   - 3.2
   - 3.3
   - 3.4


### PR DESCRIPTION
Fix for #813.

From [Travis CI team](https://github.com/travis-ci/travis-ci/issues/2219#issuecomment-41804942):

> The system site packages option does not make sense on anything other than Python 2.7 or Python 3.2. Those are the only versions that come from the OS and which you will possibly have things installed into the system site packages via `apt-get`. The new images do not include a virtualenv that includes system site packages except for 2.7 and 3.2 (because those are the ones that come with the OS).
> 
> However there's a work around here which I actually think is a much nicer way of handling things.

ImageQt.py coverage increases from 13.64% to 86.36%. Helps with #722. 

Obviously it adds more time to the build, but it means we test with and without system site packages for one Python version, if that's useful. If not, the `2.7_with_system_site_packages` build could just run the Qt test, or we could replace `2.7` with `2.7_with_system_site_packages`.
