### PR TITLE
Fixes uninitialized variable warning in _imaging.c:getink

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -875,6 +875,12 @@ class Image(object):
                     trns_im = Image()._new(core.new(self.mode, (1, 1)))
                     if self.mode == 'P':
                         trns_im.putpalette(self.palette)
+                        if type(t) == tuple:
+                            try:
+                                t = trns_im.palette.getcolor(t)
+                            except:
+                                raise ValueError("Couldn't allocate a palette "+
+                                                 "color for transparency")
                     trns_im.putpixel((0, 0), t)
 
                     if mode in ('L', 'RGB'):

--- a/_imaging.c
+++ b/_imaging.c
@@ -585,13 +585,14 @@ _fill(PyObject* self, PyObject* args)
     if (!im)
         return NULL;
 
+    buffer[0] = buffer[1] = buffer[2] = buffer[3] = 0;
     if (color) {
         if (!getink(color, im, buffer)) {
             ImagingDelete(im);
             return NULL;
         }
-    } else
-        buffer[0] = buffer[1] = buffer[2] = buffer[3] = 0;
+    }
+
 
     (void) ImagingFill(im, buffer);
 
@@ -1336,6 +1337,8 @@ _putdata(ImagingObject* self, PyObject* args)
                     char ink[4];
                     INT32 inkint;
                 } u;
+
+                u.inkint = 0;
 
                 op = PySequence_Fast_GET_ITEM(seq, i);
                 if (!op || !getink(op, image, u.ink)) {


### PR DESCRIPTION
We're getting a warning that we're using an uninitialized variable, and it appears that it can lead to logic errors, and it not, it's really confusing c code. 

* fixes the uninitialized variable issue
* Clarifies the flow of control in the getink method
* Fixes a case where we're passing a 3-tuple into putpixel in a 'P' mode image.

There are still some issues, as if we return NULL out of the function without setting a Python Exception, then we're going to cause an error higher up in the stack. 

