### PR TITLE
use PNG as intermediate format for viewing

### DIFF
--- a/PIL/ImageShow.py
+++ b/PIL/ImageShow.py
@@ -115,7 +115,7 @@ if sys.platform == "win32":
 elif sys.platform == "darwin":
 
     class MacViewer(Viewer):
-        format = "BMP"
+        format = "PNG"
 
         def get_command(self, file, **options):
             # on darwin open returns immediately resulting in the temp
@@ -142,6 +142,8 @@ else:
         return None
 
     class UnixViewer(Viewer):
+        format = "PNG"
+
         def show_file(self, file, **options):
             command, executable = self.get_command_ex(file, **options)
             command = "(%s %s; rm -f %s)&" % (command, quote(file),


### PR DESCRIPTION
This is part way towards fixing https://github.com/python-pillow/Pillow/issues/2508

Since both Apple's Preview and unix's imagemagick are capable of displaying png, (and all the linux distros which distributes xv distribute xv patched with png support), it is better to use PNG as an intermediate for displaying.

Changes proposed in this pull request:

 * PNG as intermediate format for viewing
 
