### PR TITLE
Fixed bug where player script was skipping the first image

### DIFF
--- a/Scripts/player.py
+++ b/Scripts/player.py
@@ -22,13 +22,10 @@ from PIL import Image, ImageTk
 class UI(tkinter.Label):
 
     def __init__(self, master, im):
-        if isinstance(im, list):
+        self.im = im
+        if isinstance(self.im, list):
             # list of images
-            self.im = im[1:]
-            im = self.im[0]
-        else:
-            # sequence
-            self.im = im
+            im = self.im.pop(0)
 
         if im.mode == "1":
             self.image = ImageTk.BitmapImage(im, foreground="white")


### PR DESCRIPTION
The original code -

```
# list of images
self.im = im[1:]
im = self.im[0]
```

presumably intended to remove the first image from the list, displaying it initially before loop through the rest.

However, it actually discards the first image, and selects the next image to display initially.

This PR fixes this.