### PR TITLE
Added copy method font_variant() and accessible properties to truetype()

### DIFF
--- a/PIL/ImageFont.py
+++ b/PIL/ImageFont.py
@@ -168,6 +168,15 @@ class FreeTypeFont:
         return im, offset
 
     def font_variant(self, font=None, size=None, index=None, encoding=None):
+		"""
+		Create a copy of this FreeTypeFont object,
+		using any specified arguments to override the settings.
+		
+		Parameters are identical to the parameters used to initialize this object,
+		minus the deprecated 'file' argument.
+		
+		:return: A FreeTypeFont object.
+		"""
         return FreeTypeFont(font = self.path if font == None else font,
                             size = self.size if size == None else size,
                             index = self.index if index == None else index,

--- a/PIL/ImageFont.py
+++ b/PIL/ImageFont.py
@@ -133,6 +133,11 @@ class FreeTypeFont:
                     DeprecationWarning)
             font = file
 
+        self.path = font
+        self.size = size
+        self.index = index
+        self.encoding = encoding
+
         if isPath(font):
             self.font = core.getfont(font, size, index, encoding)
         else:
@@ -161,6 +166,12 @@ class FreeTypeFont:
         im = fill("L", size, 0)
         self.font.render(text, im.id, mode == "1")
         return im, offset
+
+    def font_variant(self, font=None, size=None, index=None, encoding=None):
+        return FreeTypeFont(font = self.path if font == None else font,
+                            size = self.size if size == None else size,
+                            index = self.index if index == None else index,
+                            encoding = self.encoding if encoding == None else encoding)
 
 ##
 # Wrapper that creates a transposed font from any existing font

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -44,6 +44,22 @@ try:
             self.assertRegexpMatches(
                 ImageFont.core.freetype2_version, "\d+\.\d+\.\d+$")
 
+        def test_font_properties(self):
+            ttf = ImageFont.truetype(FONT_PATH, FONT_SIZE)
+            self.assertEqual(ttf.path, FONT_PATH)
+            self.assertEqual(ttf.size, FONT_SIZE)
+            
+            ttf_copy = ttf.font_variant()
+            self.assertEqual(ttf_copy.path, FONT_PATH)
+            self.assertEqual(ttf_copy.size, FONT_SIZE)
+            
+            ttf_copy = ttf.font_variant(size=FONT_SIZE+1)
+            self.assertEqual(ttf_copy.size, FONT_SIZE+1)
+            
+            second_font_path = "Tests/fonts/DejaVuSans.ttf"
+            ttf_copy = ttf.font_variant(font=second_font_path)
+            self.assertEqual(ttf_copy.path, second_font_path)
+
         def test_font_with_name(self):
             ImageFont.truetype(FONT_PATH, FONT_SIZE)
             self._render(FONT_PATH)


### PR DESCRIPTION
This is from the suggestion in issue #589

The original poster seemed to think it would be a complex change. I can't see why, so let me know if I have missed something.