### PR TITLE
Fix setup.py for Solaris/SmartOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -305,6 +305,10 @@ class pil_build_ext(build_ext):
                     _add_directory(library_dirs, "/usr/pkg/lib")
                     _add_directory(include_dirs, "/usr/pkg/include")
 
+        elif sys.platform.startswith("sunos5"):
+                    _add_directory(library_dirs, "/opt/local/lib")
+                    _add_directory(include_dirs, "/opt/local/include")
+		
         # FIXME: check /opt/stuff directories here?
 
         #


### PR DESCRIPTION
This is a simple patch that enables Pillow to build cleanly from Pypi on Solaris/SmartOS