### PR TITLE
Fix the error reported when libz is not found

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -510,7 +510,7 @@ class pil_build_ext(build_ext):
 
         for f in feature:
             if not getattr(feature, f) and feature.require(f):
-                if f in ('jpeg', 'libz'):
+                if f in ('jpeg', 'zlib'):
                     raise ValueError('%s is required unless explicitly disabled'
                                      ' using --disable-%s, aborting' %
                                      (f, f))


### PR DESCRIPTION
Sends the correct error when faced with a condition like #1763


Hard to test on travis -- but:
```
(vpy27)erics@builder-1204-x64:~/Pillow$ sudo mv /usr/include/zlib.h /usr/include/zlib.h-disabled
[sudo] password for erics: 
(vpy27)erics@builder-1204-x64:~/Pillow$ make clean && make install
python setup.py clean
running clean
removing 'build/temp.linux-x86_64-2.7' (and everything under it)
rm PIL/*.so || true
rm: cannot remove `PIL/*.so': No such file or directory
rm -r build || true
find . -name __pycache__ | xargs rm -r || true
rm: missing operand
Try `rm --help' for more information.
python setup.py build_ext install
running build_ext
Traceback (most recent call last):
  File "setup.py", line 768, in <module>
    zip_safe=not debug_build(),
  File "/usr/lib/python2.7/distutils/core.py", line 152, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/usr/lib/python2.7/distutils/command/build_ext.py", line 339, in run
    self.build_extensions()
  File "setup.py", line 516, in build_extensions
    (f, f))
ValueError: zlib is required unless explicitly disabled using --disable-zlib, aborting
make: *** [install] Error 1
```