### PR TITLE
Fix ImagingEffectNoise

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -168,8 +168,6 @@ class TestImage(PillowTestCase):
             ValueError,
             lambda: Image.effect_mandelbrot(size, extent, quality))
 
-    @unittest.skipUnless(sys.platform.startswith('win32'),
-                         "Stalls on Travis CI, passes on Windows")
     def test_effect_noise(self):
         # Arrange
         size = (100, 100)
@@ -180,8 +178,8 @@ class TestImage(PillowTestCase):
 
         # Assert
         self.assertEqual(im.size, (100, 100))
-        self.assertEqual(im.getpixel((0, 0)), 60)
-        self.assertEqual(im.getpixel((0, 1)), 28)
+        self.assertEqual(im.mode, "L")
+        self.assertNotEqual(im.getpixel((0, 0)), im.getpixel((0, 1)))
 
     def test_effect_spread(self):
         # Arrange

--- a/libImaging/Effects.c
+++ b/libImaging/Effects.c
@@ -98,8 +98,8 @@ ImagingEffectNoise(int xsize, int ysize, float sigma)
                 /* after numerical recipes */
                 double v1, v2, radius, factor;
                 do {
-                    v1 = rand()*(2.0/32767.0) - 1.0;
-                    v2 = rand()*(2.0/32767.0) - 1.0;
+                    v1 = rand()*(2.0/RAND_MAX) - 1.0;
+                    v2 = rand()*(2.0/RAND_MAX) - 1.0;
                     radius= v1*v1 + v2*v2;
                 } while (radius >= 1.0);
                 factor = sqrt(-2.0*log(radius)/radius);


### PR DESCRIPTION
`test_effect_noise()` was skipped on non-Windows because it was hanging on Linux (Travis CI) and on OS X.

It got stuck in an infinite loop here:
```C
                do {
                    v1 = rand()*(2.0/32767.0) - 1.0;
                    v2 = rand()*(2.0/32767.0) - 1.0;
                    radius= v1*v1 + v2*v2;
                } while (radius >= 1.0);
```

Documentation for `rand()` says:

> The C library function **int rand(void)** returns a pseudo-random number in the range of 0 to *RAND_MAX*.

> RAND_MAX is a constant whose default value may vary between implementations but it is granted to be at least 32767.

The code makes an assumption that RAND_MAX = 32767, which it generally is on Windows, but 2147483647 on other systems. So changing the magic number to the constant RAND_MAX fixes this. The test also made assumptions about pixel values for RAND_MAX = 32767 calculations, so it's been made less strict.
