### PR TITLE
How about yum install? [ci skip]

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -316,7 +316,7 @@ Or for Python 3::
 
 .. Note:: ``redhat-rpm-config`` is required on Fedora 23, but not earlier versions.
 
-Prerequisites are installed on **Ubuntu 14.04 LTS** with::
+Prerequisites can be installed on **Ubuntu 14.04 LTS** with::
 
     $ sudo apt-get install libtiff5-dev libjpeg8-dev zlib1g-dev \
         libfreetype6-dev liblcms2-dev libwebp-dev libharfbuzz-dev libfribidi-dev \
@@ -324,7 +324,12 @@ Prerequisites are installed on **Ubuntu 14.04 LTS** with::
 
 Then see ``depends/install_raqm.sh`` to install libraqm.
 
-Prerequisites are installed on **Fedora 23** with::
+Prerequisites can be installed on **RedHat/CentOS 7.4** with::
+
+    $ sudo yum install libjpeg-devel libwebp-devel freetype-devel openjpeg2-devel \
+        libtiff-devel libimagequant lcms2-devel
+
+Prerequisites can be installed on **Fedora 23** with::
 
     $ sudo dnf install libtiff-devel libjpeg-devel zlib-devel freetype-devel \
         lcms2-devel libwebp-devel tcl-devel tk-devel libraqm-devel

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -327,7 +327,7 @@ Then see ``depends/install_raqm.sh`` to install libraqm.
 Prerequisites can be installed on **RedHat/CentOS 7.4** with::
 
     $ sudo yum install libjpeg-devel libwebp-devel freetype-devel openjpeg2-devel \
-        libtiff-devel libimagequant lcms2-devel
+        libtiff-devel libimagequant-devel lcms2-devel
 
 Prerequisites can be installed on **Fedora 23** with::
 


### PR DESCRIPTION

Changes proposed in this pull request:

 * Add ``sudo yum install libjpeg-devel libwebp-devel freetype-devel openjpeg2-devel libtiff-devel libimagequant-devel lcms2-devel`` to docs/installation.rst

Seems like the whole ``installation.rst`` could use a rewrite, but in the meantime I came across @python-pillow/pillow-team not having specific Redhat/CentOS dependency installation instructions, so I'm adding them here.

Also even though I have ``libimagequant-devel`` installed, I don't get expected support (as far as I can tell)::

```

--------------------------------------------------------------------
PIL SETUP SUMMARY
--------------------------------------------------------------------
version      Pillow 4.3.0
platform     linux2 2.7.5 (default, Aug  4 2017, 00:39:18)
             [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
--------------------------------------------------------------------
--- JPEG support available
--- OPENJPEG (JPEG2000) support available (2.1)
--- ZLIB (PNG/ZIP) support available
*** LIBIMAGEQUANT support not available
--- LIBTIFF support available
--- FREETYPE2 support available
--- RAQM support available
--- LITTLECMS2 support available
--- WEBP support available
*** WEBPMUX support not available
--------------------------------------------------------------------
```

