### PR TITLE
Fix crash in ImageTk.PhotoImage on win-amd64

### DIFF
--- a/Tk/tkImaging.c
+++ b/Tk/tkImaging.c
@@ -60,7 +60,11 @@ ImagingFind(const char* name)
     Py_ssize_t id;
 
     /* FIXME: use CObject instead? */
+#if defined(_MSC_VER) && defined(_WIN64)
+    id = _atoi64(name);
+#else
     id = atol(name);
+#endif
     if (!id)
 	return NULL;
 


### PR DESCRIPTION
`atol` returns a 32 bit C long on win-amd64.

Fixes #1549