### PR TITLE
Valid range for baseline jpeg qtables 0 to 255

### DIFF
--- a/PIL/JpegImagePlugin.py
+++ b/PIL/JpegImagePlugin.py
@@ -640,7 +640,7 @@ def _save(im, fp, filename):
                 try:
                     if len(table) != 64:
                         raise
-                    table = array.array('b', table)
+                    table = array.array('B', table)
                 except TypeError:
                     raise ValueError("Invalid quantization table")
                 else:

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -315,7 +315,7 @@ class TestFileJpeg(PillowTestCase):
         self.assert_image_similar(im, self.roundtrip(im, qtables='keep'), 30)
 
         # valid bounds for baseline qtable
-        bounds_qtable = [int(s) for s in ("255 0 " * 32).split(None)]
+        bounds_qtable = [int(s) for s in ("255 1 " * 32).split(None)]
         self.roundtrip(im, qtables=[bounds_qtable])
 
         # values from wizard.txt in jpeg9-a src package.

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -314,6 +314,10 @@ class TestFileJpeg(PillowTestCase):
                                   30)
         self.assert_image_similar(im, self.roundtrip(im, qtables='keep'), 30)
 
+        # valid bounds for baseline qtable
+        bounds_qtable = [int(s) for s in ("255 0 " * 32).split(None)]
+        self.roundtrip(im, qtables=[bounds_qtable])
+
         # values from wizard.txt in jpeg9-a src package.
         standard_l_qtable = [int(s) for s in """
             16  11  10  16  24  40  51  61


### PR DESCRIPTION
 fixed issue from using signed char instead of unsigned char. added test