### PR TITLE
Correct convert matrix docs

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -822,7 +822,7 @@ class Image(object):
 
         :param mode: The requested mode. See: :ref:`concept-modes`.
         :param matrix: An optional conversion matrix.  If given, this
-           should be 4- or 16-tuple containing floating point values.
+           should be 4- or 12-tuple containing floating point values.
         :param dither: Dithering method, used when converting from
            mode "RGB" to "P" or from "RGB" or "L" to "1".
            Available methods are NONE or FLOYDSTEINBERG (default).

--- a/_imaging.c
+++ b/_imaging.c
@@ -768,11 +768,12 @@ _convert_matrix(ImagingObject* self, PyObject* args)
     float m[12];
     if (!PyArg_ParseTuple(args, "s(ffff)", &mode, m+0, m+1, m+2, m+3)) {
         PyErr_Clear();
-    if (!PyArg_ParseTuple(args, "s(ffffffffffff)", &mode,
-                  m+0, m+1, m+2, m+3,
-                  m+4, m+5, m+6, m+7,
-                  m+8, m+9, m+10, m+11))
-        return NULL;
+        if (!PyArg_ParseTuple(args, "s(ffffffffffff)", &mode,
+                              m+0, m+1, m+2, m+3,
+                              m+4, m+5, m+6, m+7,
+                              m+8, m+9, m+10, m+11)){
+            return NULL;
+        }
     }
 
     return PyImagingNew(ImagingConvertMatrix(self->image, mode, m));


### PR DESCRIPTION
* Fixes documentation complaint in http://engineering.khanacademy.org/posts/making-thumbnails-fast.htm from @wchargin that has made it from PIL through all of the releases of Pillow. 

* Fixes formatting of convert_matrix in _imaging.c so that the indentation actually matches the code flow.  