### PR TITLE
allow frame durations of less than 10 milliseconds

### DIFF
--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -187,7 +187,7 @@ class GifImageFile(ImageFile.ImageFile):
                     flags = i8(block[0])
                     if flags & 1:
                         self.info["transparency"] = i8(block[3])
-                    self.info["duration"] = i16(block[1:3]) * 10
+                    self.info["duration"] = i16(block[1:3])
 
                     # disposal method - find the value of bits 4 - 6
                     dispose_bits = 0b00011100 & flags
@@ -448,7 +448,7 @@ def _get_local_header(fp, im, offset, flags):
                         transparent_color_exists = False
 
     if "duration" in im.encoderinfo:
-        duration = int(im.encoderinfo["duration"] / 10)
+        duration = int(im.encoderinfo["duration"])
     else:
         duration = 0
     if transparent_color_exists or duration != 0:


### PR DESCRIPTION
Changes proposed in this pull request:

Allow saving animated GIFs with frame durations of less than 10 milliseconds to make smoother animations. Currently, when pillow saves a GIF it divides the duration attribute by 10 then converts to int. This rounds any duration less than 10 to 0, which falls back to the default duration. The changes in this PR remove the division by 10 (and the concomitant multiplication by 10) so durations less than 10 can be saved. Demonstrated [here](https://github.com/gboeing/lorenz-system/blob/master/lorenz-system-attractor-animate.ipynb).
