### PR TITLE
Fix expression result unused warning

### DIFF
--- a/libImaging/Bands.c
+++ b/libImaging/Bands.c
@@ -73,7 +73,7 @@ ImagingSplit(Imaging imIn, Imaging bands[4])
 
     /* Check arguments */
     if (!imIn || imIn->type != IMAGING_TYPE_UINT8) {
-        (Imaging) ImagingError_ModeError();
+        (void) ImagingError_ModeError();
         return 0;
     }
 


### PR DESCRIPTION
Fixes
```
libImaging/Bands.c:76:9: warning: expression result unused [-Wunused-value]
        (Imaging) ImagingError_ModeError();
        ^         ~~~~~~~~~~~~~~~~~~~~~~~~
```
by removing the cast.

Introduced in https://github.com/python-pillow/Pillow/pull/2676/files#diff-7dd4690995a96a7444dfaff941412c02R83