### PR TITLE
Fix "invalid escape sequence" warning in Python 3.6

### DIFF
--- a/PIL/ImageColor.py
+++ b/PIL/ImageColor.py
@@ -71,7 +71,7 @@ def getrgb(color):
             int(color[7:9], 16),
             )
 
-    m = re.match("rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$", color)
+    m = re.match(r"rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$", color)
     if m:
         return (
             int(m.group(1)),
@@ -79,7 +79,7 @@ def getrgb(color):
             int(m.group(3))
             )
 
-    m = re.match("rgb\(\s*(\d+)%\s*,\s*(\d+)%\s*,\s*(\d+)%\s*\)$", color)
+    m = re.match(r"rgb\(\s*(\d+)%\s*,\s*(\d+)%\s*,\s*(\d+)%\s*\)$", color)
     if m:
         return (
             int((int(m.group(1)) * 255) / 100.0 + 0.5),
@@ -87,7 +87,7 @@ def getrgb(color):
             int((int(m.group(3)) * 255) / 100.0 + 0.5)
             )
 
-    m = re.match("hsl\(\s*(\d+)\s*,\s*(\d+)%\s*,\s*(\d+)%\s*\)$", color)
+    m = re.match(r"hsl\(\s*(\d+)\s*,\s*(\d+)%\s*,\s*(\d+)%\s*\)$", color)
     if m:
         from colorsys import hls_to_rgb
         rgb = hls_to_rgb(
@@ -101,7 +101,7 @@ def getrgb(color):
             int(rgb[2] * 255 + 0.5)
             )
 
-    m = re.match("rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$",
+    m = re.match(r"rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$",
                  color)
     if m:
         return (

--- a/PIL/ImageShow.py
+++ b/PIL/ImageShow.py
@@ -39,7 +39,7 @@ def register(viewer, order=1):
 
 
 def show(image, title=None, **options):
-    """
+    r"""
     Display a given image.
 
     :param image: An image object.

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -32,7 +32,7 @@ class TestFileJpeg(PillowTestCase):
     def test_sanity(self):
 
         # internal version number
-        self.assertRegexpMatches(Image.core.jpeglib_version, "\d+\.\d+$")
+        self.assertRegexpMatches(Image.core.jpeglib_version, r"\d+\.\d+$")
 
         im = Image.open(TEST_FILE)
         im.load()

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -31,7 +31,7 @@ class TestFileJpeg2k(PillowTestCase):
 
     def test_sanity(self):
         # Internal version number
-        self.assertRegexpMatches(Image.core.jp2klib_version, '\d+\.\d+\.\d+$')
+        self.assertRegexpMatches(Image.core.jp2klib_version, r'\d+\.\d+\.\d+$')
 
         im = Image.open('Tests/images/test-card-lossless.jp2')
         px = im.load()

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -55,7 +55,7 @@ class TestFilePng(PillowTestCase):
 
         # internal version number
         self.assertRegexpMatches(
-            Image.core.zlib_version, "\d+\.\d+\.\d+(\.\d+)?$")
+            Image.core.zlib_version, r"\d+\.\d+\.\d+(\.\d+)?$")
 
         test_file = self.tempfile("temp.png")
 

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -43,7 +43,7 @@ class TestImageCms(PillowTestCase):
         self.assertEqual(list(map(type, v)), [str, str, str, str])
 
         # internal version number
-        self.assertRegexpMatches(ImageCms.core.littlecms_version, "\d+\.\d+$")
+        self.assertRegexpMatches(ImageCms.core.littlecms_version, r"\d+\.\d+$")
 
         self.skip_missing()
         i = ImageCms.profileToProfile(hopper(), SRGB, SRGB)

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -46,7 +46,7 @@ try:
 
         def test_sanity(self):
             self.assertRegexpMatches(
-                ImageFont.core.freetype2_version, "\d+\.\d+\.\d+$")
+                ImageFont.core.freetype2_version, r"\d+\.\d+\.\d+$")
 
         def test_font_properties(self):
             ttf = ImageFont.truetype(FONT_PATH, FONT_SIZE)

--- a/setup.py
+++ b/setup.py
@@ -680,7 +680,7 @@ class pil_build_ext(build_ext):
         else:
             return
         for line in open(zlibfile).readlines():
-            m = re.match('#define\s+ZLIB_VERSION\s+"([^"]*)"', line)
+            m = re.match(r'#define\s+ZLIB_VERSION\s+"([^"]*)"', line)
             if not m:
                 continue
             if m.group(1) < "1.2.3":


### PR DESCRIPTION
http://bugs.python.org/issue27364