### PR TITLE
RFC: Display differences

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -13,6 +13,7 @@ pip install check-manifest
 pip install olefile
 pip install pyroma
 pip install coverage
+pip install test-image-results
 
 # docs only on Python 2.7
 if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then pip install -r requirements.txt ; fi

--- a/Tests/test_uploader.py
+++ b/Tests/test_uploader.py
@@ -1,0 +1,18 @@
+from helper import unittest, PillowTestCase, hopper
+
+from PIL import Image
+
+
+class TestUploader(PillowTestCase):
+    def test_upload_equal(self):
+        result = hopper('P').convert('RGB')
+        target = hopper('RGB')
+        self.assert_image_equal(result, target)
+
+    def test_upload_similar(self):
+        result = hopper('P').convert('RGB')
+        target = hopper('RGB')
+        self.assert_image_similar(result, target, 0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tests/test_uploader.py
+++ b/Tests/test_uploader.py
@@ -4,12 +4,12 @@ from PIL import Image
 
 
 class TestUploader(PillowTestCase):
-    def test_upload_equal(self):
+    def check_upload_equal(self):
         result = hopper('P').convert('RGB')
         target = hopper('RGB')
         self.assert_image_equal(result, target)
 
-    def test_upload_similar(self):
+    def check_upload_similar(self):
         result = hopper('P').convert('RGB')
         target = hopper('RGB')
         self.assert_image_similar(result, target, 0)


### PR DESCRIPTION
I've been thinking about something like this since we had the issue that was non-reproducable on any of my machines. 

What this does is push all test failures for `assert_image_equal` and `assert_image_similar` to a webservice, where it displays those images and the difference. 

```
======================================================================

FAIL: TestUploader.test_upload_equal

----------------------------------------------------------------------

Traceback (most recent call last):

  File "/home/travis/build/wiredfool/Pillow/Tests/test_uploader.py", line 10, in test_upload_equal

    self.assert_image_equal(result, target)

  File "/home/travis/build/wiredfool/Pillow/Tests/helper.py", line 104, in assert_image_equal

    self.fail(msg or "got different content")

AssertionError: got different content

-------------------- >> begin captured logging << --------------------

urllib3.connectionpool: DEBUG: Starting new HTTPS connection (1): fmuvehxed0.execute-api.us-east-2.amazonaws.com

urllib3.connectionpool: DEBUG: https://fmuvehxed0.execute-api.us-east-2.amazonaws.com:443 "GET /prod/upload HTTP/1.1" 200 3421

urllib3.connectionpool: DEBUG: Starting new HTTPS connection (1): s3.us-east-2.amazonaws.com

urllib3.connectionpool: DEBUG: https://s3.us-east-2.amazonaws.com:443 "POST /pillow-test-image-results HTTP/1.1" 204 0

urllib3.connectionpool: DEBUG: Starting new HTTPS connection (1): s3.us-east-2.amazonaws.com

urllib3.connectionpool: DEBUG: https://s3.us-east-2.amazonaws.com:443 "POST /pillow-test-image-results HTTP/1.1" 204 0

helper: ERROR: Url for test images: https://fmuvehxed0.execute-api.us-east-2.amazonaws.com/prod/show/1510948233.21/

--------------------- >> end captured logging << ---------------------
```

I'm not 100% on the output yet, and we're still not going to trigger on some forms of errors. 

Comments?