### PR TITLE
Don't use int for handle type

### DIFF
--- a/libImaging/Dib.c
+++ b/libImaging/Dib.c
@@ -228,7 +228,7 @@ ImagingPasteDIB(ImagingDIB dib, Imaging im, int xy[4])
 }
 
 void
-ImagingExposeDIB(ImagingDIB dib, int dc)
+ImagingExposeDIB(ImagingDIB dib, void *dc)
 {
     /* Copy bitmap to display */
 
@@ -238,7 +238,7 @@ ImagingExposeDIB(ImagingDIB dib, int dc)
 }
 
 void
-ImagingDrawDIB(ImagingDIB dib, int dc, int dst[4], int src[4])
+ImagingDrawDIB(ImagingDIB dib, void *dc, int dst[4], int src[4])
 {
     /* Copy bitmap to printer/display */
 
@@ -258,7 +258,7 @@ ImagingDrawDIB(ImagingDIB dib, int dc, int dst[4], int src[4])
 }
 
 int
-ImagingQueryPaletteDIB(ImagingDIB dib, int dc)
+ImagingQueryPaletteDIB(ImagingDIB dib, void *dc)
 {
     /* Install bitmap palette */
 

--- a/libImaging/ImDib.h
+++ b/libImaging/ImDib.h
@@ -43,10 +43,10 @@ extern ImagingDIB ImagingNewDIB(const char *mode, int xsize, int ysize);
 
 extern void ImagingDeleteDIB(ImagingDIB im);
 
-extern void ImagingDrawDIB(ImagingDIB dib, int dc, int dst[4], int src[4]);
-extern void ImagingExposeDIB(ImagingDIB dib, int dc);
+extern void ImagingDrawDIB(ImagingDIB dib, void *dc, int dst[4], int src[4]);
+extern void ImagingExposeDIB(ImagingDIB dib, void *dc);
 
-extern int ImagingQueryPaletteDIB(ImagingDIB dib, int dc);
+extern int ImagingQueryPaletteDIB(ImagingDIB dib, void *dc);
 
 extern void ImagingPasteDIB(ImagingDIB dib, Imaging im, int xy[4]);
 


### PR DESCRIPTION
Couldn't accept handle values greater than 0x7FFFFFFF, which wasn't enough even on 32bit system, and completely wrong for 64bit.