### PR TITLE
Added ref to getpalette

### DIFF
--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -116,6 +116,7 @@ ITU-R 709, using the D65 luminant) to the CIE XYZ color space:
 .. automethod:: PIL.Image.Image.getcolors
 .. automethod:: PIL.Image.Image.getdata
 .. automethod:: PIL.Image.Image.getextrema
+.. automethod:: PIL.Image.Image.getpalette
 .. automethod:: PIL.Image.Image.getpixel
 .. automethod:: PIL.Image.Image.histogram
 .. automethod:: PIL.Image.Image.offset


### PR DESCRIPTION
`Image.getpalette` was missing docs. #999 
