### PR TITLE
Remove unused Python class, Path

### DIFF
--- a/src/PIL/ImagePath.py
+++ b/src/PIL/ImagePath.py
@@ -17,44 +17,4 @@
 from . import Image
 
 
-# the Python class below is overridden by the C implementation.
-
-
-class Path(object):
-
-    def __init__(self, xy):
-        pass
-
-    def compact(self, distance=2):
-        """
-        Compacts the path, by removing points that are close to each other.
-        This method modifies the path in place.
-        """
-        pass
-
-    def getbbox(self):
-        """Gets the bounding box."""
-        pass
-
-    def map(self, function):
-        """Maps the path through a function."""
-        pass
-
-    def tolist(self, flat=0):
-        """
-        Converts the path to Python list.
-        #
-        @param flat By default, this function returns a list of 2-tuples
-            [(x, y), ...].  If this argument is true, it returns a flat list
-            [x, y, ...] instead.
-        @return A list of coordinates.
-        """
-        pass
-
-    def transform(self, matrix):
-        """Transforms the path."""
-        pass
-
-
-# override with C implementation
 Path = Image.core.path


### PR DESCRIPTION
The class is always overridden by the C implementation. The Python implementation is unused.