### PR TITLE
Merged gifmaker into GifImagePlugin

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -204,6 +204,7 @@ ID = []
 OPEN = {}
 MIME = {}
 SAVE = {}
+SAVE_ALL = {}
 EXTENSION = {}
 
 # --------------------------------------------------------------------
@@ -1669,6 +1670,10 @@ class Image(object):
         # may mutate self!
         self.load()
 
+        save_all = False
+        if 'save_all' in params:
+            save_all = params['save_all']
+            del params['save_all']
         self.encoderinfo = params
         self.encoderconfig = ()
 
@@ -1686,11 +1691,12 @@ class Image(object):
                 except KeyError:
                     raise KeyError(ext)  # unknown extension
 
-        try:
-            save_handler = SAVE[format.upper()]
-        except KeyError:
+        if format.upper() not in SAVE:
             init()
-            save_handler = SAVE[format.upper()]  # unknown format
+        if save_all:
+            save_handler = SAVE_ALL[format.upper()]
+        else:
+            save_handler = SAVE[format.upper()]
 
         if isPath(fp):
             fp = builtins.open(fp, "wb")
@@ -2467,6 +2473,18 @@ def register_save(id, driver):
     :param driver: A function to save images in this format.
     """
     SAVE[id.upper()] = driver
+
+
+def register_save_all(id, driver):
+    """
+    Registers an image function to save all the frames
+    of a multiframe format.  This function should not be
+    used in application code.
+
+    :param id: An image format identifier.
+    :param driver: A function to save images in this format.
+    """
+    SAVE_ALL[id.upper()] = driver
 
 
 def register_extension(id, extension):

--- a/Scripts/gifmaker.py
+++ b/Scripts/gifmaker.py
@@ -14,104 +14,9 @@
 # See the README file for information on usage and redistribution.
 #
 
-#
-# For special purposes, you can import this module and call
-# the makedelta or compress functions yourself.  For example,
-# if you have an application that generates a sequence of
-# images, you can convert it to a GIF animation using some-
-# thing like the following code:
-#
-#       import Image
-#       import gifmaker
-#
-#       sequence = []
-#
-#       # generate sequence
-#       for i in range(100):
-#           im = <generate image i>
-#           sequence.append(im)
-#
-#       # write GIF animation
-#       fp = open("out.gif", "wb")
-#       gifmaker.makedelta(fp, sequence)
-#       fp.close()
-#
-# Alternatively, use an iterator to generate the sequence, and
-# write data directly to a socket.  Or something...
-#
-
 from __future__ import print_function
 
-from PIL import Image, ImageChops, ImageSequence
-
-from PIL.GifImagePlugin import getheader, getdata
-
-# --------------------------------------------------------------------
-# straightforward delta encoding
-
-
-def makedelta(fp, sequence):
-    """Convert list of image frames to a GIF animation file"""
-
-    frames = 0
-
-    previous = None
-
-    for im in sequence:
-
-        # To specify duration, add the time in milliseconds to getdata(),
-        # e.g. getdata(im, duration=1000)
-
-        if not previous:
-
-            # global header
-            for s in getheader(im)[0] + getdata(im):
-                fp.write(s)
-
-        else:
-
-            # delta frame
-            delta = ImageChops.subtract_modulo(im, previous)
-
-            bbox = delta.getbbox()
-
-            if bbox:
-
-                # compress difference
-                for s in getdata(im.crop(bbox), offset=bbox[:2]):
-                    fp.write(s)
-
-            else:
-                # FIXME: what should we do in this case?
-                pass
-
-        previous = im.copy()
-
-        frames += 1
-
-    fp.write(b";")
-
-    return frames
-
-# --------------------------------------------------------------------
-# main hack
-
-
-def compress(infile, outfile):
-
-    # open input image, and force loading of first frame
-    im = Image.open(infile)
-    im.load()
-
-    # open output file
-    fp = open(outfile, "wb")
-
-    seq = ImageSequence.Iterator(im)
-
-    makedelta(fp, seq)
-
-    fp.close()
-
+from PIL import Image
 
 if __name__ == "__main__":
 
@@ -122,4 +27,5 @@ if __name__ == "__main__":
         print("Usage: gifmaker infile outfile")
         sys.exit(1)
 
-    compress(sys.argv[1], sys.argv[2])
+    im = Image.open(sys.argv[1])
+    im.save(sys.argv[2], save_all=True)

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -71,6 +71,14 @@ class TestFileGif(PillowTestCase):
 
         self.assert_image_similar(reread.convert('RGB'), hopper(), 50)
 
+    def test_roundtrip_save_all(self):
+        out = self.tempfile('temp.gif')
+        im = hopper()
+        im.save(out, save_all=True)
+        reread = Image.open(out)
+
+        self.assert_image_similar(reread.convert('RGB'), im, 50)
+
     def test_palette_handling(self):
         # see https://github.com/python-pillow/Pillow/issues/513
 


### PR DESCRIPTION
Resolves #1271

This is the first step in saving multiframe images (#733), by merging the functionality of the gifmaker script into GifImagePlugin.

Happy to accept other ideas about how to do `save_all`. In this pull request, I'm imagining `im.save('test.gif', save_all=True)`