### PR TITLE
Corrected syntax in release notes

### DIFF
--- a/docs/releasenotes/3.3.2.rst
+++ b/docs/releasenotes/3.3.2.rst
@@ -11,7 +11,7 @@ disclosure or corruption.
 
 Specifically, when parameters from the image are passed into
 ``Image.core.map_buffer``, the size of the image was calculated with
-``xsize``*``ysize``*``bytes_per_pixel``. This will overflow if the
+``xsize`` * ``ysize`` * ``bytes_per_pixel``. This will overflow if the
 result is larger than SIZE_MAX. This is possible on a 32-bit system.
 
 Furthermore this ``size`` value was added to a potentially attacker


### PR DESCRIPTION
Looking at https://github.com/python-pillow/Pillow/blob/master/docs/releasenotes/3.3.2.rst, part of it is rendered as `xsize``*``ysize``*``bytes_per_pixel`

So this PR adds appropriate spaces.