### PR TITLE
Added return for J2k (and fpx) Load to return a pixel access object

### DIFF
--- a/PIL/FpxImagePlugin.py
+++ b/PIL/FpxImagePlugin.py
@@ -216,7 +216,7 @@ class FpxImageFile(ImageFile.ImageFile):
             self.fp = self.ole.openstream(self.stream[:2] +
                                           ["Subimage 0000 Data"])
 
-        ImageFile.ImageFile.load(self)
+        return ImageFile.ImageFile.load(self)
 
 #
 # --------------------------------------------------------------------

--- a/PIL/Jpeg2KImagePlugin.py
+++ b/PIL/Jpeg2KImagePlugin.py
@@ -207,7 +207,7 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
             t3 = (t[3][0], self.reduce, self.layers, t[3][3], t[3][4])
             self.tile = [(t[0], (0, 0) + self.size, t[2], t3)]
 
-        ImageFile.ImageFile.load(self)
+        return ImageFile.ImageFile.load(self)
 
 
 def _accept(prefix):

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -35,7 +35,7 @@ class TestFileJpeg2k(PillowTestCase):
 
         im = Image.open('Tests/images/test-card-lossless.jp2')
         px = im.load()
-        self.assertTrue(px)
+        self.assertEqual(px[0,0], (0, 0, 0))
         self.assertEqual(im.mode, 'RGB')
         self.assertEqual(im.size, (640, 480))
         self.assertEqual(im.format, 'JPEG2000')

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -34,7 +34,8 @@ class TestFileJpeg2k(PillowTestCase):
         self.assertRegexpMatches(Image.core.jp2klib_version, '\d+\.\d+\.\d+$')
 
         im = Image.open('Tests/images/test-card-lossless.jp2')
-        im.load()
+        px = im.load()
+        self.assertTrue(px)
         self.assertEqual(im.mode, 'RGB')
         self.assertEqual(im.size, (640, 480))
         self.assertEqual(im.format, 'JPEG2000')


### PR DESCRIPTION
Fixes #2059 .

Also fixes fpx files, but we have no actual tests for it so,  no new tests here. 