### PR TITLE
Added tests for SgiImagePlugin

### DIFF
--- a/Tests/test_file_sgi.py
+++ b/Tests/test_file_sgi.py
@@ -55,6 +55,9 @@ class TestFileSgi(PillowTestCase):
         for mode in ('L', 'RGB', 'RGBA'):
             roundtrip(hopper(mode))
 
+        # Test 1 dimension for an L mode image
+        roundtrip(Image.new('L', (10, 1)))
+
     def test_unsupported_mode(self):
         im = hopper('LA')
         out = self.tempfile('temp.sgi')

--- a/Tests/test_file_sgi.py
+++ b/Tests/test_file_sgi.py
@@ -61,6 +61,13 @@ class TestFileSgi(PillowTestCase):
 
         self.assertRaises(ValueError, lambda: im.save(out, format='sgi'))
 
+    def test_incorrect_number_of_bands(self):
+        im = hopper('YCbCr')
+        im.mode = 'RGB'
+        out = self.tempfile('temp.sgi')
+
+        self.assertRaises(ValueError, lambda: im.save(out, format='sgi'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_file_sgi.py
+++ b/Tests/test_file_sgi.py
@@ -55,6 +55,12 @@ class TestFileSgi(PillowTestCase):
         for mode in ('L', 'RGB', 'RGBA'):
             roundtrip(hopper(mode))
 
+    def test_unsupported_mode(self):
+        im = hopper('LA')
+        out = self.tempfile('temp.sgi')
+
+        self.assertRaises(ValueError, lambda: im.save(out, format='sgi'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
While I have added a test for it, I'm skeptical about the error raised at https://github.com/python-pillow/Pillow/blob/master/PIL/SgiImagePlugin.py#L136. In the current state of the plugin, it's impossible to trigger without breaking the image as I do here - from what I can see, the number of modes are static values retrieved from https://github.com/python-pillow/Pillow/blob/master/PIL/Image.py#L211.

Any thoughts from @wiredfool, who added it in https://github.com/python-pillow/Pillow/pull/2325/commits/31c204eae4e158bbaa6cda4afe7a2f8e2fcabe6e?