### PR TITLE
Fix bug in test_idf_rational_save

### DIFF
--- a/Tests/test_tiff_ifdrational.py
+++ b/Tests/test_tiff_ifdrational.py
@@ -47,7 +47,7 @@ class Test_IFDRational(PillowTestCase):
     def test_ifd_rational_save(self):
         methods = (True, False)
         if 'libtiff_encoder' not in dir(Image.core):
-            methods = (False)
+            methods = (False,)
 
         for libtiff in methods:
             TiffImagePlugin.WRITE_LIBTIFF = libtiff


### PR DESCRIPTION
A boolean wrapped in parentheses is still a boolean, not a tuple.
The comma makes this an actual tuple so it can be iterated on in
the for loop that follows.

Simple reproducer:
```python
t = (False)
type(t)
>>> <class 'bool'>
for x in t:
  print(x)
>>> TypeError: 'bool' object is not iterable

t = (False,)
type(t)
>>> <class 'tuple'>
for x in t:
  print(x)
>>> False
```