### PR TITLE
Fixed bc5 decoding

### DIFF
--- a/libImaging/BcnDecode.c
+++ b/libImaging/BcnDecode.c
@@ -815,6 +815,7 @@ static int decode_bcn(Imaging im, ImagingCodecState state, const UINT8* src, int
 	case NN: \
 		while (bytes >= SZ) { \
 			TY col[16]; \
+			memset(col, 0, 16 * sizeof(col[0])); \
 			decode_bc##NN##_block(col, ptr); \
 			put_block(im, state, (const char *)col, sizeof(col[0]), C); \
 			ptr += SZ; \


### PR DESCRIPTION
BC5 decoding uses only 2 channels instead of 4. The current algorithm did not initialize the RGBA struct which resulted in random values in the output image. This commit should initialize the decoded RGBA struct, thus setting B and A values to default (0).

Changes proposed in this pull request:

 * Initialize target buffer to zero before filling.
