### PR TITLE
In tutorial of pasting images, add to mask text.

### DIFF
--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -193,7 +193,9 @@ For more advanced tricks, the paste method can also take a transparency mask as
 an optional argument. In this mask, the value 255 indicates that the pasted
 image is opaque in that position (that is, the pasted image should be used as
 is). The value 0 means that the pasted image is completely transparent. Values
-in-between indicate different levels of transparency.
+in-between indicate different levels of transparency. For example, pasting an
+RGBA image and also using it as the mask would paste the opaque portion
+of the image but not its transparent background.
 
 The Python Imaging Library also allows you to work with the individual bands of
 an multi-band image, such as an RGB image. The split method creates a set of


### PR DESCRIPTION
Using an RGBA image as its own mask is a common question.  It shows up in a dozen Stack Overflow questions, e.g.,  (http://stackoverflow.com/questions/5324647/how-to-merge-a-transparent-png-image-with-another-image-using-pil).    Adding a sentence to the tutorial gives people a chance of noticing this.