### PR TITLE
Test: avoid random noise failure

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -100,7 +100,7 @@ class PillowTestCase(unittest.TestCase):
                     logger.error("Url for test images: %s" %url)
                 except:
                     pass
-                    
+
             self.fail(msg or "got different content")
 
     def assert_image_similar(self, a, b, epsilon, msg=None):
@@ -161,6 +161,12 @@ class PillowTestCase(unittest.TestCase):
                 self.assertTrue(found)
         return result
 
+    def assert_all_same(self, items, msg=None):
+        self.assertTrue(items.count(items[0]) == len(items), msg)
+
+    def assert_not_all_same(self, items, msg=None):
+        self.assertFalse(items.count(items[0]) == len(items), msg)
+
     def skipKnownBadTest(self, msg=None, platform=None,
                          travis=None, interpreter=None):
         # Skip if platform/travis matches, and
@@ -206,7 +212,7 @@ class PillowLeakTestCase(PillowTestCase):
     # requires unix/osx
     iterations = 100 # count
     mem_limit = 512 # k
-    
+
     def _get_mem_usage(self):
         """
         Gets the RUSAGE memory usage, returns in K. Encapsulates the difference
@@ -214,7 +220,7 @@ class PillowLeakTestCase(PillowTestCase):
 
         :returns; memory usage in kilobytes
         """
-        
+
         from resource import getpagesize, getrusage, RUSAGE_SELF
         mem = getrusage(RUSAGE_SELF).ru_maxrss
         if sys.platform == 'darwin':
@@ -225,7 +231,7 @@ class PillowLeakTestCase(PillowTestCase):
             # linux
             # man 2 getrusage
             #        ru_maxrss (since Linux 2.6.32)
-            #  This is the maximum resident set size used (in  kilobytes). 
+            #  This is the maximum resident set size used (in  kilobytes).
             return mem # Kb
 
     def _test_leak(self, core):

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -20,6 +20,7 @@ try:
 except ImportError:
     pass
 
+
 def convert_to_comparable(a, b):
     new_a, new_b = a, b
     if a.mode == 'P':
@@ -97,7 +98,7 @@ class PillowTestCase(unittest.TestCase):
             if HAS_UPLOADER:
                 try:
                     url = test_image_results.upload(a, b)
-                    logger.error("Url for test images: %s" %url)
+                    logger.error("Url for test images: %s" % url)
                 except:
                     pass
 
@@ -130,7 +131,7 @@ class PillowTestCase(unittest.TestCase):
             if HAS_UPLOADER:
                 try:
                     url = test_image_results.upload(a, b)
-                    logger.error("Url for test images: %s" %url)
+                    logger.error("Url for test images: %s" % url)
                 except:
                     pass
             raise e
@@ -207,11 +208,12 @@ class PillowTestCase(unittest.TestCase):
             return Image.open(outfile)
         raise IOError()
 
+
 @unittest.skipIf(sys.platform.startswith('win32'), "requires Unix or MacOS")
 class PillowLeakTestCase(PillowTestCase):
     # requires unix/osx
-    iterations = 100 # count
-    mem_limit = 512 # k
+    iterations = 100  # count
+    mem_limit = 512  # k
 
     def _get_mem_usage(self):
         """
@@ -221,7 +223,7 @@ class PillowLeakTestCase(PillowTestCase):
         :returns; memory usage in kilobytes
         """
 
-        from resource import getpagesize, getrusage, RUSAGE_SELF
+        from resource import getrusage, RUSAGE_SELF
         mem = getrusage(RUSAGE_SELF).ru_maxrss
         if sys.platform == 'darwin':
             # man 2 getrusage:
@@ -314,6 +316,7 @@ def imagemagick_available():
 
 def on_appveyor():
     return 'APPVEYOR' in os.environ
+
 
 if sys.platform == 'win32':
     IMCONVERT = os.environ.get('MAGICK_HOME', '')

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -348,24 +348,19 @@ class TestImage(PillowTestCase):
         # Arrange
         size = (100, 100)
         sigma = 128
-        # To reduce chance of randomly having the same value twice
-        attempts = 5
 
         # Act
-        while attempts > 0:
-            im = Image.effect_noise(size, sigma)
+        im = Image.effect_noise(size, sigma)
 
-            # Assert
-            self.assertEqual(im.size, (100, 100))
-            self.assertEqual(im.mode, "L")
-            p0 = im.getpixel((0, 0))
-            p1 = im.getpixel((0, 1))
-            if p0 == p1:
-                # Let's roll again
-                attempts -= 1
-            else:
-                break
-        self.assertNotEqual(p0, p1)
+        # Assert
+        self.assertEqual(im.size, (100, 100))
+        self.assertEqual(im.mode, "L")
+        p0 = im.getpixel((0, 0))
+        p1 = im.getpixel((0, 1))
+        p2 = im.getpixel((0, 2))
+        p3 = im.getpixel((0, 3))
+        p4 = im.getpixel((0, 4))
+        self.assert_not_all_same([p0, p1, p2, p3, p4])
 
     def test_effect_spread(self):
         # Arrange

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -22,7 +22,7 @@ class TestImage(PillowTestCase):
             'BGR;15', 'BGR;16', 'BGR;24', 'BGR;32'
         ]:
             with self.assertRaises(ValueError) as e:
-                Image.new(mode, (1, 1));
+                Image.new(mode, (1, 1))
             self.assertEqual(str(e.exception), 'unrecognized image mode')
 
     def test_sanity(self):
@@ -236,9 +236,9 @@ class TestImage(PillowTestCase):
         self.assertEqual(img_colors, expected_colors)
 
     def test_alpha_inplace(self):
-        src = Image.new('RGBA', (128,128), 'blue')
+        src = Image.new('RGBA', (128, 128), 'blue')
 
-        over = Image.new('RGBA', (128,128), 'red')
+        over = Image.new('RGBA', (128, 128), 'red')
         mask = hopper('L')
         over.putalpha(mask)
 
@@ -275,17 +275,18 @@ class TestImage(PillowTestCase):
 
         # errors
         self.assertRaises(ValueError,
-            source.alpha_composite, over, "invalid source")
+                          source.alpha_composite, over, "invalid source")
         self.assertRaises(ValueError,
-            source.alpha_composite, over, (0, 0), "invalid destination")
+                          source.alpha_composite, over, (0, 0),
+                          "invalid destination")
         self.assertRaises(ValueError,
-            source.alpha_composite, over, (0))
+                          source.alpha_composite, over, (0))
         self.assertRaises(ValueError,
-            source.alpha_composite, over, (0, 0), (0))
+                          source.alpha_composite, over, (0, 0), (0))
         self.assertRaises(ValueError,
-            source.alpha_composite, over, (0, -1))
+                          source.alpha_composite, over, (0, -1))
         self.assertRaises(ValueError,
-            source.alpha_composite, over, (0, 0), (0, -1))
+                          source.alpha_composite, over, (0, 0), (0, -1))
 
     def test_registered_extensions_uninitialized(self):
         # Arrange
@@ -500,8 +501,8 @@ class TestImage(PillowTestCase):
         im = hopper('RGB')
         im_p = hopper('P')
 
-        blank_p = Image.new('P', (10,10))
-        blank_pa = Image.new('PA', (10,10))
+        blank_p = Image.new('P', (10, 10))
+        blank_pa = Image.new('PA', (10, 10))
         blank_p.palette = None
         blank_pa.palette = None
 

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -347,14 +347,24 @@ class TestImage(PillowTestCase):
         # Arrange
         size = (100, 100)
         sigma = 128
+        # To reduce chance of randomly having the same value twice
+        attempts = 5
 
         # Act
-        im = Image.effect_noise(size, sigma)
+        while attempts > 0:
+            im = Image.effect_noise(size, sigma)
 
-        # Assert
-        self.assertEqual(im.size, (100, 100))
-        self.assertEqual(im.mode, "L")
-        self.assertNotEqual(im.getpixel((0, 0)), im.getpixel((0, 1)))
+            # Assert
+            self.assertEqual(im.size, (100, 100))
+            self.assertEqual(im.mode, "L")
+            p0 = im.getpixel((0, 0))
+            p1 = im.getpixel((0, 1))
+            if p0 == p1:
+                # Let's roll again
+                attempts -= 1
+            else:
+                break
+        self.assertNotEqual(p0, p1)
 
     def test_effect_spread(self):
         # Arrange


### PR DESCRIPTION
Just occasionally (e.g. the [last master build](https://travis-ci.org/python-pillow/Pillow/jobs/318081653#L3650)) `test_effect_noise` will fail because the random noise will put the same value in these pixels:

```python
self.assertNotEqual(im.getpixel((0, 0)), im.getpixel((0, 1)))
```


Changes proposed in this pull request:

 * Roll again if we get the same value, 5 attempts 
 * flake8

(The randomness comes from libImaging/Effects.c. If it were Python code we could do `from random import Random; random = Random(1538)`.)