### PR TITLE
Rearranged classes into alphabetical order

### DIFF
--- a/docs/reference/ImageFilter.rst
+++ b/docs/reference/ImageFilter.rst
@@ -33,9 +33,9 @@ image enhancement filters:
 * **EDGE_ENHANCE_MORE**
 * **EMBOSS**
 * **FIND_EDGES**
+* **SHARPEN**
 * **SMOOTH**
 * **SMOOTH_MORE**
-* **SHARPEN**
 
 .. autoclass:: PIL.ImageFilter.GaussianBlur
 .. autoclass:: PIL.ImageFilter.BoxBlur

--- a/src/PIL/ImageFilter.py
+++ b/src/PIL/ImageFilter.py
@@ -270,6 +270,15 @@ class FIND_EDGES(BuiltinFilter):
         )
 
 
+class SHARPEN(BuiltinFilter):
+    name = "Sharpen"
+    filterargs = (3, 3), 16, 0, (
+        -2, -2, -2,
+        -2, 32, -2,
+        -2, -2, -2
+        )
+
+
 class SMOOTH(BuiltinFilter):
     name = "Smooth"
     filterargs = (3, 3), 13, 0, (
@@ -287,13 +296,4 @@ class SMOOTH_MORE(BuiltinFilter):
         1,  5, 44,  5,  1,
         1,  5,  5,  5,  1,
         1,  1,  1,  1,  1
-        )
-
-
-class SHARPEN(BuiltinFilter):
-    name = "Sharpen"
-    filterargs = (3, 3), 16, 0, (
-        -2, -2, -2,
-        -2, 32, -2,
-        -2, -2, -2
         )


### PR DESCRIPTION
Apart from `ImageFilter.SHARPEN`, the `BuiltinFilter` classes are in alphabetical order. Moving this one class resolves that.