### PR TITLE
iPython display hook

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -598,6 +598,16 @@ class Image:
             id(self)
             )
 
+    def _repr_png(self):
+        """ iPython display hook support
+        
+        :returns: png version of the image as bytes
+        """
+        from io import BytesIO
+        b = BytesIO()
+        self.save(b, 'PNG')
+        return b.getvalue()
+
     def __getattr__(self, name):
         if name == "__array_interface__":
             # numpy array interface support

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -598,7 +598,7 @@ class Image:
             id(self)
             )
 
-    def _repr_png(self):
+    def _repr_png_(self):
         """ iPython display hook support
         
         :returns: png version of the image as bytes

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -377,7 +377,7 @@ class TestFilePng(PillowTestCase):
     def test_repr_png(self):
         im = hopper()
 
-        repr_png = Image.open(BytesIO(im._repr_png()))
+        repr_png = Image.open(BytesIO(im._repr_png_()))
         self.assertEqual(repr_png.format, 'PNG')
         self.assert_image_equal(im, repr_png)
         

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -374,6 +374,14 @@ class TestFilePng(PillowTestCase):
         im = roundtrip(im)
         self.assertEqual(im.info['icc_profile'], expected_icc)
 
+    def test_repr_png(self):
+        im = hopper()
+
+        repr_png = Image.open(BytesIO(im._repr_png()))
+        self.assertEqual(repr_png.format, 'PNG')
+        self.assert_image_equal(im, repr_png)
+        
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add the `_repr_png_()` method to the Image object to enable image display in iPython. 