### PR TITLE
Fixing test failures on python 2.6/windows

### DIFF
--- a/Tests/test_image_getim.py
+++ b/Tests/test_image_getim.py
@@ -10,7 +10,14 @@ class TestImageGetIm(PillowTestCase):
         if py3:
             self.assertIn("PyCapsule", type_repr)
 
-        self.assertIsInstance(im.im.id, int)
+
+        try:
+            #py2.6
+            target_types = (int, long)
+        except:
+            target_types = (int)
+
+        self.assertIsInstance(im.im.id, target_types)
 
 
 if __name__ == '__main__':

--- a/Tests/test_image_getim.py
+++ b/Tests/test_image_getim.py
@@ -1,5 +1,5 @@
 from helper import unittest, PillowTestCase, hopper, py3
-
+import sys
 
 class TestImageGetIm(PillowTestCase):
 
@@ -11,10 +11,10 @@ class TestImageGetIm(PillowTestCase):
             self.assertIn("PyCapsule", type_repr)
 
 
-        try:
-            #py2.6
+        if sys.hexversion < 0x2070000:
+            # py2.6 x64, windows
             target_types = (int, long)
-        except:
+        else:
             target_types = (int)
 
         self.assertIsInstance(im.im.id, target_types)

--- a/Tests/test_imagewin_pointers.py
+++ b/Tests/test_imagewin_pointers.py
@@ -74,7 +74,7 @@ if sys.platform.startswith('win32'):
         memcpy(bp + bf.bfOffBits, pixels, bi.biSizeImage)
         try:
             return bytearray(buf)
-        except:
+        except ValueError:
             # py2.6
             return buffer(buf)[:]
 

--- a/Tests/test_imagewin_pointers.py
+++ b/Tests/test_imagewin_pointers.py
@@ -72,7 +72,11 @@ if sys.platform.startswith('win32'):
         memcpy(bp, ctypes.byref(bf), ctypes.sizeof(bf))
         memcpy(bp + ctypes.sizeof(bf), ctypes.byref(bi), bi.biSize)
         memcpy(bp + bf.bfOffBits, pixels, bi.biSizeImage)
-        return bytearray(buf)
+        try:
+            return bytearray(buf)
+        except:
+            # py2.6
+            return buffer(buf)[:]
 
     class TestImageWinPointers(PillowTestCase):
         def test_pointer(self):


### PR DESCRIPTION
These two tests now succeed on Py2.6 on Windows. 