### PR TITLE
RFC: Image.Image.alpha_composite

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1373,16 +1373,27 @@ class Image(object):
         else:
             self.im.paste(im, box)
 
-    def alpha_composite(self, im, box=None):
+    def alpha_composite(self, im, box=None, source=(0,0)):
         """ 'In-place' analog of Image.alpha_composite
 
         :param im: image to composite over this one
-        :param box: Optional 2 or 4 tuple. If a 2 tuple, the upper
-        left corner. If 4 tuple, (x0,y0,x1,y1)
-
+        :param box: Optional 2 or 4 tuple specificing the bounds in
+          the destination image.  If a 2 tuple, the upper left
+          corner. If 4 tuple, (x0,y0,x1,y1)
+        :param source: Optional 2 tuple, (x0, y0) for the upper left
+          corner in the source image.
+          
         Note: Not currently implemented in-place.
         """
-        if box is None:
+
+        if not isinstance(source, tuple):
+            raise ValueError("Source must be a tuple")
+        if not len(source) == 2:
+            raise ValueError("Source must be a 2-tuple")
+        if min(source) < 0:
+            raise ValueError("Source must be non-negative")
+        
+        if box is None and source == (0, 0):
             box = (0, 0, im.width, im.height)                
             overlay = im
             if self.size == im.size:
@@ -1396,7 +1407,9 @@ class Image(object):
                 box += (box[0]+size[0], box[1]+size[1])
                 
             src = self.crop(box)
-            overlay = im.crop((0, 0, box[2]-box[0], box[3]-box[1]))
+            overlay = im.crop((source[0], source[1],
+                               source[0] + box[2] - box[0],
+                               source[1] + box[3] - box[1]))
             
         result = alpha_composite(src, overlay)
         self.paste(result, box)

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1374,16 +1374,17 @@ class Image(object):
             self.im.paste(im, box)
 
     def alpha_composite(self, im, dest=(0,0), source=(0,0)):
-        """ 'In-place' analog of Image.alpha_composite
+        """ 'In-place' analog of Image.alpha_composite. Composites an image
+        onto this image.
 
         :param im: image to composite over this one
-        :param dest: Optional 2 tuple specificing the upper left corner
-          in the this image.
-        :param source: Optional 2 or 4 tuple, (x0, y0) for the upper
-          left corner in the source image. If a 4 tuple, the bounds of
-          the source rectangle.
+        :param dest: Optional 2 tuple (top, left) specifying the upper
+          left corner in this (destination) image.
+        :param source: Optional 2 (top, left) tuple for the upper left
+          corner in the overlay source image, or 4 tuple (top, left, bottom,
+          right) for the bounds of the source rectangle
           
-        Note: Not currently implemented in-place.
+        Performance Note: Not currently implemented in-place in the core layer.
         """
 
         if not isinstance(source, tuple):

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1373,6 +1373,34 @@ class Image(object):
         else:
             self.im.paste(im, box)
 
+    def alpha_composite(self, im, box=None):
+        """ 'In-place' analog of Image.alpha_composite
+
+        :param im: image to composite over this one
+        :param box: Optional 2 or 4 tuple. If a 2 tuple, the upper
+        left corner. If 4 tuple, (x0,y0,x1,y1)
+
+        Note: Not currently implemented in-place.
+        """
+        if box is None:
+            box = (0, 0, im.width, im.height)                
+            overlay = im
+            if self.size == im.size:
+                src = self
+            else:
+                src = self.crop(box)
+        else:
+            if len(box) == 2:
+                # upper left corner given; get size from overlay image
+                size = im.size
+                box += (box[0]+size[0], box[1]+size[1])
+                
+            src = self.crop(box)
+            overlay = im.crop((0, 0, box[2]-box[0], box[3]-box[1]))
+            
+        result = alpha_composite(src, overlay)
+        self.paste(result, box)
+        
     def point(self, lut, mode=None):
         """
         Maps this image through a lookup table or function.

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -231,7 +231,14 @@ class TestImage(PillowTestCase):
         self.assert_image_equal(box.crop((96, 96, 128, 128)),
                                 src.crop((0, 0, 32, 32)))
         self.assertEqual(box.size, (128, 128))
-        
+
+        # source point
+        source = src.copy()
+        source.alpha_composite(over, (32, 32, 96, 96), (32, 32))
+
+        self.assert_image_equal(source.crop((32, 32, 96, 96)),
+                                target.crop((32, 32, 96, 96)))
+        self.assertEqual(source.size, (128, 128))
 
     def test_registered_extensions_uninitialized(self):
         # Arrange

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -202,6 +202,37 @@ class TestImage(PillowTestCase):
         img_colors = sorted(img.getcolors())
         self.assertEqual(img_colors, expected_colors)
 
+    def test_alpha_inplace(self):
+        src = Image.new('RGBA', (128,128), 'blue')
+
+        over = Image.new('RGBA', (128,128), 'red')
+        mask = hopper('L')
+        over.putalpha(mask)
+
+        target = Image.alpha_composite(src, over)
+
+        # basic
+        full = src.copy()
+        full.alpha_composite(over)
+        self.assert_image_equal(full, target)
+
+        # with offset down to right
+        offset = src.copy()
+        offset.alpha_composite(over, (64, 64))
+        self.assert_image_equal(offset.crop((64, 64, 127, 127)),
+                                target.crop((0, 0, 63, 63)))
+        self.assertEqual(offset.size, (128, 128))
+
+        # offset and crop
+        box = src.copy()
+        box.alpha_composite(over, (64, 64, 96, 96))
+        self.assert_image_equal(box.crop((64, 64, 96, 96)),
+                                target.crop((0, 0, 32, 32)))
+        self.assert_image_equal(box.crop((96, 96, 128, 128)),
+                                src.crop((0, 0, 32, 32)))
+        self.assertEqual(box.size, (128, 128))
+        
+
     def test_registered_extensions_uninitialized(self):
         # Arrange
         Image._initialized = 0

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -225,7 +225,7 @@ class TestImage(PillowTestCase):
 
         # offset and crop
         box = src.copy()
-        box.alpha_composite(over, (64, 64, 96, 96))
+        box.alpha_composite(over, (64, 64), (0, 0, 32, 32))
         self.assert_image_equal(box.crop((64, 64, 96, 96)),
                                 target.crop((0, 0, 32, 32)))
         self.assert_image_equal(box.crop((96, 96, 128, 128)),
@@ -234,7 +234,7 @@ class TestImage(PillowTestCase):
 
         # source point
         source = src.copy()
-        source.alpha_composite(over, (32, 32, 96, 96), (32, 32))
+        source.alpha_composite(over, (32, 32), (32, 32, 96, 96))
 
         self.assert_image_equal(source.crop((32, 32, 96, 96)),
                                 target.crop((32, 32, 96, 96)))

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -104,6 +104,8 @@ An instance of the :py:class:`~PIL.Image.Image` class has the following
 methods. Unless otherwise stated, all methods return a new instance of the
 :py:class:`~PIL.Image.Image` class, holding the resulting image.
 
+
+.. automethod:: PIL.Image.Image.alpha_composite
 .. automethod:: PIL.Image.Image.convert
 
 The following example converts an RGB image (linearly calibrated according to


### PR DESCRIPTION
See #1911 

Changes proposed in this pull request:

 * Adds an alpha_composite instance method on Image that does the composition 'in place', rather than returning a whole new image. 
 * Specifies a bounding box in the destination/background image, and a source point in the overlay.
 * Currently done in python, but this is an initial implementation that could be pushed into the C layer to eliminate copies and crops.

I'm doing this as a test to see if the interface makes sense as a companion of Image.Image.paste, and Image.alpha_composite. 