### PR TITLE
Close file after reading in ImagePalette.load()

### DIFF
--- a/PIL/ImagePalette.py
+++ b/PIL/ImagePalette.py
@@ -197,23 +197,23 @@ def load(filename):
 
     # FIXME: supports GIMP gradients only
 
-    fp = open(filename, "rb")
+    with open(filename, "rb") as fp:
 
-    for paletteHandler in [
-        GimpPaletteFile.GimpPaletteFile,
-        GimpGradientFile.GimpGradientFile,
-        PaletteFile.PaletteFile
-    ]:
-        try:
-            fp.seek(0)
-            lut = paletteHandler(fp).getpalette()
-            if lut:
-                break
-        except (SyntaxError, ValueError):
-            # import traceback
-            # traceback.print_exc()
-            pass
-    else:
-        raise IOError("cannot load palette")
+        for paletteHandler in [
+            GimpPaletteFile.GimpPaletteFile,
+            GimpGradientFile.GimpGradientFile,
+            PaletteFile.PaletteFile
+        ]:
+            try:
+                fp.seek(0)
+                lut = paletteHandler(fp).getpalette()
+                if lut:
+                    break
+            except (SyntaxError, ValueError):
+                # import traceback
+                # traceback.print_exc()
+                pass
+        else:
+            raise IOError("cannot load palette")
 
     return lut  # data, rawmode


### PR DESCRIPTION
Fixes some "ResourceWarning: unclosed file ..." when running tests with warnings enabled.