### PR TITLE
added instructions for Fedora 23

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -268,7 +268,10 @@ Prerequisites are installed on **Fedora 20** with::
     $ sudo yum install libtiff-devel libjpeg-devel libzip-devel freetype-devel \
         lcms2-devel libwebp-devel tcl-devel tk-devel
 
+Prerequisites are installed on **Fedora 23** with::
 
+    $ sudo dnf install libtiff-devel libjpeg-devel libzip-devel freetype-devel \
+        lcms2-devel libwebp-devel tcl-devel tk-devel redhat-rpm-config
 
 
 


### PR DESCRIPTION
Fedora has moved from `yum` to `dnf`, and I've found that the `redhat-rpm-config` package is required for Pillow to build.