### PR TITLE
Changes to cleanly compile on windows/msys2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,8 @@ environment:
   EXECUTABLE: python.exe
   PIP_DIR: Scripts
   VENV: NO
+  TEST_OPTIONS:
+  DEPLOY: YES
   matrix:
   - PYTHON: C:/vp/pypy2
     EXECUTABLE: bin/pypy.exe
@@ -21,6 +23,11 @@ environment:
   - PYTHON: C:/Python34-x64
   - PYTHON: C:/Python33
   - PYTHON: C:/Python33-x64
+  - PYTHON: C:/msys64/mingw32
+    EXECUTABLE: bin/python3
+    PIP_DIR: bin
+    TEST_OPTIONS: --processes=0
+    DEPLOY: NO
 
 
 install:
@@ -36,19 +43,38 @@ install:
       {
         c:\pillow\winbuild\appveyor_install_pypy.cmd
       }
-- c:\python34\python.exe c:\pillow\winbuild\build_dep.py
-- c:\pillow\winbuild\build_deps.cmd
-
+- ps: |
+      if ($env:PYTHON -eq "c:/msys64/mingw32")
+      {
+        c:\msys64\usr\bin\bash -l -c c:\\pillow\\winbuild\\appveyor_install_msys2_deps.sh
+      }
+      else
+      {
+        c:\python34\python.exe c:\pillow\winbuild\build_dep.py
+        c:\pillow\winbuild\build_deps.cmd
+        $host.SetShouldExit(0)  
+      }
+      
 build_script:
-- '%PYTHON%\%EXECUTABLE% c:\pillow\winbuild\build.py'
+- ps: |
+      if ($env:PYTHON -eq "c:/msys64/mingw32")
+      {
+        c:\msys64\usr\bin\bash -l -c c:\\pillow\\winbuild\\appveyor_build_msys2.sh
+        Write-Host "through install"
+        $host.SetShouldExit(0)  
+      }
+      else
+      {
+        & $env:PYTHON/$env:EXECUTABLE c:\pillow\winbuild\build.py
+        $host.SetShouldExit(0)  
+      }
 - cd c:\pillow
-- dir dist\*.egg
 - '%PYTHON%\%EXECUTABLE% selftest.py --installed'
 
 test_script:
 - cd c:\pillow
 - '%PYTHON%\%PIP_DIR%\pip.exe install nose'
-- '%PYTHON%\%EXECUTABLE% test-installed.py -v -s'
+- '%PYTHON%\%EXECUTABLE% test-installed.py -v -s %TEST_OPTIONS%'
 
 matrix:
   fast_finish: true
@@ -59,7 +85,7 @@ artifacts:
 - path: pillow\dist\*.wheel
   name: wheel
 
-after_test:
+before_deploy:
   - '%PYTHON%\%PIP_DIR%\pip.exe install wheel'
   - cd c:\pillow\winbuild\
   - '%PYTHON%\%EXECUTABLE% c:\pillow\winbuild\build.py --wheel'
@@ -77,6 +103,8 @@ deploy:
   artifact: /.*egg|wheel/
   on:
     branch: master
+    deploy: YES
+    
 
 # Uncomment the following line to get RDP access after the build/test and block for
 # up to the timeout limit (~1hr)

--- a/winbuild/appveyor_build_msys2.sh
+++ b/winbuild/appveyor_build_msys2.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cd /c/pillow && /mingw32/$EXECUTABLE setup.py install

--- a/winbuild/appveyor_install_msys2_deps.sh
+++ b/winbuild/appveyor_install_msys2_deps.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+pacman -S --noconfirm mingw32/mingw-w64-i686-python3 \
+	   mingw32/mingw-w64-i686-python3-pip \
+	   mingw32/mingw-w64-i686-python3-setuptools \
+	   mingw32/mingw-w64-i686-python2-pip \
+	   mingw32/mingw-w64-i686-python2-setuptools \
+	   mingw-w64-i686-libjpeg-turbo
+
+/mingw32/bin/pip install nose olefile
+/mingw32/bin/pip3 install nose olefile


### PR DESCRIPTION
Fixes #2731, Fixes #2688.

Changes proposed in this pull request:

 * Turn off zipsafe in setup.py
 * Use the posix/gcc branch for version literal
 * test on appveyor
