### PR TITLE
Add disposal option for saving GIF

### DIFF
--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -453,15 +453,24 @@ def _get_local_header(fp, im, offset, flags):
         duration = int(im.encoderinfo["duration"] / 10)
     else:
         duration = 0
+
+    if "disposal" in im.encoderinfo:
+        disposal = int(im.encoderinfo['disposal'])
+        if not 0<= disposal <=3:
+            disposal = 2
+    else:
+        disposal = 2
+
     if transparent_color_exists or duration != 0:
-        transparency_flag = 1 if transparent_color_exists else 0
+        packed_flag = 1 if transparent_color_exists else 0
+        packed_flag |= disposal << 2
         if not transparent_color_exists:
             transparency = 0
 
         fp.write(b"!" +
                  o8(249) +                # extension intro
                  o8(4) +                  # length
-                 o8(transparency_flag) +  # packed fields
+                 o8(packed_flag) +        # packed fields
                  o16(duration) +          # duration
                  o8(transparency) +       # transparency index
                  o8(0))

--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -454,14 +454,9 @@ def _get_local_header(fp, im, offset, flags):
     else:
         duration = 0
 
-    if "disposal" in im.encoderinfo:
-        disposal = int(im.encoderinfo['disposal'])
-        if not 0<= disposal <=3:
-            disposal = 2
-    else:
-        disposal = 2
+    disposal = int(im.encoderinfo.get('disposal', 0))
 
-    if transparent_color_exists or duration != 0:
+    if transparent_color_exists or duration != 0 or disposal:
         packed_flag = 1 if transparent_color_exists else 0
         packed_flag |= disposal << 2
         if not transparent_color_exists:

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -259,6 +259,28 @@ class TestFileGif(PillowTestCase):
         except EOFError:
             pass
 
+    def test_save_dispose(self):
+        out = self.tempfile('temp.gif')
+        im_list = [
+            Image.new('L', (100, 100), '#000'),
+            Image.new('L', (100, 100), '#111'),
+            Image.new('L', (100, 100), '#222'),
+        ]
+        for method in range(0,4):
+            im_list[0].save(
+                out,
+                save_all=True,
+                append_images=im_list[1:],
+                disposal=method
+            )
+            img = Image.open(out)
+            try:
+                while True:
+                    img.seek(img.tell() + 1)
+                    self.assertEqual(img.disposal_method, method)
+            except EOFError:
+                pass
+
     def test_iss634(self):
         img = Image.open("Tests/images/iss634.gif")
         # seek to the second frame

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -127,6 +127,14 @@ are available::
 **palette**
     Use the specified palette for the saved image.
 
+**disposal**
+    Indicates the way in which the graphic is to be treated after being displayed.
+
+    * 0 - No disposal specified.
+    * 1 - Do not dispose.
+    * 2 - Restore to background color.
+    * 3 - Restore to previous content.
+
 Reading local images
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
After Reading [GIF89a spec](https://www.w3.org/Graphics/GIF/spec-gif89a.txt), 
I add disposal option which is important for GIF animation with transparent images.

This change is independent to other options.

You can see the difference of disposal option between two images below.
![dispose_none](https://github.com/larsjsol/Pillow/blob/9e5f2f92497d067bfa2be0c6cb6167d133cefcb2/Tests/images/dispose_none.gif?raw=true)
![dispose_prev](https://github.com/larsjsol/Pillow/blob/9e5f2f92497d067bfa2be0c6cb6167d133cefcb2/Tests/images/dispose_prev.gif?raw=true)