### PR TITLE
Cleanup transforms

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1869,9 +1869,7 @@ class Image(object):
         h = box[3] - box[1]
 
         if method == AFFINE:
-            # change argument order to match implementation
-            data = (data[2], data[0], data[1],
-                    data[5], data[3], data[4])
+            data = data[0:6]
 
         elif method == EXTENT:
             # convert extent to an affine transform
@@ -1879,7 +1877,7 @@ class Image(object):
             xs = float(x1 - x0) / w
             ys = float(y1 - y0) / h
             method = AFFINE
-            data = (x0 + xs/2, xs, 0, y0 + ys/2, 0, ys)
+            data = (xs, 0, x0 + xs/2, 0, ys, y0 + ys/2)
 
         elif method == PERSPECTIVE:
             # change argument order to match implementation

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1880,7 +1880,6 @@ class Image(object):
             data = (xs, 0, x0 + xs/2, 0, ys, y0 + ys/2)
 
         elif method == PERSPECTIVE:
-            # change argument order to match implementation
             data = data[0:8]
 
         elif method == QUAD:

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -995,8 +995,7 @@ class Image(object):
             im = self.im.convert("P", 1, palette.im)
             return self._makeself(im)
 
-        im = self.im.quantize(colors, method, kmeans)
-        return self._new(im)
+        return self._new(self.im.quantize(colors, method, kmeans))
 
     def copy(self):
         """
@@ -1007,8 +1006,7 @@ class Image(object):
         :returns: An :py:class:`~PIL.Image.Image` object.
         """
         self.load()
-        im = self.im.copy()
-        return self._new(im)
+        return self._new(self.im.copy())
 
     __copy__ = copy
 
@@ -1935,8 +1933,7 @@ class Image(object):
         :param distance: Distance to spread pixels.
         """
         self.load()
-        im = self.im.effect_spread(distance)
-        return self._new(im)
+        return self._new(self.im.effect_spread(distance))
 
     def toqimage(self):
         """Returns a QImage copy of this image"""

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1583,10 +1583,10 @@ class Image(object):
 
         if expand:
             import math
-            angle = -angle * math.pi / 180
+            angle = - math.radians(angle)
             matrix = [
-                math.cos(angle), math.sin(angle), 0.0,
-                -math.sin(angle), math.cos(angle), 0.0
+                round(math.cos(angle), 15), round(math.sin(angle), 15), 0.0,
+                round(-math.sin(angle), 15), round(math.cos(angle), 15), 0.0
                 ]
 
             def transform(x, y, matrix=matrix):

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1881,9 +1881,7 @@ class Image(object):
 
         elif method == PERSPECTIVE:
             # change argument order to match implementation
-            data = (data[2], data[0], data[1],
-                    data[5], data[3], data[4],
-                    data[6], data[7])
+            data = data[0:8]
 
         elif method == QUAD:
             # quadrilateral warp.  data specifies the four corners

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1582,7 +1582,6 @@ class Image(object):
         if angle == 270 and expand:
             return self.transpose(ROTATE_270)
 
-
         angle = - math.radians(angle)
         matrix = [
             round(math.cos(angle), 15), round(math.sin(angle), 15), 0.0,

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1865,9 +1865,6 @@ class Image(object):
 
     def __transformer(self, box, image, method, data,
                       resample=NEAREST, fill=1):
-
-        # FIXME: this should be turned into a lazy operation (?)
-
         w = box[2] - box[0]
         h = box[3] - box[1]
 

--- a/_imaging.c
+++ b/_imaging.c
@@ -1553,8 +1553,8 @@ _resize(ImagingObject* self, PyObject* args)
 
         imOut = ImagingNew(imIn->mode, xsize, ysize);
 
-        imOut = ImagingTransformAffine(
-            imOut, imIn,
+        imOut = ImagingTransform(
+            imOut, imIn, IMAGING_TRANSFORM_AFFINE,
             0, 0, xsize, ysize,
             a, filter, 1);
     }
@@ -1613,7 +1613,6 @@ _transform2(ImagingObject* self, PyObject* args)
 {
     static const char* wrong_number = "wrong number of matrix entries";
 
-    Imaging imIn;
     Imaging imOut;
     int n;
     double *a;
@@ -1649,30 +1648,9 @@ _transform2(ImagingObject* self, PyObject* args)
     if (!a)
         return NULL;
 
-    imOut = self->image;
-    imIn = imagep->image;
-
-    /* FIXME: move transform dispatcher into libImaging */
-
-    switch (method) {
-    case IMAGING_TRANSFORM_AFFINE:
-        imOut = ImagingTransformAffine(
-            imOut, imIn, x0, y0, x1, y1, a, filter, 1
-            );
-        break;
-    case IMAGING_TRANSFORM_PERSPECTIVE:
-        imOut = ImagingTransformPerspective(
-            imOut, imIn, x0, y0, x1, y1, a, filter, 1
-            );
-        break;
-    case IMAGING_TRANSFORM_QUAD:
-        imOut = ImagingTransformQuad(
-            imOut, imIn, x0, y0, x1, y1, a, filter, 1
-            );
-        break;
-    default:
-        (void) ImagingError_ValueError("bad transform method");
-    }
+    imOut = ImagingTransform(
+        self->image, imagep->image, method,
+        x0, y0, x1, y1, a, filter, 1);
 
     free(a);
 

--- a/_imaging.c
+++ b/_imaging.c
@@ -1565,57 +1565,6 @@ _resize(ImagingObject* self, PyObject* args)
     return PyImagingNew(imOut);
 }
 
-static PyObject*
-_rotate(ImagingObject* self, PyObject* args)
-{
-    Imaging imOut;
-    Imaging imIn;
-
-    double theta;
-    int filter = IMAGING_TRANSFORM_NEAREST;
-    int expand;
-    if (!PyArg_ParseTuple(args, "d|i|i", &theta, &filter, &expand))
-        return NULL;
-
-    imIn = self->image;
-
-    theta = fmod(theta, 360.0);
-    if (theta < 0.0)
-        theta += 360;
-
-    if (filter && imIn->type != IMAGING_TYPE_SPECIAL) {
-        /* Rotate with resampling filter */
-        imOut = ImagingNew(imIn->mode, imIn->xsize, imIn->ysize);
-        (void) ImagingRotate(imOut, imIn, theta, filter);
-    
-    } else if ((theta == 90.0 || theta == 270.0)
-            && (expand || imIn->xsize == imIn->ysize)) {
-        /* Use fast version */
-        imOut = ImagingNew(imIn->mode, imIn->ysize, imIn->xsize);
-        if (imOut) {
-            if (theta == 90.0)
-                (void) ImagingRotate90(imOut, imIn);
-            else
-                (void) ImagingRotate270(imOut, imIn);
-        }
-    
-    } else {
-        imOut = ImagingNew(imIn->mode, imIn->xsize, imIn->ysize);
-        if (imOut) {
-            if (theta == 0.0)
-                /* No rotation: simply copy the input image */
-                (void) ImagingCopy2(imOut, imIn);
-            else if (theta == 180.0)
-                /* Use fast version */
-                (void) ImagingRotate180(imOut, imIn);
-            else
-                /* Use ordinary version */
-                (void) ImagingRotate(imOut, imIn, theta, 0);
-        }
-    }
-
-    return PyImagingNew(imOut);
-}
 
 #define IS_RGB(mode)\
     (!strcmp(mode, "RGB") || !strcmp(mode, "RGBA") || !strcmp(mode, "RGBX"))
@@ -3050,7 +2999,6 @@ static struct PyMethodDef methods[] = {
     // There were two methods for image resize before.
     // Starting from Pillow 2.7.0 stretch is depreciated.
     {"stretch", (PyCFunction)_resize, 1},
-    {"rotate", (PyCFunction)_rotate, 1},
     {"transpose", (PyCFunction)_transpose, 1},
     {"transform2", (PyCFunction)_transform2, 1},
 

--- a/_imaging.c
+++ b/_imaging.c
@@ -1544,12 +1544,12 @@ _resize(ImagingObject* self, PyObject* args)
     if (imIn->xsize == xsize && imIn->ysize == ysize) {
         imOut = ImagingCopy(imIn);
     }
-    else if ( ! filter) {
+    else if (filter == IMAGING_TRANSFORM_NEAREST) {
         double a[6];
 
         memset(a, 0, sizeof a);
-        a[1] = (double) imIn->xsize / xsize;
-        a[5] = (double) imIn->ysize / ysize;
+        a[0] = (double) imIn->xsize / xsize;
+        a[4] = (double) imIn->ysize / ysize;
 
         imOut = ImagingNew(imIn->mode, xsize, ysize);
 

--- a/_imaging.c
+++ b/_imaging.c
@@ -1581,12 +1581,13 @@ _rotate(ImagingObject* self, PyObject* args)
 
     theta = fmod(theta, 360.0);
     if (theta < 0.0)
-    theta += 360;
+        theta += 360;
 
     if (filter && imIn->type != IMAGING_TYPE_SPECIAL) {
         /* Rotate with resampling filter */
         imOut = ImagingNew(imIn->mode, imIn->xsize, imIn->ysize);
-    (void) ImagingRotate(imOut, imIn, theta, filter);
+        (void) ImagingRotate(imOut, imIn, theta, filter);
+    
     } else if ((theta == 90.0 || theta == 270.0)
             && (expand || imIn->xsize == imIn->ysize)) {
         /* Use fast version */
@@ -1597,6 +1598,7 @@ _rotate(ImagingObject* self, PyObject* args)
             else
                 (void) ImagingRotate270(imOut, imIn);
         }
+    
     } else {
         imOut = ImagingNew(imIn->mode, imIn->xsize, imIn->ysize);
         if (imOut) {

--- a/libImaging/Geometry.c
+++ b/libImaging/Geometry.c
@@ -288,7 +288,7 @@ quad_transform(double* xin, double* yin, int x, int y, void* data)
 /* transform filters (ImagingTransformFilter) */
 
 static int
-nearest_filter8(void* out, Imaging im, double xin, double yin, void* data)
+nearest_filter8(void* out, Imaging im, double xin, double yin)
 {
     int x = COORD(xin);
     int y = COORD(yin);
@@ -299,7 +299,7 @@ nearest_filter8(void* out, Imaging im, double xin, double yin, void* data)
 }
 
 static int
-nearest_filter16(void* out, Imaging im, double xin, double yin, void* data)
+nearest_filter16(void* out, Imaging im, double xin, double yin)
 {
     int x = COORD(xin);
     int y = COORD(yin);
@@ -310,7 +310,7 @@ nearest_filter16(void* out, Imaging im, double xin, double yin, void* data)
 }
 
 static int
-nearest_filter32(void* out, Imaging im, double xin, double yin, void* data)
+nearest_filter32(void* out, Imaging im, double xin, double yin)
 {
     int x = COORD(xin);
     int y = COORD(yin);
@@ -355,7 +355,7 @@ nearest_filter32(void* out, Imaging im, double xin, double yin, void* data)
 }
 
 static int
-bilinear_filter8(void* out, Imaging im, double xin, double yin, void* data)
+bilinear_filter8(void* out, Imaging im, double xin, double yin)
 {
     BILINEAR_HEAD(UINT8);
     BILINEAR_BODY(UINT8, im->image8, 1, 0);
@@ -364,7 +364,7 @@ bilinear_filter8(void* out, Imaging im, double xin, double yin, void* data)
 }
 
 static int
-bilinear_filter32I(void* out, Imaging im, double xin, double yin, void* data)
+bilinear_filter32I(void* out, Imaging im, double xin, double yin)
 {
     BILINEAR_HEAD(INT32);
     BILINEAR_BODY(INT32, im->image32, 1, 0);
@@ -373,7 +373,7 @@ bilinear_filter32I(void* out, Imaging im, double xin, double yin, void* data)
 }
 
 static int
-bilinear_filter32F(void* out, Imaging im, double xin, double yin, void* data)
+bilinear_filter32F(void* out, Imaging im, double xin, double yin)
 {
     BILINEAR_HEAD(FLOAT32);
     BILINEAR_BODY(FLOAT32, im->image32, 1, 0);
@@ -382,7 +382,7 @@ bilinear_filter32F(void* out, Imaging im, double xin, double yin, void* data)
 }
 
 static int
-bilinear_filter32LA(void* out, Imaging im, double xin, double yin, void* data)
+bilinear_filter32LA(void* out, Imaging im, double xin, double yin)
 {
     BILINEAR_HEAD(UINT8);
     BILINEAR_BODY(UINT8, im->image, 4, 0);
@@ -395,7 +395,7 @@ bilinear_filter32LA(void* out, Imaging im, double xin, double yin, void* data)
 }
 
 static int
-bilinear_filter32RGB(void* out, Imaging im, double xin, double yin, void* data)
+bilinear_filter32RGB(void* out, Imaging im, double xin, double yin)
 {
     int b;
     BILINEAR_HEAD(UINT8);
@@ -462,7 +462,7 @@ bilinear_filter32RGB(void* out, Imaging im, double xin, double yin, void* data)
 
 
 static int
-bicubic_filter8(void* out, Imaging im, double xin, double yin, void* data)
+bicubic_filter8(void* out, Imaging im, double xin, double yin)
 {
     BICUBIC_HEAD(UINT8);
     BICUBIC_BODY(UINT8, im->image8, 1, 0);
@@ -476,7 +476,7 @@ bicubic_filter8(void* out, Imaging im, double xin, double yin, void* data)
 }
 
 static int
-bicubic_filter32I(void* out, Imaging im, double xin, double yin, void* data)
+bicubic_filter32I(void* out, Imaging im, double xin, double yin)
 {
     BICUBIC_HEAD(INT32);
     BICUBIC_BODY(INT32, im->image32, 1, 0);
@@ -485,7 +485,7 @@ bicubic_filter32I(void* out, Imaging im, double xin, double yin, void* data)
 }
 
 static int
-bicubic_filter32F(void* out, Imaging im, double xin, double yin, void* data)
+bicubic_filter32F(void* out, Imaging im, double xin, double yin)
 {
     BICUBIC_HEAD(FLOAT32);
     BICUBIC_BODY(FLOAT32, im->image32, 1, 0);
@@ -494,7 +494,7 @@ bicubic_filter32F(void* out, Imaging im, double xin, double yin, void* data)
 }
 
 static int
-bicubic_filter32LA(void* out, Imaging im, double xin, double yin, void* data)
+bicubic_filter32LA(void* out, Imaging im, double xin, double yin)
 {
     BICUBIC_HEAD(UINT8);
     BICUBIC_BODY(UINT8, im->image, 4, 0);
@@ -522,7 +522,7 @@ bicubic_filter32LA(void* out, Imaging im, double xin, double yin, void* data)
 }
 
 static int
-bicubic_filter32RGB(void* out, Imaging im, double xin, double yin, void* data)
+bicubic_filter32RGB(void* out, Imaging im, double xin, double yin)
 {
     int b;
     BICUBIC_HEAD(UINT8);
@@ -550,51 +550,51 @@ getfilter(Imaging im, int filterid)
         if (im->image8)
             switch (im->type) {
             case IMAGING_TYPE_UINT8:
-                return (ImagingTransformFilter) nearest_filter8;
+                return nearest_filter8;
             case IMAGING_TYPE_SPECIAL:
                 switch (im->pixelsize) {
                 case 1:
-                    return (ImagingTransformFilter) nearest_filter8;
+                    return nearest_filter8;
                 case 2:
-                    return (ImagingTransformFilter) nearest_filter16;
+                    return nearest_filter16;
                 case 4:
-                    return (ImagingTransformFilter) nearest_filter32;
+                    return nearest_filter32;
                 }
             }
         else
-            return (ImagingTransformFilter) nearest_filter32;
+            return nearest_filter32;
         break;
     case IMAGING_TRANSFORM_BILINEAR:
         if (im->image8)
-            return (ImagingTransformFilter) bilinear_filter8;
+            return bilinear_filter8;
         else if (im->image32) {
             switch (im->type) {
             case IMAGING_TYPE_UINT8:
                 if (im->bands == 2)
-                    return (ImagingTransformFilter) bilinear_filter32LA;
+                    return bilinear_filter32LA;
                 else
-                    return (ImagingTransformFilter) bilinear_filter32RGB;
+                    return bilinear_filter32RGB;
             case IMAGING_TYPE_INT32:
-                return (ImagingTransformFilter) bilinear_filter32I;
+                return bilinear_filter32I;
             case IMAGING_TYPE_FLOAT32:
-                return (ImagingTransformFilter) bilinear_filter32F;
+                return bilinear_filter32F;
             }
         }
         break;
     case IMAGING_TRANSFORM_BICUBIC:
         if (im->image8)
-            return (ImagingTransformFilter) bicubic_filter8;
+            return bicubic_filter8;
         else if (im->image32) {
             switch (im->type) {
             case IMAGING_TYPE_UINT8:
                 if (im->bands == 2)
-                    return (ImagingTransformFilter) bicubic_filter32LA;
+                    return bicubic_filter32LA;
                 else
-                    return (ImagingTransformFilter) bicubic_filter32RGB;
+                    return bicubic_filter32RGB;
             case IMAGING_TYPE_INT32:
-                return (ImagingTransformFilter) bicubic_filter32I;
+                return bicubic_filter32I;
             case IMAGING_TYPE_FLOAT32:
-                return (ImagingTransformFilter) bicubic_filter32F;
+                return bicubic_filter32F;
             }
         }
         break;
@@ -609,7 +609,7 @@ Imaging
 ImagingGenericTransform(
     Imaging imOut, Imaging imIn, int x0, int y0, int x1, int y1,
     ImagingTransformMap transform, void* transform_data,
-    int filterid, void* filter_data, int fill)
+    int filterid, int fill)
 {
     /* slow generic transformation.  use ImagingTransformAffine or
        ImagingScaleAffine where possible. */
@@ -642,8 +642,8 @@ ImagingGenericTransform(
     for (y = y0; y < y1; y++) {
         out = imOut->image[y] + x0*imOut->pixelsize;
         for (x = x0; x < x1; x++) {
-            if (!transform(&xx, &yy, x-x0, y-y0, transform_data) ||
-                !filter(out, imIn, xx, yy, filter_data)) {
+            if ( ! transform(&xx, &yy, x-x0, y-y0, transform_data) ||
+                 ! filter(out, imIn, xx, yy)) {
                 if (fill)
                     memset(out, 0, imOut->pixelsize);
             }
@@ -831,7 +831,7 @@ ImagingTransformAffine(Imaging imOut, Imaging imIn,
             imOut, imIn,
             x0, y0, x1, y1,
             affine_transform, a,
-            filterid, NULL, fill);
+            filterid, fill);
     }
 
     if (a[2] == 0 && a[4] == 0)
@@ -930,5 +930,5 @@ ImagingTransform(Imaging imOut, Imaging imIn, int method,
     return ImagingGenericTransform(
         imOut, imIn,
         x0, y0, x1, y1,
-        transform, a, filterid, NULL, fill);
+        transform, a, filterid, fill);
 }

--- a/libImaging/Geometry.c
+++ b/libImaging/Geometry.c
@@ -1,30 +1,3 @@
-/*
- * The Python Imaging Library
- * $Id$
- *
- * the imaging geometry methods
- *
- * history:
- * 1995-06-15 fl  Created
- * 1996-04-15 fl  Changed origin
- * 1996-05-18 fl  Fixed rotate90/270 for rectangular images
- * 1996-05-27 fl  Added general purpose transform
- * 1996-11-22 fl  Don't crash when resizing from outside source image
- * 1997-08-09 fl  Fixed rounding error in resize
- * 1998-09-21 fl  Incorporated transformation patches (from Zircon #2)
- * 1998-09-22 fl  Added bounding box to transform engines
- * 1999-02-03 fl  Fixed bicubic filtering for RGB images
- * 1999-02-16 fl  Added fixed-point version of affine transform
- * 2001-03-28 fl  Fixed transform(EXTENT) for xoffset < 0
- * 2003-03-10 fl  Compiler tweaks
- * 2004-09-19 fl  Fixed bilinear/bicubic filtering of LA images
- *
- * Copyright (c) 1997-2003 by Secret Labs AB
- * Copyright (c) 1995-1997 by Fredrik Lundh
- *
- * See the README file for information on usage and redistribution.
- */
-
 #include "Imaging.h"
 
 /* For large images rotation is an inefficient operation in terms of CPU cache.
@@ -180,21 +153,6 @@ ImagingTranspose(Imaging imOut, Imaging imIn)
 #undef TRANSPOSE
 
     return imOut;
-}
-
-
-Imaging
-ImagingTransposeToNew(Imaging imIn)
-{
-    Imaging imTemp = ImagingNew(imIn->mode, imIn->ysize, imIn->xsize);
-    if ( ! imTemp)
-        return NULL;
-
-    if ( ! ImagingTranspose(imTemp, imIn)) {
-        ImagingDelete(imTemp);
-        return NULL;
-    }
-    return imTemp;
 }
 
 

--- a/libImaging/Geometry.c
+++ b/libImaging/Geometry.c
@@ -27,9 +27,6 @@
 
 #include "Imaging.h"
 
-/* Undef if you don't need resampling filters */
-#define WITH_FILTERS
-
 /* For large images rotation is an inefficient operation in terms of CPU cache.
    One row in the source image affects each column in destination.
    Rotating in chunks that fit in the cache can speed up rotation
@@ -320,8 +317,6 @@ quad_transform(double* xin, double* yin, int x, int y, void* data)
 }
 
 /* transform filters (ImagingTransformFilter) */
-
-#ifdef WITH_FILTERS
 
 static int
 nearest_filter8(void* out, Imaging im, double xin, double yin, void* data)
@@ -630,10 +625,6 @@ getfilter(Imaging im, int filterid)
     /* no such filter */
     return NULL;
 }
-
-#else
-#define getfilter(im, id) NULL
-#endif
 
 /* transformation engines */
 

--- a/libImaging/Geometry.c
+++ b/libImaging/Geometry.c
@@ -850,8 +850,6 @@ ImagingTransformAffine(Imaging imOut, Imaging imIn,
     if (y1 > imOut->ysize)
         y1 = imOut->ysize;
 
-    ImagingCopyInfo(imOut, imIn);
-
     /* translate all four corners to check if they are within the
        range that can be represented by the fixed point arithmetics */
 
@@ -862,6 +860,8 @@ ImagingTransformAffine(Imaging imOut, Imaging imIn,
     /* FIXME: cannot really think of any reasonable case when the
        following code is used.  maybe we should fall back on the slow
        generic transform engine in this case? */
+    
+    ImagingCopyInfo(imOut, imIn);
 
     xsize = (int) imIn->xsize;
     ysize = (int) imIn->ysize;

--- a/libImaging/Geometry.c
+++ b/libImaging/Geometry.c
@@ -264,8 +264,8 @@ perspective_transform(double* xin, double* yin, int x, int y, void* data)
     double a3 = a[3]; double a4 = a[4]; double a5 = a[5];
     double a6 = a[6]; double a7 = a[7];
 
-    xin[0] = (a0 + a1*x + a2*y) / (a6*x + a7*y + 1);
-    yin[0] = (a3 + a4*x + a5*y) / (a6*x + a7*y + 1);
+    xin[0] = (a0*x + a1*y + a2) / (a6*x + a7*y + 1);
+    yin[0] = (a3*x + a4*y + a5) / (a6*x + a7*y + 1);
 
     return 1;
 }

--- a/libImaging/Geometry.c
+++ b/libImaging/Geometry.c
@@ -939,34 +939,3 @@ ImagingTransformQuad(Imaging imOut, Imaging imIn,
         filter, NULL,
         fill);
 }
-
-/* -------------------------------------------------------------------- */
-/* Convenience functions */
-
-Imaging
-ImagingRotate(Imaging imOut, Imaging imIn, double theta, int filterid)
-{
-    int xsize, ysize;
-    double sintheta, costheta;
-    double a[6];
-
-    /* Setup an affine transform to rotate around the image center */
-    theta = -theta * M_PI / 180.0;
-    sintheta = sin(theta);
-    costheta = cos(theta);
-
-    xsize = imOut->xsize;
-    ysize = imOut->ysize;
-
-    a[0] = -costheta * xsize/2 - sintheta * ysize/2 + xsize/2;
-    a[1] = costheta;
-    a[2] = sintheta;
-    a[3] = sintheta * xsize/2 - costheta * ysize/2 + ysize/2;
-    a[4] = -sintheta;
-    a[5] = costheta;
-
-    return ImagingTransformAffine(
-        imOut, imIn,
-        0, 0, imOut->xsize, imOut->ysize,
-        a, filterid, 1);
-}

--- a/libImaging/Geometry.c
+++ b/libImaging/Geometry.c
@@ -606,7 +606,7 @@ getfilter(Imaging im, int filterid)
 /* transformation engines */
 
 Imaging
-ImagingTransform(
+ImagingGenericTransform(
     Imaging imOut, Imaging imIn, int x0, int y0, int x1, int y1,
     ImagingTransformMap transform, void* transform_data,
     ImagingTransformFilter filter, void* filter_data,
@@ -828,7 +828,7 @@ ImagingTransformAffine(Imaging imOut, Imaging imIn,
         ImagingTransformFilter filter = getfilter(imIn, filterid);
         if (!filter)
             return (Imaging) ImagingError_ValueError("unknown filter");
-        return ImagingTransform(
+        return ImagingGenericTransform(
             imOut, imIn,
             x0, y0, x1, y1,
             affine_transform, a,
@@ -915,7 +915,7 @@ ImagingTransformPerspective(Imaging imOut, Imaging imIn,
     if (!filter)
         return (Imaging) ImagingError_ValueError("bad filter number");
 
-    return ImagingTransform(
+    return ImagingGenericTransform(
         imOut, imIn,
         x0, y0, x1, y1,
         perspective_transform, a,
@@ -932,7 +932,7 @@ ImagingTransformQuad(Imaging imOut, Imaging imIn,
     if (!filter)
         return (Imaging) ImagingError_ValueError("bad filter number");
 
-    return ImagingTransform(
+    return ImagingGenericTransform(
         imOut, imIn,
         x0, y0, x1, y1,
         quad_transform, a,

--- a/libImaging/Imaging.h
+++ b/libImaging/Imaging.h
@@ -293,7 +293,6 @@ extern Imaging ImagingRotate180(Imaging imOut, Imaging imIn);
 extern Imaging ImagingRotate270(Imaging imOut, Imaging imIn);
 extern Imaging ImagingResample(Imaging imIn, int xsize, int ysize, int filter);
 extern Imaging ImagingTranspose(Imaging imOut, Imaging imIn);
-extern Imaging ImagingTransposeToNew(Imaging imIn);
 extern Imaging ImagingTransformPerspective(
     Imaging imOut, Imaging imIn, int x0, int y0, int x1, int y1,
     double a[8], int filter, int fill);

--- a/libImaging/Imaging.h
+++ b/libImaging/Imaging.h
@@ -236,8 +236,7 @@ extern void ImagingError_Clear(void);
 typedef int (*ImagingTransformMap)(double* X, double* Y,
                                    int x, int y, void* data);
 typedef int (*ImagingTransformFilter)(void* out, Imaging im,
-                                      double x, double y,
-                                      void* data);
+                                      double x, double y);
 
 /* Image Manipulation Methods */
 /* -------------------------- */

--- a/libImaging/Imaging.h
+++ b/libImaging/Imaging.h
@@ -286,8 +286,6 @@ extern Imaging ImagingPointTransform(
     Imaging imIn, double scale, double offset);
 extern Imaging ImagingPutBand(Imaging im, Imaging imIn, int band);
 extern Imaging ImagingRankFilter(Imaging im, int size, int rank);
-extern Imaging ImagingRotate(
-    Imaging imOut, Imaging imIn, double theta, int filter);
 extern Imaging ImagingRotate90(Imaging imOut, Imaging imIn);
 extern Imaging ImagingRotate180(Imaging imOut, Imaging imIn);
 extern Imaging ImagingRotate270(Imaging imOut, Imaging imIn);

--- a/libImaging/Imaging.h
+++ b/libImaging/Imaging.h
@@ -330,12 +330,6 @@ extern Imaging ImagingChopXor(Imaging imIn1, Imaging imIn2);
 extern void ImagingCrack(Imaging im, int x0, int y0);
 
 /* Graphics */
-struct ImagingAffineMatrixInstance {
-    float a[9];
-};
-
-typedef struct ImagingAffineMatrixInstance *ImagingAffineMatrix;
-
 extern int ImagingDrawArc(Imaging im, int x0, int y0, int x1, int y1,
                           float start, float end, const void* ink, int op);
 extern int ImagingDrawBitmap(Imaging im, int x0, int y0, Imaging bitmap,

--- a/libImaging/Imaging.h
+++ b/libImaging/Imaging.h
@@ -300,11 +300,6 @@ extern Imaging ImagingTransformAffine(
 extern Imaging ImagingTransformQuad(
     Imaging imOut, Imaging imIn, int x0, int y0, int x1, int y1,
     double a[8], int filter, int fill);
-extern Imaging ImagingTransform(
-    Imaging imOut, Imaging imIn, int x0, int y0, int x1, int y1,
-    ImagingTransformMap transform, void* transform_data,
-    ImagingTransformFilter filter, void* filter_data,
-    int fill);
 extern Imaging ImagingUnsharpMask(
     Imaging imOut, Imaging im, float radius, int percent, int threshold);
 extern Imaging ImagingBoxBlur(Imaging imOut, Imaging imIn, float radius, int n);

--- a/libImaging/Imaging.h
+++ b/libImaging/Imaging.h
@@ -291,15 +291,9 @@ extern Imaging ImagingRotate180(Imaging imOut, Imaging imIn);
 extern Imaging ImagingRotate270(Imaging imOut, Imaging imIn);
 extern Imaging ImagingResample(Imaging imIn, int xsize, int ysize, int filter);
 extern Imaging ImagingTranspose(Imaging imOut, Imaging imIn);
-extern Imaging ImagingTransformPerspective(
-    Imaging imOut, Imaging imIn, int x0, int y0, int x1, int y1,
-    double a[8], int filter, int fill);
-extern Imaging ImagingTransformAffine(
-    Imaging imOut, Imaging imIn, int x0, int y0, int x1, int y1,
-    double a[6], int filter, int fill);
-extern Imaging ImagingTransformQuad(
-    Imaging imOut, Imaging imIn, int x0, int y0, int x1, int y1,
-    double a[8], int filter, int fill);
+extern Imaging ImagingTransform(
+    Imaging imOut, Imaging imIn, int method, int x0, int y0, int x1, int y1,
+    double *a, int filter, int fill);
 extern Imaging ImagingUnsharpMask(
     Imaging imOut, Imaging im, float radius, int percent, int threshold);
 extern Imaging ImagingBoxBlur(Imaging imOut, Imaging imIn, float radius, int n);


### PR DESCRIPTION
Internal transform API was very confusing. For example, `rotate` method was calling `self.transform` or `self.im.rotate` depends on `expand` argument, but `self.im.rotate` internally also calls `ImagingTransformAffine`, so it was excessive.

Changes proposed in this pull request:

 * First of all, this PR fixes rotations bug #1917 in two ways:
    * It really uses very cheap `transpose` operations if it is possible regardless of filter. https://github.com/python-pillow/Pillow/pull/1941/commits/8203a43d262d349f71bcfa3da46e5f3e30fe99e0
    * It rounds coefficients in the transform matrix, so even if we are not using cheap transpose, we still get right dimensions because `cos(90°)` now is exactly 0, not 6.123e-17. https://github.com/python-pillow/Pillow/pull/1941/commits/7687ce829e50635838707f5153079fb4d34cd41e
 * `Image.rotate` always uses `self.transform`, so `im.rotate` was removed from core library. https://github.com/python-pillow/Pillow/pull/1941/commits/709078efd14cfcffaedf59e883f56aa16d61926e https://github.com/python-pillow/Pillow/pull/1941/commits/1f8c2527baaff6357f31761b6340d2016920781f
 * The order of coefficients in internal API now match matrix representation and order of external API. https://github.com/python-pillow/Pillow/pull/1941/commits/2b77b1cec7fae15112be03dd5c1bfbb0169c3e0b https://github.com/python-pillow/Pillow/pull/1941/commits/3d622d60cf7c6c609cfc48b774ee0d8aef2d1d85
 * Internal `ImagingTransformAffine`, `ImagingTransformPerspective` and `ImagingTransformQuad` was replaced with one entry point to all transformations: `ImagingTransform`. Former `ImagingTransform` was  renamed to `ImagingGenericTransform` and removed from extern symbols (`Imaging.h` file). https://github.com/python-pillow/Pillow/pull/1941/commits/6be3df2a432bdc61d0705ebacfc878b93cc86b9c https://github.com/python-pillow/Pillow/pull/1941/commits/9902d2e1c50712a7fa1d308fab124bf5c71f018e