### PR TITLE
Storage cleanup

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -24,7 +24,7 @@ class TestImage(PillowTestCase):
         ]:
             with self.assertRaises(ValueError) as e:
                 Image.new(mode, (1, 1));
-            self.assertEqual(e.exception.message, 'unrecognized image mode')
+            self.assertEqual(str(e.exception), 'unrecognized image mode')
 
     def test_sanity(self):
 

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -7,6 +7,25 @@ import sys
 
 class TestImage(PillowTestCase):
 
+    def test_image_modes_success(self):
+        for mode in [
+            '1', 'P', 'PA',
+            'L', 'LA', 'La',
+            'F', 'I', 'I;16', 'I;16L', 'I;16B', 'I;16N',
+            'RGB', 'RGBX', 'RGBA', 'RGBa',
+            'CMYK', 'YCbCr', 'LAB', 'HSV',
+        ]:
+            Image.new(mode, (1, 1))
+
+    def test_image_modes_fail(self):
+        for mode in [
+            '', 'bad', 'very very long',
+            'BGR;15', 'BGR;16', 'BGR;24', 'BGR;32'
+        ]:
+            with self.assertRaises(ValueError) as e:
+                Image.new(mode, (1, 1));
+            self.assertEqual(e.exception.message, 'unrecognized image mode')
+
     def test_sanity(self):
 
         im = Image.new("L", (100, 100))

--- a/libImaging/Imaging.h
+++ b/libImaging/Imaging.h
@@ -172,7 +172,6 @@ extern Imaging ImagingNewPrologue(const char *mode,
 extern Imaging ImagingNewPrologueSubtype(const char *mode,
                                   int xsize, int ysize,
                                   int structure_size);
-extern void ImagingNewEpilogue(Imaging im);
 
 extern void ImagingCopyInfo(Imaging destination, Imaging source);
 

--- a/libImaging/Imaging.h
+++ b/libImaging/Imaging.h
@@ -163,7 +163,6 @@ extern Imaging ImagingNew2(const char* mode, Imaging imOut, Imaging imIn);
 extern void    ImagingDelete(Imaging im);
 
 extern Imaging ImagingNewBlock(const char* mode, int xsize, int ysize);
-extern Imaging ImagingNewArray(const char* mode, int xsize, int ysize);
 extern Imaging ImagingNewMap(const char* filename, int readonly,
                              const char* mode, int xsize, int ysize);
 

--- a/libImaging/Imaging.h
+++ b/libImaging/Imaging.h
@@ -172,7 +172,7 @@ extern Imaging ImagingNewPrologue(const char *mode,
 extern Imaging ImagingNewPrologueSubtype(const char *mode,
                                   int xsize, int ysize,
                                   int structure_size);
-extern Imaging ImagingNewEpilogue(Imaging im);
+extern void ImagingNewEpilogue(Imaging im);
 
 extern void ImagingCopyInfo(Imaging destination, Imaging source);
 

--- a/libImaging/Storage.c
+++ b/libImaging/Storage.c
@@ -344,7 +344,8 @@ ImagingNewBlock(const char *mode, int xsize, int ysize)
     if (im->linesize &&
         im->ysize > INT_MAX / im->linesize) {
         /* punt if we're going to overflow */
-        return NULL;
+        ImagingDelete(im);
+        return (Imaging) ImagingError_MemoryError();
     }
 
     if (im->ysize * im->linesize <= 0) {

--- a/libImaging/Storage.c
+++ b/libImaging/Storage.c
@@ -205,7 +205,7 @@ ImagingNewPrologueSubtype(const char *mode, int xsize, int ysize, int size)
 
     } else {
         free(im);
-        return (Imaging) ImagingError_ValueError("unrecognized mode");
+        return (Imaging) ImagingError_ValueError("unrecognized image mode");
     }
 
     /* Setup image descriptor */
@@ -387,16 +387,13 @@ ImagingNew(const char* mode, int xsize, int ysize)
     int bytes;
     Imaging im;
 
-    if (strcmp(mode, "") == 0)
-        return (Imaging) ImagingError_ValueError("empty mode");
-
     if (strlen(mode) == 1) {
         if (mode[0] == 'F' || mode[0] == 'I')
             bytes = 4;
         else
             bytes = 1;
     } else
-        bytes = strlen(mode); /* close enough */
+        bytes = strlen(mode) || 1; /* close enough */
 
     if (xsize < 0 || ysize < 0) {
         return (Imaging) ImagingError_ValueError("bad image size");

--- a/libImaging/Storage.c
+++ b/libImaging/Storage.c
@@ -371,26 +371,17 @@ ImagingAllocateBlock(Imaging im)
 Imaging
 ImagingNew(const char* mode, int xsize, int ysize)
 {
-    int bytes;
     Imaging im;
-
-    if (strlen(mode) == 1) {
-        if (mode[0] == 'F' || mode[0] == 'I')
-            bytes = 4;
-        else
-            bytes = 1;
-    } else
-        bytes = strlen(mode) || 1; /* close enough */
 
     if (xsize < 0 || ysize < 0) {
         return (Imaging) ImagingError_ValueError("bad image size");
     }
 
     im = ImagingNewPrologue(mode, xsize, ysize);
-    if (!im)
+    if ( ! im)
         return NULL;
 
-    if ((int64_t) xsize * (int64_t) ysize <= THRESHOLD / bytes) {
+    if (im->ysize && im->linesize <= THRESHOLD / im->ysize) {
         if (ImagingAllocateBlock(im)) {
             return im;
         }

--- a/libImaging/Storage.c
+++ b/libImaging/Storage.c
@@ -46,11 +46,9 @@ int ImagingNewCount = 0;
  */
 
 Imaging
-ImagingNewPrologueSubtype(const char *mode, int xsize, int ysize,
-                          int size)
+ImagingNewPrologueSubtype(const char *mode, int xsize, int ysize, int size)
 {
     Imaging im;
-    ImagingSectionCookie cookie;
 
     im = (Imaging) calloc(1, size);
     if (!im)
@@ -212,13 +210,9 @@ ImagingNewPrologueSubtype(const char *mode, int xsize, int ysize,
     /* Setup image descriptor */
     strcpy(im->mode, mode);
 
-    ImagingSectionEnter(&cookie);
-
     /* Pointer array (allocate at least one line, to avoid MemoryError
        exceptions on platforms where calloc(0, x) returns NULL) */
     im->image = (char **) calloc((ysize > 0) ? ysize : 1, sizeof(void *));
-
-    ImagingSectionLeave(&cookie);
 
     if (!im->image) {
         free(im);

--- a/libImaging/Storage.c
+++ b/libImaging/Storage.c
@@ -50,12 +50,13 @@ ImagingNewPrologueSubtype(const char *mode, int xsize, int ysize, int size)
 {
     Imaging im;
 
-    im = (Imaging) calloc(1, size);
-    if (!im)
-        return (Imaging) ImagingError_MemoryError();
-
     /* linesize overflow check, roughly the current largest space req'd */
     if (xsize > (INT_MAX / 4) - 1) {
+        return (Imaging) ImagingError_MemoryError();
+    }
+
+    im = (Imaging) calloc(1, size);
+    if (!im) {
         return (Imaging) ImagingError_MemoryError();
     }
 
@@ -228,8 +229,7 @@ Imaging
 ImagingNewPrologue(const char *mode, int xsize, int ysize)
 {
     return ImagingNewPrologueSubtype(
-        mode, xsize, ysize, sizeof(struct ImagingMemoryInstance)
-        );
+        mode, xsize, ysize, sizeof(struct ImagingMemoryInstance));
 }
 
 Imaging
@@ -371,7 +371,6 @@ ImagingNewBlock(const char *mode, int xsize, int ysize)
         }
 
         im->destroy = ImagingDestroyBlock;
-
     }
 
     return ImagingNewEpilogue(im);

--- a/map.c
+++ b/map.c
@@ -229,8 +229,6 @@ mapping_readimage(ImagingMapperObject* mapper, PyObject* args)
 
     im->destroy = ImagingDestroyMap;
 
-    ImagingNewEpilogue(im);
-
     mapper->offset += size;
 
     return PyImagingNew(im);
@@ -367,8 +365,7 @@ PyImaging_MapBuffer(PyObject* self, PyObject* args)
     }
 
     im = ImagingNewPrologueSubtype(
-        mode, xsize, ysize, sizeof(ImagingBufferInstance)
-        );
+        mode, xsize, ysize, sizeof(ImagingBufferInstance));
     if (!im)
         return NULL;
 
@@ -385,8 +382,6 @@ PyImaging_MapBuffer(PyObject* self, PyObject* args)
     Py_INCREF(target);
     ((ImagingBufferInstance*) im)->target = target;
     ((ImagingBufferInstance*) im)->view = view;
-
-    ImagingNewEpilogue(im);
 
     return PyImagingNew(im);
 }

--- a/map.c
+++ b/map.c
@@ -229,8 +229,7 @@ mapping_readimage(ImagingMapperObject* mapper, PyObject* args)
 
     im->destroy = ImagingDestroyMap;
 
-    if (!ImagingNewEpilogue(im))
-        return NULL;
+    ImagingNewEpilogue(im);
 
     mapper->offset += size;
 
@@ -387,8 +386,7 @@ PyImaging_MapBuffer(PyObject* self, PyObject* args)
     ((ImagingBufferInstance*) im)->target = target;
     ((ImagingBufferInstance*) im)->view = view;
 
-    if (!ImagingNewEpilogue(im))
-        return NULL;
+    ImagingNewEpilogue(im);
 
     return PyImagingNew(im);
 }


### PR DESCRIPTION
This is a small cleanup before the further work on storage module.

* Tests for different modes for `Image.new`
* Fixed memory leak if no available memory for allocating new image
* Fixed memory leak if `xsize > (INT_MAX / 4) - 1`
* Use accurate `im->linesize` value instead of `strlen(mode)` approximation

Side effect: removed ImagingNewEpilogue