### PR TITLE
Aclark releasing nits

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -55,7 +55,7 @@ Released as needed for security, installation or critical bug fixes.
 
 ## Embargoed Release
 
-Released as needed to vendors before public for critical security-related bug fixes.
+Released as needed privately to individual vendors before public for critical security-related bug fixes.
 
 * [ ] Prepare patch for all versions that will get a fix. Test against local installations.
 * [ ] Commit against master, cherry pick to affected release branches.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@ Released quarterly on the first day of January, April, July, October.
 
 * [ ] Develop and prepare release in ``master`` branch.
 * [ ] Check [Travis CI](https://travis-ci.org/python-pillow/Pillow) to confirm passing tests in ``master`` branch.
-* [ ] Update version in:
+* [ ] In compliance with https://www.python.org/dev/peps/pep-0440/, update version identifier in: 
 ```
     PIL/__init__.py setup.py _imaging.c
 ```
@@ -27,21 +27,23 @@ Released quarterly on the first day of January, April, July, October.
 
 ## Point Release
 
-Released as required for security, installation or critical bug fixes.
+Released as needed for security, installation or critical bug fixes.
 
-* [ ] Make necessary changes in master.
-* [ ] Cherry pick individual commits.
-* [ ] Update version in:
-
+* [ ] Make necessary changes in ``master`` branch.
+* [ ] Cherry pick individual commits from ``master`` branch to release branch e.g. ``2.8.x``.
+* [ ] In compliance with https://www.python.org/dev/peps/pep-0440/, update version identifier in: 
 ```
     PIL/__init__.py setup.py _imaging.c
 ```
 * [ ] Update `CHANGES.rst`. 
-* [ ] Run pre-release check via `make pre`
+* [ ] Run pre-release check via `make pre`.
 * [ ] Push to release branch in personal repo. Let Travis run cleanly.
 * [ ] Tag and push to release branch in python-pillow repo.
-* [ ] Upload source and binary distributions.
-
+* [ ] Create and upload source distributions e.g.:
+```
+    $ make sdistup
+```
+* [ ] Create and upload binary distributions (see below).
 ## Embargoed Release
 
 Security fixes that need to be pushed to the distros prior to public release.
@@ -62,7 +64,7 @@ Security fixes that need to be pushed to the distros prior to public release.
 * [ ] Upload source and binary distributions.
 
 
-## Upload Process
+## Binary Distributions
 
 * [ ] Contact @cgohlke for Windows binaries.
 * [ ] From a clean source directory with no extra temp files:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,10 +54,10 @@ Security fixes that need to be pushed to the distros prior to public release.
 * [ ] Amend any commits with the CVE #
 * [ ] On release date, tag and push to GitHub.
 ```
-git checkout 2.5.x
-git tag 2.5.3
-git push origin 2.5.x
-git push origin --tags
+    git checkout 2.5.x
+    git tag 2.5.3
+    git push origin 2.5.x
+    git push origin --tags
 ```
 * [ ] Upload source and binary distributions.
 
@@ -71,7 +71,7 @@ python setup.py sdist --format=zip upload
 ```
 Or
 ```
-make sdistup
+    make sdistup
 ```
 (Debian requests a tarball, everyone else would just prefer that we choose one and stick to it. So both it is)
 * [ ] Push a commit to https://github.com/python-pillow/pillow-wheels to build OSX versions (UNDONE latest tag or specific release???)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -78,3 +78,9 @@ make sdistup
 * [ ] Retrieve the OS X Wheels from Rackspace files, upload to PyPi (Twine?)
 * [ ] Grab Windows binaries, `twine upload dist/*.[whl|egg]`. Manually upload .exe installers.
 * [ ] Announce release availability. [Twitter](https://twitter.com/pythonpillow), web.
+
+
+Footnotes[^1] have a label[^@#$%] and the footnote's content.
+
+[^1]: This is a footnote content.
+[^@#$%]: A footnote on the label: "@#$%".

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,7 @@
 
 Released quarterly on the first day of January, April, July, October.
 
+* [ ] Open a release ticket e.g. https://github.com/python-pillow/Pillow/issues/1174
 * [ ] Develop and prepare release in ``master`` branch.
 * [ ] Check [Travis CI](https://travis-ci.org/python-pillow/Pillow) to confirm passing tests in ``master`` branch.
 * [ ] In compliance with https://www.python.org/dev/peps/pep-0440/, update version identifier in: 
@@ -79,14 +80,7 @@ Released as needed privately to individual vendors for critical security-related
 ## Binary Distributions
 
 * [ ] Contact @cgohlke for Windows binaries.
-* [ ] From a clean source directory with no extra temp files:
-```
-python setup.py sdist --format=zip upload
-```
-Or
-```
-    make sdistup
-```
+
 (Debian requests a tarball, everyone else would just prefer that we choose one and stick to it. So both it is)
 * [ ] Push a commit to https://github.com/python-pillow/pillow-wheels to build OSX versions (UNDONE latest tag or specific release???)
 * [ ] Retrieve the OS X Wheels from Rackspace files, upload to PyPi (Twine?)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,7 +23,7 @@ Released quarterly on the first day of January, April, July, October.
 ```
     $ make sdistup
 ```
-* [ ] Create and upload binary distributions (see below).
+* [ ] Create and upload [binary distributions](#binary-distributions)
 
 ## Point Release
 
@@ -43,7 +43,7 @@ Released as needed for security, installation or critical bug fixes.
 ```
     $ make sdistup
 ```
-* [ ] Create and upload binary distributions (see below).
+* [ ] Create and upload [binary distributions](#binary-distributions)
 ## Embargoed Release
 
 Security fixes that need to be pushed to the distros prior to public release.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -94,6 +94,7 @@ Released as needed privately to individual vendors for critical security-related
     $ git fetch --all
     $ git commit -a -m "Pillow -> 2.9.0"
     $ git push
+```
 * [ ] Download distributions from the [Pillow OS X Wheel Builder container](http://cdf58691c5cf45771290-6a3b6a0f5f6ab91aadc447b2a897dd9a.r50.cf2.rackcdn.com/) and ``twine upload *``.
 
 ### Linux

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,6 +33,10 @@ Released as needed for security, installation or critical bug fixes.
 * [ ] Update `CHANGES.rst`. 
 * [ ] Cherry pick individual commits from ``master`` branch to release branch e.g. ``2.9.x``.
 * [ ] Check [Travis CI](https://travis-ci.org/python-pillow/Pillow) to confirm passing tests in release branch e.g. ``2.9.x``.
+* [ ] Checkout release branch e.g.:
+```
+    git checkout -t remotes/origin/2.9.x
+```
 * [ ] In compliance with https://www.python.org/dev/peps/pep-0440/, update version identifier in: 
 ```
     PIL/__init__.py setup.py _imaging.c
@@ -40,7 +44,7 @@ Released as needed for security, installation or critical bug fixes.
 * [ ] Run pre-release check via `make pre`.
 * [ ] Create tag for release e.g.:
 ```
-    $ git tag 2.9.0
+    $ git tag 2.9.1
     $ git push --tags
 ```
 * [ ] Create and upload source distributions e.g.:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -55,7 +55,7 @@ Released as needed for security, installation or critical bug fixes.
 
 ## Embargoed Release
 
-Released as needed privately to individual vendors before public for critical security-related bug fixes.
+Released as needed privately to individual vendors for critical security-related bug fixes.
 
 * [ ] Prepare patch for all versions that will get a fix. Test against local installations.
 * [ ] Commit against master, cherry pick to affected release branches.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 ## Main Release
 
-Released quarterly.
+Released quarterly on the first day of January, April, July, October.
 
 * [ ] Develop and prepare release in ``master`` branch.
 * [ ] Check [Travis CI](https://travis-ci.org/python-pillow/Pillow) to confirm passing tests in ``master`` branch.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -55,7 +55,7 @@ Released as needed for security, installation or critical bug fixes.
 
 ## Embargoed Release
 
-Security fixes that need to be pushed to the distros prior to public release.
+Released as needed to vendors before public for critical security-related bug fixes.
 
 * [ ] Prepare patch for all versions that will get a fix. Test against local installations.
 * [ ] Commit against master, cherry pick to affected release branches.
@@ -70,8 +70,11 @@ Security fixes that need to be pushed to the distros prior to public release.
     git push origin 2.5.x
     git push origin --tags
 ```
-* [ ] Upload source and binary distributions.
-
+* [ ] Create and upload source distributions e.g.:
+```
+    $ make sdistup
+```
+* [ ] Create and upload [binary distributions](#binary-distributions)
 
 ## Binary Distributions
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -78,9 +78,3 @@ make sdistup
 * [ ] Retrieve the OS X Wheels from Rackspace files, upload to PyPi (Twine?)
 * [ ] Grab Windows binaries, `twine upload dist/*.[whl|egg]`. Manually upload .exe installers.
 * [ ] Announce release availability. [Twitter](https://twitter.com/pythonpillow), web.
-
-
-Footnotes[^1] have a label[^@#$%] and the footnote's content.
-
-[^1]: This is a footnote content.
-[^@#$%]: A footnote on the label: "@#$%".

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -79,10 +79,25 @@ Released as needed privately to individual vendors for critical security-related
 
 ## Binary Distributions
 
-* [ ] Contact @cgohlke for Windows binaries.
+### Windows
+* [ ] Contact @cgohlke for Windows binaries via release ticket e.g. https://github.com/python-pillow/Pillow/issues/1174.
+* [ ] Download and extract tarball from @cgohlke and ``twine upload *``.
 
-(Debian requests a tarball, everyone else would just prefer that we choose one and stick to it. So both it is)
-* [ ] Push a commit to https://github.com/python-pillow/pillow-wheels to build OSX versions (UNDONE latest tag or specific release???)
-* [ ] Retrieve the OS X Wheels from Rackspace files, upload to PyPi (Twine?)
-* [ ] Grab Windows binaries, `twine upload dist/*.[whl|egg]`. Manually upload .exe installers.
+### OS X
+* [ ] Use the [Pillow OS X Wheel Builder](https://github.com/python-pillow/pillow-wheels):
+```
+    $ git checkout https://github.com/python-pillow/pillow-wheels
+    $ cd pillow-wheels
+    $ git submodule init
+    $ git submodule update
+    $ cd Pillow
+    $ git fetch --all
+    $ git commit -a -m "Pillow -> 2.9.0"
+    $ git push
+* [ ] Download distributions from the [Pillow OS X Wheel Builder container](http://cdf58691c5cf45771290-6a3b6a0f5f6ab91aadc447b2a897dd9a.r50.cf2.rackcdn.com/) and ``twine upload *``.
+
+### Linux
+
+## Publicize Release
+
 * [ ] Announce release availability. [Twitter](https://twitter.com/pythonpillow), web.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,20 +30,25 @@ Released quarterly on the first day of January, April, July, October.
 Released as needed for security, installation or critical bug fixes.
 
 * [ ] Make necessary changes in ``master`` branch.
-* [ ] Cherry pick individual commits from ``master`` branch to release branch e.g. ``2.8.x``.
+* [ ] Update `CHANGES.rst`. 
+* [ ] Cherry pick individual commits from ``master`` branch to release branch e.g. ``2.9.x``.
+* [ ] Check [Travis CI](https://travis-ci.org/python-pillow/Pillow) to confirm passing tests in release branch e.g. ``2.9.x``.
 * [ ] In compliance with https://www.python.org/dev/peps/pep-0440/, update version identifier in: 
 ```
     PIL/__init__.py setup.py _imaging.c
 ```
-* [ ] Update `CHANGES.rst`. 
 * [ ] Run pre-release check via `make pre`.
-* [ ] Push to release branch in personal repo. Let Travis run cleanly.
-* [ ] Tag and push to release branch in python-pillow repo.
+* [ ] Create tag for release e.g.:
+```
+    $ git tag 2.9.0
+    $ git push --tags
+```
 * [ ] Create and upload source distributions e.g.:
 ```
     $ make sdistup
 ```
 * [ ] Create and upload [binary distributions](#binary-distributions)
+
 ## Embargoed Release
 
 Security fixes that need to be pushed to the distros prior to public release.


### PR DESCRIPTION
Such updates to process! Much discussions happen! A few points for review:
- I think descriptions of git syntax can vary, as long as we achieve identical results (E.g. releasing from either master or release branch are identical, assuming hashes are identical.)
- Twine is absolutely necessary and now supports Windows executable files too!
- Should we provide Linux wheels?
- Should we consider other Pillow Wheel Builders (I.e. not just for OS X)?