### PR TITLE
Fix Access to be reloadable -- Issue #2268

### DIFF
--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -8,6 +8,7 @@ except ImportError:
 
 from PIL import Image
 import sys
+import os
 
 class AccessTest(PillowTestCase):
     # initial value
@@ -291,17 +292,22 @@ int main(int argc, char* argv[])
 
         compiler = ccompiler.new_compiler()
         compiler.add_include_dir(sysconfig.get_python_inc())
-        compiler.add_library_dir(sysconfig.get_config_var('LIBDIR'))
+        
+        libdir = sysconfig.get_config_var('LIBDIR') or sysconfig.get_python_inc().replace('include', 'libs')
+        print (libdir)
+        compiler.add_library_dir(libdir)
         objects = compiler.compile(['embed_pil.c'])
         compiler.link_executable(objects, 'embed_pil')
+
+        env = os.environ.copy()
+        env["PATH"] = sys.prefix + ';' + env["PATH"]
         
         # do not display the Windows Error Reporting dialog
         ctypes.windll.kernel32.SetErrorMode(0x0002)
         
-        process = subprocess.Popen(['embed_pil.exe'])
+        process = subprocess.Popen(['embed_pil.exe'], env=env)
         process.communicate()
         self.assertEqual(process.returncode, 0)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from helper import unittest, PillowTestCase, hopper, on_appveyor
 
 try:
     from PIL import PyAccess
@@ -252,7 +252,9 @@ class TestCffi(AccessTest):
 
 class TestEmbeddable(unittest.TestCase):
     @unittest.skipIf(not sys.platform.startswith('win32') or
-                     sys.version_info[:2] in ((3, 3), (3, 4)),
+                     sys.version_info[:2] in ((3, 3), (3, 4)) or
+                     on_appveyor(),   # failing on appveyor when run from
+                                      # subprocess, not from shell
                      "requires Python 2.7 or >=3.5 for Windows")
     def test_embeddable(self):
         import subprocess

--- a/libImaging/Access.c
+++ b/libImaging/Access.c
@@ -32,7 +32,7 @@ add_item(const char* mode)
 {
     UINT32 i = hash(mode);
     /* printf("hash %s => %d\n", mode, i); */
-    if (access_table[i].mode) {
+    if (access_table[i].mode && strcmp(access_table[i].mode, mode) != 0) {
         fprintf(stderr, "AccessInit: hash collision: %d for both %s and %s\n",
                 i, mode, access_table[i].mode);
         exit(1);


### PR DESCRIPTION
Fixes Access to be reloaded if the python interpreter is restarted when embedded. Fixes #2268.

Test from cgohlke 