### PR TITLE
Add CONTRIBUTING file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+When reporting bugs, please include example code that reproduces the issue, and if possible a problem image.
+
+Let us know:
+
+ * What is the expected output? What do you see instead?
+
+ * What versions of Pillow and Python are you using?


### PR DESCRIPTION
> Oftentimes open source projects place a CONTRIBUTING file in the root directory. It explains how a participant should do things like format code, test fixes, and submit patches. Here is a fine [example](https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md) from puppet and [another one](https://github.com/thoughtbot/factory_girl_rails/blob/master/CONTRIBUTING.md) from factory_girl_rails. From a maintainer's point of view, the document succinctly communicates how best to collaborate. And for a contributor, one quick check of this file verifies their submission follows the maintainer's guidelines.

More info: https://github.com/blog/1184-contributing-guidelines
Another example: http://contribute.md

We can pad it out later, but this can get us started. It's very useful for bug reports to include example code that reproduces the problem, it obviously gives us something concrete to help repro right away, and also is pretty much a test case.
