### PR TITLE
Mention that Image.tostring() is deprecated

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -664,6 +664,10 @@ class Image:
 
     # Declare tostring as alias to tobytes
     def tostring(self, *args, **kw):
+        """Deprecated alias to tobytes.
+
+        .. deprecated:: 2.0
+        """
         warnings.warn(
             'tostring() is deprecated. Please call tobytes() instead.',
             DeprecationWarning,


### PR DESCRIPTION
This mirrors the deprecation notice in the docstring of fromstring().

I'm assuming that tostring() and fromstring() were both deprecated at the same time (Pillow 2.0); I haven't gone out of my way to verify that assumption.
