### PR TITLE
Fix command to invoke ghostscript for eps files.

### DIFF
--- a/PIL/EpsImagePlugin.py
+++ b/PIL/EpsImagePlugin.py
@@ -123,8 +123,8 @@ def Ghostscript(tile, size, fp, scale=1):
                "-q",                         # quiet mode
                "-g%dx%d" % size,             # set output geometry (pixels)
                "-r%fx%f" % res,              # set input DPI (dots per inch)
-               "-dNOPAUSE -dSAFER",          # don't pause between pages,
-                                             # safe mode
+               "-dNOPAUSE",                  # don't pause between pages,
+               "-dSAFER",                    # safe mode
                "-sDEVICE=ppmraw",            # ppm driver
                "-sOutputFile=%s" % outfile,  # output file
                "-c", "%d %d translate" % (-bbox[0], -bbox[1]),

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -124,15 +124,18 @@ class TestFileEps(PillowTestCase):
         # Arrange
         image1 = Image.open(file1)
         image2 = Image.open(file2)
+        image3 = Image.open("Tests/images/illu10_preview.eps")
         new_size = (100, 100)
 
         # Act
         image1 = image1.resize(new_size)
         image2 = image2.resize(new_size)
+        image3 = image3.resize(new_size)
 
         # Assert
         self.assertEqual(image1.size, new_size)
         self.assertEqual(image2.size, new_size)
+        self.assertEqual(image3.size, new_size)
 
     def test_thumbnail(self):
         # Issue #619


### PR DESCRIPTION
When attempting to work with an eps file, ghostscript fails to run. For example, this happens when trying to open and resize an eps image:

```python
image = Image.open("somefile.eps")
newSize = (targetWidth, targetHeight)
print "Resizing to {}...".format(newSize)
image.resize(newSize)  <-- gs fails here
```

This PR seems to fix the problem by dividing a couple of the parameters to the gs command into separate array elements.