### PR TITLE
Replaced absolute PIL imports with relative imports

### DIFF
--- a/PIL/BdfFontFile.py
+++ b/PIL/BdfFontFile.py
@@ -19,8 +19,7 @@
 
 from __future__ import print_function
 
-from PIL import Image
-from PIL import FontFile
+from . import Image, FontFile
 
 
 # --------------------------------------------------------------------

--- a/PIL/BmpImagePlugin.py
+++ b/PIL/BmpImagePlugin.py
@@ -24,17 +24,12 @@
 #
 
 
-from PIL import Image, ImageFile, ImagePalette, _binary
+from . import Image, ImageFile, ImagePalette
+from ._binary import i8, i16le as i16, i32le as i32, \
+                     o8, o16le as o16, o32le as o32
 import math
 
 __version__ = "0.7"
-
-i8 = _binary.i8
-i16 = _binary.i16le
-i32 = _binary.i32le
-o8 = _binary.o8
-o16 = _binary.o16le
-o32 = _binary.o32le
 
 #
 # --------------------------------------------------------------------

--- a/PIL/BufrStubImagePlugin.py
+++ b/PIL/BufrStubImagePlugin.py
@@ -9,7 +9,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image, ImageFile
+from . import Image, ImageFile
 
 _handler = None
 

--- a/PIL/CurImagePlugin.py
+++ b/PIL/CurImagePlugin.py
@@ -18,16 +18,13 @@
 
 from __future__ import print_function
 
-from PIL import Image, BmpImagePlugin, _binary
+from . import Image, BmpImagePlugin
+from ._binary import i8, i16le as i16, i32le as i32
 
 __version__ = "0.1"
 
 #
 # --------------------------------------------------------------------
-
-i8 = _binary.i8
-i16 = _binary.i16le
-i32 = _binary.i32le
 
 
 def _accept(prefix):

--- a/PIL/DcxImagePlugin.py
+++ b/PIL/DcxImagePlugin.py
@@ -21,14 +21,13 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image, _binary
-from PIL.PcxImagePlugin import PcxImageFile
+from . import Image
+from ._binary import i32le as i32
+from .PcxImagePlugin import PcxImageFile
 
 __version__ = "0.2"
 
 MAGIC = 0x3ADE68B1  # QUIZ: what's this value, then?
-
-i32 = _binary.i32le
 
 
 def _accept(prefix):

--- a/PIL/DdsImagePlugin.py
+++ b/PIL/DdsImagePlugin.py
@@ -12,7 +12,7 @@ Full text of the CC0 license:
 
 import struct
 from io import BytesIO
-from PIL import Image, ImageFile
+from . import Image, ImageFile
 
 
 # Magic ("DDS ")

--- a/PIL/EpsImagePlugin.py
+++ b/PIL/EpsImagePlugin.py
@@ -23,15 +23,13 @@
 import re
 import io
 import sys
-from PIL import Image, ImageFile, _binary
+from . import Image, ImageFile
+from ._binary import i32le as i32, o32le as o32
 
 __version__ = "0.5"
 
 #
 # --------------------------------------------------------------------
-
-i32 = _binary.i32le
-o32 = _binary.o32le
 
 split = re.compile(r"^%%([^:]*):[ \t]*(.*)[ \t]*$")
 field = re.compile(r"^%[%!\w]([^:]*)[ \t]*$")

--- a/PIL/FitsStubImagePlugin.py
+++ b/PIL/FitsStubImagePlugin.py
@@ -9,7 +9,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image, ImageFile
+from . import Image, ImageFile
 
 _handler = None
 

--- a/PIL/FliImagePlugin.py
+++ b/PIL/FliImagePlugin.py
@@ -16,14 +16,10 @@
 #
 
 
-from PIL import Image, ImageFile, ImagePalette, _binary
+from . import Image, ImageFile, ImagePalette
+from ._binary import i8, i16le as i16, i32le as i32, o8
 
 __version__ = "0.2"
-
-i8 = _binary.i8
-i16 = _binary.i16le
-i32 = _binary.i32le
-o8 = _binary.o8
 
 
 #

--- a/PIL/FontFile.py
+++ b/PIL/FontFile.py
@@ -17,7 +17,7 @@
 from __future__ import print_function
 
 import os
-from PIL import Image, _binary
+from . import Image, _binary
 
 WIDTH = 800
 

--- a/PIL/FpxImagePlugin.py
+++ b/PIL/FpxImagePlugin.py
@@ -17,14 +17,12 @@
 
 from __future__ import print_function
 
-from PIL import Image, ImageFile, _binary
+from . import Image, ImageFile
+from ._binary import i32le as i32, i8
 
 import olefile
 
 __version__ = "0.1"
-
-i32 = _binary.i32le
-i8 = _binary.i8
 
 # we map from colour field tuples to (mode, rawmode) descriptors
 MODES = {

--- a/PIL/FtexImagePlugin.py
+++ b/PIL/FtexImagePlugin.py
@@ -42,7 +42,7 @@ Note: All data is stored in little-Endian (Intel) byte order.
 
 import struct
 from io import BytesIO
-from PIL import Image, ImageFile
+from . import Image, ImageFile
 
 
 MAGIC = b"FTEX"

--- a/PIL/GbrImagePlugin.py
+++ b/PIL/GbrImagePlugin.py
@@ -24,9 +24,8 @@
 # Version 3 files have a format specifier of 18 for 16bit floats in
 #   the color depth field. This is currently unsupported by Pillow.
 
-from PIL import Image, ImageFile, _binary
-
-i32 = _binary.i32be
+from . import Image, ImageFile
+from ._binary import i32be as i32
 
 
 def _accept(prefix):

--- a/PIL/GdImageFile.py
+++ b/PIL/GdImageFile.py
@@ -23,8 +23,9 @@
 # purposes only.
 
 
-from PIL import ImageFile, ImagePalette, _binary
-from PIL._util import isPath
+from . import ImageFile, ImagePalette
+from ._binary import i16be as i16
+from ._util import isPath
 
 __version__ = "0.1"
 
@@ -33,8 +34,6 @@ try:
 except ImportError:
     import __builtin__
     builtins = __builtin__
-
-i16 = _binary.i16be
 
 
 ##

--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -24,19 +24,15 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image, ImageFile, ImagePalette, \
-                ImageChops, ImageSequence, _binary
+from . import Image, ImageFile, ImagePalette, \
+              ImageChops, ImageSequence
+from ._binary import i8, i16le as i16, o8, o16le as o16
 
 __version__ = "0.9"
 
 
 # --------------------------------------------------------------------
 # Helpers
-
-i8 = _binary.i8
-i16 = _binary.i16le
-o8 = _binary.o8
-o16 = _binary.o16le
 
 
 # --------------------------------------------------------------------

--- a/PIL/GimpGradientFile.py
+++ b/PIL/GimpGradientFile.py
@@ -14,7 +14,7 @@
 #
 
 from math import pi, log, sin, sqrt
-from PIL._binary import o8
+from ._binary import o8
 
 # --------------------------------------------------------------------
 # Stuff to translate curve segments to palette values (derived from

--- a/PIL/GimpPaletteFile.py
+++ b/PIL/GimpPaletteFile.py
@@ -15,7 +15,7 @@
 #
 
 import re
-from PIL._binary import o8
+from ._binary import o8
 
 
 ##

--- a/PIL/GribStubImagePlugin.py
+++ b/PIL/GribStubImagePlugin.py
@@ -9,7 +9,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image, ImageFile
+from . import Image, ImageFile
 
 _handler = None
 

--- a/PIL/Hdf5StubImagePlugin.py
+++ b/PIL/Hdf5StubImagePlugin.py
@@ -9,7 +9,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image, ImageFile
+from . import Image, ImageFile
 
 _handler = None
 

--- a/PIL/IcnsImagePlugin.py
+++ b/PIL/IcnsImagePlugin.py
@@ -15,7 +15,8 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image, ImageFile, PngImagePlugin, _binary
+from PIL import Image, ImageFile, PngImagePlugin
+from PIL._binary import i8
 import io
 import os
 import shutil
@@ -26,8 +27,6 @@ import tempfile
 enable_jpeg2k = hasattr(Image.core, 'jp2klib_version')
 if enable_jpeg2k:
     from PIL import Jpeg2KImagePlugin
-
-i8 = _binary.i8
 
 HEADERSIZE = 8
 

--- a/PIL/IcoImagePlugin.py
+++ b/PIL/IcoImagePlugin.py
@@ -25,17 +25,14 @@
 import struct
 from io import BytesIO
 
-from PIL import Image, ImageFile, BmpImagePlugin, PngImagePlugin, _binary
+from . import Image, ImageFile, BmpImagePlugin, PngImagePlugin
+from ._binary import i8, i16le as i16, i32le as i32
 from math import log, ceil
 
 __version__ = "0.1"
 
 #
 # --------------------------------------------------------------------
-
-i8 = _binary.i8
-i16 = _binary.i16le
-i32 = _binary.i32le
 
 _MAGIC = b"\0\0\1\0"
 

--- a/PIL/ImImagePlugin.py
+++ b/PIL/ImImagePlugin.py
@@ -27,8 +27,8 @@
 
 
 import re
-from PIL import Image, ImageFile, ImagePalette
-from PIL._binary import i8
+from . import Image, ImageFile, ImagePalette
+from ._binary import i8
 
 __version__ = "0.7"
 

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -26,7 +26,7 @@
 
 from __future__ import print_function
 
-from PIL import VERSION, PILLOW_VERSION, _plugins
+from . import VERSION, PILLOW_VERSION, _plugins
 
 import logging
 import warnings
@@ -64,7 +64,7 @@ try:
     # import Image and use the Image.core variable instead.
     # Also note that Image.core is not a publicly documented interface,
     # and should be considered private and subject to change.
-    from PIL import _imaging as core
+    from . import _imaging as core
     if PILLOW_VERSION != getattr(core, 'PILLOW_VERSION', None):
         raise ImportError("The _imaging extension was built for another "
                           "version of Pillow or PIL")
@@ -109,11 +109,9 @@ except ImportError:
     import __builtin__
     builtins = __builtin__
 
-from PIL import ImageMode
-from PIL._binary import i8
-from PIL._util import isPath
-from PIL._util import isStringType
-from PIL._util import deferred_error
+from . import ImageMode
+from ._binary import i8
+from ._util import isPath, isStringType, deferred_error
 
 import os
 import sys
@@ -355,23 +353,23 @@ def preinit():
         return
 
     try:
-        from PIL import BmpImagePlugin
+        from . import BmpImagePlugin
     except ImportError:
         pass
     try:
-        from PIL import GifImagePlugin
+        from . import GifImagePlugin
     except ImportError:
         pass
     try:
-        from PIL import JpegImagePlugin
+        from . import JpegImagePlugin
     except ImportError:
         pass
     try:
-        from PIL import PpmImagePlugin
+        from . import PpmImagePlugin
     except ImportError:
         pass
     try:
-        from PIL import PngImagePlugin
+        from . import PngImagePlugin
     except ImportError:
         pass
 #   try:
@@ -525,7 +523,7 @@ class Image(object):
         if self.palette:
             new.palette = self.palette.copy()
         if im.mode == "P" and not new.palette:
-            from PIL import ImagePalette
+            from . import ImagePalette
             new.palette = ImagePalette.ImagePalette()
         new.info = self.info.copy()
         return new
@@ -775,7 +773,7 @@ class Image(object):
             if HAS_CFFI and USE_CFFI_ACCESS:
                 if self.pyaccess:
                     return self.pyaccess
-                from PIL import PyAccess
+                from . import PyAccess
                 self.pyaccess = PyAccess.new(self, self.readonly)
                 if self.pyaccess:
                     return self.pyaccess
@@ -908,7 +906,7 @@ class Image(object):
         if mode == "P" and palette == ADAPTIVE:
             im = self.im.quantize(colors)
             new = self._new(im)
-            from PIL import ImagePalette
+            from . import ImagePalette
             new.palette = ImagePalette.raw("RGB", new.im.getpalette("RGB"))
             if delete_trns:
                 # This could possibly happen if we requantize to fewer colors.
@@ -1321,7 +1319,7 @@ class Image(object):
             box += (box[0]+size[0], box[1]+size[1])
 
         if isStringType(im):
-            from PIL import ImageColor
+            from . import ImageColor
             im = ImageColor.getcolor(im, self.mode)
 
         elif isImageType(im):
@@ -1468,7 +1466,7 @@ class Image(object):
 
         :param data: A palette sequence (either a list or a string).
         """
-        from PIL import ImagePalette
+        from . import ImagePalette
 
         if self.mode not in ("L", "P"):
             raise ValueError("illegal image mode")
@@ -1583,7 +1581,7 @@ class Image(object):
         angle = angle % 360.0
 
         # Fast paths regardless of filter, as long as we're not
-        # translating or changing the center. 
+        # translating or changing the center.
         if not (center or translate):
             if angle == 0:
                 return self.copy()
@@ -1977,14 +1975,14 @@ class Image(object):
 
     def toqimage(self):
         """Returns a QImage copy of this image"""
-        from PIL import ImageQt
+        from . import ImageQt
         if not ImageQt.qt_is_installed:
             raise ImportError("Qt bindings are not installed")
         return ImageQt.toqimage(self)
 
     def toqpixmap(self):
         """Returns a QPixmap copy of this image"""
-        from PIL import ImageQt
+        from . import ImageQt
         if not ImageQt.qt_is_installed:
             raise ImportError("Qt bindings are not installed")
         return ImageQt.toqpixmap(self)
@@ -2057,7 +2055,7 @@ def new(mode, size, color=0):
     if isStringType(color):
         # css3-style specifier
 
-        from PIL import ImageColor
+        from . import ImageColor
         color = ImageColor.getcolor(color, mode)
 
     return Image()._new(core.fill(mode, size, color))
@@ -2219,7 +2217,7 @@ def fromarray(obj, mode=None):
 
 def fromqimage(im):
     """Creates an image instance from a QImage image"""
-    from PIL import ImageQt
+    from . import ImageQt
     if not ImageQt.qt_is_installed:
         raise ImportError("Qt bindings are not installed")
     return ImageQt.fromqimage(im)
@@ -2227,7 +2225,7 @@ def fromqimage(im):
 
 def fromqpixmap(im):
     """Creates an image instance from a QPixmap image"""
-    from PIL import ImageQt
+    from . import ImageQt
     if not ImageQt.qt_is_installed:
         raise ImportError("Qt bindings are not installed")
     return ImageQt.fromqpixmap(im)
@@ -2521,7 +2519,7 @@ def _show(image, **options):
 
 
 def _showxv(image, title=None, **options):
-    from PIL import ImageShow
+    from . import ImageShow
     ImageShow.show(image, title, **options)
 
 

--- a/PIL/ImageChops.py
+++ b/PIL/ImageChops.py
@@ -15,7 +15,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image
+from . import Image
 
 
 def constant(image, value):

--- a/PIL/ImageColor.py
+++ b/PIL/ImageColor.py
@@ -17,7 +17,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image
+from . import Image
 import re
 
 

--- a/PIL/ImageDraw.py
+++ b/PIL/ImageDraw.py
@@ -33,8 +33,8 @@
 import numbers
 import warnings
 
-from PIL import Image, ImageColor
-from PIL._util import isStringType
+from . import Image, ImageColor
+from ._util import isStringType
 
 """
 A simple 2D drawing interface for PIL images.
@@ -105,7 +105,7 @@ class ImageDraw(object):
         """Get the current default font."""
         if not self.font:
             # FIXME: should add a font repository
-            from PIL import ImageFont
+            from . import ImageFont
             self.font = ImageFont.load_default()
         return self.font
 
@@ -319,11 +319,11 @@ def getdraw(im=None, hints=None):
     handler = None
     if not hints or "nicest" in hints:
         try:
-            from PIL import _imagingagg as handler
+            from . import _imagingagg as handler
         except ImportError:
             pass
     if handler is None:
-        from PIL import ImageDraw2 as handler
+        from . import ImageDraw2 as handler
     if im:
         im = handler.Draw(im)
     return im, handler

--- a/PIL/ImageDraw2.py
+++ b/PIL/ImageDraw2.py
@@ -16,7 +16,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image, ImageColor, ImageDraw, ImageFont, ImagePath
+from . import Image, ImageColor, ImageDraw, ImageFont, ImagePath
 
 
 class Pen(object):

--- a/PIL/ImageEnhance.py
+++ b/PIL/ImageEnhance.py
@@ -18,7 +18,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image, ImageFilter, ImageStat
+from . import Image, ImageFilter, ImageStat
 
 
 class _Enhance(object):

--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -27,8 +27,8 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image
-from PIL._util import isPath
+from . import Image
+from ._util import isPath
 import io
 import os
 import sys

--- a/PIL/ImageFont.py
+++ b/PIL/ImageFont.py
@@ -25,8 +25,8 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image
-from PIL._util import isDirectory, isPath
+from . import Image
+from ._util import isDirectory, isPath
 import os
 import sys
 
@@ -37,7 +37,7 @@ class _imagingft_not_installed(object):
         raise ImportError("The _imagingft C module is not installed")
 
 try:
-    from PIL import _imagingft as core
+    from . import _imagingft as core
 except ImportError:
     core = _imagingft_not_installed()
 

--- a/PIL/ImageGrab.py
+++ b/PIL/ImageGrab.py
@@ -15,7 +15,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image
+from . import Image
 
 import sys
 if sys.platform not in ["win32", "darwin"]:
@@ -75,7 +75,7 @@ def grabclipboard():
         debug = 0  # temporary interface
         data = Image.core.grabclipboard(debug)
         if isinstance(data, bytes):
-            from PIL import BmpImagePlugin
+            from . import BmpImagePlugin
             import io
             return BmpImagePlugin.DibImageFile(io.BytesIO(data))
         return data

--- a/PIL/ImageMath.py
+++ b/PIL/ImageMath.py
@@ -15,8 +15,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image
-from PIL import _imagingmath
+from . import Image, _imagingmath
 
 try:
     import builtins

--- a/PIL/ImageMode.py
+++ b/PIL/ImageMode.py
@@ -34,7 +34,7 @@ def getmode(mode):
     """Gets a mode descriptor for the given mode."""
     if not _modes:
         # initialize mode cache
-        from PIL import Image
+        from . import Image
         # core modes
         for m, (basemode, basetype, bands) in Image._MODEINFO.items():
             _modes[m] = ModeDescriptor(m, bands, basemode, basetype)

--- a/PIL/ImageMorph.py
+++ b/PIL/ImageMorph.py
@@ -7,8 +7,7 @@
 
 from __future__ import print_function
 
-from PIL import Image
-from PIL import _imagingmorph
+from . import Image, _imagingmorph
 import re
 
 LUT_SIZE = 1 << 9

--- a/PIL/ImageOps.py
+++ b/PIL/ImageOps.py
@@ -17,8 +17,8 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image
-from PIL._util import isStringType
+from . import Image
+from ._util import isStringType
 import operator
 import functools
 
@@ -39,7 +39,7 @@ def _border(border):
 
 def _color(color, mode):
     if isStringType(color):
-        from PIL import ImageColor
+        from . import ImageColor
         color = ImageColor.getcolor(color, mode)
     return color
 

--- a/PIL/ImagePalette.py
+++ b/PIL/ImagePalette.py
@@ -17,10 +17,7 @@
 #
 
 import array
-from PIL import ImageColor
-from PIL import GimpPaletteFile
-from PIL import GimpGradientFile
-from PIL import PaletteFile
+from . import ImageColor, GimpPaletteFile, GimpGradientFile, PaletteFile
 
 
 class ImagePalette(object):

--- a/PIL/ImagePath.py
+++ b/PIL/ImagePath.py
@@ -14,7 +14,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image
+from . import Image
 
 
 # the Python class below is overridden by the C implementation.

--- a/PIL/ImageQt.py
+++ b/PIL/ImageQt.py
@@ -16,8 +16,8 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image
-from PIL._util import isPath
+from . import Image
+from ._util import isPath
 from io import BytesIO
 
 qt_is_installed = True

--- a/PIL/ImageTk.py
+++ b/PIL/ImageTk.py
@@ -32,7 +32,7 @@ except ImportError:
     tkinter = Tkinter
     del Tkinter
 
-from PIL import Image
+from . import Image
 from io import BytesIO
 
 
@@ -182,7 +182,7 @@ class PhotoImage(object):
         except tkinter.TclError:
             # activate Tkinter hook
             try:
-                from PIL import _imagingtk
+                from . import _imagingtk
                 try:
                     _imagingtk.tkinit(tk.interpaddr(), 1)
                 except AttributeError:

--- a/PIL/ImageTransform.py
+++ b/PIL/ImageTransform.py
@@ -13,7 +13,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image
+from . import Image
 
 
 class Transform(Image.ImageTransformHandler):

--- a/PIL/ImageWin.py
+++ b/PIL/ImageWin.py
@@ -17,7 +17,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image
+from . import Image
 
 
 class HDC(object):

--- a/PIL/ImtImagePlugin.py
+++ b/PIL/ImtImagePlugin.py
@@ -17,7 +17,7 @@
 
 import re
 
-from PIL import Image, ImageFile
+from . import Image, ImageFile
 
 __version__ = "0.2"
 

--- a/PIL/IptcImagePlugin.py
+++ b/PIL/IptcImagePlugin.py
@@ -17,16 +17,12 @@
 
 from __future__ import print_function
 
-from PIL import Image, ImageFile, _binary
+from . import Image, ImageFile
+from ._binary import i8, i16be as i16, i32be as i32, o8
 import os
 import tempfile
 
 __version__ = "0.3"
-
-i8 = _binary.i8
-i16 = _binary.i16be
-i32 = _binary.i32be
-o8 = _binary.o8
 
 COMPRESSION = {
     1: "raw",
@@ -191,7 +187,7 @@ def getiptcinfo(im):
     :returns: A dictionary containing IPTC information, or None if
         no IPTC information block was found.
     """
-    from PIL import TiffImagePlugin, JpegImagePlugin
+    from . import TiffImagePlugin, JpegImagePlugin
     import io
 
     data = None

--- a/PIL/Jpeg2KImagePlugin.py
+++ b/PIL/Jpeg2KImagePlugin.py
@@ -12,7 +12,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
-from PIL import Image, ImageFile
+from . import Image, ImageFile
 import struct
 import os
 import io

--- a/PIL/JpegImagePlugin.py
+++ b/PIL/JpegImagePlugin.py
@@ -38,14 +38,10 @@ import array
 import struct
 import io
 import warnings
-from PIL import Image, ImageFile, TiffImagePlugin, _binary
-from PIL.JpegPresets import presets
-from PIL._util import isStringType
-
-i8 = _binary.i8
-o8 = _binary.o8
-i16 = _binary.i16be
-i32 = _binary.i32be
+from . import Image, ImageFile, TiffImagePlugin
+from ._binary import i8, o8, i16be as i16, i32be as i32
+from .JpegPresets import presets
+from ._util import isStringType
 
 __version__ = "0.6"
 

--- a/PIL/McIdasImagePlugin.py
+++ b/PIL/McIdasImagePlugin.py
@@ -17,7 +17,7 @@
 #
 
 import struct
-from PIL import Image, ImageFile
+from . import Image, ImageFile
 
 __version__ = "0.2"
 

--- a/PIL/MicImagePlugin.py
+++ b/PIL/MicImagePlugin.py
@@ -17,7 +17,7 @@
 #
 
 
-from PIL import Image, TiffImagePlugin
+from . import Image, TiffImagePlugin
 
 import olefile
 

--- a/PIL/MpegImagePlugin.py
+++ b/PIL/MpegImagePlugin.py
@@ -14,8 +14,8 @@
 #
 
 
-from PIL import Image, ImageFile
-from PIL._binary import i8
+from . import Image, ImageFile
+from ._binary import i8
 
 __version__ = "0.1"
 

--- a/PIL/MpoImagePlugin.py
+++ b/PIL/MpoImagePlugin.py
@@ -18,7 +18,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image, JpegImagePlugin
+from . import Image, JpegImagePlugin
 
 __version__ = "0.1"
 

--- a/PIL/MspImagePlugin.py
+++ b/PIL/MspImagePlugin.py
@@ -17,15 +17,14 @@
 #
 
 
-from PIL import Image, ImageFile, _binary
+from . import Image, ImageFile
+from ._binary import i16le as i16, o16le as o16
 
 __version__ = "0.1"
 
 
 #
 # read MSP files
-
-i16 = _binary.i16le
 
 
 def _accept(prefix):
@@ -65,8 +64,6 @@ class MspImageFile(ImageFile.ImageFile):
 
 #
 # write MSP files (uncompressed only)
-
-o16 = _binary.o16le
 
 
 def _save(im, fp, filename):

--- a/PIL/PSDraw.py
+++ b/PIL/PSDraw.py
@@ -15,7 +15,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import EpsImagePlugin
+from . import EpsImagePlugin
 import sys
 
 ##

--- a/PIL/PaletteFile.py
+++ b/PIL/PaletteFile.py
@@ -13,7 +13,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL._binary import o8
+from ._binary import o8
 
 
 ##

--- a/PIL/PalmImagePlugin.py
+++ b/PIL/PalmImagePlugin.py
@@ -7,7 +7,8 @@
 # Image plugin for Palm pixmap images (output only).
 ##
 
-from PIL import Image, ImageFile, _binary
+from . import Image, ImageFile
+from ._binary import o8, o16be as o16b
 
 __version__ = "1.0"
 
@@ -107,9 +108,6 @@ _COMPRESSION_TYPES = {
     "rle":      0x01,
     "scanline": 0x00,
     }
-
-o8 = _binary.o8
-o16b = _binary.o16be
 
 
 #

--- a/PIL/PcdImagePlugin.py
+++ b/PIL/PcdImagePlugin.py
@@ -15,11 +15,10 @@
 #
 
 
-from PIL import Image, ImageFile, _binary
+from . import Image, ImageFile
+from ._binary import i8
 
 __version__ = "0.1"
-
-i8 = _binary.i8
 
 
 ##

--- a/PIL/PcfFontFile.py
+++ b/PIL/PcfFontFile.py
@@ -16,9 +16,8 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image
-from PIL import FontFile
-from PIL import _binary
+from . import Image, FontFile
+from ._binary import i8, i16le as l16, i32le as l32, i16be as b16, i32be as b32
 
 # --------------------------------------------------------------------
 # declarations
@@ -41,12 +40,6 @@ BYTES_PER_ROW = [
     lambda bits: ((bits+31) >> 3) & ~3,
     lambda bits: ((bits+63) >> 3) & ~7,
 ]
-
-i8 = _binary.i8
-l16 = _binary.i16le
-l32 = _binary.i32le
-b16 = _binary.i16be
-b32 = _binary.i32be
 
 
 def sz(s, o):

--- a/PIL/PcxImagePlugin.py
+++ b/PIL/PcxImagePlugin.py
@@ -28,13 +28,10 @@
 from __future__ import print_function
 
 import logging
-from PIL import Image, ImageFile, ImagePalette, _binary
+from . import Image, ImageFile, ImagePalette
+from ._binary import i8, i16le as i16, o8, o16le as o16
 
 logger = logging.getLogger(__name__)
-
-i8 = _binary.i8
-i16 = _binary.i16le
-o8 = _binary.o8
 
 __version__ = "0.6"
 
@@ -122,8 +119,6 @@ SAVE = {
     "P": (5, 8, 1, "P"),
     "RGB": (5, 8, 3, "RGB;L"),
 }
-
-o16 = _binary.o16le
 
 
 def _save(im, fp, filename, check=0):

--- a/PIL/PdfImagePlugin.py
+++ b/PIL/PdfImagePlugin.py
@@ -20,8 +20,8 @@
 # Image plugin for PDF images (output only).
 ##
 
-from PIL import Image, ImageFile
-from PIL._binary import i8
+from . import Image, ImageFile
+from ._binary import i8
 import io
 
 __version__ = "0.4"

--- a/PIL/PixarImagePlugin.py
+++ b/PIL/PixarImagePlugin.py
@@ -19,15 +19,13 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image, ImageFile, _binary
+from . import Image, ImageFile
+from ._binary import i16le as i16
 
 __version__ = "0.1"
 
 #
 # helpers
-
-i16 = _binary.i16le
-
 
 def _accept(prefix):
     return prefix[:4] == b"\200\350\000\000"

--- a/PIL/PngImagePlugin.py
+++ b/PIL/PngImagePlugin.py
@@ -38,15 +38,12 @@ import re
 import zlib
 import struct
 
-from PIL import Image, ImageFile, ImagePalette, _binary
+from . import Image, ImageFile, ImagePalette
+from ._binary import i8, i16be as i16, i32be as i32, o8, o16be as o16, o32be as o32
 
 __version__ = "0.9"
 
 logger = logging.getLogger(__name__)
-
-i8 = _binary.i8
-i16 = _binary.i16be
-i32 = _binary.i32be
 
 is_cid = re.compile(br"\w\w\w\w").match
 
@@ -620,10 +617,6 @@ class PngImageFile(ImageFile.ImageFile):
 
 # --------------------------------------------------------------------
 # PNG writer
-
-o8 = _binary.o8
-o16 = _binary.o16be
-o32 = _binary.o32be
 
 _OUTMODES = {
     # supported PIL modes, and corresponding rawmodes/bits/color combinations

--- a/PIL/PpmImagePlugin.py
+++ b/PIL/PpmImagePlugin.py
@@ -17,7 +17,7 @@
 
 import string
 
-from PIL import Image, ImageFile
+from . import Image, ImageFile
 
 __version__ = "0.2"
 

--- a/PIL/PsdImagePlugin.py
+++ b/PIL/PsdImagePlugin.py
@@ -18,7 +18,8 @@
 
 __version__ = "0.4"
 
-from PIL import Image, ImageFile, ImagePalette, _binary
+from . import Image, ImageFile, ImagePalette
+from ._binary import i8, i16be as i16, i32be as i32
 
 MODES = {
     # (photoshop mode, bits) -> (pil mode, required channels)
@@ -32,13 +33,6 @@ MODES = {
     (8, 8): ("L", 1),  # duotone
     (9, 8): ("LAB", 3)
 }
-
-#
-# helpers
-
-i8 = _binary.i8
-i16 = _binary.i16be
-i32 = _binary.i32be
 
 
 # --------------------------------------------------------------------.

--- a/PIL/SgiImagePlugin.py
+++ b/PIL/SgiImagePlugin.py
@@ -21,15 +21,12 @@
 #
 
 
-from PIL import Image, ImageFile, _binary
+from . import Image, ImageFile
+from ._binary import i8, o8, i16be as i16
 import struct
 import os
 
 __version__ = "0.3"
-
-i8 = _binary.i8
-o8 = _binary.o8
-i16 = _binary.i16be
 
 
 def _accept(prefix):
@@ -134,7 +131,7 @@ def _save(im, fp, filename):
 
     fp.write(struct.pack('404s', b'')) # dummy
 
-    #assert we've got the right number of bands. 
+    #assert we've got the right number of bands.
     if len(im.getbands()) != z:
         raise ValueError("incorrect number of bands in SGI write: %s vs %s" %
                          (z, len(im.getbands())))

--- a/PIL/TarIO.py
+++ b/PIL/TarIO.py
@@ -14,7 +14,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import ContainerIO
+from . import ContainerIO
 
 
 ##

--- a/PIL/TgaImagePlugin.py
+++ b/PIL/TgaImagePlugin.py
@@ -17,7 +17,8 @@
 #
 
 
-from PIL import Image, ImageFile, ImagePalette, _binary
+from . import Image, ImageFile, ImagePalette
+from ._binary import i8, i16le as i16, o8, o16le as o16, o32le as o32
 
 __version__ = "0.3"
 
@@ -25,9 +26,6 @@ __version__ = "0.3"
 #
 # --------------------------------------------------------------------
 # Read RGA file
-
-i8 = _binary.i8
-i16 = _binary.i16le
 
 
 MODES = {
@@ -131,10 +129,6 @@ class TgaImageFile(ImageFile.ImageFile):
 #
 # --------------------------------------------------------------------
 # Write TGA file
-
-o8 = _binary.o8
-o16 = _binary.o16le
-o32 = _binary.o32le
 
 SAVE = {
     "1": ("1", 1, 0, 3),

--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -41,10 +41,8 @@
 
 from __future__ import division, print_function
 
-from PIL import Image, ImageFile
-from PIL import ImagePalette
-from PIL import _binary
-from PIL import TiffTags
+from . import Image, ImageFile, ImagePalette, TiffTags
+from ._binary import i8, o8
 
 import collections
 from fractions import Fraction
@@ -70,9 +68,6 @@ IFD_LEGACY_API = True
 
 II = b"II"  # little-endian (Intel style)
 MM = b"MM"  # big-endian (Motorola style)
-
-i8 = _binary.i8
-o8 = _binary.o8
 
 #
 # --------------------------------------------------------------------
@@ -569,7 +564,7 @@ class ImageFileDirectory_v2(collections.MutableMapping):
 
     def _register_loader(idx, size):
         def decorator(func):
-            from PIL.TiffTags import TYPES
+            from .TiffTags import TYPES
             if func.__name__.startswith("load_"):
                 TYPES[idx] = func.__name__[5:].replace("_", " ")
             _load_dispatch[idx] = size, func
@@ -583,7 +578,7 @@ class ImageFileDirectory_v2(collections.MutableMapping):
         return decorator
 
     def _register_basic(idx_fmt_name):
-        from PIL.TiffTags import TYPES
+        from .TiffTags import TYPES
         idx, fmt, name = idx_fmt_name
         TYPES[idx] = name
         size = struct.calcsize("=" + fmt)

--- a/PIL/WalImageFile.py
+++ b/PIL/WalImageFile.py
@@ -23,15 +23,14 @@
 
 from __future__ import print_function
 
-from PIL import Image, _binary
+from . import Image
+from ._binary import i32le as i32
 
 try:
     import builtins
 except ImportError:
     import __builtin__
     builtins = __builtin__
-
-i32 = _binary.i32le
 
 
 def open(filename):

--- a/PIL/WebPImagePlugin.py
+++ b/PIL/WebPImagePlugin.py
@@ -1,7 +1,5 @@
-from PIL import Image
-from PIL import ImageFile
+from . import Image, ImageFile, _webp
 from io import BytesIO
-from PIL import _webp
 
 
 _VALID_WEBP_MODES = {
@@ -43,7 +41,7 @@ class WebPImageFile(ImageFile.ImageFile):
         self.tile = [("raw", (0, 0) + self.size, 0, self.mode)]
 
     def _getexif(self):
-        from PIL.JpegImagePlugin import _getexif
+        from .JpegImagePlugin import _getexif
         return _getexif(self)
 
 

--- a/PIL/WmfImagePlugin.py
+++ b/PIL/WmfImagePlugin.py
@@ -21,7 +21,10 @@
 
 from __future__ import print_function
 
-from PIL import Image, ImageFile, _binary
+from . import Image, ImageFile
+from ._binary import i16le as word, si16le as short, i32le as dword, si32le as _long
+
+
 
 __version__ = "0.2"
 
@@ -58,13 +61,6 @@ if hasattr(Image.core, "drawwmf"):
                 )
 
     register_handler(WmfHandler())
-
-# --------------------------------------------------------------------
-
-word = _binary.i16le
-short = _binary.si16le
-dword = _binary.i32le
-_long = _binary.si32le
 
 #
 # --------------------------------------------------------------------

--- a/PIL/XVThumbImagePlugin.py
+++ b/PIL/XVThumbImagePlugin.py
@@ -17,11 +17,10 @@
 # FIXME: make save work (this requires quantization support)
 #
 
-from PIL import Image, ImageFile, ImagePalette, _binary
+from . import Image, ImageFile, ImagePalette
+from ._binary import o8
 
 __version__ = "0.1"
-
-o8 = _binary.o8
 
 _MAGIC = b"P7 332"
 

--- a/PIL/XbmImagePlugin.py
+++ b/PIL/XbmImagePlugin.py
@@ -20,7 +20,7 @@
 #
 
 import re
-from PIL import Image, ImageFile
+from . import Image, ImageFile
 
 __version__ = "0.6"
 

--- a/PIL/XpmImagePlugin.py
+++ b/PIL/XpmImagePlugin.py
@@ -16,8 +16,8 @@
 
 
 import re
-from PIL import Image, ImageFile, ImagePalette
-from PIL._binary import i8, o8
+from . import Image, ImageFile, ImagePalette
+from ._binary import i8, o8
 
 __version__ = "0.2"
 

--- a/PIL/features.py
+++ b/PIL/features.py
@@ -1,4 +1,4 @@
-from PIL import Image
+from . import Image
 
 modules = {
     "pil": "PIL._imaging",


### PR DESCRIPTION
Resolves #2342

The following files cannot use relative imports because they may be run directly, as shown by their `if __name__ == "__main__":` line -
- IcnsImagePlugin
- ImageCms
- ImageShow
- SpiderImagePlugin