### PR TITLE
Allow append_images to set .icns scaled images

### DIFF
--- a/Tests/check_imaging_leaks.py
+++ b/Tests/check_imaging_leaks.py
@@ -9,7 +9,7 @@ min_iterations = 100
 max_iterations = 10000
 
 
-@unittest.skipIf(sys.platform.startswith('win32'), "requires Unix or MacOS")
+@unittest.skipIf(sys.platform.startswith('win32'), "requires Unix or macOS")
 class TestImagingLeaks(PillowTestCase):
 
     def _get_mem_usage(self):

--- a/Tests/check_j2k_leaks.py
+++ b/Tests/check_j2k_leaks.py
@@ -11,7 +11,7 @@ codecs = dir(Image.core)
 test_file = "Tests/images/rgb_trns_ycbc.jp2"
 
 
-@unittest.skipIf(sys.platform.startswith('win32'), "requires Unix or MacOS")
+@unittest.skipIf(sys.platform.startswith('win32'), "requires Unix or macOS")
 class TestJpegLeaks(PillowTestCase):
     def setUp(self):
         if "jpeg2k_encoder" not in codecs or "jpeg2k_decoder" not in codecs:

--- a/Tests/check_jpeg_leaks.py
+++ b/Tests/check_jpeg_leaks.py
@@ -15,7 +15,7 @@ NOSE_PROCESSES=0 NOSE_TIMEOUT=600 valgrind --tool=massif \
 """
 
 
-@unittest.skipIf(sys.platform.startswith('win32'), "requires Unix or MacOS")
+@unittest.skipIf(sys.platform.startswith('win32'), "requires Unix or macOS")
 class TestJpegLeaks(PillowTestCase):
 
     """

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -227,7 +227,7 @@ class PillowTestCase(unittest.TestCase):
         raise IOError()
 
 
-@unittest.skipIf(sys.platform.startswith('win32'), "requires Unix or MacOS")
+@unittest.skipIf(sys.platform.startswith('win32'), "requires Unix or macOS")
 class PillowLeakTestCase(PillowTestCase):
     # requires unix/osx
     iterations = 100  # count

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -22,7 +22,7 @@ class TestFileIcns(PillowTestCase):
         self.assertEqual(im.size, (1024, 1024))
         self.assertEqual(im.format, "ICNS")
 
-    @unittest.skipIf(sys.platform != 'darwin', "requires MacOS")
+    @unittest.skipIf(sys.platform != 'darwin', "requires macOS")
     def test_save(self):
         im = Image.open(TEST_FILE)
 
@@ -35,7 +35,7 @@ class TestFileIcns(PillowTestCase):
         self.assertEqual(reread.size, (1024, 1024))
         self.assertEqual(reread.format, "ICNS")
 
-    @unittest.skipIf(sys.platform != 'darwin', "requires MacOS")
+    @unittest.skipIf(sys.platform != 'darwin', "requires macOS")
     def test_save_append_images(self):
         im = Image.open(TEST_FILE)
 

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -22,8 +22,7 @@ class TestFileIcns(PillowTestCase):
         self.assertEqual(im.size, (1024, 1024))
         self.assertEqual(im.format, "ICNS")
 
-    @unittest.skipIf(sys.platform != 'darwin',
-                     "requires MacOS")
+    @unittest.skipIf(sys.platform != 'darwin', "requires MacOS")
     def test_save(self):
         im = Image.open(TEST_FILE)
 
@@ -35,6 +34,22 @@ class TestFileIcns(PillowTestCase):
         self.assertEqual(reread.mode, "RGBA")
         self.assertEqual(reread.size, (1024, 1024))
         self.assertEqual(reread.format, "ICNS")
+
+    @unittest.skipIf(sys.platform != 'darwin', "requires MacOS")
+    def test_save_append_images(self):
+        im = Image.open(TEST_FILE)
+
+        temp_file = self.tempfile("temp.icns")
+        provided_im = Image.new('RGBA', (32, 32), (255, 0, 0, 0))
+        im.save(temp_file, append_images=[provided_im])
+
+        reread = Image.open(temp_file)
+        self.assert_image_equal(reread, im)
+
+        reread = Image.open(temp_file)
+        reread.size = (16, 16, 2)
+        reread.load()
+        self.assert_image_equal(reread, provided_im)
 
     def test_sizes(self):
         # Check that we can load all of the sizes, and that the final pixel

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -540,7 +540,7 @@ class TestFilePng(PillowTestCase):
         self.assertEqual(len(chunks), 3)
 
 
-@unittest.skipIf(sys.platform.startswith('win32'), "requires Unix or MacOS")
+@unittest.skipIf(sys.platform.startswith('win32'), "requires Unix or macOS")
 class TestTruncatedPngPLeaks(PillowLeakTestCase):
     mem_limit = 2*1024  # max increase in K
     iterations = 100  # Leak is 56k/iteration, this will leak 5.6megs

--- a/Tests/test_font_leaks.py
+++ b/Tests/test_font_leaks.py
@@ -4,7 +4,7 @@ import sys
 from PIL import Image, features, ImageDraw, ImageFont
 
 
-@unittest.skipIf(sys.platform.startswith('win32'), "requires Unix or MacOS")
+@unittest.skipIf(sys.platform.startswith('win32'), "requires Unix or macOS")
 class TestTTypeFontLeak(PillowLeakTestCase):
     # fails at iteration 3 in master
     iterations = 10

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -437,7 +437,7 @@ class TestImageFont(PillowTestCase):
                 self.assertEqual(('FreeMono', 'Regular'), name)
 
     @unittest.skipIf(sys.platform.startswith('win32'),
-                     "requires Unix or MacOS")
+                     "requires Unix or macOS")
     def test_find_linux_font(self):
         # A lot of mocking here - this is more for hitting code and
         # catching syntax like errors
@@ -471,7 +471,7 @@ class TestImageFont(PillowTestCase):
                         font_directory+'/Duplicate.ttf', 'Duplicate')
 
     @unittest.skipIf(sys.platform.startswith('win32'),
-                     "requires Unix or MacOS")
+                     "requires Unix or macOS")
     def test_find_macos_font(self):
         # Like the linux test, more cover hitting code rather than testing
         # correctness.

--- a/Tests/test_shell_injection.py
+++ b/Tests/test_shell_injection.py
@@ -18,7 +18,7 @@ test_filenames = (
 )
 
 
-@unittest.skipIf(sys.platform.startswith('win32'), "requires Unix or MacOS")
+@unittest.skipIf(sys.platform.startswith('win32'), "requires Unix or macOS")
 class TestShellInjection(PillowTestCase):
 
     def assert_save_filename_check(self, src_img, save_func):

--- a/src/PIL/IcnsImagePlugin.py
+++ b/src/PIL/IcnsImagePlugin.py
@@ -310,6 +310,8 @@ def _save(im, fp, filename):
 
     # create the temporary set of pngs
     iconset = tempfile.mkdtemp('.iconset')
+    provided_images = {im.width:im for im in
+                       im.encoderinfo.get("append_images", [])}
     last_w = None
     for w in [16, 32, 128, 256, 512]:
         prefix = 'icon_{}x{}'.format(w, w)
@@ -318,10 +320,12 @@ def _save(im, fp, filename):
         if last_w == w:
             shutil.copyfile(second_path, first_path)
         else:
-            im.resize((w, w), Image.LANCZOS).save(first_path)
+            im_w = provided_images.get(w, im.resize((w, w), Image.LANCZOS))
+            im_w.save(first_path)
 
         second_path = os.path.join(iconset, prefix+'@2x.png')
-        im.resize((w*2, w*2), Image.LANCZOS).save(second_path)
+        im_w2 = provided_images.get(w*2, im.resize((w*2, w*2), Image.LANCZOS))
+        im_w2.save(second_path)
         last_w = w*2
 
     # iconutil -c icns -o {} {}


### PR DESCRIPTION
Suggestion for #2513 

To set the scaled images within `.icns`, include them in an `append_images` parameter, to match with the `save_all` functionality of other formats. The order of the images does not matter - which image is which can determined by their size.