### PR TITLE
Docs typos

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -360,7 +360,7 @@ These platforms are built and tested for every change.
 | Windows Server 2012 R2           | 2.7,3.3,3.4                   |x86, x86-64            |
 +----------------------------------+-------------------------------+-----------------------+
 
-* Mac OS X CI is not run for every commit, but is run for every release.
+\* macOS CI is not run for every commit, but is run for every release.
 
 Other Platforms
 ^^^^^^^^^^^^^^^

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -360,7 +360,7 @@ These platforms are built and tested for every change.
 | Windows Server 2012 R2           | 2.7,3.3,3.4                   |x86, x86-64            |
 +----------------------------------+-------------------------------+-----------------------+
 
-\* macOS CI is not run for every commit, but is run for every release.
+\* Mac OS X CI is not run for every commit, but is run for every release.
 
 Other Platforms
 ^^^^^^^^^^^^^^^

--- a/docs/releasenotes/4.1.0.rst
+++ b/docs/releasenotes/4.1.0.rst
@@ -6,7 +6,7 @@ Removed Deprecated Items
 
 Several deprecated items have been removed.
 
-* Support for spaces in tiff kwargs the parameters for 'x resolution', 'y
+* Support for spaces in tiff kwargs in the parameters for 'x resolution', 'y
   resolution', 'resolution unit', and 'date time' has been
   removed. Underscores should be used instead.
 
@@ -19,8 +19,8 @@ Closing Files When Opening Images
 =================================
 
 The file handling when opening images has been overhauled. Previously,
-there Pillow would attempt to close some, but not all image formats
-after loading the image data, but not all. Now, the following behavior
+Pillow would attempt to close some, but not all image formats
+after loading the image data. Now, the following behavior
 is specified:
 
 * For images where an open file is passed in, it is the
@@ -32,7 +32,7 @@ is specified:
 * If the file has more than one frame, or if it can't be determined,
   then the file is left open to permit seeking to subsequent
   frames. It will be closed, eventually, in the ``close`` or
-  ``__del__`` methods
+  ``__del__`` methods.
 
 * If the image is memory mapped, then we can't close the mapping to
   the underlying file until we are done with the image. The mapping
@@ -68,7 +68,7 @@ Added Decoder Registry and Support for Python Based Decoders
 There is now a decoder registry similar to the image plugin
 registries. Image plugins can register a decoder, and it will be
 called when the decoding is requested. This allows for the creation of
-pure Python decoders. While the python decoders will not be as fast as
+pure Python decoders. While the Python decoders will not be as fast as
 their C based counterparts, they may be easier and quicker to develop
 or safer to run.
 
@@ -79,8 +79,8 @@ Many tests have been added, including correctness tests for image
 formats that have been previously untested. 
 
 We are now running automated tests in Docker containers against more
-Linux versions than are provided on TravisCi, which is currently
-Ubuntu 14.04 x64. This Pillow release is tested on 64 bit Alpine,
-Arch, Ubuntu 12.04 and 16.04, and 32 bit Debian Stretch and Ubuntu
+Linux versions than are provided on Travis CI, which is currently
+Ubuntu 14.04 x64. This Pillow release is tested on 64-bit Alpine,
+Arch, Ubuntu 12.04 and 16.04, and 32-bit Debian Stretch and Ubuntu
 14.04. This also covers a wider range of dependency versions than are
 provided on Travis natively.


### PR DESCRIPTION
Escape asterisk, update name, some other little typos.