### PR TITLE
Added reference to Pillow to COPYING

### DIFF
--- a/docs/COPYING
+++ b/docs/COPYING
@@ -1,7 +1,14 @@
-The Python Imaging Library is
+The Python Imaging Library (PIL) is
 
-Copyright (c) 1997-2009 by Secret Labs AB
-Copyright (c) 1995-2009 by Fredrik Lundh
+    Copyright © 1997-2011 by Secret Labs AB
+    Copyright © 1995-2011 by Fredrik Lundh
+
+Pillow is the friendly PIL fork. It is
+
+    Copyright © 2016 by Alex Clark and contributors
+
+Like PIL, Pillow is licensed under the MIT-like open source PIL
+Software License:
 
 By obtaining, using, and/or copying this software and/or its
 associated documentation, you agree that you have read, understood,


### PR DESCRIPTION
Keeping it up to date with the changes from #1793, and in sync with the rest of the LICENSE file.