### PR TITLE
ImageDraw.textsize: fix zero length error

### DIFF
--- a/PIL/ImageDraw.py
+++ b/PIL/ImageDraw.py
@@ -217,7 +217,8 @@ class ImageDraw(object):
             ink = fill
         if ink is not None:
             try:
-                mask, offset = font.getmask2(text, self.fontmode, *args, **kwargs)
+                mask, offset = font.getmask2(text, self.fontmode,
+                                             *args, **kwargs)
                 xy = xy[0] + offset[0], xy[1] + offset[1]
             except AttributeError:
                 try:
@@ -254,6 +255,8 @@ class ImageDraw(object):
     def textsize(self, text, font=None, spacing=4, direction=None,
                  features=None):
         """Get the size of a given string, in pixels."""
+        if len(text) == 0:
+            return (0, 0)
         if self._multiline_check(text):
             return self.multiline_textsize(text, font, spacing,
                                            direction, features)
@@ -383,4 +386,4 @@ def _color_diff(rgb1, rgb2):
     """
     Uses 1-norm distance to calculate difference between two rgb values.
     """
-    return abs(rgb1[0]-rgb2[0]) +  abs(rgb1[1]-rgb2[1]) +  abs(rgb1[2]-rgb2[2])
+    return abs(rgb1[0]-rgb2[0]) + abs(rgb1[1]-rgb2[1]) + abs(rgb1[2]-rgb2[2])

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -380,7 +380,6 @@ class TestImageDraw(PillowTestCase):
         self.assert_image_equal(
             im, Image.open("Tests/images/imagedraw_floodfill2.png"))
 
-
     def test_floodfill_thresh(self):
         # floodfill() is experimental
 
@@ -559,6 +558,19 @@ class TestImageDraw(PillowTestCase):
 
         # Assert
         self.assert_image_similar(im, Image.open(expected), 1)
+
+    def test_textsize_empty_string(self):
+        # https://github.com/python-pillow/Pillow/issues/2783
+        # Arrange
+        im = Image.new("RGB", (W, H))
+        draw = ImageDraw.Draw(im)
+
+        # Act
+        # Should not cause 'SystemError: <built-in method getsize of
+        # ImagingFont object at 0x...> returned NULL without setting an error'
+        draw.textsize("")
+        draw.textsize("\n")
+        draw.textsize("test\n")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #2783.

Changes proposed in this pull request:

 * If the string is empty, its size is (0, 0).