### PR TITLE
Add a scale function to expand or contract a PIL image by a factor 

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1547,6 +1547,26 @@ class Image(object):
 
         return self._new(self.im.resize(size, resample))
 
+    def scale(self, factor, resample = NEAREST):
+        """
+        Returns a rescaled image by a specific factor given in parameter.
+        A factor greater than 1 expands the image, between 0 and 1 contracts the
+        image.
+
+        :param factor: The expansion factor, as a float.
+        :param resample: An optional resampling filter. Same values possible as
+           in the PIL.Image.resize function.
+        :returns: An :py:class:`~PIL.Image.Image` object.
+        """
+        if factor == 1:
+            return self._new(self.im)
+        elif factor <= 0:
+            raise ValueError("the factor must be greater than 0")
+        else:
+            size = (int(round(factor * self.width)),
+                    int(round(factor * self.height)))
+            return self.resize(size, resample)
+
     def rotate(self, angle, resample=NEAREST, expand=0):
         """
         Returns a rotated copy of this image.  This method returns a

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1547,26 +1547,6 @@ class Image(object):
 
         return self._new(self.im.resize(size, resample))
 
-    def scale(self, factor, resample = NEAREST):
-        """
-        Returns a rescaled image by a specific factor given in parameter.
-        A factor greater than 1 expands the image, between 0 and 1 contracts the
-        image.
-
-        :param factor: The expansion factor, as a float.
-        :param resample: An optional resampling filter. Same values possible as
-           in the PIL.Image.resize function.
-        :returns: An :py:class:`~PIL.Image.Image` object.
-        """
-        if factor == 1:
-            return self._new(self.im)
-        elif factor <= 0:
-            raise ValueError("the factor must be greater than 0")
-        else:
-            size = (int(round(factor * self.width)),
-                    int(round(factor * self.height)))
-            return self.resize(size, resample)
-
     def rotate(self, angle, resample=NEAREST, expand=0):
         """
         Returns a rotated copy of this image.  This method returns a

--- a/PIL/ImageOps.py
+++ b/PIL/ImageOps.py
@@ -178,6 +178,27 @@ def crop(image, border=0):
         )
 
 
+def scale(self, factor, resample=Image.NEAREST):
+        """
+        Returns a rescaled image by a specific factor given in parameter.
+        A factor greater than 1 expands the image, between 0 and 1 contracts the
+        image.
+
+        :param factor: The expansion factor, as a float.
+        :param resample: An optional resampling filter. Same values possible as
+           in the PIL.Image.resize function.
+        :returns: An :py:class:`~PIL.Image.Image` object.
+        """
+        if factor == 1:
+            return self._new(self.im)
+        elif factor <= 0:
+            raise ValueError("the factor must be greater than 0")
+        else:
+            size = (int(round(factor * self.width)),
+                    int(round(factor * self.height)))
+            return self.resize(size, resample)
+
+
 def deform(image, deformer, resample=Image.BILINEAR):
     """
     Deform the image.

--- a/PIL/ImageOps.py
+++ b/PIL/ImageOps.py
@@ -179,24 +179,24 @@ def crop(image, border=0):
 
 
 def scale(self, factor, resample=Image.NEAREST):
-        """
-        Returns a rescaled image by a specific factor given in parameter.
-        A factor greater than 1 expands the image, between 0 and 1 contracts the
-        image.
+    """
+    Returns a rescaled image by a specific factor given in parameter.
+    A factor greater than 1 expands the image, between 0 and 1 contracts the
+    image.
 
-        :param factor: The expansion factor, as a float.
-        :param resample: An optional resampling filter. Same values possible as
-           in the PIL.Image.resize function.
-        :returns: An :py:class:`~PIL.Image.Image` object.
-        """
-        if factor == 1:
-            return self._new(self.im)
-        elif factor <= 0:
-            raise ValueError("the factor must be greater than 0")
-        else:
-            size = (int(round(factor * self.width)),
-                    int(round(factor * self.height)))
-            return self.resize(size, resample)
+    :param factor: The expansion factor, as a float.
+    :param resample: An optional resampling filter. Same values possible as
+       in the PIL.Image.resize function.
+    :returns: An :py:class:`~PIL.Image.Image` object.
+    """
+    if factor == 1:
+        return self._new(self.im)
+    elif factor <= 0:
+        raise ValueError("the factor must be greater than 0")
+    else:
+        size = (int(round(factor * self.width)),
+                int(round(factor * self.height)))
+        return self.resize(size, resample)
 
 
 def deform(image, deformer, resample=Image.BILINEAR):

--- a/PIL/ImageOps.py
+++ b/PIL/ImageOps.py
@@ -190,7 +190,7 @@ def scale(image, factor, resample=Image.NEAREST):
     :returns: An :py:class:`~PIL.Image.Image` object.
     """
     if factor == 1:
-        return Image.Image._new(image.im)
+        return image.copy()
     elif factor <= 0:
         raise ValueError("the factor must be greater than 0")
     else:

--- a/PIL/ImageOps.py
+++ b/PIL/ImageOps.py
@@ -178,7 +178,7 @@ def crop(image, border=0):
         )
 
 
-def scale(self, factor, resample=Image.NEAREST):
+def scale(image, factor, resample=Image.NEAREST):
     """
     Returns a rescaled image by a specific factor given in parameter.
     A factor greater than 1 expands the image, between 0 and 1 contracts the
@@ -190,13 +190,13 @@ def scale(self, factor, resample=Image.NEAREST):
     :returns: An :py:class:`~PIL.Image.Image` object.
     """
     if factor == 1:
-        return self._new(self.im)
+        return Image.Image._new(image.im)
     elif factor <= 0:
         raise ValueError("the factor must be greater than 0")
     else:
-        size = (int(round(factor * self.width)),
-                int(round(factor * self.height)))
-        return self.resize(size, resample)
+        size = (int(round(factor * image.width)),
+                int(round(factor * image.height)))
+        return image.resize(size, resample)
 
 
 def deform(image, deformer, resample=Image.BILINEAR):

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -81,7 +81,13 @@ class TestImageOps(PillowTestCase):
     def test_scale(self):
         # Test the scaling function
         i = hopper("L").resize((50,50))
- 
+        
+        with self.assertRaises(ValueError):
+            ImageOps.scale(i,-1)
+
+        newimg = ImageOps.scale(i,1)
+        self.assertEqual(newimg.size, (50, 50))
+
         newimg = ImageOps.scale(i,2)
         self.assertEqual(newimg.size, (100, 100))
 

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -80,7 +80,7 @@ class TestImageOps(PillowTestCase):
 
     def test_scale(self):
         # Test the scaling function
-        i = hopper("L").resize((50,50))
+        i = hopper("L").resize((50, 50))
         
         with self.assertRaises(ValueError):
             ImageOps.scale(i,-1)

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -78,6 +78,16 @@ class TestImageOps(PillowTestCase):
         ImageOps.equalize(i.convert("P"))
         ImageOps.equalize(i.convert("RGB"))
 
+    def test_scale(self):
+        # Test the scaling function
+        i = hopper("L").resize((50,50))
+ 
+        newimg = ImageOps.scale(i,2)
+        self.assertEqual(newimg.size, (100, 100))
+
+        newimg = ImageOps.scale(i,0.5)
+        self.assertEqual(newimg.size, (25, 25))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -83,15 +83,15 @@ class TestImageOps(PillowTestCase):
         i = hopper("L").resize((50, 50))
         
         with self.assertRaises(ValueError):
-            ImageOps.scale(i,-1)
+            ImageOps.scale(i, -1)
 
-        newimg = ImageOps.scale(i,1)
+        newimg = ImageOps.scale(i, 1)
         self.assertEqual(newimg.size, (50, 50))
 
-        newimg = ImageOps.scale(i,2)
+        newimg = ImageOps.scale(i, 2)
         self.assertEqual(newimg.size, (100, 100))
 
-        newimg = ImageOps.scale(i,0.5)
+        newimg = ImageOps.scale(i, 0.5)
         self.assertEqual(newimg.size, (25, 25))
 
 


### PR DESCRIPTION
Add the scale function to provide an easy way to expand and contract image by a certain factor given in parameter.
This function "only" calculate the target size, and call the PIL.Image.Image.resize() function.