### PR TITLE
The optimization algorithm is only applicable to the image of mode="P" or "L".

### DIFF
--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -433,7 +433,7 @@ def getheader(im, palette=None, info=None):
 
     usedPaletteColors = paletteBytes = None
 
-    if optimize:
+    if im.mode in ("P", "L") and optimize:
         usedPaletteColors = []
 
         # check which colors are used

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -28,13 +28,22 @@ class TestFileGif(PillowTestCase):
     def test_optimize(self):
         from io import BytesIO
 
-        def test(optimize):
+        def test_grayscale(optimize):
             im = Image.new("L", (1, 1), 0)
             file = BytesIO()
             im.save(file, "GIF", optimize=optimize)
             return len(file.getvalue())
-        self.assertEqual(test(0), 800)
-        self.assertEqual(test(1), 38)
+
+        def test_bilevel(optimize):
+            im = Image.new("1", (1, 1), 0)
+            file = BytesIO()
+            im.save(file, "GIF", optimize=optimize)
+            return len(file.getvalue())
+
+        self.assertEqual(test_grayscale(0), 800)
+        self.assertEqual(test_grayscale(1), 38)
+        self.assertEqual(test_bilevel(0), 800)
+        self.assertEqual(test_bilevel(1), 800)
 
     def test_optimize_full_l(self):
         from io import BytesIO


### PR DESCRIPTION
(This issue was previously addressed as #991 )

The optimization algorithm used in getheader() assumes the image data is 8bpp and therefore it cannot be applied to the bi-level'ed image which is also supported by the GIF plugin.  It is of course possible to support optimization for such images, but it would need a specific hack around the unpacker and I don't think it is appropriate.
