### PR TITLE
Removed comment

### DIFF
--- a/Tests/test_image_point.py
+++ b/Tests/test_image_point.py
@@ -22,10 +22,6 @@ class TestImagePoint(PillowTestCase):
         """ Tests for 16 bit -> 8 bit lut for converting I->L images
             see https://github.com/python-pillow/Pillow/issues/440
             """
-        # This takes _forever_ on PyPy. Open Bug,
-        # see https://github.com/python-pillow/Pillow/issues/484
-        # self.skipKnownBadTest(msg="Too Slow on pypy", interpreter='pypy')
-
         im = hopper("I")
         im.point(list(range(256))*256, 'L')
 


### PR DESCRIPTION
Considering that the bug is no longer open - https://bitbucket.org/pypy/pypy/issues/1779/impoint-4000x-slower-than-cpython - and the test is no longer skipped, this comment is outdated and can be removed.