### PR TITLE
Convert DPI to ints when saving as JPEG

### DIFF
--- a/PIL/JpegImagePlugin.py
+++ b/PIL/JpegImagePlugin.py
@@ -593,7 +593,7 @@ def _save(im, fp, filename):
 
     info = im.encoderinfo
 
-    dpi = info.get("dpi", (0, 0))
+    dpi = [int(round(x)) for x in info.get("dpi", (0, 0))]
 
     quality = info.get("quality", 0)
     subsampling = info.get("subsampling", -1)

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -469,6 +469,19 @@ class TestFileJpeg(PillowTestCase):
             img = Image.new(mode, (20, 20))
             self.assert_warning(DeprecationWarning, img.save, out, "JPEG")
 
+    def test_save_tiff_with_dpi(self):
+        # Arrange
+        outfile = self.tempfile("temp.tif")
+        im = Image.open("Tests/images/hopper.tif")
+
+        # Act
+        im.save(outfile, 'JPEG', dpi=im.info['dpi'])
+
+        # Assert
+        reloaded = Image.open(outfile)
+        reloaded.load()
+        self.assertEqual(im.info['dpi'], reloaded.info['dpi'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #2077. Alternative to PR #2084.

Uses the test suggested in the issue.