### PR TITLE
Allow pathlib.Path in Image.open on Python 2.7

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -2279,10 +2279,14 @@ def open(fp, mode="r"):
     filename = ""
     if isPath(fp):
         filename = fp
-    elif sys.version_info >= (3, 4):
-        from pathlib import Path
-        if isinstance(fp, Path):
-            filename = str(fp.resolve())
+    else:
+        try:
+            from pathlib import Path
+            if isinstance(fp, Path):
+                filename = str(fp.resolve())
+        except ImportError:
+            pass
+
     if filename:
         fp = builtins.open(filename, "rb")
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * Allow using `pathlib.Path` for `Image.open` on Python 2.7

Although the pathlib backport for Python 2.7 may be deprecated:
https://pypi.python.org/pypi/pathlib/
It is still used by many projects. Therefore, changing to a
Try/Except pattern for checking for pathlib is not any more
obtrusive that the current >= Python 3.4 check and allows users
to use the backport without issue.