### PR TITLE
Remove unused, open files at top level of tests.

### DIFF
--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -6,7 +6,6 @@ from PIL import Image, FliImagePlugin
 # created as an export of a palette image from Gimp2.6
 # save as...-> hopper.fli, default options.
 test_file = "Tests/images/hopper.fli"
-data = open(test_file, "rb").read()
 
 
 class TestFileFli(PillowTestCase):

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -6,7 +6,6 @@ import sys
 
 # sample icon file
 TEST_FILE = "Tests/images/pillow.icns"
-data = open(TEST_FILE, "rb").read()
 
 enable_jpeg2k = hasattr(Image.core, 'jp2klib_version')
 

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -5,7 +5,6 @@ from PIL import Image, IcoImagePlugin
 
 # sample ppm stream
 TEST_ICO_FILE = "Tests/images/hopper.ico"
-TEST_DATA = open(TEST_ICO_FILE, "rb").read()
 
 
 class TestFileIco(PillowTestCase):

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -12,7 +12,6 @@ codecs = dir(Image.core)
 # sample png stream
 
 TEST_PNG_FILE = "Tests/images/hopper.png"
-TEST_DATA = open(TEST_PNG_FILE, "rb").read()
 
 # stuff to create inline PNG images
 

--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -4,7 +4,6 @@ from PIL import Image
 
 # sample ppm stream
 test_file = "Tests/images/hopper.ppm"
-data = open(test_file, "rb").read()
 
 
 class TestFilePpm(PillowTestCase):

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -4,7 +4,6 @@ from PIL import Image, PsdImagePlugin
 
 # sample ppm stream
 test_file = "Tests/images/hopper.psd"
-data = open(test_file, "rb").read()
 
 
 class TestImagePsd(PillowTestCase):


### PR DESCRIPTION
The data read from the file was unused. The files remained opened and
were never explicitly closed.

Fixes some instances of warnings during tests:

"ResourceWarning: unclosed file ..."