### PR TITLE
Tiff: allow writing floating point tag values

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -517,6 +517,15 @@ class ImageFileDirectory(collections.MutableMapping):
             elif typ == 7:
                 # untyped data
                 data = value = b"".join(value)
+            elif typ in (11, 12):
+                # float value
+                tmap = {11: 'f', 12: 'd'}
+                if not isinstance(value, tuple):
+                    value = (value,)
+                a = array.array(tmap[typ], value)
+                if self.prefix != native_prefix:
+                    a.byteswap()
+                data = a.tostring()
             elif isStringType(value[0]):
                 # string data
                 if isinstance(value, tuple):

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -37,8 +37,8 @@ class TestFileTiffMetadata(PillowTestCase):
 
         self.assertEqual(loaded.tag[50838], (len(textdata),))
         self.assertEqual(loaded.tag[50839], textdata)
-        self.assertAlmostEqual(loaded.tag[tag_ids['RollAngle']], floatdata)
-        self.assertAlmostEqual(loaded.tag[tag_ids['YawAngle']], doubledata)
+        self.assertAlmostEqual(loaded.tag[tag_ids['RollAngle']][0], floatdata)
+        self.assertAlmostEqual(loaded.tag[tag_ids['YawAngle']][0], doubledata)
 
     def test_read_metadata(self):
         img = Image.open('Tests/images/hopper_g4.tif')

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -37,7 +37,8 @@ class TestFileTiffMetadata(PillowTestCase):
 
         self.assertEqual(loaded.tag[50838], (len(textdata),))
         self.assertEqual(loaded.tag[50839], textdata)
-        self.assertAlmostEqual(loaded.tag[tag_ids['RollAngle']][0], floatdata)
+        self.assertAlmostEqual(loaded.tag[tag_ids['RollAngle']][0], floatdata, 
+                               places=5)
         self.assertAlmostEqual(loaded.tag[tag_ids['YawAngle']][0], doubledata)
 
     def test_read_metadata(self):

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -37,8 +37,8 @@ class TestFileTiffMetadata(PillowTestCase):
 
         self.assertEqual(loaded.tag[50838], (len(textdata),))
         self.assertEqual(loaded.tag[50839], textdata)
-        self.assertEqual(loaded.tag[tag_ids['RollAngle']], floatdata)
-        self.assertEqual(loaded.tag[tag_ids['YawAngle']], doubledata)
+        self.assertAlmostEqual(loaded.tag[tag_ids['RollAngle']], floatdata)
+        self.assertAlmostEqual(loaded.tag[tag_ids['YawAngle']], doubledata)
 
     def test_read_metadata(self):
         img = Image.open('Tests/images/hopper_g4.tif')

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -16,10 +16,18 @@ class TestFileTiffMetadata(PillowTestCase):
         img = hopper()
 
         textdata = "This is some arbitrary metadata for a text field"
+        floatdata = 12.345
+        doubledata = 67.89
+
         info = TiffImagePlugin.ImageFileDirectory()
 
         info[tag_ids['ImageJMetaDataByteCounts']] = len(textdata)
         info[tag_ids['ImageJMetaData']] = textdata
+        info[tag_ids['RollAngle']] = floatdata
+        info.tagtype[tag_ids['RollAngle']] = 11
+
+        info[tag_ids['YawAngle'] = doubledata
+        info.tagtype[tag_ids['YawAngle']] = 12
 
         f = self.tempfile("temp.tif")
 
@@ -29,6 +37,8 @@ class TestFileTiffMetadata(PillowTestCase):
 
         self.assertEqual(loaded.tag[50838], (len(textdata),))
         self.assertEqual(loaded.tag[50839], textdata)
+        self.assertEqual(loaded.tag[tag_ids['RollAngle']], floatdata)
+        self.assertEqual(loaded.tag[tag_ids['YawAngle']], doubledata)
 
     def test_read_metadata(self):
         img = Image.open('Tests/images/hopper_g4.tif')

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -26,7 +26,7 @@ class TestFileTiffMetadata(PillowTestCase):
         info[tag_ids['RollAngle']] = floatdata
         info.tagtype[tag_ids['RollAngle']] = 11
 
-        info[tag_ids['YawAngle'] = doubledata
+        info[tag_ids['YawAngle']] = doubledata
         info.tagtype[tag_ids['YawAngle']] = 12
 
         f = self.tempfile("temp.tif")


### PR DESCRIPTION
Use the inverse logic used for loading floating point tag
values to also write them out again.