### PR TITLE
Remove broken downloads badge

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,10 +26,6 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
    :target: https://pypi.python.org/pypi/Pillow/
    :alt: Latest PyPI version
 
-.. image:: https://img.shields.io/pypi/dm/pillow.svg
-   :target: https://pypi.python.org/pypi/Pillow/
-   :alt: Number of PyPI downloads
-
 .. image:: https://coveralls.io/repos/python-pillow/Pillow/badge.svg?branch=master
    :target: https://coveralls.io/github/python-pillow/Pillow?branch=master
    :alt: Code coverage


### PR DESCRIPTION
Let's remove the downloads badge as it's broken and showing 0 downloads/month.

---

![image](https://cloud.githubusercontent.com/assets/1324225/24976213/3e64351c-1fd1-11e7-8de8-508450701700.png)

---

https://pillow.readthedocs.io/en/4.1.x/index.html

See also https://github.com/python-pillow/Pillow/issues/2396 and https://github.com/badges/shields/issues/716.
