### PR TITLE
Increase epsilon for FreeType 2.7

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -125,7 +125,9 @@ try:
 
             target = 'Tests/images/rectangle_surrounding_text.png'
             target_img = Image.open(target)
-            self.assert_image_similar(im, target_img, .5)
+
+            # Epsilon ~.5 fails with FreeType 2.7
+            self.assert_image_similar(im, target_img, 2.5)
 
         def test_render_multiline(self):
             im = Image.new(mode='RGB', size=(300, 100))
@@ -144,7 +146,7 @@ try:
             # some versions of freetype have different horizontal spacing.
             # setting a tight epsilon, I'm showing the original test failure
             # at epsilon = ~38.
-            self.assert_image_similar(im, target_img, .5)
+            self.assert_image_similar(im, target_img, 6.2)
 
         def test_render_multiline_text(self):
             ttf = ImageFont.truetype(FONT_PATH, FONT_SIZE)
@@ -158,7 +160,8 @@ try:
             target = 'Tests/images/multiline_text.png'
             target_img = Image.open(target)
 
-            self.assert_image_similar(im, target_img, .5)
+            # Epsilon ~.5 fails with FreeType 2.7
+            self.assert_image_similar(im, target_img, 6.2)
 
             # Test that text() can pass on additional arguments
             # to multiline_text()
@@ -178,7 +181,8 @@ try:
                 target = 'Tests/images/multiline_text'+ext+'.png'
                 target_img = Image.open(target)
 
-                self.assert_image_similar(im, target_img, .5)
+                # Epsilon ~.5 fails with FreeType 2.7
+                self.assert_image_similar(im, target_img, 6.2)
 
         def test_unknown_align(self):
             im = Image.new(mode='RGB', size=(300, 100))
@@ -227,7 +231,8 @@ try:
             target = 'Tests/images/multiline_text_spacing.png'
             target_img = Image.open(target)
 
-            self.assert_image_similar(im, target_img, .5)
+            # Epsilon ~.5 fails with FreeType 2.7
+            self.assert_image_similar(im, target_img, 6.2)
 
         def test_rotated_transposed_font(self):
             img_grey = Image.new("L", (100, 100))


### PR DESCRIPTION
Fixes #2116.

Changes proposed in this pull request:

 * The text weight looks a bit different with FreeType 2.7 compared to the test images created with an older version
 * Increase the epsilon value so tests pass

Here's how the newly-generated `im` look (macOS Sierra, Python 2.7.12, Pillow master badbff1b99a939c05b3651db7e4aea11181e5bd7, FreeType 2.7) compared to the pre-generated `target_img` from the test suite.

Test | im  | target_img
--- | --- | ---
test_multiline_spacing | ![test_multiline_spacing-im](https://cloud.githubusercontent.com/assets/1324225/21098303/3e003f40-c071-11e6-8395-2ba6e8adb33d.png) | ![test_multiline_spacing-target_img](https://cloud.githubusercontent.com/assets/1324225/21098304/40e6dc32-c071-11e6-963c-44bdea98db82.png)
test_render_multiline_text | ![test_render_multiline_text-im](https://cloud.githubusercontent.com/assets/1324225/21098224/daf5e4a4-c070-11e6-8243-1c28b97eaf96.png) | ![test_render_multiline_text-target_img](https://cloud.githubusercontent.com/assets/1324225/21098232/e10af046-c070-11e6-8f55-1ec149ccd588.png)
test_render_multiline | ![test_render_multiline-im](https://cloud.githubusercontent.com/assets/1324225/21098241/ea548464-c070-11e6-9929-505e04702c79.png) | ![test_render_multiline-target_img](https://cloud.githubusercontent.com/assets/1324225/21098244/f25482ea-c070-11e6-8a31-59b302897cbf.png)
test_render_multiline_text - center | ![test_render_multiline_text_center-im](https://cloud.githubusercontent.com/assets/1324225/21100562/6e927c70-c07d-11e6-9ed2-e405441172e1.png) | ![test_render_multiline_text_center-target](https://cloud.githubusercontent.com/assets/1324225/21100572/7fb40276-c07d-11e6-99b8-54afb491bd64.png)
test_render_multiline_text - right | ![test_render_multiline_text_right-im](https://cloud.githubusercontent.com/assets/1324225/21100581/9010f21e-c07d-11e6-84f7-ad60d899b48b.png) | ![test_render_multiline_text_right-target](https://cloud.githubusercontent.com/assets/1324225/21100585/9207ac66-c07d-11e6-8dc9-81a56611ec2a.png)
test_textsize_equal | ![test_textsize_equal-im](https://cloud.githubusercontent.com/assets/1324225/21097909/8bd81ffa-c06f-11e6-8ddf-588a500d0103.png) | ![test_textsize_equal-target_img](https://cloud.githubusercontent.com/assets/1324225/21097924/96832a76-c06f-11e6-836d-c03ea4045bf1.png)
