### PR TITLE
Libtiff save in io.BytesIO

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -54,6 +54,7 @@ import sys
 import collections
 import itertools
 import os
+import io
 
 # Set these to true to force use of libtiff for reading or writing.
 READ_LIBTIFF = False
@@ -1128,7 +1129,6 @@ def _save(im, fp, filename):
             print (ifd.items())
         _fp = 0
         if hasattr(fp, "fileno"):
-            import io
             try:
                 fp.seek(0)
                 _fp = os.dup(fp.fileno())

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -326,33 +326,6 @@ class TestFileTiff(PillowTestCase):
         # Should not divide by zero
         im.save(outfile)
 
-    def test_save_bytesio(self):
-        # PR 1011
-        # Test TIFF saving to io.BytesIO() object.
-        
-        # Generate test image
-        pilim = Image.new('F', (100, 100), 0)
-        def save_bytesio(compression=None):
-            import io
-            
-            testfile = self.tempfile("temp_.tiff".format(compression))
-                        
-            buffer_io = io.BytesIO()
-            pilim.save(buffer_io, format="tiff", compression=compression)
-            buffer_io.seek(0)
-            data = buffer_io.read()
-            buffer_io.close()
-
-            with open(testfile, "wb") as fd:
-                fd.write(data)
-
-            pilim_load = Image.open(testfile)
-            self.assert_image_similar(pilim, pilim_load, 0)
-        
-        # save_bytesio()
-        save_bytesio("packbits")
-        save_bytesio("tiff_lzw")
-        
         
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Minor changes to PR #1011.
- Moved test to different file, used standard test image instead of blank F mode image. 
- Hoisted imports. 
