### PR TITLE
README fixes [ci skip]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1184,10 +1184,11 @@ Changelog (Pillow)
 - Forked PIL based on `Hanno Schlichting's re-packaging <http://dist.plone.org/thirdparty/PIL-1.1.7.tar.gz>`_
   [aclark4life]
 
-.. Note:: What follows is the original PIL 1.1.7 CHANGES
+Pre-fork
+--------
 
-0.2b5 - 1.1.7 (1995-2010)
--------------------------
+0.2b5-1.1.7
++++++++++++
 
 ::
 

--- a/Makefile
+++ b/Makefile
@@ -75,3 +75,6 @@ upload-test:
 
 upload:
 	python setup.py sdist --format=gztar,zip upload
+
+readme:
+	viewdoc

--- a/README.rst
+++ b/README.rst
@@ -37,10 +37,10 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
 More Information
 ----------------
 
-- `Documentation <http://pillow.readthedocs.org/>`_
+- `Documentation <https://pillow.readthedocs.org/>`_
 
-  - `Installation <http://pillow.readthedocs.org/installation.html>`_
-  - `Guides <http://pillow.readthedocs.org/guides.html>`_
+  - `Installation <https://pillow.readthedocs.org/installation.html>`_
+  - `Guides <https://pillow.readthedocs.org/guides.html>`_
 
 - `Contribute <https://github.com/python-pillow/Pillow/blob/master/CONTRIBUTING.md>`_
 

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Pillow
 Python Imaging Library (Fork)
 -----------------------------
 
-Pillow is the Friendly PIL Fork by `Alex Clark and Contributors <https://github.com/python-pillow/Pillow/graphs/contributors>`_. PIL is the Python Imaging Library by Fredrik Lundh and Contributors.
+Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.com/python-pillow/Pillow/graphs/contributors>`_. PIL is the Python Imaging Library by Fredrik Lundh and Contributors.
 
 .. image:: https://img.shields.io/travis/python-pillow/Pillow/master.svg?label=Linux%20build
    :target: https://travis-ci.org/python-pillow/Pillow
@@ -37,17 +37,16 @@ Pillow is the Friendly PIL Fork by `Alex Clark and Contributors <https://github.
 More Information
 ----------------
 
-- `Changelog <https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst>`_
+- `Documentation <http://pillow.readthedocs.org/>`_
 
-  - `Pre-fork <https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst#02b5---117-1995-2010>`_
+  - `Installation <http://pillow.readthedocs.org/installation.html>`_
+  - `Guides <http://pillow.readthedocs.org/guides.html>`_
 
 - `Contribute <https://github.com/python-pillow/Pillow/blob/master/CONTRIBUTING.md>`_
 
   - `Issues <https://github.com/python-pillow/Pillow/issues>`_
+  - `Pull requests <https://github.com/python-pillow/Pillow/pulls>`_
 
-- `Documentation <http://pillow.readthedocs.org/>`_
+- `Changelog <https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst>`_
 
-  - `About <http://pillow.readthedocs.org/about.html>`_
-  - `Guides <http://pillow.readthedocs.org/guides.html>`_
-  - `Installation <http://pillow.readthedocs.org/installation.html>`_
-  - `Reference <http://pillow.readthedocs.org/reference/index.html>`_
+  - `Pre-fork <https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst#pre-fork>`_


### PR DESCRIPTION
- Add Makefile target ``make readme`` to run ``viewdoc``
- Reorg "More Info" sections
  - Docs to the top
  - Less doc links (folks can find more than installation & guides from documentation link)
  - Add link to PRs
  - Reorg link to pre-fork changes