### PR TITLE
Fixed tox test script path

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,4 +11,4 @@ commands =
     {envpython} setup.py clean
     {envpython} setup.py build_ext --inplace
     {envpython} selftest.py
-    {envpython} Tests/run.py --installed
+    {envpython} test-installed.py --installed


### PR DESCRIPTION
Resolves #1307

`Tests/run.py` has been removed. The documentation lists either `test_installed.py` or `Tests/test_*.py`. Tox does not accept the wildcard format, so `test_installed.py` is the solution.