### PR TITLE
Adding coverage support for C code tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,10 @@ python:
   - 3.4
 
 install:
-  - "sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-qt4 ghostscript libffi-dev libjpeg-turbo-progs cmake imagemagick"
+  - "sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-qt4 ghostscript libffi-dev libjpeg-turbo-progs cmake imagemagick lcov"
   - "pip install cffi"
-  - "pip install coveralls nose"
+  - "pip install coveralls nose coveralls-merge"
+  - "gem install coveralls-lcov"
   - travis_retry pip install pyroma
   - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install unittest2; fi
 
@@ -31,14 +32,22 @@ install:
 script:
   - coverage erase
   - python setup.py clean
-  - python setup.py build_ext --inplace
+  - CFLAGS="-coverage" python setup.py build_ext --inplace
 
   - time coverage run --append --include=PIL/* selftest.py
   - coverage run --append --include=PIL/* -m nose -vx Tests/test_*.py
 
 after_success:
+   # gather the coverage data
+  - lcov --capture --directory . -b . --output-file coverage.info
+   # filter to remove system headers
+  - lcov --remove coverage.info '/usr/*' -o coverage.filtered.info     
+   # convert to json
+  - coveralls-lcov -v -n coverage.filtered.info > coverage.c.json
+
   - coverage report
-  - coveralls
+  - coveralls-merge coverage.c.json
+
 
   - pip install pep8 pyflakes
   - pep8 --statistics --count PIL/*.py


### PR DESCRIPTION
Or, moving the goalposts for #722. 

Currently, we're at 78.85%, 7160 of 9081 lines covered.
With this patch, we're at 73.57%, 14400 of 19573 lines covered.

So, we lose percentage, but gain instrumentation of 10k lines of code. 

It installs a couple of extra packages, including, horror of horrors, a ruby gem. Using the extra bits, it combines the output json from gcov/lcov's c coverage with the json from coveralls-python. Then, the upload. 

The coveralls-merge package can be found in my repo: https://github.com/wiredfool/coveralls-merge

Output can be found here: https://coveralls.io/builds/1029743 , especially this file:  https://coveralls.io/files/257210494

Performance ranges from not bad to a somewhat worse than just python coverage. We may want to consider covering 2.7+sitepackages, 3.4, and maybe one of the pypys, as that should get us accurate to within a few lines of coverage. (edit, according to my tests, those three (2.7+site, 3.4, pypy2.3) gets us +- 1 line of coverage compared to all 8 of them.)
