### PR TITLE
Add Landscape config and badge

### DIFF
--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -1,0 +1,2 @@
+strictness: medium
+test-warnings: yes

--- a/README.rst
+++ b/README.rst
@@ -19,3 +19,8 @@ Pillow is the "friendly" PIL fork by `Alex Clark and Contributors <https://githu
 
 .. image:: https://coveralls.io/repos/python-pillow/Pillow/badge.png?branch=master
   :target: https://coveralls.io/r/python-pillow/Pillow?branch=master
+   :alt: Code coverage
+
+.. image:: https://landscape.io/github/python-pillow/Pillow/master/landscape.png
+   :target: https://landscape.io/github/python-pillow/Pillow/master
+   :alt: Code health


### PR DESCRIPTION
Landscape is working now so here's a badge and a config file to be getting started with. We can tailor it as needed. Currently the strictness is set to `medium`, but we can upgrade to `high` or `veryhigh`.

`medium`: 75%
106 errors
765 smells
293 style
https://landscape.io/github/hugovk/Pillow/78

`high`: 51%
191 errors
1184 smells
4781 style
https://landscape.io/github/hugovk/Pillow/80

`veryhigh`: 48%
219 errors
1218 smells
5262 style
https://landscape.io/github/hugovk/Pillow/81

Closes #895.
