### PR TITLE
Fix bulletproof code from libc

### DIFF
--- a/libImaging/Storage.c
+++ b/libImaging/Storage.c
@@ -430,8 +430,8 @@ ImagingAllocateArray(Imaging im, int dirty, int block_size)
             im->blocks[current_block] = block;
             /* Bulletproof code from libc _int_memalign */
             aligned_ptr = (char *)(
-                ((unsigned long) (block.ptr + arena->alignment - 1)) &
-                -((signed long) arena->alignment));
+                ((size_t) (block.ptr + arena->alignment - 1)) &
+                -((ssize_t) arena->alignment));
         }
 
         im->image[y] = aligned_ptr + aligned_linesize * line_in_block;

--- a/libImaging/Storage.c
+++ b/libImaging/Storage.c
@@ -431,7 +431,7 @@ ImagingAllocateArray(Imaging im, int dirty, int block_size)
             /* Bulletproof code from libc _int_memalign */
             aligned_ptr = (char *)(
                 ((size_t) (block.ptr + arena->alignment - 1)) &
-                -((ssize_t) arena->alignment));
+                -((Py_ssize_t) arena->alignment));
         }
 
         im->image[y] = aligned_ptr + aligned_linesize * line_in_block;


### PR DESCRIPTION
Fixes https://github.com/python-pillow/Pillow/issues/2772 (Image.new segfaults on win-amd64). 

Tested on Windows with Python 2.7 and 3.6, 32-bit and 64-bit.