### PR TITLE
Don't test on EOL Fedora 25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ matrix:
     - env: DOCKER="centos-7-amd64"
     - env: DOCKER="amazon-1-amd64"
     - env: DOCKER="amazon-2-amd64"
-    - env: DOCKER="fedora-25-amd64"
     - env: DOCKER="fedora-26-amd64"
     - env: DOCKER="fedora-27-amd64"
 


### PR DESCRIPTION
Fedora 25 went EOL on 2017-12-12:

![image](https://user-images.githubusercontent.com/1324225/34194881-96b60e4a-e563-11e7-90fb-666e237a5f31.png)

As of https://github.com/python-pillow/Pillow/pull/2895 we now test on all the supported Fedora versions (26 and 27).