### PR TITLE
Fix BytesWarning discovered while running tests

### DIFF
--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -696,7 +696,7 @@ def getheader(im, palette=None, info=None):
             version = b"89a"
             break
     else:
-        if im.info.get("version") == "89a":
+        if im.info.get("version") == b"89a":
             version = b"89a"
 
     header = [

--- a/PIL/ImtImagePlugin.py
+++ b/PIL/ImtImagePlugin.py
@@ -69,7 +69,7 @@ class ImtImageFile(ImageFile.ImageFile):
                 s = s + self.fp.readline()
                 if len(s) == 1 or len(s) > 100:
                     break
-                if s[0] == b"*":
+                if s[0] == ord(b"*"):
                     continue  # comment
 
                 m = field.match(s)

--- a/PIL/PngImagePlugin.py
+++ b/PIL/PngImagePlugin.py
@@ -132,7 +132,7 @@ class ChunkStream(object):
     def call(self, cid, pos, length):
         "Call the appropriate chunk handler"
 
-        logger.debug("STREAM %s %s %s", cid, pos, length)
+        logger.debug("STREAM %r %s %s", cid, pos, length)
         return getattr(self, "chunk_" + cid.decode('ascii'))(pos, length)
 
     def crc(self, cid, data):
@@ -148,10 +148,10 @@ class ChunkStream(object):
             crc1 = Image.core.crc32(data, Image.core.crc32(cid))
             crc2 = i16(self.fp.read(2)), i16(self.fp.read(2))
             if crc1 != crc2:
-                raise SyntaxError("broken PNG file (bad header checksum in %s)"
+                raise SyntaxError("broken PNG file (bad header checksum in %r)"
                                   % cid)
         except struct.error:
-            raise SyntaxError("broken PNG file (incomplete checksum in %s)"
+            raise SyntaxError("broken PNG file (incomplete checksum in %r)"
                               % cid)
 
     def crc_skip(self, cid, data):
@@ -309,7 +309,7 @@ class PngStream(ChunkStream):
         # Compression method    1 byte (0)
         # Compressed profile    n bytes (zlib with deflate compression)
         i = s.find(b"\0")
-        logger.debug("iCCP profile name %s", s[:i])
+        logger.debug("iCCP profile name %r", s[:i])
         logger.debug("Compression method %s", i8(s[i]))
         comp_method = i8(s[i])
         if comp_method != 0:
@@ -539,7 +539,7 @@ class PngImageFile(ImageFile.ImageFile):
             except EOFError:
                 break
             except AttributeError:
-                logger.debug("%s %s %s (unknown)", cid, pos, length)
+                logger.debug("%r %s %s (unknown)", cid, pos, length)
                 s = ImageFile._safe_read(self.fp, length)
 
             self.png.crc(cid, s)

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -338,7 +338,7 @@ class TestFileGif(PillowTestCase):
         self.assertEqual(reread.info["version"], b"GIF87a")
 
         # Test that a GIF89a image is also saved in that format
-        im.info["version"] = "GIF89a"
+        im.info["version"] = b"GIF89a"
         im.save(out)
         reread = Image.open(out)
         self.assertEqual(reread.info["version"], b"GIF87a")

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -119,7 +119,7 @@ class TestFileTiff(PillowTestCase):
         self.assertRaises(SyntaxError,
                           lambda: TiffImagePlugin.TiffImageFile(invalid_file))
 
-        TiffImagePlugin.PREFIXES.append("\xff\xd8\xff\xe0")
+        TiffImagePlugin.PREFIXES.append(b"\xff\xd8\xff\xe0")
         self.assertRaises(SyntaxError,
                           lambda: TiffImagePlugin.TiffImageFile(invalid_file))
         TiffImagePlugin.PREFIXES.pop()


### PR DESCRIPTION
Changes proposed in this pull request:

Fixes warnings that look like: "BytesWarning: Comparison between bytes and string"

Discovered using the command:

python -b -m nose -vx Tests/test_*.py