### PR TITLE
Include Python.h before wchar.h so _GNU_SOURCE is set consistently

### DIFF
--- a/_imagingcms.c
+++ b/_imagingcms.c
@@ -25,9 +25,8 @@ kevin@cazabon.com\n\
 http://www.cazabon.com\n\
 "
 
+#include "Python.h" // Include before wchar.h so _GNU_SOURCE is set
 #include "wchar.h"
-
-#include "Python.h"
 #include "datetime.h"
 
 #include "lcms2.h"


### PR DESCRIPTION
Fixes https://github.com/python-pillow/Pillow/issues/1850

---

https://github.com/python-pillow/Pillow/issues/1850#issuecomment-218428866:

> We figured out what the real problem is. What happens is:

> First will `wchar.h`be included which will pull in `string.h` without `_GNU_SOURCE` set. Later will `Python.h` explicitly set `_GNU_SOURCE` (via `pyconfig.h`) and after that is `string.h`pulled in again but this time with `_GNU_SOURCE` set.

> This (rightfully) confuses the fortify-headers. You cannot really include some system headers with without _GNU_SOURCE and some with. It will cause problem.

> Either `Python.h` should not set `_GNU_SOURCE` (eg bug in python) or it is required to be included first, before any system headers, (eg bug is in Pillow). Workaround/fix is trivial:

````diff
diff --git a/_imagingcms.c b/_imagingcms.c
index ad5b845..117d8a7 100644
--- a/_imagingcms.c
+++ b/_imagingcms.c
@@ -25,9 +25,9 @@ kevin@cazabon.com\n\
 http://www.cazabon.com\n\
 "
 
-#include "wchar.h"
 
 #include "Python.h"
+#include "wchar.h"
 #include "datetime.h"
 
 #include "lcms2.h"
````
