### PR TITLE
Test/fix for issue #2044

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -2423,7 +2423,7 @@ def fromqpixmap(im):
 _fromarray_typemap = {
     # (shape, typestr) => mode, rawmode
     # first two members of shape are set to one
-    # ((1, 1), "|b1"): ("1", "1"), # broken
+    ((1, 1), "|b1"): ("1", "1;8"), 
     ((1, 1), "|u1"): ("L", "L"),
     ((1, 1), "|i1"): ("I", "I;8"),
     ((1, 1), "<u2"): ("I", "I;16"),

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -39,7 +39,7 @@ class TestNumpy(PillowTestCase):
         def to_image(dtype, bands=1, boolean=0):
             if bands == 1:
                 if boolean:
-                    data = [0, 1] * 50
+                    data = [0, 255] * 50
                 else:
                     data = list(range(100))
                 a = numpy.array(data, dtype=dtype)
@@ -58,9 +58,9 @@ class TestNumpy(PillowTestCase):
             return i
 
         # Check supported 1-bit integer formats
-        self.assertRaises(TypeError, lambda: to_image(numpy.bool))
-        self.assertRaises(TypeError, lambda: to_image(numpy.bool8))
-
+        self.assert_image(to_image(numpy.bool, 1, 1), '1', TEST_IMAGE_SIZE)
+        self.assert_image(to_image(numpy.bool8, 1, 1), '1', TEST_IMAGE_SIZE)
+        
         # Check supported 8-bit integer formats
         self.assert_image(to_image(numpy.uint8), "L", TEST_IMAGE_SIZE)
         self.assert_image(to_image(numpy.uint8, 3), "RGB", TEST_IMAGE_SIZE)
@@ -212,6 +212,14 @@ class TestNumpy(PillowTestCase):
 
         self.assertEqual(im.size, (0, 0))
 
+
+    def test_bool(self):
+        # https://github.com/python-pillow/Pillow/issues/2044
+        a = numpy.zeros((10,2), dtype=numpy.bool)
+        a[0][0] = True 
+
+        im2 = Image.fromarray(a)
+        self.assertEqual(im2.getdata()[0], 255)
 
 if __name__ == '__main__':
     unittest.main()

--- a/libImaging/Unpack.c
+++ b/libImaging/Unpack.c
@@ -185,6 +185,19 @@ unpack1IR(UINT8* out, const UINT8* in, int pixels)
     }
 }
 
+static void
+unpack18(UINT8* out, const UINT8* in, int pixels)
+{
+    /* Unpack a '|b1' image, which is a numpy boolean. 
+       1 == true, 0==false, in bytes */
+
+    int i;
+    for (i = 0; i < pixels; i++) {
+        out[i] = in[i] > 0 ? 255 : 0;
+    }
+}
+
+
 
 /* Unpack to "L" image */
 
@@ -1168,6 +1181,7 @@ static struct {
     {"1",       "1;I",          1,      unpack1I},
     {"1",       "1;R",          1,      unpack1R},
     {"1",       "1;IR",         1,      unpack1IR},
+    {"1",       "1;8",          1,      unpack18},
 
     /* greyscale */
     {"L",       "L;2",          2,      unpackL2},


### PR DESCRIPTION
Fixes #2044

Changes proposed in this pull request:

 * Add a new rawmode 1;8, for b/w image in bytes. 0 == 0, >0 == 255
 * Add the mapping in Image._fromarray_typemap
 * Tests for the numpy integration, fixes old boolean tests, adds specific one for this issue.

This should allow boolean arrays in numpy to be pulled into Pillow.  e.g.:
```
a = np.array((x,y), dtype=np.bool)
img = Image.fromarray(a)
```
