### PR TITLE
Fix incorrect conditional

### DIFF
--- a/encode.c
+++ b/encode.c
@@ -54,7 +54,7 @@ PyImaging_EncoderNew(int contextsize)
     ImagingEncoderObject *encoder;
     void *context;
 
-    if(!PyType_Ready(&ImagingEncoderType) < 0)
+    if(PyType_Ready(&ImagingEncoderType) < 0)
         return NULL;
 
     encoder = PyObject_New(ImagingEncoderObject, &ImagingEncoderType);


### PR DESCRIPTION
The conditional

    (!PyType_Ready(&ImagingEncoderType) < 0)

will always be false. This commit fixes this, also silencing the compiler warning

    encode.c: In function 'PyImaging_EncoderNew':
    encode.c:57:43: warning: logical not is only applied to the left hand side of comparison [-Wlogical-not-parentheses]
         if(!PyType_Ready(&ImagingEncoderType) < 0)