### PR TITLE
Test Fedora 24 and 26 in Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
     - env: DOCKER="debian-stretch-x86"
     - env: DOCKER="centos-6-amd64"
     - env: DOCKER="amazon-amd64"
+    - env: DOCKER="fedora-24-amd64"
+    - env: DOCKER="fedora-26-amd64"
 
 dist: trusty
 


### PR DESCRIPTION
Uses https://github.com/python-pillow/docker-images/pull/8

TravisCI test runs in docker for Fedora 24 and 26. 