### PR TITLE
add ico save support

### DIFF
--- a/PIL/IcoImagePlugin.py
+++ b/PIL/IcoImagePlugin.py
@@ -25,10 +25,7 @@
 __version__ = "0.1"
 
 import struct
-try:
-    from io import BytesIO
-except ImportError:
-    from cStringIO import StringIO as BytesIO
+from io import BytesIO
 
 from PIL import Image, ImageFile, BmpImagePlugin, PngImagePlugin, _binary
 from math import log, ceil
@@ -51,7 +48,7 @@ def _save(im, fp, filename):
     width, height = im.size
     filter(lambda x: False if (x[0] > width or x[1] > height or
                                x[0] > 255 or x[1] > 255) else True, sizes)
-    sizes = sorted(sizes, key=lambda x: x[0], reverse=True)
+    sizes = sorted(sizes, key=lambda x: x[0])
     fp.write(struct.pack("H", len(sizes)))  # idCount(2)
     offset = fp.tell() + len(sizes)*16
     for size in sizes:
@@ -64,8 +61,9 @@ def _save(im, fp, filename):
         fp.write(struct.pack("H", 32))  # wBitCount(2)
 
         image_io = BytesIO()
-        im.thumbnail(size, Image.ANTIALIAS)
-        im.save(image_io, "png")
+        tmp = im.copy()
+        tmp.thumbnail(size, Image.ANTIALIAS)
+        tmp.save(image_io, "png")
         image_io.seek(0)
         image_bytes = image_io.read()
         bytes_len = len(image_bytes)

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -1,5 +1,6 @@
-from helper import unittest, PillowTestCase
+from helper import unittest, PillowTestCase, hopper
 
+import io
 from PIL import Image
 
 # sample ppm stream
@@ -15,6 +16,18 @@ class TestFileIco(PillowTestCase):
         self.assertEqual(im.mode, "RGBA")
         self.assertEqual(im.size, (16, 16))
         self.assertEqual(im.format, "ICO")
+
+    def test_save_to_bytes(self):
+        output = io.BytesIO()
+        im = hopper()
+        im.save(output, "ico", sizes=[(32, 32), (64, 64)])
+
+        output.seek(0)
+        reloaded = Image.open(output)
+
+        self.assertEqual(im.mode, reloaded.mode)
+        self.assertEqual((64, 64), reloaded.size)
+        self.assertEqual(reloaded.format, "ICO")
 
 
 if __name__ == '__main__':

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -589,6 +589,14 @@ ICO
 
 ICO is used to store icons on Windows. The largest available icon is read.
 
+The :py:meth:`~PIL.Image.Image.save` method supports the following options:
+
+**sizes**
+    A list of sizes including in this ico file; these are a 2-tuple,
+    ``(width, height)``; Default to ``[(16, 16), (24, 24), (32, 32), (48, 48),
+    (64, 64), (128, 128), (255, 255)]``. Any size is bigger then the original
+    size or 255 will be ignored.
+
 ICNS
 ^^^^
 


### PR DESCRIPTION
Add ico save support (png)
- all images are stored as png
- params: sizes, e.g. [(16, 16), (24, 24)]
