### PR TITLE
Travis CI: Use default pypy/pypy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ notifications:
 matrix:
   fast_finish: true
   include:
-    - python: "pypy-5.7.1"
-    - python: "pypy3.3-5.2-alpha1"
+    - python: "pypy"
+    - python: "pypy3"
     - python: '3.6'
     - python: '2.7'
     - python:  "2.7_with_system_site_packages" # For PyQt4


### PR DESCRIPTION
This updates pypy and pypy3 with no need to specify exact versions.

pypy:
* From PyPy 5.7.1 (Python 2.7.13)
* To PyPy 5.8.0 (Python 2.7.13)

pypy3:
* From PyPy 5.2.0-alpha0 (Python 3.3.5)
* To PyPy 5.8.0-beta0 (Python 3.5.3)
