### PR TITLE
Test pypy2-v5.9.0-win32 [Do not merge]

### DIFF
--- a/winbuild/appveyor_install_pypy.cmd
+++ b/winbuild/appveyor_install_pypy.cmd
@@ -1,3 +1,3 @@
-curl -fsSL -o pypy2.zip https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.8.0-win32.zip
+curl -fsSL -o pypy2.zip https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-win32.zip
 7z x pypy2.zip -oc:\
-c:\Python34\Scripts\virtualenv.exe -p c:\pypy2-v5.8.0-win32\pypy.exe c:\vp\pypy2
+c:\Python34\Scripts\virtualenv.exe -p c:\pypy2-v5.9.0-win32\pypy.exe c:\vp\pypy2


### PR DESCRIPTION
Pillow 4.3.0 segfaults on pypy2-v5.9.0-win32:

```
--------------------------------------------------------------------
PIL SETUP SUMMARY
--------------------------------------------------------------------
version      Pillow 4.3.0
platform     win32 2.7.13 (c2437cf9b7f1, Sep 24 2017, 17:23:53)
             [PyPy 5.9.0 with MSC v.1500 32 bit]
--------------------------------------------------------------------
--- JPEG support available
--- OPENJPEG (JPEG2000) support available (2.1)
--- ZLIB (PNG/ZIP) support available
*** LIBIMAGEQUANT support not available
--- LIBTIFF support available
--- FREETYPE2 support available
*** RAQM support not available
--- LITTLECMS2 support available
--- WEBP support available
--- WEBPMUX support available
```

```
TestDecompressionCrop.testEnlargeCrop ... ok
RPython traceback:
  File "pypy_module_cpyext.c", line 6693, in wrapper_second_level__star_1_3
  File "pypy_module_cpyext_1.c", line 38392, in make_ref__StdObjSpaceConst_SomeInstance_NoneCons
Fatal RPython error: AssertionError

This application has requested the Runtime to terminate it in an unusual way.
Please contact the application's support team for more information.
```