### PR TITLE
Fix for writing Tiff to BytesIO using libtiff.

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -39,6 +39,8 @@ class LibTiffTestCase(PillowTestCase):
         out = self.tempfile("temp.png")
         im.save(out)
 
+        out_bytes = io.BytesIO()
+        im.save(out_bytes, format='tiff', compression='group4')
 
 class TestFileLibTiff(LibTiffTestCase):
 

--- a/libImaging/TiffDecode.c
+++ b/libImaging/TiffDecode.c
@@ -58,7 +58,7 @@ tsize_t _tiffWriteProc(thandle_t hdata, tdata_t buf, tsize_t size) {
 		tdata_t new;
 		tsize_t newsize=state->size;
 		while (newsize < (size + state->size)) {
-            if (newsize > (tsize_t)SIZE_MAX - 64*1024){
+            if (newsize > INT_MAX - 64*1024){
                 return 0;
             }
 			newsize += 64*1024;


### PR DESCRIPTION
Fixes #2206 .

Writing large tiff images using libtiff to a BytesIO would fail if there was a need to increase the memory buffer size. This would not happen in the case of a file, since the file pointer was passed into libtiff for direct writing. 

The overflow check for buffer size had a sign error, so that any comparison was against a negative number, so it failed every attempt to realloc. 

