### PR TITLE
Skip Pyroma on Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ install:
   - "travis_retry pip install cffi"
   - "travis_retry pip install nose"
   - "travis_retry pip install check-manifest"
-    # Pyroma tests sometimes hang on PyPy; skip for PyPy
-  - if [ $TRAVIS_PYTHON_VERSION != "pypy" ]; then travis_retry pip install pyroma; fi
+    # Pyroma tests sometimes hang on PyPy and Python 2.6; skip for those
+  - if [ $TRAVIS_PYTHON_VERSION != "pypy" ]; if [ $TRAVIS_PYTHON_VERSION != "2.6" ]; then travis_retry pip install pyroma; fi; fi
 
   - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then travis_retry pip install unittest2; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - "travis_retry pip install nose"
   - "travis_retry pip install check-manifest"
     # Pyroma tests sometimes hang on PyPy and Python 2.6; skip for those
-  - if [ $TRAVIS_PYTHON_VERSION != "pypy" ]; if [ $TRAVIS_PYTHON_VERSION != "2.6" ]; then travis_retry pip install pyroma; fi; fi
+  - if [ $TRAVIS_PYTHON_VERSION != "pypy" && $TRAVIS_PYTHON_VERSION != "2.6" ]; then travis_retry pip install pyroma; fi
 
   - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then travis_retry pip install unittest2; fi
 


### PR DESCRIPTION
Pyroma has started timing out on Python 2.6 two days ago. Skip it.

Examples:

 * https://travis-ci.org/python-pillow/Pillow/builds/81346086
 * https://travis-ci.org/python-pillow/Pillow/builds/81256118
 * https://travis-ci.org/python-pillow/Pillow/builds/81583748

(This was the last working one:
 * https://travis-ci.org/python-pillow/Pillow/builds/81247414 )
