### PR TITLE
Add newlines to error message for clarity

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -56,8 +56,9 @@ try:
     from . import _imaging as core
     if PILLOW_VERSION != getattr(core, 'PILLOW_VERSION', None):
         raise ImportError("The _imaging extension was built for another "
-                          "version of Pillow or PIL: Core Version: %s"
-                          "Pillow Version:  %s" %
+                          "version of Pillow or PIL:\n"
+                          "Core version: %s\n"
+                          "Pillow version: %s" %
                           (getattr(core, 'PILLOW_VERSION', None),
                            PILLOW_VERSION))
 


### PR DESCRIPTION
Also remove a space and lowercase "version" for sentence case.

Before:
```
/Users/hugo/github/Pillow/PIL/Image.py:77: RuntimeWarning: The _imaging extension was built for another version of Pillow or PIL: Core Version: 4.3.0.dev0Pillow Version:  4.2.0
  warnings.warn(str(v), RuntimeWarning)
Traceback (most recent call last):
  File "/tmp/Downloads/2639.py", line 1, in <module>
    from PIL import Image, ImageDraw, ImageFont
  File "/Users/hugo/github/Pillow/PIL/Image.py", line 62, in <module>
    PILLOW_VERSION))
ImportError: The _imaging extension was built for another version of Pillow or PIL: Core Version: 4.3.0.dev0Pillow Version:  4.2.0
```

After:
```
/Users/hugo/github/Pillow/PIL/Image.py:78: RuntimeWarning: The _imaging extension was built for another version of Pillow or PIL:
Core version: 4.3.0.dev0
Pillow version: 4.2.0
  warnings.warn(str(v), RuntimeWarning)
Traceback (most recent call last):
  File "/tmp/Downloads/2639.py", line 1, in <module>
    from PIL import Image, ImageDraw, ImageFont
  File "/Users/hugo/github/Pillow/PIL/Image.py", line 63, in <module>
    PILLOW_VERSION))
ImportError: The _imaging extension was built for another version of Pillow or PIL:
Core version: 4.3.0.dev0
Pillow version: 4.2.0
```