### PR TITLE
Removed unnecessary import

### DIFF
--- a/PIL/JpegImagePlugin.py
+++ b/PIL/JpegImagePlugin.py
@@ -38,7 +38,6 @@ import array
 import struct
 import io
 import warnings
-from struct import unpack_from
 from PIL import Image, ImageFile, TiffImagePlugin, _binary
 from PIL.JpegPresets import presets
 from PIL._util import isStringType
@@ -493,7 +492,7 @@ def _getmp(self):
     try:
         rawmpentries = mp[0xB002]
         for entrynum in range(0, quant):
-            unpackedentry = unpack_from(
+            unpackedentry = struct.unpack_from(
                 '{}LLLHH'.format(endianness), rawmpentries, entrynum * 16)
             labels = ('Attribute', 'Size', 'DataOffset', 'EntryNo1',
                       'EntryNo2')

--- a/PIL/_binary.py
+++ b/PIL/_binary.py
@@ -28,7 +28,6 @@ else:
 
 
 # Input, le = little endian, be = big endian
-# TODO: replace with more readable struct.unpack equivalent
 def i16le(c, o=0):
     """
     Converts a 2-bytes (16 bits) string to an unsigned integer.


### PR DESCRIPTION
Resolves a TODO in _binary to replace `from struct import ...` with `import struct`

Cherry-picks an isolated commit from #2339 that achieves the same goal in JpegImagePlugin.