### PR TITLE
Send unwanted subprocess output to /dev/null

### DIFF
--- a/PIL/EpsImagePlugin.py
+++ b/PIL/EpsImagePlugin.py
@@ -22,6 +22,7 @@
 
 import re
 import io
+import os
 import sys
 from . import Image, ImageFile
 from ._binary import i32le as i32, o32le as o32
@@ -57,8 +58,8 @@ def has_ghostscript():
     if not sys.platform.startswith('win'):
         import subprocess
         try:
-            gs = subprocess.Popen(['gs', '--version'], stdout=subprocess.PIPE)
-            gs.stdout.read()
+            with open(os.devnull, 'wb') as devnull:
+                subprocess.check_call(['gs', '--version'], stdout=devnull)
             return True
         except OSError:
             # no ghostscript
@@ -137,12 +138,8 @@ def Ghostscript(tile, size, fp, scale=1):
 
     # push data through ghostscript
     try:
-        gs = subprocess.Popen(command, stdin=subprocess.PIPE,
-                              stdout=subprocess.PIPE)
-        gs.stdin.close()
-        status = gs.wait()
-        if status:
-            raise IOError("gs failed (status %d)" % status)
+        with open(os.devnull, 'w+b') as devnull:
+            subprocess.check_call(command, stdin=devnull, stdout=devnull)
         im = Image.open(outfile)
         im.load()
     finally:

--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -519,18 +519,17 @@ def _save_netpbm(im, fp, filename):
 
     with open(filename, 'wb') as f:
         if im.mode != "RGB":
-            with tempfile.TemporaryFile() as stderr:
-                check_call(["ppmtogif", file], stdout=f, stderr=stderr)
+            with open(os.devnull, 'wb') as devnull:
+                check_call(["ppmtogif", file], stdout=f, stderr=devnull)
         else:
             # Pipe ppmquant output into ppmtogif
             # "ppmquant 256 %s | ppmtogif > %s" % (file, filename)
             quant_cmd = ["ppmquant", "256", file]
             togif_cmd = ["ppmtogif"]
-            with tempfile.TemporaryFile() as stderr:
-                quant_proc = Popen(quant_cmd, stdout=PIPE, stderr=stderr)
-            with tempfile.TemporaryFile() as stderr:
+            with open(os.devnull, 'wb') as devnull:
+                quant_proc = Popen(quant_cmd, stdout=PIPE, stderr=devnull)
                 togif_proc = Popen(togif_cmd, stdin=quant_proc.stdout,
-                                   stdout=f, stderr=stderr)
+                                   stdout=f, stderr=devnull)
 
             # Allow ppmquant to receive SIGPIPE if ppmtogif exits
             quant_proc.stdout.close()

--- a/PIL/IcnsImagePlugin.py
+++ b/PIL/IcnsImagePlugin.py
@@ -329,8 +329,8 @@ def _save(im, fp, filename):
     from subprocess import Popen, PIPE, CalledProcessError
 
     convert_cmd = ["iconutil", "-c", "icns", "-o", filename, iconset]
-    with tempfile.TemporaryFile() as stderr:
-        convert_proc = Popen(convert_cmd, stdout=PIPE, stderr=stderr)
+    with open(os.devnull, 'wb') as devnull:
+        convert_proc = Popen(convert_cmd, stdout=PIPE, stderr=devnull)
 
     convert_proc.stdout.close()
 

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -218,25 +218,25 @@ def command_succeeds(cmd):
     command succeeds, or False if an OSError was raised by subprocess.Popen.
     """
     import subprocess
-    with open(os.devnull, 'w') as f:
+    with open(os.devnull, 'wb') as f:
         try:
-            subprocess.Popen(cmd, stdout=f, stderr=subprocess.STDOUT).wait()
+            subprocess.call(cmd, stdout=f, stderr=subprocess.STDOUT)
         except OSError:
             return False
     return True
 
 
 def djpeg_available():
-    return command_succeeds(['djpeg', '--help'])
+    return command_succeeds(['djpeg', '-version'])
 
 
 def cjpeg_available():
-    return command_succeeds(['cjpeg', '--help'])
+    return command_succeeds(['cjpeg', '-version'])
 
 
 def netpbm_available():
-    return (command_succeeds(["ppmquant", "--help"]) and
-            command_succeeds(["ppmtogif", "--help"]))
+    return (command_succeeds(["ppmquant", "--version"]) and
+            command_succeeds(["ppmtogif", "--version"]))
 
 
 def imagemagick_available():


### PR DESCRIPTION
Avoids unnecessary creation of temporary files as well as unnecessarily storing process output in memory. The temporary files would sometimes remain and not be cleaned up.