### PR TITLE
Prevent `nose -v` printing docstrings

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -149,6 +149,10 @@ class PillowTestCase(unittest.TestCase):
         if skip:
             self.skipTest(msg or "Known Bad Test")
 
+    def shortDescription(self):
+        # Prevents `nose -v` printing docstrings
+        return None
+
     def tempfile(self, template):
         assert template[:5] in ("temp.", "temp_")
         fd, path = tempfile.mkstemp(template[4:], template[:4])


### PR DESCRIPTION
Before:
```
TestFileDcx.test_seek_too_far ... ok
TestFileDcx.test_tell ... ok
Check invalid prefix ... ok
Check valid prefix ... ok
Check DX10 images can be opened ... ok
Check DXT1 images can be opened ... ok
Check DXT3 images can be opened ... ok
Check DXT5 images can be opened ... ok
Check that the appropriate error is thrown for a short file ... ok
Check a short header ... ok
TestFileEps.test_bytesio_object ... ok
TestFileEps.test_cmyk ... ok
```

After:
```
TestFileDcx.test_seek_too_far ... ok
TestFileDcx.test_tell ... ok
TestFileDds.test__validate_false ... ok
TestFileDds.test__validate_true ... ok
TestFileDds.test_dx10_bc7 ... ok
TestFileDds.test_sanity_dxt1 ... ok
TestFileDds.test_sanity_dxt3 ... ok
TestFileDds.test_sanity_dxt5 ... ok
TestFileDds.test_short_file ... ok
TestFileDds.test_short_header ... ok
TestFileEps.test_bytesio_object ... ok
TestFileEps.test_cmyk ... ok
```

This means we don't necessarily need to go and remove the old docstings (see https://github.com/python-pillow/Pillow/pull/2368) and, more importantly, don't need to remember to remove/prevent them in the future.