### PR TITLE
Updated deprecated asserts

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -860,7 +860,10 @@ class TiffImageFile(ImageFile.ImageFile):
                 self.decoderconfig = (self.tag_v2[PREDICTOR],)
 
         if ICCPROFILE in self.tag_v2:
-            self.info['icc_profile'] = self.tag_v2[ICCPROFILE]
+            iccprofile = self.tag_v2[ICCPROFILE]
+            if len(iccprofile) == 1:
+                iccprofile = iccprofile[0]
+            self.info['icc_profile'] = iccprofile
 
         return args
 

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -154,7 +154,7 @@ class TestFileTiffMetadata(PillowTestCase):
 
         im.save(out)
         reloaded = Image.open(out)
-        self.assert_(type(im.info['icc_profile']) is not type(tuple))
+        self.assertNotIsInstance(im.info['icc_profile'], tuple)
         self.assertEqual(im.info['icc_profile'], reloaded.info['icc_profile'])
 
     def test_iccprofile_binary(self):


### PR DESCRIPTION
When running these tests, I get `DeprecationWarning: Please use assertTrue instead.`