### PR TITLE
Improved handling of getink color

### DIFF
--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -28,6 +28,10 @@ class TestImageQuantize(PillowTestCase):
         im.quantize()
         self.assertRaises(Exception, lambda: im.quantize(method=0))
 
+    def test_quantize(self):
+        im = Image.open('Tests/images/caption_6_33_22.png')
+        im.convert('RGB').quantize().convert('RGB')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolves #1377 

https://github.com/python-pillow/Pillow/commit/c8ce29c23903b5145ed0e1a23804e7e99faa5eb8 "gets the putdata test case to run correctly under 2.6/2.7. It fixes an
issue where the value 0xFFFFFFFF (which is long in old Python) isn't
recognized and putdata tries to parse it as a tuple."

However, it only fixed it for a specific portion of the code, not for 1 band images, or Int32 or Special image types.

This generalises that the code change from that commit.