### PR TITLE
Delete transparency info when img.convert'ing RGB/L to RGBA

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -877,8 +877,10 @@ class Image(object):
             if self.mode in ('L', 'RGB') and mode == 'RGBA':
                 # Use transparent conversion to promote from transparent
                 # color to an alpha channel.
-                return self._new(self.im.convert_transparent(
+                new_im = self._new(self.im.convert_transparent(
                     mode, self.info['transparency']))
+                del(new_im.info['transparency'])
+                return new_im
             elif self.mode in ('L', 'RGB', 'P') and mode in ('L', 'RGB', 'P'):
                 t = self.info['transparency']
                 if isinstance(t, bytes):

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -122,6 +122,10 @@ class TestImageConvert(PillowTestCase):
         self.assertIn('transparency', p.info)
         p.save(f)
 
+        p = im.convert('RGBA')
+        self.assertNotIn('transparency', p.info)
+        p.save(f)
+
         p = self.assert_warning(
             UserWarning,
             lambda: im.convert('P', palette=Image.ADAPTIVE))


### PR DESCRIPTION
`info['transparency]` was not removed when an RGB or L image
was converted to RGBA. This could result in unexpected behavior
when saving the resulting image.

Other image conversions already delete or update the transparency
info. There is a shortcut for RGB/L to RGBA which missed this.
