### PR TITLE
SpiderImagePlugin: raise an error when seeking in a non-stack file

### DIFF
--- a/PIL/SpiderImagePlugin.py
+++ b/PIL/SpiderImagePlugin.py
@@ -173,7 +173,7 @@ class SpiderImageFile(ImageFile.ImageFile):
 
     def seek(self, frame):
         if self.istack == 0:
-            return
+            raise EOFError("attempt to seek in a non-stack file")
         if frame >= self._nimages:
             raise EOFError("attempt to seek past end of file")
         self.stkoffset = self.hdrlen + frame * (self.hdrlen + self.imgbytes)

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -1,6 +1,7 @@
 from helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
+from PIL import ImageSequence
 from PIL import SpiderImagePlugin
 
 TEST_FILE = "Tests/images/hopper.spider"
@@ -84,6 +85,17 @@ class TestImageSpider(PillowTestCase):
         invalid_file = "Tests/images/invalid.spider"
 
         self.assertRaises(IOError, lambda: Image.open(invalid_file))
+
+    def test_nonstack_file(self):
+        im = Image.open(TEST_FILE)
+
+        self.assertRaises(EOFError, lambda: im.seek(0))
+
+    def test_nonstack_dos(self):
+        im = Image.open(TEST_FILE)
+        for i, frame in enumerate(ImageSequence.Iterator(im)):
+            if i > 1:
+                self.fail("Non-stack DOS file test failed")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Copy of PR #1741, with a test added.

    Using ImageSequence.Iterator on a non-stack SPIDER image leads to infinite loop.
    EOFError (which stops the iteration) is never raised because when the image isn't
    a stack, seek() returns gently without error.