### PR TITLE
Added service argument to coveralls image URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Pillow is the "friendly PIL fork" by `Alex Clark and Contributors <https://githu
    :target: https://pypi.python.org/pypi/Pillow/
    :alt: Number of PyPI downloads
 
-.. image:: https://coveralls.io/repos/python-pillow/Pillow/badge.svg?branch=master
+.. image:: https://coveralls.io/repos/python-pillow/Pillow/badge.svg?branch=master&service=github
    :target: https://coveralls.io/r/python-pillow/Pillow?branch=master
    :alt: Code coverage
 


### PR DESCRIPTION
coveralls.io displays a warning -
`We detected this repo isn’t badged! Grab the embed code to the right, add it to your repo to show off your code coverage, and when the badge is live hit the refresh button to remove this message.`

The only difference is adding `&service=github` to the image URL.