### PR TITLE
Replace PIL.OleFileIO warning with descriptive ImportError

### DIFF
--- a/PIL/OleFileIO.py
+++ b/PIL/OleFileIO.py
@@ -1,12 +1,4 @@
-import warnings
-
-warnings.warn(
+raise ImportError(
     'PIL.OleFileIO is deprecated. Use the olefile Python package '
-    'instead. This module will be removed in a future version.',
-    DeprecationWarning
+    'instead. This module will be removed in a future version.'
 )
-
-import olefile
-import sys
-
-sys.modules[__name__] = olefile


### PR DESCRIPTION
The vendored version was removed in #2199, on 13 Dec 2016, in favour of the olefile Python package and replaced with a deprecation warning that PIL.OleFileIO would be removed in a future version.

We've had four quarterly releases since then (4.0.0, 4.1.0, 4.2.0, 4.3.0), shall we now ~finish this off~ replace it with an import error that says the same thing and then remove it at a later date?

See https://github.com/python-pillow/Pillow/pull/2784 for removal at a future date.

cc: @decalage2 @jdufresne