### PR TITLE
Add targa version 2 footer

### DIFF
--- a/PIL/TgaImagePlugin.py
+++ b/PIL/TgaImagePlugin.py
@@ -181,6 +181,9 @@ def _save(im, fp, filename, check=0):
 
     ImageFile._save(
         im, fp, [("raw", (0, 0) + im.size, 0, (rawmode, 0, orientation))])
+    
+    # write targa version 2 footer
+    fp.write(b"\000" * 8 + "TRUEVISION-XFILE." + b"\000")
 
 #
 # --------------------------------------------------------------------


### PR DESCRIPTION
Add the footer that is part of the version 2 spec. Some applications don't like images without the footer. Such as perforce's p4merge tool.

Fixes # .

Changes proposed in this pull request:

 * 
 * 
 * 
