### PR TITLE
New filters! ⭐⭐⭐

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -168,13 +168,15 @@ MESH = 4
 
 # resampling filters
 NEAREST = NONE = 0
-LANCZOS = ANTIALIAS = 1
+BOX = 4
 BILINEAR = LINEAR = 2
+HAMMING = 5
 BICUBIC = CUBIC = 3
+MITCHELL = 6
+LANCZOS = ANTIALIAS = 1
 
 # dithers
-NONE = 0
-NEAREST = 0
+NEAREST = NONE = 0
 ORDERED = 1  # Not yet implemented
 RASTERIZE = 2  # Not yet implemented
 FLOYDSTEINBERG = 3  # default
@@ -1518,16 +1520,20 @@ class Image(object):
         :param size: The requested size in pixels, as a 2-tuple:
            (width, height).
         :param resample: An optional resampling filter.  This can be
-           one of :py:attr:`PIL.Image.NEAREST` (use nearest neighbour),
-           :py:attr:`PIL.Image.BILINEAR` (linear interpolation),
-           :py:attr:`PIL.Image.BICUBIC` (cubic spline interpolation), or
-           :py:attr:`PIL.Image.LANCZOS` (a high-quality downsampling filter).
+           one of :py:attr:`PIL.Image.NEAREST`, :py:attr:`PIL.Image.BOX`,
+           :py:attr:`PIL.Image.BILINEAR`, :py:attr:`PIL.Image.HAMMING`,
+           :py:attr:`PIL.Image.BICUBIC`, :py:attr:`PIL.Image.MITCHELL` or
+           :py:attr:`PIL.Image.LANCZOS`.
            If omitted, or if the image has mode "1" or "P", it is
            set :py:attr:`PIL.Image.NEAREST`.
+           See: :ref:`concept-filters`.
         :returns: An :py:class:`~PIL.Image.Image` object.
         """
 
-        if resample not in (NEAREST, BILINEAR, BICUBIC, LANCZOS):
+        if resample not in (
+                NEAREST, BILINEAR, BICUBIC, LANCZOS,
+                BOX, HAMMING, MITCHELL,
+        ):
             raise ValueError("unknown resampling filter")
 
         self.load()
@@ -1560,7 +1566,7 @@ class Image(object):
            environment), or :py:attr:`PIL.Image.BICUBIC`
            (cubic spline interpolation in a 4x4 environment).
            If omitted, or if the image has mode "1" or "P", it is
-           set :py:attr:`PIL.Image.NEAREST`.
+           set :py:attr:`PIL.Image.NEAREST`. See :ref:`concept-filters`.
         :param expand: Optional expansion flag.  If true, expands the output
            image to make it large enough to hold the entire rotated image.
            If false or omitted, make the output image the same size as the

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -172,7 +172,6 @@ BOX = 4
 BILINEAR = LINEAR = 2
 HAMMING = 5
 BICUBIC = CUBIC = 3
-MITCHELL = 6
 LANCZOS = ANTIALIAS = 1
 
 # dithers
@@ -1522,8 +1521,7 @@ class Image(object):
         :param resample: An optional resampling filter.  This can be
            one of :py:attr:`PIL.Image.NEAREST`, :py:attr:`PIL.Image.BOX`,
            :py:attr:`PIL.Image.BILINEAR`, :py:attr:`PIL.Image.HAMMING`,
-           :py:attr:`PIL.Image.BICUBIC`, :py:attr:`PIL.Image.MITCHELL` or
-           :py:attr:`PIL.Image.LANCZOS`.
+           :py:attr:`PIL.Image.BICUBIC` or :py:attr:`PIL.Image.LANCZOS`.
            If omitted, or if the image has mode "1" or "P", it is
            set :py:attr:`PIL.Image.NEAREST`.
            See: :ref:`concept-filters`.
@@ -1531,8 +1529,7 @@ class Image(object):
         """
 
         if resample not in (
-                NEAREST, BILINEAR, BICUBIC, LANCZOS,
-                BOX, HAMMING, MITCHELL,
+                NEAREST, BILINEAR, BICUBIC, LANCZOS, BOX, HAMMING,
         ):
             raise ValueError("unknown resampling filter")
 

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -126,16 +126,6 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
             for channel in case.split():
                 self.check_case(channel, self.make_sample(data, (6, 6)))
 
-    def test_reduce_mitchell(self):
-        for mode in ['RGBX', 'RGB', 'La', 'L']:
-            case = self.make_case(mode, (12, 12), 0xe1)
-            case = case.resize((6, 6), Image.MITCHELL)
-            data = ('e1 e2 cc'
-                    'e2 e3 cd'
-                    'cc cd bb')
-            for channel in case.split():
-                self.check_case(channel, self.make_sample(data, (6, 6)))
-
     def test_reduce_lanczos(self):
         for mode in ['RGBX', 'RGB', 'La', 'L']:
             case = self.make_case(mode, (16, 16), 0xe1)
@@ -184,17 +174,6 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
                     'e5 e9 f3 bc'
                     'ee f3 fd c1'
                     'b9 bc c1 a2')
-            for channel in case.split():
-                self.check_case(channel, self.make_sample(data, (8, 8)))
-
-    def test_enlarge_mitchell(self):
-        for mode in ['RGBX', 'RGB', 'La', 'L']:
-            case = self.make_case(mode, (4, 4), 0xe1)
-            case = case.resize((8, 8), Image.MITCHELL)
-            data = ('e1 e4 e6 b2'
-                    'e4 e7 e9 b3'
-                    'e6 e9 eb b4'
-                    'b2 b3 b5 9a')
             for channel in case.split():
                 self.check_case(channel, self.make_sample(data, (8, 8)))
 
@@ -274,7 +253,6 @@ class CoreResampleAlphaCorrectTest(PillowTestCase):
         self.run_levels_case(case.resize((512, 32), Image.BILINEAR))
         self.run_levels_case(case.resize((512, 32), Image.HAMMING))
         self.run_levels_case(case.resize((512, 32), Image.BICUBIC))
-        self.run_levels_case(case.resize((512, 32), Image.MITCHELL))
         self.run_levels_case(case.resize((512, 32), Image.LANCZOS))
 
     @unittest.skip("current implementation isn't precise enough")
@@ -284,7 +262,6 @@ class CoreResampleAlphaCorrectTest(PillowTestCase):
         self.run_levels_case(case.resize((512, 32), Image.BILINEAR))
         self.run_levels_case(case.resize((512, 32), Image.HAMMING))
         self.run_levels_case(case.resize((512, 32), Image.BICUBIC))
-        self.run_levels_case(case.resize((512, 32), Image.MITCHELL))
         self.run_levels_case(case.resize((512, 32), Image.LANCZOS))
 
     def make_dity_case(self, mode, clean_pixel, dirty_pixel):
@@ -312,7 +289,6 @@ class CoreResampleAlphaCorrectTest(PillowTestCase):
         self.run_dity_case(case.resize((20, 20), Image.BILINEAR), (255, 255, 0))
         self.run_dity_case(case.resize((20, 20), Image.HAMMING), (255, 255, 0))
         self.run_dity_case(case.resize((20, 20), Image.BICUBIC), (255, 255, 0))
-        self.run_dity_case(case.resize((20, 20), Image.MITCHELL), (255, 255, 0))
         self.run_dity_case(case.resize((20, 20), Image.LANCZOS), (255, 255, 0))
 
     def test_dirty_pixels_la(self):
@@ -321,7 +297,6 @@ class CoreResampleAlphaCorrectTest(PillowTestCase):
         self.run_dity_case(case.resize((20, 20), Image.BILINEAR), (255,))
         self.run_dity_case(case.resize((20, 20), Image.HAMMING), (255,))
         self.run_dity_case(case.resize((20, 20), Image.BICUBIC), (255,))
-        self.run_dity_case(case.resize((20, 20), Image.MITCHELL), (255,))
         self.run_dity_case(case.resize((20, 20), Image.LANCZOS), (255,))
 
 

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -10,7 +10,7 @@ class TestImagingResampleVulnerability(PillowTestCase):
         ysize = 1000  # unimportant
         try:
             # any resampling filter will do here
-            im.im.resize((xsize, ysize), Image.LINEAR)
+            im.im.resize((xsize, ysize), Image.BILINEAR)
             self.fail("Resize should raise MemoryError on invalid xsize")
         except MemoryError:
             self.assertTrue(True, "Should raise MemoryError")
@@ -89,12 +89,30 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
             for y in range(image.size[1])
         )
 
+    def test_reduce_box(self):
+        for mode in ['RGBX', 'RGB', 'La', 'L']:
+            case = self.make_case(mode, (8, 8), 0xe1)
+            case = case.resize((4, 4), Image.BOX)
+            data = ('e1 e1'
+                    'e1 e1')
+            for channel in case.split():
+                self.check_case(channel, self.make_sample(data, (4, 4)))
+
     def test_reduce_bilinear(self):
         for mode in ['RGBX', 'RGB', 'La', 'L']:
             case = self.make_case(mode, (8, 8), 0xe1)
             case = case.resize((4, 4), Image.BILINEAR)
             data = ('e1 c9'
                     'c9 b7')
+            for channel in case.split():
+                self.check_case(channel, self.make_sample(data, (4, 4)))
+
+    def test_reduce_hamming(self):
+        for mode in ['RGBX', 'RGB', 'La', 'L']:
+            case = self.make_case(mode, (8, 8), 0xe1)
+            case = case.resize((4, 4), Image.HAMMING)
+            data = ('e1 da'
+                    'da d3')
             for channel in case.split():
                 self.check_case(channel, self.make_sample(data, (4, 4)))
 
@@ -105,6 +123,16 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
             data = ('e1 e3 d4'
                     'e3 e5 d6'
                     'd4 d6 c9')
+            for channel in case.split():
+                self.check_case(channel, self.make_sample(data, (6, 6)))
+
+    def test_reduce_mitchell(self):
+        for mode in ['RGBX', 'RGB', 'La', 'L']:
+            case = self.make_case(mode, (12, 12), 0xe1)
+            case = case.resize((6, 6), Image.MITCHELL)
+            data = ('e1 e2 cc'
+                    'e2 e3 cd'
+                    'cc cd bb')
             for channel in case.split():
                 self.check_case(channel, self.make_sample(data, (6, 6)))
 
@@ -119,6 +147,15 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
             for channel in case.split():
                 self.check_case(channel, self.make_sample(data, (8, 8)))
 
+    def test_enlarge_box(self):
+        for mode in ['RGBX', 'RGB', 'La', 'L']:
+            case = self.make_case(mode, (2, 2), 0xe1)
+            case = case.resize((4, 4), Image.BOX)
+            data = ('e1 e1'
+                    'e1 e1')
+            for channel in case.split():
+                self.check_case(channel, self.make_sample(data, (4, 4)))
+
     def test_enlarge_bilinear(self):
         for mode in ['RGBX', 'RGB', 'La', 'L']:
             case = self.make_case(mode, (2, 2), 0xe1)
@@ -128,6 +165,17 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
             for channel in case.split():
                 self.check_case(channel, self.make_sample(data, (4, 4)))
 
+    def test_enlarge_hamming(self):
+        for mode in ['RGBX', 'RGB', 'La', 'L']:
+            case = self.make_case(mode, (4, 4), 0xe1)
+            case = case.resize((8, 8), Image.HAMMING)
+            data = ('e1 e1 ea d1'
+                    'e1 e1 ea d1'
+                    'ea ea f4 d9'
+                    'd1 d1 d9 c4')
+            for channel in case.split():
+                self.check_case(channel, self.make_sample(data, (8, 8)))
+
     def test_enlarge_bicubic(self):
         for mode in ['RGBX', 'RGB', 'La', 'L']:
             case = self.make_case(mode, (4, 4), 0xe1)
@@ -136,6 +184,17 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
                     'e5 e9 f3 bc'
                     'ee f3 fd c1'
                     'b9 bc c1 a2')
+            for channel in case.split():
+                self.check_case(channel, self.make_sample(data, (8, 8)))
+
+    def test_enlarge_mitchell(self):
+        for mode in ['RGBX', 'RGB', 'La', 'L']:
+            case = self.make_case(mode, (4, 4), 0xe1)
+            case = case.resize((8, 8), Image.MITCHELL)
+            data = ('e1 e4 e6 b2'
+                    'e4 e7 e9 b3'
+                    'e6 e9 eb b4'
+                    'b2 b3 b5 9a')
             for channel in case.split():
                 self.check_case(channel, self.make_sample(data, (8, 8)))
 
@@ -211,15 +270,21 @@ class CoreResampleAlphaCorrectTest(PillowTestCase):
     @unittest.skip("current implementation isn't precise enough")
     def test_levels_rgba(self):
         case = self.make_levels_case('RGBA')
+        self.run_levels_case(case.resize((512, 32), Image.BOX))
         self.run_levels_case(case.resize((512, 32), Image.BILINEAR))
+        self.run_levels_case(case.resize((512, 32), Image.HAMMING))
         self.run_levels_case(case.resize((512, 32), Image.BICUBIC))
+        self.run_levels_case(case.resize((512, 32), Image.MITCHELL))
         self.run_levels_case(case.resize((512, 32), Image.LANCZOS))
 
     @unittest.skip("current implementation isn't precise enough")
     def test_levels_la(self):
         case = self.make_levels_case('LA')
+        self.run_levels_case(case.resize((512, 32), Image.BOX))
         self.run_levels_case(case.resize((512, 32), Image.BILINEAR))
+        self.run_levels_case(case.resize((512, 32), Image.HAMMING))
         self.run_levels_case(case.resize((512, 32), Image.BICUBIC))
+        self.run_levels_case(case.resize((512, 32), Image.MITCHELL))
         self.run_levels_case(case.resize((512, 32), Image.LANCZOS))
 
     def make_dity_case(self, mode, clean_pixel, dirty_pixel):
@@ -243,14 +308,20 @@ class CoreResampleAlphaCorrectTest(PillowTestCase):
 
     def test_dirty_pixels_rgba(self):
         case = self.make_dity_case('RGBA', (255, 255, 0, 128), (0, 0, 255, 0))
+        self.run_dity_case(case.resize((20, 20), Image.BOX), (255, 255, 0))
         self.run_dity_case(case.resize((20, 20), Image.BILINEAR), (255, 255, 0))
+        self.run_dity_case(case.resize((20, 20), Image.HAMMING), (255, 255, 0))
         self.run_dity_case(case.resize((20, 20), Image.BICUBIC), (255, 255, 0))
+        self.run_dity_case(case.resize((20, 20), Image.MITCHELL), (255, 255, 0))
         self.run_dity_case(case.resize((20, 20), Image.LANCZOS), (255, 255, 0))
 
     def test_dirty_pixels_la(self):
         case = self.make_dity_case('LA', (255, 128), (0, 0))
+        self.run_dity_case(case.resize((20, 20), Image.BOX), (255,))
         self.run_dity_case(case.resize((20, 20), Image.BILINEAR), (255,))
+        self.run_dity_case(case.resize((20, 20), Image.HAMMING), (255,))
         self.run_dity_case(case.resize((20, 20), Image.BICUBIC), (255,))
+        self.run_dity_case(case.resize((20, 20), Image.MITCHELL), (255,))
         self.run_dity_case(case.resize((20, 20), Image.LANCZOS), (255,))
 
 

--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -39,13 +39,15 @@ class TestImagingCoreResize(PillowTestCase):
             self.assertEqual(r.im.bands, im.im.bands)
 
     def test_reduce_filters(self):
-        for f in [Image.LINEAR, Image.BILINEAR, Image.BICUBIC, Image.LANCZOS]:
+        for f in [Image.LINEAR, Image.BOX, Image.BILINEAR, Image.HAMMING,
+                Image.BICUBIC, Image.LANCZOS]:
             r = self.resize(hopper("RGB"), (15, 12), f)
             self.assertEqual(r.mode, "RGB")
             self.assertEqual(r.size, (15, 12))
 
     def test_enlarge_filters(self):
-        for f in [Image.LINEAR, Image.BILINEAR, Image.BICUBIC, Image.LANCZOS]:
+        for f in [Image.LINEAR, Image.BOX, Image.BILINEAR, Image.HAMMING,
+                Image.BICUBIC, Image.LANCZOS]:
             r = self.resize(hopper("RGB"), (212, 195), f)
             self.assertEqual(r.mode, "RGB")
             self.assertEqual(r.size, (212, 195))
@@ -64,7 +66,8 @@ class TestImagingCoreResize(PillowTestCase):
         }
         samples['dirty'].putpixel((1, 1), 128)
 
-        for f in [Image.LINEAR, Image.BILINEAR, Image.BICUBIC, Image.LANCZOS]:
+        for f in [Image.LINEAR, Image.BOX, Image.BILINEAR, Image.HAMMING,
+                Image.BICUBIC, Image.LANCZOS]:
             # samples resized with current filter
             references = dict(
                 (name, self.resize(ch, (4, 4), f))

--- a/docs/handbook/concepts.rst
+++ b/docs/handbook/concepts.rst
@@ -96,13 +96,30 @@ For geometry operations that may map multiple input pixels to a single output
 pixel, the Python Imaging Library provides four different resampling *filters*.
 
 ``NEAREST``
-    Pick the nearest pixel from the input image. Ignore all other input pixels.
+    Pick one nearest pixel from the input image. Ignore all other input pixels.
+
+``BOX``
+    Each pixel of source image contributes to one pixel of the
+    destination image with identical weights.
+    For upscaling is equivalent of ``NEAREST``.
+    This filter can only be used with the :py:meth:`~PIL.Image.Image.resize`
+    and :py:meth:`~PIL.Image.Image.thumbnail` methods.
+
+    .. versionadded:: 3.4.0
 
 ``BILINEAR``
     For resize calculate the output pixel value using linear interpolation
     on all pixels that may contribute to the output value.
     For other transformations linear interpolation over a 2x2 environment
     in the input image is used.
+
+``HAMMING``
+    Produces more sharp image than ``BILINEAR``, doesn't have dislocations
+    on local level like with ``BOX``.
+    This filter can only be used with the :py:meth:`~PIL.Image.Image.resize`
+    and :py:meth:`~PIL.Image.Image.thumbnail` methods.
+
+    .. versionadded:: 3.4.0
 
 ``BICUBIC``
     For resize calculate the output pixel value using cubic interpolation
@@ -128,7 +145,11 @@ Filters comparison table
 +============+=============+===========+=============+
 |``NEAREST`` |             |           | ⭐⭐⭐⭐⭐       |
 +------------+-------------+-----------+-------------+
+|``BOX``     | ⭐           |           | ⭐⭐⭐⭐        |
++------------+-------------+-----------+-------------+
 |``BILINEAR``| ⭐           | ⭐         | ⭐⭐⭐         |
++------------+-------------+-----------+-------------+
+|``HAMMING`` | ⭐⭐          |           | ⭐⭐⭐         |
 +------------+-------------+-----------+-------------+
 |``BICUBIC`` | ⭐⭐⭐         | ⭐⭐⭐       | ⭐⭐          |
 +------------+-------------+-----------+-------------+

--- a/libImaging/Imaging.h
+++ b/libImaging/Imaging.h
@@ -233,7 +233,6 @@ extern void ImagingError_Clear(void);
 #define IMAGING_TRANSFORM_BILINEAR 2
 #define IMAGING_TRANSFORM_HAMMING 5
 #define IMAGING_TRANSFORM_BICUBIC 3
-#define IMAGING_TRANSFORM_MITCHELL 6
 #define IMAGING_TRANSFORM_LANCZOS 1
 
 typedef int (*ImagingTransformMap)(double* X, double* Y,

--- a/libImaging/Imaging.h
+++ b/libImaging/Imaging.h
@@ -229,9 +229,12 @@ extern void ImagingError_Clear(void);
 
 /* standard filters */
 #define IMAGING_TRANSFORM_NEAREST 0
-#define IMAGING_TRANSFORM_LANCZOS 1
+#define IMAGING_TRANSFORM_BOX 4
 #define IMAGING_TRANSFORM_BILINEAR 2
+#define IMAGING_TRANSFORM_HAMMING 5
 #define IMAGING_TRANSFORM_BICUBIC 3
+#define IMAGING_TRANSFORM_MITCHELL 6
+#define IMAGING_TRANSFORM_LANCZOS 1
 
 typedef int (*ImagingTransformMap)(double* X, double* Y,
                                    int x, int y, void* data);

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -50,27 +50,6 @@ static inline double bicubic_filter(double x)
 #undef a
 }
 
-static inline double mitchell_filter(double x)
-{
-    double fB = 1.f / 3.f;
-    double fC = 1.f / 3.f;
-    double fA1 = -fB - 6*fC;
-    double fB1 = 6*fB + 30*fC;
-    double fC1 = -12*fB - 48*fC;
-    double fD1 = 8*fB + 24*fC;
-    double fA2 = 12 - 9*fB - 6*fC;
-    double fB2 = -18 + 12*fB + 6*fC;
-    double fD2 = 6 - 2*fB;
-
-    if (x < 0.0)
-        x = -x;
-    if (x < 1.0)
-        return ((fA2 * x + fB2) * x*x + fD2) * (1.f/6.f);
-    if (x < 2.0)
-        return (((fA1 * x + fB1) * x + fC1) * x + fD1) * (1.f/6.f);
-    return 0.0;
-}
-
 static inline double sinc_filter(double x)
 {
     if (x == 0.0)
@@ -91,7 +70,6 @@ static struct filter BOX = { box_filter, 0.5 };
 static struct filter BILINEAR = { bilinear_filter, 1.0 };
 static struct filter HAMMING = { hamming_filter, 1.0 };
 static struct filter BICUBIC = { bicubic_filter, 2.0 };
-static struct filter MITCHELL = { mitchell_filter, 2.0 };
 static struct filter LANCZOS = { lanczos_filter, 3.0 };
 
 
@@ -574,9 +552,6 @@ ImagingResample(Imaging imIn, int xsize, int ysize, int filter)
         break;
     case IMAGING_TRANSFORM_BICUBIC:
         filterp = &BICUBIC;
-        break;
-    case IMAGING_TRANSFORM_MITCHELL:
-        filterp = &MITCHELL;
         break;
     case IMAGING_TRANSFORM_LANCZOS:
         filterp = &LANCZOS;

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -87,7 +87,7 @@ static inline double lanczos_filter(double x)
     return 0.0;
 }
 
-static struct filter BOX = { bilinear_filter, 0.5 };
+static struct filter BOX = { box_filter, 0.5 };
 static struct filter BILINEAR = { bilinear_filter, 1.0 };
 static struct filter HAMMING = { hamming_filter, 1.0 };
 static struct filter BICUBIC = { bicubic_filter, 2.0 };


### PR DESCRIPTION
This adds two new filters to `resize` method.

BOX is event faster than LINEAR because it has a smaller window (0.5) and produces very sharp images. Applicable for significant downscaling.

HAMMING costs like LINEAR, also produces very sharp images and applicable for downscaling at any range. Doesn't look good for upscaling, though.