### PR TITLE
Allowed for wildcard paths in multiple platforms in pilfile script

### DIFF
--- a/Scripts/pilfile.py
+++ b/Scripts/pilfile.py
@@ -67,15 +67,13 @@ logging.basicConfig(level=logging_level)
 
 def globfix(files):
     # expand wildcards where necessary
-    if sys.platform == "win32":
-        out = []
-        for file in files:
-            if glob.has_magic(file):
-                out.extend(glob.glob(file))
-            else:
-                out.append(file)
-        return out
-    return files
+    out = []
+    for file in files:
+        if glob.has_magic(file):
+            out.extend(glob.glob(file))
+        else:
+            out.append(file)
+    return out
 
 for file in globfix(args):
     try:


### PR DESCRIPTION
I can't see any reason why this would be win32 only. If anyone knows, please just say.