### PR TITLE
Fixed wrong expected size of mrls read from disk.

### DIFF
--- a/PIL/ImageMorph.py
+++ b/PIL/ImageMorph.py
@@ -234,7 +234,7 @@ class MorphOp(object):
         with open(filename, 'rb') as f:
             self.lut = bytearray(f.read())
 
-        if len(self.lut) != 8192:
+        if len(self.lut) != LUT_SIZE:
             self.lut = None
             raise Exception('Wrong size operator file!')
 


### PR DESCRIPTION
Fixes the failure of  the mrl round trip test in https://github.com/python-pillow/Pillow/pull/2554 .

Changes proposed in this pull request:

 * 
 * 
 * 
