### PR TITLE
Fixed point integer resample

### DIFF
--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -150,5 +150,22 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
             self.make_sample(data, (12, 12)))
 
 
+class CoreResampleConsistencyTest(PillowTestCase):
+
+    def test_8u(self):
+        im = Image.new('RGB', (512, 9), (0, 64, 255))
+        im = im.resize((9, 512), Image.LANCZOS)
+        r, g, b = im.split()
+
+        for channel, color in [(r, 0), (g, 64), (b, 255)]:
+            px = channel.load()
+            for x in range(channel.size[0]):
+                for y in range(channel.size[1]):
+                    if px[x, y] != color:
+                        message = "{} != {} for pixel {}".format(
+                            px[x, y], color, (x, y))
+                        self.assertEqual(px[x, y], color, message)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -151,7 +151,6 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
 
 
 class CoreResampleConsistencyTest(PillowTestCase):
-
     def make_case(self, mode, fill):
         im = Image.new(mode, (512, 9), fill)
         return (im.resize((9, 512), Image.LANCZOS), im.load()[0, 0])

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -172,6 +172,7 @@ class CoreResampleConsistencyTest(PillowTestCase):
         self.run_case((r, color[0]))
         self.run_case((g, color[1]))
         self.run_case((b, color[2]))
+        self.run_case(self.make_case('L', 12))
 
     def test_32i(self):
         self.run_case(self.make_case('I', 12))

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -156,35 +156,34 @@ class CoreResampleConsistencyTest(PillowTestCase):
         im = Image.new(mode, (512, 9), fill)
         return (im.resize((9, 512), Image.LANCZOS), im.load()[0, 0])
 
-    def run_cases(self, cases):
-        for channel, color in cases:
-            px = channel.load()
-            for x in range(channel.size[0]):
-                for y in range(channel.size[1]):
-                    if px[x, y] != color:
-                        message = "{} != {} for pixel {}".format(
-                            px[x, y], color, (x, y))
-                        self.assertEqual(px[x, y], color, message)
+    def run_case(self, case):
+        channel, color = case
+        px = channel.load()
+        for x in range(channel.size[0]):
+            for y in range(channel.size[1]):
+                if px[x, y] != color:
+                    message = "{} != {} for pixel {}".format(
+                        px[x, y], color, (x, y))
+                    self.assertEqual(px[x, y], color, message)
 
     def test_8u(self):
         im, color = self.make_case('RGB', (0, 64, 255))
-        self.run_cases(zip(im.split(), color))
+        r, g, b = im.split()
+        self.run_case((r, color[0]))
+        self.run_case((g, color[1]))
+        self.run_case((b, color[2]))
 
     def test_32i(self):
-        self.run_cases([
-            self.make_case('I', 12),
-            self.make_case('I', 0x7fffffff),
-            self.make_case('I', -12),
-            self.make_case('I', -1 << 31),
-        ])
+        self.run_case(self.make_case('I', 12))
+        self.run_case(self.make_case('I', 0x7fffffff))
+        self.run_case(self.make_case('I', -12))
+        self.run_case(self.make_case('I', -1 << 31))
 
     def test_32f(self):
-        self.run_cases([
-            self.make_case('F', 1),
-            self.make_case('F', 3.40282306074e+38),
-            self.make_case('F', 1.175494e-38),
-            self.make_case('F', 1.192093e-07),
-        ])
+        self.run_case(self.make_case('F', 1))
+        self.run_case(self.make_case('F', 3.40282306074e+38))
+        self.run_case(self.make_case('F', 1.175494e-38))
+        self.run_case(self.make_case('F', 1.192093e-07))
 
 
 if __name__ == '__main__':

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -7,11 +7,11 @@
 
 
 struct filter {
-    float (*filter)(float x);
-    float support;
+    double (*filter)(double x);
+    double support;
 };
 
-static inline float sinc_filter(float x)
+static inline double sinc_filter(double x)
 {
     if (x == 0.0)
         return 1.0;
@@ -19,7 +19,7 @@ static inline float sinc_filter(float x)
     return sin(x) / x;
 }
 
-static inline float lanczos_filter(float x)
+static inline double lanczos_filter(double x)
 {
     /* truncated sinc */
     if (-3.0 <= x && x < 3.0)
@@ -27,7 +27,7 @@ static inline float lanczos_filter(float x)
     return 0.0;
 }
 
-static inline float bilinear_filter(float x)
+static inline double bilinear_filter(double x)
 {
     if (x < 0.0)
         x = -x;
@@ -36,7 +36,7 @@ static inline float bilinear_filter(float x)
     return 0.0;
 }
 
-static inline float bicubic_filter(float x)
+static inline double bicubic_filter(double x)
 {
     /* https://en.wikipedia.org/wiki/Bicubic_interpolation#Bicubic_convolution_algorithm */
 #define a -0.5
@@ -83,7 +83,7 @@ ImagingPrecompute(int inSize, int outSize, struct filter *filterp,
     double *kk, *k;
 
     /* prepare for horizontal stretch */
-    filterscale = scale = (float) inSize / outSize;
+    filterscale = scale = (double) inSize / outSize;
     if (filterscale < 1.0) {
         filterscale = 1.0;
     }

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -318,10 +318,10 @@ ImagingResampleHorizontal_32bpc(Imaging imIn, int xsize, struct filter *filterp)
 
     ImagingSectionEnter(&cookie);
     /* horizontal stretch */
-    for (yy = 0; yy < imOut->ysize; yy++) {
-        switch(imIn->type) {
-            case IMAGING_TYPE_INT32:
-                /* 32-bit integer */
+    
+    switch(imIn->type) {
+        case IMAGING_TYPE_INT32:
+            for (yy = 0; yy < imOut->ysize; yy++) {
                 for (xx = 0; xx < xsize; xx++) {
                     xmin = xbounds[xx * 2 + 0];
                     xmax = xbounds[xx * 2 + 1];
@@ -331,9 +331,11 @@ ImagingResampleHorizontal_32bpc(Imaging imIn, int xsize, struct filter *filterp)
                         ss += IMAGING_PIXEL_I(imIn, x, yy) * k[x - xmin];
                     IMAGING_PIXEL_I(imOut, xx, yy) = lround(ss);
                 }
-                break;
-            case IMAGING_TYPE_FLOAT32:
-                /* 32-bit float */
+            }
+            break;
+            
+        case IMAGING_TYPE_FLOAT32:
+            for (yy = 0; yy < imOut->ysize; yy++) {
                 for (xx = 0; xx < xsize; xx++) {
                     xmin = xbounds[xx * 2 + 0];
                     xmax = xbounds[xx * 2 + 1];
@@ -343,8 +345,8 @@ ImagingResampleHorizontal_32bpc(Imaging imIn, int xsize, struct filter *filterp)
                         ss += IMAGING_PIXEL_F(imIn, x, yy) * k[x - xmin];
                     IMAGING_PIXEL_F(imOut, xx, yy) = ss;
                 }
-                break;
-        }
+            }
+            break;
     }
     ImagingSectionLeave(&cookie);
     free(kk);

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -2,6 +2,10 @@
 
 #include <math.h>
 
+
+#define ROUND_UP(f) ((int) ((f) >= 0.0 ? (f) + 0.5F : (f) - 0.5F))
+
+
 struct filter {
     float (*filter)(float x);
     float support;
@@ -288,7 +292,7 @@ ImagingResampleHorizontal_32bpc(Imaging imIn, int xsize, struct filter *filterp)
                     ss = 0.0;
                     for (x = xmin; x < xmax; x++)
                         ss += IMAGING_PIXEL_I(imIn, x, yy) * k[x - xmin];
-                    IMAGING_PIXEL_I(imOut, xx, yy) = lround(ss);
+                    IMAGING_PIXEL_I(imOut, xx, yy) = ROUND_UP(ss);
                 }
             }
             break;

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -107,15 +107,12 @@ ImagingResampleHorizontal(Imaging imIn, int xsize, struct filter *filterp)
 
     /* prepare for horizontal stretch */
     filterscale = scale = (float) imIn->xsize / xsize;
-
-    /* determine support size (length of resampling filter) */
-    support = filterp->support;
-
     if (filterscale < 1.0) {
         filterscale = 1.0;
     }
 
-    support = support * filterscale;
+    /* determine support size (length of resampling filter) */
+    support = filterp->support * filterscale;
 
     /* maximum number of coofs */
     kmax = (int) ceil(support) * 2 + 1;

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -139,20 +139,16 @@ ImagingResampleHorizontal(Imaging imIn, int xsize, int filter)
     kmax = (int) ceil(support) * 2 + 1;
 
     // check for overflow
-    if (kmax > 0 && xsize > SIZE_MAX / kmax)
+    if (xsize > SIZE_MAX / (kmax * sizeof(float)))
         return (Imaging) ImagingError_MemoryError();
 
-    // sizeof(float) should be greater than 0
-    if (xsize * kmax > SIZE_MAX / sizeof(float))
+    // sizeof(int) should be greater than 0 as well
+    if (xsize > SIZE_MAX / (2 * sizeof(int)))
         return (Imaging) ImagingError_MemoryError();
 
     /* coefficient buffer */
     kk = malloc(xsize * kmax * sizeof(float));
     if ( ! kk)
-        return (Imaging) ImagingError_MemoryError();
-
-    // sizeof(int) should be greater than 0 as well
-    if (xsize > SIZE_MAX / (2 * sizeof(int)))
         return (Imaging) ImagingError_MemoryError();
 
     xbounds = malloc(xsize * 2 * sizeof(int));

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -103,11 +103,11 @@ ImagingPrecompute(int inSize, int outSize, struct filter *filterp,
         return 0;
 
     /* coefficient buffer */
-    kk = malloc(outSize * kmax * sizeof(double));
+    kk = calloc(outSize * kmax, sizeof(double));
     if ( ! kk)
         return 0;
 
-    xbounds = malloc(outSize * 2 * sizeof(int));
+    xbounds = calloc(outSize * 2, sizeof(int));
     if ( ! xbounds) {
         free(kk);
         return 0;
@@ -159,20 +159,15 @@ ImagingResampleHorizontal_8bpc(Imaging imIn, int xsize, struct filter *filterp)
         return (Imaging) ImagingError_MemoryError();
     }
     
-    kk = malloc(xsize * kmax * sizeof(int));
+    kk = calloc(xsize * kmax, sizeof(int));
     if ( ! kk) {
         free(xbounds);
         free(prekk);
         return (Imaging) ImagingError_MemoryError();
     }
 
-    for (xx = 0; xx < xsize; xx++) {
-        xmin = xbounds[xx * 2 + 0];
-        xmax = xbounds[xx * 2 + 1];
-        k = &kk[xx * kmax];
-        for (x = 0; x < xmax - xmin; x++) {
-            k[x] = (int) floor(0.5 + prekk[xx * kmax + x] * (1 << PRECISION_BITS));
-        }
+    for (x = 0; x < xsize * kmax; x++) {
+        kk[x] = (int) (0.5 + prekk[x] * (1 << PRECISION_BITS));
     }
 
     free(prekk);

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -326,7 +326,9 @@ ImagingResample(Imaging imIn, int xsize, int ysize, int filter)
     if (strcmp(imIn->mode, "P") == 0 || strcmp(imIn->mode, "1") == 0)
         return (Imaging) ImagingError_ModeError();
 
-    if (imIn->image8) {
+    if (imIn->type == IMAGING_TYPE_SPECIAL) {
+        return (Imaging) ImagingError_ModeError();
+    } else if (imIn->image8) {
         ResampleHorizontal = ImagingResampleHorizontal_8bpc;
     } else {
         switch(imIn->type) {

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -85,7 +85,7 @@ static inline UINT8 clip8(int in)
 
 
 Imaging
-ImagingResampleHorizontal(Imaging imIn, int xsize, struct filter *filterp)
+ImagingResampleHorizontal_8bpc(Imaging imIn, int xsize, struct filter *filterp)
 {
     ImagingSectionCookie cookie;
     Imaging imOut;
@@ -183,57 +183,140 @@ ImagingResampleHorizontal(Imaging imIn, int xsize, struct filter *filterp)
                     ss0 += ((UINT8) imIn->image8[yy][x]) * k[x - xmin];
                 imOut->image8[yy][xx] = clip8(ss0);
             }
-        } else {
-            switch(imIn->type) {
-            case IMAGING_TYPE_UINT8:
-                /* n-bit grayscale */
-                if (imIn->bands == 2) {
-                    for (xx = 0; xx < xsize; xx++) {
-                        xmin = xbounds[xx * 2 + 0];
-                        xmax = xbounds[xx * 2 + 1];
-                        k = &kk[xx * kmax];
-                        ss0 = ss1 = 1 << (PRECISION_BITS -1);
-                        for (x = xmin; x < xmax; x++) {
-                            ss0 += ((UINT8) imIn->image[yy][x*4 + 0]) * k[x - xmin];
-                            ss1 += ((UINT8) imIn->image[yy][x*4 + 3]) * k[x - xmin];
-                        }
-                        imOut->image[yy][xx*4 + 0] = clip8(ss0);
-                        imOut->image[yy][xx*4 + 3] = clip8(ss1);
+        } else if (imIn->type == IMAGING_TYPE_UINT8) {
+            /* n-bit grayscale */
+            if (imIn->bands == 2) {
+                for (xx = 0; xx < xsize; xx++) {
+                    xmin = xbounds[xx * 2 + 0];
+                    xmax = xbounds[xx * 2 + 1];
+                    k = &kk[xx * kmax];
+                    ss0 = ss1 = 1 << (PRECISION_BITS -1);
+                    for (x = xmin; x < xmax; x++) {
+                        ss0 += ((UINT8) imIn->image[yy][x*4 + 0]) * k[x - xmin];
+                        ss1 += ((UINT8) imIn->image[yy][x*4 + 3]) * k[x - xmin];
                     }
-                } else if (imIn->bands == 3) {
-                    for (xx = 0; xx < xsize; xx++) {
-                        xmin = xbounds[xx * 2 + 0];
-                        xmax = xbounds[xx * 2 + 1];
-                        k = &kk[xx * kmax];
-                        ss0 = ss1 = ss2 = 1 << (PRECISION_BITS -1);
-                        for (x = xmin; x < xmax; x++) {
-                            ss0 += ((UINT8) imIn->image[yy][x*4 + 0]) * k[x - xmin];
-                            ss1 += ((UINT8) imIn->image[yy][x*4 + 1]) * k[x - xmin];
-                            ss2 += ((UINT8) imIn->image[yy][x*4 + 2]) * k[x - xmin];
-                        }
-                        imOut->image[yy][xx*4 + 0] = clip8(ss0);
-                        imOut->image[yy][xx*4 + 1] = clip8(ss1);
-                        imOut->image[yy][xx*4 + 2] = clip8(ss2);
-                    }
-                } else {
-                    for (xx = 0; xx < xsize; xx++) {
-                        xmin = xbounds[xx * 2 + 0];
-                        xmax = xbounds[xx * 2 + 1];
-                        k = &kk[xx * kmax];
-                        ss0 = ss1 = ss2 = ss3 = 1 << (PRECISION_BITS -1);
-                        for (x = xmin; x < xmax; x++) {
-                            ss0 += ((UINT8) imIn->image[yy][x*4 + 0]) * k[x - xmin];
-                            ss1 += ((UINT8) imIn->image[yy][x*4 + 1]) * k[x - xmin];
-                            ss2 += ((UINT8) imIn->image[yy][x*4 + 2]) * k[x - xmin];
-                            ss3 += ((UINT8) imIn->image[yy][x*4 + 3]) * k[x - xmin];
-                        }
-                        imOut->image[yy][xx*4 + 0] = clip8(ss0);
-                        imOut->image[yy][xx*4 + 1] = clip8(ss1);
-                        imOut->image[yy][xx*4 + 2] = clip8(ss2);
-                        imOut->image[yy][xx*4 + 3] = clip8(ss3);
-                    }
+                    imOut->image[yy][xx*4 + 0] = clip8(ss0);
+                    imOut->image[yy][xx*4 + 3] = clip8(ss1);
                 }
-                break;
+            } else if (imIn->bands == 3) {
+                for (xx = 0; xx < xsize; xx++) {
+                    xmin = xbounds[xx * 2 + 0];
+                    xmax = xbounds[xx * 2 + 1];
+                    k = &kk[xx * kmax];
+                    ss0 = ss1 = ss2 = 1 << (PRECISION_BITS -1);
+                    for (x = xmin; x < xmax; x++) {
+                        ss0 += ((UINT8) imIn->image[yy][x*4 + 0]) * k[x - xmin];
+                        ss1 += ((UINT8) imIn->image[yy][x*4 + 1]) * k[x - xmin];
+                        ss2 += ((UINT8) imIn->image[yy][x*4 + 2]) * k[x - xmin];
+                    }
+                    imOut->image[yy][xx*4 + 0] = clip8(ss0);
+                    imOut->image[yy][xx*4 + 1] = clip8(ss1);
+                    imOut->image[yy][xx*4 + 2] = clip8(ss2);
+                }
+            } else {
+                for (xx = 0; xx < xsize; xx++) {
+                    xmin = xbounds[xx * 2 + 0];
+                    xmax = xbounds[xx * 2 + 1];
+                    k = &kk[xx * kmax];
+                    ss0 = ss1 = ss2 = ss3 = 1 << (PRECISION_BITS -1);
+                    for (x = xmin; x < xmax; x++) {
+                        ss0 += ((UINT8) imIn->image[yy][x*4 + 0]) * k[x - xmin];
+                        ss1 += ((UINT8) imIn->image[yy][x*4 + 1]) * k[x - xmin];
+                        ss2 += ((UINT8) imIn->image[yy][x*4 + 2]) * k[x - xmin];
+                        ss3 += ((UINT8) imIn->image[yy][x*4 + 3]) * k[x - xmin];
+                    }
+                    imOut->image[yy][xx*4 + 0] = clip8(ss0);
+                    imOut->image[yy][xx*4 + 1] = clip8(ss1);
+                    imOut->image[yy][xx*4 + 2] = clip8(ss2);
+                    imOut->image[yy][xx*4 + 3] = clip8(ss3);
+                }
+            }
+        }
+    }
+    ImagingSectionLeave(&cookie);
+    free(kk);
+    free(xbounds);
+    return imOut;
+}
+
+
+Imaging
+ImagingResampleHorizontal_32bpc(Imaging imIn, int xsize, struct filter *filterp)
+{
+    ImagingSectionCookie cookie;
+    Imaging imOut;
+    double support, scale, filterscale;
+    double center, ww, ss;
+    int xx, yy, x, kmax, xmin, xmax;
+    int *xbounds;
+    double *k, *kk;
+
+    /* prepare for horizontal stretch */
+    filterscale = scale = (float) imIn->xsize / xsize;
+    if (filterscale < 1.0) {
+        filterscale = 1.0;
+    }
+
+    /* determine support size (length of resampling filter) */
+    support = filterp->support * filterscale;
+
+    /* maximum number of coofs */
+    kmax = (int) ceil(support) * 2 + 1;
+
+    // check for overflow
+    if (xsize > SIZE_MAX / (kmax * sizeof(double)))
+        return (Imaging) ImagingError_MemoryError();
+
+    // sizeof(double) should be greater than 0 as well
+    if (xsize > SIZE_MAX / (2 * sizeof(double)))
+        return (Imaging) ImagingError_MemoryError();
+
+    /* coefficient buffer */
+    kk = malloc(xsize * kmax * sizeof(double));
+    if ( ! kk)
+        return (Imaging) ImagingError_MemoryError();
+
+    xbounds = malloc(xsize * 2 * sizeof(int));
+    if ( ! xbounds) {
+        free(kk);
+        return (Imaging) ImagingError_MemoryError();
+    }
+
+    for (xx = 0; xx < xsize; xx++) {
+        k = &kk[xx * kmax];
+        center = (xx + 0.5) * scale;
+        ww = 0.0;
+        ss = 1.0 / filterscale;
+        xmin = (int) floor(center - support);
+        if (xmin < 0)
+            xmin = 0;
+        xmax = (int) ceil(center + support);
+        if (xmax > imIn->xsize)
+            xmax = imIn->xsize;
+        for (x = xmin; x < xmax; x++) {
+            double w = filterp->filter((x - center + 0.5) * ss);
+            k[x - xmin] = w;
+            ww += w;
+        }
+        for (x = 0; x < xmax - xmin; x++) {
+            if (ww != 0.0)
+                k[x] /= ww;
+        }
+        xbounds[xx * 2 + 0] = xmin;
+        xbounds[xx * 2 + 1] = xmax;
+    }
+
+    imOut = ImagingNew(imIn->mode, xsize, imIn->ysize);
+    if ( ! imOut) {
+        free(kk);
+        free(xbounds);
+        return NULL;
+    }
+
+    ImagingSectionEnter(&cookie);
+    /* horizontal stretch */
+    for (yy = 0; yy < imOut->ysize; yy++) {
+        switch(imIn->type) {
             case IMAGING_TYPE_INT32:
                 /* 32-bit integer */
                 for (xx = 0; xx < xsize; xx++) {
@@ -242,8 +325,8 @@ ImagingResampleHorizontal(Imaging imIn, int xsize, struct filter *filterp)
                     k = &kk[xx * kmax];
                     ss = 0.0;
                     for (x = xmin; x < xmax; x++)
-                        ss += (IMAGING_PIXEL_I(imIn, x, yy)) * k[x - xmin];
-                    IMAGING_PIXEL_I(imOut, xx, yy) = (int) ss;
+                        ss += IMAGING_PIXEL_I(imIn, x, yy) * k[x - xmin];
+                    IMAGING_PIXEL_I(imOut, xx, yy) = lround(ss);
                 }
                 break;
             case IMAGING_TYPE_FLOAT32:
@@ -258,7 +341,6 @@ ImagingResampleHorizontal(Imaging imIn, int xsize, struct filter *filterp)
                     IMAGING_PIXEL_F(imOut, xx, yy) = ss;
                 }
                 break;
-            }
         }
     }
     ImagingSectionLeave(&cookie);
@@ -274,12 +356,26 @@ ImagingResample(Imaging imIn, int xsize, int ysize, int filter)
     Imaging imTemp1, imTemp2, imTemp3;
     Imaging imOut;
     struct filter *filterp;
+    Imaging (*ResampleHorizontal)(Imaging imIn, int xsize, struct filter *filterp);
 
     if (strcmp(imIn->mode, "P") == 0 || strcmp(imIn->mode, "1") == 0)
         return (Imaging) ImagingError_ModeError();
 
-    if (imIn->type == IMAGING_TYPE_SPECIAL)
-        return (Imaging) ImagingError_ModeError();
+    if (imIn->image8) {
+        ResampleHorizontal = ImagingResampleHorizontal_8bpc;
+    } else {
+        switch(imIn->type) {
+            case IMAGING_TYPE_UINT8:
+                ResampleHorizontal = ImagingResampleHorizontal_8bpc;
+                break;
+            case IMAGING_TYPE_INT32:
+            case IMAGING_TYPE_FLOAT32:
+                ResampleHorizontal = ImagingResampleHorizontal_32bpc;
+                break;
+            default:
+                return (Imaging) ImagingError_ModeError();
+        }
+    }
 
     /* check filter */
     switch (filter) {
@@ -299,7 +395,7 @@ ImagingResample(Imaging imIn, int xsize, int ysize, int filter)
     }
 
     /* two-pass resize, first pass */
-    imTemp1 = ImagingResampleHorizontal(imIn, xsize, filterp);
+    imTemp1 = ResampleHorizontal(imIn, xsize, filterp);
     if ( ! imTemp1)
         return NULL;
 
@@ -310,7 +406,7 @@ ImagingResample(Imaging imIn, int xsize, int ysize, int filter)
         return NULL;
 
     /* second pass */
-    imTemp3 = ImagingResampleHorizontal(imTemp2, ysize, filterp);
+    imTemp3 = ResampleHorizontal(imTemp2, ysize, filterp);
     ImagingDelete(imTemp2);
     if ( ! imTemp3)
         return NULL;

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -181,8 +181,8 @@ ImagingResampleHorizontal_8bpc(Imaging imIn, int xsize, struct filter *filterp)
     }
 
     ImagingSectionEnter(&cookie);
-    for (yy = 0; yy < imOut->ysize; yy++) {
-        if (imIn->image8) {
+    if (imIn->image8) {
+        for (yy = 0; yy < imOut->ysize; yy++) {
             for (xx = 0; xx < xsize; xx++) {
                 xmin = xbounds[xx * 2 + 0];
                 xmax = xbounds[xx * 2 + 1];
@@ -192,8 +192,10 @@ ImagingResampleHorizontal_8bpc(Imaging imIn, int xsize, struct filter *filterp)
                     ss0 += ((UINT8) imIn->image8[yy][x]) * k[x - xmin];
                 imOut->image8[yy][xx] = clip8(ss0);
             }
-        } else if (imIn->type == IMAGING_TYPE_UINT8) {
-            if (imIn->bands == 2) {
+        }
+    } else if (imIn->type == IMAGING_TYPE_UINT8) {
+        if (imIn->bands == 2) {
+            for (yy = 0; yy < imOut->ysize; yy++) {
                 for (xx = 0; xx < xsize; xx++) {
                     xmin = xbounds[xx * 2 + 0];
                     xmax = xbounds[xx * 2 + 1];
@@ -206,7 +208,9 @@ ImagingResampleHorizontal_8bpc(Imaging imIn, int xsize, struct filter *filterp)
                     imOut->image[yy][xx*4 + 0] = clip8(ss0);
                     imOut->image[yy][xx*4 + 3] = clip8(ss1);
                 }
-            } else if (imIn->bands == 3) {
+            }
+        } else if (imIn->bands == 3) {
+            for (yy = 0; yy < imOut->ysize; yy++) {
                 for (xx = 0; xx < xsize; xx++) {
                     xmin = xbounds[xx * 2 + 0];
                     xmax = xbounds[xx * 2 + 1];
@@ -221,7 +225,9 @@ ImagingResampleHorizontal_8bpc(Imaging imIn, int xsize, struct filter *filterp)
                     imOut->image[yy][xx*4 + 1] = clip8(ss1);
                     imOut->image[yy][xx*4 + 2] = clip8(ss2);
                 }
-            } else {
+            }
+        } else {
+            for (yy = 0; yy < imOut->ysize; yy++) {
                 for (xx = 0; xx < xsize; xx++) {
                     xmin = xbounds[xx * 2 + 0];
                     xmax = xbounds[xx * 2 + 1];

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -103,11 +103,11 @@ ImagingPrecompute(int inSize, int outSize, struct filter *filterp,
         return 0;
 
     /* coefficient buffer */
-    kk = calloc(outSize * kmax, sizeof(double));
+    kk = malloc(outSize * kmax * sizeof(double));
     if ( ! kk)
         return 0;
 
-    xbounds = calloc(outSize * 2, sizeof(int));
+    xbounds = malloc(outSize * 2 * sizeof(int));
     if ( ! xbounds) {
         free(kk);
         return 0;
@@ -160,7 +160,7 @@ ImagingResampleHorizontal_8bpc(Imaging imIn, int xsize, struct filter *filterp)
         return (Imaging) ImagingError_MemoryError();
     }
     
-    kk = calloc(xsize * kmax, sizeof(int));
+    kk = malloc(xsize * kmax * sizeof(int));
     if ( ! kk) {
         free(xbounds);
         free(prekk);

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -178,7 +178,7 @@ ImagingResampleHorizontal(Imaging imIn, int xsize, struct filter *filterp)
                 xmin = xbounds[xx * 2 + 0];
                 xmax = xbounds[xx * 2 + 1];
                 k = &kk[xx * kmax];
-                ss0 = 0;
+                ss0 = 1 << (PRECISION_BITS -1);
                 for (x = xmin; x < xmax; x++)
                     ss0 += ((UINT8) imIn->image8[yy][x]) * k[x - xmin];
                 imOut->image8[yy][xx] = clip8(ss0);
@@ -192,7 +192,7 @@ ImagingResampleHorizontal(Imaging imIn, int xsize, struct filter *filterp)
                         xmin = xbounds[xx * 2 + 0];
                         xmax = xbounds[xx * 2 + 1];
                         k = &kk[xx * kmax];
-                        ss0 = ss1 = 0;
+                        ss0 = ss1 = 1 << (PRECISION_BITS -1);
                         for (x = xmin; x < xmax; x++) {
                             ss0 += ((UINT8) imIn->image[yy][x*4 + 0]) * k[x - xmin];
                             ss1 += ((UINT8) imIn->image[yy][x*4 + 3]) * k[x - xmin];
@@ -205,7 +205,7 @@ ImagingResampleHorizontal(Imaging imIn, int xsize, struct filter *filterp)
                         xmin = xbounds[xx * 2 + 0];
                         xmax = xbounds[xx * 2 + 1];
                         k = &kk[xx * kmax];
-                        ss0 = ss1 = ss2 = 0;
+                        ss0 = ss1 = ss2 = 1 << (PRECISION_BITS -1);
                         for (x = xmin; x < xmax; x++) {
                             ss0 += ((UINT8) imIn->image[yy][x*4 + 0]) * k[x - xmin];
                             ss1 += ((UINT8) imIn->image[yy][x*4 + 1]) * k[x - xmin];
@@ -220,7 +220,7 @@ ImagingResampleHorizontal(Imaging imIn, int xsize, struct filter *filterp)
                         xmin = xbounds[xx * 2 + 0];
                         xmax = xbounds[xx * 2 + 1];
                         k = &kk[xx * kmax];
-                        ss0 = ss1 = ss2 = ss3 = 0;
+                        ss0 = ss1 = ss2 = ss3 = 1 << (PRECISION_BITS -1);
                         for (x = xmin; x < xmax; x++) {
                             ss0 += ((UINT8) imIn->image[yy][x*4 + 0]) * k[x - xmin];
                             ss1 += ((UINT8) imIn->image[yy][x*4 + 1]) * k[x - xmin];

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -95,19 +95,19 @@ ImagingPrecompute(int inSize, int outSize, struct filter *filterp,
     kmax = (int) ceil(support) * 2 + 1;
 
     // check for overflow
-    if (outSize > SIZE_MAX / (kmax * sizeof(double)))
+    if (outSize > INT_MAX / (kmax * sizeof(double)))
         return 0;
 
     // sizeof(double) should be greater than 0 as well
-    if (outSize > SIZE_MAX / (2 * sizeof(double)))
+    if (outSize > INT_MAX / (2 * sizeof(double)))
         return 0;
 
     /* coefficient buffer */
-    kk = malloc(outSize * kmax * sizeof(double));
+    kk = calloc(outSize * kmax, sizeof(double));
     if ( ! kk)
         return 0;
 
-    xbounds = malloc(outSize * 2 * sizeof(int));
+    xbounds = calloc(outSize * 2, sizeof(int));
     if ( ! xbounds) {
         free(kk);
         return 0;
@@ -160,7 +160,7 @@ ImagingResampleHorizontal_8bpc(Imaging imIn, int xsize, struct filter *filterp)
         return (Imaging) ImagingError_MemoryError();
     }
     
-    kk = malloc(xsize * kmax * sizeof(int));
+    kk = calloc(xsize * kmax, sizeof(int));
     if ( ! kk) {
         free(xbounds);
         free(prekk);

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -123,13 +123,14 @@ ImagingPrecompute(int inSize, int outSize, struct filter *filterp,
         xmax = (int) ceil(center + support);
         if (xmax > inSize)
             xmax = inSize;
+        xmax -= xmin;
         k = &kk[xx * kmax];
-        for (x = xmin; x < xmax; x++) {
-            double w = filterp->filter((x - center + 0.5) * ss);
-            k[x - xmin] = w;
+        for (x = 0; x < xmax; x++) {
+            double w = filterp->filter((x + xmin - center + 0.5) * ss);
+            k[x] = w;
             ww += w;
         }
-        for (x = 0; x < xmax - xmin; x++) {
+        for (x = 0; x < xmax; x++) {
             if (ww != 0.0)
                 k[x] /= ww;
         }
@@ -187,8 +188,8 @@ ImagingResampleHorizontal_8bpc(Imaging imIn, int xsize, struct filter *filterp)
                 xmax = xbounds[xx * 2 + 1];
                 k = &kk[xx * kmax];
                 ss0 = 1 << (PRECISION_BITS -1);
-                for (x = xmin; x < xmax; x++)
-                    ss0 += ((UINT8) imIn->image8[yy][x]) * k[x - xmin];
+                for (x = 0; x < xmax; x++)
+                    ss0 += ((UINT8) imIn->image8[yy][x + xmin]) * k[x];
                 imOut->image8[yy][xx] = clip8(ss0);
             }
         }
@@ -200,9 +201,9 @@ ImagingResampleHorizontal_8bpc(Imaging imIn, int xsize, struct filter *filterp)
                     xmax = xbounds[xx * 2 + 1];
                     k = &kk[xx * kmax];
                     ss0 = ss1 = 1 << (PRECISION_BITS -1);
-                    for (x = xmin; x < xmax; x++) {
-                        ss0 += ((UINT8) imIn->image[yy][x*4 + 0]) * k[x - xmin];
-                        ss1 += ((UINT8) imIn->image[yy][x*4 + 3]) * k[x - xmin];
+                    for (x = 0; x < xmax; x++) {
+                        ss0 += ((UINT8) imIn->image[yy][(x + xmin)*4 + 0]) * k[x];
+                        ss1 += ((UINT8) imIn->image[yy][(x + xmin)*4 + 3]) * k[x];
                     }
                     imOut->image[yy][xx*4 + 0] = clip8(ss0);
                     imOut->image[yy][xx*4 + 3] = clip8(ss1);
@@ -215,10 +216,10 @@ ImagingResampleHorizontal_8bpc(Imaging imIn, int xsize, struct filter *filterp)
                     xmax = xbounds[xx * 2 + 1];
                     k = &kk[xx * kmax];
                     ss0 = ss1 = ss2 = 1 << (PRECISION_BITS -1);
-                    for (x = xmin; x < xmax; x++) {
-                        ss0 += ((UINT8) imIn->image[yy][x*4 + 0]) * k[x - xmin];
-                        ss1 += ((UINT8) imIn->image[yy][x*4 + 1]) * k[x - xmin];
-                        ss2 += ((UINT8) imIn->image[yy][x*4 + 2]) * k[x - xmin];
+                    for (x = 0; x < xmax; x++) {
+                        ss0 += ((UINT8) imIn->image[yy][(x + xmin)*4 + 0]) * k[x];
+                        ss1 += ((UINT8) imIn->image[yy][(x + xmin)*4 + 1]) * k[x];
+                        ss2 += ((UINT8) imIn->image[yy][(x + xmin)*4 + 2]) * k[x];
                     }
                     imOut->image[yy][xx*4 + 0] = clip8(ss0);
                     imOut->image[yy][xx*4 + 1] = clip8(ss1);
@@ -232,11 +233,11 @@ ImagingResampleHorizontal_8bpc(Imaging imIn, int xsize, struct filter *filterp)
                     xmax = xbounds[xx * 2 + 1];
                     k = &kk[xx * kmax];
                     ss0 = ss1 = ss2 = ss3 = 1 << (PRECISION_BITS -1);
-                    for (x = xmin; x < xmax; x++) {
-                        ss0 += ((UINT8) imIn->image[yy][x*4 + 0]) * k[x - xmin];
-                        ss1 += ((UINT8) imIn->image[yy][x*4 + 1]) * k[x - xmin];
-                        ss2 += ((UINT8) imIn->image[yy][x*4 + 2]) * k[x - xmin];
-                        ss3 += ((UINT8) imIn->image[yy][x*4 + 3]) * k[x - xmin];
+                    for (x = 0; x < xmax; x++) {
+                        ss0 += ((UINT8) imIn->image[yy][(x + xmin)*4 + 0]) * k[x];
+                        ss1 += ((UINT8) imIn->image[yy][(x + xmin)*4 + 1]) * k[x];
+                        ss2 += ((UINT8) imIn->image[yy][(x + xmin)*4 + 2]) * k[x];
+                        ss3 += ((UINT8) imIn->image[yy][(x + xmin)*4 + 3]) * k[x];
                     }
                     imOut->image[yy][xx*4 + 0] = clip8(ss0);
                     imOut->image[yy][xx*4 + 1] = clip8(ss1);
@@ -285,8 +286,8 @@ ImagingResampleHorizontal_32bpc(Imaging imIn, int xsize, struct filter *filterp)
                     xmax = xbounds[xx * 2 + 1];
                     k = &kk[xx * kmax];
                     ss = 0.0;
-                    for (x = xmin; x < xmax; x++)
-                        ss += IMAGING_PIXEL_I(imIn, x, yy) * k[x - xmin];
+                    for (x = 0; x < xmax; x++)
+                        ss += IMAGING_PIXEL_I(imIn, x + xmin, yy) * k[x];
                     IMAGING_PIXEL_I(imOut, xx, yy) = ROUND_UP(ss);
                 }
             }
@@ -299,8 +300,8 @@ ImagingResampleHorizontal_32bpc(Imaging imIn, int xsize, struct filter *filterp)
                     xmax = xbounds[xx * 2 + 1];
                     k = &kk[xx * kmax];
                     ss = 0.0;
-                    for (x = xmin; x < xmax; x++)
-                        ss += IMAGING_PIXEL_F(imIn, x, yy) * k[x - xmin];
+                    for (x = 0; x < xmax; x++)
+                        ss += IMAGING_PIXEL_F(imIn, x + xmin, yy) * k[x];
                     IMAGING_PIXEL_F(imOut, xx, yy) = ss;
                 }
             }


### PR DESCRIPTION
This change speeds up resampling up to 60% and eliminates ugly `i2f` hack.

Source    | Operation               | Filter  | Before | After 
----------|-------------------------|---------|--------|-------
7712×4352 | **Resize to 16x16**     | Bilinear| 210    | 330   
          |                         | Bicubic | 109    | 177   
          |                         | Lanczos | 73.5   | 120   
          | **Resize to 320x180**   | Bilinear| 154    | 241   
          |                         | Bicubic | 88.6   | 139
          |                         | Lanczos | 60.4   | 96.5   
          | **Resize to 2048x1155** | Bilinear| 83.9   | 105   
          |                         | Bicubic | 55.3   | 75.1   
          |                         | Lanczos | 38.9   | 57.3

I'll add tests for other modes and maybe return old implementation for `IMAGING_TYPE_INT32` and `IMAGING_TYPE_FLOAT32`.