### PR TITLE
Replace deprecated platform.dist with file existence check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -313,7 +313,7 @@ class pil_build_ext(build_ext):
         elif sys.platform.startswith("linux"):
             arch_tp = (plat.processor(), plat.architecture()[0])
             # This should be correct on debian derivatives.
-            if plat.dist()[0].lower() in ('debian', 'ubuntu'):
+            if os.path.exists('/etc/debian_version'):
                 # If this doesn't work, don't just silently patch
                 # downstream because it's going to break when people
                 # try to build pillow from source instead of


### PR DESCRIPTION
Fixes https://github.com/python-pillow/Pillow/pull/2853#discussion_r152495000 .

Changes proposed in this pull request:

 * Use a filesystem check instead of the useful, but deprecated platform.dist.

(note that there is a pypi module for this, but I'd rather not pull in a dependency for what is essentially a quick check to see if it's reasonable to try running a configuration app)