### PR TITLE
add include and library directories for freebsd

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -302,6 +302,10 @@ class pil_build_ext(build_ext):
         elif sys.platform.startswith("gnu"):
             self.add_multiarch_paths()
 
+        elif sys.platform.startswith("freebsd"):
+            _add_directory(library_dirs, "/usr/local/lib")
+            _add_directory(include_dirs, "/usr/local/include")
+
         elif sys.platform.startswith("netbsd"):
             _add_directory(library_dirs, "/usr/pkg/lib")
             _add_directory(include_dirs, "/usr/pkg/include")


### PR DESCRIPTION
The install was failing on FreeBSD because shared libraries and includes were not found.
On FreeBSD, shared libraries and includes are installed in `/usr/local/lib` and `/usr/local/include`.
The `libjpeg-turbo` files are in these directories but `setup.py` was not aware of this.
So the install was failing with the output:

    running install
    running bdist_egg
    running egg_info
    creating Pillow.egg-info
    writing Pillow.egg-info/PKG-INFO
    writing dependency_links to Pillow.egg-info/dependency_links.txt
    writing top-level names to Pillow.egg-info/top_level.txt
    writing manifest file 'Pillow.egg-info/SOURCES.txt'
    reading manifest file 'Pillow.egg-info/SOURCES.txt'
    reading manifest template 'MANIFEST.in'
    writing manifest file 'Pillow.egg-info/SOURCES.txt'
    installing library code to build/bdist.freebsd-10.2-RELEASE-p7-amd64/egg
    running install_lib
    running build_py
    creating build
    creating build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5
    creating build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/FitsStubImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/DcxImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/PcfFontFile.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageMath.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/XpmImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageStat.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/BufrStubImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/XVThumbImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/MicImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/GdImageFile.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/CurImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageChops.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/TarIO.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/WmfImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/SgiImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/GribStubImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/TiffImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/PaletteFile.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/WebPImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/SunImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/JpegPresets.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/TiffTags.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/XbmImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/EpsImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ExifTags.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageShow.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/OleFileIO.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/FontFile.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageEnhance.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/BdfFontFile.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/features.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ContainerIO.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/PyAccess.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/GifImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageTransform.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/_util.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/Image.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/McIdasImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/MpoImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageColor.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageDraw2.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageFont.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/BmpImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageCms.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/WalImageFile.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageDraw.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImagePath.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageFile.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/IcnsImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/PalmImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageMorph.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/IptcImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/MspImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/JpegImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/PdfImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageQt.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageSequence.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/__init__.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/IcoImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/_binary.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/GimpGradientFile.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageFilter.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/GbrImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageMode.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/PixarImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImagePalette.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/PngImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/FpxImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/SpiderImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/TgaImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/FliImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/Hdf5StubImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/PcdImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/Jpeg2KImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/MpegImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/PcxImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageGrab.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageOps.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/PpmImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageWin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/PsdImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImtImagePlugin.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/PSDraw.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/GimpPaletteFile.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/ImageTk.py -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    copying PIL/OleFileIO-README.md -> build/lib.freebsd-10.2-RELEASE-p7-amd64-3.5/PIL
    running build_ext
    Traceback (most recent call last):
      File "setup.py", line 763, in <module>
        zip_safe=not debug_build(),
      File "/usr/local/lib/python3.5/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/usr/local/lib/python3.5/distutils/dist.py", line 955, in run_commands
        self.run_command(cmd)
      File "/usr/local/lib/python3.5/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/usr/local/lib/python3.5/site-packages/setuptools/command/install.py", line 67, in run
        self.do_egg_install()
      File "/usr/local/lib/python3.5/site-packages/setuptools/command/install.py", line 109, in do_egg_install
        self.run_command('bdist_egg')
      File "/usr/local/lib/python3.5/distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/usr/local/lib/python3.5/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/usr/local/lib/python3.5/site-packages/setuptools/command/bdist_egg.py", line 160, in run
        cmd = self.call_command('install_lib', warn_dir=0)
      File "/usr/local/lib/python3.5/site-packages/setuptools/command/bdist_egg.py", line 146, in call_command
        self.run_command(cmdname)
      File "/usr/local/lib/python3.5/distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/usr/local/lib/python3.5/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/usr/local/lib/python3.5/site-packages/setuptools/command/install_lib.py", line 10, in run
        self.build()
      File "/usr/local/lib/python3.5/distutils/command/install_lib.py", line 107, in build
        self.run_command('build_ext')
      File "/usr/local/lib/python3.5/distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/usr/local/lib/python3.5/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/usr/local/lib/python3.5/distutils/command/build_ext.py", line 338, in run
        self.build_extensions()
      File "setup.py", line 512, in build_extensions
        (f, f))
    ValueError: jpeg is required unless explicitly disabled using --disable-jpeg, aborting

This fix adds the two directories using the `_add_directory` function when the system is FreeBSD.
Everything is working for me now on FreeBSD 10.2.
I get exactly the same output from nosetests when running the tests on Arch Linux with the original version, or on FreeBSD with my fix (the change doesn't add any error).
