### PR TITLE
Make ImageFile load images in read-only mode

### DIFF
--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -163,10 +163,9 @@ class ImageFile(Image.Image):
                     else:
                         # use mmap, if possible
                         import mmap
-                        fp = open(self.filename, "r+")
+                        fp = open(self.filename, "r")
                         size = os.path.getsize(self.filename)
-                        # FIXME: on Unix, use PROT_READ etc
-                        self.map = mmap.mmap(fp.fileno(), size)
+                        self.map = mmap.mmap(fp.fileno(), size, access=mmap.ACCESS_READ)
                         self.im = Image.core.map_buffer(
                             self.map, self.size, d, e, o, a
                             )


### PR DESCRIPTION
Hello, here's a pull request to mmap images in read-only mode. I tested it on linux, but the patch is cross-platform. BTW, my use case was an infinite loop caused by using PIL with inotify. I monitored new images with inotify CLOSE_WRITE event, then opened it with PIL. Since PIL opened the image in write mode, I received another CLOSE_WRITE event.

The code path for mmapped files unnecessarily loaded images in
read-write mode and had a long standing FIXME message. This patch
uses mmap.ACCESS_READ, which is platform independent to fix this
issue.