### PR TITLE
Added register_extensions method

### DIFF
--- a/PIL/EpsImagePlugin.py
+++ b/PIL/EpsImagePlugin.py
@@ -418,7 +418,6 @@ Image.register_open(EpsImageFile.format, EpsImageFile, _accept)
 
 Image.register_save(EpsImageFile.format, _save)
 
-Image.register_extension(EpsImageFile.format, ".ps")
-Image.register_extension(EpsImageFile.format, ".eps")
+Image.register_extensions(EpsImageFile.format, [".ps", ".eps"])
 
 Image.register_mime(EpsImageFile.format, "application/postscript")

--- a/PIL/FitsStubImagePlugin.py
+++ b/PIL/FitsStubImagePlugin.py
@@ -72,5 +72,4 @@ def _save(im, fp, filename):
 Image.register_open(FITSStubImageFile.format, FITSStubImageFile, _accept)
 Image.register_save(FITSStubImageFile.format, _save)
 
-Image.register_extension(FITSStubImageFile.format, ".fit")
-Image.register_extension(FITSStubImageFile.format, ".fits")
+Image.register_extensions(FITSStubImageFile.format, [".fit", ".fits"])

--- a/PIL/FliImagePlugin.py
+++ b/PIL/FliImagePlugin.py
@@ -162,5 +162,4 @@ class FliImageFile(ImageFile.ImageFile):
 
 Image.register_open(FliImageFile.format, FliImageFile, _accept)
 
-Image.register_extension(FliImageFile.format, ".fli")
-Image.register_extension(FliImageFile.format, ".flc")
+Image.register_extensions(FliImageFile.format, [".fli", ".flc"])

--- a/PIL/FtexImagePlugin.py
+++ b/PIL/FtexImagePlugin.py
@@ -91,5 +91,4 @@ def _validate(prefix):
 
 
 Image.register_open(FtexImageFile.format, FtexImageFile, _validate)
-Image.register_extension(FtexImageFile.format, ".ftc")
-Image.register_extension(FtexImageFile.format, ".ftu")
+Image.register_extensions(FtexImageFile.format, [".ftc", ".ftu"])

--- a/PIL/Hdf5StubImagePlugin.py
+++ b/PIL/Hdf5StubImagePlugin.py
@@ -69,5 +69,4 @@ def _save(im, fp, filename):
 Image.register_open(HDF5StubImageFile.format, HDF5StubImageFile, _accept)
 Image.register_save(HDF5StubImageFile.format, _save)
 
-Image.register_extension(HDF5StubImageFile.format, ".h5")
-Image.register_extension(HDF5StubImageFile.format, ".hdf")
+Image.register_extensions(HDF5StubImageFile.format, [".h5", ".hdf"])

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -2728,6 +2728,16 @@ def register_extension(id, extension):
     """
     EXTENSION[extension.lower()] = id.upper()
 
+def register_extensions(id, extensions):
+    """
+    Registers image extensions.  This function should not be
+    used in application code.
+
+    :param id: An image format identifier.
+    :param extensions: A list of extensions used for this format.
+    """
+    for extension in extensions:
+        register_extension(id, extension)
 
 def registered_extensions():
     """

--- a/PIL/Jpeg2KImagePlugin.py
+++ b/PIL/Jpeg2KImagePlugin.py
@@ -269,12 +269,7 @@ def _save(im, fp, filename):
 Image.register_open(Jpeg2KImageFile.format, Jpeg2KImageFile, _accept)
 Image.register_save(Jpeg2KImageFile.format, _save)
 
-Image.register_extension(Jpeg2KImageFile.format, '.jp2')
-Image.register_extension(Jpeg2KImageFile.format, '.j2k')
-Image.register_extension(Jpeg2KImageFile.format, '.jpc')
-Image.register_extension(Jpeg2KImageFile.format, '.jpf')
-Image.register_extension(Jpeg2KImageFile.format, '.jpx')
-Image.register_extension(Jpeg2KImageFile.format, '.j2c')
+Image.register_extensions(Jpeg2KImageFile.format, [".jp2", ".j2k", ".jpc", ".jpf", ".jpx", ".j2c"])
 
 Image.register_mime(Jpeg2KImageFile.format, 'image/jp2')
 Image.register_mime(Jpeg2KImageFile.format, 'image/jpx')

--- a/PIL/JpegImagePlugin.py
+++ b/PIL/JpegImagePlugin.py
@@ -783,9 +783,6 @@ def jpeg_factory(fp=None, filename=None):
 Image.register_open(JpegImageFile.format, jpeg_factory, _accept)
 Image.register_save(JpegImageFile.format, _save)
 
-Image.register_extension(JpegImageFile.format, ".jfif")
-Image.register_extension(JpegImageFile.format, ".jpe")
-Image.register_extension(JpegImageFile.format, ".jpg")
-Image.register_extension(JpegImageFile.format, ".jpeg")
+Image.register_extensions(JpegImageFile.format, [".jfif", ".jpe", ".jpg", ".jpeg"])
 
 Image.register_mime(JpegImageFile.format, "image/jpeg")

--- a/PIL/MpegImagePlugin.py
+++ b/PIL/MpegImagePlugin.py
@@ -80,7 +80,6 @@ class MpegImageFile(ImageFile.ImageFile):
 
 Image.register_open(MpegImageFile.format, MpegImageFile)
 
-Image.register_extension(MpegImageFile.format, ".mpg")
-Image.register_extension(MpegImageFile.format, ".mpeg")
+Image.register_extensions(MpegImageFile.format, [".mpg", ".mpeg"])
 
 Image.register_mime(MpegImageFile.format, "video/mpeg")

--- a/PIL/PpmImagePlugin.py
+++ b/PIL/PpmImagePlugin.py
@@ -164,6 +164,4 @@ def _save(im, fp, filename):
 Image.register_open(PpmImageFile.format, PpmImageFile, _accept)
 Image.register_save(PpmImageFile.format, _save)
 
-Image.register_extension(PpmImageFile.format, ".pbm")
-Image.register_extension(PpmImageFile.format, ".pgm")
-Image.register_extension(PpmImageFile.format, ".ppm")
+Image.register_extensions(PpmImageFile.format, [".pbm", ".pgm", ".ppm"])

--- a/PIL/SgiImagePlugin.py
+++ b/PIL/SgiImagePlugin.py
@@ -149,9 +149,7 @@ Image.register_open(SgiImageFile.format, SgiImageFile, _accept)
 Image.register_save(SgiImageFile.format, _save)
 Image.register_mime(SgiImageFile.format, "image/sgi")
 Image.register_mime(SgiImageFile.format, "image/rgb")
-Image.register_extension(SgiImageFile.format, ".bw")
-Image.register_extension(SgiImageFile.format, ".rgb")
-Image.register_extension(SgiImageFile.format, ".rgba")
-Image.register_extension(SgiImageFile.format, ".sgi")
+
+Image.register_extensions(SgiImageFile.format, [".bw", ".rgb", ".rgba", ".sgi"])
 
 # End of file

--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -1792,7 +1792,6 @@ Image.register_open(TiffImageFile.format, TiffImageFile, _accept)
 Image.register_save(TiffImageFile.format, _save)
 Image.register_save_all(TiffImageFile.format, _save_all)
 
-Image.register_extension(TiffImageFile.format, ".tif")
-Image.register_extension(TiffImageFile.format, ".tiff")
+Image.register_extensions(TiffImageFile.format, [".tif", ".tiff"])
 
 Image.register_mime(TiffImageFile.format, "image/tiff")

--- a/PIL/WmfImagePlugin.py
+++ b/PIL/WmfImagePlugin.py
@@ -164,5 +164,4 @@ def _save(im, fp, filename):
 Image.register_open(WmfStubImageFile.format, WmfStubImageFile, _accept)
 Image.register_save(WmfStubImageFile.format, _save)
 
-Image.register_extension(WmfStubImageFile.format, ".wmf")
-Image.register_extension(WmfStubImageFile.format, ".emf")
+Image.register_extensions(WmfStubImageFile.format, [".wmf", ".emf"])

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -459,6 +459,22 @@ class TestImage(PillowTestCase):
             target = Image.open(target_file).convert(mode)
             self.assert_image_equal(im, target)
 
+    def test_register_extensions(self):
+        test_format = "a"
+        exts = ["b", "c"]
+        for ext in exts:
+            Image.register_extension(test_format, ext)
+        ext_individual = Image.EXTENSION.copy()
+        for ext in exts:
+            del Image.EXTENSION[ext]
+
+        Image.register_extensions(test_format, exts)
+        ext_multiple = Image.EXTENSION.copy()
+        for ext in exts:
+            del Image.EXTENSION[ext]
+
+        self.assertEqual(ext_individual, ext_multiple)
+
     def test_remap_palette(self):
         # Test illegal image mode
         im = hopper()
@@ -467,7 +483,7 @@ class TestImage(PillowTestCase):
 
     def test__new(self):
         from PIL import ImagePalette
-        
+
         im = hopper('RGB')
         im_p = hopper('P')
 
@@ -475,7 +491,7 @@ class TestImage(PillowTestCase):
         blank_pa = Image.new('PA', (10,10))
         blank_p.palette = None
         blank_pa.palette = None
-        
+
         def _make_new(base_image, im, palette_result=None):
             new_im = base_image._new(im)
             self.assertEqual(new_im.mode, im.mode)
@@ -485,12 +501,12 @@ class TestImage(PillowTestCase):
                 self.assertEqual(new_im.palette.tobytes(), palette_result.tobytes())
             else:
                 self.assertEqual(new_im.palette, None)
-            
+
         _make_new(im, im_p, im_p.palette)
         _make_new(im_p, im, None)
         _make_new(im, blank_p, ImagePalette.ImagePalette())
         _make_new(im, blank_pa, ImagePalette.ImagePalette())
-        
+
 
 class MockEncoder(object):
     pass


### PR DESCRIPTION
Rather than having multiple calls to `register_extension` from the same image plugins, I suggest a `register_extensions` method.
