### PR TITLE
If WalImageFile opens a file pointer, close

### DIFF
--- a/PIL/WalImageFile.py
+++ b/PIL/WalImageFile.py
@@ -56,6 +56,7 @@ def open(filename):
         # load pixel data
         fp.seek(offset)
 
+        Image._decompression_bomb_check(size)
         im = Image.frombytes("P", size, fp.read(size[0] * size[1]))
         im.putpalette(quake2palette)
 

--- a/PIL/WalImageFile.py
+++ b/PIL/WalImageFile.py
@@ -47,33 +47,34 @@ def open(filename):
     # FIXME: modify to return a WalImageFile instance instead of
     # plain Image object ?
 
+    def imopen(fp):
+        # read header fields
+        header = fp.read(32+24+32+12)
+        size = i32(header, 32), i32(header, 36)
+        offset = i32(header, 40)
+
+        # load pixel data
+        fp.seek(offset)
+
+        im = Image.frombytes("P", size, fp.read(size[0] * size[1]))
+        im.putpalette(quake2palette)
+
+        im.format = "WAL"
+        im.format_description = "Quake2 Texture"
+
+        # strings are null-terminated
+        im.info["name"] = header[:32].split(b"\0", 1)[0]
+        next_name = header[56:56+32].split(b"\0", 1)[0]
+        if next_name:
+            im.info["next_name"] = next_name
+
+        return im
+
     if hasattr(filename, "read"):
-        fp = filename
+        return imopen(filename)
     else:
-        fp = builtins.open(filename, "rb")
-
-    # read header fields
-    header = fp.read(32+24+32+12)
-    size = i32(header, 32), i32(header, 36)
-    offset = i32(header, 40)
-
-    # load pixel data
-    fp.seek(offset)
-
-    im = Image.frombytes("P", size, fp.read(size[0] * size[1]))
-    im.putpalette(quake2palette)
-
-    im.format = "WAL"
-    im.format_description = "Quake2 Texture"
-
-    # strings are null-terminated
-    im.info["name"] = header[:32].split(b"\0", 1)[0]
-    next_name = header[56:56+32].split(b"\0", 1)[0]
-    if next_name:
-        im.info["next_name"] = next_name
-
-    return im
-
+        with builtins.open(filename, "rb") as fp:
+            return imopen(fp)
 
 quake2palette = (
     # default palette taken from piffo 0.93 by Hans Häggström


### PR DESCRIPTION
If a file pointer is passed in to the method, leave it open.
If the method opens the file pointer itself, then close when it is no longer needed.