### PR TITLE
Fix division by zero when creating 0x0 image from numpy array

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -2036,7 +2036,7 @@ def _check_size(size):
     if len(size) != 2:
         raise ValueError("Size must be a tuple of length 2")
     if size[0] < 0 or size[1] < 0:
-        raise ValueError("Width and Height must be => 0")
+        raise ValueError("Width and height must be >= 0")
 
     return True
 

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -204,6 +204,14 @@ class TestNumpy(PillowTestCase):
 
         self.assertEqual(len(im.getdata()), len(arr))
 
+    def test_zero_size(self):
+        # Shouldn't cause floating point exception
+        # See https://github.com/python-pillow/Pillow/issues/2259
+
+        im = Image.fromarray(numpy.empty((0, 0), dtype=numpy.uint8))
+
+        self.assertEqual(im.size, (0, 0))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/map.c
+++ b/map.c
@@ -342,7 +342,7 @@ PyImaging_MapBuffer(PyObject* self, PyObject* args)
             stride = xsize * 4;
     }
 
-    if (ysize > INT_MAX / stride) {
+    if (stride > 0 && ysize > INT_MAX / stride) {
         PyErr_SetString(PyExc_MemoryError, "Integer overflow in ysize");
         return NULL;
     }
@@ -352,7 +352,7 @@ PyImaging_MapBuffer(PyObject* self, PyObject* args)
     if (offset > PY_SSIZE_T_MAX - size) {
         PyErr_SetString(PyExc_MemoryError, "Integer overflow in offset");
         return NULL;
-    }        
+    }
 
     /* check buffer size */
     if (PyImaging_GetBuffer(target, &view) < 0)


### PR DESCRIPTION
Fixes #2259.

Changes proposed in this pull request:

 * Avoid [division by zero](https://github.com/python-pillow/Pillow/blob/badc3ec1f37096ebf959524b4bcf2c14db2d7936/map.c#L345) when creating a 0x0 image from a numpy array: `stride` is zero
 * Add test case using numpy
 * Update an error message from #2262