### PR TITLE
On Windows, do not execute convert.exe without specifying path

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -155,7 +155,7 @@ class PillowTestCase(unittest.TestCase):
             raise IOError()
 
         outfile = self.tempfile("temp.png")
-        if command_succeeds(['convert', f, outfile]):
+        if command_succeeds([IMCONVERT, f, outfile]):
             from PIL import Image
             return Image.open(outfile)
         raise IOError()
@@ -251,6 +251,14 @@ def netpbm_available():
 
 
 def imagemagick_available():
-    return command_succeeds(['convert', '-version'])
+    return IMCONVERT and command_succeeds([IMCONVERT, '-version'])
+
+
+if sys.platform == 'win32':
+    IMCONVERT = os.environ.get('MAGICK_HOME', '')
+    if IMCONVERT:
+        IMCONVERT = os.path.join(IMCONVERT, 'convert.exe')
+else:
+    IMCONVERT = 'convert'
 
 # End of file


### PR DESCRIPTION
`Convert.exe` is a system tool that converts file systems.
Windows users will need to set the `MAGICK_HOME` environment variable before running Pillow tests.

Fixes one test error:

```
======================================================================
ERROR: TestFilePalm.test_monochrome
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\Build\Pillow\Pillow-git\Tests\test_file_palm.py", line 39, in test_monochrome
    self.roundtrip(mode)
  File "D:\Build\Pillow\Pillow-git\Tests\test_file_palm.py", line 29, in roundtrip
    converted = self.open_withImagemagick(outfile)
  File "D:\Build\Pillow\Pillow-git\Tests\helper.py", line 160, in open_withImagemagick
    return Image.open(outfile)
  File "D:\Build\Pillow\Pillow-git\PIL\Image.py", line 2281, in open
    % (filename if filename else fp))
OSError: cannot identify image file 'C:\\Users\\gohlke\\AppData\\Local\\Temp\\tempe1e9r8fi.png'
```
