### PR TITLE
Basic support for Termux (android) 

### DIFF
--- a/depends/termux.sh
+++ b/depends/termux.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+pkg -y install -y install python python-dev ndk-sysroot clang make \
+    libjpeg-turbo-dev 
+

--- a/depends/termux.sh
+++ b/depends/termux.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-pkg -y install -y install python python-dev ndk-sysroot clang make \
+pkg -y install python python-dev ndk-sysroot clang make \
     libjpeg-turbo-dev 
 

--- a/setup.py
+++ b/setup.py
@@ -365,6 +365,14 @@ class pil_build_ext(build_ext):
                 # work ;-)
                 self.add_multiarch_paths()
 
+                # termux support for android.
+                # system libraries (zlib) are installed in /system/lib
+                # headers are at $PREFIX/include
+                # user libs are at $PREFIX/lib
+                if os.environ.get('ANDROID_ROOT', None):
+                    _add_directory(library_dirs,
+                                  os.path.join(os.environ['ANDROID_ROOT'],'lib'))
+
         elif sys.platform.startswith("gnu"):
             self.add_multiarch_paths()
 


### PR DESCRIPTION
Fixes #1957 .

Basic support for termux (android) support (tested on chromeos/x86). The goal here is that we should be able to `pip install pillow` with at least the basic zlib and jpeg libraries 

Changes proposed in this pull request:

 * Look for ANDROID_ROOT in setup.py

Still need to test this off my own machine. Should be possible in a docker chroot, but that's going to take some research. 

