### PR TITLE
SpiderImagePlugin: raise an error when seeking in a non-stack file

### DIFF
--- a/PIL/SpiderImagePlugin.py
+++ b/PIL/SpiderImagePlugin.py
@@ -173,7 +173,7 @@ class SpiderImageFile(ImageFile.ImageFile):
 
     def seek(self, frame):
         if self.istack == 0:
-            return
+            raise EOFError("attempt to seek in a non-stack file")
         if frame >= self._nimages:
             raise EOFError("attempt to seek past end of file")
         self.stkoffset = self.hdrlen + frame * (self.hdrlen + self.imgbytes)


### PR DESCRIPTION
Using ImageSequence.Iterator on a non-stack SPIDER image leads to infinite loop.
EOFError (which stops the iteration) is never raised because when the image isn't a stack,
seek() returns gently without error.