### PR TITLE
Removed deprecated universal newlines mode from Python 3 code

### DIFF
--- a/PIL/EpsImagePlugin.py
+++ b/PIL/EpsImagePlugin.py
@@ -209,7 +209,7 @@ class EpsImageFile(ImageFile.ImageFile):
                 fp = open(self.fp.name, "Ur")
             else:
                 # Python3, can use bare open command.
-                fp = open(self.fp.name, "Ur", encoding='latin-1')
+                fp = open(self.fp.name, "r", encoding='latin-1')
         except:
             # Expect this for bytesio/stringio
             fp = PSFile(self.fp)


### PR DESCRIPTION
Universal newlines mode is deprecated, according to https://docs.python.org/3.2/library/functions.html#open