### PR TITLE
Changed from pngquant to libimagequant

### DIFF
--- a/depends/install_imagequant.sh
+++ b/depends/install_imagequant.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 # install libimagequant
 
-archive=pngquant-2.8.2
+archive=libimagequant-2.8.2
 
 ./download-and-extract.sh $archive https://raw.githubusercontent.com/python-pillow/pillow-depends/master/$archive.tar.gz
 
 pushd $archive
 
-make -C lib shared
-sudo cp lib/libimagequant.so* /usr/lib/
-sudo cp lib/libimagequant.h /usr/include/
+make shared
+sudo cp libimagequant.so* /usr/lib/
+sudo cp libimagequant.h /usr/include/
 
 popd


### PR DESCRIPTION
As pointed out in https://github.com/python-pillow/Pillow/pull/2319#discussion_r96023214, after that PR updated pngquant, there is now an error when running `make`.

This is because libimagequant has now split from pngquant to become standalone, seen in this commit - https://github.com/pornel/pngquant/commit/17f587b991a0550586a9ffafabc90c055011f60b. It now resides at https://github.com/ImageOptim/libimagequant

This PR uses the new standalone version. The new archive in pillow-depends comes from https://github.com/ImageOptim/libimagequant/archive/2.8.2.tar.gz

Before - https://travis-ci.org/python-pillow/Pillow/jobs/187814764#L2251
Broken - https://travis-ci.org/python-pillow/Pillow/jobs/187587442#L2240
After - https://travis-ci.org/python-pillow/Pillow/jobs/191874057#L2248