### PR TITLE
AppVeyor: Report failures sooner

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,3 +24,5 @@ test_script:
 - cd c:\pillow
 - '%PYTHON%\Scripts\pip.exe install nose'
 - '%PYTHON%\python.exe test-installed.py'
+matrix:
+  fast_finish: true


### PR DESCRIPTION
Fail fast: All build jobs are run, but if one fails, immediately report the whole build as a failure.