### PR TITLE
Fix TypeError for JPEG2000 parser feed

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -176,6 +176,19 @@ class TestFileJpeg2k(PillowTestCase):
         with self.assertRaises(IOError):
             Image.open('Tests/images/unbound_variable.jp2')
 
+    def test_parser_feed(self):
+        # Arrange
+        from PIL import ImageFile
+        with open('Tests/images/test-card-lossless.jp2', 'rb') as f:
+            data = f.read()
+
+        # Act
+        p = ImageFile.Parser()
+        p.feed(data)
+
+        # Assert
+        self.assertEqual(p.image.size, (640, 480))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -192,7 +192,7 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
                 length = -1
 
         self.tile = [('jpeg2k', (0, 0) + self.size, 0,
-                      (self.codec, self.reduce, self.layers, fd, length, self.fp))]
+                      (self.codec, self.reduce, self.layers, fd, length))]
 
     def load(self):
         if self.reduce:


### PR DESCRIPTION
Fixes #3006, see https://github.com/python-pillow/Pillow/issues/3006#issuecomment-373359618 for details.

Note: adding `p.image.show()` shows just a blank image, whereas this shows the test card:

```python
from PIL import Image
im = Image.open('Tests/images/test-card-lossless.jp2')
im.show()
```
However, this is also the case in Python 3.2.0 and so another issue.
