### PR TITLE
Cover PyPy and add PyPy 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,18 +33,12 @@ script:
   - python setup.py clean
   - python setup.py build_ext --inplace
 
-    # Don't cover PyPy: it fails intermittently and is x5.8 slower (#640)
-  - if [ "$TRAVIS_PYTHON_VERSION" == "pypy" ]; then time python selftest.py; fi
-  - if [ "$TRAVIS_PYTHON_VERSION" == "pypy" ]; then time nosetests -vx Tests/test_*.py; fi
-
-    # Cover the others
-  - if [ "$TRAVIS_PYTHON_VERSION" != "pypy" ]; then time coverage run --append --include=PIL/* selftest.py; fi
-  - if [ "$TRAVIS_PYTHON_VERSION" != "pypy" ]; then time coverage run --append --include=PIL/* -m nose -vx Tests/test_*.py; fi
+  - time coverage run --append --include=PIL/* selftest.py
+  - coverage run --append --include=PIL/* -m nose -vx Tests/test_*.py
 
 after_success:
   - coverage report
-    # No need to send empty coverage to Coveralls for PyPy
-  - if [ "$TRAVIS_PYTHON_VERSION" != "pypy" ]; then coveralls; fi
+  - coveralls
 
   - pip install pep8 pyflakes
   - pep8 --statistics --count PIL/*.py


### PR DESCRIPTION
Travis CI has upgraded PyPy from 2.2.1 to 2.3.1, and have added PyPy 3. 

(They've also upgraded from 2.7.6 to 2.7.8 and 3.4.0 to 3.4.1.)

http://blog.travis-ci.com/2014-07-24-upcoming-build-environment-updates/
- This means we can now cover PyPy 2 as the PyPy bug reported via https://github.com/python-pillow/Pillow/issues/640 is released in 2.3.1 (so closes #640).

Covering PyPy is still slow: about 6 minutes with, versus 1 minute without. Is this a problem? PyPy is built first and the other builds can run concurrently.
- We can also add PyPy 3 to the builds.
