### PR TITLE
Make gifmaker work with the current getheader

### DIFF
--- a/Scripts/gifmaker.py
+++ b/Scripts/gifmaker.py
@@ -78,7 +78,7 @@ def makedelta(fp, sequence):
         if not previous:
 
             # global header
-            for s in getheader(im) + getdata(im):
+            for s in getheader(im)[0] + getdata(im):
                 fp.write(s)
 
         else:


### PR DESCRIPTION
GifImagePlugin.getheader was updated about 2 years ago and changed the API that gifmaker expects.