### PR TITLE
Fix path detection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -367,7 +367,7 @@ class pil_build_ext(build_ext):
                     }
 
                 for platform_ in arch_tp:
-                    dirs = libdirs.get(platform_, None)
+                    dirs = libdirs.get(platform_, libdirs)
                     if not platform_:
                         continue
                     for path in dirs:


### PR DESCRIPTION
Sorry for not following contributing guidance.
When I build Pillow 5.0.0, I get `TypeError: 'NoneType' object is not iterable` in `setup.py` in line 373. I checked that `dirs = libdirs.get(platform_, None)` didn't get library path for me, so `path` is `None`,  then the error occurs. This PR will fix it. 