### PR TITLE
PPM: Use fixed list of whitespace, rather relying on locale

### DIFF
--- a/PIL/PpmImagePlugin.py
+++ b/PIL/PpmImagePlugin.py
@@ -24,16 +24,7 @@ __version__ = "0.2"
 #
 # --------------------------------------------------------------------
 
-b_whitespace = string.whitespace.strip()
-try:
-    import locale
-    locale_lang, locale_enc = locale.getlocale()
-    if locale_enc is None:
-        locale_lang, locale_enc = locale.getdefaultlocale()
-    b_whitespace = b_whitespace.decode(locale_enc)
-except:
-    pass
-b_whitespace = b_whitespace.encode('ascii', 'ignore')
+b_whitespace = b'\x20\x09\x0a\x0b\x0c\x0d'
 
 MODES = {
     # standard

--- a/PIL/PpmImagePlugin.py
+++ b/PIL/PpmImagePlugin.py
@@ -24,7 +24,7 @@ __version__ = "0.2"
 #
 # --------------------------------------------------------------------
 
-b_whitespace = string.whitespace
+b_whitespace = string.whitespace.strip()
 try:
     import locale
     locale_lang, locale_enc = locale.getlocale()


### PR DESCRIPTION
Updated version of and closes https://github.com/python-pillow/Pillow/pull/2820.

Changes proposed in this pull request:

 * Use a fixed list of whitespace according to the spec, rather relying on the locale
 * Fixes `UnicodeDecodeError: 'utf8' codec can't decode byte 0xa0 in position 6: invalid start byte` on SmartOS base-64 17.3.0
