### PR TITLE
Comment out broken PyPI downloads badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
     * - tests
       - | |linux| |macos| |windows| |coverage| |health|
     * - package
-      - |zenodo| |version| |downloads|
+      - |zenodo| |version|
 
 .. |docs| image:: https://readthedocs.org/projects/pillow/badge/?version=latest
    :target: https://pillow.readthedocs.io/?badge=latest
@@ -49,9 +49,9 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
    :target: https://pypi.python.org/pypi/Pillow/
    :alt: Latest PyPI version
 
-.. |downloads| image:: https://img.shields.io/pypi/dm/pillow.svg
-   :target: https://pypi.python.org/pypi/Pillow/
-   :alt: Number of PyPI downloads
+#.. |downloads| image:: https://img.shields.io/pypi/dm/pillow.svg
+#   :target: https://pypi.python.org/pypi/Pillow/
+#   :alt: Number of PyPI downloads
 
 .. end-badges
 


### PR DESCRIPTION
Let's comment out the downloads badge whilst it's broken and showing 0 downloads/month.

![downloads](https://cloud.githubusercontent.com/assets/3112309/22841419/a68c4412-f025-11e6-929f-e7ab37483986.png)

See also https://github.com/python-pillow/Pillow/issues/2396 and https://github.com/badges/shields/issues/716.