### PR TITLE
Update to RTD.io links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Bug fixes, feature additions, tests, documentation and more can be contributed v
 
 ## Bug fixes, feature additions, etc.
 
-Please send a pull request to the master branch. Please include [documentation](http://pillow.readthedocs.org) and [tests](Tests/README.rst) for new features. Tests or documentation without bug fixes or feature additions are welcome too. Feel free to ask questions [via issues](https://github.com/python-pillow/Pillow/issues/new) or irc://irc.freenode.net#pil
+Please send a pull request to the master branch. Please include [documentation](https://pillow.readthedocs.io) and [tests](Tests/README.rst) for new features. Tests or documentation without bug fixes or feature additions are welcome too. Feel free to ask questions [via issues](https://github.com/python-pillow/Pillow/issues/new) or irc://irc.freenode.net#pil
 
 - Fork the Pillow repository.
 - Create a branch from master.

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
       - |zenodo| |version| |downloads|
 
 .. |docs| image:: https://readthedocs.org/projects/pillow/badge/?version=latest
-   :target: http://pillow.readthedocs.org/?badge=latest
+   :target: https://pillow.readthedocs.io/?badge=latest
    :alt: Documentation Status
 
 .. |linux| image:: https://img.shields.io/travis/python-pillow/Pillow/master.svg?label=Linux%20build
@@ -60,10 +60,10 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
 More Information
 ----------------
 
-- `Documentation <https://pillow.readthedocs.org/>`_
+- `Documentation <https://pillow.readthedocs.io/>`_
 
-  - `Installation <https://pillow.readthedocs.org/en/latest/installation.html>`_
-  - `Handbook <https://pillow.readthedocs.org/en/latest/handbook/index.html>`_
+  - `Installation <https://pillow.readthedocs.io/en/latest/installation.html>`_
+  - `Handbook <https://pillow.readthedocs.io/en/latest/handbook/index.html>`_
 
 - `Contribute <https://github.com/python-pillow/Pillow/blob/master/.github/CONTRIBUTING.md>`_
 

--- a/Tests/test_psdraw.py
+++ b/Tests/test_psdraw.py
@@ -31,7 +31,7 @@ class TestPsDraw(PillowTestCase):
     def test_draw_postscript(self):
 
         # Based on Pillow tutorial, but there is no textsize:
-        # http://pillow.readthedocs.org/en/latest/handbook/tutorial.html
+        # https://pillow.readthedocs.io/en/latest/handbook/tutorial.html
 
         # Arrange
         tempfile = self.tempfile('temp.ps')

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
    :target: https://zenodo.org/badge/latestdoi/17549/python-pillow/Pillow
 
 .. image:: https://readthedocs.org/projects/pillow/badge/?version=latest
-   :target: http://pillow.readthedocs.org/?badge=latest
+   :target: https://pillow.readthedocs.io/?badge=latest
    :alt: Documentation Status
 
 .. image:: https://travis-ci.org/python-pillow/Pillow.svg?branch=master

--- a/setup.py
+++ b/setup.py
@@ -734,7 +734,7 @@ class pil_build_ext(build_ext):
         if not all:
             print("To add a missing option, make sure you have the required")
             print("library and headers.")
-            print("See https://pillow.readthedocs.org/en/latest/installation.html#building-from-source")
+            print("See https://pillow.readthedocs.io/en/latest/installation.html#building-from-source")
             print("")
 
         print("To check the build, run the selftest.py script.")


### PR DESCRIPTION
https://blog.readthedocs.com/securing-subdomains/

> **Securing Subdomains** 

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

> Changes to provide security against broader threats have been in place for a while, however there are still a few scenarios that can only be addressed by migrating to a separate domain.

> We implemented session hijacking detection and took precautions to limit cookie usage, but there are still a number of scenarios utilizing XSS and CSRF attacks that we aren’t able to protect against while hosting documentation from subdomains on the readthedocs.org domain. Moving documentation hosting to a separate domain will provide more complete isolation between the two user interfaces.

> Projects will automatically be redirected, and this redirect will remain in place for the foreseeable future. Still, you should plan on updating links to your documentation after the new domain goes live.

> If you notice any problems with the changes, feel free to open an issue on our issue tracker: http://github.com/rtfd/readthedocs.org/issues. If you do notice any security issues, contact us at security@readthedocs.org with more information.

> Keep on documenting, The Read the Docs Team