### PR TITLE
Add new2 function to pildriver.py

### DIFF
--- a/Scripts/pildriver.py
+++ b/Scripts/pildriver.py
@@ -122,6 +122,17 @@ class PILDriver(object):
         color = int(self.do_pop())
         self.push(Image.new("L", (xsize, ysize), color))
 
+    def do_new2(self):
+        """usage: new2 <string:mode> <int:xsize> <int:ysize> <int:color>:
+
+        Create and push a image of given mode, size and color.
+        """
+        mode = int(self.do_pop())
+        xsize = int(self.do_pop())
+        ysize = int(self.do_pop())
+        color = int(self.do_pop())
+        self.push(Image.new(mode, (xsize, ysize), color))
+
     def do_open(self):
         """usage: open <string:filename>
 


### PR DESCRIPTION
Currently `new` function creates a grayscale image in stack, it will break `paste` a colorful(i.e. `RGBA`) image.

Repro Steps
```
pildriver.py save new.png paste open test1.png 0 200 paste open test2.png 0 0 new 400 400 0
```
We will get a **grayscale**  new.png rather than a **RGBA** one.

This commit is to fix this by adding a new `new2` function.
```
pildriver.py save new.png paste open test1.png 0 200 paste open test2.png 0 0 new2 RGBA 400 400 0
```

