### PR TITLE
Rename Image.ANTIALIAS into Image.LANCZOS

### DIFF
--- a/PIL/IcoImagePlugin.py
+++ b/PIL/IcoImagePlugin.py
@@ -62,7 +62,7 @@ def _save(im, fp, filename):
 
         image_io = BytesIO()
         tmp = im.copy()
-        tmp.thumbnail(size, Image.ANTIALIAS)
+        tmp.thumbnail(size, Image.LANCZOS)
         tmp.save(image_io, "png")
         image_io.seek(0)
         image_bytes = image_io.read()

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -162,11 +162,10 @@ QUAD = 3
 MESH = 4
 
 # resampling filters
-NONE = 0
-NEAREST = 0
-ANTIALIAS = 1  # 3-lobed lanczos
-LINEAR = BILINEAR = 2
-CUBIC = BICUBIC = 3
+NEAREST = NONE = 0
+LANCZOS = ANTIALIAS = 1
+BILINEAR = LINEAR = 2
+BICUBIC = CUBIC = 3
 
 # dithers
 NONE = 0
@@ -1525,13 +1524,13 @@ class Image:
            one of :py:attr:`PIL.Image.NEAREST` (use nearest neighbour),
            :py:attr:`PIL.Image.BILINEAR` (linear interpolation),
            :py:attr:`PIL.Image.BICUBIC` (cubic spline interpolation), or
-           :py:attr:`PIL.Image.ANTIALIAS` (a high-quality downsampling filter).
+           :py:attr:`PIL.Image.LANCZOS` (a high-quality downsampling filter).
            If omitted, or if the image has mode "1" or "P", it is
            set :py:attr:`PIL.Image.NEAREST`.
         :returns: An :py:class:`~PIL.Image.Image` object.
         """
 
-        if resample not in (NEAREST, BILINEAR, BICUBIC, ANTIALIAS):
+        if resample not in (NEAREST, BILINEAR, BICUBIC, LANCZOS):
             raise ValueError("unknown resampling filter")
 
         self.load()
@@ -1753,7 +1752,7 @@ class Image:
         """
         return 0
 
-    def thumbnail(self, size, resample=ANTIALIAS):
+    def thumbnail(self, size, resample=LANCZOS):
         """
         Make this image into a thumbnail.  This method modifies the
         image to contain a thumbnail version of itself, no larger than
@@ -1770,8 +1769,8 @@ class Image:
         :param size: Requested size.
         :param resample: Optional resampling filter.  This can be one
            of :py:attr:`PIL.Image.NEAREST`, :py:attr:`PIL.Image.BILINEAR`,
-           :py:attr:`PIL.Image.BICUBIC`, or :py:attr:`PIL.Image.ANTIALIAS`.
-           If omitted, it defaults to :py:attr:`PIL.Image.ANTIALIAS`.
+           :py:attr:`PIL.Image.BICUBIC`, or :py:attr:`PIL.Image.LANCZOS`.
+           If omitted, it defaults to :py:attr:`PIL.Image.LANCZOS`.
            (was :py:attr:`PIL.Image.NEAREST` prior to version 2.5.0)
         :returns: None
         """

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -77,7 +77,7 @@ class TestFileGif(PillowTestCase):
         im = Image.open(TEST_GIF)
         im = im.convert('RGB')
 
-        im = im.resize((100, 100), Image.ANTIALIAS)
+        im = im.resize((100, 100), Image.LANCZOS)
         im2 = im.convert('P', palette=Image.ADAPTIVE, colors=256)
 
         f = self.tempfile('temp.gif')

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -30,7 +30,7 @@ class TestFileIco(PillowTestCase):
         self.assertEqual(im.mode, reloaded.mode)
         self.assertEqual((64, 64), reloaded.size)
         self.assertEqual(reloaded.format, "ICO")
-        self.assert_image_equal(reloaded, hopper().resize((64,64), Image.ANTIALIAS))
+        self.assert_image_equal(reloaded, hopper().resize((64,64), Image.LANCZOS))
 
         # the other one
         output.seek(0)
@@ -40,9 +40,9 @@ class TestFileIco(PillowTestCase):
         self.assertEqual(im.mode, reloaded.mode)
         self.assertEqual((32, 32), reloaded.size)
         self.assertEqual(reloaded.format, "ICO")
-        self.assert_image_equal(reloaded, hopper().resize((32,32), Image.ANTIALIAS))
-        
-        
+        self.assert_image_equal(reloaded, hopper().resize((32,32), Image.LANCZOS))
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -39,13 +39,13 @@ class TestImagingCoreResize(PillowTestCase):
             self.assertEqual(r.im.bands, im.im.bands)
 
     def test_reduce_filters(self):
-        for f in [Image.LINEAR, Image.BILINEAR, Image.BICUBIC, Image.ANTIALIAS]:
+        for f in [Image.LINEAR, Image.BILINEAR, Image.BICUBIC, Image.LANCZOS]:
             r = self.resize(hopper("RGB"), (15, 12), f)
             self.assertEqual(r.mode, "RGB")
             self.assertEqual(r.size, (15, 12))
 
     def test_enlarge_filters(self):
-        for f in [Image.LINEAR, Image.BILINEAR, Image.BICUBIC, Image.ANTIALIAS]:
+        for f in [Image.LINEAR, Image.BILINEAR, Image.BICUBIC, Image.LANCZOS]:
             r = self.resize(hopper("RGB"), (212, 195), f)
             self.assertEqual(r.mode, "RGB")
             self.assertEqual(r.size, (212, 195))
@@ -64,7 +64,7 @@ class TestImagingCoreResize(PillowTestCase):
         }
         samples['dirty'].putpixel((1, 1), 128)
 
-        for f in [Image.LINEAR, Image.BILINEAR, Image.BICUBIC, Image.ANTIALIAS]:
+        for f in [Image.LINEAR, Image.BILINEAR, Image.BICUBIC, Image.LANCZOS]:
             # samples resized with current filter
             references = dict(
                 (name, self.resize(ch, (4, 4), f))

--- a/docs/handbook/concepts.rst
+++ b/docs/handbook/concepts.rst
@@ -100,7 +100,7 @@ pixel, the Python Imaging Library provides four different resampling *filters*.
     For other transformations cubic interpolation over a 4x4 environment
     in the input image is used.
 
-``ANTIALIAS``
+``LANCZOS``
     Calculate the output pixel value using a high-quality Lanczos filter (a
     truncated sinc) on all pixels that may contribute to the output value. In
     the current version of PIL, this filter can only be used with the resize

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -41,7 +41,7 @@ Create thumbnails
     for infile in glob.glob("*.jpg"):
         file, ext = os.path.splitext(infile)
         im = Image.open(infile)
-        im.thumbnail(size, Image.ANTIALIAS)
+        im.thumbnail(size)
         im.save(file + ".thumbnail", "JPEG")
 
 Functions

--- a/libImaging/Imaging.h
+++ b/libImaging/Imaging.h
@@ -229,7 +229,7 @@ extern void ImagingError_Clear(void);
 
 /* standard filters */
 #define IMAGING_TRANSFORM_NEAREST 0
-#define IMAGING_TRANSFORM_ANTIALIAS 1
+#define IMAGING_TRANSFORM_LANCZOS 1
 #define IMAGING_TRANSFORM_BILINEAR 2
 #define IMAGING_TRANSFORM_BICUBIC 3
 

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -30,15 +30,15 @@ static inline float sinc_filter(float x)
     return sin(x) / x;
 }
 
-static inline float antialias_filter(float x)
+static inline float lanczos_filter(float x)
 {
-    /* lanczos (truncated sinc) */
+    /* truncated sinc */
     if (-3.0 <= x && x < 3.0)
         return sinc_filter(x) * sinc_filter(x/3);
     return 0.0;
 }
 
-static struct filter ANTIALIAS = { antialias_filter, 3.0 };
+static struct filter LANCZOS = { lanczos_filter, 3.0 };
 
 static inline float bilinear_filter(float x)
 {
@@ -108,8 +108,8 @@ ImagingResampleHorizontal(Imaging imIn, int xsize, int filter)
 
     /* check filter */
     switch (filter) {
-    case IMAGING_TRANSFORM_ANTIALIAS:
-        filterp = &ANTIALIAS;
+    case IMAGING_TRANSFORM_LANCZOS:
+        filterp = &LANCZOS;
         break;
     case IMAGING_TRANSFORM_BILINEAR:
         filterp = &BILINEAR;


### PR DESCRIPTION
When `Image.ANTIALIAS` was initially added, it was the only high-quality filter based on convolutions. Its name was supposed to say that.

Starting from Pillow 2.7 all resize method are based on convolutions. No more difference between them except filters. And filter names are "bilinear", "bicubic", "lanczos". Not "antialias", because all of them are antialias from now.

Of course we should leave `ANTIALIAS` constant for backward compatibility and make it an alias (sorry for this pun).