### PR TITLE
Do not quit Python if numpy is not installed

### DIFF
--- a/Tests/large_memory_numpy_test.py
+++ b/Tests/large_memory_numpy_test.py
@@ -14,7 +14,7 @@ from PIL import Image
 try:
     import numpy as np
 except:
-    sys.exit("Skipping: Numpy not installed")
+    raise unittest.SkipTest("numpy not installed")
 
 YDIM = 32769
 XDIM = 48000


### PR DESCRIPTION
Allows `nosetests Tests` to finish if numpy is not installed. Tested on pypy for Windows.
