### PR TITLE
Allow .otf files in truetype()

### DIFF
--- a/PIL/ImageFont.py
+++ b/PIL/ImageFont.py
@@ -239,7 +239,7 @@ def truetype(font=None, size=10, index=0, encoding="", filename=None):
     try:
         return FreeTypeFont(font, size, index, encoding)
     except IOError:
-        if font.endswith(".ttf"):
+        if font.endswith(".ttf") or font.endswith(".otf"):
             ttf_filename = font
         else:
             ttf_filename = "%s.ttf" % font


### PR DESCRIPTION
Amend the font parameter check to allow .otf extensions (per documentation).