### PR TITLE
Add Windows build badge and clarify others

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,10 @@ Pillow is the "friendly PIL fork" by `Alex Clark and Contributors <https://githu
    :target: https://travis-ci.org/python-pillow/pillow-wheels
    :alt: Travis CI build status (OS X)
 
+.. image:: https://ci.appveyor.com/api/projects/status/github/wiredfool/pillow?svg=true&branch=winbuild
+   :target: https://ci.appveyor.com/project/wiredfool/pillow
+   :alt: Travis CI build status (Windows)
+
 .. image:: https://img.shields.io/pypi/v/pillow.svg
    :target: https://pypi.python.org/pypi/Pillow/
    :alt: Latest PyPI version

--- a/README.rst
+++ b/README.rst
@@ -6,15 +6,15 @@ Python Imaging Library (Fork)
 
 Pillow is the "friendly PIL fork" by `Alex Clark and Contributors <https://github.com/python-pillow/Pillow/graphs/contributors>`_. PIL is the Python Imaging Library by Fredrik Lundh and Contributors.
 
-.. image:: https://travis-ci.org/python-pillow/Pillow.svg?branch=master
+.. image:: https://img.shields.io/travis/python-pillow/Pillow/master.svg?label=Linux%20build
    :target: https://travis-ci.org/python-pillow/Pillow
    :alt: Travis CI build status (Linux)
 
-.. image:: https://travis-ci.org/python-pillow/pillow-wheels.svg?branch=latest
+.. image:: https://img.shields.io/travis/python-pillow/pillow-wheels/latest.svg?label=OS%20X%20build
    :target: https://travis-ci.org/python-pillow/pillow-wheels
    :alt: Travis CI build status (OS X)
 
-.. image:: https://ci.appveyor.com/api/projects/status/github/wiredfool/pillow?svg=true&branch=winbuild
+.. image:: https://img.shields.io/appveyor/ci/wiredfool/pillow/winbuild.svg?label=Windows%20build
    :target: https://ci.appveyor.com/project/wiredfool/pillow
    :alt: AppVeyor CI build status (Windows)
 

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Pillow is the "friendly PIL fork" by `Alex Clark and Contributors <https://githu
 
 .. image:: https://ci.appveyor.com/api/projects/status/github/wiredfool/pillow?svg=true&branch=winbuild
    :target: https://ci.appveyor.com/project/wiredfool/pillow
-   :alt: Travis CI build status (Windows)
+   :alt: AppVeyor CI build status (Windows)
 
 .. image:: https://img.shields.io/pypi/v/pillow.svg
    :target: https://pypi.python.org/pypi/Pillow/

--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,8 @@ Pillow is the "friendly PIL fork" by `Alex Clark and Contributors <https://githu
    :target: https://travis-ci.org/python-pillow/pillow-wheels
    :alt: Travis CI build status (OS X)
 
-.. image:: https://img.shields.io/appveyor/ci/wiredfool/pillow/winbuild.svg?label=Windows%20build
-   :target: https://ci.appveyor.com/project/wiredfool/pillow
+.. image:: https://img.shields.io/appveyor/ci/wiredfool/pillow-b17vj/master.svg?label=Windows%20build
+   :target: https://ci.appveyor.com/project/wiredfool/pillow-b17vj
    :alt: AppVeyor CI build status (Windows)
 
 .. image:: https://img.shields.io/pypi/v/pillow.svg


### PR DESCRIPTION
Now we have a Windows build on AppVeyor, it makes sense to include its badge in README to make sure we spot failed builds early, before releases. 

But three "build: passing" badges in a row looks a bit odd:

> ![Travis CI build status (Linux)](https://travis-ci.org/python-pillow/Pillow.svg?branch=master) ![Travis CI build status (OS X)](https://travis-ci.org/python-pillow/pillow-wheels.svg?branch=latest) ![AppVeyor CI build status (Windows)](https://ci.appveyor.com/api/projects/status/github/wiredfool/pillow?svg=true&branch=winbuild)

AppVeyor allows you to customise the right-hand side text (http://www.appveyor.com/docs/status-badges), but Travis CI doesn't.

But Shields.io allows you to override the default left-hand-side text (which makes more sense) and supports both Travis CI and AppVeyor:

> ![Travis CI build status (Linux)](https://img.shields.io/travis/python-pillow/Pillow/master.svg?label=Linux%20build) ![Travis CI build status (OS X)](https://img.shields.io/travis/python-pillow/pillow-wheels/latest.svg?label=OS%20X%20build) ![AppVeyor CI build status (Windows)](https://img.shields.io/appveyor/ci/wiredfool/pillow/winbuild.svg?label=Windows%20build)

(TODO: update Windows branch to master when available.)