### PR TITLE
Add proper exception types

### DIFF
--- a/PIL/BdfFontFile.py
+++ b/PIL/BdfFontFile.py
@@ -18,9 +18,8 @@
 #
 
 from __future__ import print_function
-
-from PIL import Image
-from PIL import FontFile
+from PIL import Image, FontFile
+from .exceptions import InvalidFileType
 
 
 # --------------------------------------------------------------------
@@ -89,14 +88,12 @@ def bdf_char(f):
 # Font file plugin for the X11 BDF format.
 
 class BdfFontFile(FontFile.FontFile):
-
     def __init__(self, fp):
-
         FontFile.FontFile.__init__(self)
 
         s = fp.readline()
         if s[:13] != b"STARTFONT 2.1":
-            raise SyntaxError("not a valid BDF file")
+            raise InvalidFileType("not a valid BDF file")
 
         props = {}
         comments = []

--- a/PIL/BdfFontFile.py
+++ b/PIL/BdfFontFile.py
@@ -17,7 +17,6 @@
 # See the README file for information on usage and redistribution.
 #
 
-from __future__ import print_function
 from PIL import Image, FontFile
 from .exceptions import InvalidFileType
 
@@ -107,20 +106,6 @@ class BdfFontFile(FontFile.FontFile):
             if s[:i] in [b"COMMENT", b"COPYRIGHT"]:
                 if s.find(b"LogicalFontDescription") < 0:
                     comments.append(s[i+1:-1].decode('ascii'))
-
-        # font = props["FONT"].split("-")
-
-        # font[4] = bdf_slant[font[4].upper()]
-        # font[11] = bdf_spacing[font[11].upper()]
-
-        # ascent = int(props["FONT_ASCENT"])
-        # descent = int(props["FONT_DESCENT"])
-
-        # fontname = ";".join(font[1:])
-
-        # print("#", fontname)
-        # for i in comments:
-        #       print("#", i)
 
         while True:
             c = bdf_char(fp)

--- a/PIL/BmpImagePlugin.py
+++ b/PIL/BmpImagePlugin.py
@@ -23,9 +23,10 @@
 # See the README file for information on usage and redistribution.
 #
 
-
-from PIL import Image, ImageFile, ImagePalette, _binary
 import math
+from PIL import Image, ImageFile, ImagePalette, _binary
+from .exceptions import InvalidFileType, PILReadError
+
 
 __version__ = "0.7"
 
@@ -199,7 +200,7 @@ class BmpImageFile(ImageFile.ImageFile):
         head_data = self.fp.read(14)
         # choke if the file does not have the required magic bytes
         if head_data[0:2] != b"BM":
-            raise SyntaxError("Not a BMP file")
+            raise InvalidFileType("Not a BMP file")
         # read the start position of the BMP image data (u32)
         offset = i32(head_data[10:14])
         # load bitmap information (offset=raster info)

--- a/PIL/BufrStubImagePlugin.py
+++ b/PIL/BufrStubImagePlugin.py
@@ -10,6 +10,7 @@
 #
 
 from PIL import Image, ImageFile
+from .exceptions import InvalidFileType
 
 _handler = None
 
@@ -37,11 +38,10 @@ class BufrStubImageFile(ImageFile.StubImageFile):
     format_description = "BUFR"
 
     def _open(self):
-
         offset = self.fp.tell()
 
         if not _accept(self.fp.read(8)):
-            raise SyntaxError("Not a BUFR file")
+            raise InvalidFileType("Not a BUFR file")
 
         self.fp.seek(offset)
 

--- a/PIL/CurImagePlugin.py
+++ b/PIL/CurImagePlugin.py
@@ -17,8 +17,9 @@
 #
 
 from __future__ import print_function
-
 from PIL import Image, BmpImagePlugin, _binary
+from .exceptions import InvalidFileType
+
 
 __version__ = "0.1"
 
@@ -49,7 +50,7 @@ class CurImageFile(BmpImagePlugin.BmpImageFile):
         # check magic
         s = self.fp.read(6)
         if not _accept(s):
-            raise SyntaxError("not a CUR file")
+            raise InvalidFileType("not a CUR file")
 
         # pick the largest cursor in the file
         m = b""

--- a/PIL/CurImagePlugin.py
+++ b/PIL/CurImagePlugin.py
@@ -16,7 +16,6 @@
 # See the README file for information on usage and redistribution.
 #
 
-from __future__ import print_function
 from PIL import Image, BmpImagePlugin, _binary
 from .exceptions import InvalidFileType
 
@@ -60,14 +59,6 @@ class CurImageFile(BmpImagePlugin.BmpImageFile):
                 m = s
             elif i8(s[0]) > i8(m[0]) and i8(s[1]) > i8(m[1]):
                 m = s
-            # print("width", i8(s[0]))
-            # print("height", i8(s[1]))
-            # print("colors", i8(s[2]))
-            # print("reserved", i8(s[3]))
-            # print("hotspot x", i16(s[4:]))
-            # print("hotspot y", i16(s[6:]))
-            # print("bytes", i32(s[8:]))
-            # print("offset", i32(s[12:]))
         if not m:
             raise TypeError("No cursors were found")
 

--- a/PIL/DcxImagePlugin.py
+++ b/PIL/DcxImagePlugin.py
@@ -23,6 +23,8 @@
 
 from PIL import Image, _binary
 from PIL.PcxImagePlugin import PcxImageFile
+from .exceptions import InvalidFileType
+
 
 __version__ = "0.2"
 
@@ -44,11 +46,10 @@ class DcxImageFile(PcxImageFile):
     format_description = "Intel DCX"
 
     def _open(self):
-
         # Header
         s = self.fp.read(4)
         if i32(s) != MAGIC:
-            raise SyntaxError("not a DCX file")
+            raise InvalidFileType("Invalid DCS header")
 
         # Component directory
         self._offset = []

--- a/PIL/FitsStubImagePlugin.py
+++ b/PIL/FitsStubImagePlugin.py
@@ -10,6 +10,8 @@
 #
 
 from PIL import Image, ImageFile
+from .exceptions import InvalidFileType
+
 
 _handler = None
 
@@ -41,7 +43,7 @@ class FITSStubImageFile(ImageFile.StubImageFile):
         offset = self.fp.tell()
 
         if not _accept(self.fp.read(6)):
-            raise SyntaxError("Not a FITS file")
+            raise InvalidFileType("Not a FITS file")
 
         # FIXME: add more sanity checks here; mandatory header items
         # include SIMPLE, BITPIX, NAXIS, etc.

--- a/PIL/FliImagePlugin.py
+++ b/PIL/FliImagePlugin.py
@@ -17,6 +17,8 @@
 
 
 from PIL import Image, ImageFile, ImagePalette, _binary
+from .exceptions import InvalidFileType
+
 
 __version__ = "0.2"
 
@@ -50,7 +52,7 @@ class FliImageFile(ImageFile.ImageFile):
         if not (magic in [0xAF11, 0xAF12] and
                 i16(s[14:16]) in [0, 3] and  # flags
                 s[20:22] == b"\x00\x00"):  # reserved
-            raise SyntaxError("not an FLI/FLC file")
+            raise InvalidFileType("not an FLI/FLC file")
 
         # image characteristics
         self.mode = "P"

--- a/PIL/FontFile.py
+++ b/PIL/FontFile.py
@@ -14,8 +14,6 @@
 # See the README file for information on usage and redistribution.
 #
 
-from __future__ import print_function
-
 import os
 from PIL import Image, _binary
 
@@ -90,7 +88,6 @@ class FontFile(object):
                     x = xx
                 s = src[0] + x0, src[1] + y0, src[2] + x0, src[3] + y0
                 self.bitmap.paste(im.crop(src), s)
-                # print(chr(i), dst, s)
                 self.metrics[i] = d, dst, s
 
     def save(self, filename):

--- a/PIL/FpxImagePlugin.py
+++ b/PIL/FpxImagePlugin.py
@@ -15,7 +15,6 @@
 # See the README file for information on usage and redistribution.
 #
 
-from __future__ import print_function
 import olefile
 from PIL import Image, ImageFile, _binary
 from .exceptions import InvalidFileType, PILReadError
@@ -116,8 +115,6 @@ class FpxImageFile(ImageFile.ImageFile):
             if id in prop:
                 self.jpeg[i] = prop[id]
 
-        # print(len(self.jpeg), "tables loaded")
-
         self._open_subimage(1, self.maxid)
 
     def _open_subimage(self, index=1, subimage=0):
@@ -144,8 +141,6 @@ class FpxImageFile(ImageFile.ImageFile):
         # channels = i32(s, 24)
         offset = i32(s, 28)
         length = i32(s, 32)
-
-        # print(size, self.mode, self.rawmode)
 
         if size != self.size:
             raise PILReadError("subimage mismatch")

--- a/PIL/FpxImagePlugin.py
+++ b/PIL/FpxImagePlugin.py
@@ -16,10 +16,10 @@
 #
 
 from __future__ import print_function
-
-from PIL import Image, ImageFile, _binary
-
 import olefile
+from PIL import Image, ImageFile, _binary
+from .exceptions import InvalidFileType, PILReadError
+
 
 __version__ = "0.1"
 
@@ -65,10 +65,10 @@ class FpxImageFile(ImageFile.ImageFile):
         try:
             self.ole = olefile.OleFileIO(self.fp)
         except IOError:
-            raise SyntaxError("not an FPX file; invalid OLE file")
+            raise InvalidFileType("not an FPX file; invalid OLE file")
 
         if self.ole.root.clsid != "56616700-C154-11CE-8553-00AA00A1F95B":
-            raise SyntaxError("not an FPX file; bad root CLSID")
+            raise InvalidFileType("not an FPX file; bad root CLSID")
 
         self._open_index(1)
 
@@ -148,7 +148,7 @@ class FpxImageFile(ImageFile.ImageFile):
         # print(size, self.mode, self.rawmode)
 
         if size != self.size:
-            raise IOError("subimage mismatch")
+            raise PILReadError("subimage mismatch")
 
         # get tile descriptors
         fp.seek(28 + offset)
@@ -203,7 +203,7 @@ class FpxImageFile(ImageFile.ImageFile):
                     self.tile_prefix = self.jpeg[jpeg_tables]
 
             else:
-                raise IOError("unknown/invalid compression")
+                raise PILReadError("unknown/invalid compression")
 
             x = x + xtile
             if x >= xsize:

--- a/PIL/GdImageFile.py
+++ b/PIL/GdImageFile.py
@@ -25,6 +25,8 @@
 
 from PIL import ImageFile, ImagePalette, _binary
 from PIL._util import isPath
+from .exceptions import PILReadError
+
 
 __version__ = "0.1"
 
@@ -49,7 +51,6 @@ class GdImageFile(ImageFile.ImageFile):
     format_description = "GD uncompressed images"
 
     def _open(self):
-
         # Header
         s = self.fp.read(775)
 
@@ -87,5 +88,5 @@ def open(fp, mode="r"):
 
     try:
         return GdImageFile(fp, filename)
-    except SyntaxError:
-        raise IOError("cannot identify this image file")
+    except Exception as e:
+        raise PILReadError("cannot identify this image file: %s" % (e))

--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -26,6 +26,8 @@
 
 from PIL import Image, ImageFile, ImagePalette, \
                 ImageChops, ImageSequence, _binary
+from .exceptions import InvalidFileType
+
 
 __version__ = "0.9"
 
@@ -63,11 +65,10 @@ class GifImageFile(ImageFile.ImageFile):
         return None
 
     def _open(self):
-
         # Screen
         s = self.fp.read(13)
         if s[:6] not in [b"GIF87a", b"GIF89a"]:
-            raise SyntaxError("not a GIF file")
+            raise InvalidFileType("Invalid GIF header")
 
         self.info["version"] = s[:6]
         self.size = i16(s[6:]), i16(s[8:])

--- a/PIL/GimpGradientFile.py
+++ b/PIL/GimpGradientFile.py
@@ -15,6 +15,8 @@
 
 from math import pi, log, sin, sqrt
 from PIL._binary import o8
+from .exceptions import InvalidFileType
+
 
 # --------------------------------------------------------------------
 # Stuff to translate curve segments to palette values (derived from
@@ -102,9 +104,8 @@ class GradientFile(object):
 class GimpGradientFile(GradientFile):
 
     def __init__(self, fp):
-
         if fp.readline()[:13] != b"GIMP Gradient":
-            raise SyntaxError("not a GIMP gradient file")
+            raise InvalidFileType("not a GIMP gradient file")
 
         line = fp.readline()
 

--- a/PIL/GimpPaletteFile.py
+++ b/PIL/GimpPaletteFile.py
@@ -16,21 +16,20 @@
 
 import re
 from PIL._binary import o8
+from .exceptions import InvalidFileType, PILReadError
 
 
 ##
 # File handler for GIMP's palette format.
 
 class GimpPaletteFile(object):
-
     rawmode = "RGB"
 
     def __init__(self, fp):
-
         self.palette = [o8(i)*3 for i in range(256)]
 
         if fp.readline()[:12] != b"GIMP Palette":
-            raise SyntaxError("not a GIMP palette file")
+            raise InvalidFileType("not a GIMP palette file")
 
         i = 0
 
@@ -44,11 +43,11 @@ class GimpPaletteFile(object):
             if re.match(br"\w+:|#", s):
                 continue
             if len(s) > 100:
-                raise SyntaxError("bad palette file")
+                raise PILReadError("bad palette file")
 
             v = tuple(map(int, s.split()[:3]))
             if len(v) != 3:
-                raise ValueError("bad palette entry")
+                raise PILReadError("bad palette entry")
 
             if 0 <= i <= 255:
                 self.palette[i] = o8(v[0]) + o8(v[1]) + o8(v[2])
@@ -58,5 +57,4 @@ class GimpPaletteFile(object):
         self.palette = b"".join(self.palette)
 
     def getpalette(self):
-
         return self.palette, self.rawmode

--- a/PIL/GribStubImagePlugin.py
+++ b/PIL/GribStubImagePlugin.py
@@ -10,6 +10,8 @@
 #
 
 from PIL import Image, ImageFile
+from .exceptions import InvalidFileType
+
 
 _handler = None
 
@@ -37,11 +39,10 @@ class GribStubImageFile(ImageFile.StubImageFile):
     format_description = "GRIB"
 
     def _open(self):
-
         offset = self.fp.tell()
 
         if not _accept(self.fp.read(8)):
-            raise SyntaxError("Not a GRIB file")
+            raise InvalidFileType("Not a GRIB file")
 
         self.fp.seek(offset)
 

--- a/PIL/Hdf5StubImagePlugin.py
+++ b/PIL/Hdf5StubImagePlugin.py
@@ -10,6 +10,8 @@
 #
 
 from PIL import Image, ImageFile
+from .exceptions import InvalidFileType
+
 
 _handler = None
 
@@ -41,7 +43,7 @@ class HDF5StubImageFile(ImageFile.StubImageFile):
         offset = self.fp.tell()
 
         if not _accept(self.fp.read(8)):
-            raise SyntaxError("Not an HDF file")
+            raise InvalidFileType("Not an HDF file")
 
         self.fp.seek(offset)
 

--- a/PIL/IcoImagePlugin.py
+++ b/PIL/IcoImagePlugin.py
@@ -21,12 +21,11 @@
 #   * https://en.wikipedia.org/wiki/ICO_(file_format)
 #   * https://msdn.microsoft.com/en-us/library/ms997538.aspx
 
-
 import struct
 from io import BytesIO
-
-from PIL import Image, ImageFile, BmpImagePlugin, PngImagePlugin, _binary
 from math import log, ceil
+from PIL import Image, ImageFile, BmpImagePlugin, PngImagePlugin, _binary
+from .exceptions import InvalidFileType
 
 __version__ = "0.1"
 
@@ -91,7 +90,7 @@ class IcoFile(object):
         # check magic
         s = buf.read(6)
         if not _accept(s):
-            raise SyntaxError("not an ICO file")
+            raise InvalidFileType("not an ICO file")
 
         self.buf = buf
         self.entry = []

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -24,12 +24,9 @@
 # See the README file for information on usage and redistribution.
 #
 
-from __future__ import print_function
-
 import logging
 import math
 import warnings
-
 from PIL import VERSION, PILLOW_VERSION, _plugins
 from .exceptions import PILReadError, NoPluginFound
 
@@ -419,7 +416,6 @@ def _getdecoder(mode, decoder_name, args, extra=()):
     try:
         # get decoder
         decoder = getattr(core, decoder_name + "_decoder")
-        # print(decoder, mode, args + extra)
         return decoder(mode, *args + extra)
     except AttributeError:
         raise IOError("decoder %s not available" % decoder_name)
@@ -436,7 +432,6 @@ def _getencoder(mode, encoder_name, args, extra=()):
     try:
         # get encoder
         encoder = getattr(core, encoder_name + "_encoder")
-        # print(encoder, mode, args + extra)
         return encoder(mode, *args + extra)
     except AttributeError:
         raise IOError("encoder %s not available" % encoder_name)
@@ -2195,7 +2190,6 @@ def fromarray(obj, mode=None):
             typekey = (1, 1) + shape[2:], arr['typestr']
             mode, rawmode = _fromarray_typemap[typekey]
         except KeyError:
-            # print(typekey)
             raise TypeError("Cannot handle this data type")
     else:
         rawmode = mode

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -26,11 +26,12 @@
 
 from __future__ import print_function
 
-from PIL import VERSION, PILLOW_VERSION, _plugins
-
 import logging
-import warnings
 import math
+import warnings
+
+from PIL import VERSION, PILLOW_VERSION, _plugins
+from .exceptions import PILReadError, NoPluginFound
 
 logger = logging.getLogger(__name__)
 
@@ -1583,7 +1584,7 @@ class Image(object):
         angle = angle % 360.0
 
         # Fast paths regardless of filter, as long as we're not
-        # translating or changing the center. 
+        # translating or changing the center.
         if not (center or translate):
             if angle == 0:
                 return self.copy()
@@ -2329,7 +2330,7 @@ def open(fp, mode="r"):
                     im = factory(fp, filename)
                     _decompression_bomb_check(im.size)
                     return im
-            except (SyntaxError, IndexError, TypeError, struct.error):
+            except (PILReadError, NoPluginFound, IndexError, TypeError, struct.error):
                 # Leave disabled by default, spams the logs with image
                 # opening failures that are entirely expected.
                 # logger.debug("", exc_info=True)

--- a/PIL/ImageCms.py
+++ b/PIL/ImageCms.py
@@ -15,7 +15,6 @@
 # See the README file for information on usage and redistribution.  See
 # below for the original description.
 
-from __future__ import print_function
 import sys
 
 from PIL import Image
@@ -27,6 +26,7 @@ except ImportError as ex:
     from _util import deferred_error
     _imagingcms = deferred_error(ex)
 from PIL._util import isStringType
+
 
 DESCRIPTION = """
 pyCMS
@@ -149,7 +149,6 @@ for flag in FLAGS.values():
 # Profile.
 
 class ImageCmsProfile(object):
-
     def __init__(self, profile):
         """
         :param profile: Either a string representing a filename,
@@ -166,7 +165,6 @@ class ImageCmsProfile(object):
             self._set(profile)
         else:
             raise TypeError("Invalid type for Profile")
-        
 
     def _set(self, profile, filename=None):
         self.profile = profile

--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -27,12 +27,14 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image
-from PIL._util import isPath
 import io
 import os
 import sys
 import struct
+from PIL import Image
+from PIL._util import isPath
+from .exceptions import PILReadError, NoPluginFound
+
 
 MAXBLOCK = 65536
 
@@ -100,10 +102,10 @@ class ImageFile(Image.Image):
                 KeyError,  # unsupported mode
                 EOFError,  # got header but not the first frame
                 struct.error) as v:
-            raise SyntaxError(v)
+            raise PILReadError(v)
 
         if not self.mode or self.size[0] <= 0:
-            raise SyntaxError("not identified by this driver")
+            raise NoPluginFound("not identified by this driver")
 
     def draft(self, mode, size):
         "Set draft mode"

--- a/PIL/ImageFont.py
+++ b/PIL/ImageFont.py
@@ -25,10 +25,11 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image
-from PIL._util import isDirectory, isPath
 import os
 import sys
+from PIL import Image
+from PIL._util import isDirectory, isPath
+from .exceptions import InvalidFileType
 
 
 class _imagingft_not_installed(object):
@@ -61,7 +62,6 @@ class ImageFont(object):
     "PIL font wrapper"
 
     def _load_pilfont(self, filename):
-
         with open(filename, "rb") as fp:
             for ext in (".png", ".gif", ".pbm"):
                 try:
@@ -80,10 +80,9 @@ class ImageFont(object):
             return self._load_pilfont_data(fp, image)
 
     def _load_pilfont_data(self, file, image):
-
         # read PILfont header
         if file.readline() != b"PILfont\n":
-            raise SyntaxError("Not a PILfont file")
+            raise InvalidFileType("Not a PILfont file")
         file.readline().split(b";")
         self.info = []  # FIXME: should be a dictionary
         while True:

--- a/PIL/ImageMorph.py
+++ b/PIL/ImageMorph.py
@@ -5,11 +5,10 @@
 #
 # Copyright (c) 2014 Dov Grobgeld <dov.grobgeld@gmail.com>
 
-from __future__ import print_function
-
+import re
 from PIL import Image
 from PIL import _imagingmorph
-import re
+
 
 LUT_SIZE = 1 << 9
 
@@ -151,11 +150,6 @@ class LutBuilder(object):
             pattern = pattern.replace(' ', '').replace('\n', '')
 
             patterns += self._pattern_permute(pattern, options, result)
-
-#        # Debugging
-#        for p,r in patterns:
-#            print(p,r)
-#        print('--')
 
         # compile the patterns into regular expressions for speed
         for i, pattern in enumerate(patterns):

--- a/PIL/ImagePalette.py
+++ b/PIL/ImagePalette.py
@@ -17,10 +17,8 @@
 #
 
 import array
-from PIL import ImageColor
-from PIL import GimpPaletteFile
-from PIL import GimpGradientFile
-from PIL import PaletteFile
+from PIL import GimpPaletteFile, GimpGradientFile, ImageColor, PaletteFile
+from .exceptions import PILReadError
 
 
 class ImagePalette(object):
@@ -198,7 +196,6 @@ def load(filename):
     # FIXME: supports GIMP gradients only
 
     with open(filename, "rb") as fp:
-
         for paletteHandler in [
             GimpPaletteFile.GimpPaletteFile,
             GimpGradientFile.GimpGradientFile,
@@ -209,11 +206,9 @@ def load(filename):
                 lut = paletteHandler(fp).getpalette()
                 if lut:
                     break
-            except (SyntaxError, ValueError):
-                # import traceback
-                # traceback.print_exc()
+            except (PILReadError, ValueError):
                 pass
         else:
             raise IOError("cannot load palette")
 
-    return lut  # data, rawmode
+    return lut

--- a/PIL/ImageShow.py
+++ b/PIL/ImageShow.py
@@ -12,8 +12,6 @@
 # See the README file for information on usage and redistribution.
 #
 
-from __future__ import print_function
-
 from PIL import Image
 import os
 import sys

--- a/PIL/ImtImagePlugin.py
+++ b/PIL/ImtImagePlugin.py
@@ -14,10 +14,10 @@
 # See the README file for information on usage and redistribution.
 #
 
-
 import re
-
 from PIL import Image, ImageFile
+from .exceptions import InvalidFileType
+
 
 __version__ = "0.2"
 
@@ -37,12 +37,11 @@ class ImtImageFile(ImageFile.ImageFile):
     format_description = "IM Tools"
 
     def _open(self):
-
         # Quick rejection: if there's not a LF among the first
         # 100 bytes, this is (probably) not a text header.
 
         if b"\n" not in self.fp.read(100):
-            raise SyntaxError("not an IM file")
+            raise InvalidFileType("not an IM file")
         self.fp.seek(0)
 
         xsize = ysize = 0

--- a/PIL/IptcImagePlugin.py
+++ b/PIL/IptcImagePlugin.py
@@ -15,7 +15,6 @@
 # See the README file for information on usage and redistribution.
 #
 
-from __future__ import print_function
 import os
 import tempfile
 from PIL import Image, ImageFile, _binary
@@ -42,12 +41,6 @@ PAD = o8(0) * 4
 
 def i(c):
     return i32((PAD + c)[-4:])
-
-
-def dump(c):
-    for i in c:
-        print("%02x" % i8(i), end=' ')
-    print()
 
 
 ##
@@ -107,8 +100,6 @@ class IptcImageFile(ImageFile.ImageFile):
                     self.info[tag] = [self.info[tag], tagdata]
             else:
                 self.info[tag] = tagdata
-
-            # print(tag, self.info[tag])
 
         # mode
         layers = i8(self.info[(3, 60)][0])

--- a/PIL/IptcImagePlugin.py
+++ b/PIL/IptcImagePlugin.py
@@ -16,10 +16,11 @@
 #
 
 from __future__ import print_function
-
-from PIL import Image, ImageFile, _binary
 import os
 import tempfile
+from PIL import Image, ImageFile, _binary
+from .exceptions import InvalidFileType
+
 
 __version__ = "0.3"
 
@@ -72,7 +73,7 @@ class IptcImageFile(ImageFile.ImageFile):
 
         # syntax
         if i8(s[0]) != 0x1C or tag[0] < 1 or tag[0] > 9:
-            raise SyntaxError("invalid IPTC/NAA file")
+            raise InvalidFileType("invalid IPTC/NAA file")
 
         # field size
         size = i8(s[3])

--- a/PIL/JpegImagePlugin.py
+++ b/PIL/JpegImagePlugin.py
@@ -36,7 +36,6 @@ import array
 import struct
 import io
 import warnings
-from struct import unpack_from
 from PIL import Image, ImageFile, TiffImagePlugin, _binary
 from .exceptions import InvalidFileType, PILReadError
 from PIL.JpegPresets import presets
@@ -491,7 +490,7 @@ def _getmp(self):
     try:
         rawmpentries = mp[0xB002]
         for entrynum in range(0, quant):
-            unpackedentry = unpack_from(
+            unpackedentry = struct.unpack_from(
                 '{}LLLHH'.format(endianness), rawmpentries, entrynum * 16)
             labels = ('Attribute', 'Size', 'DataOffset', 'EntryNo1',
                       'EntryNo2')

--- a/PIL/JpegImagePlugin.py
+++ b/PIL/JpegImagePlugin.py
@@ -32,8 +32,6 @@
 # See the README file for information on usage and redistribution.
 #
 
-from __future__ import print_function
-
 import array
 import struct
 import io
@@ -319,7 +317,6 @@ class JpegImageFile(ImageFile.ImageFile):
 
             if i in MARKER:
                 name, description, handler = MARKER[i]
-                # print(hex(i), name, description)
                 if handler is not None:
                     handler(self, i)
                 if i == 0xFFDA:  # start of scan

--- a/PIL/McIdasImagePlugin.py
+++ b/PIL/McIdasImagePlugin.py
@@ -18,6 +18,8 @@
 
 import struct
 from PIL import Image, ImageFile
+from .exceptions import InvalidFileType
+
 
 __version__ = "0.2"
 
@@ -35,11 +37,10 @@ class McIdasImageFile(ImageFile.ImageFile):
     format_description = "McIdas area file"
 
     def _open(self):
-
         # parse area file directory
         s = self.fp.read(256)
         if not _accept(s) or len(s) != 256:
-            raise SyntaxError("not an McIdas area file")
+            raise InvalidFileType("not an McIdas area file")
 
         self.area_descriptor_raw = s
         self.area_descriptor = w = [0] + list(struct.unpack("!64i", s))
@@ -56,7 +57,7 @@ class McIdasImageFile(ImageFile.ImageFile):
             mode = "I"
             rawmode = "I;32B"
         else:
-            raise SyntaxError("unsupported McIdas format")
+            raise NotImplementedError("unsupported McIdas format: %r" % (w[11]))
 
         self.mode = mode
         self.size = w[10], w[9]

--- a/PIL/MicImagePlugin.py
+++ b/PIL/MicImagePlugin.py
@@ -16,10 +16,10 @@
 # See the README file for information on usage and redistribution.
 #
 
-
-from PIL import Image, TiffImagePlugin
-
 import olefile
+from PIL import Image, TiffImagePlugin
+from .exceptions import InvalidFileType, PILReadError
+
 
 __version__ = "0.1"
 
@@ -48,7 +48,7 @@ class MicImageFile(TiffImagePlugin.TiffImageFile):
         try:
             self.ole = olefile.OleFileIO(self.fp)
         except IOError:
-            raise SyntaxError("not an MIC file; invalid OLE file")
+            raise InvalidFileType("not an MIC file; invalid OLE file")
 
         # find ACI subfiles with Image members (maybe not the
         # best way to identify MIC files, but what the... ;-)
@@ -61,7 +61,7 @@ class MicImageFile(TiffImagePlugin.TiffImageFile):
         # if we didn't find any images, this is probably not
         # an MIC file.
         if not self.images:
-            raise SyntaxError("not an MIC file; no image entries")
+            raise PILReadError("not an MIC file; no image entries")
 
         self.__fp = self.fp
         self.frame = 0

--- a/PIL/MpegImagePlugin.py
+++ b/PIL/MpegImagePlugin.py
@@ -16,6 +16,8 @@
 
 from PIL import Image, ImageFile
 from PIL._binary import i8
+from .exceptions import InvalidFileType
+
 
 __version__ = "0.1"
 
@@ -65,11 +67,10 @@ class MpegImageFile(ImageFile.ImageFile):
     format_description = "MPEG"
 
     def _open(self):
-
         s = BitStream(self.fp)
 
         if s.read(32) != 0x1B3:
-            raise SyntaxError("not an MPEG file")
+            raise InvalidFileType("not an MPEG file")
 
         self.mode = "RGB"
         self.size = s.read(12), s.read(12)

--- a/PIL/MspImagePlugin.py
+++ b/PIL/MspImagePlugin.py
@@ -18,6 +18,8 @@
 
 
 from PIL import Image, ImageFile, _binary
+from .exceptions import InvalidFileType, PILReadError
+
 
 __version__ = "0.1"
 
@@ -46,14 +48,14 @@ class MspImageFile(ImageFile.ImageFile):
         # Header
         s = self.fp.read(32)
         if s[:4] not in [b"DanM", b"LinS"]:
-            raise SyntaxError("not an MSP file")
+            raise InvalidFileType("not an MSP file")
 
         # Header checksum
         checksum = 0
         for i in range(0, 32, 2):
             checksum = checksum ^ i16(s[i:i+2])
         if checksum != 0:
-            raise SyntaxError("bad MSP checksum")
+            raise PILReadError("bad MSP checksum")
 
         self.mode = "1"
         self.size = i16(s[4:]), i16(s[6:])

--- a/PIL/PaletteFile.py
+++ b/PIL/PaletteFile.py
@@ -14,6 +14,7 @@
 #
 
 from PIL._binary import o8
+from .exceptions import InvalidFileType
 
 
 ##
@@ -24,11 +25,9 @@ class PaletteFile(object):
     rawmode = "RGB"
 
     def __init__(self, fp):
-
         self.palette = [(i, i, i) for i in range(256)]
 
         while True:
-
             s = fp.readline()
 
             if not s:
@@ -36,7 +35,7 @@ class PaletteFile(object):
             if s[0:1] == b"#":
                 continue
             if len(s) > 100:
-                raise SyntaxError("bad palette file")
+                raise PILReadError("bad palette file")
 
             v = [int(x) for x in s.split()]
             try:

--- a/PIL/PcdImagePlugin.py
+++ b/PIL/PcdImagePlugin.py
@@ -14,8 +14,9 @@
 # See the README file for information on usage and redistribution.
 #
 
-
 from PIL import Image, ImageFile, _binary
+from .exceptions import InvalidFileType
+
 
 __version__ = "0.1"
 
@@ -39,7 +40,7 @@ class PcdImageFile(ImageFile.ImageFile):
         s = self.fp.read(2048)
 
         if s[:4] != b"PCD_":
-            raise SyntaxError("not a PCD file")
+            raise InvalidFileType("not a PCD file")
 
         orientation = i8(s[1538]) & 3
         self.tile_post_rotate = None

--- a/PIL/PcfFontFile.py
+++ b/PIL/PcfFontFile.py
@@ -16,9 +16,9 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image
-from PIL import FontFile
-from PIL import _binary
+from PIL import FontFile, Image, _binary
+from .exceptions import InvalidFileType, PILReadError
+
 
 # --------------------------------------------------------------------
 # declarations
@@ -64,7 +64,7 @@ class PcfFontFile(FontFile.FontFile):
 
         magic = l32(fp.read(4))
         if magic != PCF_MAGIC:
-            raise SyntaxError("not a PCF file")
+            raise InvalidFileType("not a PCF file")
 
         FontFile.FontFile.__init__(self)
 
@@ -194,7 +194,7 @@ class PcfFontFile(FontFile.FontFile):
         nbitmaps = i32(fp.read(4))
 
         if nbitmaps != len(metrics):
-            raise IOError("Wrong number of bitmaps")
+            raise PILReadError("Wrong number of bitmaps")
 
         offsets = []
         for i in range(nbitmaps):

--- a/PIL/PcxImagePlugin.py
+++ b/PIL/PcxImagePlugin.py
@@ -29,6 +29,8 @@ from __future__ import print_function
 
 import logging
 from PIL import Image, ImageFile, ImagePalette, _binary
+from .exceptions import InvalidFileType, PILReadError
+
 
 logger = logging.getLogger(__name__)
 
@@ -56,12 +58,12 @@ class PcxImageFile(ImageFile.ImageFile):
         # header
         s = self.fp.read(128)
         if not _accept(s):
-            raise SyntaxError("not a PCX file")
+            raise InvalidFileType("not a PCX file")
 
         # image
         bbox = i16(s, 4), i16(s, 6), i16(s, 8)+1, i16(s, 10)+1
         if bbox[2] <= bbox[0] or bbox[3] <= bbox[1]:
-            raise SyntaxError("bad PCX image size")
+            raise PILReadError("bad PCX image size")
         logger.debug("BBox: %s %s %s %s", *bbox)
 
         # format

--- a/PIL/PcxImagePlugin.py
+++ b/PIL/PcxImagePlugin.py
@@ -25,8 +25,6 @@
 # See the README file for information on usage and redistribution.
 #
 
-from __future__ import print_function
-
 import logging
 from PIL import Image, ImageFile, ImagePalette, _binary
 from .exceptions import InvalidFileType, PILReadError
@@ -54,7 +52,6 @@ class PcxImageFile(ImageFile.ImageFile):
     format_description = "Paintbrush"
 
     def _open(self):
-
         # header
         s = self.fp.read(128)
         if not _accept(s):

--- a/PIL/PixarImagePlugin.py
+++ b/PIL/PixarImagePlugin.py
@@ -20,6 +20,8 @@
 #
 
 from PIL import Image, ImageFile, _binary
+from .exceptions import InvalidFileType
+
 
 __version__ = "0.1"
 
@@ -46,7 +48,7 @@ class PixarImageFile(ImageFile.ImageFile):
         # assuming a 4-byte magic label
         s = self.fp.read(4)
         if s != b"\200\350\000\000":
-            raise SyntaxError("not a PIXAR file")
+            raise InvalidFileType("not a PIXAR file")
 
         # read rest of header
         s = s + self.fp.read(508)

--- a/PIL/PngImagePlugin.py
+++ b/PIL/PngImagePlugin.py
@@ -31,8 +31,6 @@
 # See the README file for information on usage and redistribution.
 #
 
-from __future__ import print_function
-
 import logging
 import re
 import zlib

--- a/PIL/PngImagePlugin.py
+++ b/PIL/PngImagePlugin.py
@@ -37,8 +37,9 @@ import logging
 import re
 import zlib
 import struct
-
 from PIL import Image, ImageFile, ImagePalette, _binary
+from .exceptions import InvalidFileType, PILReadError
+
 
 __version__ = "0.9"
 
@@ -118,7 +119,7 @@ class ChunkStream(object):
             length = i32(s)
 
         if not is_cid(cid):
-            raise SyntaxError("broken PNG file (chunk %s)" % repr(cid))
+            raise PILReadError("broken PNG file (chunk %s)" % repr(cid))
 
         return cid, pos, length
 
@@ -148,11 +149,9 @@ class ChunkStream(object):
             crc1 = Image.core.crc32(data, Image.core.crc32(cid))
             crc2 = i16(self.fp.read(2)), i16(self.fp.read(2))
             if crc1 != crc2:
-                raise SyntaxError("broken PNG file (bad header checksum in %r)"
-                                  % cid)
+                raise PILReadError("Bad header checksum in %r)" % (cid))
         except struct.error:
-            raise SyntaxError("broken PNG file (incomplete checksum in %r)"
-                              % cid)
+            raise PILReadError("Incomplete checksum in %r" % (cid))
 
     def crc_skip(self, cid, data):
         "Read checksum.  Used if the C module is not present"
@@ -313,8 +312,7 @@ class PngStream(ChunkStream):
         logger.debug("Compression method %s", i8(s[i]))
         comp_method = i8(s[i])
         if comp_method != 0:
-            raise SyntaxError("Unknown compression method %s in iCCP chunk" %
-                              comp_method)
+            raise PILReadError("Unknown compression method %s" % (comp_method))()
         try:
             icc_profile = _safe_zlib_decompress(s[i+2:])
         except ValueError:
@@ -339,7 +337,7 @@ class PngStream(ChunkStream):
         if i8(s[12]):
             self.im_info["interlace"] = 1
         if i8(s[11]):
-            raise SyntaxError("unknown filter category")
+            raise PILReadError("unknown filter category")
         return s
 
     def chunk_IDAT(self, pos, length):
@@ -437,7 +435,7 @@ class PngStream(ChunkStream):
         else:
             comp_method = 0
         if comp_method != 0:
-            raise SyntaxError("Unknown compression method %s in zTXt chunk" %
+            raise PILReadError("Unknown compression method %s in zTXt chunk" %
                               comp_method)
         try:
             v = _safe_zlib_decompress(v[1:])
@@ -520,7 +518,7 @@ class PngImageFile(ImageFile.ImageFile):
     def _open(self):
 
         if self.fp.read(8) != _MAGIC:
-            raise SyntaxError("not a PNG file")
+            raise InvalidFileType("not a PNG file")
 
         #
         # Parse headers up to the first IDAT chunk

--- a/PIL/PsdImagePlugin.py
+++ b/PIL/PsdImagePlugin.py
@@ -16,9 +16,11 @@
 # See the README file for information on usage and redistribution.
 #
 
-__version__ = "0.4"
-
 from PIL import Image, ImageFile, ImagePalette, _binary
+from .exceptions import InvalidFileType, PILReadError
+
+
+__version__ = "0.4"
 
 MODES = {
     # (photoshop mode, bits) -> (pil mode, required channels)
@@ -57,7 +59,6 @@ class PsdImageFile(ImageFile.ImageFile):
     format_description = "Adobe Photoshop"
 
     def _open(self):
-
         read = self.fp.read
 
         #
@@ -65,7 +66,7 @@ class PsdImageFile(ImageFile.ImageFile):
 
         s = read(26)
         if s[:4] != b"8BPS" or i16(s[4:]) != 1:
-            raise SyntaxError("not a PSD file")
+            raise InvalidFileType("not a PSD file")
 
         psd_bits = i16(s[22:])
         psd_channels = i16(s[12:])
@@ -74,7 +75,7 @@ class PsdImageFile(ImageFile.ImageFile):
         mode, channels = MODES[(psd_mode, psd_bits)]
 
         if channels > psd_channels:
-            raise IOError("not enough channels")
+            raise PILReadError("not enough channels")
 
         self.mode = mode
         self.size = i32(s[18:]), i32(s[14:])

--- a/PIL/PyAccess.py
+++ b/PIL/PyAccess.py
@@ -20,11 +20,8 @@
 #      Access.c implementation.
 #
 
-from __future__ import print_function
-
 import logging
 import sys
-
 from cffi import FFI
 
 

--- a/PIL/SpiderImagePlugin.py
+++ b/PIL/SpiderImagePlugin.py
@@ -39,6 +39,7 @@ from PIL import Image, ImageFile
 import os
 import struct
 import sys
+from .exceptions import InvalidFileType, PILReadError
 
 
 def isInt(f):
@@ -113,14 +114,14 @@ class SpiderImageFile(ImageFile.ImageFile):
                 t = struct.unpack('<27f', f)  # little-endian
                 hdrlen = isSpiderHeader(t)
             if hdrlen == 0:
-                raise SyntaxError("not a valid Spider file")
+                raise InvalidFileType("not a valid Spider file")
         except struct.error:
-            raise SyntaxError("not a valid Spider file")
+            raise InvalidFileType("not a valid Spider file")
 
         h = (99,) + t   # add 1 value : spider header index starts at 1
         iform = int(h[5])
         if iform != 1:
-            raise SyntaxError("not a Spider 2D image")
+            raise InvalidFileType("not a Spider 2D image")
 
         self.size = int(h[12]), int(h[2])  # size in pixels (width, height)
         self.istack = int(h[24])
@@ -143,7 +144,7 @@ class SpiderImageFile(ImageFile.ImageFile):
             offset = hdrlen + self.stkoffset
             self.istack = 2  # So Image knows it's still a stack
         else:
-            raise SyntaxError("inconsistent stack header values")
+            raise PILReadError("inconsistent stack header values")
 
         if self.bigendian:
             self.rawmode = "F;32BF"

--- a/PIL/SpiderImagePlugin.py
+++ b/PIL/SpiderImagePlugin.py
@@ -14,12 +14,6 @@
 # Copyright (c) 2004 by Fredrik Lundh.
 #
 
-##
-# Image plugin for the Spider image format.  This format is is used
-# by the SPIDER software, in processing image data from electron
-# microscopy and tomography.
-##
-
 #
 # SpiderImagePlugin.py
 #
@@ -32,8 +26,6 @@
 # Details about the Spider image format:
 # http://spider.wadsworth.org/spider_doc/spider/docs/image_doc.html
 #
-
-from __future__ import print_function
 
 from PIL import Image, ImageFile
 import os
@@ -76,9 +68,9 @@ def isSpiderHeader(t):
     labrec = int(h[13])   # no. records in file header
     labbyt = int(h[22])   # total no. of bytes in header
     lenbyt = int(h[23])   # record length in bytes
-    # print("labrec = %d, labbyt = %d, lenbyt = %d" % (labrec,labbyt,lenbyt))
     if labbyt != (labrec * lenbyt):
         return 0
+
     # looks like a valid header
     return labbyt
 
@@ -197,30 +189,6 @@ class SpiderImageFile(ImageFile.ImageFile):
         return ImageTk.PhotoImage(self.convert2byte(), palette=256)
 
 
-# --------------------------------------------------------------------
-# Image series
-
-# given a list of filenames, return a list of images
-def loadImageSeries(filelist=None):
-    " create a list of Image.images for use in montage "
-    if filelist is None or len(filelist) < 1:
-        return
-
-    imglist = []
-    for img in filelist:
-        if not os.path.exists(img):
-            print("unable to find %s" % img)
-            continue
-        try:
-            im = Image.open(img).convert2byte()
-        except:
-            if not isSpiderImage(img):
-                print(img + " is not a Spider image file")
-            continue
-        im.info['filename'] = img
-        imglist.append(im)
-    return imglist
-
 
 # --------------------------------------------------------------------
 # For saving images in Spider format
@@ -290,34 +258,3 @@ def _save_spider(im, fp, filename):
 
 Image.register_open(SpiderImageFile.format, SpiderImageFile)
 Image.register_save(SpiderImageFile.format, _save_spider)
-
-if __name__ == "__main__":
-
-    if not sys.argv[1:]:
-        print("Syntax: python SpiderImagePlugin.py [infile] [outfile]")
-        sys.exit()
-
-    filename = sys.argv[1]
-    if not isSpiderImage(filename):
-        print("input image must be in Spider format")
-        sys.exit()
-
-    outfile = ""
-    if len(sys.argv[1:]) > 1:
-        outfile = sys.argv[2]
-
-    im = Image.open(filename)
-    print("image: " + str(im))
-    print("format: " + str(im.format))
-    print("size: " + str(im.size))
-    print("mode: " + str(im.mode))
-    print("max, min: ", end=' ')
-    print(im.getextrema())
-
-    if outfile != "":
-        # perform some image operation
-        im = im.transpose(Image.FLIP_LEFT_RIGHT)
-        print(
-            "saving a flipped version of %s as %s " %
-            (os.path.basename(filename), outfile))
-        im.save(outfile, SpiderImageFile.format)

--- a/PIL/SunImagePlugin.py
+++ b/PIL/SunImagePlugin.py
@@ -16,8 +16,9 @@
 # See the README file for information on usage and redistribution.
 #
 
-
 from PIL import Image, ImageFile, ImagePalette, _binary
+from .exceptions import InvalidFileType
+
 
 __version__ = "0.3"
 
@@ -56,18 +57,18 @@ class SunImageFile(ImageFile.ImageFile):
         # HEAD
         s = self.fp.read(32)
         if i32(s) != 0x59a66a95:
-            raise SyntaxError("not an SUN raster file")
+            raise InvalidFileType("not a SUN raster file")
 
         offset = 32
 
         self.size = i32(s[4:8]), i32(s[8:12])
 
         depth = i32(s[12:16])
-        data_length = i32(s[16:20])  # unreliable, ignore. 
+        data_length = i32(s[16:20])  # unreliable, ignore.
         file_type = i32(s[20:24])
         palette_type = i32(s[24:28]) # 0: None, 1: RGB, 2: Raw/arbitrary
         palette_length = i32(s[28:32])
-        
+
         if depth == 1:
             self.mode, rawmode = "1", "1;I"
         elif depth == 4:
@@ -85,23 +86,23 @@ class SunImageFile(ImageFile.ImageFile):
             else:
                 self.mode, rawmode = 'RGB', 'BGRX'
         else:
-            raise SyntaxError("Unsupported Mode/Bit Depth")    
-        
+            raise NotImplementedError("Unsupported Mode/Bit Depth")
+
         if palette_length:
             if palette_length > 1024:
-                raise SyntaxError("Unsupported Color Palette Length")
+                raise NotImplementedError("Unsupported Color Palette Length")
 
             if palette_type != 1:
-                raise SyntaxError("Unsupported Palette Type")
-            
+                raise NotImplementedError("Unsupported Palette Type")
+
             offset = offset + palette_length
             self.palette = ImagePalette.raw("RGB;L", self.fp.read(palette_length))
             if self.mode == "L":
                 self.mode = "P"
                 rawmode = rawmode.replace('L', 'P')
-            
+
         # 16 bit boundaries on stride
-        stride = ((self.size[0] * depth + 15) // 16) * 2  
+        stride = ((self.size[0] * depth + 15) // 16) * 2
 
         # file type: Type is the version (or flavor) of the bitmap
         # file. The following values are typically found in the Type
@@ -126,8 +127,9 @@ class SunImageFile(ImageFile.ImageFile):
         elif file_type == 2:
             self.tile = [("sun_rle", (0, 0)+self.size, offset, rawmode)]
         else:
-            raise SyntaxError('Unsupported Sun Raster file type')
-        
+            raise NotImplementedError('Unsupported Sun Raster file type')
+
+
 #
 # registry
 

--- a/PIL/TgaImagePlugin.py
+++ b/PIL/TgaImagePlugin.py
@@ -16,8 +16,9 @@
 # See the README file for information on usage and redistribution.
 #
 
-
 from PIL import Image, ImageFile, ImagePalette, _binary
+from .exceptions import InvalidFileType, PILReadError, PILWriteError
+
 
 __version__ = "0.3"
 
@@ -69,7 +70,7 @@ class TgaImageFile(ImageFile.ImageFile):
         if colormaptype not in (0, 1) or\
            self.size[0] <= 0 or self.size[1] <= 0 or\
            depth not in (1, 8, 16, 24, 32):
-            raise SyntaxError("not a TGA file")
+            raise InvalidFileType("not a TGA file")
 
         # image mode
         if imagetype in (3, 11):
@@ -83,7 +84,7 @@ class TgaImageFile(ImageFile.ImageFile):
             if depth == 32:
                 self.mode = "RGBA"
         else:
-            raise SyntaxError("unknown TGA mode")
+            raise PILReadError("unknown TGA mode")
 
         # orientation
         orientation = flags & 0x30
@@ -92,7 +93,7 @@ class TgaImageFile(ImageFile.ImageFile):
         elif not orientation:
             orientation = -1
         else:
-            raise SyntaxError("unknown TGA orientation")
+            raise PILReadError("unknown TGA orientation")
 
         self.info["orientation"] = orientation
 
@@ -150,7 +151,7 @@ def _save(im, fp, filename, check=0):
     try:
         rawmode, bits, colormaptype, imagetype = SAVE[im.mode]
     except KeyError:
-        raise IOError("cannot write mode %s as TGA" % im.mode)
+        raise PILWriteError("cannot write mode %s as TGA" % im.mode)
 
     if check:
         return check

--- a/PIL/WalImageFile.py
+++ b/PIL/WalImageFile.py
@@ -21,8 +21,6 @@
 #    http://www.flipcode.com/archives/Quake_2_BSP_File_Format.shtml
 # and has been tested with a few sample files found using google.
 
-from __future__ import print_function
-
 from PIL import Image, _binary
 
 try:

--- a/PIL/WmfImagePlugin.py
+++ b/PIL/WmfImagePlugin.py
@@ -19,8 +19,6 @@
 # http://wvware.sourceforge.net/caolan/index.html
 # http://wvware.sourceforge.net/caolan/ora-wmf.html
 
-from __future__ import print_function
-
 from PIL import Image, ImageFile, _binary
 from .exceptions import InvalidFileType
 
@@ -111,8 +109,6 @@ class WmfStubImageFile(ImageFile.StubImageFile):
             self.info["wmf_bbox"] = x0, y0, x1, y1
 
             self.info["dpi"] = 72
-
-            # print(self.mode, self.size, self.info)
 
             # sanity check (standard metafile header)
             if s[22:26] != b"\x01\x00\t\x00":

--- a/PIL/WmfImagePlugin.py
+++ b/PIL/WmfImagePlugin.py
@@ -22,6 +22,8 @@
 from __future__ import print_function
 
 from PIL import Image, ImageFile, _binary
+from .exceptions import InvalidFileType
+
 
 __version__ = "0.2"
 
@@ -114,7 +116,7 @@ class WmfStubImageFile(ImageFile.StubImageFile):
 
             # sanity check (standard metafile header)
             if s[22:26] != b"\x01\x00\t\x00":
-                raise SyntaxError("Unsupported WMF file format")
+                raise NotImplementedError("Unsupported WMF file format")
 
         elif dword(s) == 1 and s[40:44] == b" EMF":
             # enhanced metafile
@@ -143,7 +145,7 @@ class WmfStubImageFile(ImageFile.StubImageFile):
                 self.info["dpi"] = xdpi, ydpi
 
         else:
-            raise SyntaxError("Unsupported file format")
+            raise InvalidFileType("Not a WMF file")
 
         self.mode = "RGB"
         self.size = size

--- a/PIL/XVThumbImagePlugin.py
+++ b/PIL/XVThumbImagePlugin.py
@@ -18,6 +18,8 @@
 #
 
 from PIL import Image, ImageFile, ImagePalette, _binary
+from .exceptions import InvalidFileType, PILReadError
+
 
 __version__ = "0.1"
 
@@ -46,10 +48,9 @@ class XVThumbImageFile(ImageFile.ImageFile):
     format_description = "XV thumbnail image"
 
     def _open(self):
-
         # check magic
         if self.fp.read(6) != _MAGIC:
-            raise SyntaxError("not an XV thumbnail file")
+            raise InvalidFileType("not an XV thumbnail file")
 
         # Skip to beginning of next line
         self.fp.readline()
@@ -58,7 +59,7 @@ class XVThumbImageFile(ImageFile.ImageFile):
         while True:
             s = self.fp.readline()
             if not s:
-                raise SyntaxError("Unexpected EOF reading XV thumbnail file")
+                raise PILReadError("Unexpected EOF reading XV thumbnail file")
             if s[0] != b'#':
                 break
 

--- a/PIL/XpmImagePlugin.py
+++ b/PIL/XpmImagePlugin.py
@@ -18,6 +18,8 @@
 import re
 from PIL import Image, ImageFile, ImagePalette
 from PIL._binary import i8, o8
+from .exceptions import InvalidFileType, PILReadError
+
 
 __version__ = "0.2"
 
@@ -40,13 +42,13 @@ class XpmImageFile(ImageFile.ImageFile):
     def _open(self):
 
         if not _accept(self.fp.read(9)):
-            raise SyntaxError("not an XPM file")
+            raise InvalidFileType("not an XPM file")
 
         # skip forward to next string
         while True:
             s = self.fp.readline()
             if not s:
-                raise SyntaxError("broken XPM file")
+                raise PILReadError("broken XPM file")
             m = xpm_head.match(s)
             if m:
                 break

--- a/PIL/exceptions.py
+++ b/PIL/exceptions.py
@@ -1,0 +1,37 @@
+"""
+PIL Exceptions
+"""
+
+
+class PILError(Exception):
+    """
+    Base exception for all PIL exceptions
+    """
+    pass
+
+
+class PILReadError(PILError):
+    """
+    Some error happened while reading a file.
+    """
+    pass
+
+
+class InvalidFileType(PILReadError):
+    """
+    The given file is not of the expected type.
+    """
+
+
+class NoPluginFound(PILError):
+    """
+    No plugin was found for the given format.
+    """
+    pass
+
+
+class PILWriteError(PILError):
+    """
+    Some error happened while writing a file.
+    """
+    pass

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -1,12 +1,10 @@
 """
 Helper functions.
 """
-from __future__ import print_function
+import os
 import sys
 import tempfile
-import os
 import unittest
-
 from PIL import Image, ImageMath
 
 

--- a/Tests/import_all.py
+++ b/Tests/import_all.py
@@ -7,6 +7,7 @@ import traceback
 import sys
 sys.path.insert(0, ".")
 
+
 for file in glob.glob("PIL/*.py"):
     module = os.path.basename(file)[:-3]
     try:

--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -1,8 +1,7 @@
-from __future__ import print_function
+import os
+from PIL import Image
 from helper import unittest, PillowTestCase
 
-from PIL import Image
-import os
 
 base = os.path.join('Tests', 'images', 'bmp')
 
@@ -22,7 +21,6 @@ class TestBmpReference(PillowTestCase):
                 im.load()
             except Exception:  # as msg:
                 pass
-                # print("Bad Image %s: %s" %(f,msg))
 
     def test_questionable(self):
         """ These shouldn't crash/dos, but it's not well defined that these
@@ -47,7 +45,6 @@ class TestBmpReference(PillowTestCase):
             except Exception:  # as msg:
                 if os.path.basename(f) in supported:
                     raise
-                # print("Bad Image %s: %s" %(f,msg))
 
     def test_good(self):
         """ These should all work. There's a set of target files in the

--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -1,7 +1,7 @@
-from helper import unittest, PillowTestCase, hopper
-
-from PIL import Image, BmpImagePlugin
 import io
+from PIL import Image, BmpImagePlugin
+from PIL.exceptions import InvalidFileType
+from helper import unittest, PillowTestCase, hopper
 
 
 class TestFileBmp(PillowTestCase):
@@ -27,7 +27,7 @@ class TestFileBmp(PillowTestCase):
 
     def test_invalid_file(self):
         with open("Tests/images/flower.jpg", "rb") as fp:
-            self.assertRaises(SyntaxError,
+            self.assertRaises(InvalidFileType,
                               lambda: BmpImagePlugin.BmpImageFile(fp))
 
     def test_save_to_bytes(self):

--- a/Tests/test_file_bufrstub.py
+++ b/Tests/test_file_bufrstub.py
@@ -1,6 +1,6 @@
-from helper import unittest, PillowTestCase
-
 from PIL import BufrStubImagePlugin
+from PIL.exceptions import InvalidFileType
+from helper import unittest, PillowTestCase
 
 
 class TestFileBufrStub(PillowTestCase):
@@ -8,7 +8,7 @@ class TestFileBufrStub(PillowTestCase):
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda:
                           BufrStubImagePlugin.BufrStubImageFile(invalid_file))
 

--- a/Tests/test_file_cur.py
+++ b/Tests/test_file_cur.py
@@ -1,6 +1,7 @@
+from PIL import Image, CurImagePlugin
+from PIL.exceptions import InvalidFileType
 from helper import unittest, PillowTestCase
 
-from PIL import Image, CurImagePlugin
 
 TEST_FILE = "Tests/images/deerstalker.cur"
 
@@ -20,7 +21,7 @@ class TestFileCur(PillowTestCase):
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda: CurImagePlugin.CurImageFile(invalid_file))
 
         no_cursors_file = "Tests/images/no_cursors.cur"

--- a/Tests/test_file_dcx.py
+++ b/Tests/test_file_dcx.py
@@ -1,6 +1,8 @@
 from helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, DcxImagePlugin
+from PIL.exceptions import InvalidFileType
+
 
 # Created with ImageMagick: convert hopper.ppm hopper.dcx
 TEST_FILE = "Tests/images/hopper.dcx"
@@ -22,7 +24,7 @@ class TestFileDcx(PillowTestCase):
 
     def test_invalid_file(self):
         with open("Tests/images/flower.jpg", "rb") as fp:
-            self.assertRaises(SyntaxError,
+            self.assertRaises(InvalidFileType,
                               lambda: DcxImagePlugin.DcxImageFile(fp))
 
     def test_tell(self):

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -1,7 +1,8 @@
+import io
+from PIL import Image, EpsImagePlugin
+from PIL.exceptions import InvalidFileType
 from helper import unittest, PillowTestCase
 
-from PIL import Image, EpsImagePlugin
-import io
 
 # Our two EPS test files (they are identical except for their bounding boxes)
 file1 = "Tests/images/zero_bb.eps"
@@ -54,7 +55,7 @@ class TestFileEps(PillowTestCase):
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda: EpsImagePlugin.EpsImageFile(invalid_file))
 
     def test_cmyk(self):

--- a/Tests/test_file_fitsstub.py
+++ b/Tests/test_file_fitsstub.py
@@ -1,6 +1,7 @@
 from helper import unittest, PillowTestCase
 
 from PIL import FitsStubImagePlugin
+from PIL.exceptions import InvalidFileType
 
 
 class TestFileFitsStub(PillowTestCase):
@@ -8,7 +9,7 @@ class TestFileFitsStub(PillowTestCase):
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda:
                           FitsStubImagePlugin.FITSStubImageFile(invalid_file))
 

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -1,6 +1,7 @@
+from PIL import Image, FliImagePlugin
+from PIL.exceptions import InvalidFileType
 from helper import unittest, PillowTestCase
 
-from PIL import Image, FliImagePlugin
 
 # sample ppm stream
 # created as an export of a palette image from Gimp2.6
@@ -20,7 +21,7 @@ class TestFileFli(PillowTestCase):
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda: FliImagePlugin.FliImageFile(invalid_file))
 
     def test_n_frames(self):

--- a/Tests/test_file_fpx.py
+++ b/Tests/test_file_fpx.py
@@ -1,6 +1,6 @@
-from helper import unittest, PillowTestCase
-
 from PIL import FpxImagePlugin
+from PIL.exceptions import InvalidFileType
+from helper import unittest, PillowTestCase
 
 
 class TestFileFpx(PillowTestCase):
@@ -8,12 +8,12 @@ class TestFileFpx(PillowTestCase):
     def test_invalid_file(self):
         # Test an invalid OLE file
         invalid_file = "Tests/images/flower.jpg"
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda: FpxImagePlugin.FpxImageFile(invalid_file))
 
         # Test a valid OLE file, but not an FPX file
         ole_file = "Tests/images/test-ole-file.doc"
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda: FpxImagePlugin.FpxImageFile(ole_file))
 
 

--- a/Tests/test_file_gbr.py
+++ b/Tests/test_file_gbr.py
@@ -1,14 +1,14 @@
-from helper import unittest, PillowTestCase
-
 from PIL import Image, GbrImagePlugin
+from PIL.exceptions import InvalidFileType
+from helper import unittest, PillowTestCase
 
 
 class TestFileGbr(PillowTestCase):
 
     def test_invalid_file(self):
-        invalid_file = "Tests/images/flower.jpg"
+        invalid_file = "Tests/images/no_cursors.cur"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda: GbrImagePlugin.GbrImageFile(invalid_file))
 
     def test_gbr_file(self):

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1,9 +1,8 @@
+from io import BytesIO
+from PIL import Image, GifImagePlugin
+from PIL.exceptions import InvalidFileType
 from helper import unittest, PillowTestCase, hopper, netpbm_available
 
-from PIL import Image
-from PIL import GifImagePlugin
-
-from io import BytesIO
 
 codecs = dir(Image.core)
 
@@ -31,7 +30,7 @@ class TestFileGif(PillowTestCase):
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda: GifImagePlugin.GifImageFile(invalid_file))
 
     def test_optimize(self):
@@ -56,7 +55,7 @@ class TestFileGif(PillowTestCase):
         # 256 color Palette image, posterize to > 128 and < 128 levels
         # Size bigger and smaller than 512x512
         # Check the palette for number of colors allocated.
-        # Check for correctness after conversion back to RGB        
+        # Check for correctness after conversion back to RGB
         def check(colors, size, expected_palette_length):
             # make an image with empty colors in the start of the palette range
             im = Image.frombytes('P', (colors,colors),
@@ -70,7 +69,7 @@ class TestFileGif(PillowTestCase):
             # check palette length
             palette_length = max(i+1 for i,v in enumerate(reloaded.histogram()) if v)
             self.assertEqual(expected_palette_length, palette_length)
-            
+
             self.assert_image_equal(im.convert('RGB'), reloaded.convert('RGB'))
 
 
@@ -427,7 +426,7 @@ class TestFileGif(PillowTestCase):
         reloaded = Image.open(out)
 
         self.assertEqual(reloaded.info['transparency'], 253)
-        
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_file_gimppalette.py
+++ b/Tests/test_file_gimppalette.py
@@ -1,6 +1,7 @@
 from helper import unittest, PillowTestCase
 
 from PIL.GimpPaletteFile import GimpPaletteFile
+from PIL.exceptions import InvalidFileType, PILReadError
 
 
 class TestImage(PillowTestCase):
@@ -10,13 +11,13 @@ class TestImage(PillowTestCase):
             GimpPaletteFile(fp)
 
         with open('Tests/images/hopper.jpg', 'rb') as fp:
-            self.assertRaises(SyntaxError, lambda: GimpPaletteFile(fp))
+            self.assertRaises(InvalidFileType, lambda: GimpPaletteFile(fp))
 
         with open('Tests/images/bad_palette_file.gpl', 'rb') as fp:
-            self.assertRaises(SyntaxError, lambda: GimpPaletteFile(fp))
+            self.assertRaises(PILReadError, lambda: GimpPaletteFile(fp))
 
         with open('Tests/images/bad_palette_entry.gpl', 'rb') as fp:
-            self.assertRaises(ValueError, lambda: GimpPaletteFile(fp))
+            self.assertRaises(PILReadError, lambda: GimpPaletteFile(fp))
 
     def test_get_palette(self):
         # Arrange

--- a/Tests/test_file_gribstub.py
+++ b/Tests/test_file_gribstub.py
@@ -1,6 +1,6 @@
-from helper import unittest, PillowTestCase
-
 from PIL import GribStubImagePlugin
+from PIL.exceptions import InvalidFileType
+from helper import unittest, PillowTestCase
 
 
 class TestFileGribStub(PillowTestCase):
@@ -8,7 +8,7 @@ class TestFileGribStub(PillowTestCase):
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda:
                           GribStubImagePlugin.GribStubImageFile(invalid_file))
 

--- a/Tests/test_file_hdf5stub.py
+++ b/Tests/test_file_hdf5stub.py
@@ -1,6 +1,6 @@
-from helper import unittest, PillowTestCase
-
 from PIL import Hdf5StubImagePlugin
+from PIL.exceptions import InvalidFileType
+from helper import unittest, PillowTestCase
 
 
 class TestFileHdf5Stub(PillowTestCase):
@@ -8,7 +8,7 @@ class TestFileHdf5Stub(PillowTestCase):
     def test_invalid_file(self):
         test_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda:
                           Hdf5StubImagePlugin.HDF5StubImageFile(test_file))
 

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -1,7 +1,8 @@
-from helper import unittest, PillowTestCase, hopper
-
 import io
 from PIL import Image, IcoImagePlugin
+from PIL.exceptions import InvalidFileType
+from helper import unittest, PillowTestCase, hopper
+
 
 # sample ppm stream
 TEST_ICO_FILE = "Tests/images/hopper.ico"
@@ -18,7 +19,7 @@ class TestFileIco(PillowTestCase):
 
     def test_invalid_file(self):
         with open("Tests/images/flower.jpg", "rb") as fp:
-            self.assertRaises(SyntaxError,
+            self.assertRaises(InvalidFileType,
                               lambda: IcoImagePlugin.IcoImageFile(fp))
 
     def test_save_to_bytes(self):

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -1,6 +1,8 @@
 from helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, ImImagePlugin
+from PIL.exceptions import InvalidFileType
+
 
 # sample im
 TEST_IM = "Tests/images/hopper.im"
@@ -43,7 +45,7 @@ class TestFileIm(PillowTestCase):
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda: ImImagePlugin.ImImageFile(invalid_file))
 
 

--- a/Tests/test_file_iptc.py
+++ b/Tests/test_file_iptc.py
@@ -39,27 +39,6 @@ class TestFileIptc(PillowTestCase):
         # Assert
         self.assertEqual(ret, 97)
 
-    def test_dump(self):
-        # Arrange
-        c = b"abc"
-        # Temporarily redirect stdout
-        try:
-            from cStringIO import StringIO
-        except ImportError:
-            from io import StringIO
-        import sys
-        old_stdout = sys.stdout
-        sys.stdout = mystdout = StringIO()
-
-        # Act
-        IptcImagePlugin.dump(c)
-
-        # Reset stdout
-        sys.stdout = old_stdout
-
-        # Assert
-        self.assertEqual(mystdout.getvalue(), "61 62 63 \n")
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -1,7 +1,9 @@
 from helper import unittest, PillowTestCase
 
-from PIL import Image, Jpeg2KImagePlugin
 from io import BytesIO
+from PIL import Image, Jpeg2KImagePlugin
+from PIL.exceptions import InvalidFileType
+
 
 codecs = dir(Image.core)
 
@@ -43,7 +45,7 @@ class TestFileJpeg2k(PillowTestCase):
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda:
                           Jpeg2KImagePlugin.Jpeg2KImageFile(invalid_file))
 

--- a/Tests/test_file_mcidas.py
+++ b/Tests/test_file_mcidas.py
@@ -1,6 +1,6 @@
-from helper import unittest, PillowTestCase
-
 from PIL import McIdasImagePlugin
+from PIL.exceptions import InvalidFileType
+from helper import unittest, PillowTestCase
 
 
 class TestFileMcIdas(PillowTestCase):
@@ -8,7 +8,7 @@ class TestFileMcIdas(PillowTestCase):
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda:
                           McIdasImagePlugin.McIdasImageFile(invalid_file))
 

--- a/Tests/test_file_mic.py
+++ b/Tests/test_file_mic.py
@@ -1,6 +1,7 @@
 from helper import unittest, PillowTestCase
 
 from PIL import MicImagePlugin
+from PIL.exceptions import PILReadError, InvalidFileType
 
 
 class TestFileMic(PillowTestCase):
@@ -8,12 +9,12 @@ class TestFileMic(PillowTestCase):
     def test_invalid_file(self):
         # Test an invalid OLE file
         invalid_file = "Tests/images/flower.jpg"
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda: MicImagePlugin.MicImageFile(invalid_file))
 
         # Test a valid OLE file, but not a MIC file
         ole_file = "Tests/images/test-ole-file.doc"
-        self.assertRaises(SyntaxError,
+        self.assertRaises(PILReadError,
                           lambda: MicImagePlugin.MicImageFile(ole_file))
 
 

--- a/Tests/test_file_msp.py
+++ b/Tests/test_file_msp.py
@@ -1,6 +1,7 @@
+from PIL import Image, MspImagePlugin
+from PIL.exceptions import InvalidFileType
 from helper import unittest, PillowTestCase, hopper
 
-from PIL import Image, MspImagePlugin
 
 TEST_FILE = "Tests/images/hopper.msp"
 
@@ -21,7 +22,7 @@ class TestFileMsp(PillowTestCase):
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda: MspImagePlugin.MspImageFile(invalid_file))
 
     def test_open(self):

--- a/Tests/test_file_pcx.py
+++ b/Tests/test_file_pcx.py
@@ -1,6 +1,7 @@
 from helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, ImageFile, PcxImagePlugin
+from PIL.exceptions import InvalidFileType
 
 
 class TestFilePcx(PillowTestCase):
@@ -22,7 +23,7 @@ class TestFilePcx(PillowTestCase):
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda: PcxImagePlugin.PcxImageFile(invalid_file))
 
     def test_odd(self):

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -1,11 +1,9 @@
+import zlib
+from io import BytesIO
+from PIL import Image, ImageFile, PngImagePlugin
+from PIL.exceptions import InvalidFileType, PILReadError
 from helper import unittest, PillowTestCase, hopper
 
-from io import BytesIO
-
-from PIL import Image
-from PIL import ImageFile
-from PIL import PngImagePlugin
-import zlib
 
 codecs = dir(Image.core)
 
@@ -84,7 +82,7 @@ class TestFilePng(PillowTestCase):
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda: PngImagePlugin.PngImageFile(invalid_file))
 
     def test_broken(self):
@@ -317,7 +315,7 @@ class TestFilePng(PillowTestCase):
 
             im = Image.open(BytesIO(test_file))
             self.assertTrue(im.fp is not None)
-            self.assertRaises((IOError, SyntaxError), im.verify)
+            self.assertRaises((IOError, PILReadError), im.verify)
 
     def test_verify_ignores_crc_error(self):
         # check ignores crc errors in ancillary chunks
@@ -326,7 +324,7 @@ class TestFilePng(PillowTestCase):
         broken_crc_chunk_data = chunk_data[:-1] + b'q'  # break CRC
 
         image_data = HEAD + broken_crc_chunk_data + TAIL
-        self.assertRaises(SyntaxError, PngImagePlugin.PngImageFile, BytesIO(image_data))
+        self.assertRaises(PILReadError, PngImagePlugin.PngImageFile, BytesIO(image_data))
 
         ImageFile.LOAD_TRUNCATED_IMAGES = True
         try:
@@ -342,7 +340,7 @@ class TestFilePng(PillowTestCase):
 
         ImageFile.LOAD_TRUNCATED_IMAGES = True
         try:
-            self.assertRaises(SyntaxError, PngImagePlugin.PngImageFile, BytesIO(image_data))
+            self.assertRaises(PILReadError, PngImagePlugin.PngImageFile, BytesIO(image_data))
         finally:
             ImageFile.LOAD_TRUNCATED_IMAGES = False
 

--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -1,6 +1,7 @@
 from helper import unittest, PillowTestCase
 
 from PIL import Image
+from PIL.exceptions import PILReadError
 
 # sample ppm stream
 test_file = "Tests/images/hopper.ppm"
@@ -40,15 +41,15 @@ class TestFilePpm(PillowTestCase):
         f.write('P6')
         f.close()
 
-        self.assertRaises(ValueError, lambda: Image.open(path))
+        self.assertRaises(IOError, lambda: Image.open(path))
 
 
     def test_neg_ppm(self):
         # Storage.c accepted negative values for xsize, ysize.  the
         # internal open_ppm function didn't check for sanity but it
         # has been removed. The default opener doesn't accept negative
-        # sizes. 
-        
+        # sizes.
+
         with self.assertRaises(IOError):
             Image.open('Tests/images/negative_size.ppm')
 

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -1,6 +1,8 @@
 from helper import unittest, PillowTestCase
 
 from PIL import Image, PsdImagePlugin
+from PIL.exceptions import InvalidFileType
+
 
 # sample ppm stream
 test_file = "Tests/images/hopper.psd"
@@ -18,7 +20,7 @@ class TestImagePsd(PillowTestCase):
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda: PsdImagePlugin.PsdImageFile(invalid_file))
 
     def test_n_frames(self):

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -48,29 +48,6 @@ class TestImageSpider(PillowTestCase):
         self.assertEqual(im.n_frames, 1)
         self.assertFalse(im.is_animated)
 
-    def test_loadImageSeries(self):
-        # Arrange
-        not_spider_file = "Tests/images/hopper.ppm"
-        file_list = [TEST_FILE, not_spider_file, "path/not_found.ext"]
-
-        # Act
-        img_list = SpiderImagePlugin.loadImageSeries(file_list)
-
-        # Assert
-        self.assertEqual(len(img_list), 1)
-        self.assertIsInstance(img_list[0], Image.Image)
-        self.assertEqual(img_list[0].size, (128, 128))
-
-    def test_loadImageSeries_no_input(self):
-        # Arrange
-        file_list = None
-
-        # Act
-        img_list = SpiderImagePlugin.loadImageSeries(file_list)
-
-        # Assert
-        self.assertEqual(img_list, None)
-
     def test_isInt_not_a_number(self):
         # Arrange
         not_a_number = "a"

--- a/Tests/test_file_sun.py
+++ b/Tests/test_file_sun.py
@@ -1,8 +1,8 @@
+import os
+from PIL import Image, SunImagePlugin
+from PIL.exceptions import InvalidFileType
 from helper import unittest, PillowTestCase, hopper
 
-from PIL import Image, SunImagePlugin
-
-import os
 
 EXTRA_DIR = 'Tests/images/sunraster'
 
@@ -20,9 +20,9 @@ class TestFileSun(PillowTestCase):
         self.assertEqual(im.size, (128, 128))
 
         self.assert_image_similar(im, hopper(), 5) # visually verified
-        
+
         invalid_file = "Tests/images/flower.jpg"
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda: SunImagePlugin.SunImageFile(invalid_file))
 
     def test_im1(self):
@@ -39,12 +39,12 @@ class TestFileSun(PillowTestCase):
                    in ('.sun', '.SUN', '.ras'))
         for path in files:
             with Image.open(path) as im:
-                im.load()  
+                im.load()
                 self.assertIsInstance(im, SunImagePlugin.SunImageFile)
                 target_path = "%s.png" % os.path.splitext(path)[0]
                 #im.save(target_file)
                 with Image.open(target_path) as target:
                     self.assert_image_equal(im, target)
-        
+
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_file_tga.py
+++ b/Tests/test_file_tga.py
@@ -1,7 +1,7 @@
 from helper import unittest, PillowTestCase
 
 from PIL import Image
-
+from PIL.exceptions import PILWriteError
 
 class TestFileTga(PillowTestCase):
 
@@ -42,7 +42,7 @@ class TestFileTga(PillowTestCase):
         self.assertEqual(test_im.size, (100, 100))
 
         # Unsupported mode save
-        self.assertRaises(IOError, lambda: im.convert("LA").save(test_file))
+        self.assertRaises(PILWriteError, lambda: im.convert("LA").save(test_file))
 
     def test_save_rle(self):
         test_file = "Tests/images/rgb32rle.tga"
@@ -61,7 +61,7 @@ class TestFileTga(PillowTestCase):
         self.assertEqual(test_im.size, (199, 199))
 
         # Unsupported mode save
-        self.assertRaises(IOError, lambda: im.convert("LA").save(test_file))
+        self.assertRaises(PILWriteError, lambda: im.convert("LA").save(test_file))
 
 
 if __name__ == '__main__':

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -1,11 +1,10 @@
-from __future__ import print_function
 import logging
-from io import BytesIO
 import struct
-
+from io import BytesIO
+from PIL import Image, TiffImagePlugin
+from PIL.exceptions import InvalidFileType
 from helper import unittest, PillowTestCase, hopper, py3
 
-from PIL import Image, TiffImagePlugin
 
 logger = logging.getLogger(__name__)
 
@@ -116,11 +115,11 @@ class TestFileTiff(PillowTestCase):
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda: TiffImagePlugin.TiffImageFile(invalid_file))
 
         TiffImagePlugin.PREFIXES.append(b"\xff\xd8\xff\xe0")
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda: TiffImagePlugin.TiffImageFile(invalid_file))
         TiffImagePlugin.PREFIXES.pop()
 
@@ -462,12 +461,12 @@ class TestFileTiff(PillowTestCase):
         # however does.
         im = Image.new('RGB', (1, 1))
         im.info['icc_profile'] = 'Dummy value'
-        
+
         # Try save-load round trip to make sure both handle icc_profile.
         tmpfile = self.tempfile('temp.tif')
         im.save(tmpfile, 'TIFF', compression='raw')
         reloaded = Image.open(tmpfile)
-        
+
         self.assertEqual(b'Dummy value', reloaded.info['icc_profile'])
 
 

--- a/Tests/test_file_xpm.py
+++ b/Tests/test_file_xpm.py
@@ -1,6 +1,7 @@
+from PIL import Image, XpmImagePlugin
+from PIL.exceptions import InvalidFileType
 from helper import unittest, PillowTestCase, hopper
 
-from PIL import Image, XpmImagePlugin
 
 # sample ppm stream
 TEST_FILE = "Tests/images/hopper.xpm"
@@ -21,7 +22,7 @@ class TestFileXpm(PillowTestCase):
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(SyntaxError,
+        self.assertRaises(InvalidFileType,
                           lambda: XpmImagePlugin.XpmImageFile(invalid_file))
 
     def test_load_read(self):

--- a/Tests/test_font_bdf.py
+++ b/Tests/test_font_bdf.py
@@ -1,6 +1,8 @@
 from helper import unittest, PillowTestCase
 
 from PIL import FontFile, BdfFontFile
+from PIL.exceptions import InvalidFileType
+
 
 filename = "Tests/images/courB08.bdf"
 
@@ -17,7 +19,7 @@ class TestFontBdf(PillowTestCase):
 
     def test_invalid_file(self):
         with open("Tests/images/flower.jpg", "rb") as fp:
-            self.assertRaises(SyntaxError, lambda: BdfFontFile.BdfFontFile(fp))
+            self.assertRaises(InvalidFileType, lambda: BdfFontFile.BdfFontFile(fp))
 
 
 if __name__ == '__main__':

--- a/Tests/test_font_pcf.py
+++ b/Tests/test_font_pcf.py
@@ -1,7 +1,7 @@
+from PIL import FontFile, Image, ImageDraw, ImageFont, PcfFontFile
+from PIL.exceptions import InvalidFileType
 from helper import unittest, PillowTestCase
 
-from PIL import Image, FontFile, PcfFontFile
-from PIL import ImageFont, ImageDraw
 
 codecs = dir(Image.core)
 
@@ -32,7 +32,7 @@ class TestFontPcf(PillowTestCase):
 
     def test_invalid_file(self):
         with open("Tests/images/flower.jpg", "rb") as fp:
-            self.assertRaises(SyntaxError, lambda: PcfFontFile.PcfFontFile(fp))
+            self.assertRaises(InvalidFileType, lambda: PcfFontFile.PcfFontFile(fp))
 
     def xtest_draw(self):
 

--- a/Tests/test_format_hsv.py
+++ b/Tests/test_format_hsv.py
@@ -1,10 +1,7 @@
-from __future__ import print_function
-from helper import unittest, PillowTestCase, hopper
-
-from PIL import Image
-
 import colorsys
 import itertools
+from PIL import Image
+from helper import unittest, PillowTestCase, hopper
 
 
 class TestFormatHSV(PillowTestCase):
@@ -47,10 +44,6 @@ class TestFormatHSV(PillowTestCase):
 
         img = Image.merge('RGB', (r, g, b))
 
-        # print(("%d, %d -> "% (int(1.75*px),int(.25*px))) + \
-        #        "(%s, %s, %s)"%img.getpixel((1.75*px, .25*px)))
-        # print(("%d, %d -> "% (int(.75*px),int(.25*px))) + \
-        #        "(%s, %s, %s)"%img.getpixel((.75*px, .25*px)))
         return img
 
     def to_xxx_colorsys(self, im, func, mode):
@@ -95,15 +88,6 @@ class TestFormatHSV(PillowTestCase):
         im = src.convert('HSV')
         comparable = self.to_hsv_colorsys(src)
 
-        # print(im.getpixel((448, 64)))
-        # print(comparable.getpixel((448, 64)))
-
-        # print(im.split()[0].histogram())
-        # print(comparable.split()[0].histogram())
-
-        # im.split()[0].show()
-        # comparable.split()[0].show()
-
         self.assert_image_similar(im.split()[0], comparable.split()[0],
                                   1, "Hue conversion is wrong")
         self.assert_image_similar(im.split()[1], comparable.split()[1],
@@ -111,15 +95,8 @@ class TestFormatHSV(PillowTestCase):
         self.assert_image_similar(im.split()[2], comparable.split()[2],
                                   1, "Value conversion is wrong")
 
-        # print(im.getpixel((192, 64)))
-
         comparable = src
         im = im.convert('RGB')
-
-        # im.split()[0].show()
-        # comparable.split()[0].show()
-        # print(im.getpixel((192, 64)))
-        # print(comparable.getpixel((192, 64)))
 
         self.assert_image_similar(im.split()[0], comparable.split()[0],
                                   3, "R conversion is wrong")
@@ -132,12 +109,6 @@ class TestFormatHSV(PillowTestCase):
         im = hopper('RGB').convert('HSV')
         comparable = self.to_hsv_colorsys(hopper('RGB'))
 
-#        print([ord(x) for x  in im.split()[0].tobytes()[:80]])
-#        print([ord(x) for x  in comparable.split()[0].tobytes()[:80]])
-
-#        print(im.split()[0].histogram())
-#        print(comparable.split()[0].histogram())
-
         self.assert_image_similar(im.split()[0], comparable.split()[0],
                                   1, "Hue conversion is wrong")
         self.assert_image_similar(im.split()[1], comparable.split()[1],
@@ -149,12 +120,6 @@ class TestFormatHSV(PillowTestCase):
         comparable = self.to_hsv_colorsys(hopper('RGB'))
         converted = comparable.convert('RGB')
         comparable = self.to_rgb_colorsys(comparable)
-
-        # print(converted.split()[1].histogram())
-        # print(target.split()[1].histogram())
-
-        # print([ord(x) for x  in target.split()[1].tobytes()[:80]])
-        # print([ord(x) for x  in converted.split()[1].tobytes()[:80]])
 
         self.assert_image_similar(converted.split()[0], comparable.split()[0],
                                   3, "R conversion is wrong")

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -1,6 +1,5 @@
-from __future__ import print_function
-from helper import unittest, PillowTestCase, hopper
 from PIL import Image, ImageDraw, ImageMode
+from helper import unittest, PillowTestCase, hopper
 
 
 class TestImagingResampleVulnerability(PillowTestCase):
@@ -324,10 +323,8 @@ class CoreResamplePassesTest(PillowTestCase):
 class CoreResampleCoefficientsTest(PillowTestCase):
     def test_reduce(self):
         test_color = 254
-        # print()
 
         for size in range(400000, 400010, 2):
-            # print(size)
             i = Image.new('L', (size, 1), 0)
             draw = ImageDraw.Draw(i)
             draw.rectangle((0, 0, i.size[0] // 2 - 1, 0), test_color)
@@ -335,7 +332,6 @@ class CoreResampleCoefficientsTest(PillowTestCase):
             px = i.resize((5, i.size[1]), Image.BICUBIC).load()
             if px[2, 0] != test_color // 2:
                 self.assertEqual(test_color // 2, px[2, 0])
-                # print('>', size, test_color // 2, px[2, 0])
 
     def test_nonzero_coefficients(self):
         # regression test for the wrong coefficients calculation

--- a/Tests/test_imagemath.py
+++ b/Tests/test_imagemath.py
@@ -1,8 +1,5 @@
-from __future__ import print_function
+from PIL import Image, ImageMath
 from helper import unittest, PillowTestCase
-
-from PIL import Image
-from PIL import ImageMath
 
 
 def pixel(im):

--- a/Tests/test_locale.py
+++ b/Tests/test_locale.py
@@ -1,9 +1,7 @@
-from __future__ import print_function
+import locale
+from PIL import Image
 from helper import unittest, PillowTestCase
 
-from PIL import Image
-
-import locale
 
 # ref https://github.com/python-pillow/Pillow/issues/272
 # on windows, in polish locale:

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -54,7 +54,6 @@ class TestNumpy(PillowTestCase):
                 i = Image.fromarray(a)
                 if list(i.split()[0].getdata()) != list(range(100)):
                     print("data mismatch for", dtype)
-            # print(dtype, list(i.getdata()))
             return i
 
         # Check supported 1-bit integer formats

--- a/Tests/test_tiff_ifdrational.py
+++ b/Tests/test_tiff_ifdrational.py
@@ -1,11 +1,7 @@
-from __future__ import print_function
-
-from helper import unittest, PillowTestCase, hopper
-
+from fractions import Fraction
 from PIL import TiffImagePlugin, Image
 from PIL.TiffImagePlugin import IFDRational
-
-from fractions import Fraction
+from helper import unittest, PillowTestCase, hopper
 
 
 class Test_IFDRational(PillowTestCase):

--- a/docs/handbook/writing-your-own-file-decoder.rst
+++ b/docs/handbook/writing-your-own-file-decoder.rst
@@ -51,6 +51,7 @@ true color.
 **SpamImagePlugin.py**::
 
     from PIL import Image, ImageFile
+    from PIL.exceptions import InvalidFileType, PILReadError
     import string
 
     class SpamImageFile(ImageFile.ImageFile):
@@ -59,11 +60,10 @@ true color.
         format_description = "Spam raster image"
 
         def _open(self):
-
             # check header
             header = self.fp.read(128)
             if header[:4] != "SPAM":
-                raise SyntaxError, "not a SPAM file"
+                raise InvalidFileType("not a SPAM file")
 
             header = string.split(header)
 
@@ -79,7 +79,7 @@ true color.
             elif bits == 24:
                 self.mode = "RGB"
             else:
-                raise SyntaxError, "unknown number of bits"
+                raise PILReadError("unknown number of bits")
 
             # data descriptor
             self.tile = [
@@ -95,7 +95,7 @@ The format handler must always set the
 :py:attr:`~PIL.Image.Image.size` and :py:attr:`~PIL.Image.Image.mode`
 attributes. If these are not set, the file cannot be opened. To
 simplify the decoder, the calling code considers exceptions like
-:py:exc:`SyntaxError`, :py:exc:`KeyError`, :py:exc:`IndexError`,
+:py:exc:`InvalidFileType`, :py:exc:`KeyError`, :py:exc:`IndexError`,
 :py:exc:`EOFError` and :py:exc:`struct.error` as a failure to identify
 the file.
 


### PR DESCRIPTION
Addressing #1643

This was pretty exhausting. It doesn't cover everything, there's plenty more places where IOError / ValueError etc could be replaced with PILReadError / PILWriteError.

To make this more backwards compatible we could make it subclass SyntaxError but... honestly, I'd be glad to see the end of this.

I'd love it if someone can take these commits and build on them. I suspect they break a ton of stuff due to the try/excepts all over the place.

Couple more commits to clean up the more egregious stuff I found while doing this... 