### PR TITLE
Replaced del with pop

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1660,8 +1660,7 @@ class Image(object):
 
         save_all = False
         if 'save_all' in params:
-            save_all = params['save_all']
-            del params['save_all']
+            save_all = params.pop('save_all')
         self.encoderinfo = params
         self.encoderconfig = ()
 

--- a/PIL/PngImagePlugin.py
+++ b/PIL/PngImagePlugin.py
@@ -109,8 +109,7 @@ class ChunkStream(object):
         cid = None
 
         if self.queue:
-            cid, pos, length = self.queue[-1]
-            del self.queue[-1]
+            cid, pos, length = self.queue.pop()
             self.fp.seek(pos)
         else:
             s = self.fp.read(8)

--- a/selftest.py
+++ b/selftest.py
@@ -5,8 +5,7 @@ import sys
 import os
 
 if "--installed" in sys.argv:
-    sys_path_0 = sys.path[0]
-    del sys.path[0]
+    sys_path_0 = sys.path.pop(0)
 
 from PIL import Image, ImageDraw, ImageFilter, ImageMath
 from PIL import features


### PR DESCRIPTION
    y = x['test']
    del x['test']

can be replaced with

    y = x.pop('test')

This applies to lists as well as dictionaries.