### PR TITLE
Remove unnecessary bool() calls throughout project

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -2753,7 +2753,7 @@ def registered_extensions():
     Returns a dictionary containing all file extensions belonging
     to registered plugins
     """
-    if not bool(EXTENSION):
+    if not EXTENSION:
         init()
     return EXTENSION
 

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -165,7 +165,7 @@ class PillowTestCase(unittest.TestCase):
                          travis=None, interpreter=None):
         # Skip if platform/travis matches, and
         # PILLOW_RUN_KNOWN_BAD is not true in the environment.
-        if bool(os.environ.get('PILLOW_RUN_KNOWN_BAD', False)):
+        if os.environ.get('PILLOW_RUN_KNOWN_BAD', False):
             print(os.environ.get('PILLOW_RUN_KNOWN_BAD', False))
             return
 

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -312,7 +312,7 @@ class TestImage(PillowTestCase):
         extensions = Image.registered_extensions()
 
         # Assert
-        self.assertTrue(bool(extensions))
+        self.assertTrue(extensions)
         for ext in ['.cur', '.icns', '.tif', '.tiff']:
             self.assertIn(ext, extensions)
 


### PR DESCRIPTION
Can use truthy values in boolean expressions without first coercing to a `bool`. Removes unnecessary calls to `bool()`.