### PR TITLE
Avoid unnecessary Image operations

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -875,8 +875,8 @@ class Image(object):
                     mode = "RGB"
             else:
                 return self.copy()
-
-        self.load()
+        else:
+            self.load()
 
         if matrix:
             # matrix conversion
@@ -1062,10 +1062,10 @@ class Image(object):
         :returns: An :py:class:`~PIL.Image.Image` object.
         """
 
-        self.load()
         if box is None:
             return self.copy()
 
+        self.load()
         return self._new(self._crop(self.im, box))
 
     def _crop(self, im, box):
@@ -1390,9 +1390,10 @@ class Image(object):
                     im = im.convert(self.mode)
             im = im.im
 
-        self.load()
         if self.readonly:
             self._copy()
+        else:
+            self.load()
 
         if mask:
             mask.load()
@@ -1498,9 +1499,10 @@ class Image(object):
            other color value.
         """
 
-        self.load()
         if self.readonly:
             self._copy()
+        else:
+            self.load()
 
         if self.mode not in ("LA", "RGBA"):
             # attempt to promote self to a matching alpha mode
@@ -1556,9 +1558,10 @@ class Image(object):
         :param offset: An optional offset value.  The default is 0.0.
         """
 
-        self.load()
         if self.readonly:
             self._copy()
+        else:
+            self.load()
 
         self.im.putdata(data, scale, offset)
 
@@ -1612,10 +1615,9 @@ class Image(object):
         :param value: The pixel value.
         """
 
-        self.load()
         if self.readonly:
             self._copy()
-            self.load()
+        self.load()
 
         if self.pyaccess:
             return self.pyaccess.putpixel(xy, value)

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -592,6 +592,12 @@ class Image(object):
         self.pyaccess = None
         self.readonly = 0
 
+    def _mutable(self):
+        if self.readonly:
+            self._copy()
+        else:
+            self.load()
+
     def _dump(self, file=None, format=None, **options):
         import tempfile
 
@@ -1390,10 +1396,7 @@ class Image(object):
                     im = im.convert(self.mode)
             im = im.im
 
-        if self.readonly:
-            self._copy()
-        else:
-            self.load()
+        self._mutable()
 
         if mask:
             mask.load()
@@ -1499,10 +1502,7 @@ class Image(object):
            other color value.
         """
 
-        if self.readonly:
-            self._copy()
-        else:
-            self.load()
+        self._mutable()
 
         if self.mode not in ("LA", "RGBA"):
             # attempt to promote self to a matching alpha mode
@@ -1558,10 +1558,7 @@ class Image(object):
         :param offset: An optional offset value.  The default is 0.0.
         """
 
-        if self.readonly:
-            self._copy()
-        else:
-            self.load()
+        self._mutable()
 
         self.im.putdata(data, scale, offset)
 

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -871,18 +871,16 @@ class Image(object):
         :returns: An :py:class:`~PIL.Image.Image` object.
         """
 
-        if not mode:
+        self.load()
+
+        if not mode and self.mode == "P":
             # determine default mode
-            if self.mode == "P":
-                self.load()
-                if self.palette:
-                    mode = self.palette.mode
-                else:
-                    mode = "RGB"
+            if self.palette:
+                mode = self.palette.mode
             else:
-                return self.copy()
-        else:
-            self.load()
+                mode = "RGB"
+        if not mode or (mode == self.mode and not matrix):
+            return self.copy()
 
         if matrix:
             # matrix conversion


### PR DESCRIPTION
- Avoid unnecessarily loading an image twice
- In Image's convert method, if image is already in the destination mode, do not convert
