### PR TITLE
Test on Python 3.5 dev and 3.6 nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ python:
   - "2.7_with_system_site_packages" # For PyQt4
   - 3.2
   - 3.3
+  - 3.5-dev
+  - nightly
 
 install:
   - "travis_retry sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-qt4 ghostscript libffi-dev libjpeg-turbo-progs cmake imagemagick"
@@ -107,6 +109,9 @@ after_script:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - python: 3.5-dev
+    - python: nightly
 
 env:
   global:


### PR DESCRIPTION
I noticed Travis CI now supports nightly and dev releases of Python:

> **Nightly build support**

> Travis CI supports a special version name `nightly`, which points to a recent development version of CPython build.

> **On-demand installations**

> For a limited number of Python development releases, on-demand installation is available.

> Currently, these are: 3.5.0b2, 3.5.0b3, and 3.5-dev (built nightly).

http://docs.travis-ci.com/user/languages/python/#Nightly-build-support

Right now, `nightly` is Python 3.6.0a0. I'd suggest the 3.5 betas aren't as useful as `3.5-dev`, but let's include `3.5-dev` and `nightly`. It could help us identify breaking changes in new Python versions before main releases. Of course, we don't want them to actually break our builds, so they are in the `allow_failures` section.

See also discussion in https://github.com/python-pillow/Pillow/pull/1354.