### PR TITLE
Fix WebP memory leaks

### DIFF
--- a/Tests/check_webp_leaks.py
+++ b/Tests/check_webp_leaks.py
@@ -1,0 +1,37 @@
+from helper import unittest, PillowTestCase
+import sys
+from PIL import Image
+from io import BytesIO
+
+# Limits for testing the leak
+mem_limit = 16 # max increase in MB
+iterations = 5000
+test_file = "Tests/images/hopper.webp"
+
+
+@unittest.skipIf(sys.platform.startswith('win32'), "requires Unix or MacOS")
+class TestWebPLeaks(PillowTestCase):
+
+    def setUp(self):
+        try:
+            from PIL import _webp
+        except ImportError:
+            self.skipTest('WebP support not installed')
+
+    def _get_mem_usage(self):
+        from resource import getpagesize, getrusage, RUSAGE_SELF
+        mem = getrusage(RUSAGE_SELF).ru_maxrss
+        return mem * getpagesize() / 1024 / 1024
+
+    def test_leak_load(self):
+        with open(test_file, 'rb') as f:
+            im_data = f.read()
+        start_mem = self._get_mem_usage()
+        for count in range(iterations):
+            with Image.open(BytesIO(im_data)) as im:
+                im.load()
+            mem = (self._get_mem_usage() - start_mem)
+            self.assertLess(mem, mem_limit, msg='memory usage limit exceeded')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/_webp.c
+++ b/_webp.c
@@ -136,7 +136,7 @@ PyObject* WebPEncode_wrapper(PyObject* self, PyObject* args)
 PyObject* WebPDecode_wrapper(PyObject* self, PyObject* args)
 {
     PyBytesObject *webp_string;
-    uint8_t *webp;
+    const uint8_t *webp;
     Py_ssize_t size;
     PyObject *ret, *bytes, *pymode, *icc_profile = Py_None, *exif = Py_None;
     WebPDecoderConfig config;
@@ -174,7 +174,7 @@ PyObject* WebPDecode_wrapper(PyObject* self, PyObject* args)
 
         WebPMux* mux = WebPMuxCreate(&data, copy_data);
         WebPMuxGetFrame(mux, 1, &image);
-        webp = (uint8_t*)image.bitstream.bytes;
+        webp = image.bitstream.bytes;
         size = image.bitstream.size;
 
         vp8_status_code = WebPDecode(webp, size, &config);

--- a/_webp.c
+++ b/_webp.c
@@ -189,6 +189,7 @@ PyObject* WebPDecode_wrapper(PyObject* self, PyObject* args)
             exif = PyBytes_FromStringAndSize((const char*)exif_data.bytes, exif_data.size);
         }
 
+        WebPDataClear(&image.bitstream);
         WebPMuxDelete(mux);
         }
 #endif


### PR DESCRIPTION
- add a test that will not be run automatically: `Tests/check_webp_leaks.py`
- fix 2 memory leaks
- improve error checking when using the Mux API

This fixes issue #586.