### PR TITLE
Corrected documentation reference

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -95,7 +95,7 @@ except ImportError as v:
             RuntimeWarning
             )
     # Fail here anyway. Don't let people run with a mostly broken Pillow.
-    # see docs/porting-pil-to-pillow.rst
+    # see docs/porting.rst
     raise
 
 try:


### PR DESCRIPTION
Image.py has a comment - 'see docs/porting-pil-to-pillow.rst'

The filename is 'porting.rst'