### PR TITLE
Resample vertical pass

### DIFF
--- a/PIL/ImageMode.py
+++ b/PIL/ImageMode.py
@@ -39,6 +39,7 @@ def getmode(mode):
         for m, (basemode, basetype, bands) in Image._MODEINFO.items():
             _modes[m] = ModeDescriptor(m, bands, basemode, basetype)
         # extra experimental modes
+        _modes["RGBa"] = ModeDescriptor("RGBa", ("R", "G", "B", "a"), "RGB", "L")
         _modes["LA"] = ModeDescriptor("LA", ("L", "A"), "L", "L")
         _modes["La"] = ModeDescriptor("La", ("L", "a"), "L", "L")
         _modes["PA"] = ModeDescriptor("PA", ("P", "A"), "RGB", "L")

--- a/PIL/ImageMode.py
+++ b/PIL/ImageMode.py
@@ -40,6 +40,7 @@ def getmode(mode):
             _modes[m] = ModeDescriptor(m, bands, basemode, basetype)
         # extra experimental modes
         _modes["LA"] = ModeDescriptor("LA", ("L", "A"), "L", "L")
+        _modes["La"] = ModeDescriptor("La", ("L", "a"), "L", "L")
         _modes["PA"] = ModeDescriptor("PA", ("P", "A"), "RGB", "L")
         # mapping modes
         _modes["I;16"] = ModeDescriptor("I;16", "I", "L", "L")

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -1,5 +1,5 @@
 from helper import unittest, PillowTestCase, hopper
-from PIL import Image, ImageDraw
+from PIL import Image, ImageDraw, ImageMode
 
 
 class TestImagingResampleVulnerability(PillowTestCase):
@@ -43,14 +43,12 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
         1f 1f e0 e0
         1f 1f e0 e0
         """
-        dark = (255 - color, 255 - color, 255 - color, 255 - color)
-        bright = (color, color, color, color)
+        case = Image.new('L', size, 255 - color)
+        rectangle = ImageDraw.Draw(case).rectangle
+        rectangle((0, 0, size[0] // 2 - 1, size[1] // 2 - 1), color)
+        rectangle((size[0] // 2, size[1] // 2, size[0], size[1]), color)
 
-        i = Image.new('RGBX', size, dark)
-        rectangle = ImageDraw.Draw(i).rectangle
-        rectangle((0, 0, size[0] // 2 - 1, size[1] // 2 - 1), bright)
-        rectangle((size[0] // 2, size[1] // 2, size[0], size[1]), bright)
-        return i.convert(mode)
+        return Image.merge(mode, [case] *  len(mode))
 
     def make_sample(self, data, size):
         """Restores a sample image from given data string which contains
@@ -92,7 +90,7 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
         )
 
     def test_reduce_bilinear(self):
-        for mode in ['RGBX', 'RGB', 'L']:
+        for mode in ['RGBX', 'RGB', 'La', 'L']:
             case = self.make_case(mode, (8, 8), 0xe1)
             case = case.resize((4, 4), Image.BILINEAR)
             data = ('e1 c9'
@@ -101,7 +99,7 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
                 self.check_case(channel, self.make_sample(data, (4, 4)))
 
     def test_reduce_bicubic(self):
-        for mode in ['RGBX', 'RGB', 'L']:
+        for mode in ['RGBX', 'RGB', 'La', 'L']:
             case = self.make_case(mode, (12, 12), 0xe1)
             case = case.resize((6, 6), Image.BICUBIC)
             data = ('e1 e3 d4'
@@ -111,7 +109,7 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
                 self.check_case(channel, self.make_sample(data, (6, 6)))
 
     def test_reduce_lanczos(self):
-        for mode in ['RGBX', 'RGB', 'L']:
+        for mode in ['RGBX', 'RGB', 'La', 'L']:
             case = self.make_case(mode, (16, 16), 0xe1)
             case = case.resize((8, 8), Image.LANCZOS)
             data = ('e1 e0 e4 d7'
@@ -122,7 +120,7 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
                 self.check_case(channel, self.make_sample(data, (8, 8)))
 
     def test_enlarge_bilinear(self):
-        for mode in ['RGBX', 'RGB', 'L']:
+        for mode in ['RGBX', 'RGB', 'La', 'L']:
             case = self.make_case(mode, (2, 2), 0xe1)
             case = case.resize((4, 4), Image.BILINEAR)
             data = ('e1 b0'
@@ -131,7 +129,7 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
                 self.check_case(channel, self.make_sample(data, (4, 4)))
 
     def test_enlarge_bicubic(self):
-        for mode in ['RGBX', 'RGB', 'L']:
+        for mode in ['RGBX', 'RGB', 'La', 'L']:
             case = self.make_case(mode, (4, 4), 0xe1)
             case = case.resize((8, 8), Image.BICUBIC)
             data = ('e1 e5 ee b9'
@@ -142,7 +140,7 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
                 self.check_case(channel, self.make_sample(data, (8, 8)))
 
     def test_enlarge_lanczos(self):
-        for mode in ['RGBX', 'RGB', 'L']:
+        for mode in ['RGBX', 'RGB', 'La', 'L']:
             case = self.make_case(mode, (6, 6), 0xe1)
             case = case.resize((12, 12), Image.LANCZOS)
             data = ('e1 e0 db ed f5 b8'

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -91,7 +91,7 @@ ImagingPrecompute(int inSize, int outSize, struct filter *filterp,
     /* determine support size (length of resampling filter) */
     support = filterp->support * filterscale;
 
-    /* maximum number of coofs */
+    /* maximum number of coeffs */
     kmax = (int) ceil(support) * 2 + 1;
 
     // check for overflow
@@ -102,7 +102,9 @@ ImagingPrecompute(int inSize, int outSize, struct filter *filterp,
     if (outSize > INT_MAX / (2 * sizeof(double)))
         return 0;
 
-    /* coefficient buffer */
+    /* coefficient buffer. kmax elements for each of outSize pixels.
+       Only xmax number of coefficients are initialized (xmax <= kmax),
+       other coefficients should be 0, so we are using calloc.  */
     kk = calloc(outSize * kmax, sizeof(double));
     if ( ! kk)
         return 0;

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -200,13 +200,13 @@ ImagingResampleHorizontal_8bpc(Imaging imIn, int xsize, struct filter *filterp)
                     xmin = xbounds[xx * 2 + 0];
                     xmax = xbounds[xx * 2 + 1];
                     k = &kk[xx * kmax];
-                    ss0 = ss1 = 1 << (PRECISION_BITS -1);
+                    ss0 = ss3 = 1 << (PRECISION_BITS -1);
                     for (x = 0; x < xmax; x++) {
                         ss0 += ((UINT8) imIn->image[yy][(x + xmin)*4 + 0]) * k[x];
-                        ss1 += ((UINT8) imIn->image[yy][(x + xmin)*4 + 3]) * k[x];
+                        ss3 += ((UINT8) imIn->image[yy][(x + xmin)*4 + 3]) * k[x];
                     }
                     imOut->image[yy][xx*4 + 0] = clip8(ss0);
-                    imOut->image[yy][xx*4 + 3] = clip8(ss1);
+                    imOut->image[yy][xx*4 + 3] = clip8(ss3);
                 }
             }
         } else if (imIn->bands == 3) {
@@ -294,8 +294,33 @@ ImagingResampleVertical_8bpc(Imaging imIn, int ysize, struct filter *filterp)
 
     ImagingSectionEnter(&cookie);
     if (imIn->image8) {
+        for (yy = 0; yy < ysize; yy++) {
+            k = &kk[yy * kmax];
+            ymin = xbounds[yy * 2 + 0];
+            ymax = xbounds[yy * 2 + 1];
+            for (xx = 0; xx < imOut->xsize; xx++) {
+                ss0 = 1 << (PRECISION_BITS -1);
+                for (y = 0; y < ymax; y++)
+                    ss0 += ((UINT8) imIn->image8[y + ymin][xx]) * k[y];
+                imOut->image8[yy][xx] = clip8(ss0);
+            }
+        }
     } else if (imIn->type == IMAGING_TYPE_UINT8) {
         if (imIn->bands == 2) {
+            for (yy = 0; yy < ysize; yy++) {
+                k = &kk[yy * kmax];
+                ymin = xbounds[yy * 2 + 0];
+                ymax = xbounds[yy * 2 + 1];
+                for (xx = 0; xx < imOut->xsize; xx++) {
+                    ss0 = ss3 = 1 << (PRECISION_BITS -1);
+                    for (y = 0; y < ymax; y++) {
+                        ss0 += ((UINT8) imIn->image[y + ymin][xx*4 + 0]) * k[y];
+                        ss3 += ((UINT8) imIn->image[y + ymin][xx*4 + 3]) * k[y];
+                    }
+                    imOut->image[yy][xx*4 + 0] = clip8(ss0);
+                    imOut->image[yy][xx*4 + 3] = clip8(ss3);
+                }
+            }
         } else if (imIn->bands == 3) {
             for (yy = 0; yy < ysize; yy++) {
                 k = &kk[yy * kmax];
@@ -314,6 +339,24 @@ ImagingResampleVertical_8bpc(Imaging imIn, int ysize, struct filter *filterp)
                 }
             }
         } else {
+            for (yy = 0; yy < ysize; yy++) {
+                k = &kk[yy * kmax];
+                ymin = xbounds[yy * 2 + 0];
+                ymax = xbounds[yy * 2 + 1];
+                for (xx = 0; xx < imOut->xsize; xx++) {
+                    ss0 = ss1 = ss2 = ss3 = 1 << (PRECISION_BITS -1);
+                    for (y = 0; y < ymax; y++) {
+                        ss0 += ((UINT8) imIn->image[y + ymin][xx*4 + 0]) * k[y];
+                        ss1 += ((UINT8) imIn->image[y + ymin][xx*4 + 1]) * k[y];
+                        ss2 += ((UINT8) imIn->image[y + ymin][xx*4 + 2]) * k[y];
+                        ss3 += ((UINT8) imIn->image[y + ymin][xx*4 + 3]) * k[y];
+                    }
+                    imOut->image[yy][xx*4 + 0] = clip8(ss0);
+                    imOut->image[yy][xx*4 + 1] = clip8(ss1);
+                    imOut->image[yy][xx*4 + 2] = clip8(ss2);
+                    imOut->image[yy][xx*4 + 3] = clip8(ss3);
+                }
+            }
         }
     }
 

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -102,10 +102,8 @@ ImagingPrecompute(int inSize, int outSize, struct filter *filterp,
     if (outSize > INT_MAX / (2 * sizeof(double)))
         return 0;
 
-    /* coefficient buffer. kmax elements for each of outSize pixels.
-       Only xmax number of coefficients are initialized (xmax <= kmax),
-       other coefficients should be 0, so we are using calloc.  */
-    kk = calloc(outSize * kmax, sizeof(double));
+    /* coefficient buffer */
+    kk = malloc(outSize * kmax * sizeof(double));
     if ( ! kk)
         return 0;
 
@@ -135,6 +133,10 @@ ImagingPrecompute(int inSize, int outSize, struct filter *filterp,
         for (x = 0; x < xmax; x++) {
             if (ww != 0.0)
                 k[x] /= ww;
+        }
+        // Remaining values should stay empty if they are used despite of xmax.
+        for (; x < kmax; x++) {
+            k[x] = 0;
         }
         xbounds[xx * 2 + 0] = xmin;
         xbounds[xx * 2 + 1] = xmax;

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -107,7 +107,7 @@ ImagingPrecompute(int inSize, int outSize, struct filter *filterp,
     if ( ! kk)
         return 0;
 
-    xbounds = calloc(outSize * 2, sizeof(int));
+    xbounds = malloc(outSize * 2 * sizeof(int));
     if ( ! xbounds) {
         free(kk);
         return 0;
@@ -160,7 +160,7 @@ ImagingResampleHorizontal_8bpc(Imaging imIn, int xsize, struct filter *filterp)
         return (Imaging) ImagingError_MemoryError();
     }
     
-    kk = calloc(xsize * kmax, sizeof(int));
+    kk = malloc(xsize * kmax * sizeof(int));
     if ( ! kk) {
         free(xbounds);
         free(prekk);


### PR DESCRIPTION
This PR implements separate vertical pass of resampling instead of two transposes.

Originally [I've replaced](https://github.com/python-pillow/Pillow/commit/40f9f48) two passes with transpose for the following reasons:

1. It was harder to heavily change the code in two branches simultaneously.
2. It makes downscaling faster, although upscaling became slightly slower.

Since then there are many tests for resampling were written and many optimizations were implemented. Now it is time to return upscaling performance.

Result on aws ec2 c4.large with 1920×1280 RGB image. Megapixels of source image per second.

            | Destination   | Filter  | 3.2    | FPI    | Vertical pass
------------|---------------|---------|--------|--------|--------------
Downscaling | **16x16**     | Bilinear| 229.31 | 381.97 | 386.89
            |               | Bicubic | 120.64 | 203.59 | 204.98
            |               | Lanczos |  81.33 | 135.74 | 136.20
            | **320x180**   | Bilinear| 133.08 | 161.96 | 193.30
            |               | Bicubic |  77.00 | 109.46 | 123.08
            |               | Lanczos |  51.36 |  77.48 |  83.27
Upscaling   | **2048x1155** | Bilinear|  25.78 |  27.81 |  40.14
            |               | Bicubic |  20.60 |  23.75 |  31.83
            |               | Lanczos |  17.04 |  19.50 |  25.00
            | **5120x2880** | Bilinear|   5.55 |   5.74 |   8.91
            |               | Bicubic |   4.54 |   4.98 |   7.25
            |               | Lanczos |   3.80 |   4.33 |   5.93

I also include results of stable version and fixed-point separetely to show what FPI doesn't affect upscaling too much, while vertical pass does. Vertical pass faster for upscaling in average by 40% and also makes downscaling to reasonable sizes 10% faster in average.

This last two improvements together makes all resampling operations about 60% faster.