### PR TITLE
Clarified documentation

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -110,4 +110,4 @@ Released as needed privately to individual vendors for critical security-related
 
 ## Documentation
 
-* [ ] Make sure the default version for Read the Docs is the latest release version e.g. 3.0.0 not latest: https://readthedocs.org/projects/pillow/versions/
+* [ ] Make sure the default version for Read the Docs is the latest release version, e.g. ``3.1.x`` rather than ``latest``: https://readthedocs.org/projects/pillow/versions/


### PR DESCRIPTION
I feel like this version is clearer.

Also, if the current 3.1.x branch is anything to go by, branches are typically named along the lines of 3.1.x, rather than 3.0.0.