### PR TITLE
Winbuild updates

### DIFF
--- a/winbuild/build.py
+++ b/winbuild/build.py
@@ -67,12 +67,17 @@ def build_one(py_ver, compiler):
     else:
         args['python_path'] = "%s%s\\Scripts" % (VIRT_BASE, py_ver)
     args['py_ver'] = py_ver
+    if '34' in py_ver:
+        args['tcl_ver'] = '86'
+    else:
+        args['tcl_ver'] = '85'
+        
     return r"""
 setlocal EnableDelayedExpansion
 call "%%ProgramFiles%%\Microsoft SDKs\Windows\%(env_version)s\Bin\SetEnv.Cmd" /Release %(env_flags)s
 set DISTUTILS_USE_SDK=1
 set LIB=%%LIB%%;%%INCLIB%%\%(inc_dir)s
-set INCLUDE=%%INCLUDE%%;%%INCLIB%%\%(inc_dir)s;%%INCLIB%%\tcl85\include
+set INCLUDE=%%INCLUDE%%;%%INCLIB%%\%(inc_dir)s;%%INCLIB%%\tcl%(tcl_ver)s\include
 
 setlocal
 set LIB=%%LIB%%;C:\Python%(py_ver)s\tcl

--- a/winbuild/build_dep.py
+++ b/winbuild/build_dep.py
@@ -95,6 +95,11 @@ mkdir %INCLIB%\tcl85\include\X11
 copy /Y /B %BUILD%\tcl8.5.13\generic\*.h %INCLIB%\tcl85\include\
 copy /Y /B %BUILD%\tk8.5.13\generic\*.h %INCLIB%\tcl85\include\
 copy /Y /B %BUILD%\tk8.5.13\xlib\X11\* %INCLIB%\tcl85\include\X11\
+
+mkdir %INCLIB%\tcl86\include\X11
+copy /Y /B %BUILD%\tcl8.6.4\generic\*.h %INCLIB%\tcl86\include\
+copy /Y /B %BUILD%\tk8.6.4\generic\*.h %INCLIB%\tcl86\include\
+copy /Y /B %BUILD%\tk8.6.4\xlib\X11\* %INCLIB%\tcl86\include\X11\
 """
 
 def header():
@@ -297,7 +302,7 @@ if 'PYTHON' in os.environ:
 else:
     #for compiler in compilers.values():
         #add_compiler(compiler)
-    add_compiler(compilers[(7.1,32)])
+    add_compiler(compilers[(7.0,32)])
     #add_compiler(compilers[(7.1,64)])
     
 with open('build_deps.cmd', 'w') as f:    

--- a/winbuild/config.py
+++ b/winbuild/config.py
@@ -36,14 +36,24 @@ libs = { 'zlib':{
     'hash': 'sha1:7ff1a5b721ca719760ba6eb4ec6f38d5e65381cf',
     'dir': 'lcms2-2.7',
    },
-         'tcl':{
+         'tcl-8.5':{
     'url':SF_MIRROR+'/project/tcl/Tcl/8.5.13/tcl8513-src.zip',
     'hash': 'sha1:3e01585c91293c532a3cd594ec59deca92153a5e',
     'dir': '',
    },
-         'tk':{
+         'tk-8.5':{
     'url':SF_MIRROR+'/project/tcl/Tcl/8.5.13/tk8513-src.zip',
     'hash': 'sha1:23a1d7ddd416e11e06dfdb9f86111d4bab9420b4',
+    'dir': '',
+    },
+         'tcl-8.6':{
+    'url':SF_MIRROR+'/project/tcl/Tcl/8.6.4/tcl864-src.zip',
+    'hash': 'md5:35748d2fc61e08a2fdb23b85c6f8c4a0',
+    'dir': '',
+   },
+         'tk-8.6':{
+    'url':SF_MIRROR+'/project/tcl/Tcl/8.6.4/tk864-src.zip',
+    'hash': 'md5:111d45061a69e7f5250b6ec8ca7c4f35',
     'dir': '',
     },
          'webp':{


### PR DESCRIPTION
- lcms2 except for Python2.7 64.
- tk for Python 2.7, 3.4 is not recognized yet (but the libraries are available)