### PR TITLE
Warn that tobytes is not for compressed image data

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -647,7 +647,13 @@ class Image(object):
 
     def tobytes(self, encoder_name="raw", *args):
         """
-        Return image as a bytes object
+        Return image as a bytes object.
+        
+        .. warning::
+        
+            This method is for raw-ish output, for compressed image
+            data (e.g. PNG, JPEG) use :meth:`~.save`, with a BytesIO
+            parameter for in-memory data.
 
         :param encoder_name: What encoder to use.  The default is to
                              use the standard "raw" encoder.


### PR DESCRIPTION
Every time I try to get in-memory PNG or JPEG data I tend to spend half an hour fighting with tobytes until I remember it is not going to work and I'm supposed to use `im.save(fp, format='png')`.

#985 makes me think I'm not alone, and a clear warning in the documentation can only help others (and future-me).

I don't actually know what tobytes is for, so I went with something along the lines of @wiredfool's comment in #985, they note that it's

>  only used for a couple very close to raw formats