### PR TITLE
Remove unnecessary '#if 0' code

### DIFF
--- a/src/Tk/tkImaging.c
+++ b/src/Tk/tkImaging.c
@@ -16,7 +16,7 @@
  * following lines to your Tcl_AppInit function (in tkappinit.c)
  * instead.  Put them after the calls to Tcl_Init and Tk_Init:
  *
- *	{
+ *      {
  *          extern void TkImaging_Init(Tcl_Interp* interp);
  *          TkImaging_Init(interp);
  *      }
@@ -69,7 +69,7 @@ ImagingFind(const char* name)
     id = atol(name);
 #endif
     if (!id)
-	return NULL;
+        return NULL;
 
     return (Imaging) id;
 }
@@ -112,32 +112,32 @@ PyImagingPhotoPut(ClientData clientdata, Tcl_Interp* interp,
     /* Active region */
 #if 0
     if (src_xoffset + xsize > im->xsize)
-	xsize = im->xsize - src_xoffset;
+        xsize = im->xsize - src_xoffset;
     if (src_yoffset + ysize > im->ysize)
-	ysize = im->ysize - src_yoffset;
+        ysize = im->ysize - src_yoffset;
     if (xsize < 0 || ysize < 0
-	|| src_xoffset >= im->xsize
-	|| src_yoffset >= im->ysize)
-	return TCL_OK;
+        || src_xoffset >= im->xsize
+        || src_yoffset >= im->ysize)
+        return TCL_OK;
 #endif
 
     /* Mode */
 
     if (strcmp(im->mode, "1") == 0 || strcmp(im->mode, "L") == 0) {
-	block.pixelSize = 1;
-	block.offset[0] = block.offset[1] = block.offset[2] = 0;
+        block.pixelSize = 1;
+        block.offset[0] = block.offset[1] = block.offset[2] = 0;
     } else if (strncmp(im->mode, "RGB", 3) == 0) {
-	block.pixelSize = 4;
-	block.offset[0] = 0;
-	block.offset[1] = 1;
-	block.offset[2] = 2;
+        block.pixelSize = 4;
+        block.offset[0] = 0;
+        block.offset[1] = 1;
+        block.offset[2] = 2;
         if (strcmp(im->mode, "RGBA") == 0)
             block.offset[3] = 3; /* alpha (or reserved, under 8.2) */
         else
             block.offset[3] = 0; /* no alpha */
     } else {
         TCL_APPEND_RESULT(interp, "Bad mode", (char*) NULL);
-	return TCL_ERROR;
+        return TCL_ERROR;
     }
 
     block.width = im->xsize;
@@ -146,8 +146,8 @@ PyImagingPhotoPut(ClientData clientdata, Tcl_Interp* interp,
     block.pixelPtr = (unsigned char*) im->block;
 #if 0
     block.pixelPtr = (unsigned char*) im->block +
-	             src_yoffset * im->linesize +
-	             src_xoffset * im->pixelsize;
+                     src_yoffset * im->linesize +
+                     src_xoffset * im->pixelsize;
 #endif
 
     if (TK_LT_85) { /* Tk 8.4 */

--- a/src/Tk/tkImaging.c
+++ b/src/Tk/tkImaging.c
@@ -109,18 +109,6 @@ PyImagingPhotoPut(ClientData clientdata, Tcl_Interp* interp,
         return TCL_ERROR;
     }
 
-    /* Active region */
-#if 0
-    if (src_xoffset + xsize > im->xsize)
-        xsize = im->xsize - src_xoffset;
-    if (src_yoffset + ysize > im->ysize)
-        ysize = im->ysize - src_yoffset;
-    if (xsize < 0 || ysize < 0
-        || src_xoffset >= im->xsize
-        || src_yoffset >= im->ysize)
-        return TCL_OK;
-#endif
-
     /* Mode */
 
     if (strcmp(im->mode, "1") == 0 || strcmp(im->mode, "L") == 0) {
@@ -144,11 +132,6 @@ PyImagingPhotoPut(ClientData clientdata, Tcl_Interp* interp,
     block.height = im->ysize;
     block.pitch = im->linesize;
     block.pixelPtr = (unsigned char*) im->block;
-#if 0
-    block.pixelPtr = (unsigned char*) im->block +
-                     src_yoffset * im->linesize +
-                     src_xoffset * im->pixelsize;
-#endif
 
     if (TK_LT_85) { /* Tk 8.4 */
         TK_PHOTO_PUT_BLOCK_84(photo, &block, 0, 0, block.width, block.height,


### PR DESCRIPTION
Similar to https://github.com/python-pillow/Pillow/pull/3072, this code is never compiled.

It's been like that since at least PIL 1.1.1, from October 2000, so we get to use the "Hasn't worked in 20 years" label.

https://github.com/hugovk/PIL/blame/master/Tk/tkImaging.c#L107