### PR TITLE
Fix compiling with FreeType 2.5.1

### DIFF
--- a/_imagingft.c
+++ b/_imagingft.c
@@ -70,7 +70,11 @@ struct {
     const char* message;
 } ft_errors[] =
 
+#if defined(USE_FREETYPE_2_1)
+#include FT_ERRORS_H
+#else
 #include <freetype/fterrors.h>
+#endif
 
 /* -------------------------------------------------------------------- */
 /* font objects */


### PR DESCRIPTION
Same as c6040f618 but for the 1.x branch.
