### PR TITLE
Fix some JPEG images identified as MPO

### DIFF
--- a/PIL/JpegImagePlugin.py
+++ b/PIL/JpegImagePlugin.py
@@ -713,7 +713,7 @@ def jpeg_factory(fp=None, filename=None):
             # It's actually an MPO
             from .MpoImagePlugin import MpoImageFile
             im = MpoImageFile(fp, filename)
-    except (TypeError, IndexError):
+    except (TypeError, IndexError, ValueError):
         # It is really a JPEG
         pass
     except SyntaxError:


### PR DESCRIPTION
I have some specific JPEG images, which are identified as MPO files. When i try to open them i get followng error:

```python
ValueError                                Traceback (most recent call last)
<ipython-input-3-978b1e2bbbb6> in <module>()
----> 1 Image.open('4efe72778de96c1c1f16d1d93f5b.jpg')

/home/mnogacki/.virtualenvs/naheka3/src/pillow/PIL/Image.py in open(fp, mode)
   2282         return None
   2283 
-> 2284     im = _open_core(fp, filename, prefix)
   2285 
   2286     if im is None:

/home/mnogacki/.virtualenvs/naheka3/src/pillow/PIL/Image.py in _open_core(fp, filename, prefix)
   2272                 if not accept or accept(prefix):
   2273                     fp.seek(0)
-> 2274                     im = factory(fp, filename)
   2275                     _decompression_bomb_check(im.size)
   2276                     return im

/home/mnogacki/.virtualenvs/naheka3/src/pillow/PIL/JpegImagePlugin.py in jpeg_factory(fp, filename)
    709     im = JpegImageFile(fp, filename)
    710     try:
--> 711         mpheader = im._getmp()
    712         if mpheader[45057] > 1:
    713             # It's actually an MPO

/home/mnogacki/.virtualenvs/naheka3/src/pillow/PIL/JpegImagePlugin.py in _getmp(self)
    392 
    393     def _getmp(self):
--> 394         return _getmp(self)
    395 
    396 

/home/mnogacki/.virtualenvs/naheka3/src/pillow/PIL/JpegImagePlugin.py in _getmp(self)
    456     info = TiffImagePlugin.ImageFileDirectory_v2(head)
    457     info.load(file_contents)
--> 458     mp = dict(info)
    459     # it's an error not to have a number of images
    460     try:

/home/mnogacki/.virtualenvs/naheka3/src/pillow/PIL/TiffImagePlugin.py in __getitem__(self, tag)
    350             typ = self.tagtype[tag]
    351             size, handler = self._load_dispatch[typ]
--> 352             self[tag] = handler(self, data, self.legacy_api)  # check type
    353         val = self._tags_v2[tag]
    354         if self.legacy_api and not isinstance(val, (tuple, bytes)):

/home/mnogacki/.virtualenvs/naheka3/src/pillow/PIL/TiffImagePlugin.py in __setitem__(self, tag, value)
    364 
    365     def __setitem__(self, tag, value):
--> 366         self._setitem(tag, value, self.legacy_api)
    367 
    368     def _setitem(self, tag, value, legacy_api):

/home/mnogacki/.virtualenvs/naheka3/src/pillow/PIL/TiffImagePlugin.py in _setitem(self, tag, value, legacy_api)
    405             if legacy_api and self.tagtype[tag] in [5, 10]:
    406                 values = values,
--> 407             dest[tag], = values
    408         else:
    409             dest[tag] = values

ValueError: too many values to unpack (expected 1)
```

I fixed this by adding `ValueError` as silently passing when getting MPO file header, as you can see in my commit.