### PR TITLE
adds option to ignore TCL/Tk framework installs on OS X

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -580,7 +580,8 @@ class pil_build_ext(build_ext):
                 "PIL._webp", ["_webp.c"], libraries=libs, define_macros=defs))
 
         if feature.tcl and feature.tk:
-            if sys.platform == "darwin":
+            if (sys.platform == "darwin" and
+                os.environ.get('IGNORE_OSX_TCLTK_FRAMEWORKS', False)==False):
                 # locate Tcl/Tk frameworks
                 frameworks = []
                 framework_roots = [


### PR DESCRIPTION
Fixes issue #950. Pillow's setup.py file incorrectly assumes if you are on OS X, you must link with a TCL/TK framework installation. Some OS X python installations (Anaconda, for example) provide their own TCL/TK installation, which results in segfaults when Pillow tries to load _imagingtk (usually observed with a call to PhotoImage). A simple mechanism is needed to instruct Pillow's setup.py file to not use the the TCL/TK Frameworks installations on OS X. This pull request provides an environment variable IGNORE_OSX_TCLTK_FRAMEWORKS which, if defined, allows setup.py to build against non-frameworks installations of TCL/TK.