### PR TITLE
Close files after loading

### DIFF
--- a/PIL/DcxImagePlugin.py
+++ b/PIL/DcxImagePlugin.py
@@ -59,6 +59,7 @@ class DcxImageFile(PcxImageFile):
             self._offset.append(offset)
 
         self.__fp = self.fp
+        self._exclusive_fp = False
         self.seek(0)
 
     @property

--- a/PIL/FliImagePlugin.py
+++ b/PIL/FliImagePlugin.py
@@ -88,6 +88,7 @@ class FliImageFile(ImageFile.ImageFile):
         # set things up to decode first frame
         self.__frame = -1
         self.__fp = self.fp
+        self._exclusive_fp = False
         self.__rewind = self.fp.tell()
         self._n_frames = None
         self._is_animated = None

--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -87,6 +87,7 @@ class GifImageFile(ImageFile.ImageFile):
                     break
 
         self.__fp = self.fp  # FIXME: hack
+        self._exclusive_fp = False
         self.__rewind = self.fp.tell()
         self._n_frames = None
         self._is_animated = None

--- a/PIL/ImImagePlugin.py
+++ b/PIL/ImImagePlugin.py
@@ -234,6 +234,7 @@ class ImImageFile(ImageFile.ImageFile):
         self.__offset = offs = self.fp.tell()
 
         self.__fp = self.fp  # FIXME: hack
+        self._exclusive_fp = False
 
         if self.rawmode[:2] == "F;":
 

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -2272,6 +2272,7 @@ def open(fp, mode="r"):
     if mode != "r":
         raise ValueError("bad mode %r" % mode)
 
+    exclusive_fp = False
     filename = ""
     if isPath(fp):
         filename = fp
@@ -2281,11 +2282,13 @@ def open(fp, mode="r"):
             filename = str(fp.resolve())
     if filename:
         fp = builtins.open(filename, "rb")
+        exclusive_fp = True
 
     try:
         fp.seek(0)
     except (AttributeError, io.UnsupportedOperation):
         fp = io.BytesIO(fp.read())
+        exclusive_fp = True
 
     prefix = fp.read(16)
 
@@ -2316,6 +2319,8 @@ def open(fp, mode="r"):
     if im:
         return im
 
+    if exclusive_fp:
+        fp.close()
     raise IOError("cannot identify image file %r"
                   % (filename if filename else fp))
 

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -2317,6 +2317,8 @@ def open(fp, mode="r"):
             im = _open_core(fp, filename, prefix)
 
     if im:
+        if getattr(im, '_exclusive_fp', 'undef') is None:
+            im._exclusive_fp = exclusive_fp
         return im
 
     if exclusive_fp:

--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -93,7 +93,8 @@ class ImageFile(Image.Image):
             # stream
             self.fp = fp
             self.filename = filename
-            self._exclusive_fp = False
+            # can be overridden
+            self._exclusive_fp = None
 
         try:
             self._open()

--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -88,10 +88,12 @@ class ImageFile(Image.Image):
             # filename
             self.fp = open(fp, "rb")
             self.filename = fp
+            self._exclusive_fp = True
         else:
             # stream
             self.fp = fp
             self.filename = filename
+            self._exclusive_fp = False
 
         try:
             self._open()
@@ -100,6 +102,9 @@ class ImageFile(Image.Image):
                 KeyError,  # unsupported mode
                 EOFError,  # got header but not the first frame
                 struct.error) as v:
+            # close the file only if we have opened it this constructor
+            if self._exclusive_fp:
+                self.fp.close()
             raise SyntaxError(v)
 
         if not self.mode or self.size[0] <= 0:

--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -120,6 +120,8 @@ class ImageFile(Image.Image):
 
         # raise exception if something's wrong.  must be called
         # directly after open, and closes file when finished.
+        if self._exclusive_fp:
+            self.fp.close()
         self.fp = None
 
     def load(self):
@@ -231,14 +233,16 @@ class ImageFile(Image.Image):
                         if n < 0:
                             break
                         b = b[n:]
-                    
+
                 # Need to cleanup here to prevent leaks in PyPy
                 decoder.cleanup()
 
         self.tile = []
         self.readonly = readonly
 
-        self.fp = None  # might be shared
+        if self._exclusive_fp:
+            self.fp.close()
+        self.fp = None
 
         if not self.map and not LOAD_TRUNCATED_IMAGES and err_code < 0:
             # still raised if decoder fails to return anything

--- a/PIL/MicImagePlugin.py
+++ b/PIL/MicImagePlugin.py
@@ -63,6 +63,7 @@ class MicImageFile(TiffImagePlugin.TiffImageFile):
             raise SyntaxError("not an MIC file; no image entries")
 
         self.__fp = self.fp
+        self._exclusive_fp = False
         self.frame = 0
 
         if len(self.images) > 1:

--- a/PIL/MpoImagePlugin.py
+++ b/PIL/MpoImagePlugin.py
@@ -53,6 +53,7 @@ class MpoImageFile(JpegImagePlugin.JpegImageFile):
         assert self.__framecount == len(self.__mpoffsets)
         del self.info['mpoffset']  # no longer needed
         self.__fp = self.fp  # FIXME: hack
+        self._exclusive_fp = False
         self.__fp.seek(self.__mpoffsets[0])  # get ready to read first frame
         self.__frame = 0
         self.offset = 0

--- a/PIL/SpiderImagePlugin.py
+++ b/PIL/SpiderImagePlugin.py
@@ -155,6 +155,7 @@ class SpiderImageFile(ImageFile.ImageFile):
             ("raw", (0, 0) + self.size, offset,
                 (self.rawmode, 0, 1))]
         self.__fp = self.fp  # FIXME: hack
+        self._exclusive_fp = False
 
     @property
     def n_frames(self):

--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -907,6 +907,7 @@ class TiffImageFile(ImageFile.ImageFile):
         self.__first = self.__next = self.tag_v2.next
         self.__frame = -1
         self.__fp = self.fp
+        self._exclusive_fp = False
         self._frame_pos = []
         self._n_frames = None
         self._is_animated = None

--- a/PIL/XpmImagePlugin.py
+++ b/PIL/XpmImagePlugin.py
@@ -116,8 +116,6 @@ class XpmImageFile(ImageFile.ImageFile):
         for i in range(ysize):
             s[i] = self.fp.readline()[1:xsize+1].ljust(xsize)
 
-        self.fp = None
-
         return b"".join(s)
 
 #


### PR DESCRIPTION
Draft for #2019

This PR closes files at least for files which we are opening from filename at least for not sequence formats. This breaks consistency across different codecs, though.

Is there any reliable place where we can close files for sequence formats?
