### PR TITLE
Remove palettes from non-palette modes in _new #2702

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -527,11 +527,12 @@ class Image(object):
         new.im = im
         new.mode = im.mode
         new.size = im.size
-        if self.palette:
-            new.palette = self.palette.copy()
-        if im.mode == "P" and not new.palette:
-            from . import ImagePalette
-            new.palette = ImagePalette.ImagePalette()
+        if im.mode in ('P', 'PA'):
+            if self.palette:
+                new.palette = self.palette.copy()
+            else:
+                from . import ImagePalette
+                new.palette = ImagePalette.ImagePalette()
         new.info = self.info.copy()
         return new
 

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -446,6 +446,33 @@ class TestImage(PillowTestCase):
             self.assert_image_equal(im, target)
 
 
+    def test__new(self):
+        from PIL import ImagePalette
+        
+        im = hopper('RGB')
+        im_p = hopper('P')
+
+        blank_p = Image.new('P', (10,10))
+        blank_pa = Image.new('PA', (10,10))
+        blank_p.palette = None
+        blank_pa.palette = None
+        
+        def _make_new(base_image, im, palette_result=None):
+            new_im = base_image._new(im)
+            self.assertEqual(new_im.mode, im.mode)
+            self.assertEqual(new_im.size, im.size)
+            self.assertEqual(new_im.info, base_image.info)
+            if palette_result is not None:
+                self.assertEqual(new_im.palette.tobytes(), palette_result.tobytes())
+            else:
+                self.assertEqual(new_im.palette, None)
+            
+        _make_new(im, im_p, im_p.palette)
+        _make_new(im_p, im, None)
+        _make_new(im, blank_p, ImagePalette.ImagePalette())
+        _make_new(im, blank_pa, ImagePalette.ImagePalette())
+        
+
 class MockEncoder(object):
     pass
 

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -87,6 +87,9 @@ class TestImageConvert(PillowTestCase):
 
         # Assert
         self.assertNotIn('transparency', rgba.info)
+        # https://github.com/python-pillow/Pillow/issues/2702
+        self.assertEqual(rgba.palette, None)
+        
 
     def test_trns_l(self):
         im = hopper('L')


### PR DESCRIPTION
Fixes #2702

Changes proposed in this pull request:

 * Only copy the palette if new mode is in P, PA
 * Tests.
 
(note, making a 'PA' image via putalpha fails, so tests are somewhat incomplete)
