### PR TITLE
Fixed PSDraw stdout Python 3 compatibility

### DIFF
--- a/PIL/EpsImagePlugin.py
+++ b/PIL/EpsImagePlugin.py
@@ -376,9 +376,10 @@ def _save(im, fp, filename, eps=1):
             pass
 
     base_fp = fp
-    fp = NoCloseStream(fp)
-    if sys.version_info[0] > 2:
-        fp = io.TextIOWrapper(fp, encoding='latin-1')
+    if fp != sys.stdout:
+        fp = NoCloseStream(fp)
+        if sys.version_info[0] > 2:
+            fp = io.TextIOWrapper(fp, encoding='latin-1')
 
     if eps:
         #

--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -461,6 +461,9 @@ def _save(im, fp, tile, bufsize=0):
     # But, it would need at least the image size in most cases. RawEncode is
     # a tricky case.
     bufsize = max(MAXBLOCK, bufsize, im.size[0] * 4)  # see RawEncode.c
+    if fp == sys.stdout:
+        fp.flush()
+        return
     try:
         fh = fp.fileno()
         fp.flush()

--- a/PIL/PSDraw.py
+++ b/PIL/PSDraw.py
@@ -16,10 +16,11 @@
 #
 
 from PIL import EpsImagePlugin
-
+import sys
 
 ##
 # Simple Postscript graphics interface.
+
 
 class PSDraw(object):
     """
@@ -29,12 +30,11 @@ class PSDraw(object):
 
     def __init__(self, fp=None):
         if not fp:
-            import sys
             fp = sys.stdout
         self.fp = fp
 
     def _fp_write(self, to_write):
-        if bytes is str:
+        if bytes is str or self.fp == sys.stdout:
             self.fp.write(to_write)
         else:
             self.fp.write(bytes(to_write, 'UTF-8'))
@@ -47,7 +47,7 @@ class PSDraw(object):
                        "/showpage { } def\n"
                        "%%EndComments\n"
                        "%%BeginDocument\n")
-        # self.fp_write(ERROR_PS)  # debugging!
+        # self._fp_write(ERROR_PS)  # debugging!
         self._fp_write(EDROFF_PS)
         self._fp_write(VDI_PS)
         self._fp_write("%%EndProlog\n")


### PR DESCRIPTION
If no file pointer is provided, PSDraw uses `sys.stdout`. This causes some bugs in Python 3.

To demonstrate, I've added a test.