### PR TITLE
Coveralls 4.0 doesn't support Python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,16 @@ python:
 install:
   - "travis_retry sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-qt4 ghostscript libffi-dev libjpeg-turbo-progs cmake imagemagick"
   - "travis_retry pip install cffi"
-  - "travis_retry pip install coverage nose"
+  - "travis_retry pip install nose"
   - "travis_retry pip install check-manifest"
     # Pyroma tests sometimes hang on PyPy; skip for PyPy
   - if [ $TRAVIS_PYTHON_VERSION != "pypy" ]; then travis_retry pip install pyroma; fi
 
   - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then travis_retry pip install unittest2; fi
+
+  # Coveralls 4.0 doesn't support Python 3.2
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then travis_retry pip install coverage; fi
 
   # webp
   - pushd depends && ./install_webp.sh && popd


### PR DESCRIPTION
> The latest version is coverage.py 4.0, released 20 September 2015. It is supported on Python versions 2.6, 2.7, 3.3, 3.4, and 3.5, as well as PyPy 2.4 and 2.6, and PyPy3 2.4.

https://coverage.readthedocs.org/en/latest/

3.7.1:

> Coverage.py runs on Pythons 2.3 through 3.3, and PyPy 1.9.

https://pypi.python.org/pypi/coverage/3.7.1

From the Coveralls issue tracker:

> Coverage.py 4.0 no longer supports Python 3.2. Keep using version 3.7.1 on Python 3.2. ... ython 3.2 doesn't support u"" strings, which makes it difficult to get Unicode right across a wide span of versions. You can pip installs 3.7.1 by pinning that version number in your requirements.

https://bitbucket.org/ned/coveragepy/issues/407/coverage-failing-on-python-325-using