### PR TITLE
[etc] Fix built-in name.

### DIFF
--- a/PIL/PdfImagePlugin.py
+++ b/PIL/PdfImagePlugin.py
@@ -37,11 +37,11 @@ __version__ = "0.4"
 #  4. page
 #  5. page contents
 
-def _obj(fp, obj, **dict_):
+def _obj(fp, obj, **dictionary):
     fp.write("%d 0 obj\n" % obj)
-    if dict_:
+    if dictionary:
         fp.write("<<\n")
-        for k, v in dict_.items():
+        for k, v in dictionary.items():
             if v is not None:
                 fp.write("/%s %s\n" % (k, v))
         fp.write(">>\n")

--- a/PIL/PdfImagePlugin.py
+++ b/PIL/PdfImagePlugin.py
@@ -37,11 +37,11 @@ __version__ = "0.4"
 #  4. page
 #  5. page contents
 
-def _obj(fp, obj, **dict):
+def _obj(fp, obj, **dict_):
     fp.write("%d 0 obj\n" % obj)
-    if dict:
+    if dict_:
         fp.write("<<\n")
-        for k, v in dict.items():
+        for k, v in dict_.items():
             if v is not None:
                 fp.write("/%s %s\n" % (k, v))
         fp.write(">>\n")


### PR DESCRIPTION
Changes proposed in this pull request:
 * Fix the built-in name "dict" to "dict_" in PIL/PdfImagePlugin.py
It can be seen an error when: python -c "from Cython.Build import cythonize; cythonize(['PIL/PdfImagePlugin.py'])"
