### PR TITLE
Fix Fedora prerequisites in installation docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -293,7 +293,7 @@ Prerequisites are installed on **Ubuntu 14.04 LTS** with::
 
 Prerequisites are installed on **Fedora 23** with::
 
-    $ sudo dnf install libtiff-devel libjpeg-devel libzip-devel freetype-devel \
+    $ sudo dnf install libtiff-devel libjpeg-devel zlib-devel freetype-devel \
         lcms2-devel libwebp-devel tcl-devel tk-devel
 
 


### PR DESCRIPTION
`zlib-devel` is needed, but not `libzip-devel`.