### PR TITLE
Removed support for list form of Image info

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -524,13 +524,7 @@ class Image(object):
         if im.mode == "P" and not new.palette:
             from PIL import ImagePalette
             new.palette = ImagePalette.ImagePalette()
-        try:
-            new.info = self.info.copy()
-        except AttributeError:
-            # fallback (pre-1.5.2)
-            new.info = {}
-            for k, v in self.info:
-                new.info[k] = v
+        new.info = self.info.copy()
         return new
 
     _makeself = _new  # compatibility


### PR DESCRIPTION
This code has been there since the forking of PIL. It's function is to read in a list form of the info attribute, rather than the current dictionary form.

While the person who wrote this would have had a reason, I can't imagine under what circumstances Pillow would be interacting with an object like that. If others think that it should be kept, I would then suggest adding a warning.