### PR TITLE
Fix TabError from PR #1123

### DIFF
--- a/PIL/ImageFont.py
+++ b/PIL/ImageFont.py
@@ -168,19 +168,20 @@ class FreeTypeFont:
         return im, offset
 
     def font_variant(self, font=None, size=None, index=None, encoding=None):
-		"""
-		Create a copy of this FreeTypeFont object,
-		using any specified arguments to override the settings.
-		
-		Parameters are identical to the parameters used to initialize this object,
-		minus the deprecated 'file' argument.
-		
-		:return: A FreeTypeFont object.
-		"""
-        return FreeTypeFont(font = self.path if font == None else font,
-                            size = self.size if size == None else size,
-                            index = self.index if index == None else index,
-                            encoding = self.encoding if encoding == None else encoding)
+        """
+        Create a copy of this FreeTypeFont object,
+        using any specified arguments to override the settings.
+
+        Parameters are identical to the parameters used to initialize this
+        object, minus the deprecated 'file' argument.
+
+        :return: A FreeTypeFont object.
+        """
+        return FreeTypeFont(font=self.path if font is None else font,
+                            size=self.size if size is None else size,
+                            index=self.index if index is None else index,
+                            encoding=self.encoding if encoding is None else
+                            encoding)
 
 ##
 # Wrapper that creates a transposed font from any existing font
@@ -275,8 +276,8 @@ def truetype(font=None, size=10, index=0, encoding="", filename=None):
         elif sys.platform in ('linux', 'linux2'):
             lindirs = os.environ.get("XDG_DATA_DIRS", "")
             if not lindirs:
-                #According to the freedesktop spec, XDG_DATA_DIRS should
-                #default to /usr/share
+                # According to the freedesktop spec, XDG_DATA_DIRS should
+                # default to /usr/share
                 lindirs = '/usr/share'
             lindirs = lindirs.split(":")
             for lindir in lindirs:
@@ -286,7 +287,8 @@ def truetype(font=None, size=10, index=0, encoding="", filename=None):
                         filepath = os.path.join(walkroot, ttf_filename)
                         return FreeTypeFont(filepath, size, index, encoding)
         elif sys.platform == 'darwin':
-            macdirs = ['/Library/Fonts/', '/System/Library/Fonts/', os.path.expanduser('~/Library/Fonts/')]
+            macdirs = ['/Library/Fonts/', '/System/Library/Fonts/',
+                       os.path.expanduser('~/Library/Fonts/')]
             for macdir in macdirs:
                 filepath = os.path.join(macdir, ttf_filename)
                 if os.path.exists(filepath):


### PR DESCRIPTION
The CI failed after merging PR #1123 with:

`TabError: inconsistent use of tabs and spaces in indentation`
https://travis-ci.org/python-pillow/Pillow/builds/55271699

The PR didn't pick it up because of the [CI skip], and I wouldn't have expected it to fail either. In general, I suppose if source code is edited at all, it's better to avoid CI skip! :)

Also did some other little flake8 fixes.