### PR TITLE
Added catch for UnsupportedOperation in ImageFile load

### DIFF
--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -170,7 +170,7 @@ class ImageFile(Image.Image):
                             self.map, self.size, d, e, o, a
                             )
                     readonly = 1
-                except (AttributeError, EnvironmentError, ImportError):
+                except (AttributeError, EnvironmentError, ImportError, io.UnsupportedOperation):
                     self.map = None
 
         self.load_prepare()


### PR DESCRIPTION
Resolves #1945

Added a catch for UnsupportedOperation in load. Mirrors the catch for this exception when saving at https://github.com/python-pillow/Pillow/blob/master/PIL/ImageFile.py#L461