### PR TITLE
Updating the function name at line 1829

### DIFF
--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1826,6 +1826,6 @@ Image.register_open(TiffImageFile.format, TiffImageFile, _accept)
 Image.register_save(TiffImageFile.format, _save)
 Image.register_save_all(TiffImageFile.format, _save_all)
 
-Image.register_extensions(TiffImageFile.format, [".tif", ".tiff"])
+Image.register_extension(TiffImageFile.format, [".tif", ".tiff"])
 
 Image.register_mime(TiffImageFile.format, "image/tiff")


### PR DESCRIPTION
I am requesting to update the function name from `register_extensions()` to `register_extension()`. There is a small typo.
Using [Nullege](http://nullege.com/)
If we search for [register_extensions](http://nullege.com/pages/noresult/PIL.Image.register_extensions) we get nothing
But, if we search fro [register_extension](http://nullege.com/codes/search?cq=PIL.Image.register_extension) it is present.

Fixes # .

Changes proposed in this pull request:

 * Fixing the typo at line no. 1829 in file src/PIL/TiffImagePlugin.py.
