### PR TITLE
Expose Pillow package version as PIL.__version__

### DIFF
--- a/PIL/__init__.py
+++ b/PIL/__init__.py
@@ -14,6 +14,8 @@
 VERSION = '1.1.7'  # PIL version
 PILLOW_VERSION = '3.4.0.dev0'  # Pillow
 
+__version__ = PILLOW_VERSION
+
 _plugins = ['BmpImagePlugin',
             'BufrStubImagePlugin',
             'CurImagePlugin',


### PR DESCRIPTION
Fixes this:
```
>>> import PIL
>>> from PIL import ImageGrab
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/dist-packages/PIL/ImageGrab.py", line 22, in <module>
    raise ImportError("ImageGrab is OS X and Windows only")
ImportError: ImageGrab is OS X and Windows only
>>> PIL.version
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'version'
>>> PIL.__version__
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute '__version__'
>>> PIL.get_version()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'get_version'
>>> 
```