### PR TITLE
Refactor inheritance tree of test_file_libtiff_small

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -4,8 +4,7 @@ import os
 
 from PIL import Image, TiffImagePlugin
 
-
-class TestFileLibTiff(PillowTestCase):
+class LibTiffTestCase(PillowTestCase):
 
     def setUp(self):
         codecs = dir(Image.core)
@@ -31,6 +30,8 @@ class TestFileLibTiff(PillowTestCase):
         # can we write it back out, in a different form.
         out = self.tempfile("temp.png")
         im.save(out)
+
+class TestFileLibTiff(LibTiffTestCase):
 
     def test_g4_tiff(self):
         """Test the ordinary file path load path"""

--- a/Tests/test_file_libtiff_small.py
+++ b/Tests/test_file_libtiff_small.py
@@ -2,12 +2,10 @@ from helper import unittest
 
 from PIL import Image
 
-from test_file_libtiff import TestFileLibTiff
+from test_file_libtiff import LibTiffTestCase
 
 
-class TestFileLibTiffSmall(TestFileLibTiff):
-
-    # Inherits TestFileLibTiff's setUp() and self._assert_noerr()
+class TestFileLibTiffSmall(LibTiffTestCase):
 
     """ The small lena image was failing on open in the libtiff
         decoder because the file pointer was set to the wrong place


### PR DESCRIPTION
Test_file_libtiff_small shouldn't inherit from test_file_libtiff because it will run all the tests in test_file_libtiff twice. 
