### PR TITLE
Updated spacing to be consistent between multiline methods

### DIFF
--- a/PIL/ImageDraw.py
+++ b/PIL/ImageDraw.py
@@ -296,7 +296,7 @@ class ImageDraw(object):
             font = self.getfont()
         return font.getsize(text)
 
-    def multiline_textsize(self, text, font=None, spacing=0):
+    def multiline_textsize(self, text, font=None, spacing=4):
         max_width = 0
         lines = self._multiline_split(text)
         line_spacing = self.textsize('A', font=font)[1] + spacing


### PR DESCRIPTION
The default spacing for `multiline_text` was changed to 4 in PR #1574

This changes the default spacing for `multiline_textsize` to be consistent with that.