### PR TITLE
Fix msvc build error

### DIFF
--- a/libImaging/TiffDecode.c
+++ b/libImaging/TiffDecode.c
@@ -221,9 +221,10 @@ int ImagingLibTiffDecode(Imaging im, ImagingCodecState state, UINT8* buffer, int
 	}
 
     if (clientstate->ifd){
-        unsigned int ifdoffset = clientstate->ifd;
+		int rv;
+		unsigned int ifdoffset = clientstate->ifd;
 		TRACE(("reading tiff ifd %d\n", ifdoffset));
-		int rv = TIFFSetSubDirectory(tiff, ifdoffset);
+		rv = TIFFSetSubDirectory(tiff, ifdoffset);
 		if (!rv){
 			TRACE(("error in TIFFSetSubDirectory"));
 			return -1;


### PR DESCRIPTION
Btw, `libImaging/TiffDecode.c` uses a mixture of tabs and spaces for indentation.
