### PR TITLE
Windows: build all branches

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,4 @@
 version: 2.9.pre.{build}
-branches:
-  only:
-  - winbuild
 shallow_clone: true
 clone_folder: c:\pillow
 init:


### PR DESCRIPTION
> All branches are built by default. 
http://www.appveyor.com/docs/branches