### PR TITLE
Remove deprecated PIL.OleFileIO in favour of olefile Python package

### DIFF
--- a/PIL/OleFileIO.py
+++ b/PIL/OleFileIO.py
@@ -1,4 +1,0 @@
-raise ImportError(
-    'PIL.OleFileIO is deprecated. Use the olefile Python package '
-    'instead. This module will be removed in a future version.'
-)


### PR DESCRIPTION
The vendored version was removed in #2199, on 13 Dec 2016, in favour of the olefile Python package and replaced with a deprecation warning that PIL.OleFileIO would be removed in a future version.

We've had four quarterly releases since then (4.0.0, 4.1.0, 4.2.0, 4.3.0), shall we now finish this off?

cc: @decalage2 @jdufresne