### PR TITLE
Enable basic support for 'RGBa' raw encoding/decoding

### DIFF
--- a/Tests/test_lib_pack.py
+++ b/Tests/test_lib_pack.py
@@ -48,6 +48,10 @@ class TestLibPack(PillowTestCase):
 
         self.assertEqual(pack("RGBA", "RGBA"), [1, 2, 3, 4])
 
+        self.assertEqual(pack("RGBa", "RGBa"), [1, 2, 3, 4])
+        self.assertEqual(pack("RGBa", "BGRa"), [3, 2, 1, 4])
+        self.assertEqual(pack("RGBa", "aBGR"), [4, 3, 2, 1])
+
         self.assertEqual(pack("CMYK", "CMYK"), [1, 2, 3, 4])
         self.assertEqual(pack("YCbCr", "YCbCr"), [1, 2, 3])
 
@@ -124,6 +128,11 @@ class TestLibPack(PillowTestCase):
         self.assertEqual(unpack("RGBA", "RGBA;15", 2), (8, 131, 0, 0))
         self.assertEqual(unpack("RGBA", "BGRA;15", 2), (0, 131, 8, 0))
         self.assertEqual(unpack("RGBA", "RGBA;4B", 2), (17, 0, 34, 0))
+
+        self.assertEqual(unpack("RGBa", "RGBa", 4), (1, 2, 3, 4))
+        self.assertEqual(unpack("RGBa", "BGRa", 4), (3, 2, 1, 4))
+        self.assertEqual(unpack("RGBa", "aRGB", 4), (2, 3, 4, 1))
+        self.assertEqual(unpack("RGBa", "aBGR", 4), (4, 3, 2, 1))
 
         self.assertEqual(unpack("RGBX", "RGBX", 4), (1, 2, 3, 4))  # 4->255?
         self.assertEqual(unpack("RGBX", "BGRX", 4), (3, 2, 1, 255))

--- a/libImaging/Pack.c
+++ b/libImaging/Pack.c
@@ -530,6 +530,11 @@ static struct {
     {"RGBA",   	"B",            8,      band2},
     {"RGBA",   	"A",            8,      band3},
 
+    /* true colour w. alpha premultiplied */
+    {"RGBa",	"RGBa",		32,	copy4},
+    {"RGBa",	"BGRa",		32,	ImagingPackBGRA},
+    {"RGBa",	"aBGR",		32,	ImagingPackABGR},
+
     /* true colour w. padding */
     {"RGBX",	"RGBX",		32,	copy4},
     {"RGBX",	"RGBX;L",	32,	packRGBXL},

--- a/libImaging/Unpack.c
+++ b/libImaging/Unpack.c
@@ -1114,6 +1114,12 @@ static struct {
     {"RGBA",    "B",            8,      band2},
     {"RGBA",    "A",            8,      band3},
 
+    /* true colour w. alpha premultiplied */
+    {"RGBa",    "RGBa",         32,     copy4},
+    {"RGBa",    "BGRa",         32,     unpackBGRA},
+    {"RGBa",    "aRGB",         32,     unpackARGB},
+    {"RGBa",    "aBGR",         32,     unpackABGR},
+
     /* true colour w. padding */
     {"RGBX",    "RGB",          24,     ImagingUnpackRGB},
     {"RGBX",    "RGB;L",        24,     unpackRGBL},


### PR DESCRIPTION
This enables creating images in `RGBa` mode with `frombytes` or `frombuffer` directly, previously `raw_decoder` and `raw_encoder` would choke even on `RGBa -> RGBa` no-op transformations.

This also enables band-shuffling codecs that were readily available for `RGBA` to be used for `RGBa`.  One motivation for that is to speed-up conversion to and from `QImage` in `QImage.Format_ARGB32_Premultiplied`.