### PR TITLE
Format args for Image open

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2557,7 +2557,7 @@ def _decompression_bomb_check(size):
             DecompressionBombWarning)
 
 
-def open(fp, mode="r"):
+def open(fp, mode="r", format_args=None):
     """
     Opens and identifies the given image file.
 
@@ -2601,13 +2601,13 @@ def open(fp, mode="r"):
 
     preinit()
 
-    def _open_core(fp, filename, prefix):
+    def _open_core(fp, filename, prefix, format_args):
         for i in ID:
             try:
                 factory, accept = OPEN[i]
                 if not accept or accept(prefix):
                     fp.seek(0)
-                    im = factory(fp, filename)
+                    im = factory(fp, filename, format_args)
                     _decompression_bomb_check(im.size)
                     return im
             except (SyntaxError, IndexError, TypeError, struct.error):
@@ -2617,11 +2617,11 @@ def open(fp, mode="r"):
                 continue
         return None
 
-    im = _open_core(fp, filename, prefix)
+    im = _open_core(fp, filename, prefix, format_args)
 
     if im is None:
         if init():
-            im = _open_core(fp, filename, prefix)
+            im = _open_core(fp, filename, prefix, format_args)
 
     if im:
         im._exclusive_fp = exclusive_fp

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -75,7 +75,7 @@ def _tilesort(t):
 class ImageFile(Image.Image):
     "Base class for image file format handlers."
 
-    def __init__(self, fp=None, filename=None):
+    def __init__(self, fp=None, filename=None, format_args=None):
         Image.Image.__init__(self)
 
         self._min_frame = 0
@@ -85,6 +85,10 @@ class ImageFile(Image.Image):
 
         self.decoderconfig = ()
         self.decodermaxblock = MAXBLOCK
+
+        if format_args is None:
+            format_args = {}
+        self.formats_args = format_args
 
         if isPath(fp):
             # filename

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -776,14 +776,14 @@ def _save_cjpeg(im, fp, filename):
 
 ##
 # Factory for making JPEG and MPO instances
-def jpeg_factory(fp=None, filename=None):
-    im = JpegImageFile(fp, filename)
+def jpeg_factory(fp=None, filename=None, format_args=None):
+    im = JpegImageFile(fp, filename, format_args)
     try:
         mpheader = im._getmp()
         if mpheader[45057] > 1:
             # It's actually an MPO
             from .MpoImagePlugin import MpoImageFile
-            im = MpoImageFile(fp, filename)
+            im = MpoImageFile(fp, filename, format_args)
     except (TypeError, IndexError):
         # It is really a JPEG
         pass


### PR DESCRIPTION
#569 requests the addition of a `format_args` argument to Image's `open` method, so that format-specific parameters can be set when creating the Image instance, as opposed to creating the Image instance, setting the parameters, and then calling `load`.

This provides an example of how that API could be set up, without actually making use of the additional information.
