### PR TITLE
Removed winbuild gitignore

### DIFF
--- a/winbuild/.gitignore
+++ b/winbuild/.gitignore
@@ -1,6 +1,0 @@
-*.zip
-*.tar.gz
-*.msi
-*.asc
-__pycache__
-depends/


### PR DESCRIPTION
This would have been necessary before the addition of https://github.com/python-pillow/pillow-depends as a separate repository.

The only relevant line left is `__pycache__`, and that is covered by the base directory .gitignore.