### PR TITLE
Expose registered file extensions in Image

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -2478,6 +2478,16 @@ def register_extension(id, extension):
     EXTENSION[extension.lower()] = id.upper()
 
 
+def registered_extensions():
+    """
+    Returns a dictionary containing all file extensions belonging
+    to registered plugins
+    """
+    if not bool(EXTENSION):
+        init()
+    return EXTENSION
+
+
 # --------------------------------------------------------------------
 # Simple display support.  User code may override this.
 

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -184,6 +184,24 @@ class TestImage(PillowTestCase):
         img_colors = sorted(img.getcolors())
         self.assertEqual(img_colors, expected_colors)
 
+    def test_registered_extensions_uninitialized(self):
+        # Act
+        ext = Image.registered_extensions()
+
+        # Assert
+        self.assertEqual(bool(ext), True)
+
+    def test_registered_extensions(self):
+        # Arrange
+        # Open an image to trigger plugin registration
+        Image.open('Tests/images/rgb.jpg')
+
+        # Act
+        ext = Image.registered_extensions()
+
+        # Assert
+        self.assertEqual(bool(ext), True)
+
     def test_effect_mandelbrot(self):
         # Arrange
         size = (512, 512)


### PR DESCRIPTION
This request applies the proposal made in #1955

Changes proposed in this pull request:
- Add a new method in Image (registered_extensions) that exposes the
  internal EXTENSION dictionary to consumers of the library
