### PR TITLE
Fixed length of title underlines

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -11,7 +11,7 @@ against 64-bit Windows 7 Professional and Windows Server 2012
 64-bit version on Amazon EC2.
 
 Prerequisites
-------------
+-------------
 
 Extra Build Helpers
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -2,7 +2,7 @@
 .. py:currentmodule:: PIL.ImageGrab
 
 :py:mod:`ImageGrab` Module (OS X and Windows only)
-=========================================
+==================================================
 
 The :py:mod:`ImageGrab` module can be used to copy the contents of the screen
 or the clipboard to a PIL image memory.


### PR DESCRIPTION
When running `make html` in the `docs` directory, Sphinx generates the following warnings -

    Pillow/docs/build.rst:14: WARNING: Title underline too short.
    
    Prerequisites
    ------------
    Pillow/docs/reference/ImageGrab.rst:5: WARNING: Title underline too short.

    :py:mod:`ImageGrab` Module (OS X and Windows only)
    =========================================

This fixes these warnings.