### PR TITLE
Removed reference to Landscape badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
     * - docs
       - |docs|
     * - tests
-      - | |linux| |macos| |windows| |coverage| |health|
+      - | |linux| |macos| |windows| |coverage|
     * - package
       - |zenodo| |version|
 


### PR DESCRIPTION
At https://github.com/python-pillow/Pillow, you will see a link to `|health|` in the README. This is because #2584 removed the Landscape badge.