### PR TITLE
Fix EPS import

### DIFF
--- a/PIL/EpsImagePlugin.py
+++ b/PIL/EpsImagePlugin.py
@@ -129,6 +129,7 @@ def Ghostscript(tile, size, fp, scale=1):
                "-c", "%d %d translate" % (-bbox[0], -bbox[1]),
                                              # adjust for image origin
                "-f", infile,                 # input file
+               "-c", "showpage",             # showpage (see: https://bugs.ghostscript.com/show_bug.cgi?id=698272)
                ]
 
     if gs_windows_binary is not None:

--- a/Tests/images/d15-120f10.eps
+++ b/Tests/images/d15-120f10.eps
@@ -1,0 +1,160 @@
+%!PS-Adobe-2.0
+%%BoundingBox: 0 0 553 475
+ /sp {showpage} def /gr {grestore} def /gs {gsave} def /n {newpath} def
+/s {stroke} def /m {moveto} def /l {lineto} def /tl {translate} def
+/sd {setdash} def /sw {setlinewidth} def /cp {closepath} def /f {fill} def
+/e {eofill} def /c {setrgbcolor} def /o {show} def /ff {findfont} def
+/ro {rotate} def /sf {setfont} def /cf {scalefont} def /a {arc} def
+/mf {makefont} def /sc {scale} def /k {rmoveto} def /r {rlineto} def
+/v0 {currentpoint .5 0 rlineto .5 0 360 arc -.5 0 rlineto} def
+/sml {setmiterlimit} def gs 0.240000 0.240000 sc 0 0 tl 0 ro 3 sml 0.0 0.0 0.0 c
+ /Symbol ff 101 cf sf 2073 87 m (h) o /Symbol ff 61 cf sf 2130 66 m (r) o
+/Times-Bold ff 98 cf sf 150 1285 m 90 ro (d) o -90 ro /Symbol ff 101 cf sf
+150 1340 m 90 ro (s) o -90 ro /Symbol ff 61 cf sf 171 1398 m 90 ro (g) o -90 ro
+/Times-Bold ff 59 cf sf 171 1424 m 90 ro (p) o -90 ro /Times-Bold ff 98 cf sf
+150 1461 m 90 ro (/d) o -90 ro /Symbol ff 101 cf sf 150 1543 m 90 ro (h) o
+-90 ro /Times-Bold ff 98 cf sf 150 1604 m 90 ro ( [nb]) o -90 ro []0 sd n
+497 326 m -5 12 r -12 5 r -12 -5 r -5 -12 r 5 -11 r 24 0 r cp e 4 sw n 523 326 m
+ -26 0 r s n 437 326 m 26 0 r s n 584 378 m -5 12 r -12 5 r -12 -5 r -5 -12 r
+5 -12 r 12 -5 r 12 5 r cp e n 610 378 m -26 0 r s n 523 378 m 27 0 r s n
+567 399 m 0 -4 r s n 567 356 m 0 5 r s n 670 424 m -5 12 r -12 5 r -12 -5 r
+-5 -12 r 5 -12 r 12 -5 r 12 5 r cp e n 697 424 m -27 0 r s n 610 424 m 26 0 r s
+n 653 453 m 0 -12 r s n 653 394 m 0 13 r s n 757 609 m -5 12 r -12 5 r -12 -5 r
+-5 -12 r 5 -12 r 12 -5 r 12 5 r cp e n 783 609 m -26 0 r s n 697 609 m 26 0 r s
+n 740 667 m 0 -41 r s n 740 551 m 0 41 r s n 843 861 m -5 12 r -12 5 r -12 -5 r
+-5 -12 r 5 -12 r 12 -5 r 12 5 r cp e n 870 861 m -27 0 r s n 783 861 m 26 0 r s
+n 826 952 m 0 -74 r s n 826 769 m 0 75 r s n 930 876 m -5 12 r -12 5 r -12 -5 r
+-5 -12 r 5 -12 r 12 -5 r 12 5 r cp e n 956 876 m -26 0 r s n 870 876 m 26 0 r s
+n 913 980 m 0 -87 r s n 913 773 m 0 86 r s n 1016 904 m -5 12 r -12 5 r -12 -5 r
+ -4 -12 r 4 -12 r 12 -4 r 12 4 r cp e n 1043 904 m -27 0 r s n 956 904 m 27 0 r
+s n 999 1019 m 0 -98 r s n 999 790 m 0 98 r s n 1103 913 m -5 12 r -12 4 r
+-12 -4 r -5 -12 r 5 -12 r 12 -5 r 12 5 r cp e n 1129 913 m -26 0 r s n
+1043 913 m 26 0 r s n 1086 1016 m 0 -87 r s n 1086 809 m 0 87 r s n 1189 884 m
+-5 12 r -12 5 r -11 -5 r -5 -12 r 5 -12 r 11 -4 r 12 4 r cp e n 1216 884 m
+-27 0 r s n 1129 884 m 27 0 r s n 1172 977 m 0 -76 r s n 1172 791 m 0 77 r s n
+1276 798 m -5 12 r -12 5 r -12 -5 r -5 -12 r 5 -12 r 12 -5 r 12 5 r cp e n
+1302 798 m -26 0 r s n 1216 798 m 26 0 r s n 1259 878 m 0 -63 r s n 1259 718 m
+0 63 r s n 1362 888 m -4 12 r -12 5 r -12 -5 r -5 -12 r 5 -11 r 12 -5 r 12 5 r
+cp e n 1389 888 m -27 0 r s n 1302 888 m 27 0 r s n 1346 979 m 0 -74 r s n
+1346 798 m 0 74 r s n 1449 961 m -5 12 r -12 5 r -12 -5 r -5 -12 r 5 -12 r
+12 -4 r 12 4 r cp e n 1475 961 m -26 0 r s n 1389 961 m 26 0 r s n 1432 1068 m
+0 -90 r s n 1432 855 m 0 90 r s n 1536 1107 m -5 12 r -12 4 r -12 -4 r -5 -12 r
+5 -12 r 12 -5 r 12 5 r cp e n 1562 1107 m -26 0 r s n 1475 1107 m 27 0 r s n
+1519 1226 m 0 -103 r s n 1519 987 m 0 103 r s n 1622 1385 m -5 12 r -12 4 r
+-12 -4 r -5 -12 r 5 -12 r 12 -5 r 12 5 r cp e n 1648 1385 m -26 0 r s n
+1562 1385 m 26 0 r s n 1605 1539 m 0 -138 r s n 1605 1230 m 0 138 r s n
+1709 809 m -5 12 r -12 5 r -12 -5 r -5 -12 r 5 -12 r 12 -5 r 12 5 r cp e n
+1735 809 m -26 0 r s n 1648 809 m 27 0 r s n 1692 883 m 0 -57 r s n 1692 735 m
+0 57 r s n 1795 534 m -5 12 r -12 5 r -12 -5 r -5 -12 r 5 -12 r 12 -5 r 12 5 r
+cp e n 1822 534 m -27 0 r s n 1735 534 m 26 0 r s n 1778 570 m 0 -19 r s n
+1778 497 m 0 20 r s n 1882 411 m -5 12 r -12 5 r -12 -5 r -5 -12 r 5 -12 r
+12 -5 r 12 5 r cp e n 1908 411 m -26 0 r s n 1822 411 m 26 0 r s n 1865 432 m
+0 -4 r s n 1865 390 m 0 4 r s n 1968 357 m -5 12 r -12 5 r -12 -5 r -5 -12 r
+5 -12 r 12 -5 r 12 5 r cp e n 1995 357 m -27 0 r s n 1908 357 m 26 0 r s n
+2055 327 m -5 12 r -12 5 r -12 -5 r -5 -12 r 5 -12 r 2 0 r 20 0 r 2 0 r cp e n
+2081 327 m -26 0 r s n 1995 327 m 26 0 r s n 2141 323 m -5 12 r -12 5 r -11 -5 r
+ -5 -12 r 3 -8 r 27 0 r cp e n 2168 323 m -27 0 r s n 2081 323 m 27 0 r s 3 sw n
+ 437 1805 m 0 -1490 r 1731 0 r 0 1490 r -1731 0 r cp s n 610 315 m 0 35 r s n
+956 315 m 0 35 r s n 1302 315 m 0 35 r s n 1648 315 m 0 35 r s n 1995 315 m
+0 35 r s n 610 1805 m 0 -35 r s n 956 1805 m 0 -35 r s n 1302 1805 m 0 -35 r s n
+ 1648 1805 m 0 -35 r s n 1995 1805 m 0 -35 r s n 437 315 m 35 0 r s n 437 811 m
+35 0 r s n 437 1308 m 35 0 r s n 437 1805 m 35 0 r s n 2168 315 m -35 0 r s n
+2168 811 m -35 0 r s n 2168 1308 m -35 0 r s n 2168 1805 m -35 0 r s 3 sw n
+610 315 m 0 21 r s n 783 315 m 0 21 r s n 956 315 m 0 21 r s n 1129 315 m 0 21 r
+ s n 1302 315 m 0 21 r s n 1475 315 m 0 21 r s n 1648 315 m 0 21 r s n
+1822 315 m 0 21 r s n 1995 315 m 0 21 r s n 2168 315 m 0 21 r s n 610 1805 m
+0 -21 r s n 783 1805 m 0 -21 r s n 956 1805 m 0 -21 r s n 1129 1805 m 0 -21 r s
+n 1302 1805 m 0 -21 r s n 1475 1805 m 0 -21 r s n 1648 1805 m 0 -21 r s n
+1822 1805 m 0 -21 r s n 1995 1805 m 0 -21 r s n 2168 1805 m 0 -21 r s n
+437 439 m 21 0 r s n 437 563 m 21 0 r s n 437 687 m 21 0 r s n 437 811 m 21 0 r
+s n 437 936 m 21 0 r s n 437 1060 m 21 0 r s n 437 1184 m 21 0 r s n 437 1308 m
+21 0 r s n 437 1432 m 21 0 r s n 437 1556 m 21 0 r s n 437 1681 m 21 0 r s n
+2168 439 m -21 0 r s n 2168 563 m -21 0 r s n 2168 687 m -21 0 r s n 2168 811 m
+-21 0 r s n 2168 936 m -21 0 r s n 2168 1060 m -21 0 r s n 2168 1184 m -21 0 r s
+ n 2168 1308 m -21 0 r s n 2168 1432 m -21 0 r s n 2168 1556 m -21 0 r s n
+2168 1681 m -21 0 r s /Times-Bold ff 98 cf sf 569 209 m (-4) o 915 209 m (-2) o
+1278 209 m (0) o 1624 209 m (2) o 1970 209 m (4) o 352 279 m (0) o 303 776 m
+(40) o 303 1273 m (80) o 253 1770 m (120) o /Symbol ff 101 cf sf 2073 87 m (h) o
+ /Symbol ff 61 cf sf 2130 66 m (r) o /Times-Bold ff 98 cf sf 150 1285 m 90 ro
+(d) o -90 ro /Symbol ff 101 cf sf 150 1340 m 90 ro (s) o -90 ro /Symbol ff 61 cf
+ sf 171 1398 m 90 ro (g) o -90 ro /Times-Bold ff 59 cf sf 171 1424 m 90 ro (p) o
+ -90 ro /Times-Bold ff 98 cf sf 150 1461 m 90 ro (/d) o -90 ro /Symbol ff 101 cf
+ sf 150 1543 m 90 ro (h) o -90 ro /Times-Bold ff 98 cf sf 150 1604 m 90 ro
+( [nb]) o -90 ro n 503 326 m -7 16 r -16 7 r -16 -7 r -6 -16 r 4 -11 r 36 0 r cp
+ e n 589 378 m -6 16 r -16 6 r -16 -6 r -7 -16 r 7 -16 r 16 -7 r 16 7 r cp e n
+676 424 m -7 16 r -16 6 r -16 -6 r -6 -16 r 6 -16 r 16 -7 r 16 7 r cp e 9 sw n
+653 447 m 0 -1 r s n 662 447 m -18 0 r s n 653 400 m 0 1 r s n 662 400 m -18 0 r
+ s n 762 609 m -6 16 r -16 7 r -16 -7 r -7 -16 r 7 -16 r 16 -6 r 16 6 r cp e n
+740 650 m 0 -18 r s n 749 650 m -18 0 r s n 740 568 m 0 19 r s n 749 568 m
+-18 0 r s n 849 861 m -7 16 r -16 6 r -16 -6 r -6 -16 r 6 -16 r 16 -7 r 16 7 r
+cp e n 826 914 m 0 -31 r s n 835 914 m -18 0 r s n 826 807 m 0 31 r s n
+835 807 m -18 0 r s n 935 876 m -6 16 r -16 7 r -16 -7 r -7 -16 r 7 -16 r
+16 -6 r 16 6 r cp e n 913 929 m 0 -30 r s n 922 929 m -18 0 r s n 913 824 m
+0 30 r s n 922 824 m -18 0 r s n 1022 904 m -7 16 r -16 7 r -16 -7 r -6 -16 r
+6 -16 r 16 -6 r 16 6 r cp e n 999 955 m 0 -28 r s n 1008 955 m -18 0 r s n
+999 854 m 0 28 r s n 1008 854 m -18 0 r s n 1108 913 m -6 16 r -16 6 r -16 -6 r
+-7 -16 r 7 -16 r 16 -7 r 16 7 r cp e n 1086 958 m 0 -23 r s n 1095 958 m -18 0 r
+ s n 1086 867 m 0 23 r s n 1095 867 m -18 0 r s n 1195 884 m -7 16 r -16 7 r
+-15 -7 r -7 -16 r 7 -16 r 15 -6 r 16 6 r cp e n 1172 925 m 0 -18 r s n
+1182 925 m -19 0 r s n 1172 844 m 0 18 r s n 1182 844 m -19 0 r s n 1282 798 m
+-7 16 r -16 7 r -16 -7 r -6 -16 r 6 -16 r 16 -6 r 16 6 r cp e n 1259 837 m
+0 -16 r s n 1268 837 m -18 0 r s n 1259 759 m 0 17 r s n 1268 759 m -18 0 r s n
+1368 888 m -6 16 r -16 7 r -16 -7 r -7 -16 r 7 -15 r 16 -7 r 16 7 r cp e n
+1346 928 m 0 -17 r s n 1355 928 m -18 0 r s n 1346 849 m 0 17 r s n 1355 849 m
+-18 0 r s n 1455 961 m -7 16 r -16 7 r -16 -7 r -6 -16 r 6 -16 r 16 -6 r 16 6 r
+cp e n 1432 1005 m 0 -21 r s n 1441 1005 m -18 0 r s n 1432 918 m 0 21 r s n
+1441 918 m -18 0 r s n 1541 1107 m -6 16 r -16 6 r -16 -6 r -7 -16 r 7 -16 r
+16 -7 r 16 7 r cp e n 1519 1154 m 0 -25 r s n 1528 1154 m -18 0 r s n
+1519 1059 m 0 25 r s n 1528 1059 m -18 0 r s n 1628 1385 m -7 15 r -16 7 r
+-16 -7 r -6 -15 r 6 -16 r 16 -7 r 16 7 r cp e n 1605 1446 m 0 -39 r s n
+1614 1446 m -18 0 r s n 1605 1323 m 0 39 r s n 1614 1323 m -18 0 r s n
+1714 809 m -6 16 r -16 6 r -16 -6 r -7 -16 r 7 -16 r 16 -7 r 16 7 r cp e n
+1692 847 m 0 -16 r s n 1701 847 m -18 0 r s n 1692 771 m 0 15 r s n 1701 771 m
+-18 0 r s n 1801 534 m -7 16 r -16 7 r -16 -7 r -6 -16 r 6 -16 r 16 -7 r 16 7 r
+cp e n 1778 558 m 0 -1 r s n 1787 558 m -18 0 r s n 1778 510 m 0 1 r s n
+1787 510 m -18 0 r s n 1887 411 m -6 16 r -16 7 r -16 -7 r -7 -16 r 7 -16 r
+16 -7 r 16 7 r cp e n 1974 357 m -7 16 r -16 6 r -16 -6 r -6 -16 r 6 -16 r
+16 -7 r 16 7 r cp e n 2060 327 m -6 16 r -16 7 r -16 -7 r -7 -16 r 6 -12 r
+34 0 r cp e n 2147 323 m -7 16 r -16 6 r -15 -6 r -7 -16 r 3 -8 r 39 0 r cp e
+0.0 0.0 1.000000 c n 437 324 m 86 0 r s n 523 341 m 87 0 r s n 523 324 m 0 17 r
+s n 610 386 m 87 0 r s n 610 341 m 0 45 r s n 697 491 m 86 0 r s n 697 386 m
+0 105 r s n 783 716 m 87 0 r s n 783 491 m 0 225 r s n 870 1015 m 86 0 r s n
+870 716 m 0 299 r s n 956 1152 m 87 0 r s n 956 1015 m 0 137 r s n 1043 1051 m
+86 0 r s n 1043 1152 m 0 -101 r s n 1129 933 m 87 0 r s n 1129 1051 m 0 -118 r s
+ n 1216 857 m 86 0 r s n 1216 933 m 0 -76 r s n 1302 861 m 87 0 r s n 1302 857 m
+ 0 4 r s n 1389 969 m 86 0 r s n 1389 861 m 0 108 r s n 1475 1128 m 87 0 r s n
+1475 969 m 0 159 r s n 1562 1255 m 86 0 r s n 1562 1128 m 0 127 r s n 1648 777 m
+ 87 0 r s n 1648 1255 m 0 -478 r s n 1735 473 m 87 0 r s n 1735 777 m 0 -304 r s
+ n 1822 371 m 86 0 r s n 1822 473 m 0 -102 r s n 1908 336 m 87 0 r s n
+1908 371 m 0 -35 r s n 1995 323 m 86 0 r s n 1995 336 m 0 -13 r s n 2081 318 m
+87 0 r s n 2081 323 m 0 -5 r s 0.0 0.0 0.0 c 2 sw n 437 1805 m 0 -1490 r
+1731 0 r 0 1490 r -1731 0 r cp s n 610 315 m 0 35 r s n 956 315 m 0 35 r s n
+1302 315 m 0 35 r s n 1648 315 m 0 35 r s n 1995 315 m 0 35 r s n 610 1805 m
+0 -35 r s n 956 1805 m 0 -35 r s n 1302 1805 m 0 -35 r s n 1648 1805 m 0 -35 r s
+ n 1995 1805 m 0 -35 r s n 437 315 m 35 0 r s n 437 811 m 35 0 r s n 437 1308 m
+35 0 r s n 437 1805 m 35 0 r s n 2168 315 m -35 0 r s n 2168 811 m -35 0 r s n
+2168 1308 m -35 0 r s n 2168 1805 m -35 0 r s 1 sw n 610 315 m 0 21 r s n
+783 315 m 0 21 r s n 956 315 m 0 21 r s n 1129 315 m 0 21 r s n 1302 315 m
+0 21 r s n 1475 315 m 0 21 r s n 1648 315 m 0 21 r s n 1822 315 m 0 21 r s n
+1995 315 m 0 21 r s n 2168 315 m 0 21 r s n 610 1805 m 0 -21 r s n 783 1805 m
+0 -21 r s n 956 1805 m 0 -21 r s n 1129 1805 m 0 -21 r s n 1302 1805 m 0 -21 r s
+ n 1475 1805 m 0 -21 r s n 1648 1805 m 0 -21 r s n 1822 1805 m 0 -21 r s n
+1995 1805 m 0 -21 r s n 2168 1805 m 0 -21 r s n 437 439 m 21 0 r s n 437 563 m
+21 0 r s n 437 687 m 21 0 r s n 437 811 m 21 0 r s n 437 936 m 21 0 r s n
+437 1060 m 21 0 r s n 437 1184 m 21 0 r s n 437 1308 m 21 0 r s n 437 1432 m
+21 0 r s n 437 1556 m 21 0 r s n 437 1681 m 21 0 r s n 2168 439 m -21 0 r s n
+2168 563 m -21 0 r s n 2168 687 m -21 0 r s n 2168 811 m -21 0 r s n 2168 936 m
+-21 0 r s n 2168 1060 m -21 0 r s n 2168 1184 m -21 0 r s n 2168 1308 m -21 0 r
+s n 2168 1432 m -21 0 r s n 2168 1556 m -21 0 r s n 2168 1681 m -21 0 r s
+/Times-Bold ff 98 cf sf 569 209 m (-4) o 915 209 m (-2) o 1278 209 m (0) o
+1624 209 m (2) o 1970 209 m (4) o 352 279 m (0) o 303 776 m (40) o 303 1273 m
+(80) o 253 1770 m (120) o n 586 1656 m -7 16 r -16 6 r -15 -6 r -7 -16 r 7 -16 r
+ 15 -7 r 16 7 r cp e /Times-Bold ff 78 cf sf 690 1632 m (H1 ) o 811 1632 m
+(data) o 0.0 0.0 1.000000 c 9 sw n 493 1566 m 141 0 r s 0.0 0.0 0.0 c 690 1538 m
+ (POMPYT) o /Times-Bold ff 196 cf sf 1787 1586 m (H1) o 
+%%
+%% --- global title --------
+%%
+/Symbol ff 112 cf sf 757 1855 m (r) o  /Times-Bold ff 66 cf sf 815 1895 m (0) o
+/Times-Bold ff 92 cf sf 845 1855 m ( with ) o 1070 1855 m (Forward ) o 1445 1855 m (Neutron) o
+gr

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -71,6 +71,10 @@ class TestFileEps(PillowTestCase):
             target = Image.open('Tests/images/pil_sample_rgb.jpg')
             self.assert_image_similar(cmyk_image, target, 10)
 
+    def test_showpage(self):
+        plot_image = Image.open("Tests/images/d15-120f10.eps")
+        plot_image.load()
+
     def test_file_object(self):
         # issue 479
         image1 = Image.open(file1)


### PR DESCRIPTION
Fixes #2615

Changes proposed in this pull request:

 * Adds -c showpage to the end of the gs call when importing an EPS

Fixes EPS import by adding the missing "showpage" Postscript command
to the end of the gs call.

See: https://bugs.ghostscript.com/show_bug.cgi?id=698272

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>