### PR TITLE
Travis CI: sudo apt-get update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ python:
   - nightly
 
 install:
+  - "travis_retry sudo apt-get update"
   - "travis_retry sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-qt4 ghostscript libffi-dev libjpeg-turbo-progs cmake imagemagick"
   - "travis_retry pip install cffi"
   - "travis_retry pip install nose"


### PR DESCRIPTION
Workaround to close https://github.com/python-pillow/Pillow/issues/1571.

Adding `sudo apt-get update` before installing fixes it.

[Travis say](https://github.com/travis-ci/travis-ci/issues/5221#issuecomment-162256556):

> The apt lists are currently being wiped at the end of the image-baking process, although this step was added prior to GCE and the space savings aren't as big of a deal on GCE, so I can see leaving the apt lists in place as a decent fix.

If they leave the lists in place we can remove this later, but it only takes about 10s to do the updates.