### PR TITLE
Geometry: affine_fixed breaks Minecraft Overviewer since Pillow 3.4.0

### DIFF
--- a/src/libImaging/Geometry.c
+++ b/src/libImaging/Geometry.c
@@ -862,10 +862,8 @@ affine_fixed(Imaging imOut, Imaging imIn,
 /* use 16.16 fixed point arithmetics */
 #define FIX(v) FLOOR((v)*65536.0 + 0.5)
 
-    a0 = FIX(a[0]); a1 = FIX(a[1]);
-    a3 = FIX(a[3]); a4 = FIX(a[4]);
-    a2 = FIX(a[2] + a[0] * 0.5 + a[1] * 0.5);
-    a5 = FIX(a[5] + a[3] * 0.5 + a[4] * 0.5);
+    a0 = FIX(a[0]); a1 = FIX(a[1]); a2 = FIX(a[2]);
+    a3 = FIX(a[3]); a4 = FIX(a[4]); a5 = FIX(a[5]);
 
 #undef FIX
 


### PR DESCRIPTION
Commit 5232361718bae0f0ccda76bfd5b390ebf9179b18 introduced changes to the affine_fixed function
which lead to Minecraft Overviewer issue https://github.com/overviewer/Minecraft-Overviewer/issues/1370

This patch reverts the change.

Not sure if this is the right fix in terms of the original patch, but I wanted to point it out. so a proper fix can be discussed.