### PR TITLE
Update ImageFile.py

### DIFF
--- a/PIL/ImageFile.py
+++ b/PIL/ImageFile.py
@@ -380,11 +380,8 @@ class Parser(object):
 
             # attempt to open this file
             try:
-                try:
-                    fp = io.BytesIO(self.data)
+                with io.BytesIO(self.data) as fp:
                     im = Image.open(fp)
-                finally:
-                    fp.close()  # explicitly close the virtual file
             except IOError:
                 # traceback.print_exc()
                 pass  # not enough data
@@ -432,12 +429,11 @@ class Parser(object):
         if self.data:
             # incremental parsing not possible; reopen the file
             # not that we have all data
-            try:
-                fp = io.BytesIO(self.data)
-                self.image = Image.open(fp)
-            finally:
-                self.image.load()
-                fp.close()  # explicitly close the virtual file
+            with io.BytesIO(self.data) as fp:
+                try:
+                    self.image = Image.open(fp)
+                finally:
+                    self.image.load()
         return self.image
 
 

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -95,6 +95,11 @@ class TestImageFile(PillowTestCase):
     def test_raise_ioerror(self):
         self.assertRaises(IOError, lambda: ImageFile.raise_ioerror(1))
 
+    def test_raise_typeerror(self):
+        with self.assertRaises(TypeError):
+            parser = ImageFile.Parser()
+            parser.feed(1)
+
     def test_truncated_with_errors(self):
         if "zip_encoder" not in codecs:
             self.skipTest("PNG (zlib) encoder not available")


### PR DESCRIPTION
Changes proposed in this pull request:

 * Fixes UnboundLocalError in ImageFile.py

```
Traceback (most recent call last):
  [...]
  File "/usr/local/lib/python3.5/dist-packages/PIL/ImageFile.py", line 387, in feed
    fp.close()  # explicitly close the virtual file
UnboundLocalError: local variable 'fp' referenced before assignment
```
