### PR TITLE
Changed warning to error when saving RGBA images as JPEG

### DIFF
--- a/PIL/JpegImagePlugin.py
+++ b/PIL/JpegImagePlugin.py
@@ -554,7 +554,6 @@ RAWMODE = {
     "1": "L",
     "L": "L",
     "RGB": "RGB",
-    "RGBA": "RGB",
     "RGBX": "RGB",
     "CMYK": "CMYK;I",  # assume adobe conventions
     "YCbCr": "YCbCr",
@@ -602,14 +601,6 @@ def _save(im, fp, filename):
         rawmode = RAWMODE[im.mode]
     except KeyError:
         raise IOError("cannot write mode %s as JPEG" % im.mode)
-
-    if im.mode == 'RGBA':
-        warnings.warn(
-            'You are saving RGBA image as JPEG. The alpha channel will be '
-            'discarded. This conversion is deprecated and will be disabled '
-            'in Pillow 3.7. Please, convert the image to RGB explicitly.',
-            DeprecationWarning
-        )
 
     info = im.encoderinfo
 

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -477,16 +477,9 @@ class TestFileJpeg(PillowTestCase):
 
     def test_save_wrong_modes(self):
         out = BytesIO()
-        for mode in ['LA', 'La', 'RGBa', 'P']:
+        for mode in ['LA', 'La', 'RGBA', 'RGBa', 'P']:
             img = Image.new(mode, (20, 20))
             self.assertRaises(IOError, img.save, out, "JPEG")
-
-    def test_save_modes_with_warnings(self):
-        # ref https://github.com/python-pillow/Pillow/issues/2005
-        out = BytesIO()
-        for mode in ['RGBA']:
-            img = Image.new(mode, (20, 20))
-            self.assert_warning(DeprecationWarning, img.save, out, "JPEG")
 
     def test_save_tiff_with_dpi(self):
         # Arrange


### PR DESCRIPTION
As stated in the release notes - https://github.com/python-pillow/Pillow/blob/master/docs/releasenotes/3.4.0.rst - saving RGBA images as JPEG 'will become an error in Pillow 4.2'.