### PR TITLE
Improved alpha_composite documentation

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -2302,8 +2302,8 @@ def alpha_composite(im1, im2):
     """
     Alpha composite im2 over im1.
 
-    :param im1: The first image.
-    :param im2: The second image.  Must have the same mode and size as
+    :param im1: The first image. Must have mode RGBA.
+    :param im2: The second image.  Must have mode RGBA, and the same size as
        the first image.
     :returns: An :py:class:`~PIL.Image.Image` object.
     """


### PR DESCRIPTION
When calling `alpha_composite(im1, im2)`, both images must be of mode RGBA
- An error is thrown at https://github.com/python-pillow/Pillow/blob/master/libImaging/AlphaComposite.c#L36 if the mode of the first image is not RGBA.
- The modes of the two images must also match, or an error will be thrown at https://github.com/python-pillow/Pillow/blob/master/libImaging/AlphaComposite.c#L43

It is #1695 that points out that the documentation could be improved.