### PR TITLE
Release GIL during image load (decode).

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -116,11 +116,16 @@ _decode(ImagingDecoderObject* decoder, PyObject* args)
 {
     UINT8* buffer;
     int bufsize, status;
+    ImagingSectionCookie cookie;
 
     if (!PyArg_ParseTuple(args, PY_ARG_BYTES_LENGTH, &buffer, &bufsize))
         return NULL;
 
+    ImagingSectionEnter(&cookie);
+
     status = decoder->decode(decoder->im, &decoder->state, buffer, bufsize);
+
+    ImagingSectionLeave(&cookie);
 
     return Py_BuildValue("ii", status, decoder->state.errcode);
 }


### PR DESCRIPTION
This is to fix #1221. Currently the GIL is not released during image decode. This pull request releases the GIL during only the `decode()` call. I skimmed all the decoding functions and none seem to touch Python data. (In fact, I don't see how they'd even have access to any Python data.) I've tested the change in a multi-threaded program for a few hours and saw no problems, though obviously with multi-threaded code that doesn't mean much.