### PR TITLE
TST: fix ValueError on Python 2.6

### DIFF
--- a/Tests/test_image_toqimage.py
+++ b/Tests/test_image_toqimage.py
@@ -19,7 +19,7 @@ class TestToQImage(PillowQtTestCase, PillowTestCase):
             self.assertFalse(data.isNull())
 
             # Test saving the file
-            tempfile = self.tempfile('temp_{}.png'.format(mode))
+            tempfile = self.tempfile('temp_{0}.png'.format(mode))
             data.save(tempfile)
 
 


### PR DESCRIPTION
```
======================================================================
ERROR: TestToQImage.test_sanity
----------------------------------------------------------------------
Traceback (most recent call last):
  File "Tests\test_image_toqimage.py", line 22, in test_sanity
    tempfile = self.tempfile('temp_{}.png'.format(mode))
ValueError: zero length field name in format

----------------------------------------------------------------------
```