### PR TITLE
Corrected winbuild documentation

### DIFF
--- a/winbuild/README.md
+++ b/winbuild/README.md
@@ -1,7 +1,7 @@
 Quick README
 ------------
 
-For more extensive info, see the Windows build instructions `winbuild/build.rst`.
+For more extensive info, see the [Windows build instructions](build.rst).
 
 * See https://github.com/python-pillow/Pillow/issues/553#issuecomment-37877416 and https://github.com/matplotlib/matplotlib/issues/1717#issuecomment-13343859
 

--- a/winbuild/README.md
+++ b/winbuild/README.md
@@ -1,7 +1,7 @@
 Quick README
 ------------
 
-For more extensive info, see the Windows build instructions `docs/build.rst`.
+For more extensive info, see the Windows build instructions `winbuild/build.rst`.
 
 * See https://github.com/python-pillow/Pillow/issues/553#issuecomment-37877416 and https://github.com/matplotlib/matplotlib/issues/1717#issuecomment-13343859
 

--- a/winbuild/build.rst
+++ b/winbuild/build.rst
@@ -1,8 +1,9 @@
 Building Pillow on Windows
 ==========================
 
-.. note:: For most people, the :doc:`installation instructions
-          <installation>` should be sufficient
+.. note:: For most people, the `installation instructions
+          <../docs/installation.rst#windows-installation>`_ should
+          be sufficient.
 
 This page will describe a build setup to build Pillow against the
 supported Python versions in 32 and 64-bit modes, using freely


### PR DESCRIPTION
Changed `docs/build.rst` to `winbuild/build.rst`, to better point towards https://github.com/python-pillow/Pillow/blob/master/winbuild/build.rst