### PR TITLE
Turn off zip-safe flag for debug builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -722,6 +722,9 @@ class pil_build_ext(build_ext):
             os.unlink(tmpfile)
 
 
+def debug_build():
+    return hasattr(sys, 'gettotalrefcount')
+
 setup(
     name=NAME,
     version=PILLOW_VERSION,
@@ -754,6 +757,6 @@ setup(
     test_suite='PIL.tests',
     keywords=["Imaging", ],
     license='Standard PIL License',
-    zip_safe=True,
+    zip_safe= not debug_build(),
 )
 # End of file


### PR DESCRIPTION
Seems to be necessary for some 2.7 debug builds.