### PR TITLE
Removed use of spaces in TIFF kwargs, deprecated in 2.7

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -1378,11 +1378,6 @@ def _save(im, fp, filename):
                       (DATE_TIME, "date_time"),
                       (ARTIST, "artist"),
                       (COPYRIGHT, "copyright")]:
-        name_with_spaces = name.replace("_", " ")
-        if "_" in name and name_with_spaces in im.encoderinfo:
-            warnings.warn("%r is deprecated; use %r instead" %
-                          (name_with_spaces, name), DeprecationWarning)
-            ifd[key] = im.encoderinfo[name.replace("_", " ")]
         if name in im.encoderinfo:
             ifd[key] = im.encoderinfo[name]
 

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -399,25 +399,6 @@ class TestFileTiff(PillowTestCase):
         self.assertEqual(im.tag_v2[X_RESOLUTION], 72)
         self.assertEqual(im.tag_v2[Y_RESOLUTION], 36)
 
-    def test_deprecation_warning_with_spaces(self):
-        kwargs = {'resolution unit': 'inch',
-                  'x resolution': 36,
-                  'y resolution': 72}
-        filename = self.tempfile("temp.tif")
-        self.assert_warning(DeprecationWarning,
-                            lambda: hopper("RGB").save(filename, **kwargs))
-        from PIL.TiffImagePlugin import X_RESOLUTION, Y_RESOLUTION
-
-        im = Image.open(filename)
-
-        # legacy interface
-        self.assertEqual(im.tag[X_RESOLUTION][0][0], 36)
-        self.assertEqual(im.tag[Y_RESOLUTION][0][0], 72)
-
-        # v2 interface
-        self.assertEqual(im.tag_v2[X_RESOLUTION], 36)
-        self.assertEqual(im.tag_v2[Y_RESOLUTION], 72)
-
     def test_lzw(self):
         # Act
         im = Image.open("Tests/images/hopper_lzw.tif")
@@ -462,12 +443,12 @@ class TestFileTiff(PillowTestCase):
         # however does.
         im = Image.new('RGB', (1, 1))
         im.info['icc_profile'] = 'Dummy value'
-        
+
         # Try save-load round trip to make sure both handle icc_profile.
         tmpfile = self.tempfile('temp.tif')
         im.save(tmpfile, 'TIFF', compression='raw')
         reloaded = Image.open(tmpfile)
-        
+
         self.assertEqual(b'Dummy value', reloaded.info['icc_profile'])
 
 


### PR DESCRIPTION
The discussion in #1087 indicates that this is not to be merged yet, to avoid skipping over deprecation warnings.

However, I thought I'd put this up with a 'Do Not Merge' label, so that it can be merged in the future.
