### PR TITLE
Add eog support for Ubuntu Image Viewer

### DIFF
--- a/PIL/ImageShow.py
+++ b/PIL/ImageShow.py
@@ -101,6 +101,7 @@ class Viewer(object):
 
 # --------------------------------------------------------------------
 
+
 if sys.platform == "win32":
 
     class WindowsViewer(Viewer):
@@ -161,14 +162,15 @@ else:
             command = executable = "display"
             return command, executable
 
+    if which("display"):
+        register(DisplayViewer)
+
     class EogViewer(UnixViewer):
         def get_command_ex(self, file, **options):
             command = executable = "eog"
             return command, executable
 
-    if which("display"):
-        register(DisplayViewer)
-    elif which("eog"):
+    if which("eog"):
         register(EogViewer)
 
     class XVViewer(UnixViewer):

--- a/PIL/ImageShow.py
+++ b/PIL/ImageShow.py
@@ -156,17 +156,20 @@ else:
 
     # implementations
 
-    # The default Image Viewer of Ubuntu using the command "eog" in the terminal.
-    # Reference: https://help.gnome.org/users/eog/stable/commandline.html.en
-
     class DisplayViewer(UnixViewer):
         def get_command_ex(self, file, **options):
-            command = executable = "display" or "eog"
+            command = executable = "display"
             return command, executable
 
+    class EogViewer(UnixViewer):
+        def get_command_ex(self, file, **options):
+            command = executable = "eog"
+            return command, executable
 
-    if which("display" or "eog"):
-        register(DisplayViewer)
+    if which("display"):
+        register
+    elif which("eog"):
+        register(EogViewer)
 
     class XVViewer(UnixViewer):
         def get_command_ex(self, file, title=None, **options):

--- a/PIL/ImageShow.py
+++ b/PIL/ImageShow.py
@@ -156,12 +156,16 @@ else:
 
     # implementations
 
+    # The default Image Viewer of Ubuntu using the command "eog" in the terminal.
+    # Reference: https://help.gnome.org/users/eog/stable/commandline.html.en
+
     class DisplayViewer(UnixViewer):
         def get_command_ex(self, file, **options):
-            command = executable = "display"
+            command = executable = "display" or "eog"
             return command, executable
 
-    if which("display"):
+
+    if which("display" or "eog"):
         register(DisplayViewer)
 
     class XVViewer(UnixViewer):

--- a/PIL/ImageShow.py
+++ b/PIL/ImageShow.py
@@ -167,7 +167,7 @@ else:
             return command, executable
 
     if which("display"):
-        register
+        register(DisplayViewer)
     elif which("eog"):
         register(EogViewer)
 


### PR DESCRIPTION
## Context:
*  As a Ubuntu user, ```~PIL.Image.Image.show``` method shows the image, but the default Image Viewer of Ubuntu using the command ```eog``` in the terminal. By default, Pillow looking for the commands ```xv``` and ```display``` .
## Changes proposed in this pull request:

 *  Add ```eog``` support for the Ubuntu. 
 *  Now Ubuntu user can see the image and it is very handy for debugging and tests.