### PR TITLE
Divide floats to eliminate deprecation warning.

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -46,7 +46,7 @@ class _imaging_not_installed(object):
 
 
 # Limit to around a quarter gigabyte for a 24 bit (3 bpp) image
-MAX_IMAGE_PIXELS = int(1024 * 1024 * 1024 / 4 / 3)
+MAX_IMAGE_PIXELS = int(1024 * 1024 * 1024 // 4 // 3)
 
 try:
     # give Tk a chance to set up the environment, in case we're


### PR DESCRIPTION
When running python 2.x with the [`-3`](https://docs.python.org/2/using/cmdline.html#cmdoption-3) flag the following warning occurs
> .../PIL/Image.py:48: DeprecationWarning: classic int division
  MAX_IMAGE_PIXELS = int(1024 * 1024 * 1024 / 4 / 3)

~~Simply changing the 4 and 3 to be floats instead eliminates the warning
and, because the result is cast, the resulting `int` stays the same for
python 2 and 3.~~ 
Using floor division eliminates the warning.