### PR TITLE
Copy image when saving in GifImagePlugin

### DIFF
--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -269,7 +269,7 @@ def _save(im, fp, filename):
             pass  # write uncompressed file
 
     if im.mode in RAWMODE:
-        im_out = im
+        im_out = im.copy()
     else:
         # convert on the fly (EXPERIMENTAL -- I'm not sure PIL
         # should automatically convert images on save...)

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -509,7 +509,8 @@ class Image:
         new.im = im
         new.mode = im.mode
         new.size = im.size
-        new.palette = self.palette
+        if self.palette:
+            new.palette = self.palette.copy()
         if im.mode == "P" and not new.palette:
             from PIL import ImagePalette
             new.palette = ImagePalette.ImagePalette()

--- a/PIL/ImagePalette.py
+++ b/PIL/ImagePalette.py
@@ -34,6 +34,18 @@ class ImagePalette:
                 (size != 0 and size != len(self.palette))):
             raise ValueError("wrong palette size")
 
+    def copy(self):
+        new = ImagePalette()
+
+        new.mode = self.mode
+        new.rawmode = self.rawmode
+        if self.palette is not None:
+            new.palette = self.palette[:]
+        new.colors = self.colors.copy()
+        new.dirty = self.dirty
+
+        return new
+
     def getdata(self):
         """
         Get palette contents in format suitable # for the low-level

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -92,20 +92,20 @@ class TestFileGif(PillowTestCase):
 
         def roundtrip(im, *args, **kwargs):
             out = self.tempfile('temp.gif')
-            im.save(out, *args, **kwargs)
+            im.copy().save(out, *args, **kwargs)
             reloaded = Image.open(out)
 
-            return [im, reloaded]
+            return reloaded
 
         orig = "Tests/images/test.colors.gif"
         im = Image.open(orig)
 
-        self.assert_image_equal(*roundtrip(im))
-        self.assert_image_equal(*roundtrip(im, optimize=True))
+        self.assert_image_similar(im, roundtrip(im), 1)
+        self.assert_image_similar(im, roundtrip(im, optimize=True), 1)
 
         im = im.convert("RGB")
         # check automatic P conversion
-        reloaded = roundtrip(im)[1].convert('RGB')
+        reloaded = roundtrip(im).convert('RGB')
         self.assert_image_equal(im, reloaded)
 
     @unittest.skipUnless(netpbm_available(), "netpbm not available")

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -26,7 +26,7 @@ class TestImageFile(PillowTestCase):
 
             test_file = BytesIO()
 
-            im.save(test_file, format)
+            im.copy().save(test_file, format)
 
             data = test_file.getvalue()
 
@@ -37,7 +37,8 @@ class TestImageFile(PillowTestCase):
             return im, imOut
 
         self.assert_image_equal(*roundtrip("BMP"))
-        self.assert_image_equal(*roundtrip("GIF"))
+        im1, im2 = roundtrip("GIF")
+        self.assert_image_similar(im1.convert('P'), im2, 1)
         self.assert_image_equal(*roundtrip("IM"))
         self.assert_image_equal(*roundtrip("MSP"))
         if "zip_encoder" in codecs:


### PR DESCRIPTION
#718 describes how saving an image in the GIF format can modify the palette of the original.

GifImagePlugin's getheader method has the comment 'create the new palette if not every color is used'. So that's why the image passed into getheader is modified.

The solution would seem to be to copy the image before passing it in.

However, this fails a few tests, because the image instance that was being checked against is no longer modified in sync with the saved file. Essentially, these tests should have been failing. I've changed the checks to similar rather than equal.

I also modified the tests affected to use copy() to try and avoid this way of sneaking past the tests in the future.