### PR TITLE
Separated out feature checking from selftest

### DIFF
--- a/PIL/features.py
+++ b/PIL/features.py
@@ -1,16 +1,19 @@
 from PIL import Image
 
 modules = {
-    "PIL CORE": "PIL._imaging",
-    "TKINTER": "PIL._imagingtk",
-    "FREETYPE2": "PIL._imagingft",
-    "LITTLECMS2": "PIL._imagingcms",
-    "WEBP": "PIL._webp",
-    "Transparent WEBP": ("WEBP", "WebPDecoderBuggyAlpha")
+    "pil": "PIL._imaging",
+    "tkinter": "PIL._imagingtk",
+    "freetype2": "PIL._imagingft",
+    "littlecms2": "PIL._imagingcms",
+    "webp": "PIL._webp",
+    "transp_webp": ("WEBP", "WebPDecoderBuggyAlpha")
 }
 
 
 def check_module(feature):
+    if feature not in modules:
+        raise ValueError("Unknown module %s" % feature)
+
     module = modules[feature]
 
     method_to_call = None
@@ -34,38 +37,31 @@ def check_module(feature):
 
 def get_supported_modules():
     supported_modules = []
-    for feature in get_all_modules():
+    for feature in modules:
         if check_module(feature):
             supported_modules.append(feature)
     return supported_modules
 
-
-def get_all_modules():
-    # While the dictionary keys could be used here,
-    # a static list is used to maintain order
-    return ["PIL CORE", "TKINTER", "FREETYPE2",
-            "LITTLECMS2", "WEBP", "Transparent WEBP"]
-
 codecs = {
-    "JPEG": "jpeg",
-    "JPEG 2000": "jpeg2k",
-    "ZLIB (PNG/ZIP)": "zip",
-    "LIBTIFF": "libtiff"
+    "jpg": "jpeg",
+    "jpg_2000": "jpeg2k",
+    "zlib": "zip",
+    "libtiff": "libtiff"
 }
 
 
 def check_codec(feature):
+    if feature not in codecs:
+        raise ValueError("Unknown codec %s" % feature)
+
     codec = codecs[feature]
+
     return codec + "_encoder" in dir(Image.core)
 
 
 def get_supported_codecs():
     supported_codecs = []
-    for feature in get_all_codecs():
+    for feature in codecs:
         if check_codec(feature):
             supported_codecs.append(feature)
     return supported_codecs
-
-
-def get_all_codecs():
-    return ["JPEG", "JPEG 2000", "ZLIB (PNG/ZIP)", "LIBTIFF"]

--- a/PIL/features.py
+++ b/PIL/features.py
@@ -1,0 +1,71 @@
+from PIL import Image
+
+modules = {
+    "PIL CORE": "PIL._imaging",
+    "TKINTER": "PIL._imagingtk",
+    "FREETYPE2": "PIL._imagingft",
+    "LITTLECMS2": "PIL._imagingcms",
+    "WEBP": "PIL._webp",
+    "Transparent WEBP": ("WEBP", "WebPDecoderBuggyAlpha")
+}
+
+
+def check_module(feature):
+    module = modules[feature]
+
+    method_to_call = None
+    if type(module) is tuple:
+        module, method_to_call = module
+
+    try:
+        imported_module = __import__(module)
+    except ImportError:
+        # If a method is being checked, None means that
+        # rather than the method failing, the module required for the method
+        # failed to be imported first
+        return None if method_to_call else False
+
+    if method_to_call:
+        method = getattr(imported_module, method_to_call)
+        return method() is True
+    else:
+        return True
+
+
+def get_supported_modules():
+    supported_modules = []
+    for feature in get_all_modules():
+        if check_module(feature):
+            supported_modules.append(feature)
+    return supported_modules
+
+
+def get_all_modules():
+    # While the dictionary keys could be used here,
+    # a static list is used to maintain order
+    return ["PIL CORE", "TKINTER", "FREETYPE2",
+            "LITTLECMS2", "WEBP", "Transparent WEBP"]
+
+codecs = {
+    "JPEG": "jpeg",
+    "JPEG 2000": "jpeg2k",
+    "ZLIB (PNG/ZIP)": "zip",
+    "LIBTIFF": "libtiff"
+}
+
+
+def check_codec(feature):
+    codec = codecs[feature]
+    return codec + "_encoder" in dir(Image.core)
+
+
+def get_supported_codecs():
+    supported_codecs = []
+    for feature in get_all_codecs():
+        if check_codec(feature):
+            supported_codecs.append(feature)
+    return supported_codecs
+
+
+def get_all_codecs():
+    return ["JPEG", "JPEG 2000", "ZLIB (PNG/ZIP)", "LIBTIFF"]

--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -1,0 +1,21 @@
+from helper import unittest, PillowTestCase
+
+from PIL import features
+
+
+class TestFeatures(PillowTestCase):
+
+    def test_check_features(self):
+        for feature in features.modules:
+            self.assertTrue(features.check_module(feature) in [True, False, None])
+        for feature in features.codecs:
+            self.assertTrue(features.check_codec(feature) in [True, False])
+
+    def test_supported_features(self):
+        self.assertTrue(type(features.get_supported_modules()) is list)
+        self.assertTrue(type(features.get_supported_codecs()) is list)
+
+if __name__ == '__main__':
+    unittest.main()
+
+# End of file

--- a/selftest.py
+++ b/selftest.py
@@ -194,7 +194,7 @@ if __name__ == "__main__":
             print("***", feature, "support not installed")
     for name, feature in [
         ("jpg", "JPEG"),
-        ("jpg_2000", "JPEG 2000"),
+        ("jpg_2000", "OPENJPEG (JPEG2000)"),
         ("zlib", "ZLIB (PNG/ZIP)"),
         ("libtiff", "LIBTIFF")
     ]:

--- a/selftest.py
+++ b/selftest.py
@@ -174,8 +174,15 @@ if __name__ == "__main__":
     print("Python modules loaded from", os.path.dirname(Image.__file__))
     print("Binary modules loaded from", os.path.dirname(Image.core.__file__))
     print("-"*68)
-    for feature in features.get_all_modules():
-        supported = features.check_module(feature)
+    for name, feature in [
+        ("pil", "PIL CORE"),
+        ("tkinter", "TKINTER"),
+        ("freetype2", "FREETYPE2"),
+        ("littlecms2", "LITTLECMS2"),
+        ("webp", "WEBP"),
+        ("transp_webp", "Transparent WEBP")
+    ]:
+        supported = features.check_module(name)
 
         if supported is None:
             # A method was being tested, but the module required
@@ -185,8 +192,13 @@ if __name__ == "__main__":
             print("---", feature, "support ok")
         else:
             print("***", feature, "support not installed")
-    for feature in features.get_all_codecs():
-        if features.check_codec(feature):
+    for name, feature in [
+        ("jpg", "JPEG"),
+        ("jpg_2000", "JPEG 2000"),
+        ("zlib", "ZLIB (PNG/ZIP)"),
+        ("libtiff", "LIBTIFF")
+    ]:
+        if features.check_codec(name):
             print("---", feature, "support ok")
         else:
             print("***", feature, "support not installed")

--- a/selftest.py
+++ b/selftest.py
@@ -9,6 +9,7 @@ if "--installed" in sys.argv:
     del sys.path[0]
 
 from PIL import Image, ImageDraw, ImageFilter, ImageMath
+from PIL import features
 
 if "--installed" in sys.argv:
     sys.path.insert(0, sys_path_0)
@@ -162,22 +163,6 @@ def testimage():
     """
 
 
-def check_module(feature, module):
-    try:
-        __import__(module)
-    except ImportError:
-        print("***", feature, "support not installed")
-    else:
-        print("---", feature, "support ok")
-
-
-def check_codec(feature, codec):
-    if codec + "_encoder" not in dir(Image.core):
-        print("***", feature, "support not installed")
-    else:
-        print("---", feature, "support ok")
-
-
 if __name__ == "__main__":
     # check build sanity
 
@@ -189,23 +174,22 @@ if __name__ == "__main__":
     print("Python modules loaded from", os.path.dirname(Image.__file__))
     print("Binary modules loaded from", os.path.dirname(Image.core.__file__))
     print("-"*68)
-    check_module("PIL CORE", "PIL._imaging")
-    check_module("TKINTER", "PIL._imagingtk")
-    check_codec("JPEG", "jpeg")
-    check_codec("JPEG 2000", "jpeg2k")
-    check_codec("ZLIB (PNG/ZIP)", "zip")
-    check_codec("LIBTIFF", "libtiff")
-    check_module("FREETYPE2", "PIL._imagingft")
-    check_module("LITTLECMS2", "PIL._imagingcms")
-    check_module("WEBP", "PIL._webp")
-    try:
-        from PIL import _webp
-        if _webp.WebPDecoderBuggyAlpha():
-            print("***", "Transparent WEBP", "support not installed")
+    for feature in features.get_all_modules():
+        supported = features.check_module(feature)
+
+        if supported is None:
+            # A method was being tested, but the module required
+            # for the method could not be correctly imported
+            pass
+        elif supported:
+            print("---", feature, "support ok")
         else:
-            print("---", "Transparent WEBP", "support ok")
-    except Exception:
-        pass
+            print("***", feature, "support not installed")
+    for feature in features.get_all_codecs():
+        if features.check_codec(feature):
+            print("---", feature, "support ok")
+        else:
+            print("***", feature, "support not installed")
     print("-"*68)
 
     # use doctest to make sure the test program behaves as documented!


### PR DESCRIPTION
#1182 suggests separating out feature checking code from selftest.py into it's own module, so that users can check the availability of features at any point.

This is a basic attempt at that idea.