### PR TITLE
Add jpg value in TiffImagePlugin in compression list

### DIFF
--- a/PIL/TiffImagePlugin.py
+++ b/PIL/TiffImagePlugin.py
@@ -1240,7 +1240,8 @@ class TiffImageFile(ImageFile.ImageFile):
                                                      "tiff_deflate",
                                                      "tiff_sgilog",
                                                      "tiff_sgilog24",
-                                                     "tiff_raw_16"]:
+                                                     "tiff_raw_16",
+                                                     "jpeg"]:
                 # if DEBUG:
                 #     print("Activating g4 compression for whole file")
 

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -72,12 +72,8 @@ class TestFileTiff(PillowTestCase):
         self.assertEqual(im.mode, "RGB")
         self.assertEqual(im.size, (256, 256))
         self.assertEqual(
-            im.tile, [
-                ('jpeg', (0, 0, 256, 64), 8, ('RGB', '')),
-                ('jpeg', (0, 64, 256, 128), 1215, ('RGB', '')),
-                ('jpeg', (0, 128, 256, 192), 2550, ('RGB', '')),
-                ('jpeg', (0, 192, 256, 256), 3890, ('RGB', '')),
-                ])
+            im.tile, [('jpeg', (0, 0, 256, 256), 0, ('RGB', 'jpeg', False))]
+        )
         im.load()
 
     def test_sampleformat(self):


### PR DESCRIPTION
Fix for wrong colors when jpeg embedded in tiff
https://github.com/python-pillow/Pillow/issues/2503
