### PR TITLE
Add Ubuntu 14.04 prerequisites to docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -127,6 +127,11 @@ Prerequisites are installed with on **Ubuntu 12.04 LTS** or **Raspian Wheezy
     $ sudo apt-get install libtiff4-dev libjpeg8-dev zlib1g-dev \
         libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python-tk
 
+Prerequisites are installed with on **Ubuntu 14.04 LTS** with::
+
+    $ sudo apt-get install libtiff4-dev libjpeg8-dev zlib1g-dev \
+        libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python-tk
+
 Prerequisites are installed on **Fedora 20** with::
 
     $ sudo yum install libtiff-devel libjpeg-devel libzip-devel freetype-devel \


### PR DESCRIPTION
Replaces `tcl8.5-dev` and `tk8.5-dev` with `tcl8.6-dev` and `tk8.6-dev` for 14.04.
