### PR TITLE
Added background saving to GifImagePlugin

### DIFF
--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -537,7 +537,8 @@ def getheader(im, palette=None, info=None):
     # size of global color table + global color table flag
     header.append(o8(color_table_size + 128))
     # background + reserved/aspect
-    header.append(o8(0) + o8(0))
+    background = im.info["background"] if "background" in im.info else 0
+    header.append(o8(background) + o8(0))
     # end of Logical Screen Descriptor
 
     # add the missing amount of bytes

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -201,6 +201,15 @@ class TestFileGif(PillowTestCase):
 
         self.assertEqual(reread.info['loop'], number_of_loops)
 
+    def test_background(self):
+        out = self.tempfile('temp.gif')
+        im = Image.new('L', (100, 100), '#000')
+        im.info['background'] = 1
+        im.save(out)
+        reread = Image.open(out)
+
+        self.assertEqual(reread.info['background'], im.info['background'])
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
The [latest comment](https://github.com/python-pillow/Pillow/issues/1085#issuecomment-110791612) in #1085 shows that the background color index is not saved by GifImagePlugin.