### PR TITLE
 Support Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ matrix:
   include:
     - python: "pypy"
     - python: "pypy3"
-    - python: '3.6'
+    - python: '3.7-dev'
     - python: '2.7'
     - python:  "2.7_with_system_site_packages" # For PyQt4
+    - python: '3.6'
     - python: '3.5'
     - python: '3.4'
-    - python: '3.7-dev'
     - env: DOCKER="alpine" DOCKER_TAG="pytest"
     - env: DOCKER="arch" DOCKER_TAG="pytest" # contains PyQt5
     - env: DOCKER="ubuntu-trusty-x86" DOCKER_TAG="pytest"

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,7 +19,9 @@ Notes
 
 .. note:: Pillow >= 4.0.0 < 5.0.0 supports Python versions 2.7, 3.3, 3.4, 3.5, 3.6
 
-.. note:: Pillow >= 5.0.0 supports Python versions 2.7, 3.4, 3.5, 3.6
+.. note:: Pillow >= 5.0.0 < 5.2.0 supports Python versions 2.7, 3.4, 3.5, 3.6
+
+.. note:: Pillow >= 5.2.0 supports Python versions 2.7, 3.4, 3.5, 3.6, 3.7
 
 Basic Installation
 ------------------
@@ -392,7 +394,7 @@ These platforms are built and tested for every change.
 +----------------------------------+-------------------------------+-----------------------+
 | Ubuntu Linux 16.04 LTS           | 2.7                           |x86-64                 |
 +----------------------------------+-------------------------------+-----------------------+
-| Ubuntu Linux 14.04 LTS           | 2.7, 3.4, 3.5, 3.6,           |x86-64                 |
+| Ubuntu Linux 14.04 LTS           | 2.7, 3.4, 3.5, 3.6, 3.7,      |x86-64                 |
 |                                  | pypy, pypy3                   |                       |
 |                                  +-------------------------------+-----------------------+
 |                                  | 2.7                           |x86                    |

--- a/docs/releasenotes/5.2.0.rst
+++ b/docs/releasenotes/5.2.0.rst
@@ -1,0 +1,21 @@
+5.0.0
+-----
+
+API Additions
+=============
+
+Image.rotate
+^^^^^^^^^^^^
+
+A new named parameter, ``fillcolor``, has been added to ``Image.rotate``. This
+color specifies the background color to use in the area outside the rotated
+image. This parameter takes the same color specifications as used in
+``Image.new``.
+
+Other Changes
+=============
+
+Support added for Python 3.7
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Pillow 5.2 supports Python 3.7.

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -6,6 +6,7 @@ Release Notes
 .. toctree::
   :maxdepth: 2
 
+  5.2.0
   5.1.0
   5.0.0
   4.3.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ from setuptools import Extension, setup
 import mp_compile
 
 
-if sys.platform == "win32" and sys.version_info >= (3, 7):
+if sys.platform == "win32" and sys.version_info >= (3, 8):
     warnings.warn(
         "Pillow does not yet support Python {}.{} and does not yet provide "
         "prebuilt Windows binaries. We do not recommend building from "
@@ -778,6 +778,7 @@ try:
               "Programming Language :: Python :: 3.4",
               "Programming Language :: Python :: 3.5",
               "Programming Language :: Python :: 3.6",
+              "Programming Language :: Python :: 3.7",
               "Programming Language :: Python :: Implementation :: CPython",
               "Programming Language :: Python :: Implementation :: PyPy",
           ],

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py34, py35, py36, py37
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 3.7.0 is due out on 2018-06-15, before the next quarterly Pillow release.

https://www.python.org/dev/peps/pep-0537/#schedule

`3.7-dev` is the latest available on Travis CI, let's replace it with `3.7` when that's available.
