### PR TITLE
Simplified condition in init method

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -388,7 +388,7 @@ def init():
     """
 
     global _initialized
-    if _initialized >= 2:
+    if _initialized == 2:
         return 0
 
     for plugin in _plugins:


### PR DESCRIPTION
This is minor, so if anyone would like to close, feel free to do so.

In the `init` method, there is a check for `_initialized >= 2`. However, `_initialized` never becomes > 2. So I have changed it to `== 2`, just for clarity.