### PR TITLE
Fixes TIFFImagePlugin ICC color profile saving.

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -1366,10 +1366,10 @@ def _save(im, fp, filename):
                 ifd[key] = im.tag_v2[key]
                 ifd.tagtype[key] = im.tag_v2.tagtype[key]
 
-        # preserve ICC profile (should also work when saving other formats
-        # which support profiles as TIFF) -- 2008-06-06 Florian Hoech
-        if "icc_profile" in im.info:
-            ifd[ICCPROFILE] = im.info["icc_profile"]
+    # preserve ICC profile (should also work when saving other formats
+    # which support profiles as TIFF) -- 2008-06-06 Florian Hoech
+    if "icc_profile" in im.info:
+        ifd[ICCPROFILE] = im.info["icc_profile"]
 
     for key, name in [(IMAGEDESCRIPTION, "description"),
                       (X_RESOLUTION, "resolution"),

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -499,5 +499,21 @@ class TestFileTiff(PillowTestCase):
         with Image.open(mp) as im:
             self.assertEqual(im.n_frames, 3)
 
+    def test_saving_icc_profile(self):
+        # Tests saving TIFF with icc_profile set.
+        # At the time of writing this will only work for non-compressed tiffs
+        # as libtiff does not support embedded ICC profiles, ImageFile._save(..)
+        # however does.
+        im = Image.new('RGB', (1, 1))
+        im.info['icc_profile'] = 'Dummy value'
+        
+        # Try save-load round trip to make sure both handle icc_profile.
+        tmpfile = self.tempfile('temp.tif')
+        im.save(tmpfile, 'TIFF', compression='raw')
+        reloaded = Image.open(tmpfile)
+        
+        self.assertEqual(b'Dummy value', reloaded.info['icc_profile'])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In the TIFF code saving icc_profile is conditional on tag_v2 being set which doesn't make sense to me. I believe this is merely an indentation typo.

I've been trying to save TIFFs with im.info['icc_profile'] set and compression=raw, but unfortunately this results in TIFFs without ICC color profiles.
With the attached patch TIFFs with said conditions will be saved with the profile set in im.info['icc_profile'].

Note: There are a number of different conditions that need to be met for code to succeed in saving with the profile since it branches between using libtiff and ImageFile._save(..), and the libtiff code does not currently save the ICC color profile.
For instance setting compression=tiff_lzw will result in using libtiff and no profile will be saved.
