### PR TITLE
Freebsd compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,9 @@ def _add_directory(path, subdir, where=None):
         else:
             _dbg('Inserting path %s', subdir)
             path.insert(where, subdir)
+    elif subdir in path and where is not None:
+        path.remove(subdir)
+        path.insert(where, subdir)
 
 
 def _find_include_file(self, include):
@@ -462,6 +465,9 @@ class pil_build_ext(build_ext):
                 # Add the directory to the include path so we can include
                 # <openjpeg.h> rather than having to cope with the versioned
                 # include path
+                print()
+                print("====> Adding {} to {}".format(best_path, self.compiler.include_dirs))
+                print()
                 _add_directory(self.compiler.include_dirs, best_path, 0)
                 feature.jpeg2000 = 'openjp2'
                 feature.openjpeg_version = '.'.join(str(x) for x in best_version)

--- a/setup.py
+++ b/setup.py
@@ -465,9 +465,10 @@ class pil_build_ext(build_ext):
                 # Add the directory to the include path so we can include
                 # <openjpeg.h> rather than having to cope with the versioned
                 # include path
-                print()
-                print("====> Adding {} to {}".format(best_path, self.compiler.include_dirs))
-                print()
+                # FIXME (melvyn-sopacua):
+                # At this point it's possible that best_path is already in
+                # self.compiler.include_dirs. Should investigate how that is
+                # possible.
                 _add_directory(self.compiler.include_dirs, best_path, 0)
                 feature.jpeg2000 = 'openjp2'
                 feature.openjpeg_version = '.'.join(str(x) for x in best_version)


### PR DESCRIPTION
When openjpeg 1.5 is installed (Calligra 2.x, for example) and OpenJPEG
2.1 is installed, the subdirectory is added twice.

Since the 2nd time is ignored, it is ranked after the more general
/usr/local/include and openjpeg.h from the 1.5 version is picked up.

Fix this in a more general way:
- If a directory is added that already is in path
- But where is specified

Then remove the subdir from path and insert it at the spot requested.

A FIXME is added to the code bit explaining the real issue, but lack
investigative spirit / time to dive down the rabbit hole.

Changes proposed in this pull request:

 * See above