### PR TITLE
Use Codecov for coverage

### DIFF
--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -10,8 +10,10 @@ gem install coveralls-lcov
 coveralls-lcov -v -n coverage.filtered.info > coverage.c.json
 
 coverage report
+pip install codecov
 pip install coveralls-merge
 coveralls-merge coverage.c.json
+codecov
 
 if [ "$DOCKER" == "" ]; then
 	pip install pep8 pyflakes

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: off


### PR DESCRIPTION
Because Coveralls has sometimes been a bit iffy and they rarely respond to support requests (eg. ["Changes Unknown when pulling X on branch into ** on master**"](https://github.com/lemurheavy/coveralls-public/issues/351) / ["First build on master"](https://github.com/lemurheavy/coveralls-public/issues/610)), I'd like to trial using Codecov for a while.

For example: https://codecov.io/gh/python-pillow/Pillow

We could use both Coveralls and Codecov in parallel for a while, to make sure they agree, and fine tune Codecov's notifications, and then decide which one to keep.

Here's some example PRs:
* https://github.com/hugovk/Pillow/pull/17: increase coverage
* https://github.com/hugovk/Pillow/pull/18: decrease coverage
* https://github.com/hugovk/Pillow/pull/19: increase and decrease

Thoughts?