### PR TITLE
Windows build tweaks

### DIFF
--- a/winbuild/build.py
+++ b/winbuild/build.py
@@ -1,6 +1,6 @@
 #/usr/bin/env python3
 
-import subprocess, multiprocessing
+import subprocess
 import shutil
 import sys, getopt
 import os
@@ -106,11 +106,10 @@ def main(op):
                                              compilers[(compiler_version, 64)]),
                                    footer()])))
     
-    pool = multiprocessing.Pool()
-    results = pool.map(run_script, scripts)
+    results = map(run_script, scripts)
     
     for (version, status, trace, err) in results:
-        print ("Compiled %s: %s" % (version, status))
+        print ("Compiled %s: %s" % (version, status and 'ERR' or 'OK'))
         
 def run_one(op):
     

--- a/winbuild/build_dep.py
+++ b/winbuild/build_dep.py
@@ -185,7 +185,7 @@ setlocal
 cd /D %%WEBP%%
 rd /S /Q %%WEBP%%\output\release-static
 nmake -f Makefile.vc CFG=release-static RTLIBCFG=static OBJDIR=output all
-copy /Y /B output\release-static\%(platform)s\lib\* %%INCLIB%%
+copy /Y /B output\release-static\%(webp_platform)s\lib\* %%INCLIB%%
 mkdir %%INCLIB%%\webp
 copy /Y /B src\webp\*.h %%INCLIB%%\\webp
 endlocal

--- a/winbuild/config.py
+++ b/winbuild/config.py
@@ -72,14 +72,16 @@ compilers = { (7,64): {
     'vc_version':'2008',
     'env_flags': '/x64 /xp',
     'inc_dir': 'msvcr90-x64',
-    'platform': 'x64'
+    'platform': 'x64',
+    'webp_platform': 'x64',
     },
              (7,32): {
     'env_version':'v7.0',
     'vc_version':'2008',
     'env_flags': '/x86 /xp',
     'inc_dir': 'msvcr90-x32',
-    'platform': 'Win32'
+    'platform': 'Win32',
+    'webp_platform': 'x86',
    },
 
              (7.1,64): {
@@ -88,6 +90,7 @@ compilers = { (7,64): {
     'env_flags': '/x64 /vista',
     'inc_dir': 'msvcr10-x64',
     'platform': 'x64',
+    'webp_platform': 'x64',
    },
              (7.1,32): {
     'env_version':'v7.1',
@@ -95,6 +98,7 @@ compilers = { (7,64): {
     'env_flags': '/x86 /vista',
     'inc_dir': 'msvcr10-x32',
     'platform': 'Win32',
+    'webp_platform': 'x86',
     },
 
     }


### PR DESCRIPTION
Webp is now built and recognized with all the compilers in the matrix. 

* Remove multithreading from build.py script to fix race condition
* Fix webp build script to find the libraries when compiled on x86. 