### PR TITLE
Remove unnecessary calls to dict.keys()

### DIFF
--- a/PIL/IcoImagePlugin.py
+++ b/PIL/IcoImagePlugin.py
@@ -176,8 +176,8 @@ class IcoFile(object):
             # figure out where AND mask image starts
             mode = a[0]
             bpp = 8
-            for k in BmpImagePlugin.BIT2MODE.keys():
-                if mode == BmpImagePlugin.BIT2MODE[k][1]:
+            for k, v in BmpImagePlugin.BIT2MODE.items():
+                if mode == v[1]:
                     bpp = k
                     break
 

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -274,7 +274,7 @@ def _conv_type_shape(im):
         return shape+(extra,), typ
 
 
-MODES = sorted(_MODEINFO.keys())
+MODES = sorted(_MODEINFO)
 
 # raw modes that may be memory mapped.  NOTE: if you change this, you
 # may have to modify the stride calculation in map.c too!

--- a/PIL/IptcImagePlugin.py
+++ b/PIL/IptcImagePlugin.py
@@ -95,7 +95,7 @@ class IptcImageFile(ImageFile.ImageFile):
                 tagdata = self.fp.read(size)
             else:
                 tagdata = None
-            if tag in list(self.info.keys()):
+            if tag in self.info:
                 if isinstance(self.info[tag], list):
                     self.info[tag].append(tagdata)
                 else:

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -439,7 +439,7 @@ class TestFileJpeg(PillowTestCase):
     def test_no_duplicate_0x1001_tag(self):
         # Arrange
         from PIL import ExifTags
-        tag_ids = dict(zip(ExifTags.TAGS.values(), ExifTags.TAGS.keys()))
+        tag_ids = {v: k for k, v in ExifTags.TAGS.items()}
 
         # Assert
         self.assertEqual(tag_ids['RelatedImageWidth'], 0x1001)

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -190,7 +190,7 @@ class TestFileLibTiff(LibTiffTestCase):
         # Exclude ones that have special meaning
         # that we're already testing them
         im = Image.open('Tests/images/hopper_g4.tif')
-        for tag in im.tag_v2.keys():
+        for tag in im.tag_v2:
             try:
                 del(core_items[tag])
             except:

--- a/Tests/test_imagecolor.py
+++ b/Tests/test_imagecolor.py
@@ -119,7 +119,7 @@ class TestImageColor(PillowTestCase):
     # look for rounding errors (based on code by Tim Hatch)
     def test_rounding_errors(self):
 
-        for color in list(ImageColor.colormap.keys()):
+        for color in ImageColor.colormap:
             expected = Image.new(
                 "RGB", (1, 1), color).convert("L").getpixel((0, 0))
             actual = ImageColor.getcolor(color, 'L')

--- a/winbuild/build.py
+++ b/winbuild/build.py
@@ -12,7 +12,7 @@ from config import (compilers, compiler_from_env, pythons, pyversion_from_env,
 
 def setup_vms():
     ret = []
-    for py in pythons.keys():
+    for py in pythons:
         for arch in ('', X64_EXT):
             ret.append("virtualenv -p c:/Python%s%s/python.exe --clear %s%s%s"
                        % (py, arch, VIRT_BASE, py, arch))

--- a/winbuild/config.py
+++ b/winbuild/config.py
@@ -116,7 +116,7 @@ def pyversion_from_env():
     py = os.environ['PYTHON']
 
     py_version = '27'
-    for k in pythons.keys():
+    for k in pythons:
         if k in py:
             py_version = k
             break


### PR DESCRIPTION
`iter(dict)` is equivalent to `iter(dict.keys())`, so simply act on the dict instead of adding the extra call.

Inspired by Lennart Regebro's PyCon 2017 presentation "Prehistoric Patterns in Python". Available at:

<https://www.youtube.com/watch?v=V5-JH23Vk0I>