### PR TITLE
Fix docs to match code

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -178,8 +178,8 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
 **sizes**
     A list of sizes including in this ico file; these are a 2-tuple,
     ``(width, height)``; Default to ``[(16, 16), (24, 24), (32, 32), (48, 48),
-    (64, 64), (128, 128), (255, 255)]``. Any sizes bigger than the original
-    size or 255 will be ignored.
+    (64, 64), (128, 128), (256, 256)]``. Any sizes bigger than the original
+    size or 256 will be ignored.
 
 IM
 ^^


### PR DESCRIPTION
Code was fixed in https://github.com/python-pillow/Pillow/pull/2267 but not the docs: 

default max size for ICO is (256, 256) not (255, 255).