### PR TITLE
Correct ValueError

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -550,7 +550,7 @@ class ImageFileDirectory_v2(collections.MutableMapping):
 
         dest = self._tags_v1 if legacy_api else self._tags_v2
 
-        if info.length == 1:
+        if info.length > 0 and len(values) == 1:
             if legacy_api and self.tagtype[tag] in [5, 10]:
                 values = values,
             dest[tag], = values


### PR DESCRIPTION
Fixes #2006.

When `info.length` is 1 and `len(values) > 1`, the code used to throw: 

```
ValueError: too many values to unpack (expected 1)
```

For example: tag `IMAGEJ_META_DATA_BYTE_COUNTS` (50838) can sometimes have two values (I have .tif files with metadata split between UTF8 and UTF16 => one byte count for each)
