### PR TITLE
Fix badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,26 +6,23 @@ Python Imaging Library (Fork)
 
 Pillow is the "friendly PIL fork" by `Alex Clark and Contributors <https://github.com/python-pillow/Pillow/graphs/contributors>`_. PIL is the Python Imaging Library by Fredrik Lundh and Contributors.
 
-.. 
-   image:: https://travis-ci.org/python-pillow/Pillow.svg?branch=master
+.. image:: https://travis-ci.org/python-pillow/Pillow.svg?branch=master
    :target: https://travis-ci.org/python-pillow/Pillow
    :alt: Travis CI build status (Linux)
 
-.. 
-   image:: https://pypip.in/v/Pillow/badge.png
-    :target: https://pypi.python.org/pypi/Pillow/
-    :alt: Latest PyPI version
+.. image:: https://img.shields.io/pypi/v/pillow.svg
+   :target: https://pypi.python.org/pypi/Pillow/
+   :alt: Latest PyPI version
 
-.. 
-   image:: https://pypip.in/d/Pillow/badge.png
-    :target: https://pypi.python.org/pypi/Pillow/
-    :alt: Number of PyPI downloads
+.. image:: https://img.shields.io/pypi/dm/pillow.svg
+   :target: https://pypi.python.org/pypi/Pillow/
+   :alt: Number of PyPI downloads
 
-.. image:: https://coveralls.io/repos/python-pillow/Pillow/badge.png?branch=master
-  :target: https://coveralls.io/r/python-pillow/Pillow?branch=master
+.. image:: https://coveralls.io/repos/python-pillow/Pillow/badge.svg?branch=master
+   :target: https://coveralls.io/r/python-pillow/Pillow?branch=master
    :alt: Code coverage
 
-.. image:: https://landscape.io/github/python-pillow/Pillow/master/landscape.png
+.. image:: https://landscape.io/github/python-pillow/Pillow/master/landscape.svg
    :target: https://landscape.io/github/python-pillow/Pillow/master
    :alt: Code health
 

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,10 @@ Pillow is the "friendly PIL fork" by `Alex Clark and Contributors <https://githu
    :target: https://travis-ci.org/python-pillow/Pillow
    :alt: Travis CI build status (Linux)
 
+.. image:: https://travis-ci.org/python-pillow/pillow-wheels.svg?branch=latest
+   :target: https://travis-ci.org/python-pillow/pillow-wheels
+   :alt: Travis CI build status (OS X)
+
 .. image:: https://img.shields.io/pypi/v/pillow.svg
    :target: https://pypi.python.org/pypi/Pillow/
    :alt: Latest PyPI version

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,19 +7,19 @@ Pillow is the "friendly PIL fork" by `Alex Clark and Contributors <https://githu
    :target: https://travis-ci.org/python-pillow/Pillow
    :alt: Travis CI build status (Linux)
 
-.. image:: https://pypip.in/v/Pillow/badge.png
+.. image:: https://img.shields.io/pypi/v/pillow.svg
     :target: https://pypi.python.org/pypi/Pillow/
     :alt: Latest PyPI version
 
-.. image:: https://pypip.in/d/Pillow/badge.png
+.. image:: https://img.shields.io/pypi/dm/pillow.svg
     :target: https://pypi.python.org/pypi/Pillow/
     :alt: Number of PyPI downloads
 
-.. image:: https://coveralls.io/repos/python-pillow/Pillow/badge.png?branch=master
+.. image:: https://coveralls.io/repos/python-pillow/Pillow/badge.svg?branch=master
   :target: https://coveralls.io/r/python-pillow/Pillow?branch=master
    :alt: Code coverage
 
-.. image:: https://landscape.io/github/python-pillow/Pillow/master/landscape.png
+.. image:: https://landscape.io/github/python-pillow/Pillow/master/landscape.svg
    :target: https://landscape.io/github/python-pillow/Pillow/master
    :alt: Code health
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,10 @@ Pillow is the "friendly PIL fork" by `Alex Clark and Contributors <https://githu
    :target: https://travis-ci.org/python-pillow/Pillow
    :alt: Travis CI build status (Linux)
 
+.. image:: https://travis-ci.org/python-pillow/pillow-wheels.svg?branch=latest
+   :target: https://travis-ci.org/python-pillow/pillow-wheels
+   :alt: Travis CI build status (OS X)
+
 .. image:: https://img.shields.io/pypi/v/pillow.svg
     :target: https://pypi.python.org/pypi/Pillow/
     :alt: Latest PyPI version


### PR DESCRIPTION
* Shields.io badges instead of broken pypip.in, which as been down for a few weeks
* Use SVG instead of PNG for consistency
* Travis CI have fixed the badge for OS X builds, add that back too

Fixes #1264.