### PR TITLE
Fix for issue #2514 - error handling mistake in _webp.c

### DIFF
--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -77,6 +77,11 @@ class TestFileWebp(PillowTestCase):
 
         self.assertRaises(IOError, lambda: hopper("L").save(temp_file))
 
+    def test_WebPEncode_with_invalid_args(self):
+        self.assertRaises(TypeError, _webp.WebPEncode)
+
+    def test_WebPDecode_with_invalid_args(self):
+        self.assertRaises(TypeError, _webp.WebPDecode)
 
 if __name__ == '__main__':
     unittest.main()

--- a/_webp.c
+++ b/_webp.c
@@ -29,7 +29,7 @@ PyObject* WebPEncode_wrapper(PyObject* self, PyObject* args)
     if (!PyArg_ParseTuple(args, "s#iiifss#s#",
                 (char**)&rgb, &size, &width, &height, &lossless, &quality_factor, &mode,
                 &icc_bytes, &icc_size, &exif_bytes, &exif_size)) {
-        Py_RETURN_NONE;
+        return NULL;
     }
     if (strcmp(mode, "RGBA")==0){
         if (size < width * height * 4){
@@ -145,7 +145,7 @@ PyObject* WebPDecode_wrapper(PyObject* self, PyObject* args)
     char* mode = "RGB";
 
     if (!PyArg_ParseTuple(args, "S", &webp_string)) {
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     if (!WebPInitDecoderConfig(&config)) {


### PR DESCRIPTION
This fixes (issue #2514) error handling for when functions are called with an invalid number of arguments or invalid types of arguments.
As for the tests, I've used the test provided in the issue.