### PR TITLE
Fix _i2f compilation on some GCC versions

### DIFF
--- a/src/libImaging/ImagingUtils.h
+++ b/src/libImaging/ImagingUtils.h
@@ -37,7 +37,7 @@
     ! defined(__clang__) && defined(GCC_VERSION) && (GCC_VERSION < 40900)
 static float __attribute__((always_inline)) inline _i2f(int v) {
     float x;
-    __asm__("xorps %0, %0; cvtsi2ss %1, %0" : "=X"(x) : "r"(v) );
+    __asm__("xorps %0, %0; cvtsi2ss %1, %0" : "=x"(x) : "r"(v) );
     return x;
 }
 #else


### PR DESCRIPTION
This should fix #2956:

https://twitter.com/mraleph/status/980803221718478849