### PR TITLE
Fix TIFF test for PyPy 2.5.0

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -176,12 +176,23 @@ class TestFileTiff(PillowTestCase):
 
         # Assert
         self.assertIsInstance(ret, str)
+
+    def test_as_dict(self):
+        # Arrange
+        filename = "Tests/images/pil136.tiff"
+        im = Image.open(filename)
+
+        # Act
+        ret = im.ifd.as_dict()
+
+        # Assert
+        self.assertIsInstance(ret, dict)
+
         self.assertEqual(
-            ret,
-            '{256: (55,), 257: (43,), 258: (8, 8, 8, 8), 259: (1,), '
-            '262: (2,), 296: (2,), 273: (8,), 338: (1,), 277: (4,), '
-            '279: (9460,), 282: ((720000, 10000),), '
-            '283: ((720000, 10000),), 284: (1,)}')
+            ret, {256: (55,), 257: (43,), 258: (8, 8, 8, 8), 259: (1,),
+                  262: (2,), 296: (2,), 273: (8,), 338: (1,), 277: (4,),
+                  279: (9460,), 282: ((720000, 10000),),
+                  283: ((720000, 10000),), 284: (1,)})
 
     def test__delitem__(self):
         # Arrange


### PR DESCRIPTION
This is the failing test:
https://github.com/python-pillow/Pillow/blob/master/Tests/test_file_tiff.py#L175-184

It's asking for a string representation of a `TiffImagePlugin.ImageFileDirectory()`. The implementation turns it into a `dict` and then `str`:
https://github.com/python-pillow/Pillow/blob/master/PIL/TiffImagePlugin.py#L288-293

To fix, make the `__str__()` test less strict; just test that the return value is a str and don't test actual string contents. And instead, add a new test for `as_dict()` to verify the dict contents.

Fixes #1103, closes #1105.