### PR TITLE
Remove old _imagingtiff.c stuff from setup.py

### DIFF
--- a/PIL/ImageGrab.py
+++ b/PIL/ImageGrab.py
@@ -22,13 +22,7 @@ if sys.platform not in ["win32", "darwin"]:
     raise ImportError("ImageGrab is OS X and Windows only")
 
 if sys.platform == "win32":
-    try:
-        # built-in driver (1.1.3 and later)
-        grabber = Image.core.grabscreen
-    except AttributeError:
-        # stand-alone driver (pil plus)
-        import _grabscreen
-        grabber = _grabscreen.grab
+    grabber = Image.core.grabscreen
 elif sys.platform == "darwin":
     import os
     import tempfile

--- a/_imaging.c
+++ b/_imaging.c
@@ -98,9 +98,6 @@
 
 #define WITH_DEBUG /* extra debugging interfaces */
 
-/* PIL Plus extensions */
-#undef  WITH_CRACKCODE /* pil plus */
-
 #undef    VERBOSE
 
 #define CLIP(x) ((x) <= 0 ? 0 : (x) < 256 ? (x) : 255)
@@ -370,7 +367,7 @@ getlist(PyObject* arg, int* length, const char* wrong_length, int type)
     void* list;
     PyObject* seq;
     PyObject* op;
-    
+
     if (!PySequence_Check(arg)) {
         PyErr_SetString(PyExc_TypeError, must_be_sequence);
         return NULL;
@@ -392,7 +389,7 @@ getlist(PyObject* arg, int* length, const char* wrong_length, int type)
         PyErr_SetString(PyExc_TypeError, must_be_sequence);
         return NULL;
     }
-    
+
     for (i = 0; i < n; i++) {
         op = PySequence_Fast_GET_ITEM(seq, i);
         // DRY, branch prediction is going to work _really_ well
@@ -3030,9 +3027,6 @@ static struct PyMethodDef methods[] = {
     {"convert_transparent", (PyCFunction)_convert_transparent, 1},
     {"copy", (PyCFunction)_copy, 1},
     {"copy2", (PyCFunction)_copy2, 1},
-#ifdef WITH_CRACKCODE
-    {"crackcode", (PyCFunction)_crackcode, 1},
-#endif
     {"crop", (PyCFunction)_crop, 1},
     {"expand", (PyCFunction)_expand_image, 1},
     {"filter", (PyCFunction)_filter, 1},

--- a/setup.py
+++ b/setup.py
@@ -554,10 +554,6 @@ class pil_build_ext(build_ext):
             exts.append(Extension(
                 "PIL._imagingft", ["_imagingft.c"], libraries=["freetype"]))
 
-        if os.path.isfile("_imagingtiff.c") and feature.tiff:
-            exts.append(Extension(
-                "PIL._imagingtiff", ["_imagingtiff.c"], libraries=["tiff"]))
-
         if os.path.isfile("_imagingcms.c") and feature.lcms:
             extra = []
             if sys.platform == "win32":


### PR DESCRIPTION
`git log -- _imagingtiff.c` (and `git log -1 -- _imagingtiff.c` should show when it was deleted, but I don't get anything when I run it.

I also don't see the file in any of the PIL 1.1.1 to 1.1.7 releases: https://github.com/hugovk/PIL/commits/master

Fixes #1498.