### PR TITLE
Add unpacking from BRGa to RGBA

### DIFF
--- a/Tests/test_lib_pack.py
+++ b/Tests/test_lib_pack.py
@@ -122,7 +122,9 @@ class TestLibPack(PillowTestCase):
         self.assertEqual(unpack("RGB", "XBGR", 4), (4, 3, 2))
 
         self.assertEqual(unpack("RGBA", "RGBA", 4), (1, 2, 3, 4))
+        self.assertEqual(unpack("RGBA", "RGBa", 4), (63, 127, 191, 4))
         self.assertEqual(unpack("RGBA", "BGRA", 4), (3, 2, 1, 4))
+        self.assertEqual(unpack("RGBA", "BGRa", 4), (191, 127, 63, 4))
         self.assertEqual(unpack("RGBA", "ARGB", 4), (2, 3, 4, 1))
         self.assertEqual(unpack("RGBA", "ABGR", 4), (4, 3, 2, 1))
         self.assertEqual(unpack("RGBA", "RGBA;15", 2), (8, 131, 0, 0))

--- a/libImaging/Unpack.c
+++ b/libImaging/Unpack.c
@@ -748,6 +748,30 @@ unpackRGBa(UINT8* out, const UINT8* in, int pixels)
 }
 
 static void
+unpackBGRa(UINT8* out, const UINT8* in, int pixels)
+{
+    int i;
+    /* premultiplied BGRA */
+    for (i = 0; i < pixels; i++) {
+        int a = in[3];
+        if (!a)
+            out[R] = out[G] = out[B] = out[A] = 0;
+        else if (a == 255) {
+            out[R] = in[2];
+            out[G] = in[1];
+            out[B] = in[0];
+            out[A] = a;
+        } else {
+            out[R] = CLIP(in[2] * 255 / a);
+            out[G] = CLIP(in[1] * 255 / a);
+            out[B] = CLIP(in[0] * 255 / a);
+            out[A] = a;
+        }
+        out += 4; in += 4;
+    }
+}
+
+static void
 unpackRGBAI(UINT8* out, const UINT8* in, int pixels)
 {
     int i;
@@ -1206,6 +1230,7 @@ static struct {
     {"RGBA",    "LA;16B",       32,     unpackRGBALA16B},
     {"RGBA",    "RGBA",         32,     copy4},
     {"RGBA",    "RGBa",         32,     unpackRGBa},
+    {"RGBA",    "BGRa",         32,     unpackBGRa},
     {"RGBA",    "RGBA;I",       32,     unpackRGBAI},
     {"RGBA",    "RGBA;L",       32,     unpackRGBAL},
     {"RGBA",    "RGBA;15",      16,     ImagingUnpackRGBA15},


### PR DESCRIPTION
Fixes #2053

Makes possible the next without adding extra core modes:

```python
Image.frombuffer("RGBA", (im.width, im.height), data, "raw", "BGRa", im.stride, 1)
```
