### PR TITLE
Fixed infinite loop on truncated file

### DIFF
--- a/PIL/PpmImagePlugin.py
+++ b/PIL/PpmImagePlugin.py
@@ -93,6 +93,8 @@ class PpmImageFile(ImageFile.ImageFile):
                     s = self.fp.read(1)
                     if s not in b_whitespace:
                         break
+                    if s == b"":
+                        raise ValueError("File does not extend beyond magic number")
                 if s != b"#":
                     break
                 s = self.fp.readline()

--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -35,6 +35,14 @@ class TestFilePpm(PillowTestCase):
         reloaded = Image.open(f)
         self.assert_image_equal(im, reloaded)
 
+    def test_truncated_file(self):
+        path = self.tempfile('temp.pgm')
+        f = open(path, 'w')
+        f.write('P6')
+        f.close()
+
+        self.assertRaises(ValueError, lambda: Image.open(path))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolves #1399

A truncated ppm file will result in an infinite loop. This PR raises a ValueError if the EOF is reached.