### PR TITLE
BUG fix: '' in image mode no longer causes a crash

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -29,6 +29,7 @@ class TestImage(PillowTestCase):
         self.assertEqual(im3.getcolors(), [(10000, 0)])
 
         self.assertRaises(ValueError, lambda: Image.new("X", (100, 100)))
+        self.assertRaises(ValueError, lambda: Image.new("", (100, 100)))
         # self.assertRaises(
         #     MemoryError, lambda: Image.new("L", (1000000, 1000000)))
 

--- a/libImaging/Storage.c
+++ b/libImaging/Storage.c
@@ -398,6 +398,9 @@ ImagingNew(const char* mode, int xsize, int ysize)
     int bytes;
     Imaging im;
 
+    if (strcmp(mode, "") == 0)
+        return (Imaging) ImagingError_ValueError("empty mode");
+
     if (strlen(mode) == 1) {
         if (mode[0] == 'F' || mode[0] == 'I')
             bytes = 4;


### PR DESCRIPTION
Hey,
This is a simple fix for this interpreter crashing bug:

```
>>> from PIL import Image
>>> Image.new('', (640,480))
Floating point exception
```
After the change:
```
>>> from PIL import Image
>>> Image.new('', (640,480))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/lukasz/code/python/pillow/Pillow/PIL/Image.py", line 2061, in new
    return Image()._new(core.fill(mode, size, color))
ValueError: empty mode
```
It would be nice to move the check to ImagingNewPrologueSubtype, where many other mode related checks are, but the empty string leads to division by zero in `THRESHOLD / bytes`.