### PR TITLE
Added append_images parameter to GIF saving

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -306,6 +306,24 @@ class TestFileGif(PillowTestCase):
         reread = Image.open(out)
         self.assertEqual(reread.info["version"], b"GIF87a")
 
+    def test_append_images(self):
+        out = self.tempfile('temp.gif')
+
+        # Test appending single frame images
+        im = Image.new('RGB', (100, 100), '#f00')
+        ims = [Image.new('RGB', (100, 100), color) for color in ['#0f0', '#00f']]
+        im.save(out, save_all=True, append_images=ims)
+
+        reread = Image.open(out)
+        self.assertEqual(reread.n_frames, 3)
+
+        # Tests appending single and multiple frame images
+        im = Image.open("Tests/images/dispose_none.gif")
+        ims = [Image.open("Tests/images/dispose_prev.gif")]
+        im.save(out, save_all=True, append_images=ims)
+
+        reread = Image.open(out)
+        self.assertEqual(reread.n_frames, 10)
 
 if __name__ == '__main__':
     unittest.main()

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -103,7 +103,9 @@ Saving sequences
 
 When calling :py:meth:`~PIL.Image.Image.save`, if a multiframe image is used,
 by default only the first frame will be saved. To save all frames, the
-``save_all`` parameter must be present and set to ``True``.
+``save_all`` parameter must be present and set to ``True``. To append
+additional frames when saving, the ``append_images`` parameter can be set to a
+list of images containing the extra frames.
 
 If present, the ``loop`` parameter can be used to set the number of times
 the GIF should loop, and the ``duration`` parameter can set the number of


### PR DESCRIPTION
Attempt to resolve #2098

The request was to create an animated GIF from scratch. This change is a bit more general, providing a mechanism to add different images when saving a GIF. Usage is

    im.save(out, save_all=True, append_images=[im1, im2, ...])

The `append_images` parameter will not be used unless `save_all` is true.

Please provide any feedback.