### PR TITLE
Updated deprecated asserts

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -81,12 +81,12 @@ class TestFileTiff(PillowTestCase):
         im = Image.open(filename)
 
         # legacy api
-        self.assert_(isinstance(im.tag[X_RESOLUTION][0], tuple))
-        self.assert_(isinstance(im.tag[Y_RESOLUTION][0], tuple))
+        self.assertIsInstance(im.tag[X_RESOLUTION][0], tuple)
+        self.assertIsInstance(im.tag[Y_RESOLUTION][0], tuple)
 
         # v2 api
-        self.assert_(isinstance(im.tag_v2[X_RESOLUTION], float))
-        self.assert_(isinstance(im.tag_v2[Y_RESOLUTION], float))
+        self.assertIsInstance(im.tag_v2[X_RESOLUTION], float)
+        self.assertIsInstance(im.tag_v2[Y_RESOLUTION], float)
 
         self.assertEqual(im.info['dpi'], (72., 72.))
 

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -163,7 +163,7 @@ class TestFileTiffMetadata(PillowTestCase):
 
         im = Image.open('Tests/images/hopper.iccprofile_binary.tif')
         self.assertEqual(im.tag_v2.tagtype[34675], 1)
-        self.assert_(im.info['icc_profile'])
+        self.assertTrue(im.info['icc_profile'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When running these tests, I get `DeprecationWarning: Please use assertTrue instead.`

These are the changes from #1582 that pass without issue.