### PR TITLE
Fix bicubic stretch interpolation

### DIFF
--- a/Tests/test_imaging_stretch.py
+++ b/Tests/test_imaging_stretch.py
@@ -1,0 +1,40 @@
+"""
+Tests for ImagingCore.stretch functionality.
+"""
+
+from helper import unittest, PillowTestCase
+
+from PIL import Image
+
+
+im = Image.open("Tests/images/hopper.ppm").copy()
+
+
+class TestImagingStretch(PillowTestCase):
+
+    def test_modes(self):
+        self.assertRaises(ValueError, im.convert("1").im.stretch,
+                          (15, 12), Image.ANTIALIAS)
+        self.assertRaises(ValueError, im.convert("P").im.stretch,
+                          (15, 12), Image.ANTIALIAS)
+        for mode in ["L", "I", "F", "RGB", "RGBA", "CMYK", "YCbCr"]:
+            s = im.convert(mode).im
+            r = s.stretch((15, 12), Image.ANTIALIAS)
+            self.assertEqual(r.mode, mode)
+            self.assertEqual(r.size, (15, 12))
+            self.assertEqual(r.bands, s.bands)
+
+    def test_reduce_filters(self):
+        # There is no Image.NEAREST because im.stretch implementation
+        # is not NEAREST for reduction. It should be removed
+        # or renamed to supersampling.
+        for f in [Image.BILINEAR, Image.BICUBIC, Image.ANTIALIAS]:
+            r = im.im.stretch((15, 12), f)
+            self.assertEqual(r.mode, "RGB")
+            self.assertEqual(r.size, (15, 12))
+
+    def test_enlarge_filters(self):
+        for f in [Image.BILINEAR, Image.BICUBIC, Image.ANTIALIAS]:
+            r = im.im.stretch((764, 414), f)
+            self.assertEqual(r.mode, "RGB")
+            self.assertEqual(r.size, (764, 414))

--- a/libImaging/Antialias.c
+++ b/libImaging/Antialias.c
@@ -95,6 +95,9 @@ ImagingStretch(Imaging imOut, Imaging imIn, int filter)
     if (!imOut || !imIn || strcmp(imIn->mode, imOut->mode) != 0)
         return (Imaging) ImagingError_ModeError();
 
+    if (strcmp(imIn->mode, "P") == 0 || strcmp(imIn->mode, "1") == 0)
+        return (Imaging) ImagingError_ModeError();
+
     /* check filter */
     switch (filter) {
     case IMAGING_TRANSFORM_NEAREST:


### PR DESCRIPTION
This fixes incorrect result for Bicubic interpolation in `im.stretch`, discovered by me in comment: https://github.com/python-pillow/Pillow/issues/964#issuecomment-59974608

The error was in line: https://github.com/python-pillow/Pillow/blob/master/libImaging/Antialias.c#L76
Third item was `8*x` while should be `8*a*x` (see [there](http://en.wikipedia.org/wiki/Bicubic_interpolation#Bicubic_convolution_algorithm)).

Scale down before and after PR:
![small down b](https://cloud.githubusercontent.com/assets/128982/4767357/e1af74ca-5b5c-11e4-9a05-0457807464d0.jpg)
![small down](https://cloud.githubusercontent.com/assets/128982/4767358/e1d73a00-5b5c-11e4-9d3c-250f0961cf71.jpg)

Scale up before and after PR:
![small up bc](https://cloud.githubusercontent.com/assets/128982/4779270/319847c4-5c24-11e4-92a4-ff8d03bc020d.jpg)
![small up bc](https://cloud.githubusercontent.com/assets/128982/4779273/454e789c-5c24-11e4-994a-8aab2ee73038.jpg)

Source code

``` python
# original image
image = Image.open('small.jpg').copy()
image._new(image.im.stretch((117, 77), Image.BICUBIC)).save('small.down.jpg', quality=100)
# make a small copy to enlarge it
image = image.resize((117, 77), Image.ANTIALIAS)
image._new(image.im.stretch((586, 387), Image.BICUBIC)).save('small.up.jpg', quality=100)
```
