### PR TITLE
Updated URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -763,7 +763,7 @@ try:
           long_description=_read('README.rst').decode('utf-8'),
           author='Alex Clark (Fork Author)',
           author_email='aclark@aclark.net',
-          url='https://python-pillow.org',
+          url='http://python-pillow.org',
           classifiers=[
               "Development Status :: 6 - Mature",
               "Topic :: Multimedia :: Graphics",


### PR DESCRIPTION
After https://github.com/python-pillow/Pillow/issues/2940#issuecomment-358326331, python-pillow.org redirects to http://pillow.readthedocs.io/en/latest/