### PR TITLE
Add autocontrast_preserve

### DIFF
--- a/PIL/ImageOps.py
+++ b/PIL/ImageOps.py
@@ -207,7 +207,7 @@ def autocontrast_preserve(image, cutoff=0, ignore=None):
     else:
         scale = 255.0 / (hi - lo)
         offset = -lo * scale
-        for layer in range(len(histogram) / 256):
+        for layer in range(len(histogram) // 256):
             for ix in range(256):
                 ix = int(ix * scale + offset)
                 if ix < 0:

--- a/PIL/ImageOps.py
+++ b/PIL/ImageOps.py
@@ -137,10 +137,10 @@ def autocontrast(image, cutoff=0, ignore=None):
 
 def autocontrast_preserve(image, cutoff=0, ignore=None):
     """
-    Maximize (normalize) image contrast while preserving image tone. 
-    This function calculates a histogram of the input image, removes 
-    **cutoff** percent of the lightest and darkest pixels from the 
-    histogram, and remaps the image so that the darkest pixel becomes 
+    Maximize (normalize) image contrast while preserving image tone.
+    This function calculates a histogram of the input image, removes
+    **cutoff** percent of the lightest and darkest pixels from the
+    histogram, and remaps the image so that the darkest pixel becomes
     black (0), and the lightest becomes white (255).
     :param image: The image to process.
     :param cutoff: How many percent to cut off from the histogram.

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -20,6 +20,12 @@ class TestImageOps(PillowTestCase):
         ImageOps.autocontrast(hopper("L"), cutoff=10)
         ImageOps.autocontrast(hopper("L"), ignore=[0, 255])
 
+        ImageOps.autocontrast_preserve(hopper("L"))
+        ImageOps.autocontrast_preserve(hopper("RGB"))
+
+        ImageOps.autocontrast_preserve(hopper("L"), cutoff=10)
+        ImageOps.autocontrast_preserve(hopper("L"), ignore=[0, 255])
+
         ImageOps.colorize(hopper("L"), (0, 0, 0), (255, 255, 255))
         ImageOps.colorize(hopper("L"), "black", "white")
 


### PR DESCRIPTION
Maximize (normalize) image contrast while preserving image tone. (Mimics
Photoshop autocontrast functionality as opposed to the default PIL
implementation, which operates on channels separately).
