### PR TITLE
Fixed bug when saving to a non-existent path using pathlib

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1636,7 +1636,7 @@ class Image(object):
         elif sys.version_info >= (3, 4):
             from pathlib import Path
             if isinstance(fp, Path):
-                filename = str(fp.resolve())
+                filename = str(fp)
                 open_fp = True
         elif hasattr(fp, "name") and isPath(fp.name):
             # only set the name for metadata purposes

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1,6 +1,7 @@
 from helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
+import os
 import sys
 
 
@@ -56,6 +57,11 @@ class TestImage(PillowTestCase):
         im = Image.open(Path("Tests/images/hopper.jpg"))
         self.assertEqual(im.mode, "RGB")
         self.assertEqual(im.size, (128, 128))
+
+        temp_file = self.tempfile("temp.jpg")
+        if os.path.exists(temp_file):
+            os.remove(temp_file)
+        im.save(Path(temp_file))
 
     def test_tempfile(self):
         # see #1460, pathlib support breaks tempfile.TemporaryFile on py27


### PR DESCRIPTION
Resolves #1747