### PR TITLE
Fixed _binary handling in _accept methods

### DIFF
--- a/PIL/DcxImagePlugin.py
+++ b/PIL/DcxImagePlugin.py
@@ -33,7 +33,7 @@ i32 = _binary.i32le
 
 
 def _accept(prefix):
-    return i32(prefix) == MAGIC
+    return len(prefix) >= 4 and i32(prefix) == MAGIC
 
 
 ##

--- a/PIL/EpsImagePlugin.py
+++ b/PIL/EpsImagePlugin.py
@@ -187,7 +187,7 @@ class PSFile(object):
 
 
 def _accept(prefix):
-    return prefix[:4] == b"%!PS" or i32(prefix) == 0xC6D3D0C5
+    return prefix[:4] == b"%!PS" or (len(prefix) >= 4 and i32(prefix) == 0xC6D3D0C5)
 
 ##
 # Image plugin for Encapsulated Postscript.  This plugin supports only

--- a/PIL/FliImagePlugin.py
+++ b/PIL/FliImagePlugin.py
@@ -30,7 +30,7 @@ o8 = _binary.o8
 # decoder
 
 def _accept(prefix):
-    return i16(prefix[4:6]) in [0xAF11, 0xAF12]
+    return len(prefix) >= 6 and i16(prefix[4:6]) in [0xAF11, 0xAF12]
 
 
 ##

--- a/PIL/GbrImagePlugin.py
+++ b/PIL/GbrImagePlugin.py
@@ -19,7 +19,7 @@ i32 = _binary.i32be
 
 
 def _accept(prefix):
-    return i32(prefix) >= 20 and i32(prefix[4:8]) == 1
+    return len(prefix) >= 8 and i32(prefix) >= 20 and i32(prefix[4:8]) == 1
 
 
 ##

--- a/PIL/SgiImagePlugin.py
+++ b/PIL/SgiImagePlugin.py
@@ -29,7 +29,7 @@ i32 = _binary.i32be
 
 
 def _accept(prefix):
-    return i16(prefix) == 474
+    return len(prefix) >= 2 and i16(prefix) == 474
 
 
 ##

--- a/PIL/SunImagePlugin.py
+++ b/PIL/SunImagePlugin.py
@@ -27,7 +27,7 @@ i32 = _binary.i32be
 
 
 def _accept(prefix):
-    return i32(prefix) == 0x59a66a95
+    return len(prefix) >= 4 and i32(prefix) == 0x59a66a95
 
 
 ##

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -30,6 +30,15 @@ class TestImage(PillowTestCase):
         # self.assertRaises(
         #     MemoryError, lambda: Image.new("L", (1000000, 1000000)))
 
+    def test_invalid_image(self):
+        if str is bytes:
+            import StringIO
+            im = StringIO.StringIO('')
+        else:
+            import io
+            im = io.BytesIO(b'')
+        self.assertRaises(IOError, lambda: Image.open(im))
+
     def test_internals(self):
 
         im = Image.new("L", (100, 100))


### PR DESCRIPTION
PR #1165 catches the struct.error generated by _binary methods when trying to open an invalid file.

This changes the _accept methods that are calling _binary, so that it does not call unless the data is of the correct length.

The struct.error catches are quite possibly still good for defensive programming, but I thought it would be good to highlight and deal with the problem more specifically.