### PR TITLE
Fix Image.show compress_level typo

### DIFF
--- a/PIL/ImageShow.py
+++ b/PIL/ImageShow.py
@@ -117,7 +117,7 @@ elif sys.platform == "darwin":
 
     class MacViewer(Viewer):
         format = "PNG"
-        options = {'compress-level': 1}
+        options = {'compress_level': 1}
 
         def get_command(self, file, **options):
             # on darwin open returns immediately resulting in the temp
@@ -145,7 +145,7 @@ else:
 
     class UnixViewer(Viewer):
         format = "PNG"
-        options = {'compress-level': 1}
+        options = {'compress_level': 1}
 
         def show_file(self, file, **options):
             command, executable = self.get_command_ex(file, **options)


### PR DESCRIPTION
Closes #2529.

Changes proposed in this pull request:

* Fix typo in option, should be `compress_level` rather than `compress-level`. It was using default 6 rather than 1 
* > **compress_level** 
   > ZLIB compression level, a number between 0 and 9: 1 gives best speed, 9 gives best compression, 0 gives no compression at all. Default is 6. When `optimize` option is True `compress_level` has no effect (it is set to 9 regardless of a value passed).
* https://pillow.readthedocs.io/en/4.1.x/handbook/image-file-formats.html?highlight=compress_level#png
