### PR TITLE
Fast image allocation

### DIFF
--- a/_imaging.c
+++ b/_imaging.c
@@ -599,7 +599,7 @@ _fill(PyObject* self, PyObject* args)
     if (!PyArg_ParseTuple(args, "s|(ii)O", &mode, &xsize, &ysize, &color))
         return NULL;
 
-    im = ImagingNew(mode, xsize, ysize);
+    im = ImagingNewDirty(mode, xsize, ysize);
     if (!im)
         return NULL;
 
@@ -874,7 +874,7 @@ _gaussian_blur(ImagingObject* self, PyObject* args)
         return NULL;
 
     imIn = self->image;
-    imOut = ImagingNew(imIn->mode, imIn->xsize, imIn->ysize);
+    imOut = ImagingNewDirty(imIn->mode, imIn->xsize, imIn->ysize);
     if (!imOut)
         return NULL;
 
@@ -1539,7 +1539,7 @@ _resize(ImagingObject* self, PyObject* args)
         a[0] = (double) imIn->xsize / xsize;
         a[4] = (double) imIn->ysize / ysize;
 
-        imOut = ImagingNew(imIn->mode, xsize, ysize);
+        imOut = ImagingNewDirty(imIn->mode, xsize, ysize);
 
         imOut = ImagingTransform(
             imOut, imIn, IMAGING_TRANSFORM_AFFINE,
@@ -1665,12 +1665,12 @@ _transpose(ImagingObject* self, PyObject* args)
     case 0: /* flip left right */
     case 1: /* flip top bottom */
     case 3: /* rotate 180 */
-        imOut = ImagingNew(imIn->mode, imIn->xsize, imIn->ysize);
+        imOut = ImagingNewDirty(imIn->mode, imIn->xsize, imIn->ysize);
         break;
     case 2: /* rotate 90 */
     case 4: /* rotate 270 */
     case 5: /* transpose */
-        imOut = ImagingNew(imIn->mode, imIn->ysize, imIn->xsize);
+        imOut = ImagingNewDirty(imIn->mode, imIn->ysize, imIn->xsize);
         break;
     default:
         PyErr_SetString(PyExc_ValueError, "No such transpose operation");
@@ -1715,7 +1715,7 @@ _unsharp_mask(ImagingObject* self, PyObject* args)
         return NULL;
 
     imIn = self->image;
-    imOut = ImagingNew(imIn->mode, imIn->xsize, imIn->ysize);
+    imOut = ImagingNewDirty(imIn->mode, imIn->xsize, imIn->ysize);
     if (!imOut)
         return NULL;
 
@@ -1738,7 +1738,7 @@ _box_blur(ImagingObject* self, PyObject* args)
         return NULL;
 
     imIn = self->image;
-    imOut = ImagingNew(imIn->mode, imIn->xsize, imIn->ysize);
+    imOut = ImagingNewDirty(imIn->mode, imIn->xsize, imIn->ysize);
     if (!imOut)
         return NULL;
 

--- a/libImaging/AlphaComposite.c
+++ b/libImaging/AlphaComposite.c
@@ -42,7 +42,7 @@ ImagingAlphaComposite(Imaging imDst, Imaging imSrc)
         imDst->ysize != imSrc->ysize)
         return ImagingError_Mismatch();
 
-    imOut = ImagingNew(imDst->mode, imDst->xsize, imDst->ysize);
+    imOut = ImagingNewDirty(imDst->mode, imDst->xsize, imDst->ysize);
     if (!imOut)
         return NULL;
 

--- a/libImaging/Bands.c
+++ b/libImaging/Bands.c
@@ -43,7 +43,7 @@ ImagingGetBand(Imaging imIn, int band)
     if (imIn->bands == 2 && band == 1)
         band = 3;
 
-    imOut = ImagingNew("L", imIn->xsize, imIn->ysize);
+    imOut = ImagingNewDirty("L", imIn->xsize, imIn->ysize);
     if (!imOut)
 	return NULL;
 

--- a/libImaging/Blend.c
+++ b/libImaging/Blend.c
@@ -40,7 +40,7 @@ ImagingBlend(Imaging imIn1, Imaging imIn2, float alpha)
     else if (alpha == 1.0)
 	return ImagingCopy(imIn2);
 
-    imOut = ImagingNew(imIn1->mode, imIn1->xsize, imIn1->ysize);
+    imOut = ImagingNewDirty(imIn1->mode, imIn1->xsize, imIn1->ysize);
     if (!imOut)
 	return NULL;
 

--- a/libImaging/BoxBlur.c
+++ b/libImaging/BoxBlur.c
@@ -265,7 +265,7 @@ ImagingBoxBlur(Imaging imOut, Imaging imIn, float radius, int n)
           strcmp(imIn->mode, "La") == 0))
         return ImagingError_ModeError();
 
-    imTransposed = ImagingNew(imIn->mode, imIn->ysize, imIn->xsize);
+    imTransposed = ImagingNewDirty(imIn->mode, imIn->ysize, imIn->xsize);
     if (!imTransposed)
         return NULL;
 

--- a/libImaging/Convert.c
+++ b/libImaging/Convert.c
@@ -1035,7 +1035,7 @@ frompalette(Imaging imOut, Imaging imIn, const char *mode)
     else
         return (Imaging) ImagingError_ValueError("conversion not supported");
 
-    imOut = ImagingNew2(mode, imOut, imIn);
+    imOut = ImagingNew2Dirty(mode, imOut, imIn);
     if (!imOut)
         return NULL;
 
@@ -1073,7 +1073,7 @@ topalette(Imaging imOut, Imaging imIn, ImagingPalette inpalette, int dither)
     if (!palette)
         return (Imaging) ImagingError_ValueError("no palette");
 
-    imOut = ImagingNew2("P", imOut, imIn);
+    imOut = ImagingNew2Dirty("P", imOut, imIn);
     if (!imOut) {
       if (palette != inpalette)
         ImagingPaletteDelete(palette);
@@ -1211,7 +1211,7 @@ tobilevel(Imaging imOut, Imaging imIn, int dither)
     if (strcmp(imIn->mode, "L") != 0 && strcmp(imIn->mode, "RGB") != 0)
         return (Imaging) ImagingError_ValueError("conversion not supported");
 
-    imOut = ImagingNew2("1", imOut, imIn);
+    imOut = ImagingNew2Dirty("1", imOut, imIn);
     if (!imOut)
         return NULL;
 
@@ -1344,7 +1344,7 @@ convert(Imaging imOut, Imaging imIn, const char *mode,
     }
 #endif
 
-    imOut = ImagingNew2(mode, imOut, imIn);
+    imOut = ImagingNew2Dirty(mode, imOut, imIn);
     if (!imOut)
         return NULL;
 
@@ -1407,7 +1407,7 @@ ImagingConvertTransparent(Imaging imIn, const char *mode,
         g = b = r;
     }
 
-    imOut = ImagingNew2(mode, imOut, imIn);
+    imOut = ImagingNew2Dirty(mode, imOut, imIn);
     if (!imOut){
         return NULL;
     }

--- a/libImaging/Copy.c
+++ b/libImaging/Copy.c
@@ -28,7 +28,7 @@ _copy(Imaging imOut, Imaging imIn)
     if (!imIn)
 	return (Imaging) ImagingError_ValueError(NULL);
 
-    imOut = ImagingNew2(imIn->mode, imOut, imIn);
+    imOut = ImagingNew2Dirty(imIn->mode, imOut, imIn);
     if (!imOut)
         return NULL;
 

--- a/libImaging/Crop.c
+++ b/libImaging/Crop.c
@@ -37,7 +37,7 @@ ImagingCrop(Imaging imIn, int sx0, int sy0, int sx1, int sy1)
     if (ysize < 0)
         ysize = 0;
 
-    imOut = ImagingNew(imIn->mode, xsize, ysize);
+    imOut = ImagingNewDirty(imIn->mode, xsize, ysize);
     if (!imOut)
 	return NULL;
 

--- a/libImaging/Fill.c
+++ b/libImaging/Fill.c
@@ -68,7 +68,7 @@ ImagingFillLinearGradient(const char *mode)
         return (Imaging) ImagingError_ModeError();
     }
 
-    im = ImagingNew(mode, 256, 256);
+    im = ImagingNewDirty(mode, 256, 256);
     if (!im) {
         return NULL;
     }
@@ -91,7 +91,7 @@ ImagingFillRadialGradient(const char *mode)
         return (Imaging) ImagingError_ModeError();
     }
 
-    im = ImagingNew(mode, 256, 256);
+    im = ImagingNewDirty(mode, 256, 256);
     if (!im) {
         return NULL;
     }

--- a/libImaging/Imaging.h
+++ b/libImaging/Imaging.h
@@ -160,7 +160,7 @@ extern int ImagingNewCount;
 
 extern Imaging ImagingNew(const char* mode, int xsize, int ysize);
 extern Imaging ImagingNewDirty(const char* mode, int xsize, int ysize);
-extern Imaging ImagingNew2(const char* mode, Imaging imOut, Imaging imIn);
+extern Imaging ImagingNew2Dirty(const char* mode, Imaging imOut, Imaging imIn);
 extern void    ImagingDelete(Imaging im);
 
 extern Imaging ImagingNewBlock(const char* mode, int xsize, int ysize);

--- a/libImaging/Imaging.h
+++ b/libImaging/Imaging.h
@@ -159,6 +159,7 @@ struct ImagingPaletteInstance {
 extern int ImagingNewCount;
 
 extern Imaging ImagingNew(const char* mode, int xsize, int ysize);
+extern Imaging ImagingNewDirty(const char* mode, int xsize, int ysize);
 extern Imaging ImagingNew2(const char* mode, Imaging imOut, Imaging imIn);
 extern void    ImagingDelete(Imaging im);
 

--- a/libImaging/Matrix.c
+++ b/libImaging/Matrix.c
@@ -32,7 +32,7 @@ ImagingConvertMatrix(Imaging im, const char *mode, float m[])
 
     if (strcmp(mode, "L") == 0 && im->bands == 3) {
 
-	imOut = ImagingNew("L", im->xsize, im->ysize);
+	imOut = ImagingNewDirty("L", im->xsize, im->ysize);
 	if (!imOut)
 	    return NULL;
 
@@ -49,7 +49,7 @@ ImagingConvertMatrix(Imaging im, const char *mode, float m[])
 
     } else if (strlen(mode) == 3 && im->bands == 3) {
 
-	imOut = ImagingNew(mode, im->xsize, im->ysize);
+	imOut = ImagingNewDirty(mode, im->xsize, im->ysize);
 	if (!imOut)
 	    return NULL;
 

--- a/libImaging/Negative.c
+++ b/libImaging/Negative.c
@@ -29,7 +29,7 @@ ImagingNegative(Imaging im)
     if (!im)
 	return (Imaging) ImagingError_ModeError();
 
-    imOut = ImagingNew(im->mode, im->xsize, im->ysize);
+    imOut = ImagingNewDirty(im->mode, im->xsize, im->ysize);
     if (!imOut)
 	return NULL;
 

--- a/libImaging/Offset.c
+++ b/libImaging/Offset.c
@@ -27,7 +27,7 @@ ImagingOffset(Imaging im, int xoffset, int yoffset)
     if (!im)
 	return (Imaging) ImagingError_ModeError();
 
-    imOut = ImagingNew(im->mode, im->xsize, im->ysize);
+    imOut = ImagingNewDirty(im->mode, im->xsize, im->ysize);
     if (!imOut)
 	return NULL;
 

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -249,7 +249,7 @@ ImagingResampleHorizontal_8bpc(Imaging imIn, int xsize, struct filter *filterp)
         return (Imaging) ImagingError_MemoryError();
     }
 
-    imOut = ImagingNew(imIn->mode, xsize, imIn->ysize);
+    imOut = ImagingNewDirty(imIn->mode, xsize, imIn->ysize);
     if ( ! imOut) {
         free(kk);
         free(xbounds);
@@ -354,7 +354,7 @@ ImagingResampleVertical_8bpc(Imaging imIn, int ysize, struct filter *filterp)
         return (Imaging) ImagingError_MemoryError();
     }
 
-    imOut = ImagingNew(imIn->mode, imIn->xsize, ysize);
+    imOut = ImagingNewDirty(imIn->mode, imIn->xsize, ysize);
     if ( ! imOut) {
         free(kk);
         free(xbounds);
@@ -451,7 +451,7 @@ ImagingResampleHorizontal_32bpc(Imaging imIn, int xsize, struct filter *filterp)
         return (Imaging) ImagingError_MemoryError();
     }
 
-    imOut = ImagingNew(imIn->mode, xsize, imIn->ysize);
+    imOut = ImagingNewDirty(imIn->mode, xsize, imIn->ysize);
     if ( ! imOut) {
         free(kk);
         free(xbounds);
@@ -511,7 +511,7 @@ ImagingResampleVertical_32bpc(Imaging imIn, int ysize, struct filter *filterp)
         return (Imaging) ImagingError_MemoryError();
     }
 
-    imOut = ImagingNew(imIn->mode, imIn->xsize, ysize);
+    imOut = ImagingNewDirty(imIn->mode, imIn->xsize, ysize);
     if ( ! imOut) {
         free(kk);
         free(xbounds);

--- a/libImaging/Storage.c
+++ b/libImaging/Storage.c
@@ -436,7 +436,7 @@ ImagingNewBlock(const char* mode, int xsize, int ysize)
 }
 
 Imaging
-ImagingNew2(const char* mode, Imaging imOut, Imaging imIn)
+ImagingNew2Dirty(const char* mode, Imaging imOut, Imaging imIn)
 {
     /* allocate or validate output image */
 
@@ -449,7 +449,7 @@ ImagingNew2(const char* mode, Imaging imOut, Imaging imIn)
         }
     } else {
         /* create new image */
-        imOut = ImagingNew(mode, imIn->xsize, imIn->ysize);
+        imOut = ImagingNewDirty(mode, imIn->xsize, imIn->ysize);
         if (!imOut)
             return NULL;
     }


### PR DESCRIPTION
The Pillow's `ImagingNew` function always creates images filled with zeroes (black color). While this is fine for some operations, for others this is absolutely not required and can affect performance, especially for operations which does not required intensive computation.

Zeroing is required if:
* operation depends on initial pixels values and expects zeroes
* operation can be applied on the part of the image
* operation can be applied partially, for example loading corrupted image

In other cases zeroing can be avoided.

This PR provides new `ImagingNewDirty` function which makes no warranties about the content of created images. Also, this PR uses `ImagingNewDirty` for many operations, such as resize, crop.