### PR TITLE
Refer user to installation docs on jpeg/zlib ValueError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -518,7 +518,9 @@ class pil_build_ext(build_ext):
                 if f in ('jpeg', 'zlib'):
                     raise ValueError(
                         '%s is required unless explicitly disabled'
-                        ' using --disable-%s, aborting' % (f, f))
+                        ' using --disable-%s, aborting. See https://pillow.'
+                        'readthedocs.io/en/latest/installation.html for more '
+                        'info' % (f, f))
                 raise ValueError(
                     '--enable-%s requested but %s not found, aborting.' %
                     (f, f))


### PR DESCRIPTION
We get a [lot of issues](https://github.com/python-pillow/Pillow/search?q=is+required+unless+explicitly+disabled+using&type=Issues&utf8=%E2%9C%93) about `ValueError: jpeg is required unless explicitly disabled using --disable-jpeg, aborting` or `ValueError: zlib is required unless explicitly disabled using --disable-zlib, aborting` which are usually solved by pointing them in the direction of the docs.

So let's include it in the error message.
