### PR TITLE
Deprecated function will no longer raise "Exception" but "NotImplementedError".

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -695,7 +695,7 @@ class Image(object):
         return b"".join(data)
 
     def tostring(self, *args, **kw):
-        raise Exception("tostring() has been removed. " +
+        raise NotImplementedError("tostring() has been removed. " +
                         "Please call tobytes() instead.")
 
     def tobitmap(self, name="image"):
@@ -746,7 +746,7 @@ class Image(object):
             raise ValueError("cannot decode image data")
 
     def fromstring(self, *args, **kw):
-        raise Exception("fromstring() has been removed. " +
+        raise NotImplementedError("fromstring() has been removed. " +
                         "Please call frombytes() instead.")
 
     def load(self):
@@ -1254,7 +1254,7 @@ class Image(object):
         return self.im.histogram()
 
     def offset(self, xoffset, yoffset=None):
-        raise Exception("offset() has been removed. " +
+        raise NotImplementedError("offset() has been removed. " +
                         "Please call ImageChops.offset() instead.")
 
     def paste(self, im, box=None, mask=None):
@@ -2073,7 +2073,7 @@ def frombytes(mode, size, data, decoder_name="raw", *args):
 
 
 def fromstring(*args, **kw):
-    raise Exception("fromstring() has been removed. " +
+    raise NotImplementedError("fromstring() has been removed. " +
                     "Please call frombytes() instead.")
 
 


### PR DESCRIPTION
In the file Image.py.
This will not affect users who already catch the "Exception" type since it is a base class of "NotImplementedError".