### PR TITLE
Windows build: Update Pythons to latest with .msi

### DIFF
--- a/winbuild/get_pythons.py
+++ b/winbuild/get_pythons.py
@@ -2,7 +2,7 @@ from fetch import fetch
 import os
 
 if __name__ == '__main__':
-    for version in ['2.6.6', '2.7.9', '3.2.5', '3.3.5', '3.4.3']:
+    for version in ['2.6.6', '2.7.10', '3.2.5', '3.3.5', '3.4.3']:
         for platform in ['', '.amd64']:
             for extension in ['', '.asc']:
                 fetch('https://www.python.org/ftp/python/%s/python-%s%s.msi%s'

--- a/winbuild/get_pythons.py
+++ b/winbuild/get_pythons.py
@@ -2,7 +2,7 @@ from fetch import fetch
 import os
 
 if __name__ == '__main__':
-    for version in ['2.6.5', '2.7.6', '3.2.5', '3.3.5', '3.4.3']:
+    for version in ['2.6.6', '2.7.9', '3.2.5', '3.3.5', '3.4.3']:
         for platform in ['', '.amd64']:
             for extension in ['', '.asc']:
                 fetch('https://www.python.org/ftp/python/%s/python-%s%s.msi%s'


### PR DESCRIPTION
Not all the latest Python releases at https://www.python.org/ftp/python/ have .msi files, but these do.
