### PR TITLE
Check should be against PY_SSIZE_T_MAX

### DIFF
--- a/map.c
+++ b/map.c
@@ -349,7 +349,7 @@ PyImaging_MapBuffer(PyObject* self, PyObject* args)
 
     size = (Py_ssize_t) ysize * stride;
 
-    if (offset > SIZE_MAX - size) {
+    if (offset > PY_SSIZE_T_MAX - size) {
         PyErr_SetString(PyExc_MemoryError, "Integer overflow in offset");
         return NULL;
     }        


### PR DESCRIPTION
Fixes 3.3.2, 3.4.0 test failures on build for x86 linux builds. 

(windows doesn't define SSIZE_MAX, but python defined PY_SSIZE_T_MAX, which is more exact anyway)