### PR TITLE
Improved description of method parameter

### DIFF
--- a/PIL/ImageOps.py
+++ b/PIL/ImageOps.py
@@ -206,7 +206,8 @@ def deform(image, deformer, resample=Image.BILINEAR):
     :param image: The image to deform.
     :param deformer: A deformer object.  Any object that implements a
                     **getmesh** method can be used.
-    :param resample: What resampling filter to use.
+    :param resample: An optional resampling filter. Same values possible as
+       in the PIL.Image.transform function.
     :return: An image.
     """
     return image.transform(


### PR DESCRIPTION
I've changed the description of the deform method's resample parameter to match the description of the scale method's resample parameter.