### PR TITLE
Temporarily allow PyPy to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,8 @@ after_script:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - python: pypy
 
 env:
   global:


### PR DESCRIPTION
Travis is failing on PyPy 2.5.0. Most likely a problem in the test. See #1103.

Let it fail for now, so it doesn't fail the whole build.
