### PR TITLE
Quick and Dirty fix for msys2 on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,6 +69,7 @@ build_script:
         $host.SetShouldExit(0)  
       }
 - cd c:\pillow
+- mv PIL PIL.temp
 - '%PYTHON%\%EXECUTABLE% selftest.py --installed'
 
 test_script:
@@ -86,6 +87,8 @@ artifacts:
   name: wheel
 
 before_deploy:
+  - cd c:\pillow
+  - mv PIL.temp PIL
   - '%PYTHON%\%PIP_DIR%\pip.exe install wheel'
   - cd c:\pillow\winbuild\
   - '%PYTHON%\%EXECUTABLE% c:\pillow\winbuild\build.py --wheel'


### PR DESCRIPTION
Fixes #2810 .

Underlying issue appears to be the path modification that we do to allow PIL to be imported from the work directory when we're doing an installed, not an in place build.  So it's not finding _imaging in the PIL directory. 

I haven't gone through to figure out why this is the case, but it's enough to move the PIL directory out of the way during the selftest and test runs. 