### PR TITLE
Remove commented download-count badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,10 +49,6 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
    :target: https://pypi.python.org/pypi/Pillow/
    :alt: Latest PyPI version
 
-#.. |downloads| image:: https://img.shields.io/pypi/dm/pillow.svg
-#   :target: https://pypi.python.org/pypi/Pillow/
-#   :alt: Number of PyPI downloads
-
 .. end-badges
 
 


### PR DESCRIPTION
The commenting out of https://github.com/python-pillow/Pillow/pull/2432 didn't work, so let's just remove it until the badge is fixed.

---

![image](https://cloud.githubusercontent.com/assets/1324225/23494236/262a8df2-ff1a-11e6-946f-369a6a9e8eff.png)
