### PR TITLE
Remove redundant travis_after_all stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,29 +61,3 @@ script:
 
 after_success:
   - .travis/after_success.sh
-
-after_failure:
-  - |
-      if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-        curl -Lo travis_after_all.py https://raw.github.com/dmakhno/travis_after_all/master/travis_after_all.py
-        python travis_after_all.py
-        export $(cat .to_export_back)
-        if [ "$BUILD_LEADER" = "YES" ]; then
-          if [ "$BUILD_AGGREGATE_STATUS" = "others_failed" ]; then
-            echo "All jobs failed"
-          else
-            echo "Some jobs failed"
-          fi
-        fi
-      fi
-
-after_script:
-  - |
-      if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-        echo leader=$BUILD_LEADER status=$BUILD_AGGREGATE_STATUS
-      fi
-
-env:
-  global:
-    # travis encrypt AUTH_TOKEN=
-    secure: "Vzm7aG1Qv0SDQcqiPzZMedNLn5ZmpL7IzF0DYnqcD+/l+zmKU22SnJBcX0uVXumo+r7eZfpsShpqfcdsZvMlvmQnwz+Y6AGKQru9tCKZbTMnuRjWKKXekC+tr8Xt9CKvRVtte5PyXW31paxUI3/e+fQGBwoFjEEC+6EpEOjeRfE="

--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -30,20 +30,3 @@ if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ] && [ "$DOCKER" == "" ]; then
     depends/diffcover-install.sh
     depends/diffcover-run.sh
 fi
-
-# after_all
-
-if [ "$TRAVIS_REPO_SLUG" = "python-pillow/Pillow" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-    curl -Lo travis_after_all.py https://raw.github.com/dmakhno/travis_after_all/master/travis_after_all.py
-    python travis_after_all.py
-    export $(cat .to_export_back)
-    if [ "$BUILD_LEADER" = "YES" ]; then
-        if [ "$BUILD_AGGREGATE_STATUS" = "others_succeeded" ]; then
-            echo "All jobs succeeded! Triggering macOS build..."
-            # Trigger a macOS build at the pillow-wheels repo
-            ./build_children.sh
-        else
-            echo "Some jobs failed"
-        fi
-    fi
-fi

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -24,7 +24,6 @@ exclude .editorconfig
 exclude .landscape.yaml
 exclude .travis
 exclude .travis/*
-exclude build_children.sh
 exclude tox.ini
 global-exclude .git*
 global-exclude *.pyc

--- a/build_children.sh
+++ b/build_children.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Get last child project build number from branch named "latest"
-BUILD_NUM=$(curl -s 'https://api.travis-ci.org/repos/python-pillow/pillow-wheels/branches/latest' | grep -o '^{"branch":{"id":[0-9]*,' | grep -o '[0-9]' | tr -d '\n')
-
-# Restart last child project build
-curl -X POST https://api.travis-ci.org/builds/$BUILD_NUM/restart --header "Authorization: token "$AUTH_TOKEN


### PR DESCRIPTION
The stuff done in https://github.com/python-pillow/Pillow/pull/1067 to trigger a python-pillow/pillow-wheels build after a successful python-pillow/Pillow (non-PR, master) build hasn't been working for quite some time.

Let's just remove it.

* [x] I will also delete the old, unused branch named "[latest](https://github.com/python-pillow/pillow-wheels/tree/latest)" from pillow-wheels.

Instead, I propose we enable a [cron job](https://docs.travis-ci.com/user/cron-jobs/) on pillow-wheels.

How about daily, but not if there's been a build in the last 24h?

![image](https://user-images.githubusercontent.com/1324225/35411873-10eaa64a-0223-11e8-9cc0-56d26141c823.png)

![image](https://user-images.githubusercontent.com/1324225/35411897-2934f26e-0223-11e8-8e68-687cb3ab3b1f.png)
