### PR TITLE
More ImagePalette.py tests and remove unused and uncallable new()

### DIFF
--- a/PIL/ImagePalette.py
+++ b/PIL/ImagePalette.py
@@ -18,7 +18,7 @@
 
 import array
 import warnings
-from PIL import Image, ImageColor
+from PIL import ImageColor
 
 
 class ImagePalette:
@@ -160,10 +160,6 @@ def make_gamma_lut(exp):
     for i in range(256):
         lut.append(int(((i / 255.0) ** exp) * 255.0 + 0.5))
     return lut
-
-
-def new(mode, data):
-    return Image.core.new_palette(mode, data)
 
 
 def negative(mode="RGB"):

--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -111,6 +111,41 @@ class TestImagePalette(PillowTestCase):
             DeprecationWarning,
             lambda: _make_gamma_lut(exp))
 
+    def test_rawmode_valueerrors(self):
+        # Arrange
+        from PIL.ImagePalette import raw
+        palette = raw("RGB", list(range(256))*3)
+
+        # Act / Assert
+        self.assertRaises(ValueError, lambda: palette.tobytes())
+        self.assertRaises(ValueError, lambda: palette.getcolor((1, 2, 3)))
+        f = self.tempfile("temp.lut")
+        self.assertRaises(ValueError, lambda: palette.save(f))
+
+    def test_getdata(self):
+        # Arrange
+        data_in = list(range(256))*3
+        palette = ImagePalette("RGB", data_in)
+
+        # Act
+        mode, data_out = palette.getdata()
+
+        # Assert
+        self.assertEqual(mode, "RGB;L")
+
+    def test_rawmode_getdata(self):
+        # Arrange
+        from PIL.ImagePalette import raw
+        data_in = list(range(256))*3
+        palette = raw("RGB", data_in)
+
+        # Act
+        rawmode, data_out = palette.getdata()
+
+        # Assert
+        self.assertEqual(rawmode, "RGB")
+        self.assertEqual(data_in, data_out)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- More tests for ImagePalette.py
- Remove `new()`, unused in production and test code, and calls `Image.core.new_palette()` which doesn't exist.
- Helps towards #722: Test coverage >= 80%.
