### PR TITLE
Replace try/except/fail pattern with TestCase.assertRaises()

### DIFF
--- a/Tests/check_j2k_overflow.py
+++ b/Tests/check_j2k_overflow.py
@@ -7,13 +7,8 @@ class TestJ2kEncodeOverflow(PillowTestCase):
 
         im = Image.new('RGBA', (1024, 131584))
         target = self.tempfile('temp.jpc')
-        try:
+        with self.assertRaises(IOError):
             im.save(target)
-            self.assertTrue(False, "Expected IOError, save succeeded?")
-        except IOError as err:
-            self.assertTrue(True, "IOError is expected")
-        except Exception as err:
-            self.assertTrue(False, "Expected IOError, got %s" % type(err))
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/check_libtiff_segfault.py
+++ b/Tests/check_libtiff_segfault.py
@@ -10,13 +10,9 @@ class TestLibtiffSegfault(PillowTestCase):
             libtiff >= 4.0.0
             """
 
-        try:
+        with self.assertRaises(IOError):
             im = Image.open(TEST_FILE)
             im.load()
-        except IOError:
-            self.assertTrue(True, "Got expected IOError")
-        except Exception:
-            self.fail("Should have returned IOError")
 
 
 if __name__ == '__main__':

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -174,15 +174,8 @@ class TestFileJpeg2k(PillowTestCase):
     def test_unbound_local(self):
         # prepatch, a malformed jp2 file could cause an UnboundLocalError
         # exception.
-        try:
-            jp2 = Image.open('Tests/images/unbound_variable.jp2')
-            self.assertTrue(False, 'Expecting an exception')
-        except SyntaxError as err:
-            self.assertTrue(True, 'Expecting a syntax error')
-        except IOError as err:
-            self.assertTrue(True, 'Expecting an IO error')
-        except UnboundLocalError as err:
-            self.assertTrue(False, "Prepatch error")
+        with self.assertRaises(IOError):
+            Image.open('Tests/images/unbound_variable.jp2')
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -192,11 +192,8 @@ class TestCffi(AccessTest):
 
         # Attempt to set the value on a read-only image
         access = PyAccess.new(im, True)
-        try:
+        with self.assertRaises(ValueError):
             access[(0, 0)] = color
-        except ValueError:
-            return
-        self.fail("Putpixel did not fail on a read-only image")
 
     def test_set_vs_c(self):
         rgb = hopper('RGB')

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -8,12 +8,9 @@ class TestImagingResampleVulnerability(PillowTestCase):
         im = hopper('L')
         xsize = 0x100000008 // 4
         ysize = 1000  # unimportant
-        try:
+        with self.assertRaises(MemoryError):
             # any resampling filter will do here
             im.im.resize((xsize, ysize), Image.BILINEAR)
-            self.fail("Resize should raise MemoryError on invalid xsize")
-        except MemoryError:
-            self.assertTrue(True, "Should raise MemoryError")
 
     def test_invalid_size(self):
         im = hopper()
@@ -21,17 +18,11 @@ class TestImagingResampleVulnerability(PillowTestCase):
         im.resize((100, 100))
         self.assertTrue(True, "Should not Crash")
 
-        try:
+        with self.assertRaises(ValueError):
             im.resize((-100, 100))
-            self.fail("Resize should raise a value error on x negative size")
-        except ValueError:
-            self.assertTrue(True, "Should raise ValueError")
 
-        try:
+        with self.assertRaises(ValueError):
             im.resize((100, -100))
-            self.fail("Resize should raise a value error on y negative size")
-        except ValueError:
-            self.assertTrue(True, "Should raise ValueError")
 
 
 class TestImagingCoreResampleAccuracy(PillowTestCase):

--- a/Tests/test_imagepath.py
+++ b/Tests/test_imagepath.py
@@ -63,7 +63,9 @@ class TestImagePath(PillowTestCase):
         self.assertEqual(list(p), [(0.0, 1.0)])
 
     def test_overflow_segfault(self):
-        try:
+        # Some Pythons fail getting the argument as an integer, and it falls
+        # through to the sequence. Seeing this on 32-bit Windows.
+        with self.assertRaises((TypeError, MemoryError)):
             # post patch, this fails with a memory error
             x = evil()
 
@@ -74,14 +76,6 @@ class TestImagePath(PillowTestCase):
                     x[i] = "0"*16
                 else:
                     x[i] = b'0'*16
-        except TypeError as msg:
-            # Some pythons fail getting the argument as an integer, and
-            # it falls through to the sequence. Seeing this on 32bit windows.
-            self.assertTrue(True, "Sequence required")
-        except MemoryError as msg:
-            self.assertTrue(msg)
-        except:
-            self.assertTrue(False, "Should have received a memory error")
 
 
 class evil:


### PR DESCRIPTION
Replace pattern with the builtin support for asserting exceptions.