### PR TITLE
Build: Reinstate coverage tests on nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,12 +49,12 @@ install:
   - pushd depends && ./install_imagequant.sh && popd
 
 script:
-  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then coverage erase; fi
+  - coverage erase
   - python setup.py clean
   - CFLAGS="-coverage" python setup.py build_ext --inplace
 
-  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then coverage run --append --include=PIL/* selftest.py; fi
-  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then coverage run --append --include=PIL/* -m nose -vx Tests/test_*.py; fi
+  - coverage run --append --include=PIL/* selftest.py
+  - coverage run --append --include=PIL/* -m nose -vx Tests/test_*.py
   - pushd /tmp/check-manifest && check-manifest --ignore ".coveragerc,.editorconfig,*.yml,*.yaml,tox.ini" && popd
 
   # Docs


### PR DESCRIPTION
Revert https://github.com/python-pillow/Pillow/pull/1376, as the [fix](https://bitbucket.org/ned/coveragepy/issues/391) to allow Coverage to works with the Python nightly build (now Python 3.7.0a0) has now been released.
