### PR TITLE
Updated tested versions of libjpeg

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -126,8 +126,8 @@ Many of Pillow's features require external libraries:
 
 * **libjpeg** provides JPEG functionality.
 
-  * Pillow has been tested with libjpeg versions **6b**, **8**, **9**, and
-    **9a** and libjpeg-turbo version **8**.
+  * Pillow has been tested with libjpeg versions **6b**, **8**, **9**, **9a**,
+    and **9b** and libjpeg-turbo version **8**.
   * Starting with Pillow 3.0.0, libjpeg is required by default, but
     may be disabled with the ``--disable-jpeg`` flag.
 


### PR DESCRIPTION
libjpeg 9b has been a part of Pillow since PR #1673 and https://github.com/python-pillow/pillow-wheels/pull/29