### PR TITLE
Ability to skip crc checks for ancillary chunks

### DIFF
--- a/PIL/PngImagePlugin.py
+++ b/PIL/PngImagePlugin.py
@@ -140,7 +140,7 @@ class ChunkStream(object):
 
         # Skip CRC checks for ancillary chunks if allowed to load truncated images
         # 5th byte of first char is 1 [specs, section 5.4]
-        if ImageFile.LOAD_TRUNCATED_IMAGES and (ord(cid[0]) >> 5 & 1):
+        if ImageFile.LOAD_TRUNCATED_IMAGES and (i8(cid[0]) >> 5 & 1):
             self.crc_skip(cid, data)
             return
 

--- a/PIL/PngImagePlugin.py
+++ b/PIL/PngImagePlugin.py
@@ -138,6 +138,12 @@ class ChunkStream(object):
     def crc(self, cid, data):
         "Read and verify checksum"
 
+        # Skip CRC checks for ancillary chunks if allowed to load truncated images
+        # 5th byte of first char is 1 [specs, section 5.4]
+        if ImageFile.LOAD_TRUNCATED_IMAGES and (ord(cid[0]) >> 5 & 1):
+            self.crc_skip(cid, data)
+            return
+
         try:
             crc1 = Image.core.crc32(data, Image.core.crc32(cid))
             crc2 = i16(self.fp.read(2)), i16(self.fp.read(2))

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -324,7 +324,7 @@ class TestFilePng(PillowTestCase):
         # check ignores crc errors in ancillary chunks
 
         chunk_data = chunk(b'tEXt', b'spam')
-        broken_crc_chunk_data = chunk_data[:-1] + 'q'  # break CRC
+        broken_crc_chunk_data = chunk_data[:-1] + b'q'  # break CRC
 
         image_data = HEAD + broken_crc_chunk_data + TAIL
         self.assertRaises(SyntaxError,
@@ -340,7 +340,7 @@ class TestFilePng(PillowTestCase):
     def test_verify_not_ignores_crc_error_in_required_chunk(self):
         # check does not ignore crc errors in required chunks
 
-        image_data = MAGIC + IHDR[:-1] + 'q' + TAIL
+        image_data = MAGIC + IHDR[:-1] + b'q' + TAIL
 
         ImageFile.LOAD_TRUNCATED_IMAGES = True
         try:

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -327,8 +327,7 @@ class TestFilePng(PillowTestCase):
         broken_crc_chunk_data = chunk_data[:-1] + b'q'  # break CRC
 
         image_data = HEAD + broken_crc_chunk_data + TAIL
-        self.assertRaises(SyntaxError,
-                          lambda: PngImagePlugin.PngImageFile(BytesIO(image_data)))
+        self.assertRaises(SyntaxError, PngImagePlugin.PngImageFile, BytesIO(image_data))
 
         ImageFile.LOAD_TRUNCATED_IMAGES = True
         try:
@@ -344,8 +343,7 @@ class TestFilePng(PillowTestCase):
 
         ImageFile.LOAD_TRUNCATED_IMAGES = True
         try:
-            self.assertRaises(SyntaxError,
-                              lambda: PngImagePlugin.PngImageFile(BytesIO(image_data)))
+            self.assertRaises(SyntaxError, PngImagePlugin.PngImageFile, BytesIO(image_data))
         finally:
             ImageFile.LOAD_TRUNCATED_IMAGES = False
 


### PR DESCRIPTION
I encountered that some PNG files could not be open with Pillow since  they have crc mismatch for iTXt chunks. 
Browsers and imagemagick can open them just fine (though imagemagick shows a warning)
libpng defines a way to set it's behavior to throw an error or warning for ancillary chunks.

So I am proposing use of `LOAD_TRUNCATED_IMAGES` to skip crc checks for ancillary chunks. No need to calculate if we're going to ignore an error.

