### PR TITLE
FIX: fixed isOleFile issue when passing small buffer.

### DIFF
--- a/PIL/OleFileIO.py
+++ b/PIL/OleFileIO.py
@@ -449,7 +449,9 @@ def isOleFile(filename):
         header = filename.read(len(MAGIC))
         # just in case, seek back to start of file:
         filename.seek(0)
-    elif isinstance(filename, bytes) and len(filename) >= MINIMAL_OLEFILE_SIZE:
+    elif isinstance(filename, bytes):
+        if len(filename) < MINIMAL_OLEFILE_SIZE:
+            return False
         # filename is a bytes string containing the OLE file to be parsed:
         header = filename[:len(MAGIC)]
     else:


### PR DESCRIPTION
Fixes # .
Fixed file() argument 1 must be encoded string without NULL bytes, not str
Changes proposed in this pull request:

When calling isOleFile('Hello there') we will receive an error as method determines argument as a file but should return False instead of raising an error.
 * 
 * 
 * 

…AL_OLEFILE_SIZE