### PR TITLE
Work around pycparser issue failing our builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ python:
   - nightly
 
 install:
+  - "travis_retry pip install pycparser!=2.14"  # TEMPORARY, WORKAROUND FOR https://github.com/eliben/pycparser/issues/147
   - "travis_retry sudo apt-get update"
   - "travis_retry sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-qt4 ghostscript libffi-dev libjpeg-turbo-progs cmake imagemagick"
   - "travis_retry pip install cffi"


### PR DESCRIPTION
The build has started failing (e.g. https://travis-ci.org/python-pillow/Pillow/jobs/164608656#L2452) due to https://github.com/eliben/pycparser/issues/147. 

Perfectly timed for release day :)

Let's temporarily work around it, we can remove this later when pycparser's fixed.

The workaround passes: https://travis-ci.org/hugovk/Pillow/builds/164623368