### PR TITLE
Avoid catching unexpected exceptions in tests

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -141,11 +141,9 @@ class TestFileJpeg(PillowTestCase):
         im = Image.open('Tests/images/icc_profile_big.jpg')
         f = self.tempfile("temp.jpg")
         icc_profile = im.info["icc_profile"]
-        try:
-            im.save(f, format='JPEG', progressive=True, quality=95,
-                    icc_profile=icc_profile, optimize=True)
-        except IOError:
-            self.fail("Failed saving image with icc larger than image size")
+        # Should not raise IOError for image with icc larger than image size.
+        im.save(f, format='JPEG', progressive=True, quality=95,
+                icc_profile=icc_profile, optimize=True)
 
     def test_optimize(self):
         im1 = self.roundtrip(hopper())

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -529,10 +529,8 @@ class TestFileLibTiff(LibTiffTestCase):
         im = Image.open(tmpfile)
         im.n_frames
         im.close()
-        try:
-            os.remove(tmpfile)  # Windows PermissionError here!
-        except:
-            self.fail("Should not get permission error here")
+        # Should not raise PermissionError.
+        os.remove(tmpfile)
 
     def test_read_icc(self):
         with Image.open("Tests/images/hopper.iccprofile.tif") as img:

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -133,11 +133,8 @@ class TestFileTiff(PillowTestCase):
 
     def test_bad_exif(self):
         i = Image.open('Tests/images/hopper_bad_exif.jpg')
-        try:
-            self.assert_warning(UserWarning, i._getexif)
-        except struct.error:
-            self.fail(
-                "Bad EXIF data passed incorrect values to _binary unpack")
+        # Should not raise struct.error.
+        self.assert_warning(UserWarning, i._getexif)
 
     def test_save_rgba(self):
         im = hopper("RGBA")

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -169,10 +169,8 @@ class TestFileTiffMetadata(PillowTestCase):
         f = io.BytesIO(b'II*\x00\x08\x00\x00\x00')
         head = f.read(8)
         info = TiffImagePlugin.ImageFileDirectory(head)
-        try:
-            self.assert_warning(UserWarning, info.load, f)
-        except struct.error:
-            self.fail("Should not be struct errors there.")
+        # Should not raise struct.error.
+        self.assert_warning(UserWarning, info.load, f)
 
     def test_iccprofile(self):
         # https://github.com/python-pillow/Pillow/issues/1462
@@ -223,10 +221,8 @@ class TestFileTiffMetadata(PillowTestCase):
         head = data.read(8)
         info = TiffImagePlugin.ImageFileDirectory_v2(head)
         info.load(data)
-        try:
-            info = dict(info)
-        except ValueError:
-            self.fail("Should not be struct value error there.")
+        # Should not raise ValueError.
+        info = dict(info)
         self.assertIn(33432, info)
 
     def test_PhotoshopInfo(self):
@@ -245,10 +241,8 @@ class TestFileTiffMetadata(PillowTestCase):
         ifd._tagdata[277] = struct.pack('hh', 4, 4)
         ifd.tagtype[277] = TiffTags.SHORT
 
-        try:
-            self.assert_warning(UserWarning, lambda: ifd[277])
-        except ValueError:
-            self.fail("Invalid Metadata count should not cause a Value Error.")
+        # Should not raise ValueError.
+        self.assert_warning(UserWarning, lambda: ifd[277])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Instead, allow exceptions to bubble up to the unittest exception handler.

Prevents replacing the exception trace with a less informative message. As the exceptions are always unexpected, should not need to catch them explicitly in tests.