### PR TITLE
Do not save incorrect key

### DIFF
--- a/PIL/JpegImagePlugin.py
+++ b/PIL/JpegImagePlugin.py
@@ -158,7 +158,7 @@ def SOF(self, marker):
         raise SyntaxError("cannot handle %d-layer images" % self.layers)
 
     if marker in [0xFFC2, 0xFFC6, 0xFFCA, 0xFFCE]:
-        self.info["progressive"] = self.info["progression"] = 1
+        self.info["progressive"] = 1
 
     if self.icclist:
         # fixup icc profile
@@ -673,12 +673,14 @@ def _save(im, fp, filename):
             i += 1
 
     # get keyword arguments
-    im.encoderconfig = (
-        quality,
+    if "progression" in info and not "progressive" in info:
         # "progressive" is the official name, but older documentation
         # says "progression"
         # FIXME: issue a warning if the wrong form is used (post-1.1.7)
-        "progressive" in info or "progression" in info,
+        info["progressive"] = info.pop("progression")
+    im.encoderconfig = (
+        quality,
+        "progressive" in info,
         info.get("smooth", 0),
         "optimize" in info,
         info.get("streamtype", 0),
@@ -694,7 +696,7 @@ def _save(im, fp, filename):
     # channels*size, this is a value that's been used in a django patch.
     # https://github.com/matthewwithanm/django-imagekit/issues/50
     bufsize = 0
-    if "optimize" in info or "progressive" in info or "progression" in info:
+    if "optimize" in info or "progressive" in info:
         # keep sets quality to 0, but the actual value may be high.
         if quality >= 95 or quality == 0:
             bufsize = 2 * im.size[0] * im.size[1]

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -232,11 +232,8 @@ class TestFileJpeg(PillowTestCase):
         self.assert_image_equal(im1, im2)
         self.assert_image_equal(im1, im3)
         self.assertFalse(im1.info.get("progressive"))
-        self.assertFalse(im1.info.get("progression"))
         self.assertTrue(im2.info.get("progressive"))
-        self.assertTrue(im2.info.get("progression"))
         self.assertTrue(im3.info.get("progressive"))
-        self.assertTrue(im3.info.get("progression"))
 
     def test_quality(self):
         im1 = self.roundtrip(hopper())


### PR DESCRIPTION
Originally, this PR aimed to add a warning for the JpegImagePlugin 'progression' info key, resolving the FIXME. However, my test was failing, I suspect due to the warning being caught as part of Pillow's save process.

I have instead updated this to remove setting the incorrect key when saving, so that Pillow is not actively creating incorrect files.