### PR TITLE
GIF parameters

### DIFF
--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -301,14 +301,17 @@ RAWMODE = {
 }
 
 
-def _convert_mode(im):
+def _convert_mode(im, initial_call=False):
     # convert on the fly (EXPERIMENTAL -- I'm not sure PIL
     # should automatically convert images on save...)
     if Image.getmodebase(im.mode) == "RGB":
-        palette_size = 256
-        if im.palette:
-            palette_size = len(im.palette.getdata()[1]) // 3
-        return im.convert("P", palette=1, colors=palette_size)
+        if initial_call:
+            palette_size = 256
+            if im.palette:
+                palette_size = len(im.palette.getdata()[1]) // 3
+            return im.convert("P", palette=1, colors=palette_size)
+        else:
+            return im.convert("P")
     return im.convert("L")
 
 
@@ -330,7 +333,7 @@ def _save(im, fp, filename, save_all=False):
     if im.mode in RAWMODE:
         im_out = im.copy()
     else:
-        im_out = _convert_mode(im)
+        im_out = _convert_mode(im, True)
 
     # header
     try:

--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -357,7 +357,7 @@ def _save(im, fp, filename, save_all=False):
                     fp.write(s)
             else:
                 # delta frame
-                delta = ImageChops.subtract_modulo(im_frame, previous)
+                delta = ImageChops.subtract_modulo(im_frame, previous.copy())
                 bbox = delta.getbbox()
 
                 if bbox:
@@ -368,7 +368,7 @@ def _save(im, fp, filename, save_all=False):
                 else:
                     # FIXME: what should we do in this case?
                     pass
-            previous = im_frame.copy()
+            previous = im_frame
     else:
         header = getheader(im_out, palette, im.encoderinfo)[0]
         for s in header:

--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -537,8 +537,19 @@ def getheader(im, palette=None, info=None):
 
     # Header Block
     # http://www.matthewflickinger.com/lab/whatsinagif/bits_and_bytes.asp
+
+    version = b"87a"
+    for extensionKey in ["transparency", "duration", "loop"]:
+        if info and extensionKey in info and \
+                not (extensionKey == "duration" and info[extensionKey] == 0):
+            version = b"89a"
+            break
+    else:
+        if im.info.get("version") == "89a":
+            version = b"89a"
+
     header = [
-        b"GIF87a" +             # signature + version
+        b"GIF"+version +        # signature + version
         o16(im.size[0]) +       # canvas width
         o16(im.size[1])         # canvas height
     ]

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -95,6 +95,21 @@ class TestFileGif(PillowTestCase):
 
         self.assertEqual(reread.n_frames, 5)
 
+    def test_headers_saving_for_animated_gifs(self):
+        important_headers = ['background', 'version', 'transparency', 'duration', 'loop']
+        # Multiframe image
+        im = Image.open("Tests/images/dispose_bgnd.gif")
+
+        out = self.tempfile('temp.gif')
+        im.save(out, save_all=True)
+        reread = Image.open(out)
+
+        for header in important_headers:
+            self.assertEqual(
+                im.info[header],
+                reread.info[header]
+            )
+
     def test_palette_handling(self):
         # see https://github.com/python-pillow/Pillow/issues/513
 

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -24,6 +24,7 @@ class TestFileGif(PillowTestCase):
         self.assertEqual(im.mode, "P")
         self.assertEqual(im.size, (128, 128))
         self.assertEqual(im.format, "GIF")
+        self.assertEqual(im.info["version"], b"GIF89a")
 
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
@@ -265,6 +266,34 @@ class TestFileGif(PillowTestCase):
         reread = Image.open(out)
 
         self.assertEqual(reread.info['background'], im.info['background'])
+
+    def test_version(self):
+        out = self.tempfile('temp.gif')
+
+        # Test that GIF87a is used by default
+        im = Image.new('L', (100, 100), '#000')
+        im.save(out)
+        reread = Image.open(out)
+        self.assertEqual(reread.info["version"], b"GIF87a")
+
+        # Test that adding a GIF89a feature changes the version
+        im.info["transparency"] = 1
+        im.save(out)
+        reread = Image.open(out)
+        self.assertEqual(reread.info["version"], b"GIF89a")
+
+        # Test that a GIF87a image is also saved in that format
+        im = Image.open(TEST_GIF)
+        im.save(out)
+        reread = Image.open(out)
+        self.assertEqual(reread.info["version"], b"GIF87a")
+
+        # Test that a GIF89a image is also saved in that format
+        im.info["version"] = "GIF89a"
+        im.save(out)
+        reread = Image.open(out)
+        self.assertEqual(reread.info["version"], b"GIF87a")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -96,7 +96,7 @@ class TestFileGif(PillowTestCase):
         self.assertEqual(reread.n_frames, 5)
 
     def test_headers_saving_for_animated_gifs(self):
-        important_headers = ['background', 'version', 'transparency', 'duration', 'loop']
+        important_headers = ['background', 'version', 'duration', 'loop']
         # Multiframe image
         im = Image.open("Tests/images/dispose_bgnd.gif")
 

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -54,8 +54,11 @@ GIF
 ^^^
 
 PIL reads GIF87a and GIF89a versions of the GIF file format. The library writes
-run-length encoded GIF87a files. Note that GIF files are always read as
-grayscale (``L``) or palette mode (``P``) images.
+run-length encoded files in GIF87a by default, unless GIF89a features
+are used or GIF89a is already in use.
+
+Note that GIF files are always read as grayscale (``L``)
+or palette mode (``P``) images.
 
 The :py:meth:`~PIL.Image.Image.open` method sets the following
 :py:attr:`~PIL.Image.Image.info` properties:
@@ -73,12 +76,32 @@ The :py:meth:`~PIL.Image.Image.open` method sets the following
 **version**
     Version (either ``GIF87a`` or ``GIF89a``).
 
+**duration**
+    May not be present. The time to display each frame of the GIF, in
+    milliseconds.
+
+**loop**
+    May not be present. The number of times the GIF should loop.
+
 Reading sequences
 ~~~~~~~~~~~~~~~~~
 
 The GIF loader supports the :py:meth:`~file.seek` and :py:meth:`~file.tell`
 methods. You can seek to the next frame (``im.seek(im.tell() + 1)``), or rewind
-the file by seeking to the first frame. Random access is not supported. ``im.seek()`` raises an ``EOFError`` if you try to seek after the last frame.
+the file by seeking to the first frame. Random access is not supported.
+
+``im.seek()`` raises an ``EOFError`` if you try to seek after the last frame.
+
+Saving sequences
+~~~~~~~~~~~~~~~~
+
+When calling :py:meth:`~PIL.Image.Image.save`, if a multiframe image is used,
+by default only the first frame will be saved. To save all frames, the
+``save_all`` parameter must be present and set to ``True``.
+
+If present, the ``loop`` parameter can be used to set the number of times
+the GIF should loop, and the ``duration`` parameter can set the number of
+milliseconds between each frame.
 
 Reading local images
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Train of thought started by #1355. Combines PR #1378 and #1379

GifImagePlugin currently uses only the params passed directly into Image's `save` method. It doesn't retrieve any params from the image itself. It effectively does not roundtrip properties. The reason that this has gone unnoticed is that `duration` and `loop` have only started to be saved recently, there is no test to roundtrip `transparency` that I can see, `version` has been fixed when saving and `background` is the one exception to this rule.

So this PR merges the params passed in with those of the image itself, with the parameters passed in having priority.

***

The second part of this is the GIF version. GifImagePlugin has the output version number fixed as 87a, but may use features that are only valid for 89a.

http://www.w3.org/Graphics/GIF/spec-gif89a.txt
"The specification given here defines version 89a, which is an extension of version 87a."

The features that require 89a are -

Graphic Control Extension
Comment Extension (unused by Pillow)
Plain Text Extension (unused by Pillow)
Application Extension
"An encoder should use the earliest possible version number that includes all the blocks used in the Data Stream."

I think that this sounded reasonable in 1990, but today, both versions of GIF would be supported on a given platform. My suggestion is - if 89a features are used, then 89a. Otherwise, if the input has a version, use that. Otherwise, 87a.

This PR also makes that change.