### PR TITLE
Changed register calls to use format property

### DIFF
--- a/PIL/CurImagePlugin.py
+++ b/PIL/CurImagePlugin.py
@@ -82,6 +82,6 @@ class CurImageFile(BmpImagePlugin.BmpImageFile):
 #
 # --------------------------------------------------------------------
 
-Image.register_open("CUR", CurImageFile, _accept)
+Image.register_open(CurImageFile.format, CurImageFile, _accept)
 
-Image.register_extension("CUR", ".cur")
+Image.register_extension(CurImageFile.format, ".cur")

--- a/PIL/DcxImagePlugin.py
+++ b/PIL/DcxImagePlugin.py
@@ -82,6 +82,6 @@ class DcxImageFile(PcxImageFile):
         return self.frame
 
 
-Image.register_open("DCX", DcxImageFile, _accept)
+Image.register_open(DcxImageFile.format, DcxImageFile, _accept)
 
-Image.register_extension("DCX", ".dcx")
+Image.register_extension(DcxImageFile.format, ".dcx")

--- a/PIL/FliImagePlugin.py
+++ b/PIL/FliImagePlugin.py
@@ -182,7 +182,7 @@ class FliImageFile(ImageFile.ImageFile):
 #
 # registry
 
-Image.register_open("FLI", FliImageFile, _accept)
+Image.register_open(FliImageFile.format, FliImageFile, _accept)
 
-Image.register_extension("FLI", ".fli")
-Image.register_extension("FLI", ".flc")
+Image.register_extension(FliImageFile.format, ".fli")
+Image.register_extension(FliImageFile.format, ".flc")

--- a/PIL/GbrImagePlugin.py
+++ b/PIL/GbrImagePlugin.py
@@ -66,6 +66,6 @@ class GbrImageFile(ImageFile.ImageFile):
 #
 # registry
 
-Image.register_open("GBR", GbrImageFile, _accept)
+Image.register_open(GbrImageFile.format, GbrImageFile, _accept)
 
-Image.register_extension("GBR", ".gbr")
+Image.register_extension(GbrImageFile.format, ".gbr")

--- a/PIL/IcnsImagePlugin.py
+++ b/PIL/IcnsImagePlugin.py
@@ -345,13 +345,14 @@ def _save(im, fp, filename):
     if retcode:
         raise CalledProcessError(retcode, convert_cmd)
 
-Image.register_open("ICNS", IcnsImageFile, lambda x: x[:4] == b'icns')
-Image.register_extension("ICNS", '.icns')
+Image.register_open(IcnsImageFile.format, IcnsImageFile,
+                    lambda x: x[:4] == b'icns')
+Image.register_extension(IcnsImageFile.format, '.icns')
 
 if sys.platform == 'darwin':
-    Image.register_save("ICNS", _save)
+    Image.register_save(IcnsImageFile.format, _save)
 
-    Image.register_mime("ICNS", "image/icns")
+    Image.register_mime(IcnsImageFile.format, "image/icns")
 
 
 if __name__ == '__main__':

--- a/PIL/IcoImagePlugin.py
+++ b/PIL/IcoImagePlugin.py
@@ -278,6 +278,6 @@ class IcoImageFile(ImageFile.ImageFile):
 #
 # --------------------------------------------------------------------
 
-Image.register_open("ICO", IcoImageFile, _accept)
-Image.register_save("ICO", _save)
-Image.register_extension("ICO", ".ico")
+Image.register_open(IcoImageFile.format, IcoImageFile, _accept)
+Image.register_save(IcoImageFile.format, _save)
+Image.register_extension(IcoImageFile.format, ".ico")

--- a/PIL/ImImagePlugin.py
+++ b/PIL/ImImagePlugin.py
@@ -349,7 +349,7 @@ def _save(im, fp, filename, check=0):
 # --------------------------------------------------------------------
 # Registry
 
-Image.register_open("IM", ImImageFile)
-Image.register_save("IM", _save)
+Image.register_open(ImImageFile.format, ImImageFile)
+Image.register_save(ImImageFile.format, _save)
 
-Image.register_extension("IM", ".im")
+Image.register_extension(ImImageFile.format, ".im")

--- a/PIL/IptcImagePlugin.py
+++ b/PIL/IptcImagePlugin.py
@@ -184,9 +184,9 @@ class IptcImageFile(ImageFile.ImageFile):
                 pass
 
 
-Image.register_open("IPTC", IptcImageFile)
+Image.register_open(IptcImageFile.format, IptcImageFile)
 
-Image.register_extension("IPTC", ".iim")
+Image.register_extension(IptcImageFile.format, ".iim")
 
 
 ##

--- a/PIL/Jpeg2KImagePlugin.py
+++ b/PIL/Jpeg2KImagePlugin.py
@@ -262,15 +262,15 @@ def _save(im, fp, filename):
 # ------------------------------------------------------------
 # Registry stuff
 
-Image.register_open('JPEG2000', Jpeg2KImageFile, _accept)
-Image.register_save('JPEG2000', _save)
+Image.register_open(Jpeg2KImageFile.format, Jpeg2KImageFile, _accept)
+Image.register_save(Jpeg2KImageFile.format, _save)
 
-Image.register_extension('JPEG2000', '.jp2')
-Image.register_extension('JPEG2000', '.j2k')
-Image.register_extension('JPEG2000', '.jpc')
-Image.register_extension('JPEG2000', '.jpf')
-Image.register_extension('JPEG2000', '.jpx')
-Image.register_extension('JPEG2000', '.j2c')
+Image.register_extension(Jpeg2KImageFile.format, '.jp2')
+Image.register_extension(Jpeg2KImageFile.format, '.j2k')
+Image.register_extension(Jpeg2KImageFile.format, '.jpc')
+Image.register_extension(Jpeg2KImageFile.format, '.jpf')
+Image.register_extension(Jpeg2KImageFile.format, '.jpx')
+Image.register_extension(Jpeg2KImageFile.format, '.j2c')
 
-Image.register_mime('JPEG2000', 'image/jp2')
-Image.register_mime('JPEG2000', 'image/jpx')
+Image.register_mime(Jpeg2KImageFile.format, 'image/jp2')
+Image.register_mime(Jpeg2KImageFile.format, 'image/jpx')

--- a/PIL/JpegImagePlugin.py
+++ b/PIL/JpegImagePlugin.py
@@ -728,12 +728,12 @@ def jpeg_factory(fp=None, filename=None):
 # -------------------------------------------------------------------q-
 # Registry stuff
 
-Image.register_open("JPEG", jpeg_factory, _accept)
-Image.register_save("JPEG", _save)
+Image.register_open(JpegImageFile.format, jpeg_factory, _accept)
+Image.register_save(JpegImageFile.format, _save)
 
-Image.register_extension("JPEG", ".jfif")
-Image.register_extension("JPEG", ".jpe")
-Image.register_extension("JPEG", ".jpg")
-Image.register_extension("JPEG", ".jpeg")
+Image.register_extension(JpegImageFile.format, ".jfif")
+Image.register_extension(JpegImageFile.format, ".jpe")
+Image.register_extension(JpegImageFile.format, ".jpg")
+Image.register_extension(JpegImageFile.format, ".jpeg")
 
-Image.register_mime("JPEG", "image/jpeg")
+Image.register_mime(JpegImageFile.format, "image/jpeg")

--- a/PIL/MicImagePlugin.py
+++ b/PIL/MicImagePlugin.py
@@ -99,6 +99,6 @@ class MicImageFile(TiffImagePlugin.TiffImageFile):
 #
 # --------------------------------------------------------------------
 
-Image.register_open("MIC", MicImageFile, _accept)
+Image.register_open(MicImageFile.format, MicImageFile, _accept)
 
-Image.register_extension("MIC", ".mic")
+Image.register_extension(MicImageFile.format, ".mic")

--- a/PIL/MpegImagePlugin.py
+++ b/PIL/MpegImagePlugin.py
@@ -77,9 +77,9 @@ class MpegImageFile(ImageFile.ImageFile):
 # --------------------------------------------------------------------
 # Registry stuff
 
-Image.register_open("MPEG", MpegImageFile)
+Image.register_open(MpegImageFile.format, MpegImageFile)
 
-Image.register_extension("MPEG", ".mpg")
-Image.register_extension("MPEG", ".mpeg")
+Image.register_extension(MpegImageFile.format, ".mpg")
+Image.register_extension(MpegImageFile.format, ".mpeg")
 
-Image.register_mime("MPEG", "video/mpeg")
+Image.register_mime(MpegImageFile.format, "video/mpeg")

--- a/PIL/MpoImagePlugin.py
+++ b/PIL/MpoImagePlugin.py
@@ -90,9 +90,10 @@ class MpoImageFile(JpegImagePlugin.JpegImageFile):
 
 # Note that since MPO shares a factory with JPEG, we do not need to do a
 # separate registration for it here.
-# Image.register_open("MPO", JpegImagePlugin.jpeg_factory, _accept)
-Image.register_save("MPO", _save)
+# Image.register_open(MpoImageFile.format,
+#                     JpegImagePlugin.jpeg_factory, _accept)
+Image.register_save(MpoImageFile.format, _save)
 
-Image.register_extension("MPO", ".mpo")
+Image.register_extension(MpoImageFile.format, ".mpo")
 
-Image.register_mime("MPO", "image/mpo")
+Image.register_mime(MpoImageFile.format, "image/mpo")

--- a/PIL/MspImagePlugin.py
+++ b/PIL/MspImagePlugin.py
@@ -98,7 +98,7 @@ def _save(im, fp, filename):
 #
 # registry
 
-Image.register_open("MSP", MspImageFile, _accept)
-Image.register_save("MSP", _save)
+Image.register_open(MspImageFile.format, MspImageFile, _accept)
+Image.register_save(MspImageFile.format, _save)
 
-Image.register_extension("MSP", ".msp")
+Image.register_extension(MspImageFile.format, ".msp")

--- a/PIL/PcdImagePlugin.py
+++ b/PIL/PcdImagePlugin.py
@@ -55,6 +55,6 @@ class PcdImageFile(ImageFile.ImageFile):
 #
 # registry
 
-Image.register_open("PCD", PcdImageFile)
+Image.register_open(PcdImageFile.format, PcdImageFile)
 
-Image.register_extension("PCD", ".pcd")
+Image.register_extension(PcdImageFile.format, ".pcd")

--- a/PIL/PcxImagePlugin.py
+++ b/PIL/PcxImagePlugin.py
@@ -181,7 +181,7 @@ def _save(im, fp, filename, check=0):
 # --------------------------------------------------------------------
 # registry
 
-Image.register_open("PCX", PcxImageFile, _accept)
-Image.register_save("PCX", _save)
+Image.register_open(PcxImageFile.format, PcxImageFile, _accept)
+Image.register_save(PcxImageFile.format, _save)
 
-Image.register_extension("PCX", ".pcx")
+Image.register_extension(PcxImageFile.format, ".pcx")

--- a/PIL/PngImagePlugin.py
+++ b/PIL/PngImagePlugin.py
@@ -803,9 +803,9 @@ def getchunks(im, **params):
 # --------------------------------------------------------------------
 # Registry
 
-Image.register_open("PNG", PngImageFile, _accept)
-Image.register_save("PNG", _save)
+Image.register_open(PngImageFile.format, PngImageFile, _accept)
+Image.register_save(PngImageFile.format, _save)
 
-Image.register_extension("PNG", ".png")
+Image.register_extension(PngImageFile.format, ".png")
 
-Image.register_mime("PNG", "image/png")
+Image.register_mime(PngImageFile.format, "image/png")

--- a/PIL/PpmImagePlugin.py
+++ b/PIL/PpmImagePlugin.py
@@ -164,9 +164,9 @@ def _save(im, fp, filename):
 #
 # --------------------------------------------------------------------
 
-Image.register_open("PPM", PpmImageFile, _accept)
-Image.register_save("PPM", _save)
+Image.register_open(PpmImageFile.format, PpmImageFile, _accept)
+Image.register_save(PpmImageFile.format, _save)
 
-Image.register_extension("PPM", ".pbm")
-Image.register_extension("PPM", ".pgm")
-Image.register_extension("PPM", ".ppm")
+Image.register_extension(PpmImageFile.format, ".pbm")
+Image.register_extension(PpmImageFile.format, ".pgm")
+Image.register_extension(PpmImageFile.format, ".ppm")

--- a/PIL/PsdImagePlugin.py
+++ b/PIL/PsdImagePlugin.py
@@ -307,6 +307,6 @@ def _maketile(file, mode, bbox, channels):
 # --------------------------------------------------------------------
 # registry
 
-Image.register_open("PSD", PsdImageFile, _accept)
+Image.register_open(PsdImageFile.format, PsdImageFile, _accept)
 
-Image.register_extension("PSD", ".psd")
+Image.register_extension(PsdImageFile.format, ".psd")

--- a/PIL/SgiImagePlugin.py
+++ b/PIL/SgiImagePlugin.py
@@ -81,11 +81,11 @@ class SgiImageFile(ImageFile.ImageFile):
 #
 # registry
 
-Image.register_open("SGI", SgiImageFile, _accept)
+Image.register_open(SgiImageFile.format, SgiImageFile, _accept)
 
-Image.register_extension("SGI", ".bw")
-Image.register_extension("SGI", ".rgb")
-Image.register_extension("SGI", ".rgba")
-Image.register_extension("SGI", ".sgi")
+Image.register_extension(SgiImageFile.format, ".bw")
+Image.register_extension(SgiImageFile.format, ".rgb")
+Image.register_extension(SgiImageFile.format, ".rgba")
+Image.register_extension(SgiImageFile.format, ".sgi")
 
 # End of file

--- a/PIL/SpiderImagePlugin.py
+++ b/PIL/SpiderImagePlugin.py
@@ -285,8 +285,8 @@ def _save_spider(im, fp, filename):
 
 # --------------------------------------------------------------------
 
-Image.register_open("SPIDER", SpiderImageFile)
-Image.register_save("SPIDER", _save_spider)
+Image.register_open(SpiderImageFile.format, SpiderImageFile)
+Image.register_save(SpiderImageFile.format, _save_spider)
 
 if __name__ == "__main__":
 

--- a/PIL/SunImagePlugin.py
+++ b/PIL/SunImagePlugin.py
@@ -78,6 +78,6 @@ class SunImageFile(ImageFile.ImageFile):
 #
 # registry
 
-Image.register_open("SUN", SunImageFile, _accept)
+Image.register_open(SunImageFile.format, SunImageFile, _accept)
 
-Image.register_extension("SUN", ".ras")
+Image.register_extension(SunImageFile.format, ".ras")

--- a/PIL/TgaImagePlugin.py
+++ b/PIL/TgaImagePlugin.py
@@ -193,7 +193,7 @@ def _save(im, fp, filename, check=0):
 # --------------------------------------------------------------------
 # Registry
 
-Image.register_open("TGA", TgaImageFile)
-Image.register_save("TGA", _save)
+Image.register_open(TgaImageFile.format, TgaImageFile)
+Image.register_save(TgaImageFile.format, _save)
 
-Image.register_extension("TGA", ".tga")
+Image.register_extension(TgaImageFile.format, ".tga")

--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -1262,10 +1262,10 @@ def _save(im, fp, filename):
 # --------------------------------------------------------------------
 # Register
 
-Image.register_open("TIFF", TiffImageFile, _accept)
-Image.register_save("TIFF", _save)
+Image.register_open(TiffImageFile.format, TiffImageFile, _accept)
+Image.register_save(TiffImageFile.format, _save)
 
-Image.register_extension("TIFF", ".tif")
-Image.register_extension("TIFF", ".tiff")
+Image.register_extension(TiffImageFile.format, ".tif")
+Image.register_extension(TiffImageFile.format, ".tiff")
 
-Image.register_mime("TIFF", "image/tiff")
+Image.register_mime(TiffImageFile.format, "image/tiff")

--- a/PIL/WebPImagePlugin.py
+++ b/PIL/WebPImagePlugin.py
@@ -73,8 +73,8 @@ def _save(im, fp, filename):
     fp.write(data)
 
 
-Image.register_open("WEBP", WebPImageFile, _accept)
-Image.register_save("WEBP", _save)
+Image.register_open(WebPImageFile.format, WebPImageFile, _accept)
+Image.register_save(WebPImageFile.format, _save)
 
-Image.register_extension("WEBP", ".webp")
-Image.register_mime("WEBP", "image/webp")
+Image.register_extension(WebPImageFile.format, ".webp")
+Image.register_mime(WebPImageFile.format, "image/webp")

--- a/PIL/XbmImagePlugin.py
+++ b/PIL/XbmImagePlugin.py
@@ -88,9 +88,9 @@ def _save(im, fp, filename):
     fp.write(b"};\n")
 
 
-Image.register_open("XBM", XbmImageFile, _accept)
-Image.register_save("XBM", _save)
+Image.register_open(XbmImageFile.format, XbmImageFile, _accept)
+Image.register_save(XbmImageFile.format, _save)
 
-Image.register_extension("XBM", ".xbm")
+Image.register_extension(XbmImageFile.format, ".xbm")
 
-Image.register_mime("XBM", "image/xbm")
+Image.register_mime(XbmImageFile.format, "image/xbm")

--- a/PIL/XpmImagePlugin.py
+++ b/PIL/XpmImagePlugin.py
@@ -124,8 +124,8 @@ class XpmImageFile(ImageFile.ImageFile):
 #
 # Registry
 
-Image.register_open("XPM", XpmImageFile, _accept)
+Image.register_open(XpmImageFile.format, XpmImageFile, _accept)
 
-Image.register_extension("XPM", ".xpm")
+Image.register_extension(XpmImageFile.format, ".xpm")
 
-Image.register_mime("XPM", "image/xpm")
+Image.register_mime(XpmImageFile.format, "image/xpm")


### PR DESCRIPTION
When the format plugins call `Image.register_*`, they need to pass in the format type.

[Some formats](https://github.com/python-pillow/Pillow/blob/master/PIL/TiffImagePlugin.py#L1265) simply have the format retyped, but [others](https://github.com/python-pillow/Pillow/blob/master/PIL/GifImagePlugin.py#L643) call the refer to the format property of the plugin's ImageFile class.

This PR changes the plugins to refer to the format property in the register methods wherever possible, to avoid duplicating the format.