### PR TITLE
Avoid resize operation if image is already the correct size

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1514,6 +1514,9 @@ class Image:
 
         self.load()
 
+        if self.size == size:
+            return self._new(self.im)
+
         if self.mode in ("1", "P"):
             resample = NEAREST
 


### PR DESCRIPTION
For the sake of speed, if the image being resized is already the correct size, do not run the resize operation.
