### PR TITLE
Docs: Mention when OS X support was added

### DIFF
--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -7,7 +7,7 @@
 The :py:mod:`ImageGrab` module can be used to copy the contents of the screen
 or the clipboard to a PIL image memory.
 
-.. note:: The current version works on OS X and Windows only.
+.. note:: The current version works on OS X and Windows only. OS X support was added in 3.0.0.
 
 .. versionadded:: 1.1.3
 


### PR DESCRIPTION
Re: https://pillow.readthedocs.org/en/latest/reference/ImageGrab.html

It'd be good to mention when exactly OS X support was added for `ImageGrab`To try and avoid confusion like http://stackoverflow.com/q/32799143/724176

Is this the best way to do it?