### PR TITLE
Fix UnboundLocalError in ImageFile

### DIFF
--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -196,13 +196,15 @@ class ImageFile(Image.Image):
             except AttributeError:
                 prefix = b""
 
+            # Buffer length read; assign a default value
+            t = 0
+
             for d, e, o, a in self.tile:
                 d = Image._getdecoder(self.mode, d, a, self.decoderconfig)
                 seek(o)
                 try:
                     d.setimage(self.im, e)
                 except ValueError:
-                    t = None
                     continue
                 b = prefix
                 t = len(b)

--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -202,6 +202,7 @@ class ImageFile(Image.Image):
                 try:
                     d.setimage(self.im, e)
                 except ValueError:
+                    t = None
                     continue
                 b = prefix
                 t = len(b)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../lib/python2.7/site-packages/PIL/Image.py", line 832, in convert
    self.load()
  File "/.../lib/python2.7/site-packages/PIL/ImageFile.py", line 248, in load
    if not self.map and (not LOAD_TRUNCATED_IMAGES or t == 0) and e < 0:
UnboundLocalError: local variable 't' referenced before assignment
```

Steps to reproduce:
```
from PIL import Image, ImageFile
ImageFile.LOAD_TRUNCATED_IMAGES = True
img = Image.open(<attached gif>)
img.convert("RGB")
```

![pil-error](https://cloud.githubusercontent.com/assets/1048722/6599498/0b6cc38c-c802-11e4-84fc-79dabd0b82d5.gif)

It seems like `d.setimage(self.im, e)` (https://github.com/python-pillow/Pillow/blob/master/PIL/ImageFile.py#L203) raises a ValueError so the variable `t` will never be set.

I am not 100% sure if `t = None` is the right default value, but this seems to work.