### PR TITLE
Fix #2804: sets encoderinfo for images when saving multi-page PDF

### DIFF
--- a/PIL/PdfImagePlugin.py
+++ b/PIL/PdfImagePlugin.py
@@ -139,7 +139,7 @@ def _save(im, fp, filename, save_all=False):
         for append_im in append_images:
             if append_im.mode != im.mode:
                 append_im = append_im.convert(im.mode)
-                append_im.encoderinfo = im.encoderinfo.copy()
+            append_im.encoderinfo = im.encoderinfo.copy()
             ims.append(append_im)
     numberOfPages = 0
     for im in ims:

--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -80,6 +80,13 @@ class TestFilePdf(PillowTestCase):
         self.assertTrue(os.path.isfile(outfile))
         self.assertGreater(os.path.getsize(outfile), 0)
 
+        # Append JPEG images
+        jpeg = Image.open("Tests/images/flower.jpg")
+        jpeg.save(outfile, save_all=True, append_images=[jpeg.copy()])
+
+        self.assertTrue(os.path.isfile(outfile))
+        self.assertGreater(os.path.getsize(outfile), 0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #2804 

Seeing that saving as a TIFF before saving as a PDF fixed the problem (see issue #2804 for more details), I tried to copy some of the _save_all method in TiffImagePlugin.py into the _save_all method of PdfImagePlugin.py and it seems to work.