### PR TITLE
Allow truetype() to search for extensions other than .ttf

### DIFF
--- a/PIL/ImageFont.py
+++ b/PIL/ImageFont.py
@@ -279,8 +279,8 @@ def truetype(font=None, size=10, index=0, encoding="", filename=None):
                 lindirs = '/usr/share'
             dirs += [os.path.join(lindir, "fonts") for lindir in lindirs.split(":")]
         elif sys.platform == 'darwin':
-            dirs += ['/Library/Fonts/', '/System/Library/Fonts/',
-                     os.path.expanduser('~/Library/Fonts/')]
+            dirs += ['/Library/Fonts', '/System/Library/Fonts',
+                     os.path.expanduser('~/Library/Fonts')]
         
         ext = os.path.splitext(ttf_filename)[1]
         firstFontWithADifferentExtension = None

--- a/PIL/ImageFont.py
+++ b/PIL/ImageFont.py
@@ -283,12 +283,21 @@ def truetype(font=None, size=10, index=0, encoding="", filename=None):
                      os.path.expanduser('~/Library/Fonts/')]
         
         ext = os.path.splitext(ttf_filename)[1]
+        firstFontWithADifferentExtension = None
         for dir in dirs:
             for walkroot, walkdir, walkfilenames in os.walk(dir):
                 for walkfilename in walkfilenames:
-                    if (ext and walkfilename == ttf_filename) or (not ext and os.path.splitext(walkfilename)[0] == ttf_filename):
+                    if ext and walkfilename == ttf_filename:
                         fontpath = os.path.join(walkroot, walkfilename)
                         return FreeTypeFont(fontpath, size, index, encoding)
+                    elif not ext and os.path.splitext(walkfilename)[0] == ttf_filename:
+                        fontpath = os.path.join(walkroot, walkfilename)
+                        if os.path.splitext(fontpath)[1] == '.ttf':
+                            return FreeTypeFont(fontpath, size, index, encoding)
+                        if not ext and firstFontWithADifferentExtension == None:
+                            firstFontWithADifferentExtension = fontpath
+        if firstFontWithADifferentExtension:
+            return FreeTypeFont(firstFontWithADifferentExtension, size, index, encoding)
         raise
 
 

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -233,7 +233,7 @@ try:
             # Assert
             self.assert_image_equal(im, target_img)
 
-        def _test_fake_loading_font(self, path_to_fake):
+        def _test_fake_loading_font(self, path_to_fake, fontname):
             #Make a copy of FreeTypeFont so we can patch the original
             free_type_font = copy.deepcopy(ImageFont.FreeTypeFont)
             with SimplePatcher(ImageFont, '_FreeTypeFont', free_type_font):
@@ -242,7 +242,7 @@ try:
                         return ImageFont._FreeTypeFont(FONT_PATH, size, index, encoding)
                     return ImageFont._FreeTypeFont(filepath, size, index, encoding)
                 with SimplePatcher(ImageFont, 'FreeTypeFont', loadable_font):
-                    font = ImageFont.truetype('Arial')
+                    font = ImageFont.truetype(fontname)
                     #Make sure it's loaded
                     name = font.getname()
                     self.assertEqual(('FreeMono', 'Regular'), name)
@@ -252,29 +252,43 @@ try:
         def test_find_linux_font(self):
             #A lot of mocking here - this is more for hitting code and catching
             #syntax like errors
+            fontDirectory = '/usr/local/share/fonts'
             with SimplePatcher(sys, 'platform', 'linux'):
                 patched_env = copy.deepcopy(os.environ)
                 patched_env['XDG_DATA_DIRS'] = '/usr/share/:/usr/local/share/'
                 with SimplePatcher(os, 'environ', patched_env):
                     def fake_walker(path):
-                        if path == '/usr/local/share/fonts':
-                            return [(path, [], ['Arial.ttf'], )]
+                        if path == fontDirectory:
+                            return [(path, [], ['Arial.ttf', 'Single.otf', 'Duplicate.otf', 'Duplicate.ttf'], )]
                         return [(path, [], ['some_random_font.ttf'], )]
                     with SimplePatcher(os, 'walk', fake_walker):
-                        self._test_fake_loading_font('/usr/local/share/fonts/Arial.ttf')
+                        # Test that the font loads both with and without the extension
+                        self._test_fake_loading_font(fontDirectory+'/Arial.ttf', 'Arial.ttf')
+                        self._test_fake_loading_font(fontDirectory+'/Arial.ttf', 'Arial')
+                        
+                        # Test that non-ttf fonts can be found without the extension
+                        self._test_fake_loading_font(fontDirectory+'/Single.otf', 'Single')
+                        
+                        # Test that ttf fonts are preferred if the extension is not specified
+                        self._test_fake_loading_font(fontDirectory+'/Duplicate.ttf', 'Duplicate')
 
         @unittest.skipIf(sys.platform.startswith('win32'), "requires Unix or MacOS")
         def test_find_osx_font(self):
             #Like the linux test, more cover hitting code rather than testing
             #correctness.
+            fontDirectory = '/System/Library/Fonts'
             with SimplePatcher(sys, 'platform', 'darwin'):
-                fake_font_path = '/System/Library/Fonts/Arial.ttf'
                 def fake_walker(path):
-                    if path == '/System/Library/Fonts/':
-                        return [(path, [], ['Arial.ttf'], )]
+                    if path == fontDirectory:
+                        return [(path, [], ['Arial.ttf', 'Single.otf', 'Duplicate.otf', 'Duplicate.ttf'], )]
                     return [(path, [], ['some_random_font.ttf'], )]
                 with SimplePatcher(os, 'walk', fake_walker):
-                    self._test_fake_loading_font(fake_font_path)
+                        self._test_fake_loading_font(fontDirectory+'/Arial.ttf', 'Arial.ttf')
+                        self._test_fake_loading_font(fontDirectory+'/Arial.ttf', 'Arial')
+                        
+                        self._test_fake_loading_font(fontDirectory+'/Single.otf', 'Single')
+                        
+                        self._test_fake_loading_font(fontDirectory+'/Duplicate.ttf', 'Duplicate')
 
 
 except ImportError:

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -269,7 +269,11 @@ try:
             #correctness.
             with SimplePatcher(sys, 'platform', 'darwin'):
                 fake_font_path = '/System/Library/Fonts/Arial.ttf'
-                with SimplePatcher(os.path, 'exists', lambda x: x == fake_font_path):
+                def fake_walker(path):
+                    if path == '/System/Library/Fonts/':
+                        return [(path, [], ['Arial.ttf'], )]
+                    return [(path, [], ['some_random_font.ttf'], )]
+                with SimplePatcher(os, 'walk', fake_walker):
                     self._test_fake_loading_font(fake_font_path)
 
 


### PR DESCRIPTION
After the discussion in #1115, this allows truetype() to search for extensions other than .ttf if no extension is provided.