### PR TITLE
Fix Antialias compilation on debug versions of python

### DIFF
--- a/libImaging/Antialias.c
+++ b/libImaging/Antialias.c
@@ -93,9 +93,8 @@ static inline UINT8 clip8(float in)
 /* This is work around bug in GCC prior 4.9 in 64 bit mode.
    GCC generates code with partial dependency which 3 times slower.
    See: http://stackoverflow.com/a/26588074/253146 */
-#if defined(__x86_64__) && defined(__SSE__) && \
-    ! defined(__clang__) && defined(GCC_VERSION) && (GCC_VERSION < 40900) && \
-    ! defined(Py_DEBUG)
+#if defined(__x86_64__) && defined(__SSE__) &&  ! defined(__NO_INLINE__) && \
+    ! defined(__clang__) && defined(GCC_VERSION) && (GCC_VERSION < 40900)
 static float __attribute__((always_inline)) i2f(int v) {
     float x;
     __asm__("xorps %0, %0; cvtsi2ss %1, %0" : "=X"(x) : "r"(v) );


### PR DESCRIPTION
```
...
gcc -pthread -g -O0 -Wall -Wstrict-prototypes -g -O0 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_OPENJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/usr/local/include/openjpeg-2.0 -I/home/erics/Pillow/libImaging -I/home/erics/vpy32-dbg/include -I/usr/local/include -I/usr/include -I/usr/include/python3.2dmu -I/usr/include/x86_64-linux-gnu -c libImaging/Antialias.c -o build/temp.linux-x86_64-3.2-pydebug/libImaging/Antialias.o
libImaging/Antialias.c: Assembler messages:
libImaging/Antialias.c:100: Error: operand type mismatch for `xorps'
libImaging/Antialias.c:100: Error: operand type mismatch for `cvtsi2ss'
libImaging/Antialias.c:100: Error: operand type mismatch for `xorps'
libImaging/Antialias.c:100: Error: operand type mismatch for `cvtsi2ss'
libImaging/Antialias.c:100: Error: operand type mismatch for `xorps'
...
```

I'm getting this error on python 3.2-dbg, which is the version on my Ubuntu 12.04 install that makes it easy to hack with gdb. Disabling the x64 optimization in debug builds fixes the build. 

@homm -- can you check this to make sure that it's correct/reasonable.
