### PR TITLE
Fix segfault in TestFileJpeg.test_quality_keep on win-amd64

### DIFF
--- a/libImaging/JpegEncode.c
+++ b/libImaging/JpegEncode.c
@@ -151,7 +151,7 @@ ImagingJpegEncode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
 	    if (context->quality > 0) {
 		quality = context->quality;
 	    }
-	    for (i = 0; i < sizeof(context->qtables)/sizeof(unsigned int); i++) {
+	    for (i = 0; i < sizeof(context->qtables)/sizeof(unsigned int *); i++) {
 		// TODO: Should add support for none baseline
 		jpeg_add_quant_table(&context->cinfo, i, context->qtables[i],
 				     quality, TRUE);


### PR DESCRIPTION
On win-amd64, `TestFileJpeg.test_quality_keep` segfaults in `_imaging.pyd`.

Faulthandler traceback:

```
TestFileJpeg.test_quality_keep ... Fatal Python error: Segmentation fault

Current thread 0x00001828 (most recent call first):
  File "D:\Build\Pillow\Pillow-git\PIL\ImageFile.py", line 484 in _save
  File "D:\Build\Pillow\Pillow-git\PIL\JpegImagePlugin.py", line 688 in _save
  File "D:\Build\Pillow\Pillow-git\PIL\Image.py", line 1678 in save
  File "D:\Build\Pillow\Pillow-git\Tests\test_file_jpeg.py", line 235 in test_quality_keep
  File "X:\Python34\lib\unittest\case.py", line 577 in run
  File "D:\Build\Pillow\Pillow-git\Tests\helper.py", line 28 in run
  File "X:\Python34\lib\unittest\case.py", line 625 in __call__
  File "X:\Python34\lib\site-packages\nose\case.py", line 152 in runTest
  File "X:\Python34\lib\site-packages\nose\case.py", line 134 in run
  File "X:\Python34\lib\site-packages\nose\case.py", line 46 in __call__
  File "X:\Python34\lib\site-packages\nose\suite.py", line 225 in run
  File "X:\Python34\lib\site-packages\nose\suite.py", line 178 in __call__
  File "X:\Python34\lib\site-packages\nose\suite.py", line 225 in run
  File "X:\Python34\lib\site-packages\nose\suite.py", line 178 in __call__
  File "X:\Python34\lib\site-packages\nose\suite.py", line 76 in run
  File "X:\Python34\lib\unittest\suite.py", line 87 in __call__
  File "X:\Python34\lib\site-packages\nose\suite.py", line 225 in run
  File "X:\Python34\lib\site-packages\nose\suite.py", line 178 in __call__
  File "X:\Python34\lib\site-packages\nose\core.py", line 62 in run
  File "X:\Python34\lib\site-packages\nose\core.py", line 207 in runTests
  File "X:\Python34\lib\unittest\main.py", line 93 in __init__
  File "X:\Python34\lib\site-packages\nose\core.py", line 121 in __init__
  File "X:\Python34\scripts\nosetests-3.4-script.py", line 9 in <module>
```

Call stack:  

```
    _imaging.pyd!jpeg_add_quant_table()  + 0x90 bytes   C
>   _imaging.pyd!ImagingJpegEncode(ImagingMemoryInstance * im=0x0000000090a5a8e0, ImagingCodecStateInstance * state=0x000000001b78c578, unsigned char * buf=0x000000000d7ed040, int bytes=65536)  Line 158  C
    _imaging.pyd!_encode_to_file(ImagingEncoderObject * encoder=0x000000001b78c558, _object * args=0x000000001b675c08)  Line 173 + 0x27 bytes   C
    python34.dll!PyCFunction_Call(_object * func=0x0000000000000002, _object * arg=0x00000000025618a0, _object * kw=0x000000001b67c0c8)  Line 142   C
    python34.dll!call_function(_object * * * pp_stack=0x0000000000a3bbb9, int oparg=131)  Line 4231 C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x0000000003f64098, int throwflag=0)  Line 2831  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x0000000000000004, _object * globals=0x0000000000000004, _object * locals=0x0000000003ad1568, _object * * args=0x0000000000000000, int argcount=4, _object * * kws=0x0000000003e02580, int kwcount=0, _object * * defs=0x0000000003ad1568, int defcount=1, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes  C
    python34.dll!fast_function(_object * func=0x0000000000000004, _object * * * pp_stack=0x0000000000a3be39, int n=64186296, int na=59918936, int nk=0)  Line 4338  C
    python34.dll!call_function(_object * * * pp_stack=0x0000000000a3be39, int oparg=131)  Line 4253 C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x0000000003e02338, int throwflag=10731576)  Line 2831   C
    python34.dll!fast_function(_object * func=0x0000000000000003, _object * * * pp_stack=0x0000000000a3c029, int n=73211552, int na=38444168, int nk=0)  Line 4325  C
    python34.dll!call_function(_object * * * pp_stack=0x0000000000a3c029, int oparg=131)  Line 4253 C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x0000000003de8db8, int throwflag=0)  Line 2831  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x0000000000000003, _object * globals=0x0000000000000002, _object * locals=0x0000000003b12ae0, _object * * args=0x000000005a14a160, int argcount=2, _object * * kws=0x000000001b79bcd8, int kwcount=1, _object * * defs=0x0000000003b12ae0, int defcount=1, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes  C
    python34.dll!fast_function(_object * func=0x0000000000000002, _object * * * pp_stack=0x000000001b794cc0, int n=61978008, int na=460514648, int nk=1)  Line 4338 C
    python34.dll!call_function(_object * * * pp_stack=0x0000000000a3c2a9, int oparg=131)  Line 4253 C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x000000001b79bb28, int throwflag=10732712)  Line 2831   C
    python34.dll!fast_function(_object * func=0x0000000000000001, _object * * * pp_stack=0x000000001b9f6da0, int n=460978104, int na=1511099517, int nk=0)  Line 4325   C
    python34.dll!call_function(_object * * * pp_stack=0x0000000000a3c499, int oparg=131)  Line 4253 C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x00000000036a1f78, int throwflag=0)  Line 2831  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x0000000000000002, _object * globals=0x0000000000000002, _object * locals=0x00000000037a5338, _object * * args=0x42926644d4d95bcc, int argcount=2, _object * * kws=0x0000000003d388e8, int kwcount=0, _object * * defs=0x00000000037a5338, int defcount=1, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes  C
    python34.dll!fast_function(_object * func=0x0000000000000002, _object * * * pp_stack=0x0000000000a3c719, int n=58404376, int na=1511506445, int nk=0)  Line 4338    C
    python34.dll!call_function(_object * * * pp_stack=0x0000000000a3c719, int oparg=131)  Line 4253 C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x0000000003d38748, int throwflag=0)  Line 2831  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x0000000000000002, _object * globals=0x0000000000000002, _object * locals=0x0000000000000000, _object * * args=0x0000000000000000, int argcount=2, _object * * kws=0x0000000000bf0060, int kwcount=0, _object * * defs=0x0000000003ac8ed0, int defcount=1, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes  C
    python34.dll!function_call(_object * func=0x0000000003ac3048, _object * arg=0x000000001b6fc908, _object * kw=0x0000000000000000)  Line 638 + 0x45 bytes C
    python34.dll!PyObject_Call(_object * func=0x000000001b6fc908, _object * arg=0x000000001b790088, _object * kw=0x000000001b7940f0)  Line 2068 C
    python34.dll!ext_do_call(_object * func=0x0000000003ac3048, _object * * * pp_stack=0x0000000000a3c9d9, int flags=64197104, int na=1, int nk=0)  Line 4551 + 0xe bytes   C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x0000000003d39048, int throwflag=0)  Line 2872  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x0000000000000001, _object * globals=0x0000000000000001, _object * locals=0x0000000000000000, _object * * args=0x0000000000a3cc10, int argcount=2, _object * * kws=0x0000000000000000, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes  C
    python34.dll!function_call(_object * func=0x00000000037b2f28, _object * arg=0x000000001b68c708, _object * kw=0x0000000000000000)  Line 638 + 0x45 bytes C
    python34.dll!PyObject_Call(_object * func=0x000000001b68c708, _object * arg=0x0000000000000001, _object * kw=0x0000000000107940)  Line 2068 C
    python34.dll!method_call(_object * func=0x000000001b678a08, _object * arg=0x000000001b794048, _object * kw=0x0000000000000000)  Line 348    C
    python34.dll!PyObject_Call(_object * func=0x000000001b678a08, _object * arg=0x000000001b794048, _object * kw=0x000000001b794048)  Line 2068 C
    python34.dll!slot_tp_call(_object * self=0x000000001b9f6da0, _object * args=0x0000000000000000, _object * kwds=0x0000000000000000)  Line 5810   C
    python34.dll!PyObject_Call(_object * func=0x0000000000000000, _object * arg=0x0000000000000001, _object * kw=0x000000001b794048)  Line 2068 C
    python34.dll!do_call(_object * func=0x0000000000000001, _object * * * pp_stack=0x0000000000a3cda9, int na=463433120, int nk=10735032)  Line 4456 + 0xe bytes    C
    python34.dll!call_function(_object * * * pp_stack=0x0000000000a3cda9, int oparg=131)  Line 4256 C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x0000000003d1acc0, int throwflag=10735528)  Line 2831   C
    python34.dll!fast_function(_object * func=0x0000000000000002, _object * * * pp_stack=0x000000001b9f6dd8, int n=59880040, int na=1511399033, int nk=0)  Line 4325    C
    python34.dll!call_function(_object * * * pp_stack=0x0000000000a3cf99, int oparg=131)  Line 4253 C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x000000000367a2e8, int throwflag=0)  Line 2831  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x0000000000000002, _object * globals=0x0000000000000002, _object * locals=0x0000000000000000, _object * * args=0x000000000000006a, int argcount=2, _object * * kws=0x0000000000bf0060, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes  C
    python34.dll!function_call(_object * func=0x000000000391b1e0, _object * arg=0x000000001b683248, _object * kw=0x0000000000000000)  Line 638 + 0x45 bytes C
    python34.dll!PyObject_Call(_object * func=0x000000001b683248, _object * arg=0x000000001b7b1fc8, _object * kw=0x000000001b786e48)  Line 2068 C
    python34.dll!ext_do_call(_object * func=0x000000000391b1e0, _object * * * pp_stack=0x0000000000a3d259, int flags=64072864, int na=1, int nk=0)  Line 4551 + 0xe bytes   C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x0000000003d1aaf8, int throwflag=0)  Line 2872  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x0000000000000001, _object * globals=0x0000000000000001, _object * locals=0x0000000000000000, _object * * args=0x00000000038a0dd0, int argcount=2, _object * * kws=0x0000000000000000, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes  C
    python34.dll!function_call(_object * func=0x00000000038f3c80, _object * arg=0x000000001b68c9c8, _object * kw=0x0000000000000000)  Line 638 + 0x45 bytes C
    python34.dll!PyObject_Call(_object * func=0x000000001b68c9c8, _object * arg=0x0000000000000001, _object * kw=0x00000000000fa218)  Line 2068 C
    python34.dll!method_call(_object * func=0x0000000003d35b08, _object * arg=0x000000001b786be0, _object * kw=0x0000000000000000)  Line 348    C
    python34.dll!PyObject_Call(_object * func=0x0000000003d35b08, _object * arg=0x000000001b786be0, _object * kw=0x000000001b786be0)  Line 2068 C
    python34.dll!slot_tp_call(_object * self=0x000000001b9f6dd8, _object * args=0x0000000000000000, _object * kwds=0x0000000003934400)  Line 5810   C
    python34.dll!PyObject_Call(_object * func=0x0000000000000000, _object * arg=0x0000000000000001, _object * kw=0x000000001b786be0)  Line 2068 C
    python34.dll!do_call(_object * func=0x0000000000000001, _object * * * pp_stack=0x0000000000a3d629, int na=463433176, int nk=10737208)  Line 4456 + 0xe bytes    C
    python34.dll!call_function(_object * * * pp_stack=0x0000000000a3d629, int oparg=131)  Line 4256 C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x0000000003f61f48, int throwflag=0)  Line 2831  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x0000000000000002, _object * globals=0x0000000000000002, _object * locals=0x0000000000000000, _object * * args=0x000000000000006a, int argcount=2, _object * * kws=0x0000000000bf0060, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes  C
    python34.dll!function_call(_object * func=0x0000000003936378, _object * arg=0x000000001b68ca08, _object * kw=0x0000000000000000)  Line 638 + 0x45 bytes C
    python34.dll!PyObject_Call(_object * func=0x000000001b68ca08, _object * arg=0x000000001b799d48, _object * kw=0x000000001b7869b0)  Line 2068 C
    python34.dll!ext_do_call(_object * func=0x0000000003936378, _object * * * pp_stack=0x0000000000a3d8e9, int flags=460559856, int na=1, int nk=0)  Line 4551 + 0xe bytes  C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x000000001b739448, int throwflag=0)  Line 2872  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x0000000000000001, _object * globals=0x0000000000000001, _object * locals=0x0000000000000000, _object * * args=0x000000005a134950, int argcount=2, _object * * kws=0x0000000000000000, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes  C
    python34.dll!function_call(_object * func=0x00000000039361e0, _object * arg=0x000000001b683108, _object * kw=0x0000000000000000)  Line 638 + 0x45 bytes C
    python34.dll!PyObject_Call(_object * func=0x000000001b683108, _object * arg=0x0000000000000001, _object * kw=0x0000000000103db0)  Line 2068 C
    python34.dll!method_call(_object * func=0x00000000039b1e08, _object * arg=0x000000001b786eb8, _object * kw=0x0000000000000000)  Line 348    C
    python34.dll!PyObject_Call(_object * func=0x00000000039b1e08, _object * arg=0x000000001b786eb8, _object * kw=0x000000001b786eb8)  Line 2068 C
    python34.dll!slot_tp_call(_object * self=0x000000001b9f6fd0, _object * args=0x0000000000000000, _object * kwds=0x0000000003934400)  Line 5810   C
    python34.dll!PyObject_Call(_object * func=0x0000000000000000, _object * arg=0x0000000000000001, _object * kw=0x000000001b786eb8)  Line 2068 C
    python34.dll!do_call(_object * func=0x0000000000000001, _object * * * pp_stack=0x0000000000a3dcb9, int na=463433680, int nk=10738888)  Line 4456 + 0xe bytes    C
    python34.dll!call_function(_object * * * pp_stack=0x0000000000a3dcb9, int oparg=131)  Line 4256 C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x0000000003f626f8, int throwflag=0)  Line 2831  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x0000000000000002, _object * globals=0x0000000000000002, _object * locals=0x0000000000000000, _object * * args=0x000000001b7873c8, int argcount=2, _object * * kws=0x0000000000bf0060, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes  C
    python34.dll!function_call(_object * func=0x0000000003936378, _object * arg=0x000000001b67e188, _object * kw=0x0000000000000000)  Line 638 + 0x45 bytes C
    python34.dll!PyObject_Call(_object * func=0x000000001b67e188, _object * arg=0x000000001b7873c8, _object * kw=0x000000001b786f28)  Line 2068 C
    python34.dll!ext_do_call(_object * func=0x0000000003936378, _object * * * pp_stack=0x0000000000a3df79, int flags=460282256, int na=1, int nk=0)  Line 4551 + 0xe bytes  C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x000000001b6f57e8, int throwflag=0)  Line 2872  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x0000000000000001, _object * globals=0x0000000000000001, _object * locals=0x0000000000000000, _object * * args=0x0000000000000005, int argcount=2, _object * * kws=0x0000000000000000, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes  C
    python34.dll!function_call(_object * func=0x00000000039361e0, _object * arg=0x000000001b67ae88, _object * kw=0x0000000003ab51e0)  Line 638 + 0x45 bytes C
    python34.dll!PyObject_Call(_object * func=0x000000001b67ae88, _object * arg=0x0000000000000001, _object * kw=0x000000000010bea8)  Line 2068 C
    python34.dll!method_call(_object * func=0x0000000003ab4248, _object * arg=0x000000001b786d30, _object * kw=0x0000000000000000)  Line 348    C
    python34.dll!PyObject_Call(_object * func=0x0000000003ab4248, _object * arg=0x000000001b786d30, _object * kw=0x000000001b786d30)  Line 2068 C
    python34.dll!slot_tp_call(_object * self=0x000000001b786f98, _object * args=0x0000000000000000, _object * kwds=0x0000000003ab5048)  Line 5810   C
    python34.dll!PyObject_Call(_object * func=0x0000000000000000, _object * arg=0x0000000000000001, _object * kw=0x000000001b786d30)  Line 2068 C
    python34.dll!do_call(_object * func=0x0000000000000001, _object * * * pp_stack=0x0000000000a3e349, int na=460877720, int nk=10740568)  Line 4456 + 0xe bytes    C
    python34.dll!call_function(_object * * * pp_stack=0x0000000000a3e349, int oparg=131)  Line 4256 C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x0000000003ab5048, int throwflag=0)  Line 2831  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x0000000000000002, _object * globals=0x0000000000000002, _object * locals=0x0000000000000000, _object * * args=0x000000000000006a, int argcount=2, _object * * kws=0x0000000000bf0060, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes  C
    python34.dll!function_call(_object * func=0x0000000003934d08, _object * arg=0x0000000003a8cf08, _object * kw=0x0000000000000000)  Line 638 + 0x45 bytes C
    python34.dll!PyObject_Call(_object * func=0x0000000003a8cf08, _object * arg=0x0000000003ab4408, _object * kw=0x000000000395b278)  Line 2068 C
    python34.dll!ext_do_call(_object * func=0x0000000003934d08, _object * * * pp_stack=0x0000000000a3e609, int flags=61316712, int na=1, int nk=0)  Line 4551 + 0xe bytes   C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x0000000003a79cc0, int throwflag=0)  Line 2872  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x0000000000000001, _object * globals=0x0000000000000001, _object * locals=0x0000000000000000, _object * * args=0x0000000000000004, int argcount=2, _object * * kws=0x0000000000000000, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes  C
    python34.dll!function_call(_object * func=0x00000000037aaae8, _object * arg=0x0000000003a8d1c8, _object * kw=0x0000000003400208)  Line 638 + 0x45 bytes C
    python34.dll!PyObject_Call(_object * func=0x0000000003a8d1c8, _object * arg=0x0000000000000001, _object * kw=0xffffffffff2d45b8)  Line 2068 C
    python34.dll!method_call(_object * func=0x0000000003aa9588, _object * arg=0x0000000002d61780, _object * kw=0x0000000000000000)  Line 348    C
    python34.dll!PyObject_Call(_object * func=0x0000000003aa9588, _object * arg=0x0000000002d61780, _object * kw=0x0000000002d61780)  Line 2068 C
    python34.dll!slot_tp_call(_object * self=0x0000000003aa7710, _object * args=0x0000000000000000, _object * kwds=0x0000000003934400)  Line 5810   C
    python34.dll!PyObject_Call(_object * func=0x0000000000000000, _object * arg=0x0000000000000001, _object * kw=0x0000000002d61780)  Line 2068 C
    python34.dll!do_call(_object * func=0x0000000000000001, _object * * * pp_stack=0x0000000000a3e9d9, int na=61503248, int nk=10742248)  Line 4456 + 0xe bytes C
    python34.dll!call_function(_object * * * pp_stack=0x0000000000a3e9d9, int oparg=131)  Line 4256 C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x0000000003400068, int throwflag=0)  Line 2831  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x0000000000000002, _object * globals=0x0000000000000002, _object * locals=0x0000000000000000, _object * * args=0x00000000025618a0, int argcount=2, _object * * kws=0x0000000000bf0060, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes  C
    python34.dll!function_call(_object * func=0x0000000003936378, _object * arg=0x00000000036e1fc8, _object * kw=0x0000000000000000)  Line 638 + 0x45 bytes C
    python34.dll!PyObject_Call(_object * func=0x00000000036e1fc8, _object * arg=0x0000000003ab4388, _object * kw=0x000000000396bf28)  Line 2068 C
    python34.dll!ext_do_call(_object * func=0x0000000003936378, _object * * * pp_stack=0x0000000000a3ec99, int flags=61315800, int na=1, int nk=0)  Line 4551 + 0xe bytes   C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x0000000003a79930, int throwflag=0)  Line 2872  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x0000000000000001, _object * globals=0x0000000000000001, _object * locals=0x0000000000000000, _object * * args=0x0000000000000005, int argcount=2, _object * * kws=0x0000000000000000, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes  C
    python34.dll!function_call(_object * func=0x00000000039361e0, _object * arg=0x0000000003a8ce48, _object * kw=0x0000000002f037d8)  Line 638 + 0x45 bytes C
    python34.dll!PyObject_Call(_object * func=0x0000000003a8ce48, _object * arg=0x0000000000000001, _object * kw=0xffffffffffecf0a8)  Line 2068 C
    python34.dll!method_call(_object * func=0x00000000032a66c8, _object * arg=0x000000000395bef0, _object * kw=0x0000000000000000)  Line 348    C
    python34.dll!PyObject_Call(_object * func=0x00000000032a66c8, _object * arg=0x000000000395bef0, _object * kw=0x000000000395bef0)  Line 2068 C
    python34.dll!slot_tp_call(_object * self=0x0000000002d61748, _object * args=0x0000000000000000, _object * kwds=0x0000000000000000)  Line 5810   C
    python34.dll!PyObject_Call(_object * func=0x0000000000000000, _object * arg=0x0000000000000001, _object * kw=0x000000000395bef0)  Line 2068 C
    python34.dll!do_call(_object * func=0x0000000000000001, _object * * * pp_stack=0x0000000000a3f069, int na=47585096, int nk=10743928)  Line 4456 + 0xe bytes C
    python34.dll!call_function(_object * * * pp_stack=0x0000000000a3f069, int oparg=131)  Line 4256 C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x0000000002f03628, int throwflag=10744424)  Line 2831   C
    python34.dll!fast_function(_object * func=0x0000000000000002, _object * * * pp_stack=0x0000000003aa75f8, int n=59998824, int na=1511398972, int nk=0)  Line 4325    C
    python34.dll!call_function(_object * * * pp_stack=0x0000000000a3f259, int oparg=131)  Line 4253 C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x00000000037acda0, int throwflag=10744920)  Line 2831   C
    python34.dll!fast_function(_object * func=0x0000000000000001, _object * * * pp_stack=0x0000000002db7eb8, int n=59999776, int na=1511399033, int nk=0)  Line 4325    C
    python34.dll!call_function(_object * * * pp_stack=0x0000000000a3f449, int oparg=131)  Line 4253 C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x0000000003340cc8, int throwflag=0)  Line 2831  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x000000000000000c, _object * globals=0x0000000000000001, _object * locals=0x0000000000000006, _object * * args=0x00000000037f67b8, int argcount=1, _object * * kws=0x0000000002fcfc90, int kwcount=6, _object * * defs=0x00000000037ba6c0, int defcount=11, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes C
    python34.dll!function_call(_object * func=0x00000000037f67b8, _object * arg=0x00000000036e57f0, _object * kw=0x0000000000000010)  Line 638 + 0x45 bytes C
    python34.dll!PyObject_Call(_object * func=0x00000000036e57f0, _object * arg=0x00000000036efb88, _object * kw=0x0000000000000000)  Line 2068 C
    python34.dll!ext_do_call(_object * func=0x00000000037f67b8, _object * * * pp_stack=0x0000000000a3f709, int flags=48826824, int na=1, int nk=5)  Line 4551 + 0xe bytes   C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x0000000002e90778, int throwflag=0)  Line 2872  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x000000000000000c, _object * globals=0x0000000000000001, _object * locals=0x0000000000000000, _object * * args=0x000000005a1d3241, int argcount=1, _object * * kws=0x0000000000000000, int kwcount=0, _object * * defs=0x0000000003938390, int defcount=11, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes C
    python34.dll!function_call(_object * func=0x00000000039382f0, _object * arg=0x0000000002d80208, _object * kw=0x0000000000000000)  Line 638 + 0x45 bytes C
    python34.dll!PyObject_Call(_object * func=0x0000000002d80208, _object * arg=0x0000000000000000, _object * kw=0x0000000000bf0048)  Line 2068 C
    python34.dll!method_call(_object * func=0x00000000024bfe08, _object * arg=0x0000000000bf0048, _object * kw=0x0000000000000000)  Line 348    C
    python34.dll!PyObject_Call(_object * func=0x0000000000000000, _object * arg=0x0000000000bf0048, _object * kw=0x0000000000bf0048)  Line 2068 C
    python34.dll!slot_tp_init(_object * self=0x0000000002db7eb8, _object * args=0x0000000000000000, _object * kwds=0x0000000000000000)  Line 6024   C
    python34.dll!type_call(_typeobject * type=0x0000000003456a38, _object * args=0x0000000000bf0048, _object * kwds=0x0000000000000000)  Line 870   C
    python34.dll!PyObject_Call(_object * func=0x0000000000000000, _object * arg=0x0000000000000000, _object * kw=0x0000000000bf0048)  Line 2068 C
    python34.dll!do_call(_object * func=0x0000000000000000, _object * * * pp_stack=0x0000000000a3fb09, int na=54880824, int nk=10746648)  Line 4456 + 0xe bytes C
    python34.dll!call_function(_object * * * pp_stack=0x0000000000a3fb09, int oparg=131)  Line 4256 C
    python34.dll!PyEval_EvalFrameEx(_frame * f=0x00000000024c2438, int throwflag=0)  Line 2831  C
    python34.dll!PyEval_EvalCodeEx(_object * _co=0x0000000000000000, _object * globals=0x0000000000000000, _object * locals=0x000000000250a810, _object * * args=0x0000000002561620, int argcount=0, _object * * kws=0x0000000000000000, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * kwdefs=0x0000000000000000, _object * closure=0x0000000000000000)  Line 3578 + 0xa bytes  C
    python34.dll!PyEval_EvalCode(_object * co=0x0000000002d75350, _object * globals=0x0000000002de76e0, _object * locals=0x00000000024bd9c8)  Line 779  C
    python34.dll!run_mod(_mod * mod=0x0000000002d75350, _object * filename=0x0000000002dc4260, _object * globals=0x0000000002dc4260, _object * locals=0x0000000000000000, PyCompilerFlags * flags=0x0000000000a3fed0, _arena * arena=0x0000000002dc4260)  Line 2181 C
    python34.dll!PyRun_FileExFlags(_iobuf * fp=0x00000000024dcbe1, const char * filename_str=0x00000000024dcbe0, int start=-1, _object * globals=0x00000000024c0c28, _object * locals=0x00000000024bd9c8, int closeit=1, PyCompilerFlags * flags=0x0000000000a3fed0)  Line 2133 + 0x20 bytes    C
    python34.dll!PyRun_SimpleFileExFlags(_iobuf * fp=0x0000000000a3fed0, const char * filename=0x00000000024dcbe0, int closeit=10747600, PyCompilerFlags * flags=0x0000000000a3fed0)  Line 1607 + 0x2b bytes    C
    python34.dll!PyRun_AnyFileExFlags(_iobuf * fp=0x00000000024dcbc0, const char * filename=0x0000000002552946, int closeit=0, PyCompilerFlags * flags=0x0000000002552946)  Line 1293   C
    python34.dll!run_file(_iobuf * fp=0x00000000ffffffff, const wchar_t * filename=0x0000000000000000, PyCompilerFlags * p_cf=0x0000000000000000)  Line 319 + 0x18 bytes    C
    python34.dll!Py_Main(int argc=0, unsigned short * * argv=0x000000a900000000)  Line 751 + 0x15 bytes C
    python.exe!__tmainCRTStartup()  Line 552 + 0x19 bytes   C
    kernel32.dll!BaseThreadInitThunk()  + 0xd bytes 
    ntdll.dll!RtlUserThreadStart()  + 0x1d bytes    
```
