### PR TITLE
Enable pip cache in appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,6 +82,9 @@ after_test:
 matrix:
   fast_finish: true
 
+cache:
+- '%LOCALAPPDATA%\pip\Cache'
+
 artifacts:
 - path: pillow\dist\*.egg
   name: egg


### PR DESCRIPTION
Enable pip cache in the appveyor build so packages are cached.