### PR TITLE
Docs: Update http to https

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog (Pillow)
 
 - Preserve aux/alpha channels when performing Imagecms transforms #2355
   [gunjambi]
-  
+
 - Test linear and radial gradient effects #2382
   [hugovk]
 
@@ -18,10 +18,10 @@ Changelog (Pillow)
 
 - BUG: Empty image mode no longer causes a crash #2380
   [evalapply]
-  
+
 - Exclude .travis and contents from manifest #2386
   [radarhere]
-  
+
 - Remove 'MIT-like' from license #2145
   [wiredfool]
 
@@ -42,19 +42,19 @@ Changelog (Pillow)
 
 - Tests: Added docker images for testing alternate platforms. See also https://github.com/python-pillow/docker-images. #2368
   [wiredfool]
-  
+
 - Removed PIL 1.0 era TK readme that concerns Windows 95/NT #2360
   [wiredfool]
 
 - Prevent `nose -v` printing docstrings #2369
   [hugovk]
-  
+
 - Replaced absolute PIL imports with relative imports #2349
   [radarhere]
 
 - Added context managers for file handling #2307
   [radarhere]
-  
+
 - Expose registered file extensions in Image #2343
   [iggomez, radarhere]
 
@@ -81,16 +81,16 @@ Changelog (Pillow)
 
 - Add center and translate option to Image.rotate. #2328
   [lambdafu]
-  
+
 - Test: Relax WMF test condition, fixes #2323
-  [wiredfool] 
+  [wiredfool]
 
 - Allow 0 size images, Fixes #2259, Reverts to pre-3.4 behavior.
   [wiredfool]
-  
+
 - SGI: Save uncompressed SGI/BW/RGB/RGBA files #2325
   [jbltx]
-  
+
 - Depends: Updated pngquant to 2.8.2 #2319
   [radarhere]
 
@@ -1983,7 +1983,7 @@ Changelog (Pillow)
 - Use PyCapsule for py3.1 #238 (fixes #237)
   [wiredfool]
 
-- Workaround for: http://bugs.python.org/issue16754 in 3.2.x < 3.2.4 and 3.3.0.
+- Workaround for: https://bugs.python.org/issue16754 in 3.2.x < 3.2.4 and 3.3.0.
 
 2.0.0 (2013-03-15)
 ------------------
@@ -2132,7 +2132,7 @@ Changelog (Pillow)
 ----------------
 
 - Remove support for ``import Image``, etc. from the standard namespace. ``from PIL import Image`` etc. now required.
-- Forked PIL based on `Hanno Schlichting's re-packaging <http://dist.plone.org/thirdparty/PIL-1.1.7.tar.gz>`_
+- Forked PIL based on `Hanno Schlichting's re-packaging <https://dist.plone.org/thirdparty/PIL-1.1.7.tar.gz>`_
   [aclark4life]
 
 Pre-fork

--- a/PIL/SpiderImagePlugin.py
+++ b/PIL/SpiderImagePlugin.py
@@ -27,10 +27,10 @@
 # image data from electron microscopy and tomography.
 #
 # Spider home page:
-# http://spider.wadsworth.org/spider_doc/spider/docs/spider.html
+# https://spider.wadsworth.org/spider_doc/spider/docs/spider.html
 #
 # Details about the Spider image format:
-# http://spider.wadsworth.org/spider_doc/spider/docs/image_doc.html
+# https://spider.wadsworth.org/spider_doc/spider/docs/image_doc.html
 #
 
 from __future__ import print_function

--- a/PIL/SunImagePlugin.py
+++ b/PIL/SunImagePlugin.py
@@ -118,7 +118,7 @@ class SunImageFile(ImageFile.ImageFile):
         # RGB looks similar to standard, but RGB byte order
         # TIFF and IFF mean that they were converted from T/IFF
         # Experimental means that it's something else.
-        # (http://www.fileformat.info/format/sunraster/egff.htm)
+        # (https://www.fileformat.info/format/sunraster/egff.htm)
 
         if file_type in (0, 1, 3, 4, 5):
             self.tile = [("raw", (0, 0)+self.size, offset, (rawmode, stride))]

--- a/PIL/WalImageFile.py
+++ b/PIL/WalImageFile.py
@@ -18,7 +18,7 @@
 # the WalImageFile.open() function instead.
 
 # This reader is based on the specification available from:
-#    http://www.flipcode.com/archives/Quake_2_BSP_File_Format.shtml
+#    https://www.flipcode.com/archives/Quake_2_BSP_File_Format.shtml
 # and has been tested with a few sample files found using google.
 
 from __future__ import print_function

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -168,7 +168,7 @@ class TestImage(PillowTestCase):
         self.assertTrue(im1 != im2)
 
     def test_alpha_composite(self):
-        # http://stackoverflow.com/questions/3374878
+        # https://stackoverflow.com/questions/3374878
         # Arrange
         from PIL import ImageDraw
 

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -100,7 +100,7 @@ class TestNumpy(PillowTestCase):
         self.assert_image(to_image(numpy.uint8, 4), "RGBA", (10, 10))
 
     # based on an erring example at
-    # http://stackoverflow.com/questions/10854903/what-is-causing-dimension-dependent-attributeerror-in-pil-fromarray-function
+    # https://stackoverflow.com/questions/10854903/what-is-causing-dimension-dependent-attributeerror-in-pil-fromarray-function
     def test_3d_array(self):
         size = (5, TEST_IMAGE_SIZE[0], TEST_IMAGE_SIZE[1])
         a = numpy.ones(size, dtype=numpy.uint8)

--- a/_imagingcms.c
+++ b/_imagingcms.c
@@ -828,7 +828,7 @@ static cmsBool _calculate_rgb_primaries(CmsProfileObject* self, cmsCIEXYZTRIPLE*
     cmsHPROFILE hXYZ;
     cmsHTRANSFORM hTransform;
 
-    /* http://littlecms2.blogspot.com/2009/07/less-is-more.html */
+    /* https://littlecms2.blogspot.com/2009/07/less-is-more.html */
 
     // double array of RGB values with max on each identity
     hXYZ = cmsCreateXYZProfile();
@@ -1606,7 +1606,7 @@ PyInit__imagingcms(void) {
 
     if (setup_module(m) < 0)
         return NULL;
-   
+
     PyDateTime_IMPORT;
 
     return m;

--- a/docs/_templates/sidebarhelp.html
+++ b/docs/_templates/sidebarhelp.html
@@ -1,4 +1,4 @@
 <h3>Need help?</h3>
 <p>
-    You can get help via IRC at <a href="irc://irc.freenode.net#pil">irc://irc.freenode.net#pil</a> or Stack Overflow <a href="http://stackoverflow.com/questions/tagged/pillow">here</a> and <a href="http://stackoverflow.com/questions/tagged/pil">here</a>. Please <a href="https://github.com/python-pillow/Pillow/issues/new">report issues on GitHub</a>.
+    You can get help via IRC at <a href="irc://irc.freenode.net#pil">irc://irc.freenode.net#pil</a> or Stack Overflow <a href="https://stackoverflow.com/questions/tagged/pillow">here</a> and <a href="https://stackoverflow.com/questions/tagged/pil">here</a>. Please <a href="https://github.com/python-pillow/Pillow/issues/new">report issues on GitHub</a>.
 </p>

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -79,7 +79,7 @@ The :py:meth:`~PIL.Image.Image.open` method sets the following
 **version**
     Version (either ``GIF87a`` or ``GIF89a``).
 
-**duration** 
+**duration**
     May not be present. The time to display the current frame
     of the GIF, in milliseconds.
 
@@ -514,8 +514,8 @@ the output format must be specified explicitly::
 For more information about the SPIDER image processing package, see the
 `SPIDER homepage`_ at `Wadsworth Center`_.
 
-.. _SPIDER homepage: http://spider.wadsworth.org/spider_doc/spider/docs/spider.html
-.. _Wadsworth Center: http://www.wadsworth.org/
+.. _SPIDER homepage: https://spider.wadsworth.org/spider_doc/spider/docs/spider.html
+.. _Wadsworth Center: https://www.wadsworth.org/
 
 TIFF
 ^^^^

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -243,7 +243,7 @@ have the full Xcode package installed.  It may be necessary to run
 tools.
 
 The easiest way to install external libraries is via `Homebrew
-<http://brew.sh/>`_. After you install Homebrew, run::
+<https://brew.sh/>`_. After you install Homebrew, run::
 
     $ brew install libtiff libjpeg webp little-cms2
 

--- a/libImaging/SunRleDecode.c
+++ b/libImaging/SunRleDecode.c
@@ -58,7 +58,7 @@ ImagingSunRleDecode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
                 if (bytes < 3)
                     break;
 
-                /* from (http://www.fileformat.info/format/sunraster/egff.htm)
+                /* from (https://www.fileformat.info/format/sunraster/egff.htm)
 
                    For example, a run of 100 pixels with the value of
                    0Ah would encode as the values 80h 64h 0Ah. A
@@ -67,8 +67,8 @@ ImagingSunRleDecode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
                    would be stored in the RLE stream as 12h 34h 56h
                    78h.  100 pixels, n=100, not 100 pixels, n=99.
 
-                   But Wait! There's More! 
-                   (http://www.fileformat.info/format/sunraster/spec/598a59c4fac64c52897585d390d86360/view.htm)
+                   But Wait! There's More!
+                   (https://www.fileformat.info/format/sunraster/spec/598a59c4fac64c52897585d390d86360/view.htm)
 
                    If the first byte is 0x80, and the second byte is
                    not zero, the record is three bytes long. The
@@ -78,7 +78,7 @@ ImagingSunRleDecode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
                    2 specs, same site, but Imagemagick and GIMP seem
                    to agree on the second one.
                 */
-                n += 1; 
+                n += 1;
 
                 if (state->x + n > state->bytes) {
                     extra_bytes = n;  /* full value */
@@ -96,8 +96,8 @@ ImagingSunRleDecode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
 
         } else {
 
-            /* Literal byte */ 
-            n = 1; 
+            /* Literal byte */
+            n = 1;
 
             state->buffer[state->x] = ptr[0];
 
@@ -108,7 +108,7 @@ ImagingSunRleDecode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
 
         for (;;) {
             state->x += n;
-        
+
             if (state->x >= state->bytes) {
 
                 /* Got a full line, unpack it */
@@ -123,7 +123,7 @@ ImagingSunRleDecode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
                     return -1;
                 }
             }
-            
+
             if (extra_bytes == 0) {
                 break;
             }

--- a/mp_compile.py
+++ b/mp_compile.py
@@ -72,7 +72,7 @@ def install():
         # explicitly don't enable if environment says 1 processor
         try:
             # bug, only enable if we can make a Pool. see issue #790 and
-            # http://stackoverflow.com/questions/6033599/oserror-38-errno-38-with-multiprocessing
+            # https://stackoverflow.com/questions/6033599/oserror-38-errno-38-with-multiprocessing
             pool = Pool(2)
             CCompiler.compile = _mp_compile
         except Exception as msg:

--- a/setup.py
+++ b/setup.py
@@ -718,7 +718,7 @@ try:
           long_description=_read('README.rst').decode('utf-8'),
           author='Alex Clark (Fork Author)',
           author_email='aclark@aclark.net',
-          url='http://python-pillow.org',
+          url='https://python-pillow.org',
           classifiers=[
               "Development Status :: 6 - Mature",
               "Topic :: Multimedia :: Graphics",
@@ -753,7 +753,7 @@ The headers or library files could not be found for %s,
 a required dependency when compiling Pillow from source.
 
 Please see the install instructions at:
-   http://pillow.readthedocs.io/en/latest/installation.html
+   https://pillow.readthedocs.io/en/latest/installation.html
 
 """ % (str(err))
     sys.stderr.write(msg)

--- a/winbuild/config.py
+++ b/winbuild/config.py
@@ -37,7 +37,7 @@ libs = {
         'dir': 'tiff-4.0.6',
     },
     'freetype': {
-        'url': 'http://download.savannah.gnu.org/releases/freetype/freetype-2.7.1.tar.gz',
+        'url': 'https://download.savannah.gnu.org/releases/freetype/freetype-2.7.1.tar.gz',
         'filename': PILLOW_DEPENDS_DIR + 'freetype-2.7.1.tar.gz',
         'hash': 'md5:78701bee8d249578d83bb9a2f3aa3616',
         'dir': 'freetype-2.7.1',


### PR DESCRIPTION
Fixes these:
```
(line  514) redirect  http://www.wadsworth.org/ - permanently to https://www.wadsworth.org/
(line  514) redirect  http://spider.wadsworth.org/spider_doc/spider/docs/spider.html - permanently to https://spider.wadsworth.org/spider_doc/spider/docs/spider.html
...
(line  245) redirect  http://brew.sh/ - permanently to https://brew.sh/
```
https://travis-ci.org/python-pillow/Pillow/jobs/201197416#L3852

Also update some other `http:` to `https:`.