### PR TITLE
Remove long deprecated ImageDraw methods

### DIFF
--- a/PIL/ImageDraw.py
+++ b/PIL/ImageDraw.py
@@ -31,7 +31,6 @@
 #
 
 import numbers
-import warnings
 
 from PIL import Image, ImageColor
 from PIL._util import isStringType
@@ -86,20 +85,6 @@ class ImageDraw(object):
             self.fontmode = "L"  # aliasing is okay for other modes
         self.fill = 0
         self.font = None
-
-    def setink(self, ink):
-        raise NotImplementedError("setink() has been removed. " +
-                                  "Please use keyword arguments instead.")
-
-    def setfill(self, onoff):
-        raise NotImplementedError("setfill() has been removed. " +
-                                  "Please use keyword arguments instead.")
-
-    def setfont(self, font):
-        warnings.warn("setfont() is deprecated. " +
-                      "Please set the attribute directly instead.")
-        # compatibility
-        self.font = font
 
     def getfont(self):
         """Get the current default font."""

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -44,14 +44,6 @@ class TestImageDraw(PillowTestCase):
         draw.polygon(list(range(100)))
         draw.rectangle(list(range(4)))
 
-    def test_removed_methods(self):
-        im = hopper()
-
-        draw = ImageDraw.Draw(im)
-
-        self.assertRaises(Exception, lambda: draw.setink(0))
-        self.assertRaises(Exception, lambda: draw.setfill(0))
-
     def test_valueerror(self):
         im = Image.open("Tests/images/chi.gif")
 


### PR DESCRIPTION
Deprecated in 89ccf66ff7f2646c3e649d6a3bba0a7e1c38a99e since Sep 29,
2015, version 3.0.0.

I think enough time has passed to now remove these.