### PR TITLE
Removed unused test helper

### DIFF
--- a/Tests/test_file_iptc.py
+++ b/Tests/test_file_iptc.py
@@ -7,18 +7,6 @@ TEST_FILE = "Tests/images/iptc.jpg"
 
 class TestFileIptc(PillowTestCase):
 
-    # Helpers
-
-    def dummy_IptcImagePlugin(self):
-        # Create an IptcImagePlugin object without initializing it
-        class FakeImage(object):
-            pass
-        im = FakeImage()
-        im.__class__ = IptcImagePlugin.IptcImageFile
-        return im
-
-    # Tests
-
     def test_getiptcinfo_jpg_none(self):
         # Arrange
         im = hopper()


### PR DESCRIPTION
It was added as part of https://github.com/python-pillow/Pillow/pull/832/commits/4c5a5c1f0eddef0d384f18d46657c92e954b5075 on #832, but then removed as part of https://github.com/python-pillow/Pillow/pull/832/commits/a0aff1a87faa72373010d0e5c71667c7dcc34e19 on that same PR.