### PR TITLE
Fix "invalid escape sequence" warning on Python 3.6+

### DIFF
--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -777,7 +777,7 @@ def getdata(im, offset=(0, 0), **params):
 
     :param im: Image object
     :param offset: Tuple of (x, y) pixels. Defaults to (0,0)
-    :param \**params: E.g. duration or other encoder info parameters
+    :param \\**params: E.g. duration or other encoder info parameters
     :returns: List of Bytes containing gif encoded frame data
 
     """


### PR DESCRIPTION
Follow up to 505eb799. Tested by building docs and checking output doesn't changed.