### PR TITLE
fix for issue #1557

### DIFF
--- a/PIL/ImageQt.py
+++ b/PIL/ImageQt.py
@@ -17,6 +17,7 @@
 #
 
 import PIL
+import PIL.Image
 from PIL._util import isPath
 from io import BytesIO
 


### PR DESCRIPTION
This fixes issue #1557

I tried to write a test for this that would fail but couldn't.
This is because all the other tests have already imported PIL.Image.
To really test this you can't test Tests/test_*.py, you'd have to invoke nose for a single test alone which never imports PIL.Image but tries to use fromqimage.
Probably not worth the hassle you'd have to do with travis, etc.