### PR TITLE
Improved append_images documentation

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -110,6 +110,7 @@ are available::
 **append_images**
     A list of images to append as additional frames. Each of the
     images in the list can be single or multiframe images.
+    This is currently only supported for GIF, PDF and TIFF.
 
 **duration**
     The display duration of each frame of the multiframe gif, in


### PR DESCRIPTION
Issues #2191 and #2511 arose because users did not understand that `append_images` was only available for GIF. While we have added support now for the relevant formats, this improves the documentation to try and avoid similar confusion in the future.