### PR TITLE
'make linkcheck' fixes

### DIFF
--- a/PIL/JpegPresets.py
+++ b/PIL/JpegPresets.py
@@ -27,7 +27,7 @@ Subsampling
 
 Subsampling is the practice of encoding images by implementing less resolution
 for chroma information than for luma information.
-(ref.: http://en.wikipedia.org/wiki/Chroma_subsampling)
+(ref.: https://en.wikipedia.org/wiki/Chroma_subsampling)
 
 Possible subsampling values are 0, 1 and 2 that correspond to 4:4:4, 4:2:2 and
 4:1:1 (or 4:2:0?).
@@ -41,8 +41,8 @@ Quantization tables
 
 They are values use by the DCT (Discrete cosine transform) to remove
 *unnecessary* information from the image (the lossy part of the compression).
-(ref.: http://en.wikipedia.org/wiki/Quantization_matrix#Quantization_matrices,
-http://en.wikipedia.org/wiki/JPEG#Quantization)
+(ref.: https://en.wikipedia.org/wiki/Quantization_matrix#Quantization_matrices,
+https://en.wikipedia.org/wiki/JPEG#Quantization)
 
 You can get the quantization tables of a JPEG with::
 

--- a/PIL/WalImageFile.py
+++ b/PIL/WalImageFile.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+#
 # The Python Imaging Library.
 # $Id$
 #

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -52,12 +52,12 @@ Compilers
 Download and install:
 
 * `Microsoft Windows SDK for Windows 7 and .NET Framework 3.5
-  SP1 <http://www.microsoft.com/en-us/download/details.aspx?id=3138>`_
+  SP1 <https://www.microsoft.com/en-us/download/details.aspx?id=3138>`_
 
 * `Microsoft Windows SDK for Windows 7 and .NET Framework
-  4 <http://www.microsoft.com/en-us/download/details.aspx?id=8279>`_
+  4 <https://www.microsoft.com/en-us/download/details.aspx?id=8279>`_
 
-* `CMake-2.8.10.2-win32-x86.exe <http://www.cmake.org/cmake/resources/software.html>`_
+* `CMake-2.8.10.2-win32-x86.exe <https://cmake.org/download/>`_
 
 The samples and the .NET SDK portions aren't required, just the
 compilers and other tools. UNDONE -- check exact wording.
@@ -83,7 +83,7 @@ Once the dependencies are built, run `python build.py --clean` to
 build and install Pillow in virtualenvs for each python
 build. `build.py --dist` will build Windows installers instead of
 installing into virtualenvs.
- 
+
 UNDONE -- suppressed output, what about failures.
 
 Testing Pillow

--- a/docs/reference/ImagePath.rst
+++ b/docs/reference/ImagePath.rst
@@ -36,7 +36,7 @@ vector data. Path objects can be passed to the methods on the
     **distance** is measured as `Manhattan distance`_ and defaults to two
     pixels.
 
-.. _Manhattan distance: http://en.wikipedia.org/wiki/Manhattan_distance
+.. _Manhattan distance: https://en.wikipedia.org/wiki/Manhattan_distance
 
 .. py:method:: PIL.ImagePath.Path.getbbox()
 


### PR DESCRIPTION
Some fixes for things found when running `cd docs && make linkcheck`.

---

The output of the command *after* these fixes is:
```bash
$ make linkcheck
sphinx-build -b linkcheck -d _build/doctrees   . _build/linkcheck
Running Sphinx v1.3.3
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [linkcheck]: targets for 44 source files that are out of date
updating environment: 0 added, 1 changed, 0 removed
reading sources... [100%] reference/index                                                                                              
/Users/hugo/github/Pillow/docs/reference/index.rst:4: WARNING: toctree contains reference to nonexisting document u'reference/TiffTags'
looking for now-outdated files... none found
pickling environment... done
checking consistency... /Users/hugo/github/Pillow/docs/build.rst:: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [  2%] PIL                                                                                                           
(line   27) ok        https://en.wikipedia.org/wiki/Chroma_subsampling
(line   41) ok        https://en.wikipedia.org/wiki/Quantization_matrix#Quantization_matrices
(line   64) ok        http://www.jpegcameras.com/libjpeg/libjpeg-3.html
(line   41) ok        https://en.wikipedia.org/wiki/JPEG#Quantization
writing output... [  4%] about                                                                                                         
(line    9) ok        https://travis-ci.org/python-pillow/Pillow
(line   11) ok        https://pypi.python.org/pypi/Pillow
(line   20) ok        http://www.pythonware.com/products/pil/license.htm
(line   10) ok        https://github.com/python-pillow/Pillow
(line   38) ok        https://mail.python.org/pipermail/image-sig/2010-August/006480.html
(line   50) ok        https://github.com/python-pillow/Pillow/issues
(line   50) ok        https://bitbucket.org/effbot/pil-2009-raclette/issues
writing output... [  6%] build                                                                                                         
(line   57) broken    https://www.microsoft.com/en-us/download/details.aspx?id=8279 - HTTP Error 503: Service Unavailable
(line   54) broken    https://www.microsoft.com/en-us/download/details.aspx?id=3138 - HTTP Error 503: Service Unavailable
(line   60) ok        https://cmake.org/download/
writing output... [  9%] handbook/appendices                                                                                           
writing output... [ 11%] handbook/concepts                                                                                             
writing output... [ 13%] handbook/image-file-formats                                                                                   
(line  441) ok        http://spider.wadsworth.org/spider_doc/spider/docs/spider.html
(line  441) ok        http://www.wadsworth.org/
writing output... [ 15%] handbook/index                                                                                                
writing output... [ 18%] handbook/overview                                                                                             
writing output... [ 20%] handbook/tutorial                                                                                             
writing output... [ 22%] handbook/writing-your-own-file-decoder                                                                        
writing output... [ 25%] index                                                                                                         
(line    4) ok        https://github.com/python-pillow/Pillow/graphs/contributors
(line    2) ok        https://travis-ci.org/python-pillow/pillow-wheels
(line    2) ok        https://ci.appveyor.com/project/python-pillow/Pillow
(line    2) redirect  http://pillow.readthedocs.org/?badge=latest - with Found to http://pillow.readthedocs.org/en/3.0.x/
(line    2) ok        https://pypi.python.org/pypi/Pillow/
(line    2) ok        https://pypi.python.org/pypi/Pillow/
(line    2) redirect  https://landscape.io/github/python-pillow/Pillow/master - with Found to https://landscape.io/github/python-pillow/Pillow/374
(line    2) redirect  https://coveralls.io/r/python-pillow/Pillow?branch=master:alt:Codecoverage - permanently to https://coveralls.io/github/python-pillow/Pillow
(line    2) redirect  https://zenodo.org/badge/latestdoi/17549/python-pillow/Pillow - with Found to http://zenodo.org/record/31892
writing output... [ 27%] installation                                                                                                  
(line  196) ok        http://brew.sh/
(line  331) ok        https://pypi.python.org/pypi/Pillow/1.0
(line   39) ok        http://peak.telecommunity.com/DevCenter/PythonEggs
writing output... [ 29%] porting                                                                                                       
writing output... [ 31%] reference/ExifTags                                                                                            
writing output... [ 34%] reference/Image                                                                                               
(line   53) ok        https://en.wikipedia.org/wiki/Zip_bomb
(line   53) ok        https://docs.python.org/2/library/logging.html?highlight=logging#integration-with-the-warnings-module
writing output... [ 36%] reference/ImageChops                                                                                          
writing output... [ 38%] reference/ImageCms                                                                                            
writing output... [ 40%] reference/ImageColor                                                                                          
writing output... [ 43%] reference/ImageDraw                                                                                           
(line   12) ok        http://effbot.org/zone/aggdraw-index.htm
writing output... [ 45%] reference/ImageEnhance                                                                                        
writing output... [ 47%] reference/ImageFile                                                                                           
writing output... [ 50%] reference/ImageFilter                                                                                         
(line    3) ok        https://en.wikipedia.org/wiki/Unsharp_masking#Digital_unsharp_masking
writing output... [ 52%] reference/ImageFont                                                                                           
writing output... [ 54%] reference/ImageGrab                                                                                           
writing output... [ 56%] reference/ImageMath                                                                                           
writing output... [ 59%] reference/ImageMorph                                                                                          
writing output... [ 61%] reference/ImageOps                                                                                            
writing output... [ 63%] reference/ImagePalette                                                                                        
writing output... [ 65%] reference/ImagePath                                                                                           
(line   36) ok        https://en.wikipedia.org/wiki/Manhattan_distance
writing output... [ 68%] reference/ImageQt                                                                                             
writing output... [ 70%] reference/ImageSequence                                                                                       
writing output... [ 72%] reference/ImageStat                                                                                           
writing output... [ 75%] reference/ImageTk                                                                                             
writing output... [ 77%] reference/ImageWin                                                                                            
writing output... [ 79%] reference/OleFileIO                                                                                           
(line   12) ok        http://www.decalage.info/python/olefileio
(line  329) ok        http://decalage.info/contact
(line  342) ok        http://decalage.info/contact
(line  325) ok        https://bitbucket.org/decalage/olefileio_pl
(line  342) ok        https://bitbucket.org/decalage/olefileio_pl/issues?status=new&status=open
(line   16) redirect  http://sedna-soft.de/summary-information-stream/ - permanently to http://sedna-soft.de/articles/summary-information-stream/
(line   16) redirect  http://msdn.microsoft.com/en-us/library/aa372045.aspx - permanently to https://msdn.microsoft.com/en-us/library/aa372045.aspx
(line   16) ok        http://poi.apache.org/apidocs/org/apache/poi/hpsf/SummaryInformation.html
(line   16) redirect  http://msdn.microsoft.com/en-us/library/dd942545.aspx - permanently to https://msdn.microsoft.com/en-us/library/dd942545.aspx
(line   16) redirect  http://msdn.microsoft.com/en-us/library/windows/desktop/aa380376%28v=vs.85%29.aspx - permanently to https://msdn.microsoft.com/en-us/library/windows/desktop/aa380376(v=vs.85).aspx
(line   24) ok        http://poi.apache.org/apidocs/org/apache/poi/hpsf/DocumentSummaryInformation.html
(line   16) redirect  http://msdn.microsoft.com/en-us/library/dd925819%28v=office.12%29.aspx - permanently to https://msdn.microsoft.com/en-us/library/dd925819(v=office.12).aspx
(line   24) redirect  http://msdn.microsoft.com/en-us/library/windows/desktop/aa380374%28v=vs.85%29.aspx - permanently to https://msdn.microsoft.com/en-us/library/windows/desktop/aa380374(v=vs.85).aspx
(line   24) redirect  http://msdn.microsoft.com/en-us/library/dd945671%28v=office.12%29.aspx - permanently to https://msdn.microsoft.com/en-us/library/dd945671(v=office.12).aspx
writing output... [ 81%] reference/PSDraw                                                                                              
writing output... [ 84%] reference/PixelAccess                                                                                         
writing output... [ 86%] reference/PyAccess                                                                                            
writing output... [ 88%] reference/index                                                                                               
writing output... [ 90%] reference/plugins                                                                                             
(line   11) ok        https://code.google.com/p/casadebender/wiki/Win32IconImagePlugin
writing output... [ 93%] releasenotes/2.7.0                                                                                            
(line    7) ok        https://github.com/python-pillow/Sane
writing output... [ 95%] releasenotes/2.8.0                                                                                            
writing output... [ 97%] releasenotes/3.0.0                                                                                            
writing output... [100%] releasenotes/index                                                                                            

/Users/hugo/github/Pillow/docs/handbook/concepts.rst:27: WARNING: term not in glossary: mode
/Users/hugo/github/Pillow/docs/reference/ImageMath.rst:84: WARNING: unknown keyword: and
/Users/hugo/github/Pillow/docs/reference/ImageMath.rst:84: WARNING: unknown keyword: or
/Users/hugo/github/Pillow/docs/reference/ImageMath.rst:84: WARNING: unknown keyword: not
/Users/hugo/github/Pillow/docs/reference/ImageMath.rst:90: WARNING: unknown keyword: and
/Users/hugo/github/Pillow/docs/reference/ImageMath.rst:90: WARNING: unknown keyword: or
build finished with problems, 8 warnings.
make: *** [linkcheck] Error 1
```