### PR TITLE
Relaxing similarity on showpage test, Arch has rendering differences

### DIFF
--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -79,7 +79,7 @@ class TestFileEps(PillowTestCase):
         #should not crash/hang
         plot_image.load()
         #  fonts could be slightly different
-        self.assert_image_similar(plot_image, target, 2)
+        self.assert_image_similar(plot_image, target, 5)
 
     def test_file_object(self):
         # issue 479


### PR DESCRIPTION
Required for a new Docker image build to pass.

I've validated the images visually that they're close.