### PR TITLE
fix MPO parsing issue

### DIFF
--- a/PIL/JpegImagePlugin.py
+++ b/PIL/JpegImagePlugin.py
@@ -467,7 +467,7 @@ def _getmp(self):
     try:
         quant = mp[0xB001]
     except KeyError:
-        raise SyntaxError("malformed MP Index (no number of images)")
+        raise TypeError("malformed MP Index (no number of images)")
     # get MP entries
     try:
         mpentries = []
@@ -491,7 +491,7 @@ def _getmp(self):
             if mpentryattr['ImageDataFormat'] == 0:
                 mpentryattr['ImageDataFormat'] = 'JPEG'
             else:
-                raise SyntaxError("unsupported picture format in MPO")
+                raise TypeError("unsupported picture format in MPO")
             mptypemap = {
                 0x000000: 'Undefined',
                 0x010001: 'Large Thumbnail (VGA Equivalent)',
@@ -507,7 +507,7 @@ def _getmp(self):
             mpentries.append(mpentry)
         mp[0xB002] = mpentries
     except KeyError:
-        raise SyntaxError("malformed MP Index (bad MP Entry)")
+        raise TypeError("malformed MP Index (bad MP Entry)")
     # Next we should try and parse the individual image unique ID list;
     # we don't because I've never seen this actually used in a real MPO
     # file and so can't test it.
@@ -713,8 +713,8 @@ def _save_cjpeg(im, fp, filename):
 # Factory for making JPEG and MPO instances
 def jpeg_factory(fp=None, filename=None):
     im = JpegImageFile(fp, filename)
-    mpheader = im._getmp()
     try:
+        mpheader = im._getmp()
         if mpheader[45057] > 1:
             # It's actually an MPO
             from .MpoImagePlugin import MpoImageFile


### PR DESCRIPTION
fix an issue preventing the load of certain jpg images that are incorrectly considered MPO's

example image:
![bad_image](https://cloud.githubusercontent.com/assets/879170/7918384/d277516c-0845-11e5-868f-286894c25e47.jpg)
