### PR TITLE
ExtraSamples tag should be a SHORT, not a BYTE

### DIFF
--- a/PIL/TiffTags.py
+++ b/PIL/TiffTags.py
@@ -106,7 +106,7 @@ TAGS_V2 = {
     334: ("NumberOfInks", 3, 1),
     336: ("DotRange", 3, 0),
     337: ("TargetPrinter", 2, 1),
-    338: ("ExtraSamples", 1, 0),
+    338: ("ExtraSamples", 3, 0),
     339: ("SampleFormat", 3, 0),
 
     340: ("SMinSampleValue", 12, 0),

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -115,6 +115,11 @@ class TestFileTiff(PillowTestCase):
             self.fail(
                  "Bad EXIF data passed incorrect values to _binary unpack")
 
+    def test_save_rgba(self):
+        im = hopper("RGBA")
+        outfile = self.tempfile("temp.tif")
+        im.save(outfile)
+
     def test_save_unsupported_mode(self):
         im = hopper("HSV")
         outfile = self.tempfile("temp.tif")


### PR DESCRIPTION
According to http://www.awaresystems.be/imaging/tiff/tifftags/extrasamples.html, this tag should be a short, not a byte. Seems to be a regression from the TIFF metadata rewrite in 3.0.0. See #1524 (only affects RGBA and RGBX formats, which are the only formats that try to write the ExtraSamples tag).