### PR TITLE
Revert "docs for new --disable-osx-tclck-frameworks option"

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -216,10 +216,6 @@ Build Options
   automated build systems that configure the proper paths in the
   environment variables (e.g. Buildroot).
 
-* Build flag: ``--disable-osx-tcltk-framework``. Skips linking against
-  the OSX system TCL/TK frameworks for systems that have alternate
-  versions of the libraries installed. 
-
 * Build flag: ``--debug``. Adds a debugging flag to the include and
   library search process to dump all paths searched for and found to
   stdout.


### PR DESCRIPTION
This reverts commit da62f7c25b8a01a87a8e18b3a483c27927a9d1e3.