### PR TITLE
Allow saving RowsPerStrip with libtiff. 

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -1277,8 +1277,10 @@ def _save(im, fp, filename):
             except io.UnsupportedOperation:
                 pass
 
-        # ICC Profile crashes.
-        blocklist = [STRIPOFFSETS, STRIPBYTECOUNTS, ROWSPERSTRIP, ICCPROFILE]
+        # STRIPOFFSETS and STRIPBYTECOUNTS are added by the library
+        # based on the data in the strip.
+        # ICCPROFILE crashes.
+        blocklist = [STRIPOFFSETS, STRIPBYTECOUNTS, ICCPROFILE]
         atts = {}
         # bits per sample is a single short in the tiff directory, not a list.
         atts[BITSPERSAMPLE] = bits[0]

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -165,6 +165,13 @@ class TestFileLibTiff(LibTiffTestCase):
                         self.assertEqual(
                             val, value, msg="%s didn't roundtrip" % tag)
 
+            # https://github.com/python-pillow/Pillow/issues/1561
+            requested_fields = ['StripByteCounts',
+                                'RowsPerStrip',
+                                'StripOffsets']
+            for field in requested_fields:
+                self.assertTrue(field in reloaded, "%s not in metadata" %field)
+
     def test_g3_compression(self):
         i = Image.open('Tests/images/hopper_g4_500.tif')
         out = self.tempfile("temp.tif")


### PR DESCRIPTION
TiffImagePlugin incorrectly strips RowsPerStrip from the metadata prior to saving with libtiff. This fixes #1561.