### PR TITLE
Enabled conversion to numpy array for HSV images. #1559

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog (Pillow)
 3.1.0 (unreleased)
 ------------------
 
+- Enabled conversion to numpy array for HSV images. #1559
+  [cartisan]
+
 - Fix command to invoke ghostscript for eps files. #1478
   [baumatron, radarhere]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,6 @@ Changelog (Pillow)
 3.1.0 (unreleased)
 ------------------
 
-- Enabled conversion to numpy array for HSV images. #1559
-  [cartisan]
-
 - Fix command to invoke ghostscript for eps files. #1478
   [baumatron, radarhere]
 

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -250,6 +250,7 @@ _MODE_CONV = {
     "CMYK": ('|u1', 4),
     "YCbCr": ('|u1', 3),
     "LAB": ('|u1', 3),  # UNDONE - unsigned |u1i1i1
+    "HSV": ('|u1', 3),
     # I;16 == I;16L, and I;32 == I;32L
     "I;16": ('<u2', None),
     "I;16B": ('>u2', None),

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -113,6 +113,7 @@ class TestNumpy(PillowTestCase):
                  ("I;16", '<u2'),
                  ("I;16B", '>u2'),
                  ("I;16L", '<u2'),
+                 ("HSV", 'uint8'),
                  ]
 
         for mode in modes:


### PR DESCRIPTION
Added an HSV entry in the conversion table in Image.py. Analogous to RGB it contains unsigned ints, and the dimensions for each entry are 3 values.

Added an HSV entry in the respective test.

Resolves #1559 .

