### PR TITLE
Fixed typo

### DIFF
--- a/libImaging/TiffDecode.h
+++ b/libImaging/TiffDecode.h
@@ -35,7 +35,7 @@ typedef struct {
     int ifd; /* offset of the ifd, used for multipage */
 	TIFF *tiff; /* Used in write */
 	toff_t eof;
-	int flrealloc; /* may we realloc */
+	int flrealloc; /* may be realloc */
 } TIFFSTATE;
 
 


### PR DESCRIPTION
To give some context, based on https://github.com/python-pillow/Pillow/blob/master/libImaging/TiffDecode.c#L57, `flrealloc` is a flag indicating whether or not to realloc.