### PR TITLE
Corrected version number when saving GIFs

### DIFF
--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -533,8 +533,18 @@ def getheader(im, palette=None, info=None):
 
     # Header Block
     # http://www.matthewflickinger.com/lab/whatsinagif/bits_and_bytes.asp
+
+    version = b"87a"
+    for extensionKey in ["transparency", "duration", "loop"]:
+        if info and extensionKey in info:
+            version = b"89a"
+            break
+    else:
+        if im.info.get("version") == "89a":
+            version = b"89a"
+
     header = [
-        b"GIF87a" +             # signature + version
+        b"GIF"+version +        # signature + version
         o16(im.size[0]) +       # canvas width
         o16(im.size[1])         # canvas height
     ]

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -24,6 +24,7 @@ class TestFileGif(PillowTestCase):
         self.assertEqual(im.mode, "P")
         self.assertEqual(im.size, (128, 128))
         self.assertEqual(im.format, "GIF")
+        self.assertEqual(im.info["version"], b"GIF89a")
 
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
@@ -250,6 +251,28 @@ class TestFileGif(PillowTestCase):
         reread = Image.open(out)
 
         self.assertEqual(reread.info['background'], im.info['background'])
+
+    def test_version(self):
+        out = self.tempfile('temp.gif')
+
+        # Test that GIF87a is used by default
+        im = Image.new('L', (100, 100), '#000')
+        im.save(out)
+        reread = Image.open(out)
+        self.assertEqual(reread.info["version"], b"GIF87a")
+
+        # Test that a GIF87a image is also saved in that format
+        im = Image.open(TEST_GIF)
+        im.save(out)
+        reread = Image.open(out)
+        self.assertEqual(reread.info["version"], b"GIF87a")
+
+        # Test that a GIF89a image is also saved in that format
+        im.info["version"] = "GIF89a"
+        im.save(out)
+        reread = Image.open(out)
+        self.assertEqual(reread.info["version"], b"GIF87a")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Reported in #1355. GifImagePlugin has the output version number fixed a 87a, but may use features that are only valid for 89a.

http://www.w3.org/Graphics/GIF/spec-gif89a.txt
"The specification given here defines version 89a, which is an extension of version 87a."

The features that require 89a are -
- Graphic Control Extension
- Comment Extension (unused by Pillow)
- Plain Text Extension (unused by Pillow)
- Application Extension

"An encoder should use the earliest possible version number that includes all the blocks used in the Data Stream."

I think that this sounded reasonable in 1990, but today, both versions of GIF would be supported on a given platform. My suggestion is - if 89a features are used, then 89a. Otherwise, if the input has a version, use that. Otherwise, 87a.

This PR makes that change.