### PR TITLE
Ensure that the `err_code` variable is initialized before using.

### DIFF
--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -178,7 +178,7 @@ class ImageFile(Image.Image):
                     self.map = None
 
         self.load_prepare()
-
+        err_code = 0
         if not self.map:
             # sort tiles in file order
             self.tile.sort(key=_tilesort)

--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -178,7 +178,7 @@ class ImageFile(Image.Image):
                     self.map = None
 
         self.load_prepare()
-        err_code = 0
+        err_code = -3 # initialize to unknown error
         if not self.map:
             # sort tiles in file order
             self.tile.sort(key=_tilesort)


### PR DESCRIPTION
### What did you do?

Called ``image = image.convert("RGB")``

### What actually happened?

Unfortunately I cannot retrieve the actual image that causes this to occur, but there is a scenario where the ``err_code`` variable is not initialized.

```
  File "PIL/Image.py", line 841, in convert
  File "PIL/ImageFile.py", line 238, in load
UnboundLocalError: local variable 'err_code' referenced before assignment
```

### What versions of Pillow and Python are you using?

 - Pillow 3.3.3
 - Python 2.7.12
