### PR TITLE
Round crop's arguments to nearest integers

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1941,7 +1941,9 @@ class _ImageCrop(Image):
 
         Image.__init__(self)
 
-        x0, y0, x1, y1 = box
+        # Round to nearest integer, runs int(round(x)) when unpacking
+        x0, y0, x1, y1 = map(int, map(round, box))
+
         if x1 < x0:
             x1 = x0
         if y1 < y0:

--- a/Tests/test_image_crop.py
+++ b/Tests/test_image_crop.py
@@ -52,6 +52,20 @@ class TestImageCrop(PillowTestCase):
         self.assertEqual(len(im.getdata()), 0)
         self.assertRaises(IndexError, lambda: im.getdata()[0])
 
+    def test_crop_float(self):
+        # Check cropping floats are rounded to nearest integer
+        # https://github.com/python-pillow/Pillow/issues/1744
+
+        # Arrange
+        im = Image.new("RGB", (10, 10))
+        self.assertEqual(im.size, (10, 10))
+
+        # Act
+        cropped = im.crop((0.9, 1.1, 4.2, 5.8))
+
+        # Assert
+        self.assertEqual(cropped.size, (3, 5))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Round the x0, y0, x1, y1 box arguments to the nearest integer before cropping. 

This is what ImageMagick does.

Fixes #1744.