### PR TITLE
use ID as global variable

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -2287,6 +2287,7 @@ def open(fp, mode="r"):
     preinit()
 
     def _open_core(fp, filename, prefix):
+        global ID
         for i in ID:
             try:
                 factory, accept = OPEN[i]
@@ -2428,6 +2429,8 @@ def register_open(id, factory, accept=None):
     :param accept: An optional function that can be used to quickly
        reject images having another format.
     """
+    global ID
+
     id = id.upper()
     ID.append(id)
     OPEN[id] = factory, accept


### PR DESCRIPTION
if ID is not used as global variable in python 2 it is empty after load image plugins in functions using it.

    $ python2 --version
    Python 2.7.11

Even more, if you do not import as

    from PIL import Image

as ImageTk do

[PIL/ImageTk.py:35](https://github.com/python-pillow/Pillow/blob/master/PIL/ImageTk.py#L35)

two instances of ID are created so load image always say:

[PIL/Image.py:2314](https://github.com/python-pillow/Pillow/blob/master/PIL/Image.py#L2314)

>cannot identify image file

As many people seems to be suffering

http://stackoverflow.com/a/20863145/848072

you can check with any simple test case adding:

print(__builtin__.id(ID))

to check there's two instances of ID using `import Image`

Is there a better aproach? Maybe changing that import on ImageTk?

