### PR TITLE
Allow to save tiff stacks from separate images

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -473,6 +473,18 @@ class TestFileTiff(PillowTestCase):
         with Image.open(mp) as im:
             self.assertEqual(im.n_frames, 3)
 
+        # Test appending images
+        mp = io.BytesIO()
+        im = Image.new('RGB', (100, 100), '#f00')
+        ims = [Image.new('RGB', (100, 100), color) for color
+               in ['#0f0', '#00f']]
+        im.save(mp, format="TIFF", save_all=True, append_images=ims)
+
+        mp.seek(0, os.SEEK_SET)
+        reread = Image.open(mp)
+        self.assertEqual(reread.n_frames, 3)
+
+
     def test_saving_icc_profile(self):
         # Tests saving TIFF with icc_profile set.
         # At the time of writing this will only work for non-compressed tiffs


### PR DESCRIPTION
This is a quick solution that will allow to save tiff stacks from separate images, _e.g._ from Numpy arrays. Previously, tiff stacks could be saved only from multiframe images.
This behavior is similar to what is possible now with GIFs. Note however, that for correct results, all the appended images should have the same ```encoder{info,config}``` properties.

Example:
```python
import numpy as np
from PIL import Image
a = np.ones((100,100,100), dtype=np.uint8)
imlist = []
for m in a:
    imlist.append(Image.fromarray(m))

imlist[0].save("test.tif", compression="tiff_deflate", save_all=True,
               append_images=imlist[1:])
```
...This should result in a 100-frame, 100x100 tiff stack. (Previously: would save only the first frame, despite ```save_all``` and ```append_images```.)

Please see the discussion here: #2401
And a previous pull request here: #2404 (I deleted my fork previously, so opening a new one)
