### PR TITLE
Build: Test on Python 3.5 dev and 3.6 dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ python:
   - 3.2
   - 3.3
   - 3.4
+  - 3.5-dev
+  - 3.6-dev
   - nightly
 
 install:
@@ -127,6 +129,8 @@ after_script:
 matrix:
   fast_finish: true
   allow_failures:
+    - python: 3.5-dev
+    - python: 3.6-dev
     - python: nightly
 
 env:


### PR DESCRIPTION
The `nightly` build was `3.6-dev`, but has now moved on to `3.7-dev` (right now 3.7.0a0). Until 3.6 is released later this year, let's  explicitly test against `3.6-dev`.

We already test against `3.5`, is there any value in also testing against `3.5-dev`?

`3.5-dev`, `3.6-dev` and `nightly` are all in `allow_failures` so if they fail (possibly due to errors in Python itself, possibly due to some change we'll need to support) they won't fail our builds, but we'll know about them.

(`nightly` was first added in https://github.com/python-pillow/Pillow/pull/1361)

---

[Travis CI docs](https://docs.travis-ci.com/user/languages/python/#Choosing-Python-versions-to-test-against) say:

> Travis CI supports Python versions 2.6, 2.7, 3.2, 3.3, 3.4, 3.5, as well as recent development versions.
> 
> ``` yaml
> language: python
> python:
>   - "2.6"
>   - "2.7"
>   - "3.2"
>   - "3.3"
>   - "3.4"
>   - "3.5"
>   - "3.5-dev" # 3.5 development branch
>   - "3.6-dev" # 3.6 development branch
>   - "nightly" # currently points to 3.7-dev
> # command to install dependencies
> install: "pip install -r requirements.txt"
> # command to run tests
> script: nosetests
> ```
