### PR TITLE
Fix failing build on mavericks with clang

### DIFF
--- a/libImaging/Convert.c
+++ b/libImaging/Convert.c
@@ -293,10 +293,10 @@ hsv2rgb(UINT8* out, const UINT8* in, int xsize)
 { // following colorsys.py
     
     int p,q,t;
-    uint up,uq,ut;
+    unsigned int up,uq,ut;
     int i, x;
     float f, fs;
-    uint h,s,v;
+    unsigned int h,s,v;
        
     for (x = 0; x < xsize; x++, in += 4) {
         h = in[0];


### PR DESCRIPTION
`uint` is apparently not a standard type. The C standard uses `unsigned int` instead? This fixes a build error with `clang`. 

Builds with `gcc` and `clang` on 10.9 against python `3.4.1`.

This only affects master after commit `0bb1cd39`
