### PR TITLE
Added support for generators when using append_images for WEBP

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -1784,14 +1784,14 @@ class AppendingTiffWriter:
 def _save_all(im, fp, filename):
     encoderinfo = im.encoderinfo.copy()
     encoderconfig = im.encoderconfig
-    append_images = encoderinfo.get("append_images", [])
+    append_images = list(encoderinfo.get("append_images", []))
     if not hasattr(im, "n_frames") and not append_images:
         return _save(im, fp, filename)
 
     cur_idx = im.tell()
     try:
         with AppendingTiffWriter(fp) as tf:
-            for ims in itertools.chain([im], append_images):
+            for ims in [im]+append_images:
                 ims.encoderinfo = encoderinfo
                 ims.encoderconfig = encoderconfig
                 if not hasattr(ims, "n_frames"):

--- a/PIL/WebPImagePlugin.py
+++ b/PIL/WebPImagePlugin.py
@@ -167,7 +167,7 @@ class WebPImageFile(ImageFile.ImageFile):
 
 def _save_all(im, fp, filename):
     encoderinfo = im.encoderinfo.copy()
-    append_images = encoderinfo.get("append_images", [])
+    append_images = list(encoderinfo.get("append_images", []))
 
     # If total frame count is 1, then save using the legacy API, which
     # will preserve non-alpha modes

--- a/Tests/test_file_webp_animated.py
+++ b/Tests/test_file_webp_animated.py
@@ -66,7 +66,6 @@ class TestFileWebpAnimation(PillowTestCase):
         """
 
         temp_file = self.tempfile("temp.webp")
-        temp_file2 = self.tempfile("temp.png")
         frame1 = Image.open('Tests/images/anim_frame1.webp')
         frame2 = Image.open('Tests/images/anim_frame2.webp')
         frame1.save(temp_file,
@@ -77,7 +76,6 @@ class TestFileWebpAnimation(PillowTestCase):
 
         # Compare first frame to original
         im.load()
-        im.save(temp_file2)
         self.assert_image_equal(im, frame1.convert("RGBA"))
 
         # Compare second frame to original


### PR DESCRIPTION
I'm converting the generator to a list for WEBP, rather than using itertools, since `append_images` is called twice.

I also have a commit changing TIFF saving to using a list rather than itertools as well, in order to use single frame save if it is given a single frame image and an empty generator.