### PR TITLE
Store TIFF DPI as integer

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -52,6 +52,7 @@ from numbers import Number, Rational
 
 import io
 import itertools
+import math
 import os
 import struct
 import sys
@@ -1154,9 +1155,9 @@ class TiffImageFile(ImageFile.ImageFile):
         if xres and yres:
             resunit = self.tag_v2.get(RESOLUTION_UNIT, 1)
             if resunit == 2:  # dots per inch
-                self.info["dpi"] = xres, yres
+                self.info["dpi"] = int(math.ceil(xres)), int(math.ceil(yres))
             elif resunit == 3:  # dots per centimeter. convert to dpi
-                self.info["dpi"] = xres * 2.54, yres * 2.54
+                self.info["dpi"] = int(math.ceil(xres * 2.54)), int(math.ceil(yres * 2.54))
             else:  # No absolute unit of measurement
                 self.info["resolution"] = xres, yres
 

--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -52,7 +52,6 @@ from numbers import Number, Rational
 
 import io
 import itertools
-import math
 import os
 import struct
 import sys
@@ -1155,9 +1154,9 @@ class TiffImageFile(ImageFile.ImageFile):
         if xres and yres:
             resunit = self.tag_v2.get(RESOLUTION_UNIT, 1)
             if resunit == 2:  # dots per inch
-                self.info["dpi"] = int(math.ceil(xres)), int(math.ceil(yres))
+                self.info["dpi"] = int(round(xres)), int(round(yres))
             elif resunit == 3:  # dots per centimeter. convert to dpi
-                self.info["dpi"] = int(math.ceil(xres * 2.54)), int(math.ceil(yres * 2.54))
+                self.info["dpi"] = int(round(xres * 2.54)), int(round(yres * 2.54))
             else:  # No absolute unit of measurement
                 self.info["resolution"] = xres, yres
 

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -470,6 +470,20 @@ class TestFileTiff(PillowTestCase):
         im = Image.open(infile)
         self.assertEqual(im.getpixel((0, 0)), pixel_value)
 
+    def test_save_tiff_with_dpi(self):
+
+        outfile = self.tempfile("temp.tif")
+
+        infile = "Tests/images/hopper.tif"
+        im = Image.open(infile)
+
+        im.save(outfile, 'JPEG', dpi=im.info['dpi'])
+
+        reloaded = Image.open(outfile)
+        reloaded.load()
+
+        self.assertEqual(im.info['dpi'], reloaded.info['dpi'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #2077 which prevents TIFF from being saved as JPEG with its original DPI.

Stores the TIFF DPI as integers

