### PR TITLE
Lambdafu/tiff nframes

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -1096,10 +1096,6 @@ class TiffImageFile(ImageFile.ImageFile):
 
         self.tile = []
         self.readonly = 0
-        # libtiff closed the fp in a, we need to close self.fp, if possible
-        if hasattr(self.fp, 'close'):
-            if not self.__next:
-                self.fp.close()
         self.fp = None  # might be shared
 
         if err < 0:

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -370,7 +370,8 @@ class TestFileLibTiff(LibTiffTestCase):
         fn = im.fp.fileno()
 
         os.fstat(fn)
-        im.load()  # this should close it.
+        im.load()
+        im.close() # this should close it.
         self.assertRaises(OSError, lambda: os.fstat(fn))
         im = None  # this should force even more closed.
         self.assertRaises(OSError, lambda: os.fstat(fn))

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -399,6 +399,19 @@ class TestFileLibTiff(LibTiffTestCase):
 
         TiffImagePlugin.READ_LIBTIFF = False
 
+    def test_multipage_nframes(self):
+        # issue #862
+        TiffImagePlugin.READ_LIBTIFF = True
+        im = Image.open('Tests/images/multipage.tiff')
+        frames = im.n_frames
+        self.assertEqual(frames, 3)
+        for idx in range(frames):
+            im.seek(0)
+            # Should not raise ValueError: I/O operation on closed file
+            im.load()
+
+        TiffImagePlugin.READ_LIBTIFF = False
+
     def test__next(self):
         TiffImagePlugin.READ_LIBTIFF = True
         im = Image.open('Tests/images/hopper.tif')
@@ -521,7 +534,7 @@ class TestFileLibTiff(LibTiffTestCase):
         except:
             self.fail("Should not get permission error here")
 
-    
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #2229 

This includes a test for #2229 and in another commit a fix.  The fix causes the fp_leak test to fail, so that test case is adjusted accordingly (I think the Tiff plugin can only make a promise to close after close(), not after load(), but maybe we need another fix to close any fps zealously after load() for single-frame TIFFs).  The fix depends on #2194 to properly close all fps after close().

Changes proposed in this pull request:

 * Don't close fp after load() when __next is None (this is what causes n_frames to close the fp
 * Now fp is not closed after load even for single-frame TIFFs.  This may be a regression.
 * Does not close even after close() without #2194.
