### PR TITLE
Make PngImagePlugin.add_text() zip argument type bool

### DIFF
--- a/PIL/PngImagePlugin.py
+++ b/PIL/PngImagePlugin.py
@@ -249,7 +249,7 @@ class PngInfo(object):
             self.add(b"iTXt", key + b"\0\0\0" + lang + b"\0" + tkey + b"\0" +
                      value)
 
-    def add_text(self, key, value, zip=0):
+    def add_text(self, key, value, zip=False):
         """Appends a text chunk.
 
         :param key: latin-1 encodable text key name
@@ -259,14 +259,14 @@ class PngInfo(object):
 
         """
         if isinstance(value, iTXt):
-            return self.add_itxt(key, value, value.lang, value.tkey, bool(zip))
+            return self.add_itxt(key, value, value.lang, value.tkey, zip=zip)
 
         # The tEXt chunk stores latin-1 text
         if not isinstance(value, bytes):
             try:
                 value = value.encode('latin-1', 'strict')
             except UnicodeError:
-                return self.add_itxt(key, value, zip=bool(zip))
+                return self.add_itxt(key, value, zip=zip)
 
         if not isinstance(key, bytes):
             key = key.encode('latin-1', 'strict')

--- a/Tests/check_png_dos.py
+++ b/Tests/check_png_dos.py
@@ -41,7 +41,7 @@ class TestPngDos(PillowTestCase):
         info = PngImagePlugin.PngInfo()
 
         for x in range(64):
-            info.add_text('t%s' % x, compressed_data, 1)
+            info.add_text('t%s' % x, compressed_data, zip=True)
             info.add_itxt('i%s' % x, compressed_data, zip=True)
 
         b = BytesIO()

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -360,7 +360,7 @@ class TestFilePng(PillowTestCase):
 
         info = PngImagePlugin.PngInfo()
         info.add_text("TXT", "VALUE")
-        info.add_text("ZIP", "VALUE", 1)
+        info.add_text("ZIP", "VALUE", zip=True)
 
         im = roundtrip(im, pnginfo=info)
         self.assertEqual(im.info, {'TXT': 'VALUE', 'ZIP': 'VALUE'})


### PR DESCRIPTION
Always used as a `bool`, but was previously defined as 0/1. Use modern idiomatic Python by using the `bool` type for `bool` arguments.

