### PR TITLE
Changed default frombuffer raw decoder args

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2592,13 +2592,6 @@ def frombuffer(mode, size, data, decoder_name="raw", *args):
 
     if decoder_name == "raw":
         if args == ():
-            warnings.warn(
-                "the frombuffer defaults will change in Pillow 7.0.0; "
-                "for portability, change the call to read:\n"
-                "  frombuffer(mode, size, data, 'raw', mode, 0, 1)",
-                RuntimeWarning,
-                stacklevel=2,
-            )
             args = mode, 0, 1
         if args[0] in _MAPMODES:
             im = new(mode, (1, 1))

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2599,7 +2599,7 @@ def frombuffer(mode, size, data, decoder_name="raw", *args):
                 RuntimeWarning,
                 stacklevel=2,
             )
-            args = mode, 0, -1  # may change to (mode, 0, 1) post-1.1.6
+            args = mode, 0, 1
         if args[0] in _MAPMODES:
             im = new(mode, (1, 1))
             im = im._new(core.map_buffer(data, size, decoder_name, None, 0, args))


### PR DESCRIPTION
The comment suggests changing the default values post 1.1.6, so that they are in line with the warning displayed to the user.

Sounds reasonable.
