### PR TITLE
RFC: Specify Version in one place

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -56,7 +56,10 @@ try:
     from . import _imaging as core
     if PILLOW_VERSION != getattr(core, 'PILLOW_VERSION', None):
         raise ImportError("The _imaging extension was built for another "
-                          "version of Pillow or PIL")
+                          "version of Pillow or PIL: Core Version: %s"
+                          "Pillow Version:  %s" %
+                          (getattr(core, 'PILLOW_VERSION', None),
+                           PILLOW_VERSION))
 
 except ImportError as v:
     core = _imaging_not_installed()

--- a/PIL/__init__.py
+++ b/PIL/__init__.py
@@ -11,8 +11,10 @@
 
 # ;-)
 
-VERSION = '1.1.7'  # PIL version
-PILLOW_VERSION = '4.2.0.dev0'  # Pillow
+from . import version
+
+
+PILLOW_VERSION =  version.__version__
 
 __version__ = PILLOW_VERSION
 

--- a/PIL/__init__.py
+++ b/PIL/__init__.py
@@ -13,7 +13,7 @@
 
 from . import version
 
-
+VERSION = '1.1.7'  # PIL Version
 PILLOW_VERSION =  version.__version__
 
 __version__ = PILLOW_VERSION

--- a/PIL/version.py
+++ b/PIL/version.py
@@ -1,2 +1,2 @@
 # Master version for Pillow
-__version__ = '4.1.0'
+__version__ = '4.2.0.dev0'

--- a/PIL/version.py
+++ b/PIL/version.py
@@ -1,0 +1,2 @@
+# Master version for Pillow
+__version__ = '4.1.0'

--- a/_imaging.c
+++ b/_imaging.c
@@ -71,8 +71,6 @@
  * See the README file for information on usage and redistribution.
  */
 
-#define PILLOW_VERSION "4.2.0.dev0"
-
 #include "Python.h"
 
 #ifdef HAVE_LIBZ

--- a/_imaging.c
+++ b/_imaging.c
@@ -3435,6 +3435,7 @@ static PyMethodDef functions[] = {
 static int
 setup_module(PyObject* m) {
     PyObject* d = PyModule_GetDict(m);
+    const char* version = (char*)PILLOW_VERSION;
 
     /* Ready object types */
     if (PyType_Ready(&Imaging_Type) < 0)
@@ -3479,7 +3480,7 @@ setup_module(PyObject* m) {
   }
 #endif
 
-    PyDict_SetItemString(d, "PILLOW_VERSION", PyUnicode_FromString(PILLOW_VERSION));
+    PyDict_SetItemString(d, "PILLOW_VERSION", PyUnicode_FromString(version));
 
     return 0;
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 4.2.pre.{build}
+version: '{build}'
 clone_folder: c:\pillow
 init:
 - ECHO %PYTHON%

--- a/setup.py
+++ b/setup.py
@@ -584,7 +584,10 @@ class pil_build_ext(build_ext):
         if struct.unpack("h", "\0\1".encode('ascii'))[0] == 1:
             defs.append(("WORDS_BIGENDIAN", None))
 
-        defs.append(("PILLOW_VERSION", '"%s"'%PILLOW_VERSION))
+        if sys.platform == "win32":
+            defs.append(("PILLOW_VERSION", '"\\"%s\\""'%PILLOW_VERSION))
+        else:
+            defs.append(("PILLOW_VERSION", '"%s"'%PILLOW_VERSION))
 
         exts = [(Extension("PIL._imaging",
                            files,

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ def _read(file):
 
 def get_version():
     version_file = 'PIL/version.py'
-    with open(version_file, 'ra') as f:
+    with open(version_file, 'r') as f:
         exec(compile(f.read(), version_file, 'exec'))
     return locals()['__version__']
 

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,12 @@ def _read(file):
         return fp.read()
 
 
+def get_version():
+    version_file = 'PIL/version.py'
+    with open(version_file, 'ra') as f:
+        exec(compile(f.read(), version_file, 'exec'))
+    return locals()['__version__']
+
 try:
     import _tkinter
 except (ImportError, OSError):
@@ -102,7 +108,7 @@ except (ImportError, OSError):
     _tkinter = None
 
 NAME = 'Pillow'
-PILLOW_VERSION = '4.2.0.dev0'
+PILLOW_VERSION = get_version()
 JPEG_ROOT = None
 JPEG2K_ROOT = None
 ZLIB_ROOT = None
@@ -577,6 +583,8 @@ class pil_build_ext(build_ext):
             libs.extend(["kernel32", "user32", "gdi32"])
         if struct.unpack("h", "\0\1".encode('ascii'))[0] == 1:
             defs.append(("WORDS_BIGENDIAN", None))
+
+        defs.append(("PILLOW_VERSION", '"%s"'%PILLOW_VERSION))
 
         exts = [(Extension("PIL._imaging",
                            files,


### PR DESCRIPTION
Changes proposed in this pull request:

 * Improves the release process by having one place to change the version number for Pillow, then including that value elsewhere, when required. 
 * Does not update the appveyor version number. I'm wondering if just a build is ok there. 

