### PR TITLE
Speed up GIF save optimization step

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -59,7 +59,8 @@ class TestFileGif(PillowTestCase):
         # Check for correctness after conversion back to RGB        
         def check(colors, size, expected_palette_length):
             # make an image with empty colors in the start of the palette range
-            im = Image.frombytes('P', (colors,colors), bytes(bytearray(range(256-colors,256)*colors)))
+            im = Image.frombytes('P', (colors,colors),
+                                 bytes(bytearray(list(range(256-colors,256))*colors)))
             im = im.resize((size,size))
             outfile = BytesIO()
             im.save(outfile, 'GIF')


### PR DESCRIPTION
Fixes #2093 .

Changes proposed in this pull request:

 * Only optimize a gif's palette if: 
   - We have to (L mode)
   - It's got less than 128 colors (otherwise, we're just padding with zeros anyway)
   - It changed
   - The image is smaller than 1/4 mpix. (otherwise, the potential savings is lost in the noise)
 * Do it in C, using the existing conversion machinery, and some monkeying with palettes and convert. 
 

