### PR TITLE
Keep user-specified ordering of icon sizes

### DIFF
--- a/PIL/IcoImagePlugin.py
+++ b/PIL/IcoImagePlugin.py
@@ -48,7 +48,6 @@ def _save(im, fp, filename):
     width, height = im.size
     filter(lambda x: False if (x[0] > width or x[1] > height or
                                x[0] > 255 or x[1] > 255) else True, sizes)
-    sizes = sorted(sizes, key=lambda x: x[0])
     fp.write(struct.pack("H", len(sizes)))  # idCount(2)
     offset = fp.tell() + len(sizes)*16
     for size in sizes:


### PR DESCRIPTION
Some consumers of icon files such as py2exe care about the order that icon sizes are added, so the user should be fully in charge of this, instead of force sorting them.