### PR TITLE
Fix dereferencing type-punned pointer will break strict-aliasing

### DIFF
--- a/Tests/test_imagepath.py
+++ b/Tests/test_imagepath.py
@@ -17,6 +17,11 @@ class TestImagePath(PillowTestCase):
         self.assertEqual(p[0], (0.0, 1.0))
         self.assertEqual(p[-1], (8.0, 9.0))
         self.assertEqual(list(p[:1]), [(0.0, 1.0)])
+        with self.assertRaises(TypeError) as cm:
+            p['foo']
+        self.assertEqual(
+            str(cm.exception),
+            "Path indices must be integers, not str")
         self.assertEqual(
             list(p),
             [(0.0, 1.0), (2.0, 3.0), (4.0, 5.0), (6.0, 7.0), (8.0, 9.0)])

--- a/src/path.c
+++ b/src/path.c
@@ -571,7 +571,7 @@ path_subscript(PyPathObject* self, PyObject* item) {
     else {
         PyErr_Format(PyExc_TypeError,
                      "Path indices must be integers, not %.200s",
-                     Py_TYPE(&item)->tp_name);
+                     Py_TYPE(item)->tp_name);
         return NULL;
     }
 }


### PR DESCRIPTION
Compiler warning appeared as:

```
src/path.c:574:22: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
                      Py_TYPE(&item)->tp_name);
                      ^~~~~~~
```

As item is already of type `PyObject*`, and the `Py_TYPE` macro is
equivalent to `(((PyObject*)(o))->ob_type)`, no need for the dereference.

https://docs.python.org/3/c-api/structures.html#c.Py_TYPE