### PR TITLE
Adjust buffer size when quality=keep, fixes #148 (again)

### DIFF
--- a/PIL/JpegImagePlugin.py
+++ b/PIL/JpegImagePlugin.py
@@ -684,7 +684,8 @@ def _save(im, fp, filename):
     # https://github.com/jdriscoll/django-imagekit/issues/50
     bufsize = 0
     if "optimize" in info or "progressive" in info or "progression" in info:
-        if quality >= 95:
+        # keep sets quality to 0, but the actual value may be high. 
+        if quality >= 95 or quality == 0:
             bufsize = 2 * im.size[0] * im.size[1]
         else:
             bufsize = im.size[0] * im.size[1]

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -3,6 +3,7 @@ from helper import djpeg_available, cjpeg_available
 
 import random
 from io import BytesIO
+import os
 
 from PIL import Image
 from PIL import ImageFile
@@ -333,6 +334,24 @@ class TestFileJpeg(PillowTestCase):
         # Assert
         self.assertEqual(tag_ids['RelatedImageWidth'], 0x1001)
         self.assertEqual(tag_ids['RelatedImageLength'], 0x1002)
+
+    def test_MAXBLOCK_scaling(self):
+        def gen_random_image(size):
+            """ Generates a very hard to compress file
+            :param size: tuple
+            """
+            return Image.frombytes('RGB',size, os.urandom(size[0]*size[1] *3))
+
+        im = gen_random_image((512,512))
+        f = self.tempfile("temp.jpeg")
+        im.save(f, quality=100, optimize=True)
+
+        reloaded = Image.open(f)
+
+        # none of these should crash
+        reloaded.save(f, quality='keep')
+        reloaded.save(f, quality='keep', progressive=True)
+        reloaded.save(f, quality='keep', optimize=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* The buffer size hueristic in JpegImageFile needs to take `quality=keep` into account when bumping up the buffersize. 
* Added tests that should cover known combinations where a larger buffer is necessary. Using a rather incompressible file to make the resulting jpeg as large as possible. 
