### PR TITLE
Fillcolor parameter for Transform

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -2074,7 +2074,8 @@ class Image(object):
 
     # FIXME: the different transform methods need further explanation
     # instead of bloating the method docs, add a separate chapter.
-    def transform(self, size, method, data=None, resample=NEAREST, fill=None):
+    def transform(self, size, method, data=None, resample=NEAREST,
+                  fill=1, fillcolor=None):
         """
         Transforms this image.  This method creates a new image with the
         given size, and the same mode as the original, and copies data
@@ -2095,7 +2096,7 @@ class Image(object):
            environment), or :py:attr:`PIL.Image.BICUBIC` (cubic spline
            interpolation in a 4x4 environment). If omitted, or if the image
            has mode "1" or "P", it is set to :py:attr:`PIL.Image.NEAREST`.
-        :param fill: Optional fill color for the area outside the transform
+        :param fillcolor: Optional fill color for the area outside the transform
            in the output image.
         :returns: An :py:class:`~PIL.Image.Image` object.
         """
@@ -2109,7 +2110,6 @@ class Image(object):
                 size, method, data, resample, fill).convert('RGBA')
 
         if isinstance(method, ImageTransformHandler):
-            fill = 1
             return method.transform(size, self, resample=resample, fill=fill)
 
         if hasattr(method, "getdata"):
@@ -2119,13 +2119,15 @@ class Image(object):
         if data is None:
             raise ValueError("missing method data")
 
-        im = new(self.mode, size, fill)
+        im = new(self.mode, size, fillcolor)
         if method == MESH:
             # list of quads
             for box, quad in data:
-                im.__transformer(box, self, QUAD, quad, resample, fill is None)
+                im.__transformer(box, self, QUAD, quad, resample,
+                                 fillcolor is None)
         else:
-            im.__transformer((0, 0)+size, self, method, data, resample, fill is None)
+            im.__transformer((0, 0)+size, self, method, data,
+                             resample, fillcolor is None)
 
         return im
 

--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -2074,7 +2074,7 @@ class Image(object):
 
     # FIXME: the different transform methods need further explanation
     # instead of bloating the method docs, add a separate chapter.
-    def transform(self, size, method, data=None, resample=NEAREST, fill=1):
+    def transform(self, size, method, data=None, resample=NEAREST, fill=None):
         """
         Transforms this image.  This method creates a new image with the
         given size, and the same mode as the original, and copies data
@@ -2095,9 +2095,11 @@ class Image(object):
            environment), or :py:attr:`PIL.Image.BICUBIC` (cubic spline
            interpolation in a 4x4 environment). If omitted, or if the image
            has mode "1" or "P", it is set to :py:attr:`PIL.Image.NEAREST`.
+        :param fill: Optional fill color for the area outside the transform
+           in the output image.
         :returns: An :py:class:`~PIL.Image.Image` object.
         """
-
+        
         if self.mode == 'LA':
             return self.convert('La').transform(
                 size, method, data, resample, fill).convert('LA')
@@ -2107,6 +2109,7 @@ class Image(object):
                 size, method, data, resample, fill).convert('RGBA')
 
         if isinstance(method, ImageTransformHandler):
+            fill = 1
             return method.transform(size, self, resample=resample, fill=fill)
 
         if hasattr(method, "getdata"):
@@ -2116,13 +2119,13 @@ class Image(object):
         if data is None:
             raise ValueError("missing method data")
 
-        im = new(self.mode, size, None)
+        im = new(self.mode, size, fill)
         if method == MESH:
             # list of quads
             for box, quad in data:
-                im.__transformer(box, self, QUAD, quad, resample, fill)
+                im.__transformer(box, self, QUAD, quad, resample, fill is None)
         else:
-            im.__transformer((0, 0)+size, self, method, data, resample, fill)
+            im.__transformer((0, 0)+size, self, method, data, resample, fill is None)
 
         return im
 

--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -267,16 +267,5 @@ class TestImageTransformPerspective(TestImageTransformAffine):
     # Repeat all tests for AFFINE transformations with PERSPECTIVE
     transform = Image.PERSPECTIVE
 
-class TestFill(unittest.TestCase):
-    def test_fill(self):
-        im = hopper('RGB')
-        (w, h) = im.size
-        transformed = im.transform(im.size, Image.EXTENT,
-                                   (0, 0,
-                                    w*2, h*2),
-                                   Image.BILINEAR,
-                                   fill = 'red')
-        transformed.show()
-        self.assertEqual(transformed.getpixel((w-1,h-1)), (255,0,0))
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -52,6 +52,17 @@ class TestImageTransform(PillowTestCase):
 
         self.assert_image_equal(transformed, scaled)
 
+    def test_fill(self):
+        im = hopper('RGB')
+        (w, h) = im.size
+        transformed = im.transform(im.size, Image.EXTENT,
+                                   (0, 0,
+                                    w*2, h*2),
+                                   Image.BILINEAR,
+                                   fill = 'red')
+
+        self.assertEqual(transformed.getpixel((w-1,h-1)), (255,0,0))
+
     def test_mesh(self):
         # this should be a checkerboard of halfsized hoppers in ul, lr
         im = hopper('RGBA')
@@ -256,6 +267,16 @@ class TestImageTransformPerspective(TestImageTransformAffine):
     # Repeat all tests for AFFINE transformations with PERSPECTIVE
     transform = Image.PERSPECTIVE
 
-
+class TestFill(unittest.TestCase):
+    def test_fill(self):
+        im = hopper('RGB')
+        (w, h) = im.size
+        transformed = im.transform(im.size, Image.EXTENT,
+                                   (0, 0,
+                                    w*2, h*2),
+                                   Image.BILINEAR,
+                                   fill = 'red')
+        transformed.show()
+        self.assertEqual(transformed.getpixel((w-1,h-1)), (255,0,0))
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -59,7 +59,7 @@ class TestImageTransform(PillowTestCase):
                                    (0, 0,
                                     w*2, h*2),
                                    Image.BILINEAR,
-                                   fill = 'red')
+                                   fillcolor = 'red')
 
         self.assertEqual(transformed.getpixel((w-1,h-1)), (255,0,0))
 

--- a/_imaging.c
+++ b/_imaging.c
@@ -1612,7 +1612,7 @@ _transform2(ImagingObject* self, PyObject* args)
     int fill = 1;
     if (!PyArg_ParseTuple(args, "(iiii)O!iO|ii",
                           &x0, &y0, &x1, &y1,
-              &Imaging_Type, &imagep,
+                          &Imaging_Type, &imagep,
                           &method, &data,
                           &filter, &fill))
     return NULL;
@@ -1637,7 +1637,7 @@ _transform2(ImagingObject* self, PyObject* args)
 
     imOut = ImagingTransform(
         self->image, imagep->image, method,
-        x0, y0, x1, y1, a, filter, 1);
+        x0, y0, x1, y1, a, filter, fill);
 
     free(a);
 


### PR DESCRIPTION
Fixes #2837 .

Changes proposed in this pull request:

 * Adds fillcolor parameter to transform to fill the target image prior to the transform
 * Pipes through the existing fill parameter in `_imaging.transform2` rather than hardwiring it to true.
 
Note: This _extends_ the api and retains the currently mostly ignored `fill` parameter. This `fill` parameter is currently passed into the ImageTransformHandler api, which has user supplied code that we don't control. If we repurpose that parameter, we risk breaking existing code. 
