### PR TITLE
Fix unexpected keyword argument 'align'

### DIFF
--- a/PIL/ImageFont.py
+++ b/PIL/ImageFont.py
@@ -36,6 +36,7 @@ class _imagingft_not_installed(object):
     def __getattr__(self, id):
         raise ImportError("The _imagingft C module is not installed")
 
+
 try:
     from . import _imagingft as core
 except ImportError:
@@ -113,7 +114,6 @@ class ImageFont(object):
         return self.font.getmask(text, mode)
 
 
-
 ##
 # Wrapper for FreeType fonts.  Application code should use the
 # <b>truetype</b> factory function to create font objects.
@@ -162,7 +162,7 @@ class FreeTypeFont(object):
     def getmask(self, text, mode="", direction=None, features=None):
         return self.getmask2(text, mode, direction=direction, features=features)[0]
 
-    def getmask2(self, text, mode="", fill=Image.core.fill, direction=None, features=None):
+    def getmask2(self, text, mode="", fill=Image.core.fill, direction=None, features=None, *args, **kwargs):
         size, offset = self.font.getsize(text, direction, features)
         im = fill("L", size, 0)
         self.font.render(text, im.id, mode == "1", direction, features)
@@ -250,7 +250,7 @@ def truetype(font=None, size=10, index=0, encoding="",
                      and "armn" (Apple Roman). See the FreeType documentation
                      for more information.
     :param layout_engine: Which layout engine to use, if available:
-                     `ImageFont.LAYOUT_BASIC` or `ImageFont.LAYOUT_RAQM`.                  
+                     `ImageFont.LAYOUT_BASIC` or `ImageFont.LAYOUT_RAQM`.
     :return: A font object.
     :exception IOError: If the file could not be read.
     """

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -40,13 +40,15 @@ class SimplePatcher(object):
         else:
             delattr(self._parent_obj, self._attr_name)
 
+
 @unittest.skipUnless(HAS_FREETYPE, "ImageFont not Available")
 class TestImageFont(PillowTestCase):
     LAYOUT_ENGINE = ImageFont.LAYOUT_BASIC
 
     # Freetype has different metrics depending on the version.
     # (and, other things, but first things first)
-    METRICS = { ('2', '3'): {'multiline': 30,
+    METRICS = {
+                ('2', '3'): {'multiline': 30,
                              'textsize': 12,
                              'getters': (13, 16)},
                 ('2', '7'): {'multiline': 6.2,
@@ -212,6 +214,14 @@ class TestImageFont(PillowTestCase):
                           lambda: draw.multiline_text((0, 0), TEST_TEXT,
                                                       font=ttf,
                                                       align="unknown"))
+
+    def test_draw_align(self):
+        im = Image.new('RGB', (300, 100), 'white')
+        draw = ImageDraw.Draw(im)
+        ttf = self.get_font()
+        line = "some text"
+        draw.text((100, 40), line, (0, 0, 0), font=ttf, align='left')
+        del draw
 
     def test_multiline_size(self):
         ttf = self.get_font()
@@ -395,7 +405,7 @@ class TestImageFont(PillowTestCase):
 
     def test_getsize_empty(self):
         font = self.get_font()
-        # should not crash. 
+        # should not crash.
         self.assertEqual((0, 0), font.getsize(''))
 
     def _test_fake_loading_font(self, path_to_fake, fontname):
@@ -493,6 +503,7 @@ class TestImageFont(PillowTestCase):
 @unittest.skipUnless(HAS_RAQM, "Raqm not Available")
 class TestImageFont_RaqmLayout(TestImageFont):
     LAYOUT_ENGINE = ImageFont.LAYOUT_RAQM
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #2639.

In Pillow 4.2.0 and 4.2.1 (but not 4.1.0):
```python
        im = Image.new('RGB', (300, 100), 'white')
        draw = ImageDraw.Draw(im)
        ttf = self.get_font()
        line = "some text"
        draw.text((100, 40), line, (0, 0, 0), font=ttf, align='left')
        del draw
```
Causes:
```
  File "/usr/local/lib/python2.7/site-packages/PIL/ImageDraw.py", line 217, in text
    mask, offset = font.getmask2(text, self.fontmode, *args, **kwargs)
TypeError: getmask2() got an unexpected keyword argument 'align'
```

Can be fixed by adding `*args, **kwargs` into:
```python
def getmask2(self, text, mode="", fill=Image.core.fill, direction=None, features=None):
 ```