### PR TITLE
Changed urls to point to githup pillow-depends repo

### DIFF
--- a/depends/install_openjpeg.sh
+++ b/depends/install_openjpeg.sh
@@ -3,7 +3,7 @@
 
 
 if [ ! -f openjpeg-2.1.0.tar.gz ]; then
-    wget 'http://iweb.dl.sourceforge.net/project/openjpeg.mirror/2.1.0/openjpeg-2.1.0.tar.gz'
+    wget -O 'openjpeg-2.1.0.tar.gz' 'https://github.com/python-pillow/pillow-depends/blob/master/openjpeg-2.1.0.tar.gz?raw=true'
 
 fi
 

--- a/depends/install_webp.sh
+++ b/depends/install_webp.sh
@@ -2,7 +2,7 @@
 # install webp
 
 if [ ! -f libwebp-0.5.0.tar.gz ]; then
-    wget 'http://downloads.webmproject.org/releases/webp/libwebp-0.5.0.tar.gz'
+    wget -O 'libwebp-0.5.0.tar.gz' 'https://github.com/python-pillow/pillow-depends/blob/master/libwebp-0.5.0.tar.gz?raw=true'
 fi
 
 rm -r libwebp-0.5.0


### PR DESCRIPTION
Fixes travis errors. 

Changes proposed in this pull request:

 * Changed urls in install_openjpeg.sh and install_webp.sh to point to the cached copies in the pillow-depends repo. 

