### PR TITLE
Add Python 3.4 to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33
+envlist = py26, py27, py32, py33, py34
 
 [testenv]
 commands =


### PR DESCRIPTION
I don't know if Tox is used by anyone, but Python 3.4 was missing.

Replaces PR https://github.com/python-pillow/Pillow/pull/1213 which added 3.4 to tox.ini but also added a duplicate 3.4 to .travis.yml.