### PR TITLE
Add licence classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -352,7 +352,7 @@ class pil_build_ext(build_ext):
                     's390x':   ["/usr/lib64", "/usr/lib/s390x-linux-gnu"],
                     's390':    ["/usr/lib/s390-linux-gnu"],
                     }
-                    
+
                 for platform_ in arch_tp:
                     dirs = libdirs.get(platform_, None)
                     if not platform_:
@@ -360,7 +360,7 @@ class pil_build_ext(build_ext):
                     for path in dirs:
                         _add_directory(library_dirs, path)
                     break
-                
+
                 else:
                     raise ValueError(
                         "Unable to identify Linux platform: `%s`" % platform_)
@@ -763,6 +763,7 @@ try:
               "Topic :: Multimedia :: Graphics :: Capture :: Screen Capture",
               "Topic :: Multimedia :: Graphics :: Graphics Conversion",
               "Topic :: Multimedia :: Graphics :: Viewers",
+              "License :: Other/Proprietary License",
               "Programming Language :: Python :: 2",
               "Programming Language :: Python :: 2.7",
               "Programming Language :: Python :: 3",


### PR DESCRIPTION
Changes proposed in this pull request:

 * Add a licence classifier.

Pyroma has been updated and now complains about "You should specify license in classifiers.", failing a test ([eg.](https://travis-ci.org/hugovk/Pillow/jobs/308874822#L3843)).

The PIL licence isn't available as a classifier. Would something like "Free To Use But Restricted" or another be better than "Other/Proprietary License"?

Here's the full list from https://pypi.python.org/pypi?%3Aaction=list_classifiers:
```
License :: Aladdin Free Public License (AFPL)
License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
License :: CeCILL-B Free Software License Agreement (CECILL-B)
License :: CeCILL-C Free Software License Agreement (CECILL-C)
License :: DFSG approved
License :: Eiffel Forum License (EFL)
License :: Free For Educational Use
License :: Free For Home Use
License :: Free for non-commercial use
License :: Freely Distributable
License :: Free To Use But Restricted
License :: Freeware
License :: Netscape Public License (NPL)
License :: Nokia Open Source License (NOKOS)
License :: OSI Approved
License :: OSI Approved :: Academic Free License (AFL)
License :: OSI Approved :: Apache Software License
License :: OSI Approved :: Apple Public Source License
License :: OSI Approved :: Artistic License
License :: OSI Approved :: Attribution Assurance License
License :: OSI Approved :: Boost Software License 1.0 (BSL-1.0)
License :: OSI Approved :: BSD License
License :: OSI Approved :: CEA CNRS Inria Logiciel Libre License, version 2.1 (CeCILL-2.1)
License :: OSI Approved :: Common Development and Distribution License 1.0 (CDDL-1.0)
License :: OSI Approved :: Common Public License
License :: OSI Approved :: Eclipse Public License 1.0 (EPL-1.0)
License :: OSI Approved :: Eiffel Forum License
License :: OSI Approved :: European Union Public Licence 1.0 (EUPL 1.0)
License :: OSI Approved :: European Union Public Licence 1.1 (EUPL 1.1)
License :: OSI Approved :: GNU Affero General Public License v3
License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)
License :: OSI Approved :: GNU Free Documentation License (FDL)
License :: OSI Approved :: GNU General Public License (GPL)
License :: OSI Approved :: GNU General Public License v2 (GPLv2)
License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)
License :: OSI Approved :: GNU General Public License v3 (GPLv3)
License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)
License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)
License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)
License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)
License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)
License :: OSI Approved :: IBM Public License
License :: OSI Approved :: Intel Open Source License
License :: OSI Approved :: ISC License (ISCL)
License :: OSI Approved :: Jabber Open Source License
License :: OSI Approved :: MIT License
License :: OSI Approved :: MITRE Collaborative Virtual Workspace License (CVW)
License :: OSI Approved :: Motosoto License
License :: OSI Approved :: Mozilla Public License 1.0 (MPL)
License :: OSI Approved :: Mozilla Public License 1.1 (MPL 1.1)
License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
License :: OSI Approved :: Nethack General Public License
License :: OSI Approved :: Nokia Open Source License
License :: OSI Approved :: Open Group Test Suite License
License :: OSI Approved :: Python License (CNRI Python License)
License :: OSI Approved :: Python Software Foundation License
License :: OSI Approved :: Qt Public License (QPL)
License :: OSI Approved :: Ricoh Source Code Public License
License :: OSI Approved :: Sleepycat License
License :: OSI Approved :: Sun Industry Standards Source License (SISSL)
License :: OSI Approved :: Sun Public License
License :: OSI Approved :: Universal Permissive License (UPL)
License :: OSI Approved :: University of Illinois/NCSA Open Source License
License :: OSI Approved :: Vovida Software License 1.0
License :: OSI Approved :: W3C License
License :: OSI Approved :: X.Net License
License :: OSI Approved :: zlib/libpng License
License :: OSI Approved :: Zope Public License
License :: Other/Proprietary License
License :: Public Domain
License :: Repoze Public License
```