### PR TITLE
Added width and height properties

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -504,6 +504,14 @@ class Image(object):
         self.readonly = 0
         self.pyaccess = None
 
+    @property
+    def width(self):
+        return self.size[0]
+
+    @property
+    def height(self):
+        return self.size[1]
+
     def _new(self, im):
         new = Image()
         new.im = im

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -30,6 +30,15 @@ class TestImage(PillowTestCase):
         # self.assertRaises(
         #     MemoryError, lambda: Image.new("L", (1000000, 1000000)))
 
+    def test_width_height(self):
+        im = Image.new("RGB", (1, 2))
+        self.assertEqual(im.width, 1)
+        self.assertEqual(im.height, 2)
+
+        im.size = (3, 4)
+        self.assertEqual(im.width, 3)
+        self.assertEqual(im.height, 4)
+
     def test_invalid_image(self):
         if str is bytes:
             import StringIO


### PR DESCRIPTION
As per the suggestion in #1279

This adds width and height properties to Image, so that in addition to `im.size`, users can also call `im.width` and `im.height`