### PR TITLE
RFC: Decompression bomb error

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -36,6 +36,8 @@ logger = logging.getLogger(__name__)
 class DecompressionBombWarning(RuntimeWarning):
     pass
 
+class DecompressionBombError(Exception):
+    pass
 
 class _imaging_not_installed(object):
     # module placeholder
@@ -2378,6 +2380,12 @@ def _decompression_bomb_check(size):
         return
 
     pixels = size[0] * size[1]
+
+    if pixels > 2 * MAX_IMAGE_PIXELS:
+        raise DecompressionBombError(
+            "Image size (%d pixels) exceeds limit of %d pixels, "
+            "could be decompression bomb DOS attack." %
+            (pixels, 2* MAX_IMAGE_PIXELS))
 
     if pixels > MAX_IMAGE_PIXELS:
         warnings.warn(

--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -29,14 +29,20 @@ class TestDecompressionBomb(PillowTestCase):
         Image.open(TEST_FILE)
 
     def test_warning(self):
-        # Arrange
-        # Set limit to a low, easily testable value
-        Image.MAX_IMAGE_PIXELS = 10
-        self.assertEqual(Image.MAX_IMAGE_PIXELS, 10)
+        # Set limit to trigger warning on the test file
+        Image.MAX_IMAGE_PIXELS = 128 * 128 -1
+        self.assertEqual(Image.MAX_IMAGE_PIXELS, 128 * 128 - 1)
 
-        # Act / Assert
         self.assert_warning(Image.DecompressionBombWarning,
                             lambda: Image.open(TEST_FILE))
+
+    def test_exception(self):
+        # Set limit to trigger exception on the test file
+        Image.MAX_IMAGE_PIXELS = 64 * 128 -1
+        self.assertEqual(Image.MAX_IMAGE_PIXELS, 64 * 128 - 1)
+
+        self.assertRaises(Image.DecompressionBombError,
+                          lambda: Image.open(TEST_FILE))
 
 class TestDecompressionCrop(PillowTestCase):
 
@@ -53,6 +59,7 @@ class TestDecompressionCrop(PillowTestCase):
         box = (0, 0, self.src.width * 2, self.src.height * 2)
         self.assert_warning(Image.DecompressionBombWarning,
                             lambda: self.src.crop(box))    
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -48,7 +48,7 @@ class TestDecompressionCrop(PillowTestCase):
 
     def setUp(self):
         self.src = hopper()
-        Image.MAX_IMAGE_PIXELS = self.src.height * self.src.width
+        Image.MAX_IMAGE_PIXELS = self.src.height * self.src.width * 4 - 1
 
     def tearDown(self):
         Image.MAX_IMAGE_PIXELS = ORIGINAL_LIMIT


### PR DESCRIPTION
Noted in #2410.

Changes proposed in this pull request:

 *  Added a DecompressionBombError for if the requested size is 2*Image.MAX_PIXELS


Note that this will cause new exceptions, so we should make sure we really want to do this. 