### PR TITLE
Appveyor Upgrades

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ environment:
   - PYTHON: C:/Python34-x64
   - PYTHON: C:/Python33
   - PYTHON: C:/Python33-x64
+
 install:
 - git clone https://github.com/python-pillow/pillow-depends.git c:\pillow-depends
 - xcopy c:\pillow-depends\*.zip c:\pillow\winbuild\
@@ -21,22 +22,34 @@ install:
 - cd c:\pillow\winbuild\
 - c:\python34\python.exe c:\pillow\winbuild\build_dep.py
 - c:\pillow\winbuild\build_deps.cmd
+
 build_script:
 - '%PYTHON%\python.exe c:\pillow\winbuild\build.py'
 - cd c:\pillow
 - dir dist\*.egg
 - '%PYTHON%\python.exe selftest.py --installed'
+
 test_script:
 - cd c:\pillow
 - '%PYTHON%\Scripts\pip.exe install nose'
 - '%PYTHON%\python.exe test-installed.py -v -s'
+
 matrix:
   fast_finish: true
+
 artifacts:
 - path: pillow\dist\*.egg
-  name: build
+  name: egg
+- path: pillow\dist\*.wheel
+  name: wheel
+
 after_test:
-  - ps: Get-ChildItem .\dist\*.egg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+  - '%PYTHON%\Scripts\pip.exe install wheel'
+  - cd c:\pillow\winbuild\
+  - '%PYTHON%\python.exe c:\pillow\winbuild\build.py --wheel'
+  - cd c:\pillow
+  - ps: Get-ChildItem .\dist\*.* | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+
 deploy:
   provider: S3
   access_key_id: AKIAIRAXC62ZNTVQJMOQ 
@@ -44,7 +57,7 @@ deploy:
     secure: Hwb6klTqtBeMgxAjRoDltiiqpuH8xbwD4UooDzBSiCWXjuFj1lyl4kHgHwTCCGqi
   bucket: pillow-nightly
   folder: win/$(APPVEYOR_BUILD_NUMBER)/
-  artifact: /.*egg/
+  artifact: /.*egg|wheel/
   on: 
     branch: master
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@ version: 3.3.pre.{build}
 clone_folder: c:\pillow
 init:
 - ECHO %PYTHON%
+#- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+# Uncomment previous line to get RDP access during the build. 
+
 environment:
   X64_EXT: -x64
   matrix:
@@ -42,4 +45,11 @@ deploy:
   bucket: pillow-nightly
   folder: win/$(APPVEYOR_BUILD_NUMBER)/
   artifact: /.*egg/
-
+  on: 
+    branch: master
+    
+# Uncomment the following line to get RDP access after the build/test and block for
+# up to the timeout limit (~1hr)
+#
+#on_finish:
+#- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/winbuild/build.py
+++ b/winbuild/build.py
@@ -142,7 +142,7 @@ def run_one(op):
 
 
 if __name__ == '__main__':
-    opts, args = getopt.getopt(sys.argv[1:], '', ['clean', 'dist'])
+    opts, args = getopt.getopt(sys.argv[1:], '', ['clean', 'dist', 'wheel'])
     opts = dict(opts)
 
     if '--clean' in opts:
@@ -151,7 +151,9 @@ if __name__ == '__main__':
     op = 'install'
     if '--dist' in opts:
         op = "bdist_wininst --user-access-control=auto"
-
+    elif '--wheel' in opts:
+        op = "bdist_wheel"
+        
     if 'PYTHON' in os.environ:
         run_one(op)
     else:


### PR DESCRIPTION
A couple of enhancements for appveyor:

* Commented out commands to get an RDP console on Appveyor's servers. These block, so we can't leave them in, but they can be useful to figure things out for people who don't have a windows machine they want to fire up.
* S3 deployment is only on the master branch. I'd like to make it just from python-pillow, but I don't see that in the docs. This prevents deployment failure stopping the test runs for everyone else. 
* Added wheel builds as in #1815 by @techtonik, but with a specific option for it, uploads to s3, and less intrusive changes to the build script. 