### PR TITLE
Skip Pyroma test on PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ install:
   - "travis_retry sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-qt4 ghostscript libffi-dev libjpeg-turbo-progs cmake imagemagick"
   - "travis_retry pip install cffi"
   - "travis_retry pip install coverage nose"
-  - "travis_retry pip install pyroma"
+    # Pyroma tests sometimes hang on PyPy; skip for PyPy
+  - if [ $TRAVIS_PYTHON_VERSION != "pypy" ]; then travis_retry pip install pyroma; fi
 
   - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then travis_retry pip install unittest2; fi
 


### PR DESCRIPTION
On a few occasions, PyPy build jobs error because the Pyroma test hangs for over 10 minutes. 

Restarting the build and they pass, but it's an annoyance.

Closes #1250.