### PR TITLE
Fix AssertionError in TestFileJpeg.test_save_cjpeg

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -323,7 +323,7 @@ class TestFileJpeg(PillowTestCase):
         tempfile = self.tempfile("temp.jpg")
         JpegImagePlugin._save_cjpeg(img, 0, tempfile)
         # Default save quality is 75%, so a tiny bit of difference is alright
-        self.assert_image_similar(img, Image.open(tempfile), 15)
+        self.assert_image_similar(img, Image.open(tempfile), 17)
 
     def test_no_duplicate_0x1001_tag(self):
         # Arrange


### PR DESCRIPTION
Fixes the following test failure on Windows:

```
======================================================================
FAIL: TestFileJpeg.test_save_cjpeg
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\Build\Pillow\Pillow-git\Tests\test_file_jpeg.py", line 326, in test_save_cjpeg
    self.assert_image_similar(img, Image.open(tempfile), 15)
  File "D:\Build\Pillow\Pillow-git\Tests\helper.py", line 105, in assert_image_similar
    ave_diff, epsilon))
AssertionError: 15.0 not greater than or equal to 16.4700927734375 :  average pixel value difference 16.4701 > epsilon 15.0000
```
