### PR TITLE
Fix for issue #1902 Applied patch: matplotlib/matplotlib/commit/a9155…

### DIFF
--- a/PIL/ImageTk.py
+++ b/PIL/ImageTk.py
@@ -277,6 +277,8 @@ class BitmapImage(object):
 
 
 def getimage(photo):
+    """ This function is unimplemented """
+    
     """Copies the contents of a PhotoImage to a PIL image memory."""
     photo.tk.call("PyImagingPhotoGet", photo)
 

--- a/Tests/test_imagetk.py
+++ b/Tests/test_imagetk.py
@@ -1,22 +1,29 @@
-from helper import unittest, PillowTestCase
+from helper import unittest, PillowTestCase, hopper
 from PIL import Image
+
 
 try:
     from PIL import ImageTk
+    import Tkinter as tk
     dir(ImageTk)
+    HAS_TK = True
 except (OSError, ImportError) as v:
     # Skipped via setUp()
-    pass
-
+    HAS_TK = False
+    
+TK_MODES = ('1', 'L', 'P', 'RGB', 'RGBA')
 
 class TestImageTk(PillowTestCase):
 
     def setUp(self):
+        if not HAS_TK:
+            self.skipTest("Tk not installed")
         try:
-            from PIL import ImageTk
-            dir(ImageTk)
-        except (OSError, ImportError) as v:
-            self.skipTest(v)
+            # setup tk
+            app = tk.Frame()
+            #root = tk.Tk()
+        except (tk.TclError) as v:
+            self.skipTest("TCL Error: %s" % v)
 
     def test_kw(self):
         TEST_JPG = "Tests/images/hopper.jpg"
@@ -40,5 +47,47 @@ class TestImageTk(PillowTestCase):
         self.assertEqual(im, None)
 
 
+    def test_photoimage(self):
+        for mode in TK_MODES:
+            # test as image:
+            im = hopper(mode)
+            
+            # this should not crash
+            im_tk = ImageTk.PhotoImage(im)
+
+            self.assertEqual(im_tk.width(), im.width)
+            self.assertEqual(im_tk.height(), im.height)
+
+            # _tkinter.TclError: this function is not yet supported
+            #reloaded = ImageTk.getimage(im_tk)
+            #self.assert_image_equal(reloaded, im)
+
+            
+
+    def test_photoimage_blank(self):
+        # test a image using mode/size:
+        for mode in TK_MODES:
+            im_tk = ImageTk.PhotoImage(mode, (100,100))
+            
+            self.assertEqual(im_tk.width(), 100)
+            self.assertEqual(im_tk.height(), 100)
+            
+            #reloaded = ImageTk.getimage(im_tk)
+            #self.assert_image_equal(reloaded, im)
+
+    def test_bitmapimage(self):
+        im = hopper('1')
+
+        # this should not crash
+        im_tk = ImageTk.BitmapImage(im)
+        
+        self.assertEqual(im_tk.width(), im.width)
+        self.assertEqual(im_tk.height(), im.height)
+        
+        #reloaded = ImageTk.getimage(im_tk)
+        #self.assert_image_equal(reloaded, im)
+    
+
+            
 if __name__ == '__main__':
     unittest.main()

--- a/Tk/tkImaging.c
+++ b/Tk/tkImaging.c
@@ -24,10 +24,7 @@
  * This registers a Tcl command called "PyImagingPhoto", which is used
  * to communicate between PIL and Tk's PhotoImage handler.
  *
- * Compile and link tkImaging.c with tkappinit.c and _tkinter (see the
- * Setup file for details on how to use tkappinit.c).  Note that
- * _tkinter.c must be compiled with WITH_APPINIT.
- *
+
  * History:
  * 1995-09-12 fl  Created
  * 1996-04-08 fl  Ready for release
@@ -169,7 +166,7 @@ PyImagingPhotoPut(ClientData clientdata, Tcl_Interp* interp,
     return TCL_OK;
 }
 
-
+/*  Warning -- this does not work at all */
 static int
 PyImagingPhotoGet(ClientData clientdata, Tcl_Interp* interp,
                int argc, const char **argv)

--- a/_imagingtk.c
+++ b/_imagingtk.c
@@ -36,18 +36,18 @@ _tkinit(PyObject* self, PyObject* args)
 {
     Tcl_Interp* interp;
 
-    Py_ssize_t arg;
+    PyObject* arg;
     int is_interp;
-    if (!PyArg_ParseTuple(args, "ni", &arg, &is_interp))
+    if (!PyArg_ParseTuple(args, "Oi", &arg, &is_interp))
         return NULL;
 
     if (is_interp)
-        interp = (Tcl_Interp*) arg;
+        interp = (Tcl_Interp*)PyLong_AsVoidPtr(arg);
     else {
         TkappObject* app;
 	/* Do it the hard way.  This will break if the TkappObject
 	   layout changes */
-        app = (TkappObject*) arg;
+        app = (TkappObject*)PyLong_AsVoidPtr(arg);
         interp = app->interp;
     }
 


### PR DESCRIPTION
 Applied patch: https://github.com/matplotlib/matplotlib/commit/a91559b82cf23ee407cd57580653015fc7dc35f0 to fix issue #1902
Changes proposed in this pull request:

 * Use PyLong_AsVoidPtr instead of converting a pyint to a py_ssizet, which misses the top half of the address space on 32 bit machines. 
