### PR TITLE
Export only required properties in unsafe_ptrs

### DIFF
--- a/PIL/PyAccess.py
+++ b/PIL/PyAccess.py
@@ -49,8 +49,7 @@ class PyAccess(object):
         self.image8 = ffi.cast('unsigned char **', vals['image8'])
         self.image32 = ffi.cast('int **', vals['image32'])
         self.image = ffi.cast('unsigned char **', vals['image'])
-        self.xsize = vals['xsize']
-        self.ysize = vals['ysize']
+        self.xsize, self.ysize = img.im.size
 
         # Keep pointer to im object to prevent dereferencing.
         self._im = img.im

--- a/_imaging.c
+++ b/_imaging.c
@@ -3138,21 +3138,10 @@ _getattr_ptr(ImagingObject* self, void* closure)
 static PyObject*
 _getattr_unsafe_ptrs(ImagingObject* self, void* closure)
 {
-    return Py_BuildValue("(ss)(si)(si)(si)(si)(si)(sn)(sn)(sn)(sn)(sn)(si)(si)(sn)",
-                         "mode", self->image->mode,
-                         "type", self->image->type,
-                         "depth", self->image->depth,
-                         "bands", self->image->bands,
-                         "xsize", self->image->xsize,
-                         "ysize", self->image->ysize,
-                         "palette", self->image->palette,
+    return Py_BuildValue("(sn)(sn)(sn)",
                          "image8", self->image->image8,
                          "image32", self->image->image32,
-                         "image", self->image->image,
-                         "block", self->image->block,
-                         "pixelsize", self->image->pixelsize,
-                         "linesize", self->image->linesize,
-                         "destroy", self->image->destroy
+                         "image", self->image->image
                         );
 };
 


### PR DESCRIPTION
Some of this properties are already available through `im` properties. In general, there is no need to expose internals like `destroy` or `block` pointers to python. `depth` is unused even in C code.