### PR TITLE
Expose registered file extensions in Image

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -2512,6 +2512,16 @@ def register_extension(id, extension):
     EXTENSION[extension.lower()] = id.upper()
 
 
+def registered_extensions():
+    """
+    Returns a dictionary containing all file extensions belonging
+    to registered plugins
+    """
+    if not bool(EXTENSION):
+        init()
+    return EXTENSION
+
+
 # --------------------------------------------------------------------
 # Simple display support.  User code may override this.
 

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -201,7 +201,7 @@ class TestImage(PillowTestCase):
         ext = Image.registered_extensions()
 
         # Assert
-        self.assertEqual(bool(ext), True)
+        self.assertTrue(bool(ext))
 
     def test_registered_extensions(self):
         # Arrange
@@ -212,7 +212,7 @@ class TestImage(PillowTestCase):
         ext = Image.registered_extensions()
 
         # Assert
-        self.assertEqual(bool(ext), True)
+        self.assertTrue(bool(ext))
 
     def test_effect_mandelbrot(self):
         # Arrange

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -196,6 +196,24 @@ class TestImage(PillowTestCase):
         img_colors = sorted(img.getcolors())
         self.assertEqual(img_colors, expected_colors)
 
+    def test_registered_extensions_uninitialized(self):
+        # Act
+        ext = Image.registered_extensions()
+
+        # Assert
+        self.assertEqual(bool(ext), True)
+
+    def test_registered_extensions(self):
+        # Arrange
+        # Open an image to trigger plugin registration
+        Image.open('Tests/images/rgb.jpg')
+
+        # Act
+        ext = Image.registered_extensions()
+
+        # Assert
+        self.assertEqual(bool(ext), True)
+
     def test_effect_mandelbrot(self):
         # Arrange
         size = (512, 512)

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -197,11 +197,20 @@ class TestImage(PillowTestCase):
         self.assertEqual(img_colors, expected_colors)
 
     def test_registered_extensions_uninitialized(self):
+        # Arrange
+        Image._initialized = 0
+        extension = Image.EXTENSION
+        Image.EXTENSION = {}
+
         # Act
-        ext = Image.registered_extensions()
+        Image.registered_extensions()
 
         # Assert
-        self.assertTrue(bool(ext))
+        self.assertEqual(Image._initialized, 2)
+
+        # Restore the original state and assert
+        Image.EXTENSION = extension
+        self.assertTrue(Image.EXTENSION)
 
     def test_registered_extensions(self):
         # Arrange
@@ -209,10 +218,12 @@ class TestImage(PillowTestCase):
         Image.open('Tests/images/rgb.jpg')
 
         # Act
-        ext = Image.registered_extensions()
+        extensions = Image.registered_extensions()
 
         # Assert
-        self.assertTrue(bool(ext))
+        self.assertTrue(bool(extensions))
+        for ext in ['.cur', '.icns', '.tif', '.tiff']:
+            self.assertIn(ext, extensions)
 
     def test_effect_mandelbrot(self):
         # Arrange


### PR DESCRIPTION
This is a copy of #1968. The changes made are the ones suggested by @hugovk
- to ensure that the new `init()` line is called from tests
- to check for some expected extensions in the returned dictionary
- to simplify `assertEqual` to `assertTrue`.