### PR TITLE
Fixing typo to have proper testing

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -93,7 +93,7 @@ class TestFileGif(PillowTestCase):
         im.save(out, save_all=True)
         reread = Image.open(out)
 
-        self.assertEqual(im.n_frames, 5)
+        self.assertEqual(reread.n_frames, 5)
 
     def test_palette_handling(self):
         # see https://github.com/python-pillow/Pillow/issues/513


### PR DESCRIPTION
It looks like that test was working not as expected, it was checking input data instead of output file.