### PR TITLE
Run faster Dockers last so slower jobs don't hold up the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ notifications:
 
 # Run slow PyPy* first, to give them a headstart and reduce waiting time.
 # Run latest 3.x and 2.x next, to get quick compatibility results.
-# Then run the remainder.
+# Then run the remainder, with fastest Docker jobs last.
 
 matrix:
   fast_finish: true
@@ -14,17 +14,17 @@ matrix:
     - python: "pypy3"
     - python: '3.6'
     - python: '2.7'
+    - python:  "2.7_with_system_site_packages" # For PyQt4
+    - python: '3.5'
+    - python: '3.4'
+    - python: '3.3'
     - env: DOCKER="alpine"
     - env: DOCKER="arch" # contains PyQt5
     - env: DOCKER="ubuntu-trusty-x86"
     - env: DOCKER="ubuntu-xenial-amd64"
     - env: DOCKER="ubuntu-precise-amd64"
     - env: DOCKER="debian-stretch-x86"
-    - python:  "2.7_with_system_site_packages" # For PyQt4
-    - python: '3.5'
-    - python: '3.4'
-    - python: '3.3'
-  
+
 dist: trusty
 
 sudo: required
@@ -53,7 +53,7 @@ script:
 
 after_success:
   - .travis/after_success.sh
-  
+
 after_failure:
   - |
       if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then


### PR DESCRIPTION
Run the faster Docker jobs last (which are all under two minutes), so the slower ones don't hold up the build.

Similarly, this is why the slow PyPy jobs are first.

This PR:
* Ran for 9 min 40 sec https://travis-ci.org/python-pillow/Pillow/builds/215293752
* Ran for 9 min 55 sec https://travis-ci.org/hugovk/Pillow/builds/215289384

Older master builds:
* Ran for 10 min 8 sec https://travis-ci.org/python-pillow/Pillow/builds/215172329
* Ran for 12 min 32 sec https://travis-ci.org/python-pillow/Pillow/builds/214990466
* Ran for 9 min 58 sec https://travis-ci.org/python-pillow/Pillow/builds/214990372
* Ran for 11 min 45 sec https://travis-ci.org/python-pillow/Pillow/builds/214012098 
* Ran for 10 min 35 sec https://travis-ci.org/python-pillow/Pillow/builds/214011829