### PR TITLE
Fix image loading when rotating by 0 deg

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1572,7 +1572,7 @@ class Image(object):
 
         # Fast paths regardless of filter
         if angle == 0:
-            return self._new(self.im)
+            return self.copy()
         if angle == 180:
             return self.transpose(ROTATE_180)
         if angle == 90 and expand:

--- a/Tests/test_image_rotate.py
+++ b/Tests/test_image_rotate.py
@@ -11,11 +11,14 @@ class TestImageRotate(PillowTestCase):
             self.assertEqual(out.size, im.size)  # default rotate clips output
             out = im.rotate(angle, expand=1)
             self.assertEqual(out.mode, mode)
-            self.assertNotEqual(out.size, im.size)
+            if angle % 180 == 0:
+                self.assertEqual(out.size, im.size)
+            else:
+                self.assertNotEqual(out.size, im.size)
         for mode in "1", "P", "L", "RGB", "I", "F":
             im = hopper(mode)
             rotate(im, mode, 45)
-        for angle in 90, 270:
+        for angle in 0, 90, 180, 270:
             im = Image.open('Tests/images/test-card.png')
             rotate(im, im.mode, angle)
 


### PR DESCRIPTION
This fixes image rotation in cases when `angle % 360.0 == 0` and image is not loaded yet.