### PR TITLE
Simplify version checks

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -265,7 +265,7 @@ class PillowLeakTestCase(PillowTestCase):
 
 # helpers
 
-py3 = (sys.version_info >= (3, 0))
+py3 = sys.version_info.major >= 3
 
 
 def fromstring(data):

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -379,7 +379,7 @@ def _save(im, fp, filename, eps=1):
     base_fp = fp
     if fp != sys.stdout:
         fp = NoCloseStream(fp)
-        if sys.version_info[0] > 2:
+        if sys.version_info.major > 2:
             fp = io.TextIOWrapper(fp, encoding='latin-1')
 
     if eps:

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -584,7 +584,7 @@ class Image(object):
         # object is gone.
         self.im = deferred_error(ValueError("Operation on closed image"))
 
-    if sys.version_info >= (3, 4, 0):
+    if sys.version_info.major >= 3:
         def __del__(self):
             if (hasattr(self, 'fp') and hasattr(self, '_exclusive_fp')
                and self.fp and self._exclusive_fp):

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -18,7 +18,7 @@ from PIL import Image
 import os
 import sys
 
-if sys.version_info >= (3, 3):
+if sys.version_info.major >= 3:
     from shlex import quote
 else:
     from pipes import quote

--- a/src/PIL/ImageTk.py
+++ b/src/PIL/ImageTk.py
@@ -27,7 +27,7 @@
 
 import sys
 
-if sys.version_info[0] > 2:
+if sys.version_info.major > 2:
     import tkinter
 else:
     import Tkinter as tkinter

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -653,7 +653,7 @@ class ImageFileDirectory_v2(collections.MutableMapping):
     @_register_writer(2)
     def write_string(self, value):
         # remerge of https://github.com/python-pillow/Pillow/pull/1416
-        if sys.version_info[0] == 2:
+        if sys.version_info.major == 2:
             value = value.decode('ascii', 'replace')
         return b"" + value.encode('ascii', 'replace') + b"\0"
 

--- a/src/PIL/_tkinter_finder.py
+++ b/src/PIL/_tkinter_finder.py
@@ -2,7 +2,7 @@
 """
 import sys
 
-if sys.version_info[0] > 2:
+if sys.version_info.major > 2:
     from tkinter import _tkinter as tk
 else:
     from Tkinter import tkinter as tk


### PR DESCRIPTION
* Named version attributes are available from Python 2.7+.

* Because 3.4 is our minimum supported 3.x, we can simplify these:
  * `sys.version_info >= (3, 4, 0)`
  * `sys.version_info >= (3, 3)`
* Into:
  * `sys.version_info.major >= 3`
