### PR TITLE
Default to inch-interpretation for missing ResolutionUnit in TiffImagePlugin

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -1163,11 +1163,15 @@ class TiffImageFile(ImageFile.ImageFile):
         yres = self.tag_v2.get(Y_RESOLUTION, 1)
 
         if xres and yres:
-            resunit = self.tag_v2.get(RESOLUTION_UNIT, 1)
+            resunit = self.tag_v2.get(RESOLUTION_UNIT)
             if resunit == 2:  # dots per inch
                 self.info["dpi"] = xres, yres
             elif resunit == 3:  # dots per centimeter. convert to dpi
                 self.info["dpi"] = xres * 2.54, yres * 2.54
+            elif resunit == None: # used to default to 1, but now 2)
+                self.info["dpi"] = xres, yres
+                # For backward compatibility, we also preserve the old behavior.
+                self.info["resolution"] = xres, yres
             else:  # No absolute unit of measurement
                 self.info["resolution"] = xres, yres
 

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -93,6 +93,24 @@ class TestFileTiff(PillowTestCase):
 
         self.assertEqual(im.info['dpi'], (72., 72.))
 
+    def test_xyres_fallback_tiff(self):
+        from PIL.TiffImagePlugin import X_RESOLUTION, Y_RESOLUTION, RESOLUTION_UNIT
+        filename = "Tests/images/compression.tif"
+        im = Image.open(filename)
+
+        # v2 api
+        self.assertIsInstance(im.tag_v2[X_RESOLUTION],
+                              TiffImagePlugin.IFDRational)
+        self.assertIsInstance(im.tag_v2[Y_RESOLUTION],
+                              TiffImagePlugin.IFDRational)
+        self.assertRaises(KeyError,
+                          lambda: im.tag_v2[RESOLUTION_UNIT])
+
+        # Legacy.
+        self.assertEqual(im.info['resolution'], (100., 100.))
+        # Fallback "inch".
+        self.assertEqual(im.info['dpi'], (100., 100.))
+
     def test_int_resolution(self):
         from PIL.TiffImagePlugin import X_RESOLUTION, Y_RESOLUTION
         filename = "Tests/images/pil168.tif"


### PR DESCRIPTION
Changes proposed in this pull request:

 * Default to inch-interpretation for Tiff images missing ResolutionUnit tag, thus creating an im.info['dpi'] attribute.
 * Keep old im.info['resolution'] attribute in such cases for compatibility.
 * Test case for this.
