### PR TITLE
Removed unused argument in ImageDraw text

### DIFF
--- a/PIL/ImageDraw.py
+++ b/PIL/ImageDraw.py
@@ -266,9 +266,9 @@ class ImageDraw(object):
 
         return text.split(split_character)
 
-    def text(self, xy, text, fill=None, font=None, anchor=None):
+    def text(self, xy, text, fill=None, font=None):
         if self._multiline_check(text):
-            return self.multiline_text(xy, text, fill, font, anchor)
+            return self.multiline_text(xy, text, fill, font)
 
         ink, fill = self._getink(fill)
         if font is None:
@@ -286,7 +286,7 @@ class ImageDraw(object):
                     mask = font.getmask(text)
             self.draw.draw_bitmap(xy, mask, ink)
 
-    def multiline_text(self, xy, text, fill=None, font=None, anchor=None,
+    def multiline_text(self, xy, text, fill=None, font=None,
                        spacing=0, align="left"):
         widths, heights = [], []
         max_width = 0
@@ -306,7 +306,7 @@ class ImageDraw(object):
                 left += (max_width - widths[idx])
             else:
                 assert False, 'align must be "left", "center" or "right"'
-            self.text((left, top), line, fill, font, anchor)
+            self.text((left, top), line, fill, font)
             top += heights[idx] + spacing
             left = xy[0]
 

--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -227,7 +227,7 @@ Methods
 
     Draw a shape.
 
-.. py:method:: PIL.ImageDraw.Draw.text(xy, text, fill=None, font=None, anchor=None)
+.. py:method:: PIL.ImageDraw.Draw.text(xy, text, fill=None, font=None)
 
     Draws the string at the given position.
 
@@ -237,7 +237,7 @@ Methods
     :param font: An :py:class:`~PIL.ImageFont.ImageFont` instance.
     :param fill: Color to use for the text.
 
-.. py:method:: PIL.ImageDraw.Draw.multiline_text(xy, text, fill=None, font=None, anchor=None, spacing=0, align="left")
+.. py:method:: PIL.ImageDraw.Draw.multiline_text(xy, text, fill=None, font=None, spacing=0, align="left")
 
     Draws the string at the given position.
 


### PR DESCRIPTION
I'm aware this could be considered an api change, but at the same time, I can't think of any instance where code would use this.

Examining the history, I looked at the 1.x branch, and the argument is there, but still has no effect.