### PR TITLE
Convert CMYK to RGB like Google Chrome

### DIFF
--- a/libImaging/Convert.c
+++ b/libImaging/Convert.c
@@ -536,12 +536,15 @@ rgb2cmyk(UINT8* out, const UINT8* in, int xsize)
 static void
 cmyk2rgb(UINT8* out, const UINT8* in, int xsize)
 {
-    int x;
-    for (x = 0; x < xsize; x++, in += 4) {
-        *out++ = CLIP(255 - (in[0] + in[3]));
-        *out++ = CLIP(255 - (in[1] + in[3]));
-        *out++ = CLIP(255 - (in[2] + in[3]));
-        *out++ = 255;
+    int x, nk, tmp;
+    for (x = 0; x < xsize; x++) {
+        nk = 255 - in[3];
+        out[0] = CLIP(nk - MULDIV255(in[0], nk, tmp));
+        out[1] = CLIP(nk - MULDIV255(in[1], nk, tmp));
+        out[2] = CLIP(nk - MULDIV255(in[2], nk, tmp));
+        out[3] = 255;
+        out += 4;
+        in += 4;
     }
 }
 


### PR DESCRIPTION
There is no easy way to convert CMYK to RGB without complicated color management. But there are some approximations. Pillow used to use the simplest one, which, for example, could be [found there](http://www.rapidtables.com/convert/color/rgb-to-cmyk.htm). It is not too accurate and produces very dark images. On the other hand, I found [this formulas](https://www.easyrgb.com/en/math.php) which produces far better result.

```
C = ( C * ( 1 - K ) + K )
M = ( M * ( 1 - K ) + K )
Y = ( Y * ( 1 - K ) + K )

R = ( 1 - C ) * 255
G = ( 1 - M ) * 255
B = ( 1 - Y ) * 255
```
or in one equation:
```
R = 255 - K - C * ( 255 - K ) / 255
G = 255 - K - M * ( 255 - K ) / 255
B = 255 - K - Y * ( 255 - K ) / 255
```

Original CMYK image opened in Safari (and probably how it should looks like with correct color management)
![_out_cmyk](https://user-images.githubusercontent.com/128982/29778390-e63844c4-8c17-11e7-91d8-22cedaea5d34.jpg)

Converted to RGB using the new formula and also CMYK image looks absolutely the same in Google Chrome
![_out_new](https://user-images.githubusercontent.com/128982/29778398-ee66aea6-8c17-11e7-8e32-1f78ea8b0789.jpg)

Converted to RGB using the old formula
![_out_old](https://user-images.githubusercontent.com/128982/29778403-f225ab64-8c17-11e7-8d79-507cf738d8af.jpg)