### PR TITLE
ImageColor.getrgb hexadecimal RGBA

### DIFF
--- a/PIL/ImageColor.py
+++ b/PIL/ImageColor.py
@@ -84,6 +84,7 @@ def getrgb(color):
             int(m.group(2)),
             int(m.group(3))
             )
+
     m = re.match("rgb\(\s*(\d+)%\s*,\s*(\d+)%\s*,\s*(\d+)%\s*\)$", color)
     if m:
         return (
@@ -91,6 +92,7 @@ def getrgb(color):
             int((int(m.group(2)) * 255) / 100.0 + 0.5),
             int((int(m.group(3)) * 255) / 100.0 + 0.5)
             )
+
     m = re.match("hsl\(\s*(\d+)\s*,\s*(\d+)%\s*,\s*(\d+)%\s*\)$", color)
     if m:
         from colorsys import hls_to_rgb
@@ -104,6 +106,7 @@ def getrgb(color):
             int(rgb[1] * 255 + 0.5),
             int(rgb[2] * 255 + 0.5)
             )
+
     m = re.match("rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$",
                  color)
     if m:

--- a/PIL/ImageColor.py
+++ b/PIL/ImageColor.py
@@ -45,21 +45,38 @@ def getrgb(color):
             return rgb
         colormap[color] = rgb = getrgb(rgb)
         return rgb
+
     # check for known string formats
-    m = re.match("#\w\w\w$", color)
-    if m:
+    if re.match('#[a-f0-9]{3}$', color, re.I):
         return (
             int(color[1]*2, 16),
             int(color[2]*2, 16),
-            int(color[3]*2, 16)
+            int(color[3]*2, 16),
             )
-    m = re.match("#\w\w\w\w\w\w$", color)
-    if m:
+
+    if re.match('#[a-f0-9]{4}$', color, re.I):
+        return (
+            int(color[1]*2, 16),
+            int(color[2]*2, 16),
+            int(color[3]*2, 16),
+            int(color[4]*2, 16),
+            )
+
+    if re.match('#[a-f0-9]{6}$', color, re.I):
         return (
             int(color[1:3], 16),
             int(color[3:5], 16),
-            int(color[5:7], 16)
+            int(color[5:7], 16),
             )
+
+    if re.match('#[a-f0-9]{8}$', color, re.I):
+        return (
+            int(color[1:3], 16),
+            int(color[3:5], 16),
+            int(color[5:7], 16),
+            int(color[7:9], 16),
+            )
+
     m = re.match("rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$", color)
     if m:
         return (

--- a/PIL/ImageColor.py
+++ b/PIL/ImageColor.py
@@ -31,15 +31,9 @@ def getrgb(color):
     :param color: A color string
     :return: ``(red, green, blue[, alpha])``
     """
-    try:
-        rgb = colormap[color]
-    except KeyError:
-        try:
-            # fall back on case-insensitive lookup
-            rgb = colormap[color.lower()]
-        except KeyError:
-            rgb = None
-    # found color in cache
+    color = color.lower()
+
+    rgb = colormap.get(color, None)
     if rgb:
         if isinstance(rgb, tuple):
             return rgb
@@ -47,14 +41,14 @@ def getrgb(color):
         return rgb
 
     # check for known string formats
-    if re.match('#[a-f0-9]{3}$', color, re.I):
+    if re.match('#[a-f0-9]{3}$', color):
         return (
             int(color[1]*2, 16),
             int(color[2]*2, 16),
             int(color[3]*2, 16),
             )
 
-    if re.match('#[a-f0-9]{4}$', color, re.I):
+    if re.match('#[a-f0-9]{4}$', color):
         return (
             int(color[1]*2, 16),
             int(color[2]*2, 16),
@@ -62,14 +56,14 @@ def getrgb(color):
             int(color[4]*2, 16),
             )
 
-    if re.match('#[a-f0-9]{6}$', color, re.I):
+    if re.match('#[a-f0-9]{6}$', color):
         return (
             int(color[1:3], 16),
             int(color[3:5], 16),
             int(color[5:7], 16),
             )
 
-    if re.match('#[a-f0-9]{8}$', color, re.I):
+    if re.match('#[a-f0-9]{8}$', color):
         return (
             int(color[1:3], 16),
             int(color[3:5], 16),

--- a/Tests/test_imagecolor.py
+++ b/Tests/test_imagecolor.py
@@ -7,51 +7,68 @@ from PIL import ImageColor
 class TestImageColor(PillowTestCase):
 
     def test_hash(self):
+        # short 3 components
         self.assertEqual((255, 0, 0), ImageColor.getrgb("#f00"))
         self.assertEqual((0, 255, 0), ImageColor.getrgb("#0f0"))
         self.assertEqual((0, 0, 255), ImageColor.getrgb("#00f"))
 
+        # short 4 components
         self.assertEqual((255, 0, 0, 0), ImageColor.getrgb("#f000"))
         self.assertEqual((0, 255, 0, 0), ImageColor.getrgb("#0f00"))
         self.assertEqual((0, 0, 255, 0), ImageColor.getrgb("#00f0"))
         self.assertEqual((0, 0, 0, 255), ImageColor.getrgb("#000f"))
 
+        # long 3 components
         self.assertEqual((222, 0, 0), ImageColor.getrgb("#de0000"))
         self.assertEqual((0, 222, 0), ImageColor.getrgb("#00de00"))
         self.assertEqual((0, 0, 222), ImageColor.getrgb("#0000de"))
 
+        # long 4 components
         self.assertEqual((222, 0, 0, 0), ImageColor.getrgb("#de000000"))
         self.assertEqual((0, 222, 0, 0), ImageColor.getrgb("#00de0000"))
         self.assertEqual((0, 0, 222, 0), ImageColor.getrgb("#0000de00"))
         self.assertEqual((0, 0, 0, 222), ImageColor.getrgb("#000000de"))
 
+        # case insensitivity
         self.assertEqual(ImageColor.getrgb("#DEF"), ImageColor.getrgb("#def"))
+        self.assertEqual(ImageColor.getrgb("#CDEF"), ImageColor.getrgb("#cdef"))
+        self.assertEqual(ImageColor.getrgb("#DEFDEF"),
+                         ImageColor.getrgb("#defdef"))
+        self.assertEqual(ImageColor.getrgb("#CDEFCDEF"),
+                         ImageColor.getrgb("#cdefcdef"))
 
+        # not a number
         self.assertRaises(ValueError, ImageColor.getrgb, "#fo0")
         self.assertRaises(ValueError, ImageColor.getrgb, "#fo00")
         self.assertRaises(ValueError, ImageColor.getrgb, "#fo0000")
         self.assertRaises(ValueError, ImageColor.getrgb, "#fo000000")
 
+        # wrong number of components
         self.assertRaises(ValueError, ImageColor.getrgb, "#f0000")
         self.assertRaises(ValueError, ImageColor.getrgb, "#f000000")
         self.assertRaises(ValueError, ImageColor.getrgb, "#f00000000")
+        self.assertRaises(ValueError, ImageColor.getrgb, "#f000000000")
+        self.assertRaises(ValueError, ImageColor.getrgb, "#f00000 ")
 
     def test_colormap(self):
         self.assertEqual((0, 0, 0), ImageColor.getrgb("black"))
         self.assertEqual((255, 255, 255), ImageColor.getrgb("white"))
         self.assertEqual((255, 255, 255), ImageColor.getrgb("WHITE"))
 
-        self.assertRaises(ValueError, ImageColor.getrgb, "black0")
+        self.assertRaises(ValueError, ImageColor.getrgb, "black ")
 
     def test_functions(self):
+        # rgb numbers
         self.assertEqual((255, 0, 0), ImageColor.getrgb("rgb(255,0,0)"))
         self.assertEqual((0, 255, 0), ImageColor.getrgb("rgb(0,255,0)"))
         self.assertEqual((0, 0, 255), ImageColor.getrgb("rgb(0,0,255)"))
 
+        # percents
         self.assertEqual((255, 0, 0), ImageColor.getrgb("rgb(100%,0%,0%)"))
         self.assertEqual((0, 255, 0), ImageColor.getrgb("rgb(0%,100%,0%)"))
         self.assertEqual((0, 0, 255), ImageColor.getrgb("rgb(0%,0%,100%)"))
 
+        # rgba numbers
         self.assertEqual((255, 0, 0, 0), ImageColor.getrgb("rgba(255,0,0,0)"))
         self.assertEqual((0, 255, 0, 0), ImageColor.getrgb("rgba(0,255,0,0)"))
         self.assertEqual((0, 0, 255, 0), ImageColor.getrgb("rgba(0,0,255,0)"))
@@ -61,15 +78,27 @@ class TestImageColor(PillowTestCase):
         self.assertEqual((255, 0, 0), ImageColor.getrgb("hsl(360,100%,50%)"))
         self.assertEqual((0, 255, 255), ImageColor.getrgb("hsl(180,100%,50%)"))
 
-        actual = ImageColor.getrgb("rgb(  255  ,  0  ,  0  )")
-        self.assertEqual((255, 0, 0), actual)
-        actual = ImageColor.getrgb("rgb(  100%  ,  0%  ,  0%  )")
-        self.assertEqual((255, 0, 0), actual)
-        actual = ImageColor.getrgb("rgba(  255  ,  0  ,  0  ,  0  )")
-        self.assertEqual((255, 0, 0, 0), actual)
-        actual = ImageColor.getrgb("hsl(  0  ,  100%  ,  50%  )")
-        self.assertEqual((255, 0, 0), actual)
+        # case insensitivity
+        self.assertEqual(ImageColor.getrgb("RGB(255,0,0)"),
+                         ImageColor.getrgb("rgb(255,0,0)"))
+        self.assertEqual(ImageColor.getrgb("RGB(100%,0%,0%)"),
+                         ImageColor.getrgb("rgb(100%,0%,0%)"))
+        self.assertEqual(ImageColor.getrgb("RGBA(255,0,0,0)"),
+                         ImageColor.getrgb("rgba(255,0,0,0)"))
+        self.assertEqual(ImageColor.getrgb("HSL(0,100%,50%)"),
+                         ImageColor.getrgb("hsl(0,100%,50%)"))
 
+        # space agnosticism
+        self.assertEqual((255, 0, 0),
+                         ImageColor.getrgb("rgb(  255  ,  0  ,  0  )"))
+        self.assertEqual((255, 0, 0),
+                         ImageColor.getrgb("rgb(  100%  ,  0%  ,  0%  )"))
+        self.assertEqual((255, 0, 0, 0),
+                         ImageColor.getrgb("rgba(  255  ,  0  ,  0  ,  0  )"))
+        self.assertEqual((255, 0, 0),
+                         ImageColor.getrgb("hsl(  0  ,  100%  ,  50%  )"))
+
+        # wrong number of components
         self.assertRaises(ValueError, ImageColor.getrgb, "rgb(255,0)")
         self.assertRaises(ValueError, ImageColor.getrgb, "rgb(255,0,0,0)")
 

--- a/Tests/test_imagecolor.py
+++ b/Tests/test_imagecolor.py
@@ -39,6 +39,7 @@ class TestImageColor(PillowTestCase):
     def test_colormap(self):
         self.assertEqual((0, 0, 0), ImageColor.getrgb("black"))
         self.assertEqual((255, 255, 255), ImageColor.getrgb("white"))
+        self.assertEqual((255, 255, 255), ImageColor.getrgb("WHITE"))
 
         self.assertRaises(ValueError, ImageColor.getrgb, "black0")
 

--- a/Tests/test_imagecolor.py
+++ b/Tests/test_imagecolor.py
@@ -6,20 +6,85 @@ from PIL import ImageColor
 
 class TestImageColor(PillowTestCase):
 
-    def test_sanity(self):
+    def test_hash(self):
         self.assertEqual((255, 0, 0), ImageColor.getrgb("#f00"))
-        self.assertEqual((255, 0, 0), ImageColor.getrgb("#ff0000"))
-        self.assertEqual((255, 0, 0), ImageColor.getrgb("rgb(255,0,0)"))
-        self.assertEqual((255, 0, 0), ImageColor.getrgb("rgb(255, 0, 0)"))
-        self.assertEqual((255, 0, 0), ImageColor.getrgb("rgb(100%,0%,0%)"))
-        self.assertEqual((255, 0, 0), ImageColor.getrgb("hsl(0, 100%, 50%)"))
-        self.assertEqual((255, 0, 0, 0), ImageColor.getrgb("rgba(255,0,0,0)"))
-        self.assertEqual(
-            (255, 0, 0, 0), ImageColor.getrgb("rgba(255, 0, 0, 0)"))
-        self.assertEqual((255, 0, 0), ImageColor.getrgb("red"))
+        self.assertEqual((0, 255, 0), ImageColor.getrgb("#0f0"))
+        self.assertEqual((0, 0, 255), ImageColor.getrgb("#00f"))
 
-        self.assertRaises(ValueError,
-                          lambda: ImageColor.getrgb("invalid color"))
+        self.assertEqual((255, 0, 0, 0), ImageColor.getrgb("#f000"))
+        self.assertEqual((0, 255, 0, 0), ImageColor.getrgb("#0f00"))
+        self.assertEqual((0, 0, 255, 0), ImageColor.getrgb("#00f0"))
+        self.assertEqual((0, 0, 0, 255), ImageColor.getrgb("#000f"))
+
+        self.assertEqual((222, 0, 0), ImageColor.getrgb("#de0000"))
+        self.assertEqual((0, 222, 0), ImageColor.getrgb("#00de00"))
+        self.assertEqual((0, 0, 222), ImageColor.getrgb("#0000de"))
+
+        self.assertEqual((222, 0, 0, 0), ImageColor.getrgb("#de000000"))
+        self.assertEqual((0, 222, 0, 0), ImageColor.getrgb("#00de0000"))
+        self.assertEqual((0, 0, 222, 0), ImageColor.getrgb("#0000de00"))
+        self.assertEqual((0, 0, 0, 222), ImageColor.getrgb("#000000de"))
+
+        self.assertEqual(ImageColor.getrgb("#DEF"), ImageColor.getrgb("#def"))
+
+        self.assertRaises(ValueError, ImageColor.getrgb, "#fo0")
+        self.assertRaises(ValueError, ImageColor.getrgb, "#fo00")
+        self.assertRaises(ValueError, ImageColor.getrgb, "#fo0000")
+        self.assertRaises(ValueError, ImageColor.getrgb, "#fo000000")
+
+        self.assertRaises(ValueError, ImageColor.getrgb, "#f0000")
+        self.assertRaises(ValueError, ImageColor.getrgb, "#f000000")
+        self.assertRaises(ValueError, ImageColor.getrgb, "#f00000000")
+
+    def test_colormap(self):
+        self.assertEqual((0, 0, 0), ImageColor.getrgb("black"))
+        self.assertEqual((255, 255, 255), ImageColor.getrgb("white"))
+
+        self.assertRaises(ValueError, ImageColor.getrgb, "black0")
+
+    def test_functions(self):
+        self.assertEqual((255, 0, 0), ImageColor.getrgb("rgb(255,0,0)"))
+        self.assertEqual((0, 255, 0), ImageColor.getrgb("rgb(0,255,0)"))
+        self.assertEqual((0, 0, 255), ImageColor.getrgb("rgb(0,0,255)"))
+
+        self.assertEqual((255, 0, 0), ImageColor.getrgb("rgb(100%,0%,0%)"))
+        self.assertEqual((0, 255, 0), ImageColor.getrgb("rgb(0%,100%,0%)"))
+        self.assertEqual((0, 0, 255), ImageColor.getrgb("rgb(0%,0%,100%)"))
+
+        self.assertEqual((255, 0, 0, 0), ImageColor.getrgb("rgba(255,0,0,0)"))
+        self.assertEqual((0, 255, 0, 0), ImageColor.getrgb("rgba(0,255,0,0)"))
+        self.assertEqual((0, 0, 255, 0), ImageColor.getrgb("rgba(0,0,255,0)"))
+        self.assertEqual((0, 0, 0, 255), ImageColor.getrgb("rgba(0,0,0,255)"))
+
+        self.assertEqual((255, 0, 0), ImageColor.getrgb("hsl(0,100%,50%)"))
+        self.assertEqual((255, 0, 0), ImageColor.getrgb("hsl(360,100%,50%)"))
+        self.assertEqual((0, 255, 255), ImageColor.getrgb("hsl(180,100%,50%)"))
+
+        actual = ImageColor.getrgb("rgb(  255  ,  0  ,  0  )")
+        self.assertEqual((255, 0, 0), actual)
+        actual = ImageColor.getrgb("rgb(  100%  ,  0%  ,  0%  )")
+        self.assertEqual((255, 0, 0), actual)
+        actual = ImageColor.getrgb("rgba(  255  ,  0  ,  0  ,  0  )")
+        self.assertEqual((255, 0, 0, 0), actual)
+        actual = ImageColor.getrgb("hsl(  0  ,  100%  ,  50%  )")
+        self.assertEqual((255, 0, 0), actual)
+
+        self.assertRaises(ValueError, ImageColor.getrgb, "rgb(255,0)")
+        self.assertRaises(ValueError, ImageColor.getrgb, "rgb(255,0,0,0)")
+
+        self.assertRaises(ValueError, ImageColor.getrgb, "rgb(100%,0%)")
+        self.assertRaises(ValueError, ImageColor.getrgb, "rgb(100%,0%,0)")
+        self.assertRaises(ValueError, ImageColor.getrgb, "rgb(100%,0%,0 %)")
+        self.assertRaises(ValueError, ImageColor.getrgb, "rgb(100%,0%,0%,0%)")
+
+        self.assertRaises(ValueError, ImageColor.getrgb, "rgba(255,0,0)")
+        self.assertRaises(ValueError, ImageColor.getrgb, "rgba(255,0,0,0,0)")
+
+        self.assertRaises(ValueError, ImageColor.getrgb, "hsl(0,100%)")
+        self.assertRaises(ValueError, ImageColor.getrgb, "hsl(0,100%,0%,0%)")
+        self.assertRaises(ValueError, ImageColor.getrgb, "hsl(0%,100%,50%)")
+        self.assertRaises(ValueError, ImageColor.getrgb, "hsl(0,100,50%)")
+        self.assertRaises(ValueError, ImageColor.getrgb, "hsl(0,100%,50)")
 
     # look for rounding errors (based on code by Tim Hatch)
     def test_rounding_errors(self):
@@ -27,11 +92,9 @@ class TestImageColor(PillowTestCase):
         for color in list(ImageColor.colormap.keys()):
             expected = Image.new(
                 "RGB", (1, 1), color).convert("L").getpixel((0, 0))
-            actual = Image.new("L", (1, 1), color).getpixel((0, 0))
+            actual = ImageColor.getcolor(color, 'L')
             self.assertEqual(expected, actual)
 
-        self.assertEqual((0, 0, 0), ImageColor.getcolor("black", "RGB"))
-        self.assertEqual((255, 255, 255), ImageColor.getcolor("white", "RGB"))
         self.assertEqual(
             (0, 255, 115), ImageColor.getcolor("rgba(0, 255, 115, 33)", "RGB"))
         Image.new("RGB", (1, 1), "white")


### PR DESCRIPTION
Support of [hexadecimal RGBA](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgba) notations.

