### PR TITLE
Removed FIXME from ImageDraw test

### DIFF
--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -64,7 +64,6 @@ class TestImageDraw(PillowTestCase):
         draw = ImageDraw.Draw(im)
 
         # Act
-        # FIXME Fill param should be named outline.
         draw.arc(bbox, 0, 180)
         del draw
 


### PR DESCRIPTION
I presume that this FIXME is not referring to the test itself, but to the `arc` method.

Since the general attitude here is not to change APIs unnecessarily, I figure that this can be removed.