### PR TITLE
Crop decompression

### DIFF
--- a/PIL/GifImagePlugin.py
+++ b/PIL/GifImagePlugin.py
@@ -257,7 +257,7 @@ class GifImageFile(ImageFile.ImageFile):
 
             # only dispose the extent in this frame
             if self.dispose:
-                self.dispose = self.dispose.crop(self.dispose_extent)
+                self.dispose = self._crop(self.dispose, self.dispose_extent)
         except (AttributeError, KeyError):
             pass
 
@@ -280,7 +280,7 @@ class GifImageFile(ImageFile.ImageFile):
         if self._prev_im and self.disposal_method == 1:
             # we do this by pasting the updated area onto the previous
             # frame which we then use as the current image content
-            updated = self.im.crop(self.dispose_extent)
+            updated = self._crop(self.im, self.dispose_extent)
             self._prev_im.paste(updated, self.dispose_extent,
                                 updated.convert('RGBA'))
             self.im = self._prev_im

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1042,6 +1042,20 @@ class Image(object):
         if box is None:
             return self.copy()
 
+        return self._new(self._crop(self.im, box))
+
+    def _crop(self, im, box):
+        """
+        Returns a rectangular region from the core image object im.
+
+        This is equivalent to calling im.crop((x0, y0, x1, y1)), but
+        includes additional sanity checks.
+
+        :param im: a core image object
+        :param box: The crop rectangle, as a (left, upper, right, lower)-tuple.
+        :returns: A core image object.
+        """
+
         x0, y0, x1, y1 = map(int, map(round, box))
 
         if x0 == 0 and y0 == 0 and (x1, y1) == self.size:
@@ -1052,8 +1066,10 @@ class Image(object):
         if y1 < y0:
             y1 = y0
 
-        return self._new(self.im.crop((x0, y0, x1, y1)))
+        _decompression_bomb_check((x1, y1))
 
+        return im.crop((x0, y0, x1, y1))
+         
     def draft(self, mode, size):
         """
         Configures the image file loader so it returns a version of the

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1058,9 +1058,6 @@ class Image(object):
 
         x0, y0, x1, y1 = map(int, map(round, box))
 
-        if x0 == 0 and y0 == 0 and (x1, y1) == self.size:
-            return self.copy()
-
         if x1 < x0:
             x1 = x0
         if y1 < y0:

--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 
@@ -35,9 +35,24 @@ class TestDecompressionBomb(PillowTestCase):
         self.assertEqual(Image.MAX_IMAGE_PIXELS, 10)
 
         # Act / Assert
-        self.assert_warning(
-            Image.DecompressionBombWarning,
-            lambda: Image.open(TEST_FILE))
+        self.assert_warning(Image.DecompressionBombWarning,
+                            lambda: Image.open(TEST_FILE))
+
+class TestDecompressionCrop(PillowTestCase):
+
+    def setUp(self):
+        self.src = hopper()
+        Image.MAX_IMAGE_PIXELS = self.src.height * self.src.width
+
+    def tearDown(self):
+        Image.MAX_IMAGE_PIXELS = ORIGINAL_LIMIT
+
+    def testEnlargeCrop(self):
+        # Crops can extend the extents, therefore we should have the
+        # same decompression bomb warnings on them.
+        box = (0, 0, self.src.width * 2, self.src.height * 2)
+        self.assert_warning(Image.DecompressionBombWarning,
+                            lambda: self.src.crop(box))    
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #2402 .

Changes proposed in this pull request:

 * Add decompression bomb check for image.crop, since it can enlarge images.
 * Refactor out checks to _crop, so that we can apply them to any core image object.
 * Gif disposal is where the bug in #2402 was, it was requesting a 1GP dispose_extents.

Still need to: 
~- [ ] Generate a gif with extra large extents~
 - [x] Consider making decompression bombs an error at some level, as now the gif from #2402 kicks out a warning, then dies. 
