### PR TITLE
Travis CI: Update PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ notifications:
 matrix:
   fast_finish: true
   include:
-    - python: "pypy"
-    - python: "pypy3"
+    - python: "pypy-5.7.1"
+    - python: "pypy3.3-5.2-alpha1"
     - python: '3.6'
     - python: '2.7'
     - python:  "2.7_with_system_site_packages" # For PyQt4

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -9,12 +9,10 @@ pip install cffi
 pip install nose
 pip install check-manifest
 pip install olefile
-# Pyroma tests sometimes hang on PyPy; skip
-if [ "$TRAVIS_PYTHON_VERSION" != "pypy" ]; then pip install pyroma; fi
-
+pip install pyroma
 pip install coverage
 
-# docs only on python 2.7
+# docs only on Python 2.7
 if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then pip install -r requirements.txt ; fi
 
 # clean checkout for manifest

--- a/mp_compile.py
+++ b/mp_compile.py
@@ -54,7 +54,8 @@ def _mp_compile(self, sources, output_dir=None, macros=None,
 
 def install():
 
-    fl_pypy3 = hasattr(sys, 'pypy_version_info') and sys.version_info > (3, 0)
+    fl_pypy3 = (hasattr(sys, 'pypy_version_info') and
+                (3, 0) < sys.version_info < (3, 3))
     fl_win = sys.platform.startswith('win')
     fl_cygwin = sys.platform.startswith('cygwin')
 
@@ -81,5 +82,6 @@ def install():
     else:
         print("Single threaded build, not installing mp_compile:"
               "%s processes" % MAX_PROCS)
+
 
 install()


### PR DESCRIPTION
Travis CI now has updated PyPy versions: https://github.com/travis-ci/travis-ci/issues/6727#issuecomment-307186234

* This updates to the latest available PyPy (`pypy-5.7.1`).

* The latest PyPy3 (`pypy3.3-5.5-alpha`) results in a [segmentation fault](https://travis-ci.org/hugovk/Pillow/jobs/240935588#L2465), so instead this PR includes the one before that (`pypy3.3-5.2-alpha1`) which has no segfault.

Updating these means we can use multithreaded builds for PyPy3 and install pyroma for both PyPys.

---

Before, the logs showed these versions:
`pypy`:
```
Python 2.7.10 (c95650101a99, Sep 06 2016, 11:10:29)
[PyPy 5.4.1 with GCC 4.8.2]
```
`pypy3`:
```
Python 3.2.5 (b2091e973da69152b3f928bfaabd5d2347e6df46, Oct 24 2014, 12:08:04)
[PyPy 2.4.0 with GCC 4.8.2]
```
---
And after:
`pypy-5.7.1`:
```
Python 2.7.13 (1aa2d8e03cdf, Mar 31 2017, 10:20:27)
[PyPy 5.7.1 with GCC 6.2.0 20160901]
```
`pypy3.3-5.2-alpha1`:
```
Python 3.3.5 (619c0d5af0e5, Oct 08 2016, 21:08:33)
[PyPy 5.5.0-alpha0 with GCC 4.8.2]
```