### PR TITLE
Fixed variable name in JpegImagePlugin

### DIFF
--- a/PIL/JpegImagePlugin.py
+++ b/PIL/JpegImagePlugin.py
@@ -704,7 +704,7 @@ def _save_cjpeg(im, fp, filename):
     tempfile = im._dump()
     subprocess.check_call(["cjpeg", "-outfile", filename, tempfile])
     try:
-        os.unlink(file)
+        os.unlink(tempfile)
     except:
         pass
 


### PR DESCRIPTION
Looking at https://github.com/python-pillow/Pillow/commit/d8f55e3f50b0df2c850d15deedb46cb0e33a4cd8#diff-42c79834cd0653b67739d44923e685ac, it would seem apparent that this variable name just wasn't updated with the rest of the change.