### PR TITLE
Remove unused variable in libImaging

### DIFF
--- a/libImaging/Draw.c
+++ b/libImaging/Draw.c
@@ -600,7 +600,6 @@ ImagingDrawWideLine(Imaging im, int x0, int y0, int x1, int y1,
     double big_hypotenuse, small_hypotenuse, ratio_max, ratio_min;
     int dxmin, dxmax, dymin, dymax;
     Edge e[4];
-    int vertices[4][2];
 
     DRAWINIT();
 


### PR DESCRIPTION
Building on Mac OS X 10.9.5, the following warning is generated.

```
libImaging/Draw.c:603:9: warning: unused variable 'vertices' [-Wunused-variable]
int vertices[4][2];
    ^
```
