### PR TITLE
Test support for centos/amazon linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
     - env: DOCKER="ubuntu-xenial-amd64"
     - env: DOCKER="ubuntu-precise-amd64"
     - env: DOCKER="debian-stretch-x86"
+    - env: DOCKER="centos-6-amd64"
+    - env: DOCKER="amazon-amd64"
 
 dist: trusty
 


### PR DESCRIPTION
This is test support on docker for centos/amazon linux.

It's parameterizing changes in test_imagefont.py, but unfortunately that is a really messy diff built from the complex text changes. So this has #2576 as a dependency. 