### PR TITLE
Dynamically link libraqm

### DIFF
--- a/PIL/ImageFont.py
+++ b/PIL/ImageFont.py
@@ -30,6 +30,8 @@ from ._util import isDirectory, isPath
 import os
 import sys
 
+LAYOUT_BASIC = 0
+LAYOUT_RAQM = 1
 
 class _imagingft_not_installed(object):
     # module placeholder
@@ -42,8 +44,6 @@ try:
 except ImportError:
     core = _imagingft_not_installed()
 
-LAYOUT_BASIC = 0
-LAYOUT_RAQM = 1
 
 # FIXME: add support for pilfont2 format (see FontFile.py)
 

--- a/_imagingft.c
+++ b/_imagingft.c
@@ -193,7 +193,7 @@ setraqm(void)
           p_raqm.set_freetype_face &&
           p_raqm.layout &&
           p_raqm.get_glyphs &&
-          p_raqm.destroy) {
+          p_raqm.destroy)) {
         FreeLibrary(p_raqm.raqm);
         p_raqm.raqm = NULL;
         return 2;

--- a/_imagingft.c
+++ b/_imagingft.c
@@ -131,6 +131,9 @@ setraqm(void)
     /* Microsoft needs a totally different system */
 #if !defined(_MSC_VER)
     p_raqm.raqm = dlopen("libraqm.so.0", RTLD_LAZY);
+    if (!p_raqm.raqm) {
+        p_raqm.raqm = dlopen("libraqm.dylib", RTLD_LAZY);
+    }
 #else
     p_raqm.raqm = LoadLibrary("libraqm");
 #endif

--- a/_imagingft.c
+++ b/_imagingft.c
@@ -194,7 +194,7 @@ setraqm(void)
     p_raqm.set_freetype_face = (t_raqm_set_freetype_face)GetProcAddress(p_raqm.raqm, "raqm_set_freetype_face");
     p_raqm.layout = (t_raqm_layout)GetProcAddress(p_raqm.raqm, "raqm_layout");
     p_raqm.destroy = (t_raqm_destroy)GetProcAddress(p_raqm.raqm, "raqm_destroy");
-    if(dlsym(p_raqm.raqm, "raqm_index_to_position")) {
+    if(GetProcAddress(p_raqm.raqm, "raqm_index_to_position")) {
         p_raqm.get_glyphs = (t_raqm_get_glyphs)GetProcAddress(p_raqm.raqm, "raqm_get_glyphs");
         p_raqm.version = 2;
     } else {

--- a/_imagingft.c
+++ b/_imagingft.c
@@ -79,30 +79,30 @@ typedef struct {
 static PyTypeObject Font_Type;
 
 typedef struct {
-	void* raqm;
-	raqm_t* (*create)(void);
-	int (*set_text)(raqm_t         *rq,
+    void* raqm;
+    raqm_t* (*create)(void);
+    int (*set_text)(raqm_t         *rq,
                     const uint32_t *text,
                     size_t          len);
-	bool (*set_text_utf8) (raqm_t     *rq,
+    bool (*set_text_utf8) (raqm_t     *rq,
                            const char *text,
                            size_t      len);
-	bool (*set_par_direction) (raqm_t          *rq,
-							   raqm_direction_t dir);
-	bool (*add_font_feature)  (raqm_t     *rq,
-							   const char *feature,
-							   int         len);
-	bool (*set_freetype_face) (raqm_t *rq,
-							   FT_Face face);
-	bool (*layout) (raqm_t *rq);
-	raqm_glyph_t* (*get_glyphs) (raqm_t *rq,
+    bool (*set_par_direction) (raqm_t          *rq,
+                               raqm_direction_t dir);
+    bool (*add_font_feature)  (raqm_t     *rq,
+                               const char *feature,
+                               int         len);
+    bool (*set_freetype_face) (raqm_t *rq,
+                               FT_Face face);
+    bool (*layout) (raqm_t *rq);
+    raqm_glyph_t* (*get_glyphs) (raqm_t *rq,
                                  size_t *length);
     void (*destroy) (raqm_t *rq);
 
 } p_raqm_func;
 
 static p_raqm_func p_raqm;
-	
+
 
 /* round a 26.6 pixel coordinate to the nearest larger integer */
 #define PIXEL(x) ((((x)+63) & -64)>>6)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -39,7 +39,7 @@ Windows Installation
 We provide Pillow binaries for Windows compiled for the matrix of
 supported Pythons in both 32 and 64-bit versions in wheel, egg, and
 executable installers. These binaries have all of the optional
-libraries included::
+libraries included except for raqm and libimagequant::
 
   > pip install Pillow
 
@@ -47,9 +47,10 @@ libraries included::
 macOS Installation
 ^^^^^^^^^^^^^^^^^^
 
-We provide binaries for macOS for each of the supported Python versions
-in the wheel format. These include support for all optional libraries
-except OpenJPEG::
+We provide binaries for macOS for each of the supported Python
+versions in the wheel format. These include support for all optional
+libraries except libimagequant.  Raqm support requires libraqm,
+fribidi, and harfbuzz to be installed separately::
 
   $ pip install Pillow
 
@@ -58,7 +59,8 @@ Linux Installation
 
 We provide binaries for Linux for each of the supported Python
 versions in the manylinux wheel format. These include support for all
-optional libraries except Raqm::
+optional libraries except libimagequant. Raqm support requires
+libraqm, fribidi, and harfbuzz to be installed separately::
 
   $ pip install Pillow
 
@@ -170,6 +172,8 @@ Many of Pillow's features require external libraries:
     if not available as package in your system.
   * setting text direction or font features is not supported without
     libraqm.
+  * libraqm is dynamically loaded in Pillow 4.4.0 and above, so support
+	is available if all the libraries are installed. 
   * Windows support: Raqm support is currently unsupported on Windows.
 
 Once you have installed the prerequisites, run::
@@ -204,7 +208,7 @@ Build Options
   ``--disable-tiff``, ``--disable-freetype``, ``--disable-tcl``,
   ``--disable-tk``, ``--disable-lcms``, ``--disable-webp``,
   ``--disable-webpmux``, ``--disable-jpeg2000``,
-  ``--disable-imagequant``, ``--disable-raqm``.
+  ``--disable-imagequant``.
   Disable building the corresponding feature even if the development
   libraries are present on the building machine.
 
@@ -212,7 +216,7 @@ Build Options
   ``--enable-tiff``, ``--enable-freetype``, ``--enable-tcl``,
   ``--enable-tk``, ``--enable-lcms``, ``--enable-webp``,
   ``--enable-webpmux``, ``--enable-jpeg2000``,
-  ``--enable-imagequant``,  ``--enable-raqm``.
+  ``--enable-imagequant``.
   Require that the corresponding feature is built. The build will raise
   an exception if the libraries are not found. Webpmux (WebP metadata)
   relies on WebP support. Tcl and Tk also must be used together.

--- a/libImaging/raqm.h
+++ b/libImaging/raqm.h
@@ -29,8 +29,12 @@
 #include "config.h"
 #endif
 
-#include <stdbool.h>
-#include <stdint.h>
+#ifndef bool
+typedef int bool;
+#endif
+#ifndef uint32_t
+typedef UINT32 uint32_t;
+#endif
 #include <ft2build.h>
 #include FT_FREETYPE_H
 

--- a/libImaging/raqm.h
+++ b/libImaging/raqm.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2015 Information Technology Authority (ITA) <foss@ita.gov.om>
+ * Copyright © 2016 Khaled Hosny <khaledhosny@eglug.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ */
+
+#ifndef _RAQM_H_
+#define _RAQM_H_
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <ft2build.h>
+#include FT_FREETYPE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * raqm_t:
+ *
+ * This is the main object holding all state of the currently processed text as
+ * well as its output.
+ *
+ * Since: 0.1
+ */
+typedef struct _raqm raqm_t;
+
+/**
+ * raqm_direction_t:
+ * @RAQM_DIRECTION_DEFAULT: Detect paragraph direction automatically.
+ * @RAQM_DIRECTION_RTL: Paragraph is mainly right-to-left text.
+ * @RAQM_DIRECTION_LTR: Paragraph is mainly left-to-right text.
+ * @RAQM_DIRECTION_TTB: Paragraph is mainly vertical top-to-bottom text.
+ *
+ * Base paragraph direction, see raqm_set_par_direction().
+ *
+ * Since: 0.1
+ */
+typedef enum
+{
+    RAQM_DIRECTION_DEFAULT,
+    RAQM_DIRECTION_RTL,
+    RAQM_DIRECTION_LTR,
+    RAQM_DIRECTION_TTB
+} raqm_direction_t;
+
+/**
+ * raqm_glyph_t:
+ * @index: the index of the glyph in the font file.
+ * @x_advance: the glyph advance width in horizontal text.
+ * @y_advance: the glyph advance width in vertical text.
+ * @x_offset: the horizontal movement of the glyph from the current point.
+ * @y_offset: the vertical movement of the glyph from the current point.
+ * @cluster: the index of original character in input text.
+ * @ftface: the @FT_Face of the glyph.
+ *
+ * The structure that holds information about output glyphs, returned from
+ * raqm_get_glyphs().
+ */
+typedef struct raqm_glyph_t {
+    unsigned int index;
+    int x_advance;
+    int y_advance;
+    int x_offset;
+    int y_offset;
+    uint32_t cluster;
+    FT_Face ftface;
+} raqm_glyph_t;
+
+raqm_t *
+raqm_create (void);
+
+raqm_t *
+raqm_reference (raqm_t *rq);
+
+void
+raqm_destroy (raqm_t *rq);
+
+bool
+raqm_set_text (raqm_t         *rq,
+               const uint32_t *text,
+               size_t          len);
+
+bool
+raqm_set_text_utf8 (raqm_t     *rq,
+                    const char *text,
+                    size_t      len);
+
+bool
+raqm_set_par_direction (raqm_t          *rq,
+                        raqm_direction_t dir);
+
+bool
+raqm_set_language (raqm_t       *rq,
+                   const char   *lang,
+                   size_t        start,
+                   size_t        len);
+
+bool
+raqm_add_font_feature  (raqm_t     *rq,
+                        const char *feature,
+                        int         len);
+
+bool
+raqm_set_freetype_face (raqm_t *rq,
+                        FT_Face face);
+
+bool
+raqm_set_freetype_face_range (raqm_t *rq,
+                              FT_Face face,
+                              size_t  start,
+                              size_t  len);
+
+bool
+raqm_set_freetype_load_flags (raqm_t *rq,
+                              int flags);
+
+bool
+raqm_layout (raqm_t *rq);
+
+raqm_glyph_t *
+raqm_get_glyphs (raqm_t *rq,
+                 size_t *length);
+
+bool
+raqm_index_to_position (raqm_t *rq,
+                        size_t *index,
+                        int *x,
+                        int *y);
+
+bool
+raqm_position_to_index (raqm_t *rq,
+                        int x,
+                        int y,
+                        size_t *index);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* _RAQM_H_ */

--- a/libImaging/raqm.h
+++ b/libImaging/raqm.h
@@ -94,6 +94,19 @@ typedef struct raqm_glyph_t {
     FT_Face ftface;
 } raqm_glyph_t;
 
+/**
+ * version 0.1 of the raqm_glyph_t structure
+ */
+typedef struct raqm_glyph_t_01 {
+    unsigned int index;
+    int x_advance;
+    int y_advance;
+    int x_offset;
+    int y_offset;
+    uint32_t cluster;
+} raqm_glyph_t_01;
+
+
 raqm_t *
 raqm_create (void);
 

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,6 @@ IMAGEQUANT_ROOT = None
 TIFF_ROOT = None
 FREETYPE_ROOT = None
 LCMS_ROOT = None
-RAQM_ROOT = None
 
 
 def _pkg_config(name):
@@ -164,7 +163,7 @@ def _pkg_config(name):
 
 class pil_build_ext(build_ext):
     class feature:
-        features = ['zlib', 'jpeg', 'tiff', 'freetype', 'raqm', 'lcms', 'webp',
+        features = ['zlib', 'jpeg', 'tiff', 'freetype', 'lcms', 'webp',
                     'webpmux', 'jpeg2000', 'imagequant']
 
         required = {'jpeg', 'zlib'}
@@ -546,14 +545,6 @@ class pil_build_ext(build_ext):
                     if subdir:
                         _add_directory(self.compiler.include_dirs, subdir, 0)
 
-        if feature.want('raqm'):
-            _dbg('Looking for raqm')
-            if _find_include_file(self, "raqm.h"):
-                if _find_library_file(self, "raqm") and \
-                   _find_library_file(self, "harfbuzz") and \
-                   _find_library_file(self, "fribidi"):
-                    feature.raqm = ["raqm", "harfbuzz", "fribidi"]
-
         if feature.want('lcms'):
             _dbg('Looking for lcms')
             if _find_include_file(self, "lcms2.h"):
@@ -639,9 +630,6 @@ class pil_build_ext(build_ext):
         if feature.freetype:
             libs = ["freetype"]
             defs = []
-            if feature.raqm:
-                libs.extend(feature.raqm)
-                defs.append(('HAVE_RAQM', None))
             exts.append(Extension(
                 "PIL._imagingft", ["_imagingft.c"], libraries=libs,
                 define_macros=defs))
@@ -706,7 +694,6 @@ class pil_build_ext(build_ext):
             (feature.imagequant, "LIBIMAGEQUANT"),
             (feature.tiff, "LIBTIFF"),
             (feature.freetype, "FREETYPE2"),
-            (feature.raqm, "RAQM"),
             (feature.lcms, "LITTLECMS2"),
             (feature.webp, "WEBP"),
             (feature.webpmux, "WEBPMUX"),


### PR DESCRIPTION
We can't currently distribute a binary of Pillow with support for raqm due to license incompatibility, because while libraqm is MIT licensed, it links to GPL libraries. Unfortunately, this means that nearly no one gets support for complex text, as we're providing binaries on the big three platforms now. 

This PR replaces the build dependency on libraqm with an attempt to dynamically load the dll, should it be installed by the user. To do this, we're shipping the header from the libraqm project (which is MIT licensed), using this for types, and then dynamically resolving the function addresses at runtime. 

To Do:
 * [x] fix fedora
 * [x] fix osx
 * [x] test on windows
 * [x] check freebsd
 * [x] works on my machine
 * [ ] release notes, 
 * [x] instructions