### PR TITLE
Bug about Image.fromarray

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -2429,7 +2429,7 @@ def fromarray(obj, mode=None):
     if ndim > ndmax:
         raise ValueError("Too many dimensions: %d > %d." % (ndim, ndmax))
 
-    size = shape[1], shape[0]
+    size = shape[0], shape[1]
     if strides is not None:
         if hasattr(obj, 'tobytes'):
             obj = obj.tobytes()


### PR DESCRIPTION
Fixes # .Image.fromarray
When I use Pillow like that "img = Image.fromarray(matrix)" I find it will change my image size(exchange width and height). I can gain a proper result by use this function like that
"w, h = matrix.shape
    matrix = np.reshape(matrix, (h, w))
    img = Image.fromarray(matrix)
"

So, I think there must be a mistake such that exchange width and height.

Changes proposed in this pull request:

 *  Exchange shape[1] and shape[0]
---
I am not a native English speaker and hope you can understand me.