### PR TITLE
Set ContainerIO test file as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.ppm binary
+*.container binary


### PR DESCRIPTION
Fixes two test errors when cloning the master branch on Windows:

```
--------------------------------------------------------------------
PIL SETUP SUMMARY
--------------------------------------------------------------------
version      Pillow 4.1.0.dev0
platform     win32 3.6.1 (v3.6.1:69c0db5, Mar 21 2017, 18:41:36)
             [MSC v.1900 64 bit (AMD64)]
--------------------------------------------------------------------
--- JPEG support available
--- OPENJPEG (JPEG2000) support available (2.1)
--- ZLIB (PNG/ZIP) support available
*** LIBIMAGEQUANT support not available
--- LIBTIFF support available
--- FREETYPE2 support available
--- LITTLECMS2 support available
--- WEBP support available
--- WEBPMUX support available
<snip>
======================================================================
FAIL: TestFileContainer.test_read_n
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\Build\Pillow\Pillow-git\Tests\test_file_container.py", line 82, in test_read_n
    self.assertEqual(data, "7\nT")
AssertionError: ' li' != '7\nT'
-  li
+ 7
T


======================================================================
FAIL: TestFileContainer.test_read_n0
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\Build\Pillow\Pillow-git\Tests\test_file_container.py", line 70, in test_read_n0
    self.assertEqual(data, "7\nThis is line 8\n")
AssertionError: ' line 7\nThis is lin' != '7\nThis is line 8\n'
-  line 7
+ 7
- This is lin+ This is line 8
?            ++++
```

It seems that the `ContainerIO` class is not general purpose but is intended for files opened in binary mode and containing Unix line endings only (?).