### PR TITLE
Clarify docstring about mask values [ci skip]

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1292,8 +1292,7 @@ class Image:
         channels if they have them.
 
         See :py:meth:`~PIL.Image.Image.alpha_composite` if you want to
-        combine images with a partial mask without setting the alpha
-        channel.
+        combine images with respect to their alpha channels.
 
         Note that if you paste an "RGBA" image, the alpha band is
         ignored.  You can work around this by using the same image as

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1288,9 +1288,8 @@ class Image:
         images (in the latter case, the alpha band is used as mask).
         Where the mask is 255, the given image is copied as is.  Where
         the mask is 0, the current value is preserved.  Intermediate
-        values will mix the two images together.  If this image has an
-        alpha channel, intermediate values will also set the alpha
-        channel to themselves.
+        values will mix the two images together, including their alpha
+        channels if they have them.
 
         See :py:meth:`~PIL.Image.Image.alpha_composite` if you want to
         combine images with a partial mask without setting the alpha

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1294,10 +1294,6 @@ class Image:
         See :py:meth:`~PIL.Image.Image.alpha_composite` if you want to
         combine images with respect to their alpha channels.
 
-        Note that if you paste an "RGBA" image, the alpha band is
-        ignored.  You can work around this by using the same image as
-        both source image and mask.
-
         :param im: Source image or pixel value (integer or tuple).
         :param box: An optional 4-tuple giving the region to paste into.
            If a 2-tuple is used instead, it's treated as the upper left

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1288,7 +1288,13 @@ class Image:
         images (in the latter case, the alpha band is used as mask).
         Where the mask is 255, the given image is copied as is.  Where
         the mask is 0, the current value is preserved.  Intermediate
-        values can be used for transparency effects.
+        values will mix the two images together.  If this image has an
+        alpha channel, intermediate values will also set the alpha
+        channel to themselves.
+
+        See :py:meth:`~PIL.Image.Image.alpha_composite` if you want to
+        combine images with a partial mask without setting the alpha
+        channel.
 
         Note that if you paste an "RGBA" image, the alpha band is
         ignored.  You can work around this by using the same image as


### PR DESCRIPTION
The behavior of paste() with regard to intermediate mask values was
unclear, so this commit clarifies how it works.

This patch addresses an issue raised in https://github.com/python-pillow/Pillow/issues/1133