### PR TITLE
Workaround Pypy regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,6 @@ after_success:
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then Scripts/diffcover-run.sh; fi
 
 matrix:
-  - fast_finish: true
-  - allow_failures:
-     - python: pypy
+  fast_finish: true
+  allow_failures:
+   - python: pypy


### PR DESCRIPTION
There's a regression in the latest PyPy (2.4.0) which causes test failures (see #952) so allow it to fail.

Explicitly add the previous PyPy 2.3.1 so we still get useful results. 

(List of Travis CI's supported Python versions: https://github.com/travis-ci/travis-cookbooks/blob/master/ci_environment/python/attributes/default.rb )
