### PR TITLE
Fix for integer overflow in path.c

### DIFF
--- a/Tests/test_imagepath.py
+++ b/Tests/test_imagepath.py
@@ -1,6 +1,6 @@
 from helper import unittest, PillowTestCase
 
-from PIL import ImagePath
+from PIL import ImagePath, Image
 
 import array
 import struct
@@ -69,18 +69,21 @@ class TestImagePath(PillowTestCase):
             
             # This fails due to the invalid malloc above,
             # and segfaults
-            for i in xrange(200000):
-                x[i] = "0"*16
+            for i in range(200000):
+                if str is bytes:
+                    x[i] = "0"*16
+                else:
+                    x[i] = b'0'*16
                 
         except MemoryError as msg:
             self.assertTrue(msg)
         except:
-            self.asserTrue(False, "Should have received a memory error")
+            self.assertTrue(False, "Should have received a memory error")
 
 
 class evil:
 	def __init__(self):
-		self.corrupt = ImagePath.Path(0x4000000000000000)
+		self.corrupt = Image.core.path(0x4000000000000000)
 
 	def __getitem__(self, i):
 		x = self.corrupt[i]

--- a/Tests/test_imagepath.py
+++ b/Tests/test_imagepath.py
@@ -74,7 +74,10 @@ class TestImagePath(PillowTestCase):
                     x[i] = "0"*16
                 else:
                     x[i] = b'0'*16
-                
+        except TypeError as msg:
+            # Some pythons fail getting the argument as an integer, and
+            # it falls through to the sequence. Seeing this on 32bit windows.
+            self.assertTrue(True, "Sequence required")
         except MemoryError as msg:
             self.assertTrue(msg)
         except:

--- a/path.c
+++ b/path.c
@@ -57,6 +57,10 @@ alloc_array(Py_ssize_t count)
         PyErr_NoMemory();
         return NULL;
     }
+    if (count > (SIZE_MAX / (2 * sizeof(double))) - 1 ) {
+        PyErr_NoMemory();
+        return NULL;
+    }
     xy = malloc(2 * count * sizeof(double) + 1);
     if (!xy)
         PyErr_NoMemory();


### PR DESCRIPTION
This issue was found by @nedwill .  Thanks for the notification and the test case. 

In all versions of Pillow and at least in PIL 1.1.7, there is a possibility for integer overflow in a malloc in path.c which can lead lead to memory corruption or a segfault. This does not appear to be a remote code execution bug, as this is triggered by python code, not a loaded image which would be attacker controlled. 

This patch checks the size calculation for overflow prior to the malloc, and returns a memory error if there is an overflow. 

ref #1715
