### PR TITLE
Travis CI: Python nightly and dev releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ python:
   - "2.7_with_system_site_packages" # For PyQt4
   - 3.2
   - 3.3
+  - nightly
+  - 3.5.0b2
+  - 3.5.0b3
+  - 3.5-dev
 
 install:
   - "travis_retry sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-qt4 ghostscript libffi-dev libjpeg-turbo-progs cmake imagemagick"
@@ -107,6 +111,11 @@ after_script:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - python: nightly
+    - python: 3.5.0b2
+    - python: 3.5.0b3
+    - python: 3.5-dev
 
 env:
   global:


### PR DESCRIPTION
I noticed Travis CI now supports nightly and dev releases of Python:

> **Nightly build support**

> Travis CI supports a special version name `nightly`, which points to a recent development version of CPython build.

> **On-demand installations**

> For a limited number of Python development releases, on-demand installation is available.

> Currently, these are: 3.5.0b2, 3.5.0b3, and 3.5-dev (built nightly).

http://docs.travis-ci.com/user/languages/python/#Nightly-build-support

Would it be a good idea to include any of these in our build? It could help us identify breaking changes in new Python versions before main releases. Of course, we don't want them to actually break our builds, so they need to be in the `allow_failures` section.

Right now all four pass, and take around the same time as the other CPythons.

Right now, `nightly` is Python 3.6.0a0. I'd suggest the 3.5 betas aren't as useful as `3.5-dev`, so perhaps just  `3.5-dev` and `nightly`.

Thoughts?