### PR TITLE
Added null handler to loggers

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -28,7 +28,13 @@ from __future__ import print_function
 
 from PIL import VERSION, PILLOW_VERSION, _plugins
 
+import sys
 import logging
+if sys.version_info < (2, 7):
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+    logging.NullHandler = NullHandler
 import warnings
 
 logger = logging.getLogger(__name__)
@@ -112,7 +118,6 @@ from PIL._util import isStringType
 from PIL._util import deferred_error
 
 import os
-import sys
 import io
 import struct
 

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -32,6 +32,7 @@ import logging
 import warnings
 
 logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 class DecompressionBombWarning(RuntimeWarning):

--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -36,6 +36,8 @@ import sys
 import struct
 
 logger = logging.getLogger(__name__)
+if sys.version_info < (2, 7):
+    logging.NullHandler = Image.NullHandler
 logger.addHandler(logging.NullHandler())
 
 MAXBLOCK = 65536

--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -36,6 +36,7 @@ import sys
 import struct
 
 logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 MAXBLOCK = 65536
 

--- a/PIL/PcxImagePlugin.py
+++ b/PIL/PcxImagePlugin.py
@@ -27,10 +27,13 @@
 
 from __future__ import print_function
 
+import sys
 import logging
 from PIL import Image, ImageFile, ImagePalette, _binary
 
 logger = logging.getLogger(__name__)
+if sys.version_info < (2, 7):
+    logging.NullHandler = Image.NullHandler
 logger.addHandler(logging.NullHandler())
 
 i8 = _binary.i8

--- a/PIL/PcxImagePlugin.py
+++ b/PIL/PcxImagePlugin.py
@@ -31,6 +31,7 @@ import logging
 from PIL import Image, ImageFile, ImagePalette, _binary
 
 logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 i8 = _binary.i8
 i16 = _binary.i16le

--- a/PIL/PngImagePlugin.py
+++ b/PIL/PngImagePlugin.py
@@ -33,6 +33,7 @@
 
 from __future__ import print_function
 
+import sys
 import logging
 import re
 import zlib
@@ -42,6 +43,8 @@ from PIL import Image, ImageFile, ImagePalette, _binary
 __version__ = "0.9"
 
 logger = logging.getLogger(__name__)
+if sys.version_info < (2, 7):
+    logging.NullHandler = Image.NullHandler
 logger.addHandler(logging.NullHandler())
 
 i8 = _binary.i8

--- a/PIL/PngImagePlugin.py
+++ b/PIL/PngImagePlugin.py
@@ -42,6 +42,7 @@ from PIL import Image, ImageFile, ImagePalette, _binary
 __version__ = "0.9"
 
 logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 i8 = _binary.i8
 i16 = _binary.i16be

--- a/PIL/PyAccess.py
+++ b/PIL/PyAccess.py
@@ -29,6 +29,9 @@ from cffi import FFI
 
 
 logger = logging.getLogger(__name__)
+if sys.version_info < (2, 7):
+    from PIL import Image
+    logging.NullHandler = Image.NullHandler
 logger.addHandler(logging.NullHandler())
 
 

--- a/PIL/PyAccess.py
+++ b/PIL/PyAccess.py
@@ -29,6 +29,7 @@ from cffi import FFI
 
 
 logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 defs = """

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -3,6 +3,7 @@ from helper import unittest, PillowTestCase, hopper, py3
 
 from ctypes import c_float
 import io
+import sys
 import logging
 import itertools
 import os
@@ -10,6 +11,8 @@ import os
 from PIL import Image, TiffImagePlugin
 
 logger = logging.getLogger(__name__)
+if sys.version_info < (2, 7):
+    logging.NullHandler = Image.NullHandler
 logger.addHandler(logging.NullHandler())
 
 

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -10,6 +10,7 @@ import os
 from PIL import Image, TiffImagePlugin
 
 logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 class LibTiffTestCase(PillowTestCase):

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import sys
 import logging
 import struct
 
@@ -7,6 +8,8 @@ from helper import unittest, PillowTestCase, hopper, py3
 from PIL import Image, TiffImagePlugin
 
 logger = logging.getLogger(__name__)
+if sys.version_info < (2, 7):
+    logging.NullHandler = Image.NullHandler
 logger.addHandler(logging.NullHandler())
 
 

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -7,6 +7,7 @@ from helper import unittest, PillowTestCase, hopper, py3
 from PIL import Image, TiffImagePlugin
 
 logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 class TestFileTiff(PillowTestCase):


### PR DESCRIPTION
In Issue #1550, it is reported that Python 2 prints 'No handlers could be found for logger "PIL.ImageFile"'.

Looking at https://docs.python.org/3/howto/logging.html#what-happens-if-no-configuration-is-provided 'What happens if no configuration is provided' and 'Configuring Logging for a Library', it appears that the solution is to add a `NullHandler`.

@anntzer may have an opinion on this, since he wrote PR #1207 that added logging.