### PR TITLE
Added icns save

### DIFF
--- a/PIL/IcnsImagePlugin.py
+++ b/PIL/IcnsImagePlugin.py
@@ -248,7 +248,7 @@ class IcnsFile:
 
 class IcnsImageFile(ImageFile.ImageFile):
     """
-    PIL read-only image support for Mac OS .icns files.
+    PIL image support for Mac OS .icns files.
     Chooses the best resolution, but will possibly load
     a different size image if you mutate the size attribute
     before calling 'load'.
@@ -295,6 +295,13 @@ class IcnsImageFile(ImageFile.ImageFile):
         self.load_end()
 
 def _save(im, fp, filename):
+    """
+    Saves the image as a series of PNG files,
+    that are then converted to a .icns file
+    using the OS X command line utility 'iconutil'.
+    
+    OS X only.
+    """
     try:
         fp.flush()
     except:

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -2,6 +2,8 @@ from helper import unittest, PillowTestCase
 
 from PIL import Image
 
+import sys
+
 # sample icon file
 file = "Tests/images/pillow.icns"
 data = open(file, "rb").read()
@@ -19,6 +21,20 @@ class TestFileIcns(PillowTestCase):
         self.assertEqual(im.mode, "RGBA")
         self.assertEqual(im.size, (1024, 1024))
         self.assertEqual(im.format, "ICNS")
+
+    @unittest.skipIf(sys.platform != 'darwin',
+                     "requires MacOS")
+    def test_save(self):
+        im = Image.open(file)
+        
+        test_file = self.tempfile("temp.icns")
+        im.save(test_file)
+        
+        reread = Image.open(test_file)
+        
+        self.assertEqual(reread.mode, "RGBA")
+        self.assertEqual(reread.size, (1024, 1024))
+        self.assertEqual(reread.format, "ICNS")
 
     def test_sizes(self):
         # Check that we can load all of the sizes, and that the final pixel


### PR DESCRIPTION
As per #998, this adds the ability to save the .icns format on OS X using the 'iconutil' tool.