### PR TITLE
Build: Python 3.6 is out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,16 @@ notifications:
 python:
   - "pypy"
   - "pypy3"
-  - 3.5
+  - 3.6
   - 2.7
   - "2.7_with_system_site_packages" # For PyQt4
-  - 3.3
+  - 3.5
   - 3.4
+  - 3.3
   - nightly
 
 dist: trusty
-  
+
 install:
   - "travis_retry sudo apt-get update"
   - "travis_retry sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-qt4 ghostscript libffi-dev libjpeg-turbo-progs cmake imagemagick"
@@ -43,10 +44,10 @@ install:
 
   # libimagequant
   - pushd depends && ./install_imagequant.sh && popd
-  
+
   # extra test images
-  - pushd depends && ./install_extra_test_images.sh && popd  
-  
+  - pushd depends && ./install_extra_test_images.sh && popd
+
 
   - travis_retry pip install -e .
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -17,7 +17,7 @@ Notes
 
 .. note:: Pillow >= 2.0.0 < 3.5.0 supports Python versions 2.6, 2.7, 3.2, 3.3, 3.4, 3.5
 
-.. note:: Pillow >= 3.5.0 supports Python versions 2.7, 3.3, 3.4, 3.5
+.. note:: Pillow >= 3.5.0 supports Python versions 2.7, 3.3, 3.4, 3.5, 3.6
 
 Basic Installation
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -763,6 +763,7 @@ try:
               "Programming Language :: Python :: 3.3",
               "Programming Language :: Python :: 3.4",
               "Programming Language :: Python :: 3.5",
+              "Programming Language :: Python :: 3.6",
               'Programming Language :: Python :: Implementation :: CPython',
               'Programming Language :: Python :: Implementation :: PyPy',
           ],

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py33, py34, py35
+envlist = py27, py33, py34, py35, py36
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 3.6.0 was officially released today and is available on Travis CI. 

https://www.python.org/downloads/release/python-360/
