### PR TITLE
Fix truncated png loading

### DIFF
--- a/PIL/PngImagePlugin.py
+++ b/PIL/PngImagePlugin.py
@@ -113,7 +113,8 @@ class ChunkStream(object):
             length = i32(s)
 
         if not is_cid(cid):
-            raise SyntaxError("broken PNG file (chunk %s)" % repr(cid))
+            if not ImageFile.LOAD_TRUNCATED_IMAGES:
+                raise SyntaxError("broken PNG file (chunk %s)" % repr(cid))
 
         return cid, pos, length
 

--- a/decode.c
+++ b/decode.c
@@ -779,6 +779,7 @@ PyImaging_ZipDecoderNew(PyObject* self, PyObject* args)
         return NULL;
 
     decoder->decode = ImagingZipDecode;
+    decoder->cleanup = ImagingZipDecodeCleanup;
 
     ((ZIPSTATE*)decoder->state.context)->interlaced = interlaced;
 

--- a/libImaging/Imaging.h
+++ b/libImaging/Imaging.h
@@ -455,6 +455,7 @@ extern int ImagingXbmEncode(Imaging im, ImagingCodecState state,
 #ifdef	HAVE_LIBZ
 extern int ImagingZipDecode(Imaging im, ImagingCodecState state,
 			    UINT8* buffer, int bytes);
+extern int ImagingZipDecodeCleanup(ImagingCodecState state);
 extern int ImagingZipEncode(Imaging im, ImagingCodecState state,
 			    UINT8* buffer, int bytes);
 extern int ImagingZipEncodeCleanup(ImagingCodecState state);

--- a/libImaging/JpegDecode.c
+++ b/libImaging/JpegDecode.c
@@ -268,7 +268,7 @@ ImagingJpegDecode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
 /* -------------------------------------------------------------------- */
 
 int ImagingJpegDecodeCleanup(ImagingCodecState state){
-	/* called to fee the decompression engine when the decode terminates
+	/* called to free the decompression engine when the decode terminates
 	   due to a corrupt or truncated image
 	*/
     JPEGSTATE* context = (JPEGSTATE*) state->context;

--- a/libImaging/ZipDecode.c
+++ b/libImaging/ZipDecode.c
@@ -281,7 +281,7 @@ ImagingZipDecode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
 
 
 int ImagingZipDecodeCleanup(ImagingCodecState state){
-    /* called to fee the decompression engine when the decode terminates
+    /* called to free the decompression engine when the decode terminates
        due to a corrupt or truncated image
     */
     ZIPSTATE* context = (ZIPSTATE*) state->context;

--- a/libImaging/ZipDecode.c
+++ b/libImaging/ZipDecode.c
@@ -85,6 +85,7 @@ ImagingZipDecode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
         err = inflateInit(&context->z_stream);
         if (err < 0) {
             state->errcode = IMAGING_CODEC_CONFIG;
+            free(context->previous);
             return -1;
         }
 

--- a/libImaging/ZipDecode.c
+++ b/libImaging/ZipDecode.c
@@ -86,6 +86,7 @@ ImagingZipDecode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
         if (err < 0) {
             state->errcode = IMAGING_CODEC_CONFIG;
             free(context->previous);
+            context->previous = NULL;
             return -1;
         }
 
@@ -127,6 +128,7 @@ ImagingZipDecode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
             else
                 state->errcode = IMAGING_CODEC_CONFIG;
             free(context->previous);
+            context->previous = NULL;
             inflateEnd(&context->z_stream);
             return -1;
         }
@@ -192,6 +194,7 @@ ImagingZipDecode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
             default:
                 state->errcode = IMAGING_CODEC_UNKNOWN;
                 free(context->previous);
+                context->previous = NULL;
                 inflateEnd(&context->z_stream);
                 return -1;
             }
@@ -259,6 +262,7 @@ ImagingZipDecode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
                 state->errcode = IMAGING_CODEC_BROKEN; */
 
             free(context->previous);
+            context->previous = NULL;
             inflateEnd(&context->z_stream);
             return -1; /* end of file (errcode=0) */
 
@@ -273,6 +277,22 @@ ImagingZipDecode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
 
     return bytes; /* consumed all of it */
 
+}
+
+
+int ImagingZipDecodeCleanup(ImagingCodecState state){
+    /* called to fee the decompression engine when the decode terminates
+       due to a corrupt or truncated image
+    */
+    ZIPSTATE* context = (ZIPSTATE*) state->context;
+
+    /* Clean up */
+    if (context->previous) {
+        inflateEnd(&context->z_stream);
+        free(context->previous);
+        context->previous = NULL;
+    }
+    return -1;
 }
 
 #endif


### PR DESCRIPTION
This PR fixes two problems:

### PngImagePlugin

Pillow can't open some truncated PNG images even with `ImageFile.LOAD_TRUNCATED_IMAGES = True`.

`SyntaxError: broken PNG file (chunk '\x00\x00\x00\x00')`

Example image: https://ucarecdn.com/99b9dc77-abd0-4077-887b-2b7a0a753d76/587593.png

### ImagingZipDecodeCleanup

This is general memory leak while loading truncated PNG files regardless of LOAD_TRUNCATED_IMAGES flag. The reason is `inflate` operates normally if source stream is truncated and returns no errors. For `ImagingZipDecode` function this look like normal behavior. But on the python level we see than the file if over and we should call `inflateEnd` and free `context->previous` somehow. This PR adds `ImagingZipDecodeCleanup` function for this.