### PR TITLE
Build: Refactor dependency installation

### DIFF
--- a/depends/download-and-extract.sh
+++ b/depends/download-and-extract.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Usage: ./download-and-extract.sh something.tar.gz https://example.com/something.tar.gz
+
+archive=$1
+url=$2
+
+if [ ! -f $archive.tar.gz ]; then
+    wget -O $archive.tar.gz $url
+fi
+
+rm -r $archive
+tar -xvzf $archive.tar.gz

--- a/depends/install_imagequant.sh
+++ b/depends/install_imagequant.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 # install libimagequant
 
-git clone -b 2.6.0 https://github.com/pornel/pngquant
+archive=pngquant-2.6.0
 
-pushd pngquant
+./download-and-extract.sh $archive https://github.com/python-pillow/pillow-depends/blob/master/$archive.tar.gz?raw=true
+
+pushd $archive
 
 make -C lib shared
 sudo cp lib/libimagequant.so* /usr/lib/

--- a/depends/install_imagequant.sh
+++ b/depends/install_imagequant.sh
@@ -3,7 +3,7 @@
 
 archive=pngquant-2.6.0
 
-./download-and-extract.sh $archive https://github.com/python-pillow/pillow-depends/blob/master/$archive.tar.gz?raw=true
+./download-and-extract.sh $archive https://raw.githubusercontent.com/python-pillow/pillow-depends/master/$archive.tar.gz
 
 pushd $archive
 

--- a/depends/install_openjpeg.sh
+++ b/depends/install_openjpeg.sh
@@ -1,19 +1,12 @@
 #!/bin/bash
 # install openjpeg
 
+archive=openjpeg-2.1.2
 
-if [ ! -f openjpeg-2.1.2.tar.gz ]; then
-    wget -O 'openjpeg-2.1.2.tar.gz' 'https://github.com/python-pillow/pillow-depends/blob/master/openjpeg-2.1.2.tar.gz?raw=true'
+./download-and-extract.sh $archive https://github.com/python-pillow/pillow-depends/blob/master/$archive.tar.gz?raw=true
 
-fi
-
-rm -r openjpeg-2.1.2
-tar -xvzf openjpeg-2.1.2.tar.gz
-
-
-pushd openjpeg-2.1.2
+pushd $archive
 
 cmake -DCMAKE_INSTALL_PREFIX=/usr . && make -j4 && sudo make -j4 install
 
 popd
-

--- a/depends/install_openjpeg.sh
+++ b/depends/install_openjpeg.sh
@@ -3,7 +3,7 @@
 
 archive=openjpeg-2.1.2
 
-./download-and-extract.sh $archive https://github.com/python-pillow/pillow-depends/blob/master/$archive.tar.gz?raw=true
+./download-and-extract.sh $archive https://raw.githubusercontent.com/python-pillow/pillow-depends/master/$archive.tar.gz
 
 pushd $archive
 

--- a/depends/install_webp.sh
+++ b/depends/install_webp.sh
@@ -3,7 +3,7 @@
 
 archive=libwebp-0.5.2
 
-./download-and-extract.sh $archive https://github.com/python-pillow/pillow-depends/blob/master/$archive.tar.gz?raw=true
+./download-and-extract.sh $archive https://raw.githubusercontent.com/python-pillow/pillow-depends/master/$archive.tar.gz
 
 pushd $archive
 

--- a/depends/install_webp.sh
+++ b/depends/install_webp.sh
@@ -1,14 +1,11 @@
 #!/bin/bash
 # install webp
 
-if [ ! -f libwebp-0.5.2.tar.gz ]; then
-    wget -O 'libwebp-0.5.2.tar.gz' 'https://github.com/python-pillow/pillow-depends/blob/master/libwebp-0.5.2.tar.gz?raw=true'
-fi
+archive=libwebp-0.5.2
 
-rm -r libwebp-0.5.2
-tar -xvzf libwebp-0.5.2.tar.gz
+./download-and-extract.sh $archive https://github.com/python-pillow/pillow-depends/blob/master/$archive.tar.gz?raw=true
 
-pushd libwebp-0.5.2
+pushd $archive
 
 ./configure --prefix=/usr --enable-libwebpmux --enable-libwebpdemux && make -j4 && sudo make -j4 install
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * Refactor common stuff from install_openjpeg.sh and install_webp.sh into a new download-and-extract.sh: means updating new version numbers in fewer places.

 * Use this new download-and-extract.sh in install_imagequant.sh to get libimagequant from pillow-depends instead of cloning from its Git repo

* Instead of using a URL like https://github.com/python-pillow/pillow-depends/blob/master/pngquant-2.6.0.tar.gz?raw=true which resolves to https://github.com/python-pillow/pillow-depends/raw/master/pngquant-2.6.0.tar.gz and then resolves to https://raw.githubusercontent.com/python-pillow/pillow-depends/master/pngquant-2.6.0.tar.gz just use the latter. Shaves a second or two.

