### PR TITLE
Fixed documentation syntax

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -262,6 +262,7 @@ The easiest way to install external libraries is via `Homebrew
     $ brew install libtiff libjpeg webp little-cms2
 
 To install libraqm on macOS use Homebrew to install its dependencies::
+
     $ brew install freetype harfbuzz fribidi
 
 Then see ``depends/install_raqm_cmake.sh`` to install libraqm.

--- a/docs/reference/ImageCms.rst
+++ b/docs/reference/ImageCms.rst
@@ -265,7 +265,7 @@ can be easily displayed in a chromaticity diagram, for example).
         Calculates the white point temperature (see the LCMS documentation
         for more information).
 
-        :type: :py:class:`float` or `None`
+        :type: :py:class:`float` or ``None``
 
     .. py:attribute:: viewing_condition
 


### PR DESCRIPTION
* Added a blank line in 'installation.rst' - See https://github.com/python-pillow/Pillow/blob/master/docs/installation.rst#building-on-macos vs https://github.com/radarhere/Pillow/blob/docs/docs/installation.rst#building-on-macos
* Changed single backticks surrounding None to double backticks surrounding None in 'ImageCms.rst' - see the text above and below it