### PR TITLE
Set landscape max-line-length

### DIFF
--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -1,2 +1,3 @@
 strictness: medium
 test-warnings: yes
+max-line-length: 80


### PR DESCRIPTION
Our standard is to use a max-line-length of 80, as is the default for flake8. However, on our current medium strictness setting, landscape.io has a max-line-length of 160 - https://docs.landscape.io/configuration.html. This changes the setting to 80.