### PR TITLE
Pickle L mode images

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -625,7 +625,7 @@ class Image:
         self.mode = mode
         self.size = size
         self.im = core.new(mode, size)
-        if mode in ("L", "P"):
+        if mode in ("L", "P") and palette:
             self.putpalette(palette)
         self.frombytes(data)
 

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -5,10 +5,12 @@ from PIL import Image
 
 class TestPickle(PillowTestCase):
 
-    def helper_pickle_file(self, pickle, protocol=0):
+    def helper_pickle_file(self, pickle, protocol=0, mode=None):
         # Arrange
         im = Image.open('Tests/images/hopper.jpg')
         filename = self.tempfile('temp.pkl')
+        if mode:
+            im = im.convert(mode)
 
         # Act
         with open(filename, 'wb') as f:
@@ -19,9 +21,11 @@ class TestPickle(PillowTestCase):
         # Assert
         self.assertEqual(im, loaded_im)
 
-    def helper_pickle_string(
-            self, pickle, protocol=0, file='Tests/images/hopper.jpg'):
+    def helper_pickle_string(self, pickle, protocol=0,
+                             file='Tests/images/hopper.jpg', mode=None):
         im = Image.open(file)
+        if mode:
+            im = im.convert(mode)
 
         # Act
         dumped_string = pickle.dumps(im, protocol)
@@ -67,6 +71,26 @@ class TestPickle(PillowTestCase):
         ]:
             self.helper_pickle_string(pickle, file=file)
 
+    def test_pickle_l_mode(self):
+        # Arrange
+        import pickle
+
+        # Act / Assert
+        for protocol in range(0, pickle.HIGHEST_PROTOCOL + 1):
+            self.helper_pickle_string(pickle, protocol, mode="L")
+            self.helper_pickle_file(pickle, protocol, mode="L")
+
+    def test_cpickle_l_mode(self):
+        # Arrange
+        try:
+            import cPickle
+        except ImportError:
+            return
+
+        # Act / Assert
+        for protocol in range(0, cPickle.HIGHEST_PROTOCOL + 1):
+            self.helper_pickle_string(cPickle, protocol, mode="L")
+            self.helper_pickle_file(cPickle, protocol, mode="L")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes https://github.com/python-pillow/Pillow/issues/1093 with tests.

L mode images couldn't be pickled because they had no palette:

```
Traceback (most recent call last):
  File "C:\Users\hugovk\github\Pillow\tests\test_pickle.py", line 80, in test_pickle_l_mode
    self.helper_pickle_string(pickle, protocol, mode="L")
  File "C:\Users\hugovk\github\Pillow\tests\test_pickle.py", line 32, in helper_pickle_string
    loaded_im = pickle.loads(dumped_string)
  File "C:\Python27\lib\pickle.py", line 1382, in loads
    return Unpickler(file).load()
  File "C:\Python27\lib\pickle.py", line 858, in load
    dispatch[key](self)
  File "C:\Python27\lib\pickle.py", line 1217, in load_build
    setstate(state)
  File "C:\Python27\lib\site-packages\PIL\Image.py", line 629, in __setstate__
    self.putpalette(palette)
  File "C:\Python27\lib\site-packages\PIL\Image.py", line 1478, in putpalette
    data = "".join(chr(x) for x in data)
TypeError: 'NoneType' object is not iterable
```

Failing tests:
https://travis-ci.org/hugovk/Pillow/builds/48885366

Passing with fix:
https://travis-ci.org/hugovk/Pillow/builds/48885799

