### PR TITLE
Removed the handles_eof flag in the decoder, as there are no users of it

### DIFF
--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -210,7 +210,7 @@ class ImageFile(Image.Image):
                             else:
                                 raise IOError("image file is truncated")
 
-                        if not s and not decoder.handles_eof:  # truncated jpeg
+                        if not s:  # truncated jpeg
                             self.tile = []
 
                             # JpegDecode needs to clean things up here either way

--- a/decode.c
+++ b/decode.c
@@ -52,7 +52,6 @@ typedef struct {
     struct ImagingCodecStateInstance state;
     Imaging im;
     PyObject* lock;
-    int handles_eof;
     int pulls_fd;
 } ImagingDecoderObject;
 
@@ -94,9 +93,6 @@ PyImaging_DecoderNew(int contextsize)
 
     /* Initialize the cleanup function pointer */
     decoder->cleanup = NULL;
-
-    /* Most decoders don't want to handle EOF themselves */
-    decoder->handles_eof = 0;
 
     /* set if the decoder needs to pull data from the fd, instead of
        having it pushed */
@@ -240,12 +236,6 @@ _setfd(ImagingDecoderObject* decoder, PyObject* args)
 
 
 static PyObject *
-_get_handles_eof(ImagingDecoderObject *decoder)
-{
-    return PyBool_FromLong(decoder->handles_eof);
-}
-
-static PyObject *
 _get_pulls_fd(ImagingDecoderObject *decoder)
 {
     return PyBool_FromLong(decoder->pulls_fd);
@@ -260,9 +250,6 @@ static struct PyMethodDef methods[] = {
 };
 
 static struct PyGetSetDef getseters[] = {
-    {"handles_eof", (getter)_get_handles_eof, NULL,
-     "True if this decoder expects to handle EOF itself.",
-     NULL},
    {"pulls_fd", (getter)_get_pulls_fd, NULL,
      "True if this decoder expects to pull from self.fd itself.",
      NULL},
@@ -918,7 +905,6 @@ PyImaging_Jpeg2KDecoderNew(PyObject* self, PyObject* args)
     if (decoder == NULL)
         return NULL;
 
-    decoder->handles_eof = 1;
     decoder->pulls_fd = 1;
     decoder->decode = ImagingJpeg2KDecode;
     decoder->cleanup = ImagingJpeg2KDecodeCleanup;


### PR DESCRIPTION
There are no users of decoder.handles_eof. 

It has been superseded by the decoder cleanup method. 