### PR TITLE
Fixed type to be byteslike object.

### DIFF
--- a/_imaging.c
+++ b/_imaging.c
@@ -1433,7 +1433,7 @@ _putpalettealphas(ImagingObject* self, PyObject* args)
     int i;
     UINT8 *values;
     int length;
-    if (!PyArg_ParseTuple(args, "s#", &values, &length))
+    if (!PyArg_ParseTuple(args, PY_ARG_BYTES_LENGTH, &values, &length))
         return NULL;
 
     if (!self->image->palette) {

--- a/_imagingft.c
+++ b/_imagingft.c
@@ -121,7 +121,8 @@ getfont(PyObject* self_, PyObject* args, PyObject* kw)
         return NULL;
     }
 
-    if (!PyArg_ParseTupleAndKeywords(args, kw, "eti|iss#i", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kw, "eti|is"PY_ARG_BYTES_LENGTH"i", 
+                                     kwlist,
                                      Py_FileSystemDefaultEncoding, &filename,
                                      &size, &index, &encoding, &font_bytes,
                                      &font_bytes_size, &layout_engine)) {

--- a/_webp.c
+++ b/_webp.c
@@ -26,7 +26,7 @@ PyObject* WebPEncode_wrapper(PyObject* self, PyObject* args)
     Py_ssize_t  exif_size;
     size_t ret_size;
 
-    if (!PyArg_ParseTuple(args, "s#iiifss#s#",
+    if (!PyArg_ParseTuple(args, PY_ARG_BYTES_LENGTH"iiifss#s#",
                 (char**)&rgb, &size, &width, &height, &lossless, &quality_factor, &mode,
                 &icc_bytes, &icc_size, &exif_bytes, &exif_size)) {
         return NULL;


### PR DESCRIPTION
Changes proposed in this pull request:

 * The parameter for _putpallettealphas should not have any unicode conversion on py3. Use the PY_ARG_BYTES_LENGTH macro instead of the py2 's#'

