### PR TITLE
Fix ValueError: invalid version number '1.0.0rc1'

### DIFF
--- a/Tests/test_scipy.py
+++ b/Tests/test_scipy.py
@@ -1,5 +1,5 @@
 from helper import unittest, PillowTestCase
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 try:
     import numpy as np
     from numpy.testing import assert_equal
@@ -31,7 +31,7 @@ class Test_scipy_resize(PillowTestCase):
     # this test fails prior to scipy 0.14.0b1
     # https://github.com/scipy/scipy/commit/855ff1fff805fb91840cf36b7082d18565fc8352
     @unittest.skipIf(HAS_SCIPY and
-					 (StrictVersion(scipy.__version__) < StrictVersion('0.14.0')),
+					 (LooseVersion(scipy.__version__) < LooseVersion('0.14.0')),
                      "Test fails on scipy < 0.14.0")
     def test_imresize4(self):
         im = np.array([[1, 2],


### PR DESCRIPTION
Fixes one test error when using scipy release candidate:
```
======================================================================
ERROR: Failure: ValueError (invalid version number '1.0.0rc1')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python36\lib\site-packages\nose\failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "X:\Python36\lib\site-packages\nose\loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "X:\Python36\lib\site-packages\nose\importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "X:\Python36\lib\site-packages\nose\importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "X:\Python36\lib\imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "X:\Python36\lib\imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 675, in _load
  File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 205, in _call_with_frames_removed
  File "D:\Build\Pillow\Pillow-git\Tests\test_scipy.py", line 14, in <module>
    class Test_scipy_resize(PillowTestCase):
  File "D:\Build\Pillow\Pillow-git\Tests\test_scipy.py", line 34, in Test_scipy_resize
    (StrictVersion(scipy.__version__) < StrictVersion('0.14.0')),
  File "X:\Python36\lib\distutils\version.py", line 40, in __init__
    self.parse(vstring)
  File "X:\Python36\lib\distutils\version.py", line 137, in parse
    raise ValueError("invalid version number '%s'" % vstring)
ValueError: invalid version number '1.0.0rc1'
----------------------------------------------------------------------
```
