### PR TITLE
Tiff: Bail out if there are no valid exif tags

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -551,7 +551,7 @@ class ImageFileDirectory_v2(collections.MutableMapping):
 
         dest = self._tags_v1 if legacy_api else self._tags_v2
 
-        if info.length == 1:
+        if info.length == 1 and len(values) > 0:
             if legacy_api and self.tagtype[tag] in [5, 10]:
                 values = values,
             dest[tag], = values


### PR DESCRIPTION
Fixes #1950.

Changes proposed in this pull request:

 * Just return if there aren't any valid-looking EXIF tags

Some corrupted images end up with no valid exif tags.  This case is
currently not handled gracefully, resulting in the following:

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/mitchhumpherys/Sites/str-prod/env/lib/python2.7/site-packages/PIL/JpegImagePlugin.py", line 391, in _getexif
        return _getexif(self)
      File "/Users/mitchhumpherys/Sites/str-prod/env/lib/python2.7/site-packages/PIL/JpegImagePlugin.py", line 426, in _getexif
        exif = dict(_fixup_dict(info))
      File "/Users/mitchhumpherys/Sites/str-prod/env/lib/python2.7/site-packages/PIL/JpegImagePlugin.py", line 407, in _fixup_dict
        return dict([(k, _fixup(v)) for k, v in src_dict.items()])
      File "/Users/mitchhumpherys/Sites/str-prod/env/bin/../lib/python2.7/_abcoll.py", line 414, in items
        return [(key, self[key]) for key in self]
      File "/Users/mitchhumpherys/Sites/str-prod/env/lib/python2.7/site-packages/PIL/TiffImagePlugin.py", line 854, in __getitem__
        self._setitem(tag, handler(self, data, legacy), legacy)
      File "/Users/mitchhumpherys/Sites/str-prod/env/lib/python2.7/site-packages/PIL/TiffImagePlugin.py", line 534, in _setitem
        dest[tag], = values
    ValueError: need more than 0 values to unpack

Just bail out if there aren't any valid tags.

Fixes #1950