### PR TITLE
Skip test when icc profile is not available, fixes #1887

### DIFF
--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -256,6 +256,7 @@ class TestImageCms(PillowTestCase):
                          ImageCms.getProfileDescription(p2))
 
     def test_extended_information(self):
+        self.skip_missing()
         o = ImageCms.getOpenProfile(SRGB)
         p = o.profile
 


### PR DESCRIPTION
Applied patch from #1887. Thanks @doko42