### PR TITLE
Fix documentation references

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
    reference/index.rst
    porting.rst
    about.rst
+   build.rst
    releasenotes/index.rst
 
 .. raw:: html

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -26,7 +26,6 @@ Reference
    ImageTk
    ImageWin
    ExifTags
-   TiffTags
    OleFileIO
    PSDraw
    PixelAccess


### PR DESCRIPTION
Fixes some docuemntation warnings -
- https://travis-ci.org/python-pillow/Pillow/jobs/102700434#L3267 - /home/travis/build/python-pillow/Pillow/docs/reference/index.rst:4: WARNING: toctree contains reference to nonexisting document 'reference/TiffTags'
- https://travis-ci.org/python-pillow/Pillow/jobs/102700434#L3270 - checking consistency... /home/travis/build/python-pillow/Pillow/docs/build.rst:: WARNING: document isn't included in any toctree