### PR TITLE
CRITICAL: Allow lists as arguments for Image.new()

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1020,7 +1020,7 @@ class Image(object):
         4-tuple defining the left, upper, right, and lower pixel
         coordinate.
 
-        Note: Prior to Pillow 3.4.0, this was a lazy operation. 
+        Note: Prior to Pillow 3.4.0, this was a lazy operation.
 
         :param box: The crop rectangle, as a (left, upper, right, lower)-tuple.
         :rtype: :py:class:`~PIL.Image.Image`
@@ -1993,7 +1993,7 @@ def _check_size(size):
     :returns: True, or raises a ValueError
     """
 
-    if not isinstance(size, tuple):
+    if not isinstance(size, (list, tuple)):
         raise ValueError("Size must be a tuple")
     if len(size) != 2:
         raise ValueError("Size must be a tuple of length 2")
@@ -2019,7 +2019,7 @@ def new(mode, size, color=0):
     """
 
     _check_size(size)
-    
+
     if color is None:
         # don't initialize
         return Image()._new(core.new(mode, size))

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -248,7 +248,8 @@ class TestImage(PillowTestCase):
 
         self.assertTrue(Image.new('RGB', (1,1)))
         # Should pass lists too
-        self.assertTrue(Image.new('RGB', [1,1]))
+        i = Image.new('RGB', [1,1])
+        self.assertEqual(type(i.size), tuple)
 
     def test_storage_neg(self):
         # Storage.c accepted negative values for xsize, ysize.  Was

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -238,7 +238,7 @@ class TestImage(PillowTestCase):
         self.assert_image_similar(im2, im3, 110)
 
     def test_check_size(self):
-        # Checking that the _check_size function throws value errors when we want it to. 
+        # Checking that the _check_size function throws value errors when we want it to.
         with self.assertRaises(ValueError):
             Image.new('RGB', 0)  # not a tuple
         with self.assertRaises(ValueError):
@@ -247,19 +247,21 @@ class TestImage(PillowTestCase):
             Image.new('RGB', (0,0))  # w,h <= 0
 
         self.assertTrue(Image.new('RGB', (1,1)))
+        # Should pass lists too
+        self.assertTrue(Image.new('RGB', [1,1]))
 
     def test_storage_neg(self):
         # Storage.c accepted negative values for xsize, ysize.  Was
         # test_neg_ppm, but the core function for that has been
         # removed Calling directly into core to test the error in
         # Storage.c, rather than the size check above
-        
+
         with self.assertRaises(ValueError):
             Image.core.fill('RGB', (2,-2), (0,0,0))
 
 
 
-            
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes the broken backward compatibility introduced in #2146

I believe that this breaks is A LOT of code and the fix should be released as 3.4.1.

@aclark4life @hugovk @wiredfool 