### PR TITLE
Pyroma installation no longer slow on Py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,7 @@ install:
   - "travis_retry sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-qt4 ghostscript libffi-dev libjpeg-turbo-progs cmake imagemagick"
   - "travis_retry pip install cffi"
   - "travis_retry pip install coverage nose"
-
-    # Pyroma installation is slow on Py3, so just do it for Py2.
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then travis_retry pip install pyroma; fi
+  - "travis_retry pip install pyroma"
 
   - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then travis_retry pip install unittest2; fi
 


### PR DESCRIPTION
`pip install pyroma` used to be a lot slower on Python 3:

```
pypy    8s
pypy3   70s
2.6     3s
2.7     2s
3.2     111s
3.3     82s
3.4     86s
```

Because of this, we only ran the pyroma tests on Python 2. The reason for pyroma's slow installation was due to one of its dependencies -- docutils. Docutils have now created wheels for Python 3 which has now brought installation times in line for all Python versions.

So we can now remove this special case.

Ref:
https://bitbucket.org/regebro/pyroma/issue/22/installation-slow-for-python-3
https://sourceforge.net/p/docutils/bugs/279/
