### PR TITLE
Docs: Move intro text below its header

### DIFF
--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -12,12 +12,12 @@ images.
 Examples
 --------
 
+Open, rotate, and display an image (using the default viewer)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 The following script loads an image, rotates it 45 degrees, and displays it
 using an external viewer (usually xv on Unix, and the paint program on
 Windows).
-
-Open, rotate, and display an image (using the default viewer)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: python
 
@@ -25,11 +25,11 @@ Open, rotate, and display an image (using the default viewer)
     im = Image.open("bride.jpg")
     im.rotate(45).show()
 
-The following script creates nice thumbnails of all JPEG images in the
-current directory preserving aspect ratios with 128x128 max resolution.
-
 Create thumbnails
 ^^^^^^^^^^^^^^^^^
+
+The following script creates nice thumbnails of all JPEG images in the
+current directory preserving aspect ratios with 128x128 max resolution.
 
 .. code-block:: python
 


### PR DESCRIPTION
Allows hotlinking to include relevant intro:
https://pillow.readthedocs.io/en/latest/reference/Image.html#create-thumbnails

## Before

![image](https://user-images.githubusercontent.com/1324225/36788481-b507993a-1c96-11e8-96d3-853600278692.png)

## After

![image](https://user-images.githubusercontent.com/1324225/36788509-dcb6b9ca-1c96-11e8-82c6-7bde590f4bdd.png)
