### PR TITLE
Update info.icc_profile when using libtiff reader.

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -1010,9 +1010,6 @@ class TiffImageFile(ImageFile.ImageFile):
                 # Section 14: Differencing Predictor
                 self.decoderconfig = (self.tag_v2[PREDICTOR],)
 
-        if ICCPROFILE in self.tag_v2:
-            self.info['icc_profile'] = self.tag_v2[ICCPROFILE]
-
         return args
 
     def load(self):
@@ -1284,6 +1281,10 @@ class TiffImageFile(ImageFile.ImageFile):
             if DEBUG:
                 print("- unsupported data organization")
             raise SyntaxError("unknown data organization")
+
+        # Fix up info.
+        if ICCPROFILE in self.tag_v2:
+            self.info['icc_profile'] = self.tag_v2[ICCPROFILE]
 
         # fixup palette descriptor
 

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -521,8 +521,16 @@ class TestFileLibTiff(LibTiffTestCase):
         except:
             self.fail("Should not get permission error here")
 
-    
-
+    def test_read_icc(self):
+        with Image.open("Tests/images/hopper.iccprofile.tif") as img:
+            icc = img.info.get('icc_profile')
+            self.assertNotEqual(icc, None)
+        TiffImagePlugin.READ_LIBTIFF = True
+        with Image.open("Tests/images/hopper.iccprofile.tif") as img:
+            icc_libtiff = img.info.get('icc_profile')
+            self.assertNotEqual(icc_libtiff, None)
+        TiffImagePlugin.READ_LIBTIFF = False
+        self.assertEqual(icc, icc_libtiff)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When using libtiff reader, the ICCPROFILE from the tags is not copied to .info.  This fixes it by moving the code from _decoder to _setup.

Tests included.