### PR TITLE
Fix fast rotate operations

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1621,7 +1621,7 @@ class Image(object):
         if self.mode in ("1", "P"):
             resample = NEAREST
 
-        return self._new(self.im.rotate(angle, resample))
+        return self._new(self.im.rotate(angle, resample, expand))
 
     def save(self, fp, format=None, **params):
         """

--- a/Tests/test_image_rotate.py
+++ b/Tests/test_image_rotate.py
@@ -1,19 +1,23 @@
 from helper import unittest, PillowTestCase, hopper
+from PIL import Image
 
 
 class TestImageRotate(PillowTestCase):
 
     def test_rotate(self):
-        def rotate(mode):
-            im = hopper(mode)
-            out = im.rotate(45)
+        def rotate(im, mode, angle):
+            out = im.rotate(angle)
             self.assertEqual(out.mode, mode)
             self.assertEqual(out.size, im.size)  # default rotate clips output
-            out = im.rotate(45, expand=1)
+            out = im.rotate(angle, expand=1)
             self.assertEqual(out.mode, mode)
             self.assertNotEqual(out.size, im.size)
         for mode in "1", "P", "L", "RGB", "I", "F":
-            rotate(mode)
+            im = hopper(mode)
+            rotate(im, mode, 45)
+        for angle in 90, 270:
+            im = Image.open('Tests/images/test-card.png')
+            rotate(im, im.mode, angle)
 
 
 if __name__ == '__main__':

--- a/_imaging.c
+++ b/_imaging.c
@@ -1550,7 +1550,8 @@ _rotate(ImagingObject* self, PyObject* args)
 
     double theta;
     int filter = IMAGING_TRANSFORM_NEAREST;
-    if (!PyArg_ParseTuple(args, "d|i", &theta, &filter))
+    int expand;
+    if (!PyArg_ParseTuple(args, "d|i|i", &theta, &filter, &expand))
         return NULL;
 
     imIn = self->image;
@@ -1563,7 +1564,8 @@ _rotate(ImagingObject* self, PyObject* args)
         /* Rotate with resampling filter */
         imOut = ImagingNew(imIn->mode, imIn->xsize, imIn->ysize);
     (void) ImagingRotate(imOut, imIn, theta, filter);
-    } else if (theta == 90.0 || theta == 270.0) {
+    } else if ((theta == 90.0 || theta == 270.0)
+            && (expand || imIn->xsize == imIn->ysize)) {
         /* Use fast version */
         imOut = ImagingNew(imIn->mode, imIn->ysize, imIn->xsize);
         if (imOut) {


### PR DESCRIPTION
Resolves #1369 

If certain filters are used, for 90 or 270 degree rotation operations, a faster algorithm is used. However, these faster algorithms ignore the expand option.

So this creates a change so that those fast operations are only used if the expand flag is in use, or if the image is square.