### PR TITLE
Renamed references to OS X to macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   # Coverage 4.0 doesn't support Python 3.2
   - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
   - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then travis_retry pip install coverage; fi
-  
+
   # docs only on python 2.7
   - if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then travis_retry pip install -r requirements.txt ; fi
 
@@ -94,8 +94,8 @@ after_success:
         export $(cat .to_export_back)
         if [ "$BUILD_LEADER" = "YES" ]; then
           if [ "$BUILD_AGGREGATE_STATUS" = "others_succeeded" ]; then
-            echo "All jobs succeded! Triggering OS X build..."
-            # Trigger an OS X build at the pillow-wheels repo
+            echo "All jobs succeded! Triggering macOS build..."
+            # Trigger a macOS build at the pillow-wheels repo
             ./build_children.sh
           else
             echo "Some jobs failed"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Changelog (Pillow)
 - Added append_images parameter to GIF saving #2103
   [radarhere]
 
-- Speedup paste with masks up to 80% #2015 
+- Speedup paste with masks up to 80% #2015
   [homm]
 
 - Rewrite DDS decoders in C, add DXT3 and BC7 decoders #2068
@@ -109,7 +109,7 @@ Changelog (Pillow)
 - Added CMYK mode for opening EPS files #1826
   [radarhere]
 
-- Docs: OSX build instruction clarification #1994
+- Docs: OS X build instruction clarification #1994
   [wiredfool]
 
 - Docs: Filter comparison table #1993

--- a/PIL/IcnsImagePlugin.py
+++ b/PIL/IcnsImagePlugin.py
@@ -2,7 +2,7 @@
 # The Python Imaging Library.
 # $Id$
 #
-# Mac OS X icns file decoder, based on icns.py by Bob Ippolito.
+# macOS icns file decoder, based on icns.py by Bob Ippolito.
 #
 # history:
 # 2004-10-09 fl   Turned into a PIL plugin; removed 2.3 dependencies.
@@ -302,9 +302,9 @@ def _save(im, fp, filename):
     """
     Saves the image as a series of PNG files,
     that are then converted to a .icns file
-    using the OS X command line utility 'iconutil'.
+    using the macOS command line utility 'iconutil'.
 
-    OS X only.
+    macOS only.
     """
     if hasattr(fp, "flush"):
         fp.flush()

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1725,7 +1725,7 @@ class Image(object):
         PPM file, and calls either the **xv** utility or the **display**
         utility, depending on which one can be found.
 
-        On OS X, this method saves the image to a temporary BMP file, and opens
+        On macOS, this method saves the image to a temporary BMP file, and opens
         it with the native Preview application.
 
         On Windows, it saves the image to a temporary BMP file, and uses

--- a/PIL/ImageGrab.py
+++ b/PIL/ImageGrab.py
@@ -2,7 +2,7 @@
 # The Python Imaging Library
 # $Id$
 #
-# screen grabber (OS X and Windows only)
+# screen grabber (macOS and Windows only)
 #
 # History:
 # 2001-04-26 fl  created
@@ -19,7 +19,7 @@ from PIL import Image
 
 import sys
 if sys.platform not in ["win32", "darwin"]:
-    raise ImportError("ImageGrab is OS X and Windows only")
+    raise ImportError("ImageGrab is macOS and Windows only")
 
 if sys.platform == "win32":
     grabber = Image.core.grabscreen

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
     * - docs
       - |docs|
     * - tests
-      - | |linux| |osx| |windows| |coverage| |health|
+      - | |linux| |macos| |windows| |coverage| |health|
     * - package
       - |zenodo| |version| |downloads|
 
@@ -26,9 +26,9 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
    :target: https://travis-ci.org/python-pillow/Pillow
    :alt: Travis CI build status (Linux)
 
-.. |osx| image:: https://img.shields.io/travis/python-pillow/pillow-wheels/latest.svg?label=OS%20X%20build
+.. |macos| image:: https://img.shields.io/travis/python-pillow/pillow-wheels/latest.svg?label=OS%20X%20build
    :target: https://travis-ci.org/python-pillow/pillow-wheels
-   :alt: Travis CI build status (OS X)
+   :alt: Travis CI build status (macOS)
 
 .. |windows| image:: https://img.shields.io/appveyor/ci/python-pillow/Pillow/master.svg?label=Windows%20build
    :target: https://ci.appveyor.com/project/python-pillow/Pillow

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -88,8 +88,8 @@ Released as needed privately to individual vendors for critical security-related
 * [ ] Contact @cgohlke for Windows binaries via release ticket e.g. https://github.com/python-pillow/Pillow/issues/1174.
 * [ ] Download and extract tarball from @cgohlke and ``twine upload *``.
 
-### OS X
-* [ ] Use the [Pillow OS X Wheel Builder](https://github.com/python-pillow/pillow-wheels):
+### macOS
+* [ ] Use the [Pillow macOS Wheel Builder](https://github.com/python-pillow/pillow-wheels):
 ```
     $ git checkout https://github.com/python-pillow/pillow-wheels
     $ cd pillow-wheels
@@ -100,7 +100,7 @@ Released as needed privately to individual vendors for critical security-related
     $ git commit -a -m "Pillow -> 2.9.0"
     $ git push
 ```
-* [ ] Download distributions from the [Pillow OS X Wheel Builder container](http://cdf58691c5cf45771290-6a3b6a0f5f6ab91aadc447b2a897dd9a.r50.cf2.rackcdn.com/) and ``twine upload *``.
+* [ ] Download distributions from the [Pillow macOS Wheel Builder container](http://cdf58691c5cf45771290-6a3b6a0f5f6ab91aadc447b2a897dd9a.r50.cf2.rackcdn.com/) and ``twine upload *``.
 
 ### Linux
 

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -40,7 +40,7 @@ class TestFileTiff(PillowTestCase):
         im = Image.open(filename)
 
     def test_mac_tiff(self):
-        # Read RGBa images from Mac OS X [@PIL136]
+        # Read RGBa images from macOS [@PIL136]
 
         filename = "Tests/images/pil136.tiff"
         im = Image.open(filename)

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -422,7 +422,7 @@ try:
 
         @unittest.skipIf(sys.platform.startswith('win32'),
                          "requires Unix or MacOS")
-        def test_find_osx_font(self):
+        def test_find_macos_font(self):
             # Like the linux test, more cover hitting code rather than testing
             # correctness.
             font_directory = '/System/Library/Fonts'

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -42,7 +42,7 @@ class TestImageGrabImport(PillowTestCase):
         else:
             self.assertIsInstance(exception, ImportError)
             self.assertEqual(str(exception),
-                             "ImageGrab is OS X and Windows only")
+                             "ImageGrab is macOS and Windows only")
 
 
 if __name__ == '__main__':

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -131,7 +131,7 @@ attributes before loading the file::
 ICNS
 ^^^^
 
-PIL reads and (OS X only) writes Mac OS X ``.icns`` files.  By default, the
+PIL reads and (macOS only) writes macOS ``.icns`` files.  By default, the
 largest available icon is read, though you can override this by setting the
 :py:attr:`~PIL.Image.Image.size` property before calling
 :py:meth:`~PIL.Image.Image.load`.  The :py:meth:`~PIL.Image.Image.open` method

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
 
 .. image:: https://travis-ci.org/python-pillow/pillow-wheels.svg?branch=latest
    :target: https://travis-ci.org/python-pillow/pillow-wheels
-   :alt: Travis CI build status (OS X)
+   :alt: Travis CI build status (macOS)
 
 .. image:: https://img.shields.io/appveyor/ci/python-pillow/Pillow/master.svg?label=Windows%20build
    :target: https://ci.appveyor.com/project/python-pillow/Pillow

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -28,7 +28,7 @@ Basic Installation
 
 .. note::
 
-   The basic installation works on Windows and OS X using the binaries
+   The basic installation works on Windows and macOS using the binaries
    from PyPI. Other installations require building from source as
    detailed below.
 
@@ -58,11 +58,11 @@ or::
   > easy_install Pillow
 
 
-OS X Installation
+macOS Installation
 ^^^^^^^^^^^^^^^^^
 
-We provide binaries for OS X  for each of the supported Python versions
-in the wheel format. These  include support for all optional libraries
+We provide binaries for macOS for each of the supported Python versions
+in the wheel format. These include support for all optional libraries
 except OpenJPEG::
 
   $ pip install Pillow
@@ -230,7 +230,7 @@ or using pip::
     $ pip install pillow --global-option="build_ext" --global-option="--enable-[feature]"
 
 
-Building on OS X
+Building on macOS
 ^^^^^^^^^^^^^^^^
 
 The Xcode command line tools are required to compile portions of
@@ -326,7 +326,7 @@ Platform Support
 Current platform support for Pillow. Binary distributions are contributed for
 each release on a volunteer basis, but the source should compile and run
 everywhere platform support is listed. In general, we aim to support all
-current versions of Linux, OS X, and Windows.
+current versions of Linux, macOS, and Windows.
 
 .. note::
 

--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -1,23 +1,23 @@
 .. py:module:: PIL.ImageGrab
 .. py:currentmodule:: PIL.ImageGrab
 
-:py:mod:`ImageGrab` Module (OS X and Windows only)
+:py:mod:`ImageGrab` Module (macOS and Windows only)
 ==================================================
 
 The :py:mod:`ImageGrab` module can be used to copy the contents of the screen
 or the clipboard to a PIL image memory.
 
-.. note:: The current version works on OS X and Windows only.
+.. note:: The current version works on macOS and Windows only.
 
 .. versionadded:: 1.1.3
 
 .. py:function:: PIL.ImageGrab.grab(bbox=None)
 
     Take a snapshot of the screen. The pixels inside the bounding box are
-    returned as an "RGB" image on Windows or "RGBA" on OS X.
+    returned as an "RGB" image on Windows or "RGBA" on macOS.
     If the bounding box is omitted, the entire screen is copied.
 
-    .. versionadded:: 1.1.3 (Windows), 3.0.0 (OS X)
+    .. versionadded:: 1.1.3 (Windows), 3.0.0 (macOS)
 
     :param bbox: What region to copy. Default is the entire screen.
     :return: An image
@@ -26,7 +26,7 @@ or the clipboard to a PIL image memory.
 
     Take a snapshot of the clipboard image, if any.
 
-    .. versionadded:: 1.1.4 (Windows), 3.3.0 (OS X)
+    .. versionadded:: 1.1.4 (Windows), 3.3.0 (macOS)
 
     :return: On Windows, an image, a list of filenames,
              or None if the clipboard does not contain image data or filenames.


### PR DESCRIPTION
Thought I'd suggest this. With the release of macOS Sierra, OS X has been renamed to macOS.