### PR TITLE
Replace the truncating of zero coefficients with math power

### DIFF
--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -158,14 +158,12 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
 
     def test_enlarge_hamming(self):
         for mode in ['RGBX', 'RGB', 'La', 'L']:
-            case = self.make_case(mode, (4, 4), 0xe1)
-            case = case.resize((8, 8), Image.HAMMING)
-            data = ('e1 e1 ea d1'
-                    'e1 e1 ea d1'
-                    'ea ea f4 d9'
-                    'd1 d1 d9 c4')
+            case = self.make_case(mode, (2, 2), 0xe1)
+            case = case.resize((4, 4), Image.HAMMING)
+            data = ('e1 d2'
+                    'd2 c5')
             for channel in case.split():
-                self.check_case(channel, self.make_sample(data, (8, 8)))
+                self.check_case(channel, self.make_sample(data, (4, 4)))
 
     def test_enlarge_bicubic(self):
         for mode in ['RGBX', 'RGB', 'La', 'L']:

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -168,10 +168,12 @@ precompute_coeffs(int inSize, int outSize, struct filter *filterp,
         center = (xx + 0.5) * scale;
         ww = 0.0;
         ss = 1.0 / filterscale;
-        xmin = (int) floor(center - support);
+        // Round the value
+        xmin = (int) (center - support + 0.5);
         if (xmin < 0)
             xmin = 0;
-        xmax = (int) ceil(center + support);
+        // Round the value
+        xmax = (int) (center + support + 0.5);
         if (xmax > inSize)
             xmax = inSize;
         xmax -= xmin;
@@ -180,21 +182,6 @@ precompute_coeffs(int inSize, int outSize, struct filter *filterp,
             double w = filterp->filter((x + xmin - center + 0.5) * ss);
             k[x] = w;
             ww += w;
-            
-            // We can skip extreme coefficients if they are zeroes.
-            if (w == 0) {
-                // Skip from the start.
-                if (x == 0) {
-                    // At next loop `x` will be 0.
-                    x -= 1;
-                    // But `w` will not be 0, because it based on `xmin`.
-                    xmin += 1;
-                    xmax -= 1;
-                } else if (x == xmax - 1) {
-                    // Truncate the last coefficient for current `xx`.
-                    xmax -= 1;
-                }
-            }
         }
         for (x = 0; x < xmax; x++) {
             if (ww != 0.0)

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -32,6 +32,8 @@ static inline double hamming_filter(double x)
         x = -x;
     if (x == 0.0)
         return 1.0;
+    if (x >= 1.0)
+        return 0.0;
     x = x * M_PI;
     return sin(x) / x * (0.54f + 0.46f * cos(x));
 }


### PR DESCRIPTION
The Initial idea: while resizing we are excluding zero coefficients on the edges. For example, if `xmin = 103` and `xmax = 103 + 7` and we have coefficients `[0, -0.15, -0.3, 0,5, 0.53, -0.34, 0]`, it is equivalent of `xmin = 104`, `xmax = 104 + 5`, `[-0.15, -0.3, 0,5, 0.53, -0.34]`.

Currently, the following code is responsible for this:
https://github.com/python-pillow/Pillow/blob/5a359fbf287d6962def2d0d482d2570625c90bf6/libImaging/Resample.c#L183-L195

But it is possible mathematically prove, that we can just do not calculate these coefficients, instead of excluding them.

```
We need to find:
w = filterp->filter((x + xmin - center + 0.5) * ss)
, where xmin = (int) floor(center - support)

let center - support == n + λ, where 0.5 <= λ < 1
, then xmin == floor(center - support) == n
, then xmin - center + 0.5 == n - n - λ - support + 0.5 == 0.5 - λ - support
, where -0.5 < 0.5 - λ <= 0

if support == filterp->support * filterscale
, and ss == 1.0 / filterscale
, then ss == filterp->support / support

(xmin - center + 0.5) * ss == (0.5 - λ - support) * (filterp->support / support)
== (0.5 - λ) * filterp->support / support - filterp->support

(0.5 - λ) * filterp->support / support will always be less than 0
```

We know what each value of `filterp->filter` for parameters less than `- filterp->support` will be 0.

So we shouldn't consider `0.5 <= λ < 1`. `xmin  = floor(center - support)` can be safely replaced by `xmin  = round(center - support)`. Same for `xmax`.