### PR TITLE
Documentation notes

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -770,11 +770,9 @@ zero-indexed and random access is supported.
 PCD
 ^^^
 
-PIL reads PhotoCD files containing ``RGB`` data. By default, the 768x512
-resolution is read. You can use the :py:meth:`~PIL.Image.Image.draft` method to
-read the lower resolution versions instead, thus effectively resizing the image
-to 384x256 or 192x128. Higher resolutions cannot be read by the Python Imaging
-Library.
+PIL reads PhotoCD files containing ``RGB`` data. This only reads the 768x512
+resolution image from the file. Higher resolutions are encoded in a proprietary
+encoding.
 
 PIXAR
 ^^^^^

--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -523,6 +523,7 @@ This is only available for JPEG and MPO files.
 
 ::
 
+    from PIL import Image
     from __future__ import print_function
     im = Image.open(file)
     print("original =", im.mode, im.size)

--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -519,6 +519,8 @@ is done by reconfiguring the image decoder.
 Reading in draft mode
 ^^^^^^^^^^^^^^^^^^^^^
 
+This is only available for JPEG and MPO files.
+
 ::
 
     from __future__ import print_function


### PR DESCRIPTION
* The PCD `draft` method was removed in #1169
* Added note in the docs about format support for the `draft` method.
* Added an `import` statement to a docs example. Considering that there is another `import` statement there, it felt to me like it should be a bit more self-contained.