### PR TITLE
Disabled Travis coverage script for nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,12 @@ install:
   - pushd depends && ./install_openjpeg.sh && popd
 
 script:
-  - coverage erase
+  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then coverage erase; fi
   - python setup.py clean
   - CFLAGS="-coverage" python setup.py build_ext --inplace
 
-  - coverage run --append --include=PIL/* selftest.py
-  - coverage run --append --include=PIL/* -m nose -vx Tests/test_*.py
+  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then coverage run --append --include=PIL/* selftest.py; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then coverage run --append --include=PIL/* -m nose -vx Tests/test_*.py; fi
   - check-manifest --ignore "depends/*"
 
 after_success:


### PR DESCRIPTION
The Travis CI Python 3.6 build fails with -
`AttributeError: module 'inspect' has no attribute 'getargspec'`

This is a known issue with coverage - https://bitbucket.org/ned/coveragepy/issues/391. It has been fixed, but presumably won't take effect at least until 4.0, whenever that is released.

Until then, to make Travis CI Python 3.6 builds more meaningful, this change disables the coverage script for `nightly`