### PR TITLE
Replaced broken URL

### DIFF
--- a/PIL/EpsImagePlugin.py
+++ b/PIL/EpsImagePlugin.py
@@ -321,7 +321,7 @@ class EpsImageFile(ImageFile.ImageFile):
             # EPS can contain binary data
             # or start directly with latin coding
             # more info see:
-            # http://partners.adobe.com/public/developer/en/ps/5002.EPSF_Spec.pdf
+            # https://web.archive.org/web/20160528181353/http://partners.adobe.com/public/developer/en/ps/5002.EPSF_Spec.pdf
             offset = i32(s[4:8])
             length = i32(s[8:12])
         else:

--- a/PIL/JpegPresets.py
+++ b/PIL/JpegPresets.py
@@ -62,7 +62,7 @@ The tables format between im.quantization and quantization in presets differ in
 You can convert the dict format to the preset format with the
 `JpegImagePlugin.convert_dict_qtables(dict_qtables)` function.
 
-Libjpeg ref.: http://web.archive.org/web/20120328125543/http://www.jpegcameras.com/libjpeg/libjpeg-3.html
+Libjpeg ref.: https://web.archive.org/web/20120328125543/http://www.jpegcameras.com/libjpeg/libjpeg-3.html
 
 """
 


### PR DESCRIPTION
http://partners.adobe.com/public/developer/en/ps/5002.EPSF_Spec.pdf no longer works, so this PR replaces it with a web.archive.org URL.

Also replaces a http URL with https, in the spirit of #2403