### PR TITLE
Let EditorConfig take care of some basic formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# Top-most EditorConfig file
+root = true
+
+[*]
+# Unix-style newlines with a newline ending every file
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+# Four-space indentation
+indent_size = 4
+indent_style = space
+
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.yml]
+# Two-space indentation
+indent_size = 2
+indent_style = space
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
EditorConfig is built in to several popular editors, and many others have a plugin. It lets you define some simple common code standard things regarding text formatting and takes care of them automatically in the editor.

Get your plugin here: http://editorconfig.org