### PR TITLE
Docker images for additional travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ notifications:
 # Then run the remainder.
 
 matrix:
-  fast_finish: false
+  fast_finish: true
   allow_failures:
     - python: nightly
   include:
@@ -24,6 +24,7 @@ matrix:
     - python: '3.5'
     - python: '3.4'
     - python: '3.3'
+    - python: 'nightly'
   
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,49 +6,37 @@ notifications:
 # Run slow PyPy* first, to give them a headstart and reduce waiting time.
 # Run latest 3.x and 2.x next, to get quick compatibility results.
 # Then run the remainder.
-python:
-  - "pypy"
-  - "pypy3"
-  - 3.6
-  - 2.7
-  - "2.7_with_system_site_packages" # For PyQt4
-  - 3.5
-  - 3.4
-  - 3.3
-  - nightly
 
+matrix:
+  fast_finish: false
+  allow_failures:
+    - python: nightly
+  include:
+    - python: "pypy"
+    - python: "pypy3"
+    - python: '3.6'
+    - python: '2.7'
+    - env: DOCKER="alpine"
+    - env: DOCKER="ubuntu-trusty-x86"
+    - env: DOCKER="ubuntu-xenial-amd64"
+    - env: DOCKER="ubuntu-precise-amd64"     
+    - python:  "2.7_with_system_site_packages" # For PyQt4
+    - python: '3.5'
+    - python: '3.4'
+    - python: '3.3'
+  
 dist: trusty
 
+sudo: required
+
+services:
+  - docker
+
 install:
-  - "travis_retry sudo apt-get update"
-  - "travis_retry sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-qt4 ghostscript libffi-dev libjpeg-turbo-progs cmake imagemagick"
-  - "travis_retry pip install cffi"
-  - "travis_retry pip install nose"
-  - "travis_retry pip install check-manifest"
-  - "travis_retry pip install olefile"
-    # Pyroma tests sometimes hang on PyPy; skip
-  - if [ $TRAVIS_PYTHON_VERSION != "pypy" ]; then travis_retry pip install pyroma; fi
+  - if [ "$DOCKER" == "" ]; then .travis/install.sh; fi
 
-  - "travis_retry pip install coverage"
-
-  # docs only on python 2.7
-  - if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then travis_retry pip install -r requirements.txt ; fi
-
-  # clean checkout for manifest
-  - mkdir /tmp/check-manifest && cp -a . /tmp/check-manifest
-
-  # webp
-  - pushd depends && ./install_webp.sh && popd
-
-  # openjpeg
-  - pushd depends && ./install_openjpeg.sh && popd
-
-  # libimagequant
-  - pushd depends && ./install_imagequant.sh && popd
-
-  # extra test images
-  - pushd depends && ./install_extra_test_images.sh && popd
-
+before_install:
+  - if [ "$DOCKER" ]; then docker pull pythonpillow/$DOCKER; fi
 
 before_script:
 # Qt needs a display for some of the tests, and it's only run on the system site packages install
@@ -56,60 +44,16 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
 
 script:
-  - coverage erase
-  - python setup.py clean
-  - CFLAGS="-coverage" python setup.py build_ext --inplace
-
-  - coverage run --append --include=PIL/* selftest.py
-  - coverage run --append --include=PIL/* -m nose -vx Tests/test_*.py
-  - pushd /tmp/check-manifest && check-manifest --ignore ".coveragerc,.editorconfig,*.yml,*.yaml,tox.ini" && popd
-
-  # Docs
-  - if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then make install && make doccheck; fi
+  - |
+       if [ "$DOCKER" == "" ]; then
+          .travis/script.sh
+       else
+          docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/$DOCKER
+       fi
 
 after_success:
-   # gather the coverage data
-  - travis_retry sudo apt-get -qq install lcov
-  - lcov --capture --directory . -b . --output-file coverage.info
-   # filter to remove system headers
-  - lcov --remove coverage.info '/usr/*' -o coverage.filtered.info
-   # convert to json
-  - travis_retry gem install coveralls-lcov
-  - coveralls-lcov -v -n coverage.filtered.info > coverage.c.json
-
-  - coverage report
-  - travis_retry pip install coveralls-merge
-  - coveralls-merge coverage.c.json
-
-  - travis_retry pip install pep8 pyflakes
-  - pep8 --statistics --count PIL/*.py
-  - pep8 --statistics --count Tests/*.py
-  - pyflakes *.py       | tee >(wc -l)
-  - pyflakes PIL/*.py   | tee >(wc -l)
-  - pyflakes Tests/*.py | tee >(wc -l)
-
-    # Coverage and quality reports on just the latest diff.
-    # (Installation is very slow on Py3, so just do it for Py2.)
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then depends/diffcover-install.sh; fi
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then depends/diffcover-run.sh; fi
-
-  # after_all
-  - |
-      if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-        curl -Lo travis_after_all.py https://raw.github.com/dmakhno/travis_after_all/master/travis_after_all.py
-        python travis_after_all.py
-        export $(cat .to_export_back)
-        if [ "$BUILD_LEADER" = "YES" ]; then
-          if [ "$BUILD_AGGREGATE_STATUS" = "others_succeeded" ]; then
-            echo "All jobs succeded! Triggering macOS build..."
-            # Trigger a macOS build at the pillow-wheels repo
-            ./build_children.sh
-          else
-            echo "Some jobs failed"
-          fi
-        fi
-      fi
-
+  - .travis/after_success.sh
+  
 after_failure:
   - |
       if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
@@ -130,11 +74,6 @@ after_script:
       if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
         echo leader=$BUILD_LEADER status=$BUILD_AGGREGATE_STATUS
       fi
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - python: nightly
 
 env:
   global:

--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# gather the coverage data
+sudo apt-get -qq install lcov
+lcov --capture --directory . -b . --output-file coverage.info
+#  filter to remove system headers
+lcov --remove coverage.info '/usr/*' -o coverage.filtered.info
+#  convert to json
+gem install coveralls-lcov
+coveralls-lcov -v -n coverage.filtered.info > coverage.c.json
+
+coverage report
+pip install coveralls-merge
+coveralls-merge coverage.c.json
+
+if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then
+	pip install pep8 pyflakes
+	pep8 --statistics --count PIL/*.py
+	pep8 --statistics --count Tests/*.py
+	pyflakes *.py       | tee >(wc -l)
+	pyflakes PIL/*.py   | tee >(wc -l)
+	pyflakes Tests/*.py | tee >(wc -l)
+fi
+
+# Coverage and quality reports on just the latest diff.
+# (Installation is very slow on Py3, so just do it for Py2.)
+if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then depends/diffcover-install.sh; fi
+if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then depends/diffcover-run.sh; fi
+
+# after_all
+
+if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+    curl -Lo travis_after_all.py https://raw.github.com/dmakhno/travis_after_all/master/travis_after_all.py
+    python travis_after_all.py
+    export $(cat .to_export_back)
+    if [ "$BUILD_LEADER" = "YES" ]; then
+        if [ "$BUILD_AGGREGATE_STATUS" = "others_succeeded" ]; then
+            echo "All jobs succeded! Triggering macOS build..."
+            # Trigger a macOS build at the pillow-wheels repo
+            ./build_children.sh
+        else
+            echo "Some jobs failed"
+        fi
+    fi

--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -13,14 +13,16 @@ coverage report
 pip install coveralls-merge
 coveralls-merge coverage.c.json
 
-if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ] && [ "$DOCKER" == "" ]; then
+if [ "$DOCKER" == "" ]; then
 	pip install pep8 pyflakes
 	pep8 --statistics --count PIL/*.py
 	pep8 --statistics --count Tests/*.py
 	pyflakes *.py       | tee >(wc -l)
 	pyflakes PIL/*.py   | tee >(wc -l)
 	pyflakes Tests/*.py | tee >(wc -l)
+fi
 
+if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ] && [ "$DOCKER" == "" ]; then
 	# Coverage and quality reports on just the latest diff.
 	# (Installation is very slow on Py3, so just do it for Py2.)
 	depends/diffcover-install.sh

--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -13,19 +13,19 @@ coverage report
 pip install coveralls-merge
 coveralls-merge coverage.c.json
 
-if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then
+if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ] && [ "$DOCKER" == "" ]; then
 	pip install pep8 pyflakes
 	pep8 --statistics --count PIL/*.py
 	pep8 --statistics --count Tests/*.py
 	pyflakes *.py       | tee >(wc -l)
 	pyflakes PIL/*.py   | tee >(wc -l)
 	pyflakes Tests/*.py | tee >(wc -l)
-fi
 
-# Coverage and quality reports on just the latest diff.
-# (Installation is very slow on Py3, so just do it for Py2.)
-if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then depends/diffcover-install.sh; fi
-if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then depends/diffcover-run.sh; fi
+	# Coverage and quality reports on just the latest diff.
+	# (Installation is very slow on Py3, so just do it for Py2.)
+	depends/diffcover-install.sh
+	depends/diffcover-run.sh
+fi
 
 # after_all
 

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+sudo apt-get update
+sudo apt-get -qq install libfreetype6-dev liblcms2-dev\
+			 python-qt4 ghostscript libffi-dev libjpeg-turbo-progs cmake imagemagick
+pip install cffi
+pip install nose
+pip install check-manifest
+pip install olefile
+# Pyroma tests sometimes hang on PyPy; skip
+if [ "$TRAVIS_PYTHON_VERSION" != "pypy" ]; then pip install pyroma; fi
+
+pip install coverage
+
+# docs only on python 2.7
+if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then pip install -r requirements.txt ; fi
+
+# clean checkout for manifest
+mkdir /tmp/check-manifest && cp -a . /tmp/check-manifest
+
+# webp
+pushd depends && ./install_webp.sh && popd
+
+# openjpeg
+pushd depends && ./install_openjpeg.sh && popd
+
+# libimagequant
+pushd depends && ./install_imagequant.sh && popd
+
+# extra test images
+pushd depends && ./install_extra_test_images.sh && popd
+

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+coverage erase
+python setup.py clean
+CFLAGS="-coverage" python setup.py build_ext --inplace
+
+coverage run --append --include=PIL/* selftest.py
+coverage run --append --include=PIL/* -m nose -vx Tests/test_*.py
+pushd /tmp/check-manifest && check-manifest --ignore ".coveragerc,.editorconfig,*.yml,*.yaml,tox.ini" && popd
+
+# Docs
+if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then make install && make doccheck; fi

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -135,7 +135,12 @@ class TestNumpy(PillowTestCase):
         img = Image.fromarray(arr * 255).convert('1')
         self.assertEqual(img.mode, '1')
         arr_back = numpy.array(img)
-        numpy.testing.assert_array_equal(arr, arr_back)
+        # numpy 1.8 and earlier return this as a boolean. (trusty/precise)
+        if arr_back.dtype == numpy.bool:
+            arr_bool = numpy.array([[1, 0, 0, 1, 0], [0, 1, 0, 0, 0]], 'bool')
+            numpy.testing.assert_array_equal(arr_bool, arr_back)
+        else:
+            numpy.testing.assert_array_equal(arr, arr_back)
 
     def test_save_tiff_uint16(self):
         # Tests that we're getting the pixel value in the right byte order.

--- a/Tests/test_scipy.py
+++ b/Tests/test_scipy.py
@@ -1,10 +1,11 @@
 from helper import unittest, PillowTestCase
-
+from distutils.version import StrictVersion
 try:
     import numpy as np
     from numpy.testing import assert_equal
 
     from scipy import misc
+    import scipy
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False
@@ -27,6 +28,11 @@ class Test_scipy_resize(PillowTestCase):
             im1 = misc.imresize(im, T(1.101))
             self.assertEqual(im1.shape, (11, 22))
 
+    # this test fails prior to scipy 0.14.0b1
+    # https://github.com/scipy/scipy/commit/855ff1fff805fb91840cf36b7082d18565fc8352
+    @unittest.skipIf(HAS_SCIPY and
+					 (StrictVersion(scipy.__version__) < StrictVersion('0.14.0')),
+                     "Test fails on scipy < 0.14.0")
     def test_imresize4(self):
         im = np.array([[1, 2],
                        [3, 4]])


### PR DESCRIPTION
Fixes #2152.

This is a big, in progress refactor and addition. 

* I've added 4 new test items in the matrix, Alpine, Precise (12.04), Xenial (16.04), and Trusty X86 (14.04). They're all testing py2.7 for now. I particularly want the x86 part of the matrix, because we've tripped over that recently. (and there's a pr requiring x86 testing: #2359) Precise and Xenial wind up testing different library versions, also useful and necessary for the tiff metadata pr #2288.
* I've added a repo of docker files, so they can be pulled from the dockerhub.  I'm not convinced that it's tons faster to do that rather than just install from bare images.
* ~I've converted a few random test docstrings so that the -v listing shows all the test names that have been run.~ 
* I've re-orged the .travis.yml file, refactoring some of it into scripts so that it's easier to gate on docker/non-docker. This unfortunately removes the travis_retry verb, since it's implemented in travis, not shell. 
* ~I'm going to at least rebase the many commits this prior to merge.~

And the big one -- Tests are failing:
* ~There are actual failing tests on the trusty one.~
* ~Precise is hanging, I think on Jpeg2k. It doesn't do it OMM, where I'm building the docker image. (go figure).~  