### PR TITLE
Fix after_success.sh syntax error

### DIFF
--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -44,3 +44,4 @@ if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "mas
             echo "Some jobs failed"
         fi
     fi
+fi


### PR DESCRIPTION
Before:
```
.travis/after_success.sh: line 47: syntax error: unexpected end of file
```
https://travis-ci.org/python-pillow/Pillow/jobs/196494746#L4663