### PR TITLE
Fix "Fatal Python error: UNREF invalid object" in debug builds

### DIFF
--- a/_imagingft.c
+++ b/_imagingft.c
@@ -153,7 +153,7 @@ getfont(PyObject* self_, PyObject* args, PyObject* kw)
         if (self->font_bytes) {
             PyMem_Free(self->font_bytes);
         }
-        PyObject_Del(self);
+        Py_DECREF(self);
         return geterror(error);
     }
 

--- a/_imagingft.c
+++ b/_imagingft.c
@@ -119,7 +119,9 @@ getfont(PyObject* self_, PyObject* args, PyObject* kw)
             PyMem_Free(filename);
         return NULL;
     }
-
+    
+    self->face = NULL;
+    
     if (filename && font_bytes_size <= 0) {
         self->font_bytes = NULL;
         error = FT_New_Face(library, filename, index, &self->face);
@@ -440,7 +442,9 @@ font_render(FontObject* self, PyObject* args)
 static void
 font_dealloc(FontObject* self)
 {
-    FT_Done_Face(self->face);
+    if (self->face) {
+        FT_Done_Face(self->face);
+    }
     if (self->font_bytes) {
         PyMem_Free(self->font_bytes);
     }

--- a/map.c
+++ b/map.c
@@ -73,7 +73,7 @@ PyImaging_MapperNew(const char* filename, int readonly)
         NULL);
     if (mapper->hFile == (HANDLE)-1) {
         PyErr_SetString(PyExc_IOError, "cannot open file");
-        PyObject_Del(mapper);
+        Py_DECREF(mapper);
         return NULL;
     }
 
@@ -84,7 +84,7 @@ PyImaging_MapperNew(const char* filename, int readonly)
     if (mapper->hMap == (HANDLE)-1) {
         CloseHandle(mapper->hFile);
         PyErr_SetString(PyExc_IOError, "cannot map file");
-        PyObject_Del(mapper);
+        Py_DECREF(mapper);
         return NULL;
     }
 


### PR DESCRIPTION
 PyObject_Del() should only be called on the self object in a dealloc call, not after failing to make a new object. Replace with Py_DECREF, which eventually calls PyObject_Del()

http://bugs.python.org/issue3299#msg78740
https://mail.python.org/pipermail/python-dev/2003-February/033258.html