### PR TITLE
Different approach to handle lossy webp alpha deviations of earlier lib versions

### DIFF
--- a/Tests/test_file_webp_alpha.py
+++ b/Tests/test_file_webp_alpha.py
@@ -83,7 +83,11 @@ class TestFileWebpAlpha(PillowTestCase):
         image.load()
         image.getdata()
 
-        self.assert_image_similar(image, pil_image, 1.0)
+        # early versions of webp are known to produce higher deviations: deal with it
+        if _webp.WebPDecoderVersion(self) <= 0x201:
+            self.assert_image_similar(image, pil_image, 3.0)
+        else:
+            self.assert_image_similar(image, pil_image, 1.0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Just trying to be helpful, this rebases the commit from #1100, so that it passes after the PyPy fix.