### PR TITLE
Fix the problem with icc_profile on tiff to png conversion

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -555,6 +555,10 @@ class ImageFileDirectory_v2(collections.MutableMapping):
             if legacy_api and self.tagtype[tag] in [5, 10]:
                 values = values,
             dest[tag], = values
+        elif tag == ICCPROFILE and self.tagtype[tag] == 7:
+            dest[tag], = values
+        elif tag == ICCPROFILE and self.tagtype[tag] == 1:
+            dest[tag] = bytes(values)
         else:
             dest[tag] = values
 


### PR DESCRIPTION
Taking care of special cases for icc_profile information to always return a bytes variable.