### PR TITLE
Fixed bug when comparing frames in GifImagePlugin

### DIFF
--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -365,6 +365,7 @@ def _save(im, fp, filename, save_all=False):
                 # e.g. getdata(im_frame, duration=1000)
                 if not previous:
                     # global header
+                    previous = im_frame.copy()
                     first_frame = getheader(im_frame, palette, encoderinfo)[0]
                     first_frame += getdata(im_frame, (0, 0), **encoderinfo)
                 else:
@@ -386,7 +387,7 @@ def _save(im, fp, filename, save_all=False):
                     else:
                         # FIXME: what should we do in this case?
                         pass
-                previous = im_frame
+                    previous = im_frame
         if first_frame:
             save_all = False
     if not save_all:

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -406,10 +406,10 @@ class TestFileGif(PillowTestCase):
 
     def test_transparent_optimize(self):
         # from issue #2195, if the transparent color is incorrectly
-        # optimized out, gif loses transparency Need a palette that
-        # isn't using the 0 color, and one that's > 128 items where
-        # the transparent color is actually the top palette entry to
-        # trigger the bug.
+        # optimized out, gif loses transparency
+        # Need a palette that isn't using the 0 color, and one
+        # that's > 128 items where the transparent color is actually
+        # the top palette entry to trigger the bug.
 
         from PIL import ImagePalette
 
@@ -425,7 +425,17 @@ class TestFileGif(PillowTestCase):
         reloaded = Image.open(out)
 
         self.assertEqual(reloaded.info['transparency'], 253)
-        
+
+    def test_bbox(self):
+        out = self.tempfile('temp.gif')
+
+        im = Image.new('RGB', (100,100), '#fff')
+        ims = [Image.new("RGB", (100,100), '#000')]
+        im.save(out, save_all=True, append_images=ims)
+
+        reread = Image.open(out)
+        self.assertEqual(reread.n_frames, 2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/issues/2314#issuecomment-274265583 raises a bug.

In the first iteration of the frames loop, `getheader` is called, which in turn calls `_get_palette_bytes`. In this test case, that changes the image, and so changes the resulting delta to say that there are no differences between the first and the second frames.

So, this PR makes a copy of the frame before `getheader` is called, and that copy is used for the comparison.