### PR TITLE
Return bool from isblock function

### DIFF
--- a/_imaging.c
+++ b/_imaging.c
@@ -1756,7 +1756,14 @@ _box_blur(ImagingObject* self, PyObject* args)
 static PyObject*
 _isblock(ImagingObject* self, PyObject* args)
 {
-    return PyInt_FromLong((long) self->image->block);
+    if (self->image->block == NULL) {
+        Py_INCREF(Py_False);
+        return Py_False;
+    }
+    else {
+        Py_INCREF(Py_True);
+        return Py_True;
+    }
 }
 
 static PyObject*


### PR DESCRIPTION
Maybe I am missing something, but it looks like the `isblock` function should return a `bool`. 

This also fixes a compiler warning and a potential issue on 64-bit Windows:
```
_imaging.c(1759): warning C4311: 'type cast': pointer truncation from 'char *' to 'long'
```