### PR TITLE
Removing spammy debug logging

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -2309,7 +2309,10 @@ def open(fp, mode="r"):
                     _decompression_bomb_check(im.size)
                     return im
             except (SyntaxError, IndexError, TypeError, struct.error):
-                logger.debug("", exc_info=True)
+                # Leave disabled by default, spams the logs with image
+                # opening failures that are entirely expected.                
+                #logger.debug("", exc_info=True)
+                continue
         return None
 
     im = _open_core(fp, filename, prefix)

--- a/PIL/PyAccess.py
+++ b/PIL/PyAccess.py
@@ -54,7 +54,9 @@ class PyAccess(object):
         self.xsize = vals['xsize']
         self.ysize = vals['ysize']
 
-        logger.debug("%s", vals)
+        # Debugging is polluting test traces, only useful here
+        # when hacking on PyAccess
+        #logger.debug("%s", vals)
         self._post_init()
 
     def _post_init(self):
@@ -310,7 +312,6 @@ def new(img, readonly=False):
     if not access_type:
         logger.debug("PyAccess Not Implemented: %s", img.mode)
         return None
-    logger.debug("New PyAccess: %s", img.mode)
     return access_type(img, readonly)
 
 # End of file


### PR DESCRIPTION
When converting to the logging infrastructure, these logs were enabled (when previously commented out) at the default debugging level.

* The inner code of Image._open_core is designed to fail over and over until one of the image formats matches. When there is an actual error in a test, it's totally buried in thousands of lines of extraneous errors. 

* PyAccess debugging is low level debugging only useful for hacking on PyAccess. It's not of general interest, and It also shows up in totally extraneous contexts, since it's hit on module load. 

e.g.: 
```
======================================================================
FAIL: Test writing arbitrary metadata into the tiff image directory
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/erics/Pillow/Tests/test_file_tiff_metadata.py", line 40, in test_rt_metadata
    self.assertEqual(loaded.tag[50839], basetextdata + " ?")
AssertionError: 'This is some arbitrary metadata for a text field \xff' != 'This is some arbitrary metadata for a text field ?'
-------------------- >> begin captured logging << --------------------
PIL.PyAccess: DEBUG: New PyAccess: RGB
PIL.PyAccess: DEBUG: {'palette': 0, 'bands': 3, 'image': 43230208, 'ysize': 128, 'image32': 43230208, 'depth': 0, 'image8': 0, 'mode': 'RGB', 'xsize': 128, 'linesize': 512, 'destroy': 47373773600256, 'pixelsize': 4, 'type': 0, 'block': 47355472}
--------------------- >> end captured logging << ---------------------

======================================================================
FAIL: Test metadata writing through the python code
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/erics/Pillow/Tests/test_file_tiff_metadata.py", line 93, in test_write_metadata
    original[tag], value, "%s didn't roundtrip" % tag)
AssertionError: WhitePoint didn't roundtrip
-------------------- >> begin captured logging << --------------------
PIL.PyAccess: DEBUG: New PyAccess: RGB
PIL.PyAccess: DEBUG: {'palette': 0, 'bands': 3, 'image': 43238928, 'ysize': 128, 'image32': 43238928, 'depth': 0, 'image8': 0, 'mode': 'RGB', 'xsize': 128, 'linesize': 512, 'destroy': 47373773600256, 'pixelsize': 4, 'type': 0, 'block': 47355472}
--------------------- >> end captured logging << ---------------------
```