### PR TITLE
Fix resize with box when no resize required

### DIFF
--- a/_imaging.c
+++ b/_imaging.c
@@ -1529,8 +1529,10 @@ _resize(ImagingObject* self, PyObject* args)
         return ImagingError_ValueError("box can't be empty");
     }
 
-    if (box[0] == 0 && box[1] == 0 && box[2] == xsize && box[3] == ysize) {
-        imOut = ImagingCopy(imIn);
+    // If box's coordinates are int and box size matches requested size
+    if (box[0] - (int) box[0] == 0 && box[1] - (int) box[1] == 0
+            && box[2] - box[0] == xsize && box[3] - box[1] == ysize) {
+        imOut = ImagingCrop(imIn, box[0], box[1], box[2], box[3]);
     }
     else if (filter == IMAGING_TRANSFORM_NEAREST) {
         double a[6];

--- a/_imaging.c
+++ b/_imaging.c
@@ -1530,8 +1530,8 @@ _resize(ImagingObject* self, PyObject* args)
     }
 
     // If box's coordinates are int and box size matches requested size
-    if (box[0] - (int) box[0] == 0 && box[1] - (int) box[1] == 0
-            && box[2] - box[0] == xsize && box[3] - box[1] == ysize) {
+    if (box[0] - (int) box[0] == 0 && box[2] - box[0] == xsize
+            && box[1] - (int) box[1] == 0 && box[3] - box[1] == ysize) {
         imOut = ImagingCrop(imIn, box[0], box[1], box[2], box[3]);
     }
     else if (filter == IMAGING_TRANSFORM_NEAREST) {

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -554,7 +554,7 @@ ImagingResampleInner(Imaging imIn, int xsize, int ysize,
     Imaging imOut = NULL;
 
     int i;
-    int yroi_min, yroi_max;
+    int ybox_first, ybox_last;
     int ksize_horiz, ksize_vert;
     int *bounds_horiz, *bounds_vert;
     double *kk_horiz, *kk_vert;
@@ -574,21 +574,21 @@ ImagingResampleInner(Imaging imIn, int xsize, int ysize,
     }
 
     // First used row in the source image
-    yroi_min = bounds_vert[0];
+    ybox_first = bounds_vert[0];
     // Last used row in the source image
-    yroi_max = bounds_vert[ysize*2 - 2] + bounds_vert[ysize*2 - 1];
+    ybox_last = bounds_vert[ysize*2 - 2] + bounds_vert[ysize*2 - 1];
 
 
     /* two-pass resize, first pass */
     if (box[0] || box[2] != xsize) {
         // Shift bounds for vertical pass
         for (i = 0; i < ysize; i++) {
-            bounds_vert[i * 2] -= yroi_min;
+            bounds_vert[i * 2] -= ybox_first;
         }
 
-        imTemp = ImagingNewDirty(imIn->mode, xsize, yroi_max - yroi_min);
+        imTemp = ImagingNewDirty(imIn->mode, xsize, ybox_last - ybox_first);
         if (imTemp) {
-            ResampleHorizontal(imTemp, imIn, yroi_min,
+            ResampleHorizontal(imTemp, imIn, ybox_first,
                                ksize_horiz, bounds_horiz, kk_horiz);
         }
         free(bounds_horiz);

--- a/libImaging/Resample.c
+++ b/libImaging/Resample.c
@@ -553,11 +553,14 @@ ImagingResampleInner(Imaging imIn, int xsize, int ysize,
     Imaging imTemp = NULL;
     Imaging imOut = NULL;
 
-    int i;
+    int i, need_horizontal, need_vertical;
     int ybox_first, ybox_last;
     int ksize_horiz, ksize_vert;
     int *bounds_horiz, *bounds_vert;
     double *kk_horiz, *kk_vert;
+
+    need_horizontal = xsize != imIn->xsize || box[0] || box[2] != xsize;
+    need_vertical = ysize != imIn->ysize || box[1] || box[3] != ysize;
 
     ksize_horiz = precompute_coeffs(imIn->xsize, box[0], box[2], xsize,
                                     filterp, &bounds_horiz, &kk_horiz);
@@ -579,8 +582,8 @@ ImagingResampleInner(Imaging imIn, int xsize, int ysize,
     ybox_last = bounds_vert[ysize*2 - 2] + bounds_vert[ysize*2 - 1];
 
 
-    /* two-pass resize, first pass */
-    if (box[0] || box[2] != xsize) {
+    /* two-pass resize, horizontal pass */
+    if (need_horizontal) {
         // Shift bounds for vertical pass
         for (i = 0; i < ysize; i++) {
             bounds_vert[i * 2] -= ybox_first;
@@ -605,8 +608,8 @@ ImagingResampleInner(Imaging imIn, int xsize, int ysize,
         free(kk_horiz);
     }
 
-    /* second pass */
-    if (box[1] || box[3] != ysize) {
+    /* vertical pass */
+    if (need_vertical) {
         imOut = ImagingNewDirty(imIn->mode, imIn->xsize, ysize);
         if (imOut) {
             /* imIn can be the original image or horizontally resampled one */


### PR DESCRIPTION
I found many errors with box argument when x0 & y0 coordinates are 0. In all following cases result resolution should be 400x400:

```python
>>> im.size
<<< (1034, 1280)

>>> im.resize((400, 400), Image.LANCZOS, (0, 0, 400, 400)).size
<<< (1034, 1280)

>>> im.resize((400, 400), Image.LANCZOS, (0, 0, 400, 1024)).size
<<< (1034, 400)

>>> im.resize((400, 400), Image.LANCZOS, (0, 0, 1024, 400)).size
<<< (400, 403)
```

I'm opening PR just to let know what the problem exists and I'm working on the fix.