### PR TITLE
Scripts no longer part of this package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,7 +9,6 @@ include *.sh
 include *.txt
 include LICENSE
 include Makefile
-graft Scripts
 graft Tests
 graft PIL
 graft Tk


### PR DESCRIPTION
Since https://github.com/python-pillow/Pillow/pull/2901, Scripts now live in their own repo at https://github.com/python-pillow/pillow-scripts.