### PR TITLE
Corrected AppVeyor testing status documentation

### DIFF
--- a/winbuild/README.md
+++ b/winbuild/README.md
@@ -13,6 +13,6 @@ For more extensive info, see the windows build instructions `docs/build.rst`.
 * (in powershell) `build_deps.cmd` invokes the dependency build.
 * `python build.py --clean` makes Pillow for the matrix of Pythons.
 * `python test.py` runs the tests on Pillow in all the virtual envs.
-*  Currently working with zlib, libjpeg, freetype, and libtiff on Python 2.7, 3.3, and 3.4, both 32 and 64 bit, on a local win7 pro machine and appveyor.com (3.3 untested there)
+*  Currently working with zlib, libjpeg, freetype, and libtiff on Python 2.7, 3.3, and 3.4, both 32 and 64 bit, on a local win7 pro machine and appveyor.com
 * Webp is built, not detected.
 * LCMS and OpenJpeg are not building.


### PR DESCRIPTION
@wiredfool should feel free to correct me, but I would think that Python 3.3 is actually tested on AppVeyor.

The simplest explanation is that this documentation was written before 3.3 testing was setup there.