### PR TITLE
test_imagecms: Reduce precision of extended info

### DIFF
--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -260,9 +260,19 @@ class TestImageCms(PillowTestCase):
         o = ImageCms.getOpenProfile(SRGB)
         p = o.profile
 
+        def assert_truncated_tuple_equal(tup1, tup2, digits=10):
+            # Helper function to reduce precision of tuples of floats
+            # recursively and then check equality.
+            power = 10 ** digits
+            def truncate_tuple(tuple_or_float):
+                return tuple(
+                    truncate_tuple(val) if isinstance(val, tuple)
+                    else int(val * power) / power for val in tuple_or_float)
+            self.assertEqual(truncate_tuple(tup1), truncate_tuple(tup2))
+
         self.assertEqual(p.attributes, 4294967296)
-        self.assertEqual(p.blue_colorant, ((0.14306640625, 0.06060791015625, 0.7140960693359375), (0.1558847490315394, 0.06603820639433387, 0.06060791015625)))
-        self.assertEqual(p.blue_primary, ((0.14306641366715667, 0.06060790921083026, 0.7140960805782015), (0.15588475410450106, 0.06603820408959558, 0.06060790921083026)))
+        assert_truncated_tuple_equal(p.blue_colorant, ((0.14306640625, 0.06060791015625, 0.7140960693359375), (0.1558847490315394, 0.06603820639433387, 0.06060791015625)))
+        assert_truncated_tuple_equal(p.blue_primary, ((0.14306641366715667, 0.06060790921083026, 0.7140960805782015), (0.15588475410450106, 0.06603820408959558, 0.06060790921083026)))
         self.assertEqual(p.chromatic_adaptation, (((1.04791259765625, 0.0229339599609375, -0.050201416015625), (0.02960205078125, 0.9904632568359375, -0.0170745849609375), (-0.009246826171875, 0.0150604248046875, 0.7517852783203125)), ((1.0267159024652783, 0.022470062342089134, 0.0229339599609375), (0.02951378324103937, 0.9875098886387147, 0.9904632568359375), (-0.012205438066465256, 0.01987915407854985, 0.0150604248046875))))
         self.assertEqual(p.chromaticity, None)
         self.assertEqual(p.clut, {0: (False, False, True), 1: (False, False, True), 2: (False, False, True), 3: (False, False, True)})
@@ -274,8 +284,8 @@ class TestImageCms(PillowTestCase):
         self.assertEqual(p.copyright, 'Copyright International Color Consortium, 2009')
         self.assertEqual(p.creation_date, datetime.datetime(2009, 2, 27, 21, 36, 31))
         self.assertEqual(p.device_class, 'mntr')
-        self.assertEqual(p.green_colorant, ((0.3851470947265625, 0.7168731689453125, 0.097076416015625), (0.32119769927720654, 0.5978443449048152, 0.7168731689453125)))
-        self.assertEqual(p.green_primary, ((0.3851470888162112, 0.7168731974161346, 0.09707641738998518), (0.32119768793686687, 0.5978443567149709, 0.7168731974161346)))
+        assert_truncated_tuple_equal(p.green_colorant, ((0.3851470947265625, 0.7168731689453125, 0.097076416015625), (0.32119769927720654, 0.5978443449048152, 0.7168731689453125)))
+        assert_truncated_tuple_equal(p.green_primary, ((0.3851470888162112, 0.7168731974161346, 0.09707641738998518), (0.32119768793686687, 0.5978443567149709, 0.7168731974161346)))
         self.assertEqual(p.header_flags, 0)
         self.assertEqual(p.header_manufacturer, '\x00\x00\x00\x00')
         self.assertEqual(p.header_model, '\x00\x00\x00\x00')
@@ -286,8 +296,8 @@ class TestImageCms(PillowTestCase):
         self.assertEqual(p.is_matrix_shaper, True)
         self.assertEqual(p.luminance, ((0.0, 80.0, 0.0), (0.0, 1.0, 80.0)))
         self.assertEqual(p.manufacturer, None)
-        self.assertEqual(p.media_black_point, ((0.012054443359375, 0.0124969482421875, 0.01031494140625), (0.34573304157549234, 0.35842450765864337, 0.0124969482421875)))
-        self.assertEqual(p.media_white_point, ((0.964202880859375, 1.0, 0.8249053955078125), (0.3457029219802284, 0.3585375327567059, 1.0)))
+        assert_truncated_tuple_equal(p.media_black_point, ((0.012054443359375, 0.0124969482421875, 0.01031494140625), (0.34573304157549234, 0.35842450765864337, 0.0124969482421875)))
+        assert_truncated_tuple_equal(p.media_white_point, ((0.964202880859375, 1.0, 0.8249053955078125), (0.3457029219802284, 0.3585375327567059, 1.0)))
         self.assertEqual(p.media_white_point_temperature, 5000.722328847392)
         self.assertEqual(p.model, 'IEC 61966-2-1 Default RGB Colour Space - sRGB')
         self.assertEqual(p.pcs, 'XYZ')
@@ -299,8 +309,8 @@ class TestImageCms(PillowTestCase):
         self.assertEqual(p.product_model, 'IEC 61966-2-1 Default RGB Colour Space - sRGB')
         self.assertEqual(p.profile_description, 'sRGB IEC61966-2-1 black scaled')
         self.assertEqual(p.profile_id, b')\xf8=\xde\xaf\xf2U\xaexB\xfa\xe4\xca\x839\r')
-        self.assertEqual(p.red_colorant, ((0.436065673828125, 0.2224884033203125, 0.013916015625), (0.6484536316398539, 0.3308524880306778, 0.2224884033203125)))
-        self.assertEqual(p.red_primary, ((0.43606566581047446, 0.22248840582960838, 0.013916015621759925), (0.6484536250319214, 0.3308524944738204, 0.22248840582960838)))
+        assert_truncated_tuple_equal(p.red_colorant, ((0.436065673828125, 0.2224884033203125, 0.013916015625), (0.6484536316398539, 0.3308524880306778, 0.2224884033203125)))
+        assert_truncated_tuple_equal(p.red_primary, ((0.43606566581047446, 0.22248840582960838, 0.013916015621759925), (0.6484536250319214, 0.3308524944738204, 0.22248840582960838)))
         self.assertEqual(p.rendering_intent, 0)
         self.assertEqual(p.saturation_rendering_intent_gamut, None)
         self.assertEqual(p.screening_description, None)


### PR DESCRIPTION
Fixes (partially) https://github.com/python-pillow/Pillow/issues/1859 .

Changes proposed in this pull request:

 * Reduce precision in some tests that seem to be failing in 32bit.

In 32bit computers(When making wheels) it was found that the
precision of the extended information in test_extended_information() was
found to be lesser than what was being tested. This commit adds a helper
function which reduces the precision using `round()` and testing the
rounded numbers rather than the original numbers.