### PR TITLE
Update Windows badge [ci skip]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,8 @@ Pillow is the "friendly PIL fork" by `Alex Clark and Contributors <https://githu
    :target: https://travis-ci.org/python-pillow/pillow-wheels
    :alt: Travis CI build status (OS X)
 
-.. image:: https://img.shields.io/appveyor/ci/wiredfool/pillow-b17vj/master.svg?label=Windows%20build
-   :target: https://ci.appveyor.com/project/wiredfool/pillow-b17vj
+.. image:: https://img.shields.io/appveyor/ci/Pythonpillow/pillow/master.svg?label=Windows%20build
+   :target: https://ci.appveyor.com/project/Pythonpillow/pillow
    :alt: AppVeyor CI build status (Windows)
 
 .. image:: https://img.shields.io/pypi/v/pillow.svg


### PR DESCRIPTION
[wiredfool/pillow-b17vj](https://ci.appveyor.com/project/wiredfool/pillow-b17vj) appears to have been discontinued, so this switches the badge over to [Pythonpillow/pillow](https://ci.appveyor.com/project/Pythonpillow/pillow)