### PR TITLE
Fixed README links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,8 +44,8 @@ More Information
 
 - `Documentation <https://pillow.readthedocs.org/>`_
 
-  - `Installation <https://pillow.readthedocs.org/installation.html>`_
-  - `Handbook <https://pillow.readthedocs.org/handbook/index.html>`_
+  - `Installation <https://pillow.readthedocs.org/en/latest/installation.html>`_
+  - `Handbook <https://pillow.readthedocs.org/en/latest/handbook/index.html>`_
 
 - `Contribute <https://github.com/python-pillow/Pillow/blob/master/CONTRIBUTING.md>`_
 


### PR DESCRIPTION
Resolves #1471

In the README section of the base repository - https://github.com/python-pillow/Pillow - the Installation and Handbook links do not work. This change fixes that issue.