### PR TITLE
Corrected scripts path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -751,7 +751,7 @@ setup(
     ext_modules=[Extension("PIL._imaging", ["_imaging.c"])],
     include_package_data=True,
     packages=find_packages(),
-    scripts=glob.glob("Scripts/pil*.py"),
+    scripts=glob.glob("Scripts/*.py"),
     test_suite='nose.collector',
     keywords=["Imaging", ],
     license='Standard PIL License',


### PR DESCRIPTION
Perhaps this was the correct path in earlier versions, but now it would seem to exclude several of the scripts.