### PR TITLE
Test 3.7-dev ahead of 3.7.0's expected 2018-06-15 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
     - python: '3.5'
     - python: '3.4'
     - python: '3.3'
+    - python: '3.7-dev'
     - env: DOCKER="alpine"
     - env: DOCKER="arch" # contains PyQt5
     - env: DOCKER="ubuntu-trusty-x86"


### PR DESCRIPTION
Python 3.7.0 is due out on 2018-06-15, or after two Pillow releases.

https://www.python.org/dev/peps/pep-0537/#schedule

One 3.7 incompatibility has been caught in https://github.com/python-pillow/Pillow/pull/2869, but shall we start testing against 3.7-dev already to make sure nothing else sneaks in there before it's out?

We don't test setup.py, so this doesn't didn't actually catch `platform.dist`'s removal, but the good news is all the existing tests pass.