### PR TITLE
Remove unused functions

### DIFF
--- a/_imaging.c
+++ b/_imaging.c
@@ -632,18 +632,6 @@ _new(PyObject* self, PyObject* args)
 }
 
 static PyObject*
-_new_array(PyObject* self, PyObject* args)
-{
-    char* mode;
-    int xsize, ysize;
-
-    if (!PyArg_ParseTuple(args, "s(ii)", &mode, &xsize, &ysize))
-        return NULL;
-
-    return PyImagingNew(ImagingNewArray(mode, xsize, ysize));
-}
-
-static PyObject*
 _new_block(PyObject* self, PyObject* args)
 {
     char* mode;
@@ -3027,7 +3015,6 @@ static struct PyMethodDef methods[] = {
 #endif
 
     /* Misc. */
-    {"new_array", (PyCFunction)_new_array, 1},
     {"new_block", (PyCFunction)_new_block, 1},
 
     {"save_ppm", (PyCFunction)_save_ppm, 1},

--- a/_imagingft.c
+++ b/_imagingft.c
@@ -281,47 +281,6 @@ font_getsize(FontObject* self, PyObject* args)
 }
 
 static PyObject*
-font_getabc(FontObject* self, PyObject* args)
-{
-    FT_ULong ch;
-    FT_Face face;
-    double a, b, c;
-
-    /* calculate ABC values for a given string */
-
-    PyObject* string;
-    if (!PyArg_ParseTuple(args, "O:getabc", &string))
-        return NULL;
-
-#if PY_VERSION_HEX >= 0x03000000
-    if (!PyUnicode_Check(string)) {
-#else
-    if (!PyUnicode_Check(string) && !PyString_Check(string)) {
-#endif
-        PyErr_SetString(PyExc_TypeError, "expected string");
-        return NULL;
-    }
-
-    if (font_getchar(string, 0, &ch)) {
-        int index, error;
-        face = self->face;
-        index = FT_Get_Char_Index(face, ch);
-	/* Note: bitmap fonts within ttf fonts do not work, see #891/pr#960 */
-        error = FT_Load_Glyph(face, index, FT_LOAD_DEFAULT|FT_LOAD_NO_BITMAP);
-        if (error)
-            return geterror(error);
-        a = face->glyph->metrics.horiBearingX / 64.0;
-        b = face->glyph->metrics.width / 64.0;
-        c = (face->glyph->metrics.horiAdvance -
-             face->glyph->metrics.horiBearingX -
-             face->glyph->metrics.width) / 64.0;
-    } else
-        a = b = c = 0.0;
-
-    return Py_BuildValue("ddd", a, b, c);
-}
-
-static PyObject*
 font_render(FontObject* self, PyObject* args)
 {
     int i, x, y;
@@ -454,7 +413,6 @@ font_dealloc(FontObject* self)
 static PyMethodDef font_methods[] = {
     {"render", (PyCFunction) font_render, METH_VARARGS},
     {"getsize", (PyCFunction) font_getsize, METH_VARARGS},
-    {"getabc", (PyCFunction) font_getabc, METH_VARARGS},
     {NULL, NULL}
 };
 

--- a/outline.c
+++ b/outline.c
@@ -135,25 +135,11 @@ _outline_close(OutlineObject* self, PyObject* args)
     return Py_None;
 }
 
-static PyObject*
-_outline_transform(OutlineObject* self, PyObject* args)
-{
-    double a[6];
-    if (!PyArg_ParseTuple(args, "(dddddd)", a+0, a+1, a+2, a+3, a+4, a+5))
-        return NULL;
-
-    ImagingOutlineTransform(self->outline, a);
-
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
 static struct PyMethodDef _outline_methods[] = {
     {"line", (PyCFunction)_outline_line, 1},
     {"curve", (PyCFunction)_outline_curve, 1},
     {"move", (PyCFunction)_outline_move, 1},
     {"close", (PyCFunction)_outline_close, 1},
-    {"transform", (PyCFunction)_outline_transform, 1},
     {NULL, NULL} /* sentinel */
 };
 


### PR DESCRIPTION
Remove some unused C functions (added in 1996, 2006 and 2000) which are not called by any other C or Python code.

Helps a bit towards #722.