### PR TITLE
Pyroma installation is slow on Py3, so just do it for Py2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,10 @@ install:
   - "pip install cffi"
   - "pip install coveralls nose coveralls-merge"
   - "gem install coveralls-lcov"
-  - travis_retry pip install pyroma
+
+    # Pyroma installation is slow on Py3, so just do it for Py2.
+  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then travis_retry pip install pyroma; fi
+
   - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install unittest2; fi
 
   # webp


### PR DESCRIPTION
Pyroma installation is a lot slower for Python 3. For example:

```
pypy    8s
pypy3   70s
2.6     3s
2.7     2s
3.2     111s
3.3     82s
3.4     86s
```

Let's skip the installation on Python 3. The test will also skip.

Last master build: 46 min total.
This PR: 39 min total.

Reported to Pyroma: https://bitbucket.org/regebro/pyroma/issue/22/installation-slow-for-python-3
