### PR TITLE
Replace type() equality checks with isinstance

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -879,7 +879,7 @@ class Image(object):
                     trns_im = Image()._new(core.new(self.mode, (1, 1)))
                     if self.mode == 'P':
                         trns_im.putpalette(self.palette)
-                        if type(t) == tuple:
+                        if isinstance(t, tuple):
                             try:
                                 t = trns_im.palette.getcolor(t)
                             except:

--- a/PIL/ImageDraw.py
+++ b/PIL/ImageDraw.py
@@ -208,12 +208,12 @@ class ImageDraw(object):
 
     def _multiline_check(self, text):
         """Draw text."""
-        split_character = "\n" if isinstance(text, type("")) else b"\n"
+        split_character = "\n" if isinstance(text, str) else b"\n"
 
         return split_character in text
 
     def _multiline_split(self, text):
-        split_character = "\n" if isinstance(text, type("")) else b"\n"
+        split_character = "\n" if isinstance(text, str) else b"\n"
 
         return text.split(split_character)
 

--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -278,12 +278,12 @@ class IFDRational(Rational):
         self._numerator = value
         self._val = float(1)
 
-        if type(value) == Fraction:
+        if isinstance(value, Fraction):
             self._numerator = value.numerator
             self._denominator = value.denominator
             self._val = value
 
-        if type(value) == IFDRational:
+        if isinstance(value, IFDRational):
             self._denominator = value.denominator
             self._numerator = value.numerator
             self._val = value._val
@@ -294,7 +294,7 @@ class IFDRational(Rational):
             return
 
         elif denominator == 1:
-            if sys.hexversion < 0x2070000 and type(value) == float:
+            if sys.hexversion < 0x2070000 and isinstance(value, float):
                 # python 2.6 is different.
                 self._val = Fraction.from_float(value)
             else:
@@ -1056,7 +1056,7 @@ class TiffImageFile(ImageFile.ImageFile):
             # io.BytesIO have a fileno, but returns an IOError if
             # it doesn't use a file descriptor.
             fp = False
-        
+
         if fp:
             args[2] = fp
 

--- a/PIL/features.py
+++ b/PIL/features.py
@@ -17,7 +17,7 @@ def check_module(feature):
     module = modules[feature]
 
     method_to_call = None
-    if type(module) is tuple:
+    if isinstance(module, tuple):
         module, method_to_call = module
 
     try:

--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -13,8 +13,8 @@ class TestFeatures(PillowTestCase):
             self.assertTrue(features.check_codec(feature) in [True, False])
 
     def test_supported_features(self):
-        self.assertTrue(type(features.get_supported_modules()) is list)
-        self.assertTrue(type(features.get_supported_codecs()) is list)
+        self.assertIsInstance(features.get_supported_modules(), list)
+        self.assertIsInstance(features.get_supported_codecs(), list)
 
     def test_unsupported_codec(self):
         # Arrange

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -392,7 +392,7 @@ class TestFilePng(PillowTestCase):
         info = PngImagePlugin.PngInfo()
         info.add_text("Text", "Ascii")
         im = roundtrip(im, pnginfo=info)
-        self.assertEqual(type(im.info["Text"]), str)
+        self.assertIsInstance(im.info["Text"], str)
 
     def test_unicode_text(self):
         # Check preservation of non-ASCII characters on Python3

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -123,10 +123,9 @@ class TestFileTiffMetadata(PillowTestCase):
         reloaded = loaded.tag_v2.named()
 
         for k, v in original.items():
-            if type(v) == IFDRational:
+            if isinstance(v, IFDRational):
                 original[k] = IFDRational(*_limit_rational(v, 2**31))
-            if type(v) == tuple and \
-               type(v[0]) == IFDRational:
+            if isinstance(v, tuple) and isinstance(v[0], IFDRational):
                 original[k] = tuple([IFDRational(
                                      *_limit_rational(elt, 2**31)) for elt in v])
 
@@ -136,8 +135,8 @@ class TestFileTiffMetadata(PillowTestCase):
         for tag, value in reloaded.items():
             if tag in ignored:
                 continue
-            if (type(original[tag]) == tuple
-               and type(original[tag][0]) == IFDRational):
+            if (isinstance(original[tag], tuple)
+               and isinstance(original[tag][0], IFDRational)):
                 # Need to compare element by element in the tuple,
                 # not comparing tuples of object references
                 self.assert_deep_equal(original[tag],
@@ -175,7 +174,7 @@ class TestFileTiffMetadata(PillowTestCase):
 
         im.save(out)
         reloaded = Image.open(out)
-        self.assert_(type(im.info['icc_profile']) is not tuple)
+        self.assertNotIsInstance(im.info['icc_profile'], tuple)
         self.assertEqual(im.info['icc_profile'], reloaded.info['icc_profile'])
 
     def test_iccprofile_binary(self):

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -249,7 +249,7 @@ class TestImage(PillowTestCase):
         self.assertTrue(Image.new('RGB', (1,1)))
         # Should pass lists too
         i = Image.new('RGB', [1,1])
-        self.assertEqual(type(i.size), tuple)
+        self.assertIsInstance(i.size, tuple)
 
     def test_storage_neg(self):
         # Storage.c accepted negative values for xsize, ysize.  Was

--- a/Tests/test_imagemath.py
+++ b/Tests/test_imagemath.py
@@ -9,7 +9,7 @@ def pixel(im):
     if hasattr(im, "im"):
         return "%s %r" % (im.mode, im.getpixel((0, 0)))
     else:
-        if isinstance(im, type(0)):
+        if isinstance(im, int):
             return int(im)  # hack to deal with booleans
         print(im)
 

--- a/Tests/test_olefileio.py
+++ b/Tests/test_olefileio.py
@@ -106,9 +106,8 @@ class TestOleFileIo(PillowTestCase):
         mtime = root_entry.getmtime()
 
         # Assert
-        self.assertIsInstance(ctime, type(None))
+        self.assertIsNone(ctime)
         self.assertIsInstance(mtime, datetime.datetime)
-        self.assertEqual(ctime, None)
         self.assertEqual(mtime.year, 2014)
         ole.close()
 

--- a/setup.py
+++ b/setup.py
@@ -189,7 +189,7 @@ class pil_build_ext(build_ext):
 
         for root in (JPEG_ROOT, JPEG2K_ROOT, TIFF_ROOT, ZLIB_ROOT,
                      FREETYPE_ROOT, LCMS_ROOT, IMAGEQUANT_ROOT):
-            if isinstance(root, type(())):
+            if isinstance(root, tuple):
                 lib_root, include_root = root
             else:
                 lib_root = include_root = root


### PR DESCRIPTION
Changes proposed in this pull request:
- Use more Pythonic "isinstance()" in places where a variable's type is being checked.
