### PR TITLE
Pypy buffer interface workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ python:
   - 3.4
   - nightly
 
+dist: trusty
+  
 install:
   - "travis_retry sudo apt-get update"
   - "travis_retry sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-qt4 ghostscript libffi-dev libjpeg-turbo-progs cmake imagemagick"

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,13 @@ install:
 	python setup.py install
 	python selftest.py --installed
 
+debug:
+# make a debug version if we don't have a -dbg python. Leaves in symbols
+# for our stuff, kills optimization, and redirects to dev null so we 
+# see any build failures.
+	make clean > /dev/null
+	CFLAGS='-g -O0' python setup.py build_ext install > /dev/null
+
 install-req:
 	pip install -r requirements.txt
 

--- a/_imaging.c
+++ b/_imaging.c
@@ -251,7 +251,9 @@ int PyImaging_GetBuffer(PyObject* buffer, Py_buffer *view)
     /* Use new buffer protocol if available
        (mmap doesn't support this in 2.7, go figure) */
     if (PyObject_CheckBuffer(buffer)) {
-        return PyObject_GetBuffer(buffer, view, PyBUF_SIMPLE);
+        int success = PyObject_GetBuffer(buffer, view, PyBUF_SIMPLE);
+        if (!success) { return success; }
+        PyErr_Clear();
     }
 
     /* Pretend we support the new protocol; PyBuffer_Release happily ignores


### PR DESCRIPTION
Includes/Replaces/Fixes #2289 


Pypy in versions 5.4.1 and 5.6 fail prepatch, but 5.3.1 is successful (on both precise and trusty, it's a pypy thing, not a ubuntu version thing, even though it's coming up because we're looking at updating the testing distro).

Specifically, in _imaging.c, this line:
```
    if (PyObject_CheckBuffer(buffer)) {
        return PyObject_GetBuffer(buffer, view, PyBUF_SIMPLE);
    }
```
Returns a failure when passed a string buffer, e.g. 

```
arr = array.array("f", [0.1, 0.1])
p = ImagePath.Path(arr.tostring())   # < this argument is passed as the buffer parameter.

Breakpoint 1, PyPath_Create (self=0x0, args=0x7794b0) at path.c:253
253	    if (PyArg_ParseTuple(args, "n:Path", &count)) {
(gdb) c
Continuing.

Breakpoint 2, PyPath_Flatten (data=0x69c4f0, pxy=0x7fffffffd758) at path.c:130
130	        if (PyImaging_GetBuffer(data, &buffer) == 0) {
(gdb) c
Continuing.

Breakpoint 3, PyImaging_GetBuffer (buffer=0x69c4f0, view=0x7fffffffd660) at _imaging.c:254
254	        int success = PyObject_GetBuffer(buffer, view, PyBUF_SIMPLE);
(gdb) n
255	        if (!success) { return success; }
(gdb) info locals
success = -1
(gdb) n
276	}
(gdb) p buffer[0]
$17 = {ob_refcnt = 2305843009213693953, ob_pypy_link = 140737353791688, ob_type = 0x7ffff7dd7a80}
(gdb) p view[0]
$18 = {buf = 0x7fffffffd730, obj = 0x7fffffffd670, len = 6931696, itemsize = 140737303942710, readonly = -10424, ndim = 32767, format = 0x1340 <Address 0x1340 out of bounds>, 
  shape = 0x78000904c934, strides = 0x66b3b0, suboffsets = 0x2000000000000000, internal = 0x7ffff696d7c0}

```

In this particular case, if the buffer fails, the item is then interpreted as a tuple, and that fails. There are other calls where this fails directly back to python, such as `test_file_icns.py:test_jp2_icon` 

```
Breakpoint 3, PyImaging_GetBuffer (buffer=0x6d2ea0, view=0x7fffffffb0c0) at _imaging.c:254
254	        int success = PyObject_GetBuffer(buffer, view, PyBUF_SIMPLE);
(gdb) frame
#0  PyImaging_GetBuffer (buffer=0x6d2ea0, view=0x7fffffffb0c0) at _imaging.c:254
254	        int success = PyObject_GetBuffer(buffer, view, PyBUF_SIMPLE);
(gdb) p buffer[0]
$1 = {ob_refcnt = 2305843009213693953, ob_pypy_link = 140737353484784, ob_type = 0x7ffff7dd7a80}
(gdb) p buffer[0]->ob_type[0]
$2 = {ob_refcnt = 2305843009213693953, ob_pypy_link = 140737330642368, ob_type = 0x7ffff7dd3760, ob_size = 0, tp_name = 0x7a21d0 "str", tp_basicsize = 48, tp_itemsize = 1, 
  tp_dealloc = 0x7ffff549a850, tp_print = 0, tp_getattr = 0, tp_setattr = 0, tp_compare = 0, tp_repr = 0x7ffff542b120, tp_as_number = 0x7a21f0, tp_as_sequence = 0x7a2330, 
  tp_as_mapping = 0x0, tp_hash = 0, tp_call = 0, tp_str = 0x7ffff542b140, tp_getattro = 0x7ffff5471b00, tp_setattro = 0x7ffff5471ae0, tp_as_buffer = 0x7a2190, 
  tp_flags = 2101249, tp_doc = 0x0, tp_traverse = 0, tp_clear = 0, tp_richcompare = 0, tp_weaklistoffset = 0, tp_iter = 0, tp_iternext = 0, tp_methods = 0x0, 
  tp_members = 0x0, tp_getset = 0x0, tp_base = 0x7ffff7dd5500, tp_dict = 0x67b940, tp_descr_get = 0, tp_descr_set = 0, tp_dictoffset = 0, tp_init = 0x7ffff5471ac0, 
  tp_alloc = 0x7ffff53de810 <PyPyType_GenericAlloc>, tp_new = 0x7ffff542ace0, tp_free = 0x7ffff53be150 <PyPyObject_Free>, tp_is_gc = 0, tp_bases = 0x67b8b0, 
  tp_mro = 0x67b8f0, tp_cache = 0x0, tp_subclasses = 0x0, tp_weaklist = 0x0, tp_del = 0, tp_version_tag = 0}
(gdb) n
255	        if (!success) { return success; }
(gdb) p success
$3 = -1
```

Changes proposed in this pull request:

 * Interpret the error and attempt to fall back to previous buffer interface.
