### PR TITLE
Test fix for bigendian machines

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -463,13 +463,20 @@ class TestFileTiff(PillowTestCase):
         im2 = hopper()
         self.assert_image_similar(im, im2, 5)
 
-    def test_open_tiff_uint16(self):
+    def test_roundtrip_tiff_uint16(self):
         # Test an image of all '0' values
         pixel_value = 0x1234
         infile = "Tests/images/uint16_1_4660.tif"
         im = Image.open(infile)
         self.assertEqual(im.getpixel((0, 0)), pixel_value)
 
+        tmpfile = self.tempfile("temp.tif")
+        im.save(tmpfile)
+        
+        reloaded = Image.open(tmpfile)
+        
+        self.assert_image_equal(im, reloaded)
+        
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import sys
 from helper import unittest, PillowTestCase, hopper
+import sys
 
 from PIL import Image
 
@@ -137,19 +138,14 @@ class TestNumpy(PillowTestCase):
         numpy.testing.assert_array_equal(arr, arr_back)
 
     def test_save_tiff_uint16(self):
-        '''
-        Open a single-channel uint16 greyscale image and verify that it can be saved without
-        losing precision.
-        '''
-        tmpfile = self.tempfile("temp.tif")
+        # Tests that we're getting the pixel value in the right byte order. 
         pixel_value = 0x1234
-        filename = "Tests/images/uint16_1_4660.tif"
         a = numpy.array([pixel_value] * TEST_IMAGE_SIZE[0] * TEST_IMAGE_SIZE[1], dtype=numpy.uint16)
         a.shape = TEST_IMAGE_SIZE
-        Image.fromarray(a).save(tmpfile)
-        im_test = Image.open(tmpfile)
-        im_good = Image.open(filename)
-        self.assert_image_equal(im_good, im_test)
+        img = Image.fromarray(a)
+
+        img_px = img.load()
+        self.assertEqual(img_px[0,0], pixel_value)
 
     @unittest.skipIf(SKIP_NUMPY_ON_PYPY, "numpy.array(Image) is flaky on PyPy")
     def test_to_array(self):


### PR DESCRIPTION

Moved tiff save / load of uint16 to test_file_tiff.

Saving a numpy generated image as a tiff will save in native endian, and comparing it to a
little endian tiff will fail on bigendian machines.