### PR TITLE
Do not do unnecessary passes on resizing

### DIFF
--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -254,5 +254,25 @@ class CoreResampleAlphaCorrectTest(PillowTestCase):
         self.run_dity_case(case.resize((20, 20), Image.LANCZOS), (255,))
 
 
+class CoreResamplePassesTest(PillowTestCase):
+    def test_horizontal(self):
+        im = hopper('L')
+        count = Image.core.getcount()
+        im.resize((im.size[0] + 10, im.size[1]), Image.BILINEAR)
+        self.assertEqual(Image.core.getcount(), count + 1)
+
+    def test_vertical(self):
+        im = hopper('L')
+        count = Image.core.getcount()
+        im.resize((im.size[0], im.size[1] + 10), Image.BILINEAR)
+        self.assertEqual(Image.core.getcount(), count + 1)
+
+    def test_both(self):
+        im = hopper('L')
+        count = Image.core.getcount()
+        im.resize((im.size[0] + 10, im.size[1] + 10), Image.BILINEAR)
+        self.assertEqual(Image.core.getcount(), count + 2)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is a relatively rare case, but why not?

From some point of view, this breaks the consistency because resampling filter is applied to one pass and isn't for another. But Pillow already returns a copy of the image if both dimensions are the same, and there is no way to apply resampling filter to the image from python code without affecting dimension.