### PR TITLE
Removed warnings check

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -2103,13 +2103,12 @@ def frombuffer(mode, size, data, decoder_name="raw", *args):
 
     if decoder_name == "raw":
         if args == ():
-            if warnings:
-                warnings.warn(
-                    "the frombuffer defaults may change in a future release; "
-                    "for portability, change the call to read:\n"
-                    "  frombuffer(mode, size, data, 'raw', mode, 0, 1)",
-                    RuntimeWarning, stacklevel=2
-                )
+            warnings.warn(
+                "the frombuffer defaults may change in a future release; "
+                "for portability, change the call to read:\n"
+                "  frombuffer(mode, size, data, 'raw', mode, 0, 1)",
+                RuntimeWarning, stacklevel=2
+            )
             args = mode, 0, -1  # may change to (mode, 0, 1) post-1.1.6
         if args[0] in _MAPMODES:
             im = new(mode, (1, 1))

--- a/PIL/ImageDraw.py
+++ b/PIL/ImageDraw.py
@@ -31,15 +31,10 @@
 #
 
 import numbers
+import warnings
 
 from PIL import Image, ImageColor
 from PIL._util import isStringType
-
-try:
-    import warnings
-except ImportError:
-    warnings = None
-
 
 ##
 # A simple 2D drawing interface for PIL images.
@@ -99,9 +94,8 @@ class ImageDraw(object):
                         "Please use keyword arguments instead.")
 
     def setfont(self, font):
-        if warnings:
-            warnings.warn("setfont() is deprecated. " +
-                          "Please set the attribute directly instead.")
+        warnings.warn("setfont() is deprecated. " +
+                      "Please set the attribute directly instead.")
         # compatibility
         self.font = font
 

--- a/PIL/ImageFont.py
+++ b/PIL/ImageFont.py
@@ -30,11 +30,6 @@ from PIL._util import isDirectory, isPath
 import os
 import sys
 
-try:
-    import warnings
-except ImportError:
-    warnings = None
-
 
 class _imagingft_not_installed(object):
     # module placeholder


### PR DESCRIPTION
Five files in the repository import `warnings`. Two of them check that there isn't an ImportError when doing so.

I'm not sure why there is a check, since it is a standard Python module as far as I can see. However, since three files work without it, I presume it is unnecessary.