### PR TITLE
Documentation contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Please send a pull request to the master branch. Please include [documentation](
 - Separate code commits from reformatting commits.
 - Provide tests for any newly added code.
 - Follow PEP8.
-- When committing only trivial changes please include [ci skip] in the commit message to avoid running tests on Travis-CI.
+- When committing only documentation changes please include [ci skip] in the commit message to avoid running tests on Travis-CI.
 
 ## Reporting Issues
 


### PR DESCRIPTION
At some point in the past, I made a PR where I changed a docstring with a `[ci skip]`. This was merged because it looked trivial, but it turned out that I had actually made an indentation change that broke the script.

The point is - contributions using `[ci skip]` need to be documentation changes, not trivial ones.