### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ class pil_build_ext(build_ext):
         features = ['zlib', 'jpeg', 'tiff', 'freetype', 'lcms', 'webp',
                     'webpmux', 'jpeg2000', 'imagequant']
 
-        required = {'jpeg', 'zlib'}
+        required = ['jpeg', 'zlib']
 
         def __init__(self):
             for f in self.features:


### PR DESCRIPTION
When I Install Pillow with pip:

`pip install Pillow`

It will response:
```
  File "setup.py", line 138
    required = {'jpeg','zlib'}
                      ^
SyntaxError: invalid syntax
```
so, I make a change :
```
   required = ['jpeg','zlib']
```
