### PR TITLE
Docs: Escape the s next to inline code formatting

### DIFF
--- a/docs/releasenotes/5.0.0.rst
+++ b/docs/releasenotes/5.0.0.rst
@@ -17,7 +17,7 @@ Decompression Bombs now raise Exceptions
 
 Pillow has previously emitted warnings for images that are
 unexpectedly large and may be a denial of service. These warnings are
-now upgraded to ``DecompressionBombError``s for images that are twice
+now upgraded to ``DecompressionBombError``\s for images that are twice
 the size of images that trigger the ``DecompressionBombWarning``. The
 default threshold is 128Mpx, or 0.5GB for an ``RGB`` or ``RGBA``
 image. This can be disabled or changed by setting


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/1324225/34565304-fbde9e3a-f162-11e7-80b8-373ac48cdf72.png)


After:

![image](https://user-images.githubusercontent.com/1324225/34565255-cbdf6174-f162-11e7-86ab-e09a1c74e4e5.png)

Ref:

http://www.sphinx-doc.org/en/stable/rest.html#inline-markup
