### PR TITLE
Use correct Windows handle type

### DIFF
--- a/_imagingcms.c
+++ b/_imagingcms.c
@@ -595,6 +595,13 @@ cms_profile_is_intent_supported(CmsProfileObject *self, PyObject *args)
 }
 
 #ifdef _WIN32
+
+#ifdef _WIN64
+#define F_HANDLE "K"
+#else
+#define F_HANDLE "k"
+#endif
+
 static PyObject *
 cms_get_display_profile_win32(PyObject* self, PyObject* args)
 {
@@ -602,9 +609,9 @@ cms_get_display_profile_win32(PyObject* self, PyObject* args)
     cmsUInt32Number filename_size;
     BOOL ok;
 
-    int handle = 0;
+    HANDLE handle = 0;
     int is_dc = 0;
-    if (!PyArg_ParseTuple(args, "|ii:get_display_profile", &handle, &is_dc))
+    if (!PyArg_ParseTuple(args, "|" F_HANDLE "i:get_display_profile", &handle, &is_dc))
         return NULL;
 
     filename_size = sizeof(filename);


### PR DESCRIPTION
Fix potential issue on 64-bit Windows.

Fixes compiler warnings:
```
_imagingcms.c(613): warning C4312: 'type cast': conversion from 'int' to 'HDC' of greater size
_imagingcms.c(615): warning C4312: 'type cast': conversion from 'int' to 'HWND' of greater size
_imagingcms.c(617): warning C4312: 'type cast': conversion from 'int' to 'HWND' of greater size
```