### PR TITLE
Ignore large text blocks in PNG if LOAD_TRUNCATED_IMAGES is enabled

### DIFF
--- a/PIL/PngImagePlugin.py
+++ b/PIL/PngImagePlugin.py
@@ -311,6 +311,11 @@ class PngStream(ChunkStream):
                               comp_method)
         try:
             icc_profile = _safe_zlib_decompress(s[i+2:])
+        except ValueError:
+            if ImageFile.LOAD_TRUNCATED_IMAGES:
+                icc_profile = None
+            else:
+                raise
         except zlib.error:
             icc_profile = None  # FIXME
         self.im_info["icc_profile"] = icc_profile
@@ -430,6 +435,11 @@ class PngStream(ChunkStream):
                               comp_method)
         try:
             v = _safe_zlib_decompress(v[1:])
+        except ValueError:
+            if ImageFile.LOAD_TRUNCATED_IMAGES:
+                v = b""
+            else:
+                raise
         except zlib.error:
             v = b""
 
@@ -462,6 +472,11 @@ class PngStream(ChunkStream):
             if cm == 0:
                 try:
                     v = _safe_zlib_decompress(v)
+                except ValueError:
+                    if ImageFile.LOAD_TRUNCATED_IMAGES:
+                        return s
+                    else:
+                        raise
                 except zlib.error:
                     return s
             else:

--- a/Tests/check_png_dos.py
+++ b/Tests/check_png_dos.py
@@ -1,5 +1,5 @@
 from helper import unittest, PillowTestCase
-from PIL import Image, PngImagePlugin
+from PIL import Image, PngImagePlugin, ImageFile
 from io import BytesIO
 import zlib
 
@@ -7,6 +7,21 @@ TEST_FILE = "Tests/images/png_decompression_dos.png"
 
 
 class TestPngDos(PillowTestCase):
+    def test_ignore_dos_text(self):
+        ImageFile.LOAD_TRUNCATED_IMAGES = True
+
+        try:
+            im = Image.open(TEST_FILE)
+            im.load()
+        finally:
+            ImageFile.LOAD_TRUNCATED_IMAGES = False
+
+        for s in im.text.values():
+            self.assertLess(len(s), 1024*1024, "Text chunk larger than 1M")
+
+        for s in im.info.values():
+            self.assertLess(len(s), 1024*1024, "Text chunk larger than 1M")
+
     def test_dos_text(self):
 
         try:


### PR DESCRIPTION
Sometimes large text block is just large text block while the image is still valid. We can safely ignore this blocks and still read the image. Because we are losing some information, I do this only when the `LOAD_TRUNCATED_IMAGES` flag is enabled.