### PR TITLE
Fix msvc9/10 compile error

### DIFF
--- a/libImaging/Jpeg2KDecode.c
+++ b/libImaging/Jpeg2KDecode.c
@@ -56,10 +56,11 @@ j2k_read(void *p_buffer, OPJ_SIZE_T p_nb_bytes, void *p_user_data)
 static OPJ_OFF_T
 j2k_skip(OPJ_OFF_T p_nb_bytes, void *p_user_data)
 {
+    off_t pos;
     ImagingCodecState state = (ImagingCodecState)p_user_data;
 
     _imaging_seek_pyFd(state->fd, p_nb_bytes, SEEK_CUR);
-    off_t pos = _imaging_tell_pyFd(state->fd);
+    pos = _imaging_tell_pyFd(state->fd);
 
     return pos ? pos : (OPJ_OFF_T)-1;
 }


### PR DESCRIPTION
With this patch:
```
--------------------------------------------------------------------
PIL SETUP SUMMARY
--------------------------------------------------------------------
version      Pillow 3.3.0.dev0
platform     win32 2.7.12 (v2.7.12:d33e0cf91556, Jun 27 2016, 15:24:40)
             [MSC v.1500 64 bit (AMD64)]
--------------------------------------------------------------------
--- JPEG support available
--- OPENJPEG (JPEG2000) support available (2.1)
--- ZLIB (PNG/ZIP) support available
*** LIBIMAGEQUANT support not available
--- LIBTIFF support available
--- FREETYPE2 support available
--- LITTLECMS2 support available
--- WEBP support available
--- WEBPMUX support available
--------------------------------------------------------------------
To add a missing option, make sure you have the required
library and headers.
See https://pillow.readthedocs.io/en/latest/installation.html#building-from-source

To check the build, run the selftest.py script.

--------------------------------------------------------------------
Pillow 3.3.0.dev0 TEST SUMMARY
--------------------------------------------------------------------
Python modules loaded from D:\Build\Pillow\Pillow-git\PIL
Binary modules loaded from D:\Build\Pillow\Pillow-git\PIL
--------------------------------------------------------------------
--- PIL CORE support ok
--- TKINTER support ok
--- FREETYPE2 support ok
--- LITTLECMS2 support ok
--- WEBP support ok
--- JPEG support ok
--- OPENJPEG (JPEG2000) support ok
--- ZLIB (PNG/ZIP) support ok
--- LIBTIFF support ok
--------------------------------------------------------------------
Running selftest:
--- 57 tests passed.

<snip>
Ran 746 tests in 28.676s

OK (SKIP=21)
```
