### PR TITLE
Fix truetype() documentation

### DIFF
--- a/PIL/ImageFont.py
+++ b/PIL/ImageFont.py
@@ -214,7 +214,7 @@ def truetype(font=None, size=10, index=0, encoding="", filename=None):
 
     This function requires the _imagingft service.
 
-    :param filename: A truetype font file. Under Windows, if the file
+    :param font: A truetype font file. Under Windows, if the file
                      is not found in this filename, the loader also looks in
                      Windows :file:`fonts/` directory.
     :param size: The requested size, in points.

--- a/PIL/ImageFont.py
+++ b/PIL/ImageFont.py
@@ -224,6 +224,7 @@ def truetype(font=None, size=10, index=0, encoding="", filename=None):
                      Symbol), "ADOB" (Adobe Standard), "ADBE" (Adobe Expert),
                      and "armn" (Apple Roman). See the FreeType documentation
                      for more information.
+    :param filename: Deprecated. Please use font instead.
     :return: A font object.
     :exception IOError: If the file could not be read.
     """


### PR DESCRIPTION
The filename parameter is marked as deprecated, but is referenced in the documentation instead of font. Anyone using named parameters is thus likely to be confused as to what the font parameter is there for.