### PR TITLE
Run OS X tests after successful Linux build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,13 +55,17 @@ after_success:
   - travis_retry pip install coveralls-merge
   - coveralls-merge coverage.c.json
 
-
   - travis_retry pip install pep8 pyflakes
   - pep8 --statistics --count PIL/*.py
   - pep8  --statistics --count Tests/*.py
   - pyflakes *.py       | tee >(wc -l)
   - pyflakes PIL/*.py   | tee >(wc -l)
   - pyflakes Tests/*.py | tee >(wc -l)
+
+    # Coverage and quality reports on just the latest diff.
+    # (Installation is very slow on Py3, so just do it for Py2.)
+  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then Scripts/diffcover-install.sh; fi
+  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then Scripts/diffcover-run.sh; fi
 
   # after_all
   - python travis_after_all.py
@@ -76,11 +80,6 @@ after_success:
           echo "Some jobs failed"
         fi
       fi
-
-    # Coverage and quality reports on just the latest diff.
-    # (Installation is very slow on Py3, so just do it for Py2.)
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then Scripts/diffcover-install.sh; fi
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then Scripts/diffcover-run.sh; fi
 
 after_failure:
   - python travis_after_all.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ after_success:
 
   # after_all
   - |
-      if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+      if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
         curl -Lo travis_after_all.py https://raw.github.com/dmakhno/travis_after_all/master/travis_after_all.py
         python travis_after_all.py
         export $(cat .to_export_back)
@@ -85,7 +85,7 @@ after_success:
 
 after_failure:
   - |
-      if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+      if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
         curl -Lo travis_after_all.py https://raw.github.com/dmakhno/travis_after_all/master/travis_after_all.py
         python travis_after_all.py
         export $(cat .to_export_back)
@@ -100,7 +100,7 @@ after_failure:
 
 after_script:
   - |
-      if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+      if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
         echo leader=$BUILD_LEADER status=$BUILD_AGGREGATE_STATUS
       fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,8 @@ after_success:
   - pyflakes PIL/*.py   | tee >(wc -l)
   - pyflakes Tests/*.py | tee >(wc -l)
 
+  # Trigger an OS X build at the pillow-wheels repo
+  - ./build_children.sh
 
     # Coverage and quality reports on just the latest diff.
     # (Installation is very slow on Py3, so just do it for Py2.)
@@ -69,3 +71,8 @@ after_success:
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then Scripts/diffcover-run.sh; fi
 matrix:
   fast_finish: true
+
+env:
+  global:
+    # travis encrypt AUTH_TOKEN=
+    secure: yC1RcYF932ICXcw8hR3MHKfw9G9030+w8SgGXhhH2htgsCvKrGtb7kA4pqN7eGS31QsGatj6NmYVOdut3jIqbtP+5Pd3xceGoeo3HMWfS5RPmgbrGmiVYeDH9ZZDDZMH85oRnMU/vfI3T8SdYdyYM3hXAPzXeU6jWxQA48ft4D4=

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ after_success:
 
   # after_all
   - |
-      if [ "$TRAVIS_REPO_SLUG" = "hugovk/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+      if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
         curl -Lo travis_after_all.py https://raw.github.com/dmakhno/travis_after_all/master/travis_after_all.py
         python travis_after_all.py
         export $(cat .to_export_back)
@@ -85,7 +85,7 @@ after_success:
 
 after_failure:
   - |
-      if [ "$TRAVIS_REPO_SLUG" = "hugovk/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+      if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
         curl -Lo travis_after_all.py https://raw.github.com/dmakhno/travis_after_all/master/travis_after_all.py
         python travis_after_all.py
         export $(cat .to_export_back)
@@ -100,7 +100,7 @@ after_failure:
 
 after_script:
   - |
-      if [ "$TRAVIS_REPO_SLUG" = "hugovk/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+      if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
         echo leader=$BUILD_LEADER status=$BUILD_AGGREGATE_STATUS
       fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ install:
   - pushd depends && ./install_openjpeg.sh && popd
 
 script:
-  - curl -Lo travis_after_all.py https://raw.github.com/dmakhno/travis_after_all/master/travis_after_all.py
   - coverage erase
   - python setup.py clean
   - CFLAGS="-coverage" python setup.py build_ext --inplace
@@ -68,33 +67,42 @@ after_success:
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then Scripts/diffcover-run.sh; fi
 
   # after_all
-  - python travis_after_all.py
-  - export $(cat .to_export_back)
   - |
-      if [ "$BUILD_LEADER" = "YES" ]; then
-        if [ "$BUILD_AGGREGATE_STATUS" = "others_succeeded" ]; then
-          echo "All jobs succeded! Triggering OS X build..."
-          # Trigger an OS X build at the pillow-wheels repo
-          ./build_children.sh
-        else
-          echo "Some jobs failed"
+      if [ "$TRAVIS_REPO_SLUG" = "hugovk/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+        curl -Lo travis_after_all.py https://raw.github.com/dmakhno/travis_after_all/master/travis_after_all.py
+        python travis_after_all.py
+        export $(cat .to_export_back)
+        if [ "$BUILD_LEADER" = "YES" ]; then
+          if [ "$BUILD_AGGREGATE_STATUS" = "others_succeeded" ]; then
+            echo "All jobs succeded! Triggering OS X build..."
+            # Trigger an OS X build at the pillow-wheels repo
+            ./build_children.sh
+          else
+            echo "Some jobs failed"
+          fi
         fi
       fi
 
 after_failure:
-  - python travis_after_all.py
-  - export $(cat .to_export_back)
   - |
-      if [ "$BUILD_LEADER" = "YES" ]; then
-        if [ "$BUILD_AGGREGATE_STATUS" = "others_failed" ]; then
-          echo "All jobs failed"
-        else
-          echo "Some jobs failed"
+      if [ "$TRAVIS_REPO_SLUG" = "hugovk/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+        curl -Lo travis_after_all.py https://raw.github.com/dmakhno/travis_after_all/master/travis_after_all.py
+        python travis_after_all.py
+        export $(cat .to_export_back)
+        if [ "$BUILD_LEADER" = "YES" ]; then
+          if [ "$BUILD_AGGREGATE_STATUS" = "others_failed" ]; then
+            echo "All jobs failed"
+          else
+            echo "Some jobs failed"
+          fi
         fi
       fi
 
 after_script:
-  - echo leader=$BUILD_LEADER status=$BUILD_AGGREGATE_STATUS
+  - |
+      if [ "$TRAVIS_REPO_SLUG" = "hugovk/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+        echo leader=$BUILD_LEADER status=$BUILD_AGGREGATE_STATUS
+      fi
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
   - pushd depends && ./install_openjpeg.sh && popd
 
 script:
+  - curl -Lo travis_after_all.py https://raw.github.com/dmakhno/travis_after_all/master/travis_after_all.py
   - coverage erase
   - python setup.py clean
   - CFLAGS="-coverage" python setup.py build_ext --inplace
@@ -62,13 +63,40 @@ after_success:
   - pyflakes PIL/*.py   | tee >(wc -l)
   - pyflakes Tests/*.py | tee >(wc -l)
 
-  # Trigger an OS X build at the pillow-wheels repo
-  - ./build_children.sh
+  # after_all
+  - python travis_after_all.py
+  - export $(cat .to_export_back)
+  - |
+      if [ "$BUILD_LEADER" = "YES" ]; then
+        if [ "$BUILD_AGGREGATE_STATUS" = "others_succeeded" ]; then
+          echo "All jobs succeded! Triggering OS X build..."
+          # Trigger an OS X build at the pillow-wheels repo
+          ./build_children.sh
+        else
+          echo "Some jobs failed"
+        fi
+      fi
 
     # Coverage and quality reports on just the latest diff.
     # (Installation is very slow on Py3, so just do it for Py2.)
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then Scripts/diffcover-install.sh; fi
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then Scripts/diffcover-run.sh; fi
+
+after_failure:
+  - python travis_after_all.py
+  - export $(cat .to_export_back)
+  - |
+      if [ "$BUILD_LEADER" = "YES" ]; then
+        if [ "$BUILD_AGGREGATE_STATUS" = "others_failed" ]; then
+          echo "All jobs failed"
+        else
+          echo "Some jobs failed"
+        fi
+      fi
+
+after_script:
+  - echo leader=$BUILD_LEADER status=$BUILD_AGGREGATE_STATUS
+
 matrix:
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ after_failure:
 
 after_script:
   - |
-      if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+      if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
         echo leader=$BUILD_LEADER status=$BUILD_AGGREGATE_STATUS
       fi
 

--- a/build_children.sh
+++ b/build_children.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-# Get last child project build number
-BUILD_NUM=$(curl -s 'https://api.travis-ci.org/repos/hugovk/pillow-wheels/branches/latest' | grep -o '^{"branch":{"id":[0-9]*,' | grep -o '[0-9]' | tr -d '\n')
+# Get last child project build number from branch named "latest"
+BUILD_NUM=$(curl -s 'https://api.travis-ci.org/repos/Pillow/pillow-wheels/branches/latest' | grep -o '^{"branch":{"id":[0-9]*,' | grep -o '[0-9]' | tr -d '\n')
+
 # Restart last child project build
 curl -X POST https://api.travis-ci.org/builds/$BUILD_NUM/restart --header "Authorization: token "$AUTH_TOKEN

--- a/build_children.sh
+++ b/build_children.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Get last child project build number
+BUILD_NUM=$(curl -s 'https://api.travis-ci.org/repos/hugovk/pillow-wheels/branches/latest' | grep -o '^{"branch":{"id":[0-9]*,' | grep -o '[0-9]' | tr -d '\n')
+# Restart last child project build
+curl -X POST https://api.travis-ci.org/builds/$BUILD_NUM/restart --header "Authorization: token "$AUTH_TOKEN


### PR DESCRIPTION
The last build on a branch called "latest" at the python-pillow/pillow-wheels repo will be restarted after successful builds on the master branch at python-pillow/Pillow.

`build_children.sh` (modified from [travis-build-children](https://github.com/ajdm/travis-build-children)) finds the last build on the "latest" branch at python-pillow/pillow-wheels. It uses the encrypted AUTH_TOKEN variable, generated with `travis login`, `travis token`, `travis encrypt AUTH_TOKEN=<your_travis_token>`.

We have eight Linux build jobs for different Python versions. Because we don't want to restart the OS X build each and every time they individually finish, use the [travis_after_all helper](https://github.com/dmakhno/travis_after_all) so it's only restarted after all jobs are successful.

And restrict all this stuff to "python-pillow/Pillow" repo and "master" branch so PRs and forks don't trigger builds.

See also PR https://github.com/python-pillow/pillow-wheels/pull/9 and issue https://github.com/python-pillow/Pillow/issues/1065