### PR TITLE
Fix test according to original

### DIFF
--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -27,10 +27,10 @@ class TestFileIcns(PillowTestCase):
     def test_save(self):
         im = Image.open(TEST_FILE)
 
-        TEST_FILE = self.tempfile("temp.icns")
-        im.save(TEST_FILE)
+        temp_file = self.tempfile("temp.icns")
+        im.save(temp_file)
 
-        reread = Image.open(TEST_FILE)
+        reread = Image.open(temp_file)
 
         self.assertEqual(reread.mode, "RGBA")
         self.assertEqual(reread.size, (1024, 1024))


### PR DESCRIPTION
PR https://github.com/python-pillow/Pillow/pull/1215 didn't properly fix PR #1209.

The original test was:

```
file = "Tests/images/pillow.icns"

...

    @unittest.skipIf(sys.platform != 'darwin',
                     "requires MacOS")
    def test_save(self):
        im = Image.open(file)
        
        test_file = self.tempfile("temp.icns")
        im.save(test_file)
        
        reread = Image.open(test_file)
        
        self.assertEqual(reread.mode, "RGBA")
        self.assertEqual(reread.size, (1024, 1024))
        self.assertEqual(reread.format, "ICNS")
```

https://github.com/python-pillow/Pillow/commit/689f28aae7c9cc3fddb73e7ec2a07f169b91d4ba#diff-d48d995756d16b9d9b8151e27377a37dR25


So with renamed variables:
```
TEST_FILE = "Tests/images/pillow.icns"

...

    @unittest.skipIf(sys.platform != 'darwin',
                     "requires MacOS")
    def test_save(self):
        im = Image.open(TEST_FILE)

        temp_file = self.tempfile("temp.icns")
        im.save(temp_file)

        reread = Image.open(temp_file)

        self.assertEqual(reread.mode, "RGBA")
        self.assertEqual(reread.size, (1024, 1024))
        self.assertEqual(reread.format, "ICNS")
```

Tested locally on Mac before committing.

