### PR TITLE
Changed documentation references to 2.x to 2.7

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Please send a pull request to the master branch. Please include [documentation](
 - Fork the Pillow repository.
 - Create a branch from master.
 - Develop bug fixes, features, tests, etc.
-- Run the test suite on both Python 2.x and 3.x. You can enable [Travis CI](https://travis-ci.org/profile/) and [AppVeyor](https://ci.appveyor.com/projects/new) on your repo to catch test failures prior to the pull request, and [Coveralls](https://coveralls.io/repos/new) to see if the changed code is covered by tests.
+- Run the test suite on Python 2.7 and 3.x. You can enable [Travis CI](https://travis-ci.org/profile/) and [AppVeyor](https://ci.appveyor.com/projects/new) on your repo to catch test failures prior to the pull request, and [Coveralls](https://coveralls.io/repos/new) to see if the changed code is covered by tests.
 - Create a pull request to pull the changes from your branch to the Pillow master.
 
 ### Guidelines

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -88,7 +88,7 @@ Pillow can be installed on FreeBSD via the official Ports or Packages systems:
     The `Pillow FreeBSD port
     <https://www.freshports.org/graphics/py-pillow/>`_ and packages
     are tested by the ports team with all supported FreeBSD versions
-    and against Python 2.x and 3.x.
+    and against Python 2.7 and 3.x.
 
 
 Building From Source


### PR DESCRIPTION
Suggesting this as a way of making it clearer that Python 2.6 is no longer supported.