### PR TITLE
setup.py: Close open file handle before deleting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -706,6 +706,7 @@ class pil_build_ext(build_ext):
             if ret >> 8 == 0:
                 fp = open(tmpfile, 'r')
                 multiarch_path_component = fp.readline().strip()
+                fp.close()
                 _add_directory(
                     self.compiler.library_dirs,
                     '/usr/lib/' + multiarch_path_component)


### PR DESCRIPTION
When installing Pillow onto a Vagrant virtual machine with Linux as the guest OS, and Windows as the host OS, setup.py fails with the error "Text file busy." The temporary installation directory is a shared folder from the host OS, mounted in the guest OS, and the underlying Windows file system doesn't allow deleting the "multiarch" temporary file while a file handle for it is still open. This change closes the file handle once it is no longer being used, but before the file itself is unlinked.
