### PR TITLE
fix for #272 on SmartOS. Stripping whitespace from string.whitespace.

### DIFF
--- a/PIL/PpmImagePlugin.py
+++ b/PIL/PpmImagePlugin.py
@@ -24,7 +24,7 @@ __version__ = "0.2"
 #
 # --------------------------------------------------------------------
 
-b_whitespace = string.whitespace
+b_whitespace = string.whitespace.strip()
 try:
     import locale
     locale_lang, locale_enc = locale.getlocale()


### PR DESCRIPTION
Fixes #272 
Strips the whitespace that comes through on the `string.whitespace` call on SmartOS systems. 

Changes proposed in this pull request:

 * 
 * 
 * 
