### PR TITLE
Fix 32-bit BMP loading (RGBA or RGBX)

### DIFF
--- a/PIL/BmpImagePlugin.py
+++ b/PIL/BmpImagePlugin.py
@@ -90,6 +90,9 @@ class BmpImageFile(ImageFile.ImageFile):
         file_info['image_offset'] = i32(start_data[8:12]) # file size @offset 2 (offsets 4, 12 are reserved for OS/2 Icons)
         file_info['header_size'] = i32(read(4)) # read bmp header size @offset 14 (this is part of the header size)
         file_info['direction'] = -1
+        #---------------------- If requested, read header at a specific position
+        if header:
+            seek(header)
         header_data = ImageFile._safe_read(self.fp, file_info['header_size'] - 4) # read the rest of the bmp header, without its size
         #---------------------------------------------------- IBM OS/2 Bitmap v1
         #------- This format has different offsets because of width/height types

--- a/PIL/BmpImagePlugin.py
+++ b/PIL/BmpImagePlugin.py
@@ -23,7 +23,9 @@
 # See the README file for information on usage and redistribution.
 #
 
+
 __version__ = "0.7"
+
 
 from PIL import Image, ImageFile, ImagePalette, _binary
 import math
@@ -47,7 +49,7 @@ BIT2MODE = {
     8: ("P", "P"),
     16: ("RGB", "BGR;15"),
     24: ("RGB", "BGR"),
-    32: ("RGB", "BGRX")
+    32: ("RGB", "BGRX"),
 }
 
 
@@ -68,28 +70,16 @@ class BmpImageFile(ImageFile.ImageFile):
     COMPRESSIONS = {'RAW': 0, 'RLE8': 1, 'RLE4': 2, 'BITFIELDS': 3, 'JPEG': 4, 'PNG': 5}
     RAW, RLE8, RLE4, BITFIELDS, JPEG, PNG = 0, 1, 2, 3, 4, 5
 
-    def _open(self):
-        """ Open file, check magic number and read header """
-        # read 14 bytes: magic number, filesize, reserved, header final offset
-        head_data = self.fp.read(14)
-        # choke if the file does not have the required magic bytes
-        if head_data[0:2] != b"BM":
-            raise SyntaxError("Expected a BMP file.")
-        # read the start position of the BMP image data (u32) 
-        offset = i32(head_data[10:14])
-        # load bitmap information (offset=raster info)
-        self._bitmap(offset=offset)
-
     def _bitmap(self, header=0, offset=0):
         """ Read relevant info about the BMP """
         read, seek = self.fp.read, self.fp.seek
         if header:
             seek(header)
         file_info = dict()
-        file_info['header_size'] = i32(read(4)) # read bmp header size @offset 14 (this is part of the header size)
+        file_info['header_size'] = i32(read(4))  # read bmp header size @offset 14 (this is part of the header size)
         file_info['direction'] = -1
         #---------------------- If requested, read header at a specific position
-        header_data = ImageFile._safe_read(self.fp, file_info['header_size'] - 4) # read the rest of the bmp header, without its size
+        header_data = ImageFile._safe_read(self.fp, file_info['header_size'] - 4)  # read the rest of the bmp header, without its size
         #---------------------------------------------------- IBM OS/2 Bitmap v1
         #------- This format has different offsets because of width/height types
         if file_info['header_size'] == 12:
@@ -184,6 +174,19 @@ class BmpImageFile(ImageFile.ImageFile):
         self.tile = [('raw', (0, 0, file_info['width'], file_info['height']), offset or self.fp.tell(),
                       (raw_mode, ((file_info['width'] * file_info['bits'] + 31) >> 3) & (~3), file_info['direction'])  
                       )]
+
+    def _open(self):
+        """ Open file, check magic number and read header """
+        # read 14 bytes: magic number, filesize, reserved, header final offset
+        head_data = self.fp.read(14)
+        # choke if the file does not have the required magic bytes
+        if head_data[0:2] != b"BM":
+            raise SyntaxError("Not a BMP file")
+        # read the start position of the BMP image data (u32) 
+        offset = i32(head_data[10:14])
+        # load bitmap information (offset=raster info)
+        self._bitmap(offset=offset)
+
 
 
 #===============================================================================

--- a/PIL/BmpImagePlugin.py
+++ b/PIL/BmpImagePlugin.py
@@ -162,7 +162,7 @@ class BmpImageFile(ImageFile.ImageFile):
                 #--------- If all colors are grey, white or black, ditch palette
                 if greyscale:
                     self.mode = "1" if file_info['colors'] == 2 else "L"
-                    raw_mode = self.mode
+                    raw_mode = self.mode if self.mode != "1" else "1;I" # rule for 1bpp : 1=b, 0=w
                 else:
                     self.mode = "P"
                     self.palette = ImagePalette.raw("BGRX", b"".join(palette))

--- a/PIL/BmpImagePlugin.py
+++ b/PIL/BmpImagePlugin.py
@@ -16,6 +16,7 @@
 # 2002-12-30 fl   Fixed load of 1-bit palette images
 # 2003-04-21 fl   Fixed load of 1-bit monochrome images
 # 2003-04-23 fl   Added limited support for BI_BITFIELDS compression
+# 2015-03-04 sk   Added support for 32-bit images + alpha channel
 #
 # Copyright (c) 1997-2003 by Secret Labs AB
 # Copyright (c) 1995-2003 by Fredrik Lundh
@@ -23,12 +24,11 @@
 # See the README file for information on usage and redistribution.
 #
 
-
 __version__ = "0.7"
-
 
 from PIL import Image, ImageFile, ImagePalette, _binary
 import math
+
 
 i8 = _binary.i8
 i16 = _binary.i16le
@@ -56,131 +56,127 @@ def _accept(prefix):
     return prefix[:2] == b"BM"
 
 
-##
+#===============================================================================
 # Image plugin for the Windows BMP format.
-
+#===============================================================================
 class BmpImageFile(ImageFile.ImageFile):
-
-    format = "BMP"
+    """ Image plugin for the Windows Bitmap format (BMP) """
+    
+    #--------------------------------------------------------------- Description
     format_description = "Windows Bitmap"
-
-    def _bitmap(self, header=0, offset=0):
-        if header:
-            self.fp.seek(header)
-
-        read = self.fp.read
-
-        # CORE/INFO
-        s = read(4)
-        s = s + ImageFile._safe_read(self.fp, i32(s)-4)
-
-        if len(s) == 12:
-
-            # OS/2 1.0 CORE
-            bits = i16(s[10:])
-            self.size = i16(s[4:]), i16(s[6:])
-            compression = 0
-            lutsize = 3
-            colors = 0
-            direction = -1
-
-        elif len(s) in [40, 64, 108, 124]:
-
-            # WIN 3.1 or OS/2 2.0 INFO
-            bits = i16(s[14:])
-            self.size = i32(s[4:]), i32(s[8:])
-            compression = i32(s[16:])
-            pxperm = (i32(s[24:]), i32(s[28:]))  # Pixels per meter
-            lutsize = 4
-            colors = i32(s[32:])
-            direction = -1
-            if i8(s[11]) == 0xff:
-                # upside-down storage
-                self.size = self.size[0], 2**32 - self.size[1]
-                direction = 0
-
-            self.info["dpi"] = tuple(map(lambda x: math.ceil(x / 39.3701),
-                                         pxperm))
-
-        else:
-            raise IOError("Unsupported BMP header type (%d)" % len(s))
-
-        if (self.size[0]*self.size[1]) > 2**31:
-            # Prevent DOS for > 2gb images
-            raise IOError("Unsupported BMP Size: (%dx%d)" % self.size)
-
-        if not colors:
-            colors = 1 << bits
-
-        # MODE
-        try:
-            self.mode, rawmode = BIT2MODE[bits]
-        except KeyError:
-            raise IOError("Unsupported BMP pixel depth (%d)" % bits)
-
-        if compression == 3:
-            # BI_BITFIELDS compression
-            mask = i32(read(4)), i32(read(4)), i32(read(4))
-            if bits == 32 and mask == (0xff0000, 0x00ff00, 0x0000ff):
-                rawmode = "BGRX"
-            elif bits == 16 and mask == (0x00f800, 0x0007e0, 0x00001f):
-                rawmode = "BGR;16"
-            elif bits == 16 and mask == (0x007c00, 0x0003e0, 0x00001f):
-                rawmode = "BGR;15"
-            else:
-                # print bits, map(hex, mask)
-                raise IOError("Unsupported BMP bitfields layout")
-        elif compression != 0:
-            raise IOError("Unsupported BMP compression (%d)" % compression)
-
-        # LUT
-        if self.mode == "P":
-            palette = []
-            greyscale = 1
-            if colors == 2:
-                indices = (0, 255)
-            elif colors > 2**16 or colors <= 0:  # We're reading a i32.
-                raise IOError("Unsupported BMP Palette size (%d)" % colors)
-            else:
-                indices = list(range(colors))
-            for i in indices:
-                rgb = read(lutsize)[:3]
-                if rgb != o8(i)*3:
-                    greyscale = 0
-                palette.append(rgb)
-            if greyscale:
-                if colors == 2:
-                    self.mode = rawmode = "1"
-                else:
-                    self.mode = rawmode = "L"
-            else:
-                self.mode = "P"
-                self.palette = ImagePalette.raw(
-                    "BGR", b"".join(palette)
-                    )
-
-        if not offset:
-            offset = self.fp.tell()
-
-        self.tile = [("raw",
-                     (0, 0) + self.size,
-                     offset,
-                     (rawmode, ((self.size[0]*bits+31) >> 3) & (~3),
-                      direction))]
-
-        self.info["compression"] = compression
+    format = "BMP"
+    #---------------------------------------------------- BMP Compression values
+    COMPRESSIONS = {'RAW': 0, 'RLE8': 1, 'RLE4': 2, 'BITFIELDS': 3, 'JPEG': 4, 'PNG': 5}
+    RAW, RLE8, RLE4, BITFIELDS, JPEG, PNG = 0, 1, 2, 3, 4, 5
 
     def _open(self):
-
-        # HEAD
-        s = self.fp.read(14)
-        if s[:2] != b"BM":
-            raise SyntaxError("Not a BMP file")
-        offset = i32(s[10:])
-
+        """ Open file, check magic number and read header """
+        # read 14 bytes: magic number, filesize, reserved, header final offset
+        head_data = self.fp.read(14)
+        # choke if the file does not have the required magic bytes
+        if head_data[0:2] != b"BM":
+            raise SyntaxError("Expected a BMP file.")
+        # read the start position of the BMP image data (u32) 
+        offset = i32(head_data[10:14])
+        # load bitmap information (offset=raster info)
         self._bitmap(offset=offset)
 
+    def _bitmap(self, header=0, offset=0):
+        """ Read relevant info about the BMP """
+        read, seek = self.fp.read, self.fp.seek
+        seek(2)
+        file_info = dict()
+        file_info['filesize'] = i32(read(12)[0:4]) # file size @offset 2 (offsets 4, 12 are reserved for OS/2 Icons)
+        file_info['header_size'] = i32(read(4)) # read bmp header size @offset 14 (this is part of the header size)
+        file_info['direction'] = -1
+        header_data = ImageFile._safe_read(self.fp, file_info['header_size'] - 4) # read the rest of the bmp header, without its size
+        
+        #---------------------------------------------------- IBM OS/2 Bitmap v1
+        #------- This format has different offsets because of width/height types
+        if file_info['header_size'] == 12:
+            file_info['width'] = i16(header_data[0:2])
+            file_info['height'] = i16(header_data[2:4])
+            file_info['planes'] = i16(header_data[4:6])
+            file_info['bits'] = i16(header_data[6:8])
+            file_info['compression'] = self.RAW
+            file_info['palette_padding'] = 3
+        #----------------------------------------------- Windows Bitmap v2 to v5
+        elif file_info['header_size'] in {40, 64, 108, 124}: # v3, OS/2 v2, v4, v5
+            if file_info['header_size'] >= 64:
+                file_info['r_mask'] = i32(header_data[36:40])
+                file_info['g_mask'] = i32(header_data[40:44])
+                file_info['b_mask'] = i32(header_data[44:48])
+                file_info['a_mask'] = i32(header_data[48:52])
+                file_info['rgb_mask'] = (file_info['r_mask'], file_info['g_mask'], file_info['b_mask'])
+                file_info['rgba_mask'] = (file_info['r_mask'], file_info['g_mask'], file_info['b_mask'], file_info['a_mask'])
+            if file_info['header_size'] >= 40:  # v3 and OS/2
+                file_info['y_flip'] = i8(header_data[7]) == 0xff
+                file_info['direction'] = 0 if file_info['y_flip'] else -1
+                file_info['width'] = i32(header_data[0:4])
+                file_info['height'] = i32(header_data[4:8]) if not file_info['y_flip'] else 2**32 - i32(header_data[4:8])
+                file_info['planes'] = i16(header_data[8:10])
+                file_info['bits'] = i16(header_data[10:12])
+                file_info['compression'] = i32(header_data[12:16])
+                file_info['data_size'] = i32(header_data[16:20])  # byte size of pixel data
+                file_info['pixels_per_meter'] = (i32(header_data[20:24]), i32(header_data[24:28])) 
+                file_info['colors'] = i32(header_data[28:32])
+                file_info['palette_padding'] = 4
+                self.info["dpi"] = tuple(map(lambda x: math.ceil(x / 39.3701), file_info['pixels_per_meter']))
+        else:
+            raise IOError("BMP images with a {0} byte header are not supported".format(file_info['header_size']))
+        self.size = file_info['width'], file_info['height']
+        #--------- If color count was not found in the header, compute from bits
+        file_info['colors'] = file_info['colors'] if file_info.get('colors', 0) else (1 << file_info['bits'])
+        #--------------------------------- Check abnormal values for DOS attacks
+        if file_info['width'] * file_info['height'] > 2**31:
+            raise IOError("BMP images with more than 2 billion pixels are not supported (here {0} pixels)".format(file_info['width'] * file_info['height']))
+        
+        #------------------------ Check bit depth for unusual unsupported values
+        self.mode, raw_mode = BIT2MODE.get(file_info['bits'], (None, None))
+        if self.mode is None:
+            raise IOError("BMP images with a {0}-bit pixel depth are not supported".format(file_info['bits']))
+        
+        #------------------ Process BMP with Bitfields compression (not palette)
+        if file_info['compression'] == self.BITFIELDS:
+            SUPPORTED = {32: [(0xff0000, 0xff00, 0xff, 0x0), (0xff0000, 0xff00, 0xff, 0xff000000)], 24: [(0xff0000, 0xff00, 0xff, 0x0)], 16: [(0xf800, 0x7e0, 0x1f, 0x0), (0x7c00, 0x3e0, 0x1f, 0x0)]}
+            MASK_MODES = {(32, (0xff0000, 0xff00, 0xff, 0x0)): "BGRX", (32, (0xff0000, 0xff00, 0xff, 0xff000000)): "BGRA", (24, (0xff0000, 0xff00, 0xff)): "BGR", (16, (0xf800, 0x7e0, 0x1f)): "BGR;16", (16, (0x7c00, 0x3e0, 0x1f)): "BGR;15"}
+            if file_info['bits'] in SUPPORTED and file_info['rgba_mask'] in SUPPORTED[file_info['bits']]:
+                raw_mode = MASK_MODES[(file_info['bits'], file_info['rgba_mask'])]
+                if raw_mode in {"BGRA"}:
+                    self.mode = "RGBA"
+            else:
+                raise IOError("BMP images with the provided bitfield information are not supported")
+        elif file_info['compression'] != self.RAW:
+            raise IOError("BMP files with RLE (1/2), JPEG (4) and PNG (5) compression are not supported")
+        
+        #----------------- Once the header is processed, process the palette/LUT
+        if self.mode == "P":  # Paletted for 1, 4 and 8 bit images
+            #------------------------------------------------------ 1-bit images
+            if not (0 < file_info['colors'] <= 65536):
+                raise IOError("BMP palette must have between 1 and 256 colors")
+            else:
+                padding = file_info['palette_padding']
+                palette = read(padding * file_info['colors'])
+                #------------------- Check if greyscale and ignore palette if so
+                greyscale = all([palette[ind] == palette[ind+1] == palette[ind+2] for ind in range(len(palette), padding)])
+                #--------- If all colors are grey, white or black, ditch palette
+                if greyscale:
+                    self.mode = "1" if file_info['colors'] == 2 else "L"
+                    raw_mode = self.mode
+                else:
+                    self.mode = "P"
+                    self.palette = ImagePalette.raw("BGRX", b"".join(palette))
+        
+        #------------------------------ Finally set the tile data for the plugin
+        self.info['compression'] = file_info['compression']
+        self.tile = [('raw', (0, 0, file_info['width'], file_info['height']), self.fp.tell(),
+                      (raw_mode, ((file_info['width'] * file_info['bits'] + 31) >> 3) & (~3), file_info['direction'])  
+                      )]
 
+
+#===============================================================================
+# Image plugin for the DIB format (BMP alias)
+#===============================================================================
 class DibImageFile(BmpImageFile):
 
     format = "DIB"
@@ -188,6 +184,8 @@ class DibImageFile(BmpImageFile):
 
     def _open(self):
         self._bitmap()
+
+
 
 #
 # --------------------------------------------------------------------
@@ -198,11 +196,13 @@ SAVE = {
     "L": ("L", 8, 256),
     "P": ("P", 8, 256),
     "RGB": ("BGR", 24, 0),
+    "RGBA": ("BGRA", 32, 0),
 }
 
 
 def _save(im, fp, filename, check=0):
     try:
+        print im.mode
         rawmode, bits, colors = SAVE[im.mode]
     except KeyError:
         raise IOError("cannot write mode %s as BMP" % im.mode)

--- a/PIL/BmpImagePlugin.py
+++ b/PIL/BmpImagePlugin.py
@@ -81,7 +81,6 @@ class BmpImageFile(ImageFile.ImageFile):
         self._bitmap(offset=offset)
 
     def _bitmap(self, header=0, offset=0):
-        print offset, header
         """ Read relevant info about the BMP """
         read, seek = self.fp.read, self.fp.seek
         if header:
@@ -180,7 +179,6 @@ class BmpImageFile(ImageFile.ImageFile):
                     self.mode = "P"
                     self.palette = ImagePalette.raw("BGRX" if padding == 4 else "BGR", b"".join(palette))
         
-        print file_info, self.mode, raw_mode, self.fp.tell()
         #------------------------------ Finally set the tile data for the plugin
         self.info['compression'] = file_info['compression']
         self.tile = [('raw', (0, 0, file_info['width'], file_info['height']), offset or self.fp.tell(),

--- a/PIL/BmpImagePlugin.py
+++ b/PIL/BmpImagePlugin.py
@@ -23,12 +23,11 @@
 # See the README file for information on usage and redistribution.
 #
 
-
 __version__ = "0.7"
-
 
 from PIL import Image, ImageFile, ImagePalette, _binary
 import math
+
 
 i8 = _binary.i8
 i16 = _binary.i16le
@@ -56,131 +55,147 @@ def _accept(prefix):
     return prefix[:2] == b"BM"
 
 
-##
+#===============================================================================
 # Image plugin for the Windows BMP format.
-
+#===============================================================================
 class BmpImageFile(ImageFile.ImageFile):
-
-    format = "BMP"
+    """ Image plugin for the Windows Bitmap format (BMP) """
+    
+    #--------------------------------------------------------------- Description
     format_description = "Windows Bitmap"
-
-    def _bitmap(self, header=0, offset=0):
-        if header:
-            self.fp.seek(header)
-
-        read = self.fp.read
-
-        # CORE/INFO
-        s = read(4)
-        s = s + ImageFile._safe_read(self.fp, i32(s)-4)
-
-        if len(s) == 12:
-
-            # OS/2 1.0 CORE
-            bits = i16(s[10:])
-            self.size = i16(s[4:]), i16(s[6:])
-            compression = 0
-            lutsize = 3
-            colors = 0
-            direction = -1
-
-        elif len(s) in [40, 64, 108, 124]:
-
-            # WIN 3.1 or OS/2 2.0 INFO
-            bits = i16(s[14:])
-            self.size = i32(s[4:]), i32(s[8:])
-            compression = i32(s[16:])
-            pxperm = (i32(s[24:]), i32(s[28:]))  # Pixels per meter
-            lutsize = 4
-            colors = i32(s[32:])
-            direction = -1
-            if i8(s[11]) == 0xff:
-                # upside-down storage
-                self.size = self.size[0], 2**32 - self.size[1]
-                direction = 0
-
-            self.info["dpi"] = tuple(map(lambda x: math.ceil(x / 39.3701),
-                                         pxperm))
-
-        else:
-            raise IOError("Unsupported BMP header type (%d)" % len(s))
-
-        if (self.size[0]*self.size[1]) > 2**31:
-            # Prevent DOS for > 2gb images
-            raise IOError("Unsupported BMP Size: (%dx%d)" % self.size)
-
-        if not colors:
-            colors = 1 << bits
-
-        # MODE
-        try:
-            self.mode, rawmode = BIT2MODE[bits]
-        except KeyError:
-            raise IOError("Unsupported BMP pixel depth (%d)" % bits)
-
-        if compression == 3:
-            # BI_BITFIELDS compression
-            mask = i32(read(4)), i32(read(4)), i32(read(4))
-            if bits == 32 and mask == (0xff0000, 0x00ff00, 0x0000ff):
-                rawmode = "BGRX"
-            elif bits == 16 and mask == (0x00f800, 0x0007e0, 0x00001f):
-                rawmode = "BGR;16"
-            elif bits == 16 and mask == (0x007c00, 0x0003e0, 0x00001f):
-                rawmode = "BGR;15"
-            else:
-                # print bits, map(hex, mask)
-                raise IOError("Unsupported BMP bitfields layout")
-        elif compression != 0:
-            raise IOError("Unsupported BMP compression (%d)" % compression)
-
-        # LUT
-        if self.mode == "P":
-            palette = []
-            greyscale = 1
-            if colors == 2:
-                indices = (0, 255)
-            elif colors > 2**16 or colors <= 0:  # We're reading a i32.
-                raise IOError("Unsupported BMP Palette size (%d)" % colors)
-            else:
-                indices = list(range(colors))
-            for i in indices:
-                rgb = read(lutsize)[:3]
-                if rgb != o8(i)*3:
-                    greyscale = 0
-                palette.append(rgb)
-            if greyscale:
-                if colors == 2:
-                    self.mode = rawmode = "1"
-                else:
-                    self.mode = rawmode = "L"
-            else:
-                self.mode = "P"
-                self.palette = ImagePalette.raw(
-                    "BGR", b"".join(palette)
-                    )
-
-        if not offset:
-            offset = self.fp.tell()
-
-        self.tile = [("raw",
-                     (0, 0) + self.size,
-                     offset,
-                     (rawmode, ((self.size[0]*bits+31) >> 3) & (~3),
-                      direction))]
-
-        self.info["compression"] = compression
+    format = "BMP"
+    #---------------------------------------------------- BMP Compression values
+    COMPRESSIONS = {'RAW': 0, 'RLE8': 1, 'RLE4': 2, 'BITFIELDS': 3, 'JPEG': 4, 'PNG': 5}
+    RAW, RLE8, RLE4, BITFIELDS, JPEG, PNG = 0, 1, 2, 3, 4, 5
 
     def _open(self):
-
-        # HEAD
-        s = self.fp.read(14)
-        if s[:2] != b"BM":
-            raise SyntaxError("Not a BMP file")
-        offset = i32(s[10:])
-
+        """ Open file, check magic number and read header """
+        # read 14 bytes: magic number, filesize, reserved, header final offset
+        head_data = self.fp.read(14)
+        # choke if the file does not have the required magic bytes
+        if head_data[0:2] != b"BM":
+            raise SyntaxError("Expected a BMP file.")
+        # read the start position of the BMP image data (u32) 
+        offset = i32(head_data[10:14])
+        # load bitmap information (offset=raster info)
         self._bitmap(offset=offset)
 
+    def _bitmap(self, header=0, offset=0):
+        """ Read relevant info about the BMP """
+        read, seek = self.fp.read, self.fp.seek
+        seek(2)
+        start_data = read(12)
+        file_info = dict()
+        file_info['filesize'] = i32(start_data[0:4]) # file size @offset 2 (offsets 4, 12 are reserved for OS/2 Icons)
+        file_info['image_offset'] = i32(start_data[8:12]) # file size @offset 2 (offsets 4, 12 are reserved for OS/2 Icons)
+        file_info['header_size'] = i32(read(4)) # read bmp header size @offset 14 (this is part of the header size)
+        file_info['direction'] = -1
+        header_data = ImageFile._safe_read(self.fp, file_info['header_size'] - 4) # read the rest of the bmp header, without its size
+        #---------------------------------------------------- IBM OS/2 Bitmap v1
+        #------- This format has different offsets because of width/height types
+        if file_info['header_size'] == 12:
+            file_info['width'] = i16(header_data[0:2])
+            file_info['height'] = i16(header_data[2:4])
+            file_info['planes'] = i16(header_data[4:6])
+            file_info['bits'] = i16(header_data[6:8])
+            file_info['compression'] = self.RAW
+            file_info['palette_padding'] = 3
+        #----------------------------------------------- Windows Bitmap v2 to v5
+        elif file_info['header_size'] in {40, 64, 108, 124}: # v3, OS/2 v2, v4, v5
+            if file_info['header_size'] >= 64:
+                file_info['r_mask'] = i32(header_data[36:40])
+                file_info['g_mask'] = i32(header_data[40:44])
+                file_info['b_mask'] = i32(header_data[44:48])
+                file_info['a_mask'] = i32(header_data[48:52])
+                file_info['rgb_mask'] = (file_info['r_mask'], file_info['g_mask'], file_info['b_mask'])
+                file_info['rgba_mask'] = (file_info['r_mask'], file_info['g_mask'], file_info['b_mask'], file_info['a_mask'])
+            if file_info['header_size'] >= 40:  # v3 and OS/2
+                file_info['y_flip'] = i8(header_data[7]) == 0xff
+                file_info['direction'] = 1 if file_info['y_flip'] else -1
+                file_info['width'] = i32(header_data[0:4])
+                file_info['height'] = i32(header_data[4:8]) if not file_info['y_flip'] else 2**32 - i32(header_data[4:8])
+                file_info['planes'] = i16(header_data[8:10])
+                file_info['bits'] = i16(header_data[10:12])
+                file_info['compression'] = i32(header_data[12:16])
+                file_info['data_size'] = i32(header_data[16:20])  # byte size of pixel data
+                file_info['pixels_per_meter'] = (i32(header_data[20:24]), i32(header_data[24:28])) 
+                file_info['colors'] = i32(header_data[28:32])
+                file_info['palette_padding'] = 4
+                #------------------- Special case : header is reported 40, which
+                #----------------------- is shorter than real size for bpp >= 16
+                if file_info['header_size'] < 64 and file_info['bits'] >= 16:
+                    file_info['r_mask'] = i32(read(4))
+                    file_info['g_mask'] = i32(read(4))
+                    file_info['b_mask'] = i32(read(4))
+                    file_info['a_mask'] = i32(read(4))
+                    file_info['rgb_mask'] = (file_info['r_mask'], file_info['g_mask'], file_info['b_mask'])
+                    file_info['rgba_mask'] = (file_info['r_mask'], file_info['g_mask'], file_info['b_mask'], file_info['a_mask'])
+                    
+                self.info["dpi"] = tuple(map(lambda x: math.ceil(x / 39.3701), file_info['pixels_per_meter']))
+        else:
+            raise IOError("BMP images with a {0} byte header are not supported".format(file_info['header_size']))
+        self.size = file_info['width'], file_info['height']
+        #--------- If color count was not found in the header, compute from bits
+        file_info['colors'] = file_info['colors'] if file_info.get('colors', 0) else (1 << file_info['bits'])
+        #--------------------------------- Check abnormal values for DOS attacks
+        if file_info['width'] * file_info['height'] > 2**31:
+            raise IOError("BMP images with more than 2 billion pixels are not supported (here {0} pixels)".format(file_info['width'] * file_info['height']))
+        
+        #------------------------ Check bit depth for unusual unsupported values
+        self.mode, raw_mode = BIT2MODE.get(file_info['bits'], (None, None))
+        if self.mode is None:
+            raise IOError("BMP images with a {0}-bit pixel depth are not supported".format(file_info['bits']))
+        
+        #------------------ Process BMP with Bitfields compression (not palette)
+        if file_info['compression'] == self.BITFIELDS:
+            SUPPORTED = {32: [(0xff0000, 0xff00, 0xff, 0x0), (0xff0000, 0xff00, 0xff, 0xff000000)], 24: [(0xff0000, 0xff00, 0xff)], 16: [(0xf800, 0x7e0, 0x1f), (0x7c00, 0x3e0, 0x1f)]}
+            MASK_MODES = {(32, (0xff0000, 0xff00, 0xff, 0x0)): "BGRX", (32, (0xff0000, 0xff00, 0xff, 0xff000000)): "BGRA", (24, (0xff0000, 0xff00, 0xff)): "BGR", (16, (0xf800, 0x7e0, 0x1f)): "BGR;16", (16, (0x7c00, 0x3e0, 0x1f)): "BGR;15"}
+            if file_info['bits'] in SUPPORTED:
+                if file_info['bits'] == 32 and file_info['rgba_mask'] in SUPPORTED[file_info['bits']]:
+                    raw_mode = MASK_MODES[(file_info['bits'], file_info['rgba_mask'])]
+                    self.mode = "RGBA" if raw_mode in ("BGRA",) else self.mode
+                elif file_info['bits'] in (24, 16) and file_info['rgb_mask'] in SUPPORTED[file_info['bits']]:
+                    raw_mode = MASK_MODES[(file_info['bits'], file_info['rgb_mask'])]
+                else:
+                    raise IOError("BMP images with the provided bitfield mask are not supported")
+            else:
+                raise IOError("BMP images with the provided bitfield information are not supported")
+        elif file_info['compression'] != self.RAW:
+            raise IOError("BMP files with RLE (1/2), JPEG (4) and PNG (5) compression are not supported")
+        
+        #----------------- Once the header is processed, process the palette/LUT
+        if self.mode == "P":  # Paletted for 1, 4 and 8 bit images
+            #------------------------------------------------------ 1-bit images
+            if not (0 < file_info['colors'] <= 65536):
+                raise IOError("BMP palette must have between 1 and 256 colors")
+            else:
+                padding = file_info['palette_padding']
+                palette = read(padding * file_info['colors'])
+                greyscale = True
+                indices = (0, 255) if file_info['colors'] == 2 else list(range(file_info['colors']))
+                #------------------- Check if greyscale and ignore palette if so
+                for ind, val in enumerate(indices):
+                    rgb = palette[ind*padding:ind*padding + 3]
+                    if rgb != o8(val) * 3:
+                        greyscale = False
+                #--------- If all colors are grey, white or black, ditch palette
+                if greyscale:
+                    self.mode = "1" if file_info['colors'] == 2 else "L"
+                    raw_mode = self.mode
+                else:
+                    self.mode = "P"
+                    self.palette = ImagePalette.raw("BGRX" if padding == 4 else "BGR", b"".join(palette))
+        
+        #------------------------------ Finally set the tile data for the plugin
+        self.info['compression'] = file_info['compression']
+        self.tile = [('raw', (0, 0, file_info['width'], file_info['height']), file_info['image_offset'],
+                      (raw_mode, ((file_info['width'] * file_info['bits'] + 31) >> 3) & (~3), file_info['direction'])  
+                      )]
 
+
+#===============================================================================
+# Image plugin for the DIB format (BMP alias)
+#===============================================================================
 class DibImageFile(BmpImageFile):
 
     format = "DIB"
@@ -188,6 +203,8 @@ class DibImageFile(BmpImageFile):
 
     def _open(self):
         self._bitmap()
+
+
 
 #
 # --------------------------------------------------------------------
@@ -198,6 +215,7 @@ SAVE = {
     "L": ("L", 8, 256),
     "P": ("P", 8, 256),
     "RGB": ("BGR", 24, 0),
+    "RGBA": ("BGRA", 32, 0),
 }
 
 

--- a/PIL/BmpImagePlugin.py
+++ b/PIL/BmpImagePlugin.py
@@ -23,11 +23,12 @@
 # See the README file for information on usage and redistribution.
 #
 
+
 __version__ = "0.7"
+
 
 from PIL import Image, ImageFile, ImagePalette, _binary
 import math
-
 
 i8 = _binary.i8
 i16 = _binary.i16le
@@ -55,147 +56,131 @@ def _accept(prefix):
     return prefix[:2] == b"BM"
 
 
-#===============================================================================
+##
 # Image plugin for the Windows BMP format.
-#===============================================================================
-class BmpImageFile(ImageFile.ImageFile):
-    """ Image plugin for the Windows Bitmap format (BMP) """
-    
-    #--------------------------------------------------------------- Description
-    format_description = "Windows Bitmap"
-    format = "BMP"
-    #---------------------------------------------------- BMP Compression values
-    COMPRESSIONS = {'RAW': 0, 'RLE8': 1, 'RLE4': 2, 'BITFIELDS': 3, 'JPEG': 4, 'PNG': 5}
-    RAW, RLE8, RLE4, BITFIELDS, JPEG, PNG = 0, 1, 2, 3, 4, 5
 
-    def _open(self):
-        """ Open file, check magic number and read header """
-        # read 14 bytes: magic number, filesize, reserved, header final offset
-        head_data = self.fp.read(14)
-        # choke if the file does not have the required magic bytes
-        if head_data[0:2] != b"BM":
-            raise SyntaxError("Expected a BMP file.")
-        # read the start position of the BMP image data (u32) 
-        offset = i32(head_data[10:14])
-        # load bitmap information (offset=raster info)
-        self._bitmap(offset=offset)
+class BmpImageFile(ImageFile.ImageFile):
+
+    format = "BMP"
+    format_description = "Windows Bitmap"
 
     def _bitmap(self, header=0, offset=0):
-        """ Read relevant info about the BMP """
-        read, seek = self.fp.read, self.fp.seek
-        seek(2)
-        start_data = read(12)
-        file_info = dict()
-        file_info['filesize'] = i32(start_data[0:4]) # file size @offset 2 (offsets 4, 12 are reserved for OS/2 Icons)
-        file_info['image_offset'] = i32(start_data[8:12]) # file size @offset 2 (offsets 4, 12 are reserved for OS/2 Icons)
-        file_info['header_size'] = i32(read(4)) # read bmp header size @offset 14 (this is part of the header size)
-        file_info['direction'] = -1
-        header_data = ImageFile._safe_read(self.fp, file_info['header_size'] - 4) # read the rest of the bmp header, without its size
-        #---------------------------------------------------- IBM OS/2 Bitmap v1
-        #------- This format has different offsets because of width/height types
-        if file_info['header_size'] == 12:
-            file_info['width'] = i16(header_data[0:2])
-            file_info['height'] = i16(header_data[2:4])
-            file_info['planes'] = i16(header_data[4:6])
-            file_info['bits'] = i16(header_data[6:8])
-            file_info['compression'] = self.RAW
-            file_info['palette_padding'] = 3
-        #----------------------------------------------- Windows Bitmap v2 to v5
-        elif file_info['header_size'] in {40, 64, 108, 124}: # v3, OS/2 v2, v4, v5
-            if file_info['header_size'] >= 64:
-                file_info['r_mask'] = i32(header_data[36:40])
-                file_info['g_mask'] = i32(header_data[40:44])
-                file_info['b_mask'] = i32(header_data[44:48])
-                file_info['a_mask'] = i32(header_data[48:52])
-                file_info['rgb_mask'] = (file_info['r_mask'], file_info['g_mask'], file_info['b_mask'])
-                file_info['rgba_mask'] = (file_info['r_mask'], file_info['g_mask'], file_info['b_mask'], file_info['a_mask'])
-            if file_info['header_size'] >= 40:  # v3 and OS/2
-                file_info['y_flip'] = i8(header_data[7]) == 0xff
-                file_info['direction'] = 1 if file_info['y_flip'] else -1
-                file_info['width'] = i32(header_data[0:4])
-                file_info['height'] = i32(header_data[4:8]) if not file_info['y_flip'] else 2**32 - i32(header_data[4:8])
-                file_info['planes'] = i16(header_data[8:10])
-                file_info['bits'] = i16(header_data[10:12])
-                file_info['compression'] = i32(header_data[12:16])
-                file_info['data_size'] = i32(header_data[16:20])  # byte size of pixel data
-                file_info['pixels_per_meter'] = (i32(header_data[20:24]), i32(header_data[24:28])) 
-                file_info['colors'] = i32(header_data[28:32])
-                file_info['palette_padding'] = 4
-                #------------------- Special case : header is reported 40, which
-                #----------------------- is shorter than real size for bpp >= 16
-                if file_info['header_size'] < 64 and file_info['bits'] >= 16:
-                    file_info['r_mask'] = i32(read(4))
-                    file_info['g_mask'] = i32(read(4))
-                    file_info['b_mask'] = i32(read(4))
-                    file_info['a_mask'] = i32(read(4))
-                    file_info['rgb_mask'] = (file_info['r_mask'], file_info['g_mask'], file_info['b_mask'])
-                    file_info['rgba_mask'] = (file_info['r_mask'], file_info['g_mask'], file_info['b_mask'], file_info['a_mask'])
-                    
-                self.info["dpi"] = tuple(map(lambda x: math.ceil(x / 39.3701), file_info['pixels_per_meter']))
+        if header:
+            self.fp.seek(header)
+
+        read = self.fp.read
+
+        # CORE/INFO
+        s = read(4)
+        s = s + ImageFile._safe_read(self.fp, i32(s)-4)
+
+        if len(s) == 12:
+
+            # OS/2 1.0 CORE
+            bits = i16(s[10:])
+            self.size = i16(s[4:]), i16(s[6:])
+            compression = 0
+            lutsize = 3
+            colors = 0
+            direction = -1
+
+        elif len(s) in [40, 64, 108, 124]:
+
+            # WIN 3.1 or OS/2 2.0 INFO
+            bits = i16(s[14:])
+            self.size = i32(s[4:]), i32(s[8:])
+            compression = i32(s[16:])
+            pxperm = (i32(s[24:]), i32(s[28:]))  # Pixels per meter
+            lutsize = 4
+            colors = i32(s[32:])
+            direction = -1
+            if i8(s[11]) == 0xff:
+                # upside-down storage
+                self.size = self.size[0], 2**32 - self.size[1]
+                direction = 0
+
+            self.info["dpi"] = tuple(map(lambda x: math.ceil(x / 39.3701),
+                                         pxperm))
+
         else:
-            raise IOError("BMP images with a {0} byte header are not supported".format(file_info['header_size']))
-        self.size = file_info['width'], file_info['height']
-        #--------- If color count was not found in the header, compute from bits
-        file_info['colors'] = file_info['colors'] if file_info.get('colors', 0) else (1 << file_info['bits'])
-        #--------------------------------- Check abnormal values for DOS attacks
-        if file_info['width'] * file_info['height'] > 2**31:
-            raise IOError("BMP images with more than 2 billion pixels are not supported (here {0} pixels)".format(file_info['width'] * file_info['height']))
-        
-        #------------------------ Check bit depth for unusual unsupported values
-        self.mode, raw_mode = BIT2MODE.get(file_info['bits'], (None, None))
-        if self.mode is None:
-            raise IOError("BMP images with a {0}-bit pixel depth are not supported".format(file_info['bits']))
-        
-        #------------------ Process BMP with Bitfields compression (not palette)
-        if file_info['compression'] == self.BITFIELDS:
-            SUPPORTED = {32: [(0xff0000, 0xff00, 0xff, 0x0), (0xff0000, 0xff00, 0xff, 0xff000000)], 24: [(0xff0000, 0xff00, 0xff)], 16: [(0xf800, 0x7e0, 0x1f), (0x7c00, 0x3e0, 0x1f)]}
-            MASK_MODES = {(32, (0xff0000, 0xff00, 0xff, 0x0)): "BGRX", (32, (0xff0000, 0xff00, 0xff, 0xff000000)): "BGRA", (24, (0xff0000, 0xff00, 0xff)): "BGR", (16, (0xf800, 0x7e0, 0x1f)): "BGR;16", (16, (0x7c00, 0x3e0, 0x1f)): "BGR;15"}
-            if file_info['bits'] in SUPPORTED:
-                if file_info['bits'] == 32 and file_info['rgba_mask'] in SUPPORTED[file_info['bits']]:
-                    raw_mode = MASK_MODES[(file_info['bits'], file_info['rgba_mask'])]
-                    self.mode = "RGBA" if raw_mode in ("BGRA",) else self.mode
-                elif file_info['bits'] in (24, 16) and file_info['rgb_mask'] in SUPPORTED[file_info['bits']]:
-                    raw_mode = MASK_MODES[(file_info['bits'], file_info['rgb_mask'])]
-                else:
-                    raise IOError("BMP images with the provided bitfield mask are not supported")
+            raise IOError("Unsupported BMP header type (%d)" % len(s))
+
+        if (self.size[0]*self.size[1]) > 2**31:
+            # Prevent DOS for > 2gb images
+            raise IOError("Unsupported BMP Size: (%dx%d)" % self.size)
+
+        if not colors:
+            colors = 1 << bits
+
+        # MODE
+        try:
+            self.mode, rawmode = BIT2MODE[bits]
+        except KeyError:
+            raise IOError("Unsupported BMP pixel depth (%d)" % bits)
+
+        if compression == 3:
+            # BI_BITFIELDS compression
+            mask = i32(read(4)), i32(read(4)), i32(read(4))
+            if bits == 32 and mask == (0xff0000, 0x00ff00, 0x0000ff):
+                rawmode = "BGRX"
+            elif bits == 16 and mask == (0x00f800, 0x0007e0, 0x00001f):
+                rawmode = "BGR;16"
+            elif bits == 16 and mask == (0x007c00, 0x0003e0, 0x00001f):
+                rawmode = "BGR;15"
             else:
-                raise IOError("BMP images with the provided bitfield information are not supported")
-        elif file_info['compression'] != self.RAW:
-            raise IOError("BMP files with RLE (1/2), JPEG (4) and PNG (5) compression are not supported")
-        
-        #----------------- Once the header is processed, process the palette/LUT
-        if self.mode == "P":  # Paletted for 1, 4 and 8 bit images
-            #------------------------------------------------------ 1-bit images
-            if not (0 < file_info['colors'] <= 65536):
-                raise IOError("BMP palette must have between 1 and 256 colors")
+                # print bits, map(hex, mask)
+                raise IOError("Unsupported BMP bitfields layout")
+        elif compression != 0:
+            raise IOError("Unsupported BMP compression (%d)" % compression)
+
+        # LUT
+        if self.mode == "P":
+            palette = []
+            greyscale = 1
+            if colors == 2:
+                indices = (0, 255)
+            elif colors > 2**16 or colors <= 0:  # We're reading a i32.
+                raise IOError("Unsupported BMP Palette size (%d)" % colors)
             else:
-                padding = file_info['palette_padding']
-                palette = read(padding * file_info['colors'])
-                greyscale = True
-                indices = (0, 255) if file_info['colors'] == 2 else list(range(file_info['colors']))
-                #------------------- Check if greyscale and ignore palette if so
-                for ind in indices:
-                    rgb = palette[ind*padding:ind*padding + 3]
-                    if rgb != o8(ind) * 3:
-                        greyscale = False
-                #--------- If all colors are grey, white or black, ditch palette
-                if greyscale:
-                    self.mode = "1" if file_info['colors'] == 2 else "L"
-                    raw_mode = self.mode
+                indices = list(range(colors))
+            for i in indices:
+                rgb = read(lutsize)[:3]
+                if rgb != o8(i)*3:
+                    greyscale = 0
+                palette.append(rgb)
+            if greyscale:
+                if colors == 2:
+                    self.mode = rawmode = "1"
                 else:
-                    self.mode = "P"
-                    self.palette = ImagePalette.raw("BGRX" if padding == 4 else "BGR", b"".join(palette))
-        
-        #------------------------------ Finally set the tile data for the plugin
-        self.info['compression'] = file_info['compression']
-        self.tile = [('raw', (0, 0, file_info['width'], file_info['height']), file_info['image_offset'],
-                      (raw_mode, ((file_info['width'] * file_info['bits'] + 31) >> 3) & (~3), file_info['direction'])  
-                      )]
+                    self.mode = rawmode = "L"
+            else:
+                self.mode = "P"
+                self.palette = ImagePalette.raw(
+                    "BGR", b"".join(palette)
+                    )
+
+        if not offset:
+            offset = self.fp.tell()
+
+        self.tile = [("raw",
+                     (0, 0) + self.size,
+                     offset,
+                     (rawmode, ((self.size[0]*bits+31) >> 3) & (~3),
+                      direction))]
+
+        self.info["compression"] = compression
+
+    def _open(self):
+
+        # HEAD
+        s = self.fp.read(14)
+        if s[:2] != b"BM":
+            raise SyntaxError("Not a BMP file")
+        offset = i32(s[10:])
+
+        self._bitmap(offset=offset)
 
 
-#===============================================================================
-# Image plugin for the DIB format (BMP alias)
-#===============================================================================
 class DibImageFile(BmpImageFile):
 
     format = "DIB"
@@ -203,8 +188,6 @@ class DibImageFile(BmpImageFile):
 
     def _open(self):
         self._bitmap()
-
-
 
 #
 # --------------------------------------------------------------------
@@ -215,7 +198,6 @@ SAVE = {
     "L": ("L", 8, 256),
     "P": ("P", 8, 256),
     "RGB": ("BGR", 24, 0),
-    "RGBA": ("BGRA", 32, 0),
 }
 
 

--- a/PIL/BmpImagePlugin.py
+++ b/PIL/BmpImagePlugin.py
@@ -91,6 +91,7 @@ class BmpImageFile(ImageFile.ImageFile):
         file_info['header_size'] = i32(read(4)) # read bmp header size @offset 14 (this is part of the header size)
         file_info['direction'] = -1
         header_data = ImageFile._safe_read(self.fp, file_info['header_size'] - 4) # read the rest of the bmp header, without its size
+        file_info['header_size'] = len(header_data) + 4
         #---------------------------------------------------- IBM OS/2 Bitmap v1
         #------- This format has different offsets because of width/height types
         if file_info['header_size'] == 12:
@@ -101,7 +102,7 @@ class BmpImageFile(ImageFile.ImageFile):
             file_info['compression'] = self.RAW
             file_info['palette_padding'] = 3
         #----------------------------------------------- Windows Bitmap v2 to v5
-        elif file_info['header_size'] in {40, 64, 108, 124}: # v3, OS/2 v2, v4, v5
+        elif file_info['header_size'] in (40, 64, 108, 124): # v3, OS/2 v2, v4, v5
             if file_info['header_size'] >= 64:
                 file_info['r_mask'] = i32(header_data[36:40])
                 file_info['g_mask'] = i32(header_data[40:44])

--- a/PIL/BmpImagePlugin.py
+++ b/PIL/BmpImagePlugin.py
@@ -171,8 +171,13 @@ class BmpImageFile(ImageFile.ImageFile):
             else:
                 padding = file_info['palette_padding']
                 palette = read(padding * file_info['colors'])
+                greyscale = True
+                indices = (0, 255) if file_info['colors'] == 2 else list(range(file_info['colors']))
                 #------------------- Check if greyscale and ignore palette if so
-                greyscale = all([palette[ind] == palette[ind+1] == palette[ind+2] == ind / padding for ind in range(0, len(palette), padding)])
+                for ind in indices:
+                    rgb = palette[ind*padding:ind*padding + 3]
+                    if rgb != o8(ind) * 3:
+                        greyscale = False
                 #--------- If all colors are grey, white or black, ditch palette
                 if greyscale:
                     self.mode = "1" if file_info['colors'] == 2 else "L"

--- a/PIL/BmpImagePlugin.py
+++ b/PIL/BmpImagePlugin.py
@@ -202,7 +202,6 @@ SAVE = {
 
 def _save(im, fp, filename, check=0):
     try:
-        print im.mode
         rawmode, bits, colors = SAVE[im.mode]
     except KeyError:
         raise IOError("cannot write mode %s as BMP" % im.mode)

--- a/PIL/BmpImagePlugin.py
+++ b/PIL/BmpImagePlugin.py
@@ -126,7 +126,6 @@ class BmpImageFile(ImageFile.ImageFile):
         self.mode, raw_mode = BIT2MODE.get(file_info['bits'], (None, None))
         if self.mode is None:
             raise IOError("Unsupported BMP pixel depth (%d)" % file_info['bits'])
-        
         #------------------ Process BMP with Bitfields compression (not palette)
         if file_info['compression'] == self.BITFIELDS:
             SUPPORTED = {32: [(0xff0000, 0xff00, 0xff, 0x0), (0xff0000, 0xff00, 0xff, 0xff000000), (0x0, 0x0, 0x0, 0x0)], 24: [(0xff0000, 0xff00, 0xff)], 16: [(0xf800, 0x7e0, 0x1f), (0x7c00, 0x3e0, 0x1f)]}
@@ -167,7 +166,7 @@ class BmpImageFile(ImageFile.ImageFile):
                     raw_mode = self.mode
                 else:
                     self.mode = "P"
-                    self.palette = ImagePalette.raw("BGRX" if padding == 4 else "BGR", b"".join(palette))
+                    self.palette = ImagePalette.raw("BGRX" if padding == 4 else "BGR", palette)
         
         #------------------------------ Finally set the tile data for the plugin
         self.info['compression'] = file_info['compression']

--- a/PIL/BmpImagePlugin.py
+++ b/PIL/BmpImagePlugin.py
@@ -85,8 +85,10 @@ class BmpImageFile(ImageFile.ImageFile):
         """ Read relevant info about the BMP """
         read, seek = self.fp.read, self.fp.seek
         seek(2)
+        start_data = read(12)
         file_info = dict()
-        file_info['filesize'] = i32(read(12)[0:4]) # file size @offset 2 (offsets 4, 12 are reserved for OS/2 Icons)
+        file_info['filesize'] = i32(start_data[0:4]) # file size @offset 2 (offsets 4, 12 are reserved for OS/2 Icons)
+        file_info['image_offset'] = i32(start_data[8:12]) # file size @offset 2 (offsets 4, 12 are reserved for OS/2 Icons)
         file_info['header_size'] = i32(read(4)) # read bmp header size @offset 14 (this is part of the header size)
         file_info['direction'] = -1
         header_data = ImageFile._safe_read(self.fp, file_info['header_size'] - 4) # read the rest of the bmp header, without its size
@@ -101,7 +103,7 @@ class BmpImageFile(ImageFile.ImageFile):
             file_info['compression'] = self.RAW
             file_info['palette_padding'] = 3
         #----------------------------------------------- Windows Bitmap v2 to v5
-        elif file_info['header_size'] in {40, 64, 108, 124}: # v3, OS/2 v2, v4, v5
+        elif file_info['header_size'] in (40, 64, 108, 124): # v3, OS/2 v2, v4, v5
             if file_info['header_size'] >= 64:
                 file_info['r_mask'] = i32(header_data[36:40])
                 file_info['g_mask'] = i32(header_data[40:44])

--- a/PIL/BmpImagePlugin.py
+++ b/PIL/BmpImagePlugin.py
@@ -171,7 +171,7 @@ class BmpImageFile(ImageFile.ImageFile):
         
         #------------------------------ Finally set the tile data for the plugin
         self.info['compression'] = file_info['compression']
-        self.tile = [('raw', (0, 0, file_info['width'], file_info['height']), self.fp.tell(),
+        self.tile = [('raw', (0, 0, file_info['width'], file_info['height']), file_info['image_offset'],
                       (raw_mode, ((file_info['width'] * file_info['bits'] + 31) >> 3) & (~3), file_info['direction'])  
                       )]
 

--- a/Tests/test_file_cur.py
+++ b/Tests/test_file_cur.py
@@ -16,9 +16,9 @@ class TestFileCur(PillowTestCase):
         self.assertEqual(im.size, (32, 32))
         self.assertIsInstance(im, CurImagePlugin.CurImageFile)
         # Check some pixel colors to ensure image is loaded properly
-        self.assertEqual(im.getpixel((10, 1)), (0, 0, 0))
-        self.assertEqual(im.getpixel((11, 1)), (253, 254, 254))
-        self.assertEqual(im.getpixel((16, 16)), (84, 87, 86))
+        self.assertEqual(im.getpixel((10, 1)), (0, 0, 0, 0))
+        self.assertEqual(im.getpixel((11, 1)), (253, 254, 254, 1))
+        self.assertEqual(im.getpixel((16, 16)), (84, 87, 86, 255))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
PIL choked on perfectly valid BMP files (32 bits with Alpha). It could not handle valid RGBA masks to determine the raw format.
To clarify things, I:
- Rewrote the `BmpImagePlugin.BmpImageFile` class to be far more readable
- Made error messages more explicit (e.g. say that RLE bitmaps are unsupported)
- Made a readable dict to contain BMP header information
- Kept the existing security checks
- Instead of reading palette info by chunks of 3/4 bytes, read the whole palette info at once and parse the data.
- Now works with BMPv4/5 with Alpha (and can be exported to alpha PNG for example)
- Tested load and save with RGB24, RGB8, RGB8L, RGB32 and RGBA32.
- Tested with one bogus file. File not accepted, as expected.
- Size of header attributes is made explicit in this code

I wanted to test more BMP formats, but I could not find that many images.
But for all the types I tested, it worked flawlessly.