### PR TITLE
Raise NotImplementedError for verify()

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -790,7 +790,7 @@ class Image(object):
         the image after using this method, you must reopen the image
         file.
         """
-        pass
+        raise NotImplementedError("File verification not yet implemented")
 
     def convert(self, mode=None, matrix=None, dither=None,
                 palette=WEB, colors=256):


### PR DESCRIPTION
Let people know that the verify() method does not provide verification.