### PR TITLE
Add TIFF save_all writer.

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1686,7 +1686,9 @@ class Image(object):
             save_handler = SAVE[format.upper()]
 
         if open_fp:
-            fp = builtins.open(filename, "wb")
+            # Open also for reading ("+"), because TIFF save_all
+            # writer needs to go back and edit the written data.
+            fp = builtins.open(filename, "w+b")
 
         try:
             save_handler(self, fp, filename)

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -487,6 +487,17 @@ class TestFileTiff(PillowTestCase):
 
         self.assert_image_equal(im, reloaded)
 
+    def test_tiff_save_all(self):
+        import io
+        import os
+
+        mp = io.BytesIO()
+        with Image.open("Tests/images/multipage.tiff") as im:
+            im.save(mp, format="tiff", save_all=True)
+
+        mp.seek(0, os.SEEK_SET)
+        with Image.open(mp) as im:
+            self.assertEqual(im.n_frames, 3)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #733 .

Changes proposed in this pull request:

 * Open files for reading in addition to writing in Image.save
 * Add AppendingTiffWriter to TiffImagePlugin.py (this code is from @vashek)
 * Add _save_all support to TiffImagePlugin.py.

Note that the resulting multipage tiff files may be mmappable by PIL, requiring #2139 to be loaded correctly after saving.
