### PR TITLE
Added Usage message to painter script

### DIFF
--- a/Scripts/painter.py
+++ b/Scripts/painter.py
@@ -68,6 +68,10 @@ class PaintCanvas(Canvas):
 
 root = Tk()
 
+if len(sys.argv) != 2:
+    print("Usage: painter file")
+    sys.exit(1)
+
 im = Image.open(sys.argv[1])
 
 if im.mode != "RGB":


### PR DESCRIPTION
In addition to being helpful, this prevents an error from being generated if the script is run without the required number of arguments.