### PR TITLE
Fix for ImageCms Segfault

### DIFF
--- a/PIL/ImageCms.py
+++ b/PIL/ImageCms.py
@@ -162,8 +162,11 @@ class ImageCmsProfile(object):
             self._set(core.profile_open(profile), profile)
         elif hasattr(profile, "read"):
             self._set(core.profile_frombytes(profile.read()))
+        elif isinstance(profile, _imagingcms.CmsProfile):
+            self._set(profile)
         else:
-            self._set(profile)  # assume it's already a profile
+            raise TypeError("Invalid type for Profile")
+        
 
     def _set(self, profile, filename=None):
         self.profile = profile

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -321,5 +321,17 @@ class TestImageCms(PillowTestCase):
         self.assertEqual(p.viewing_condition, 'Reference Viewing Condition in IEC 61966-2-1')
         self.assertEqual(p.xcolor_space, 'RGB ')
 
+    def test_profile_typesafety(self):
+        """ Profile init type safety
+
+        prepatch, these would segfault, postpatch they should emit a typeerror
+        """
+        
+        with self.assertRaises(TypeError):
+            ImageCms.ImageCmsProfile(0).tobytes()
+        with self.assertRaises(TypeError):
+            ImageCms.ImageCmsProfile(1).tobytes()
+    
+
 if __name__ == '__main__':
     unittest.main()

--- a/_imagingcms.c
+++ b/_imagingcms.c
@@ -1378,7 +1378,8 @@ static struct PyGetSetDef cms_profile_getsetters[] = {
 
 static PyTypeObject CmsProfile_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "CmsProfile", sizeof(CmsProfileObject), 0,
+    "PIL._imagingcms.CmsProfile",   /*tp_name */
+    sizeof(CmsProfileObject), 0,/*tp_basicsize, tp_itemsize */
     /* methods */
     (destructor) cms_profile_dealloc, /*tp_dealloc*/
     0, /*tp_print*/
@@ -1470,9 +1471,14 @@ setup_module(PyObject* m) {
 
     d = PyModule_GetDict(m);
 
+    CmsProfile_Type.tp_new = PyType_GenericNew;
+
     /* Ready object types */
     PyType_Ready(&CmsProfile_Type);
     PyType_Ready(&CmsTransform_Type);
+
+    Py_INCREF(&CmsProfile_Type);
+    PyModule_AddObject(m, "CmsProfile", (PyObject *)&CmsProfile_Type);
 
     d = PyModule_GetDict(m);
 
@@ -1499,7 +1505,7 @@ PyInit__imagingcms(void) {
 
     if (setup_module(m) < 0)
         return NULL;
-
+   
     PyDateTime_IMPORT;
 
     return m;


### PR DESCRIPTION
Fixes #2037 .

Changes proposed in this pull request:

 * Check the type of objects passed into ImageCms.ImageCmsCmsProfile.
 * Added CmsProfile type to _imagingcms module. 
 

Note that I'm not classifying this as a security issue because it's triggered by a programming error, not an image. 