### PR TITLE
Fix for PR #915, keep track of the qtables length

### DIFF
--- a/encode.c
+++ b/encode.c
@@ -535,7 +535,7 @@ PyImaging_ZipEncoderNew(PyObject* self, PyObject* args)
 
 #include "Jpeg.h"
 
-static unsigned int** get_qtables_arrays(PyObject* qtables) {
+static unsigned int** get_qtables_arrays(PyObject* qtables, int* qtablesLen) {
     PyObject* tables;
     PyObject* table;
     PyObject* table_data;
@@ -588,6 +588,7 @@ static unsigned int** get_qtables_arrays(PyObject* qtables) {
     }
 
     Py_DECREF(tables);
+    *qtablesLen = num_tables; 
 
     if (PyErr_Occurred()) {
         PyMem_Free(qarrays);
@@ -614,6 +615,7 @@ PyImaging_JpegEncoderNew(PyObject* self, PyObject* args)
     int subsampling = -1; /* -1=default, 0=none, 1=medium, 2=high */
     PyObject* qtables=NULL;
     unsigned int **qarrays = NULL;
+    int qtablesLen = 0;
     char* extra = NULL;
     int extra_size;
     char* rawExif = NULL;
@@ -633,7 +635,7 @@ PyImaging_JpegEncoderNew(PyObject* self, PyObject* args)
     if (get_packer(encoder, mode, rawmode) < 0)
         return NULL;
 
-    qarrays = get_qtables_arrays(qtables);
+    qarrays = get_qtables_arrays(qtables, &qtablesLen);
 
     if (extra && extra_size > 0) {
         char* p = malloc(extra_size);
@@ -657,6 +659,7 @@ PyImaging_JpegEncoderNew(PyObject* self, PyObject* args)
 
     ((JPEGENCODERSTATE*)encoder->state.context)->quality = quality;
     ((JPEGENCODERSTATE*)encoder->state.context)->qtables = qarrays;
+    ((JPEGENCODERSTATE*)encoder->state.context)->qtablesLen = qtablesLen;
     ((JPEGENCODERSTATE*)encoder->state.context)->subsampling = subsampling;
     ((JPEGENCODERSTATE*)encoder->state.context)->progressive = progressive;
     ((JPEGENCODERSTATE*)encoder->state.context)->smooth = smooth;

--- a/libImaging/Jpeg.h
+++ b/libImaging/Jpeg.h
@@ -90,6 +90,7 @@ typedef struct {
 
     /* Custom quantization tables () */
     unsigned int **qtables;
+    int qtablesLen;
 
     /* Extra data (to be injected after header) */
     char* extra; int extra_size;

--- a/libImaging/JpegEncode.c
+++ b/libImaging/JpegEncode.c
@@ -151,7 +151,7 @@ ImagingJpegEncode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
 	    if (context->quality > 0) {
 		quality = context->quality;
 	    }
-	    for (i = 0; i < sizeof(context->qtables)/sizeof(unsigned int *); i++) {
+	    for (i = 0; i < context->qtablesLen; i++) {
 		// TODO: Should add support for none baseline
 		jpeg_add_quant_table(&context->cinfo, i, context->qtables[i],
 				     quality, TRUE);


### PR DESCRIPTION
Keep track of the qtables length, Don't try to calculate it in a way that doesn't work with dynamically allocated arrays.
