### PR TITLE
Allow the olefile dependency to be optional

### DIFF
--- a/Tests/test_file_fpx.py
+++ b/Tests/test_file_fpx.py
@@ -1,8 +1,14 @@
 from helper import unittest, PillowTestCase
 
-from PIL import FpxImagePlugin
+try:
+    from PIL import FpxImagePlugin
+except ImportError:
+    olefile_installed = False
+else:
+    olefile_installed = True
 
 
+@unittest.skipUnless(olefile_installed, "olefile package not installed")
 class TestFileFpx(PillowTestCase):
 
     def test_invalid_file(self):

--- a/Tests/test_file_mic.py
+++ b/Tests/test_file_mic.py
@@ -1,10 +1,18 @@
 from helper import unittest, PillowTestCase, hopper
 
-from PIL import Image, ImagePalette, MicImagePlugin
+from PIL import Image, ImagePalette
+
+try:
+    from PIL import MicImagePlugin
+except ImportError:
+    olefile_installed = False
+else:
+    olefile_installed = True
 
 TEST_FILE = "Tests/images/hopper.mic"
 
 
+@unittest.skipUnless(olefile_installed, "olefile package not installed")
 class TestFileMic(PillowTestCase):
 
     def test_sanity(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ docutils
 jarn.viewdoc
 nose-cov
 nose
+olefile
 pep8
 pyflakes
 pyroma

--- a/setup.py
+++ b/setup.py
@@ -780,7 +780,6 @@ try:
           include_package_data=True,
           packages=find_packages(),
           scripts=glob.glob("Scripts/*.py"),
-          install_requires=['olefile'],
           test_suite='nose.collector',
           keywords=["Imaging", ],
           license='Standard PIL License',
@@ -806,4 +805,3 @@ which was requested by the option flag --enable-%s
 """ % (str(err), str(err))
     sys.stderr.write(msg)
     raise DependencyException(msg)
-


### PR DESCRIPTION
Support for plugins requiring olefile will not be loaded if it is not installed. Allows library consumers to avoid installing this dependency if they choose. Some library consumers have little interest in the format support and would like to keep dependencies to a minimum.

Changes proposed in this pull request:

 * olefile support is no longer a required dependency
 * if it is exists, image support requiring olefile continues to be available

