### PR TITLE
Avoid deprecated 'U' mode when opening files

### DIFF
--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -1,7 +1,6 @@
 from helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, EpsImagePlugin
-from PIL._util import py3
 import io
 
 # Our two EPS test files (they are identical except for their bounding boxes)
@@ -196,41 +195,15 @@ class TestFileEps(PillowTestCase):
         self.assertEqual(t.readline().strip('\r\n'), 'baz', ending)
         self.assertEqual(t.readline().strip('\r\n'), 'bif', ending)
 
-    def _test_readline_stringio(self, test_string, ending):
-        # check all the freaking line endings possible
-        try:
-            import StringIO
-        except ImportError:
-            # don't skip, it skips everything in the parent test
-            return
-        t = StringIO.StringIO(test_string)
+    def _test_readline_io_psfile(self, test_string, ending):
+        f = io.BytesIO(test_string.encode('latin-1'))
+        t = EpsImagePlugin.PSFile(f)
         self._test_readline(t, ending)
-
-    def _test_readline_io(self, test_string, ending):
-        if py3:
-            t = io.StringIO(test_string)
-        else:
-            t = io.StringIO(unicode(test_string))
-        self._test_readline(t, ending)
-
-    def _test_readline_file_universal(self, test_string, ending):
-        f = self.tempfile('temp.txt')
-        with open(f, 'wb') as w:
-            if py3:
-                w.write(test_string.encode('UTF-8'))
-            else:
-                w.write(test_string)
-
-        with open(f, 'rU') as t:
-            self._test_readline(t, ending)
 
     def _test_readline_file_psfile(self, test_string, ending):
         f = self.tempfile('temp.txt')
         with open(f, 'wb') as w:
-            if py3:
-                w.write(test_string.encode('UTF-8'))
-            else:
-                w.write(test_string)
+            w.write(test_string.encode('latin-1'))
 
         with open(f, 'rb') as r:
             t = EpsImagePlugin.PSFile(r)
@@ -239,29 +212,12 @@ class TestFileEps(PillowTestCase):
     def test_readline(self):
         # check all the freaking line endings possible from the spec
         # test_string = u'something\r\nelse\n\rbaz\rbif\n'
-        line_endings = ['\r\n', '\n']
-        not_working_endings = ['\n\r', '\r']
+        line_endings = ['\r\n', '\n', '\n\r', '\r']
         strings = ['something', 'else', 'baz', 'bif']
 
         for ending in line_endings:
             s = ending.join(strings)
-            # Native Python versions will pass these endings.
-            # self._test_readline_stringio(s, ending)
-            # self._test_readline_io(s, ending)
-            # self._test_readline_file_universal(s, ending)
-
-            self._test_readline_file_psfile(s, ending)
-
-        for ending in not_working_endings:
-            # these only work with the PSFile, while they're in spec,
-            # they're not likely to be used
-            s = ending.join(strings)
-
-            # Native Python versions may fail on these endings.
-            # self._test_readline_stringio(s, ending)
-            # self._test_readline_io(s, ending)
-            # self._test_readline_file_universal(s, ending)
-
+            self._test_readline_io_psfile(s, ending)
             self._test_readline_file_psfile(s, ending)
 
     def test_open_eps(self):

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -26,7 +26,6 @@ import os
 import sys
 from . import Image, ImageFile
 from ._binary import i32le as i32
-from ._util import py3
 
 __version__ = "0.5"
 
@@ -206,16 +205,7 @@ class EpsImageFile(ImageFile.ImageFile):
 
         # Rewrap the open file pointer in something that will
         # convert line endings and decode to latin-1.
-        try:
-            if py3:
-                # Python3, can use bare open command.
-                fp = open(self.fp.name, "Ur", encoding='latin-1')
-            else:
-                # Python2, no encoding conversion necessary
-                fp = open(self.fp.name, "Ur")
-        except:
-            # Expect this for bytesio/stringio
-            fp = PSFile(self.fp)
+        fp = PSFile(self.fp)
 
         # go to offset - start of "%!PS"
         fp.seek(offset)


### PR DESCRIPTION
<s>Instead, use [io.open()](https://docs.python.org/2/library/io.html#io.open) wrapper to handle universal newlines for all Python versions.</s> (Different approach taken, see below.)

Fixes warning "DeprecationWarning: 'U' mode is deprecated" in tests.