### PR TITLE
Fix for UnicodeDecodeError: ascii codec cannot decode byte while saving a TIFF image

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -550,6 +550,8 @@ class ImageFileDirectory(collections.MutableMapping):
                 # contains a 7-bit ASCII code; the last byte must be
                 # NUL (binary zero). Also, I don't think this was well
                 # exercised before.
+                if sys.version_info[0] == 2:
+                    value = value.decode('ascii','replace')
                 data = value = b"" + value.encode('ascii', 'replace') + b"\0"
             else:
                 # integer data

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -15,7 +15,8 @@ class TestFileTiffMetadata(PillowTestCase):
 
         img = hopper()
 
-        textdata = "This is some arbitrary metadata for a text field"
+        basetextdata = "This is some arbitrary metadata for a text field"
+        textdata = basetextdata + " \xff"
         floatdata = 12.345
         doubledata = 67.89
 
@@ -35,8 +36,8 @@ class TestFileTiffMetadata(PillowTestCase):
 
         loaded = Image.open(f)
 
-        self.assertEqual(loaded.tag[50838], (len(textdata),))
-        self.assertEqual(loaded.tag[50839], textdata)
+        self.assertEqual(loaded.tag[50838], (len(basetextdata + " ?"),))
+        self.assertEqual(loaded.tag[50839], basetextdata + " ?")
         self.assertAlmostEqual(loaded.tag[tag_ids['RollAngle']][0], floatdata,
                                places=5)
         self.assertAlmostEqual(loaded.tag[tag_ids['YawAngle']][0], doubledata)


### PR DESCRIPTION
If a rebase is all that is stopping #1309 from being merged, then here is the rebase.