### PR TITLE
FIX: fixed isOleFile issue when passing file content with len < MINIM…

### DIFF
--- a/PIL/OleFileIO.py
+++ b/PIL/OleFileIO.py
@@ -453,6 +453,9 @@ def isOleFile(filename):
         # filename is a bytes string containing the OLE file to be parsed:
         header = filename[:len(MAGIC)]
     else:
+        if len(filename) < MINIMAL_OLEFILE_SIZE:
+            return False
+
         # string-like object: filename of file on disk
         header = open(filename, 'rb').read(len(MAGIC))
     if header == MAGIC:


### PR DESCRIPTION
Fixes # .
fixed isOleFile: file() argument 1 must be encoded string without NULL bytes, not str
Changes proposed in this pull request:

When calling isOleFile('Hello there') we will receive an error as method determines argument as a file but should return False instead of raising an error.

 * 
 * 
 * 

…AL_OLEFILE_SIZE