### PR TITLE
Divide by zero in Exif

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -44,6 +44,7 @@ from __future__ import division, print_function
 from PIL import Image, ImageFile
 from PIL import ImagePalette
 from PIL import _binary
+from PIL import TiffTags
 
 import collections
 from fractions import Fraction
@@ -56,7 +57,8 @@ import struct
 import sys
 import warnings
 
-from .TiffTags import TAGS_V2, TYPES, TagInfo
+from .TiffTags import TYPES, TagInfo
+
 
 __version__ = "1.3.5"
 DEBUG = False  # Needs to be merged with the new logging approach.
@@ -461,7 +463,7 @@ class ImageFileDirectory_v2(collections.MutableMapping):
 
         Returns the complete tag dictionary, with named tags where possible.
         """
-        return dict((TAGS_V2.get(code, TagInfo()).name, value)
+        return dict((TiffTags.lookup(code).name, value)
                     for code, value in self.items())
 
     def __len__(self):
@@ -493,7 +495,7 @@ class ImageFileDirectory_v2(collections.MutableMapping):
         if bytes is str:
             basetypes += unicode,
 
-        info = TAGS_V2.get(tag, TagInfo())
+        info = TiffTags.lookup(tag)
         values = [value] if isinstance(value, basetypes) else value
 
         if tag not in self.tagtype:
@@ -648,7 +650,7 @@ class ImageFileDirectory_v2(collections.MutableMapping):
             for i in range(self._unpack("H", self._ensure_read(fp, 2))[0]):
                 tag, typ, count, data = self._unpack("HHL4s", self._ensure_read(fp, 12))
                 if DEBUG:
-                    tagname = TAGS_V2.get(tag, TagInfo()).name
+                    tagname = TiffTags.lookup(tag).name
                     typname = TYPES.get(typ, "unknown")
                     print("tag: %s (%d) - type: %s (%d)" %
                           (tagname, tag, typname, typ), end=" ")
@@ -716,7 +718,7 @@ class ImageFileDirectory_v2(collections.MutableMapping):
             values = value if isinstance(value, tuple) else (value,)
             data = self._write_dispatch[typ](self, *values)
             if DEBUG:
-                tagname = TAGS_V2.get(tag, TagInfo()).name
+                tagname = TiffTags.lookup(tag).name
                 typname = TYPES.get(typ, "unknown")
                 print("save: %s (%d) - type: %s (%d)" %
                       (tagname, tag, typname, typ), end=" ")

--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -313,7 +313,8 @@ class IFDRational(Rational):
     """ a = ['add','radd', 'sub', 'rsub','div', 'rdiv', 'mul', 'rmul',
              'truediv', 'rtruediv', 'floordiv',
              'rfloordiv','mod','rmod', 'pow','rpow', 'pos', 'neg',
-             'abs', 'trunc', 'lt', 'gt', 'le', 'ge', 'nonzero']
+             'abs', 'trunc', 'lt', 'gt', 'le', 'ge', 'nonzero',
+             'ceil', 'floor', 'round']
         print "\n".join("__%s__ = _delegate('__%s__')" % (s,s) for s in a)
         """
 
@@ -342,6 +343,9 @@ class IFDRational(Rational):
     __le__ = _delegate('__le__')
     __ge__ = _delegate('__ge__')
     __nonzero__ = _delegate('__nonzero__')
+    __ceil__ = _delegate('__ceil__')
+    __floor__ = _delegate('__floor__')
+    __round__ = _delegate('__round__')
 
     
 

--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -497,11 +497,13 @@ class ImageFileDirectory_v2(collections.MutableMapping):
         values = [value] if isinstance(value, basetypes) else value
 
         if tag not in self.tagtype:
-            try:
+            if info.type:
                 self.tagtype[tag] = info.type
-            except KeyError:
+            else:
                 self.tagtype[tag] = 7
-                if all(isinstance(v, int) for v in values):
+                if all(isinstance(v, IFDRational) for v in values):
+                    self.tagtype[tag] = 5
+                elif all(isinstance(v, int) for v in values):
                     if all(v < 2 ** 16 for v in values):
                         self.tagtype[tag] = 3
                     else:

--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -282,6 +282,13 @@ class IFDRational(Fraction):
 
     def __repr__(self):
         return str(float(self._val))
+
+    def __eq__(self,other):
+        if type(other) == float:
+            return float(self) == other
+        if type(other) == int:
+            return float(self) == float(int(self)) and int(self) == other
+        return float(self) == float(other)
     
 
 class ImageFileDirectory_v2(collections.MutableMapping):

--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -237,7 +237,7 @@ class IFDRational(Rational):
 
     """
     
-    __slots__ = ('numerator', 'denominator', '_val') 
+    __slots__ = ('_numerator', '_denominator', '_val') 
 
     def __init__(self, value, denominator=1):
         """
@@ -245,18 +245,18 @@ class IFDRational(Rational):
         float/rational/other number, or an IFDRational
         :param denominator: Optional integer denominator
         """
-        self.denominator = denominator
-        self.numerator = value
+        self._denominator = denominator
+        self._numerator = value
         self._val = float(1)
 
         if type(value) == Fraction:
-            self.numerator = value.numerator
-            self.denominator = value.denominator
+            self._numerator = value.numerator
+            self._denominator = value.denominator
             self._val = value
         
         if type(value) == IFDRational:
-            self.denominator = value.denominator
-            self.numerator = value.numerator
+            self._denominator = value.denominator
+            self._numerator = value.numerator
             self._val = value._val
             return
 
@@ -273,6 +273,14 @@ class IFDRational(Rational):
                 self._val = Fraction(value)
         else:
             self._val = Fraction(value, denominator)
+
+    @property
+    def numerator(a):
+        return a._numerator
+
+    @property
+    def denominator(a):
+        return a._denominator
 
 
     def limit_rational(self, max_denominator):

--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -283,12 +283,16 @@ class IFDRational(Fraction):
     def __repr__(self):
         return str(float(self._val))
 
+    def __hash__(self):
+        return self._val.__hash__()
+
     def __eq__(self,other):
         if type(other) == float:
             return float(self) == other
         if type(other) == int:
             return float(self) == float(int(self)) and int(self) == other
         return float(self) == float(other)
+
     
 
 class ImageFileDirectory_v2(collections.MutableMapping):

--- a/PIL/TiffTags.py
+++ b/PIL/TiffTags.py
@@ -30,6 +30,18 @@ class TagInfo(namedtuple("_TagInfo", "value name type length enum")):
     def cvt_enum(self, value):
         return self.enum.get(value, value)
 
+def lookup(tag):
+    """
+    :param tag: Integer tag number
+    :returns: Taginfo namedtuple, From the TAGS_V2 info if possible,
+        otherwise just populating the value and name from TAGS.
+        If the tag is not recognized, "unknown" is returned for the name
+        
+    """
+    
+    return TAGS_V2.get(tag, TagInfo(tag, TAGS.get(tag, 'unknown')))
+
+
 ##
 # Map tag numbers to tag info.
 #

--- a/PIL/TiffTags.py
+++ b/PIL/TiffTags.py
@@ -23,7 +23,7 @@ from collections import namedtuple
 class TagInfo(namedtuple("_TagInfo", "value name type length enum")):
     __slots__ = []
 
-    def __new__(cls, value=None, name="unknown", type=4, length=0, enum=None):
+    def __new__(cls, value=None, name="unknown", type=None, length=0, enum=None):
         return super(TagInfo, cls).__new__(
             cls, value, name, type, length, enum or {})
 

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -84,9 +84,9 @@ class TestFileTiff(PillowTestCase):
         self.assertIsInstance(im.tag[X_RESOLUTION][0], tuple)
         self.assertIsInstance(im.tag[Y_RESOLUTION][0], tuple)
 
-        # v2 api
-        self.assertIsInstance(im.tag_v2[X_RESOLUTION], float)
-        self.assertIsInstance(im.tag_v2[Y_RESOLUTION], float)
+        #v2 api
+        self.assert_(isinstance(im.tag_v2[X_RESOLUTION], TiffImagePlugin.IFDRational))
+        self.assert_(isinstance(im.tag_v2[Y_RESOLUTION], TiffImagePlugin.IFDRational))
 
         self.assertEqual(im.info['dpi'], (72., 72.))
 

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -73,7 +73,7 @@ class TestFileTiffMetadata(PillowTestCase):
     def test_read_metadata(self):
         img = Image.open('Tests/images/hopper_g4.tif')
 
-        self.assertEqual({'YResolution': 4294967295 / 113653537,
+        self.assertEqual({'YResolution': TiffImagePlugin.IFDRational(4294967295, 113653537),
                           'PlanarConfiguration': 1,
                           'BitsPerSample': (1,),
                           'ImageLength': 128,
@@ -83,7 +83,7 @@ class TestFileTiffMetadata(PillowTestCase):
                           'ResolutionUnit': 3,
                           'PhotometricInterpretation': 0,
                           'PageNumber': (0, 1),
-                          'XResolution': 4294967295 / 113653537,
+                          'XResolution': TiffImagePlugin.IFDRational(4294967295, 113653537),
                           'ImageWidth': 128,
                           'Orientation': 1,
                           'StripByteCounts': (1968,),
@@ -125,7 +125,16 @@ class TestFileTiffMetadata(PillowTestCase):
             'StripByteCounts', 'RowsPerStrip', 'PageNumber', 'StripOffsets']
 
         for tag, value in reloaded.items():
-            if tag not in ignored:
+            if tag in ignored: continue
+            if (type(original[tag]) == tuple
+                and type(original[tag][0]) == TiffImagePlugin.IFDRational):
+                # Need to compare element by element in the tuple,
+                # not comparing tuples of object references
+                self.assert_deep_equal(original[tag],
+                                       value,
+                                       "%s didn't roundtrip, %s, %s" %
+                                       (tag, original[tag], value))
+            else:
                 self.assertEqual(original[tag],
                                  value,
                                  "%s didn't roundtrip, %s, %s" %

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -185,6 +185,20 @@ class TestFileTiffMetadata(PillowTestCase):
         self.assertEqual(im.tag_v2.tagtype[34675], 1)
         self.assertTrue(im.info['icc_profile'])
 
+    def test_exif_div_zero(self):
+        im = hopper()
+        info = TiffImagePlugin.ImageFileDirectory_v2()
+        info[41988] = TiffImagePlugin.IFDRational(0,0)
+
+        out = self.tempfile('temp.tiff')
+        im.save(out, tiffinfo=info, compression='raw')
+
+        reloaded = Image.open(out)
+        self.assertEqual(0, reloaded.tag_v2[41988][0].numerator)
+        self.assertEqual(0, reloaded.tag_v2[41988][0].denominator)
+
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -6,7 +6,7 @@ import struct
 from helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, TiffImagePlugin, TiffTags
-from TiffImagePlugin import _limit_rational, IFDRational
+from PIL.TiffImagePlugin import _limit_rational, IFDRational
 
 tag_ids = dict((info.name, info.value) for info in TiffTags.TAGS_V2.values())
 

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -126,8 +126,10 @@ class TestFileTiffMetadata(PillowTestCase):
 
         for tag, value in reloaded.items():
             if tag not in ignored:
-                self.assertEqual(
-                    original[tag], value, "%s didn't roundtrip" % tag)
+                self.assertEqual(original[tag],
+                                 value,
+                                 "%s didn't roundtrip, %s, %s" %
+                                 (tag, original[tag], value))
 
         for tag, value in original.items():
             if tag not in ignored:

--- a/Tests/test_tiff_ifdrational.py
+++ b/Tests/test_tiff_ifdrational.py
@@ -1,0 +1,46 @@
+from __future__ import print_function
+
+from helper import PillowTestCase
+
+from PIL.TiffImagePlugin import IFDRational
+
+from fractions import Fraction
+
+class Test_IFDRational(PillowTestCase):
+
+
+    def _test_equal(self, num, denom, target):
+        
+        t = IFDRational(num, denom)
+
+        self.assertEqual(target, t)
+        self.assertEqual(t, target)
+    
+    def test_sanity(self):
+        
+        self._test_equal(1, 1, 1)
+        self._test_equal(1, 1, Fraction(1,1))
+
+        self._test_equal(2, 2, 1)
+        self._test_equal(1.0, 1, Fraction(1,1))
+
+        self._test_equal(Fraction(1,1), 1, Fraction(1,1))
+        self._test_equal(IFDRational(1,1), 1, 1)
+        
+        
+        self._test_equal(1, 2, Fraction(1,2))
+        self._test_equal(1, 2, IFDRational(1,2))
+
+    def test_nonetype(self):
+        " Fails if the _delegate function doesn't return a valid function" 
+
+        xres = IFDRational(72) 
+        yres = IFDRational(72) 
+        self.assert_(xres._val is not None)
+        self.assert_(xres.numerator is not None)
+        self.assert_(xres.denominator is not None)
+        self.assert_(yres._val is not None)
+        
+        self.assert_(xres and 1)
+        self.assert_(xres and yres)
+

--- a/Tests/test_tiff_ifdrational.py
+++ b/Tests/test_tiff_ifdrational.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
 
-from helper import PillowTestCase
+from helper import PillowTestCase, hopper
 
+from PIL import TiffImagePlugin, Image
 from PIL.TiffImagePlugin import IFDRational
 
 from fractions import Fraction
@@ -43,4 +44,18 @@ class Test_IFDRational(PillowTestCase):
         
         self.assert_(xres and 1)
         self.assert_(xres and yres)
+
+
+    def test_ifd_rational_save(self):
+        for libtiff in (True, False):
+            TiffImagePlugin.WRITE_LIBTIFF = libtiff
+            
+            im = hopper()
+            out = self.tempfile('temp.tiff')
+            res = IFDRational(301,1)
+            im.save(out, dpi=(res,res), compression='raw')
+
+            reloaded = Image.open(out)
+            self.assertEqual(float(IFDRational(301,1)),
+                             float(reloaded.tag_v2[282]))
 

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -477,10 +477,12 @@ The :py:meth:`~PIL.Image.Image.open` method sets the following
     .. versionadded:: 1.1.5
 
 
-The :py:attr:`~PIL.Image.Image.tag_v2` attribute contains a dictionary of
-TIFF metadata. The keys are numerical indexes from `~PIL.TiffTags.TAGS_V2`.
-Values are strings or numbers for single items, multiple values are returned
-in a tuple of values. Rational numbers are returned as a single value.
+The :py:attr:`~PIL.Image.Image.tag_v2` attribute contains a dictionary
+of TIFF metadata. The keys are numerical indexes from
+`~PIL.TiffTags.TAGS_V2`.  Values are strings or numbers for single
+items, multiple values are returned in a tuple of values. Rational
+numbers are returned as a :py:class:`~PIL.TiffImagePlugin.IFDRational`
+object.
 
     .. versionadded:: 3.0.0
 
@@ -510,20 +512,27 @@ The :py:meth:`~PIL.Image.Image.save` method can take the following keyword argum
 
     .. versionadded:: 2.3.0
 
-    For compatibility with legacy code, a
-    `~PIL.TiffImagePlugin.ImageFileDirectory_v1` object may be passed
-    in this field. However, this is deprecated.
+    Metadata values that are of the rational type should be passed in
+    using a :py:class:`~PIL.TiffImagePlugin.IFDRational` object.
 
-    ..versionadded:: 3.0.0
+    .. versionadded:: 3.1.0
+
+    For compatibility with legacy code, a
+    :py:class:`~PIL.TiffImagePlugin.ImageFileDirectory_v1` object may
+    be passed in this field. However, this is deprecated.
+
+    .. versionadded:: 3.0.0
 
 **compression**
     A string containing the desired compression method for the
 	file. (valid only with libtiff installed) Valid compression
-	methods are: ``[None, "tiff_ccitt", "group3", "group4",
-	"tiff_jpeg", "tiff_adobe_deflate", "tiff_thunderscan",
-	"tiff_deflate", "tiff_sgilog", "tiff_sgilog24", "tiff_raw_16"]``
+	methods are: ``None``, ``"tiff_ccitt"``, ``"group3"``,
+	``"group4"``, ``"tiff_jpeg"``, ``"tiff_adobe_deflate"``,
+	``"tiff_thunderscan"``, ``"tiff_deflate"``, ``"tiff_sgilog"``,
+	``"tiff_sgilog24"``, ``"tiff_raw_16"``
 
-These arguments to set the tiff header fields are an alternative to using the general tags available through tiffinfo.
+These arguments to set the tiff header fields are an alternative to
+using the general tags available through tiffinfo.
 
 **description**
 
@@ -545,10 +554,11 @@ These arguments to set the tiff header fields are an alternative to using the ge
 
 **y_resolution**
 
-**dpi**
-    Either a Float, Integer, or 2 tuple of (numerator,
-    denominator). Resolution implies an equal x and y resolution, dpi
-    also implies a unit of inches.
+**dpi** 
+    Either a Float, 2 tuple of (numerator, denominator) or a
+    :py:class:`~PIL.TiffImagePlugin.IFDRational`. Resolution implies
+    an equal x and y resolution, dpi also implies a unit of inches.
+
 
 WebP
 ^^^^


### PR DESCRIPTION
Not quite complete version of #1492 which preserves the semantics of 0/0 when that's what's actually in the file. It passes the existing test suite, with the exception of python 2.6.

* [x] Needs specific tests for the bug being fixed
* [x] Needs more detailed tests to define the behavior of the class that I've added.
* [x] Needs to work on 2.6
 
Please try this PR and let me know if it works for your use case. 