### PR TITLE
Drop spaces deprecation warning

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -1381,11 +1381,6 @@ def _save(im, fp, filename):
                       (DATE_TIME, "date_time"),
                       (ARTIST, "artist"),
                       (COPYRIGHT, "copyright")]:
-        name_with_spaces = name.replace("_", " ")
-        if "_" in name and name_with_spaces in im.encoderinfo:
-            warnings.warn("%r is deprecated; use %r instead" %
-                          (name_with_spaces, name), DeprecationWarning)
-            ifd[key] = im.encoderinfo[name.replace("_", " ")]
         if name in im.encoderinfo:
             ifd[key] = im.encoderinfo[name]
 

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -413,25 +413,6 @@ class TestFileTiff(PillowTestCase):
         self.assertEqual(im.tag_v2[X_RESOLUTION], 72)
         self.assertEqual(im.tag_v2[Y_RESOLUTION], 36)
 
-    def test_deprecation_warning_with_spaces(self):
-        kwargs = {'resolution unit': 'inch',
-                  'x resolution': 36,
-                  'y resolution': 72}
-        filename = self.tempfile("temp.tif")
-        self.assert_warning(DeprecationWarning,
-                            lambda: hopper("RGB").save(filename, **kwargs))
-        from PIL.TiffImagePlugin import X_RESOLUTION, Y_RESOLUTION
-
-        im = Image.open(filename)
-
-        # legacy interface
-        self.assertEqual(im.tag[X_RESOLUTION][0][0], 36)
-        self.assertEqual(im.tag[Y_RESOLUTION][0][0], 72)
-
-        # v2 interface
-        self.assertEqual(im.tag_v2[X_RESOLUTION], 36)
-        self.assertEqual(im.tag_v2[Y_RESOLUTION], 72)
-
     def test_multipage_compression(self):
         im = Image.open('Tests/images/compression.tif')
 


### PR DESCRIPTION
Deprecated in 800480db526b3c763fc821db4d29775ec9ba3c73. Included in 2.7 release. Almost 2 years ago.