### PR TITLE
Fix for return without none set

### DIFF
--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -380,7 +380,6 @@ class TestImageDraw(PillowTestCase):
         self.assert_image_equal(
             im, Image.open("Tests/images/imagedraw_floodfill2.png"))
 
-
     def test_floodfill_thresh(self):
         # floodfill() is experimental
 
@@ -559,6 +558,19 @@ class TestImageDraw(PillowTestCase):
 
         # Assert
         self.assert_image_similar(im, Image.open(expected), 1)
+
+    def test_textsize_empty_string(self):
+        # https://github.com/python-pillow/Pillow/issues/2783
+        # Arrange
+        im = Image.new("RGB", (W, H))
+        draw = ImageDraw.Draw(im)
+
+        # Act
+        # Should not cause 'SystemError: <built-in method getsize of
+        # ImagingFont object at 0x...> returned NULL without setting an error'
+        draw.textsize("")
+        draw.textsize("\n")
+        draw.textsize("test\n")
 
 
 if __name__ == '__main__':

--- a/_imaging.c
+++ b/_imaging.c
@@ -2260,12 +2260,14 @@ _font_getmask(ImagingFontObject* self, PyObject* args)
 
     _font_text_asBytes(encoded_string, &text);
     if (!text) {
+        ImagingError_MemoryError();
         return NULL;
     }
 
     im = ImagingNew(self->bitmap->mode, textwidth(self, text), self->ysize);
     if (!im) {
         free(text);
+        ImagingError_MemoryError();
         return NULL;
     }
 
@@ -2297,7 +2299,7 @@ _font_getmask(ImagingFontObject* self, PyObject* args)
   failed:
     free(text);
     ImagingDelete(im);
-    return NULL;
+    Py_RETURN_NONE;
 }
 
 static PyObject*
@@ -2312,6 +2314,7 @@ _font_getsize(ImagingFontObject* self, PyObject* args)
 
     _font_text_asBytes(encoded_string, &text);
     if (!text) {
+        ImagingError_MemoryError();
         return NULL;
     }
 

--- a/_imaging.c
+++ b/_imaging.c
@@ -2212,16 +2212,15 @@ void _font_text_asBytes(PyObject* encoded_string, unsigned char** text){
         PyBytes_AsStringAndSize(encoded_string, &buffer, &len);
     }
 
-    if (len) {
-        *text = calloc(len,1);
-        if (*text) {
-            memcpy(*text, buffer, len);
-        }
-        if(bytes) {
-            Py_DECREF(bytes);
-        }
-        return;
+    *text = calloc(len,1);
+    if (*text) {
+        memcpy(*text, buffer, len);
     }
+    if(bytes) {
+        Py_DECREF(bytes);
+    }
+
+    return;
 
 
 #if PY_VERSION_HEX < 0x03000000

--- a/_imagingft.c
+++ b/_imagingft.c
@@ -225,11 +225,11 @@ text_layout_raqm(PyObject* string, FontObject* self, const char* dir,
     if (PyUnicode_Check(string)) {
         Py_UNICODE *text = PyUnicode_AS_UNICODE(string);
         Py_ssize_t size = PyUnicode_GET_SIZE(string);
-	if (! size) {
-	    /* return 0 and clean up, no glyphs==no size, 
-	       and raqm fails with empty strings */
-	    goto failed;
-	}
+        if (! size) {
+            /* return 0 and clean up, no glyphs==no size,
+               and raqm fails with empty strings */
+            goto failed;
+        }
         if (!raqm_set_text(rq, (const uint32_t *)(text), size)) {
             PyErr_SetString(PyExc_ValueError, "raqm_set_text() failed");
             goto failed;
@@ -239,9 +239,9 @@ text_layout_raqm(PyObject* string, FontObject* self, const char* dir,
     else if (PyString_Check(string)) {
         char *text = PyString_AS_STRING(string);
         int size = PyString_GET_SIZE(string);
-	if (! size) {
-	    goto failed;
-	}
+        if (! size) {
+            goto failed;
+        }
         if (!raqm_set_text_utf8(rq, text, size)) {
             PyErr_SetString(PyExc_ValueError, "raqm_set_text_utf8() failed");
             goto failed;


### PR DESCRIPTION
Fixes #2783 .

Changes proposed in this pull request:

 * Don't return NULL without an error set.
 * Don't handle 0 length strings differently.
