### PR TITLE
Reenable QPixmap tests on arch

### DIFF
--- a/Tests/test_image_fromqpixmap.py
+++ b/Tests/test_image_fromqpixmap.py
@@ -3,8 +3,6 @@ from test_imageqt import PillowQtTestCase, PillowQPixmapTestCase
 
 from PIL import ImageQt
 
-@unittest.skipIf(ImageQt.qt_version == '5' and distro() == 'arch',
-				 "Topixmap fails on Arch + QT5")
 class TestFromQPixmap(PillowQPixmapTestCase, PillowTestCase):
 
     def roundtrip(self, expected):

--- a/Tests/test_image_toqpixmap.py
+++ b/Tests/test_image_toqpixmap.py
@@ -9,8 +9,6 @@ if ImageQt.qt_is_installed:
 
 class TestToQPixmap(PillowQPixmapTestCase, PillowTestCase):
 
-    @unittest.skipIf(ImageQt.qt_version == '5' and distro() == 'arch',
-                     "Topixmap fails on Arch + QT5")
     def test_sanity(self):
         PillowQtTestCase.setUp(self)
 


### PR DESCRIPTION
Arch qpixmap is fixed on on the docker side with the environment variable QT_QPA_PLATFORM=offscreen
