### PR TITLE
ResourceWarning tests

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -122,7 +122,9 @@ class PillowTestCase(unittest.TestCase):
 
             # Verify some things.
             if warn_class is None:
-                self.assertEqual(len(w), 0)
+                self.assertEqual(len(w), 0,
+                                 "Expected no warnings, got %s" %
+                                 list(v.category for v in w))
             else:
                 self.assertGreaterEqual(len(w), 1)
                 found = False

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -121,13 +121,16 @@ class PillowTestCase(unittest.TestCase):
             result = func(*args, **kwargs)
 
             # Verify some things.
-            self.assertGreaterEqual(len(w), 1)
-            found = False
-            for v in w:
-                if issubclass(v.category, warn_class):
-                    found = True
-                    break
-            self.assertTrue(found)
+            if warn_class is None:
+                self.assertEqual(len(w), 0)
+            else:
+                self.assertGreaterEqual(len(w), 1)
+                found = False
+                for v in w:
+                    if issubclass(v.category, warn_class):
+                        found = True
+                        break
+                self.assertTrue(found)
         return result
 
     def skipKnownBadTest(self, msg=None, platform=None,

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -514,16 +514,6 @@ class TestImage(PillowTestCase):
         with Image.open(test_file) as im:
             self.assert_warning(None, lambda: im.save('test_img.jpg'))
 
-    def test_no_resource_warning_for_numpy_array(self):
-        # https://github.com/python-pillow/Pillow/issues/835
-        # Arrange
-        from numpy import array
-        test_file = 'Tests/images/hopper.png'
-        im = Image.open(test_file)
-
-        # Act/Assert
-        self.assert_warning(None, lambda: array(im))
-
 
 class MockEncoder(object):
     pass

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -514,6 +514,16 @@ class TestImage(PillowTestCase):
         with Image.open(test_file) as im:
             self.assert_warning(None, lambda: im.save('test_img.jpg'))
 
+    def test_no_resource_warning_for_numpy_array(self):
+        # https://github.com/python-pillow/Pillow/issues/835
+        # Arrange
+        from numpy import array
+        test_file = 'Tests/images/hopper.png'
+        im = Image.open(test_file)
+
+        # Act/Assert
+        self.assert_warning(None, lambda: array(im))
+
 
 class MockEncoder(object):
     pass

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -478,7 +478,6 @@ class TestImage(PillowTestCase):
         im = hopper()
         self.assertRaises(ValueError, im.remap_palette, None)
 
-
     def test__new(self):
         from PIL import ImagePalette
 
@@ -496,7 +495,8 @@ class TestImage(PillowTestCase):
             self.assertEqual(new_im.size, im.size)
             self.assertEqual(new_im.info, base_image.info)
             if palette_result is not None:
-                self.assertEqual(new_im.palette.tobytes(), palette_result.tobytes())
+                self.assertEqual(new_im.palette.tobytes(),
+                                 palette_result.tobytes())
             else:
                 self.assertEqual(new_im.palette, None)
 
@@ -504,6 +504,15 @@ class TestImage(PillowTestCase):
         _make_new(im_p, im, None)
         _make_new(im, blank_p, ImagePalette.ImagePalette())
         _make_new(im, blank_pa, ImagePalette.ImagePalette())
+
+    def test_no_resource_warning_on_save(self):
+        # https://github.com/python-pillow/Pillow/issues/835
+        # Arrange
+        test_file = 'Tests/images/hopper.png'
+
+        # Act/Assert
+        with Image.open(test_file) as im:
+            self.assert_warning(None, lambda: im.save('test_img.jpg'))
 
 
 class MockEncoder(object):
@@ -533,6 +542,7 @@ class TestRegistry(PillowTestCase):
                                                       'DoesNotExist',
                                                       ('args',),
                                                       extra=('extra',))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -212,7 +212,6 @@ class TestNumpy(PillowTestCase):
 
         self.assertEqual(im.size, (0, 0))
 
-
     def test_bool(self):
         # https://github.com/python-pillow/Pillow/issues/2044
         a = numpy.zeros((10,2), dtype=numpy.bool)
@@ -220,6 +219,17 @@ class TestNumpy(PillowTestCase):
 
         im2 = Image.fromarray(a)
         self.assertEqual(im2.getdata()[0], 255)
+
+    def test_no_resource_warning_for_numpy_array(self):
+        # https://github.com/python-pillow/Pillow/issues/835
+        # Arrange
+        from numpy import array
+        test_file = 'Tests/images/hopper.png'
+        im = Image.open(test_file)
+
+        # Act/Assert
+        self.assert_warning(None, lambda: array(im))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #835.

These are tests that were failing in #835, cherry-picked onto latest master.

Something along the way means they now pass, so they can go into the test suite to guard against regressions, and the issue can be closed.