### PR TITLE
Use generator expressions instead of list comprehension

### DIFF
--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -600,7 +600,7 @@ def _get_palette_bytes(im, palette, info):
         if palette and isinstance(palette, bytes):
             source_palette = palette[:768]
         else:
-            source_palette = bytearray([i//3 for i in range(768)])
+            source_palette = bytearray(i//3 for i in range(768))
 
     used_palette_colors = palette_bytes = None
 

--- a/PIL/ImageMorph.py
+++ b/PIL/ImageMorph.py
@@ -78,7 +78,7 @@ class LutBuilder(object):
     def build_default_lut(self):
         symbols = [0, 1]
         m = 1 << 4  # pos of current pixel
-        self.lut = bytearray([symbols[(i & m) > 0] for i in range(LUT_SIZE)])
+        self.lut = bytearray(symbols[(i & m) > 0] for i in range(LUT_SIZE))
 
     def get_lut(self):
         return self.lut
@@ -88,7 +88,7 @@ class LutBuilder(object):
         string permuted according to the permutation list.
         """
         assert(len(permutation) == 9)
-        return ''.join([pattern[p] for p in permutation])
+        return ''.join(pattern[p] for p in permutation)
 
     def _pattern_permute(self, basic_pattern, options, basic_result):
         """pattern_permute takes a basic pattern and its result and clones

--- a/PIL/JpegImagePlugin.py
+++ b/PIL/JpegImagePlugin.py
@@ -408,7 +408,7 @@ def _fixup_dict(src_dict):
         except: pass
         return value
 
-    return dict([(k, _fixup(v)) for k, v in src_dict.items()])
+    return dict((k, _fixup(v)) for k, v in src_dict.items())
 
 
 def _getexif(self):

--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -132,7 +132,7 @@ COMPRESSION_INFO = {
     34677: "tiff_sgilog24",
 }
 
-COMPRESSION_INFO_REV = dict([(v, k) for (k, v) in COMPRESSION_INFO.items()])
+COMPRESSION_INFO_REV = dict((v, k) for (k, v) in COMPRESSION_INFO.items())
 
 OPEN_INFO = {
     # (ByteOrder, PhotoInterpretation, SampleFormat, FillOrder, BitsPerSample,

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -49,7 +49,7 @@ class PillowTestCase(unittest.TestCase):
                 len(a), len(b),
                 msg or "got length %s, expected %s" % (len(a), len(b)))
             self.assertTrue(
-                all([x == y for x, y in zip(a, b)]),
+                all(x == y for x, y in zip(a, b)),
                 msg or "got %s, expected %s" % (a, b))
         except:
             self.assertEqual(a, b, msg)

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -60,7 +60,7 @@ class TestFileGif(PillowTestCase):
         def check(colors, size, expected_palette_length):
             # make an image with empty colors in the start of the palette range
             im = Image.frombytes('P', (colors,colors),
-                                 bytes(bytearray(list(range(256-colors,256))*colors)))
+                                 bytes(bytearray(range(256-colors,256))*colors))
             im = im.resize((size,size))
             outfile = BytesIO()
             im.save(outfile, 'GIF')

--- a/Tests/test_font_pcf.py
+++ b/Tests/test_font_pcf.py
@@ -55,7 +55,7 @@ class TestFontPcf(PillowTestCase):
         self.assert_image_equal(image, compare)
 
     def test_high_characters(self):
-        message = "".join([chr(i+1) for i in range(140, 232)])
+        message = "".join(chr(i+1) for i in range(140, 232))
         self._test_high_characters(message)
         # accept bytes instances in Py3.
         if bytes is not str:

--- a/Tests/test_imagemorph.py
+++ b/Tests/test_imagemorph.py
@@ -25,8 +25,8 @@ class MorphTests(PillowTestCase):
         chars = '.1'
         width, height = im.size
         return '\n'.join(
-            [''.join([chars[im.getpixel((c, r)) > 0] for c in range(width)])
-             for r in range(height)])
+            ''.join(chars[im.getpixel((c, r)) > 0] for c in range(width))
+            for r in range(height))
 
     def string_to_img(self, image_string):
         """Turn a string image representation into a binary image"""

--- a/setup.py
+++ b/setup.py
@@ -405,8 +405,7 @@ class pil_build_ext(build_ext):
             best_path = None
             for name in os.listdir(program_files):
                 if name.startswith('OpenJPEG '):
-                    version = tuple([int(x) for x in name[9:].strip().split(
-                        '.')])
+                    version = tuple(int(x) for x in name[9:].strip().split('.'))
                     if version > best_version:
                         best_version = version
                         best_path = os.path.join(program_files, name)
@@ -466,7 +465,7 @@ class pil_build_ext(build_ext):
                         os.path.isfile(os.path.join(directory, name,
                                                     'openjpeg.h')):
                         _dbg('Found openjpeg.h in %s/%s', (directory, name))
-                        version = tuple([int(x) for x in name[9:].split('.')])
+                        version = tuple(int(x) for x in name[9:].split('.'))
                         if best_version is None or version > best_version:
                             best_version = version
                             best_path = os.path.join(directory, name)
@@ -479,8 +478,7 @@ class pil_build_ext(build_ext):
                 # include path
                 _add_directory(self.compiler.include_dirs, best_path, 0)
                 feature.jpeg2000 = 'openjp2'
-                feature.openjpeg_version = '.'.join([str(x) for x in
-                                                     best_version])
+                feature.openjpeg_version = '.'.join(str(x) for x in best_version)
 
         if feature.want('imagequant'):
             _dbg('Looking for imagequant')


### PR DESCRIPTION
Avoids unnecessary temporary lists in memory.