### PR TITLE
Rename PIL.version to PIL._version and remove it from module

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,7 +8,7 @@ Released quarterly on the first day of January, April, July, October.
 * [ ] Develop and prepare release in ``master`` branch.
 * [ ] Check [Travis CI](https://travis-ci.org/python-pillow/Pillow) and [AppVeyor CI](https://ci.appveyor.com/project/python-pillow/Pillow) to confirm passing tests in ``master`` branch.
 * [ ] Check that all of the wheel builds [Pillow Wheel Builder](https://github.com/python-pillow/pillow-wheels) pass the tests in TravisCI.
-* [ ] In compliance with https://www.python.org/dev/peps/pep-0440/, update version identifier in `PIL/version.py`
+* [ ] In compliance with https://www.python.org/dev/peps/pep-0440/, update version identifier in `src/PIL/_version.py`
 * [ ] Update `CHANGES.rst`.
 * [ ] Run pre-release check via `make release-test` in a freshly cloned repo.
 * [ ] Create branch and tag for release e.g.:
@@ -38,7 +38,7 @@ Released as needed for security, installation or critical bug fixes.
 ```
     git checkout -t remotes/origin/2.9.x
 ```
-* [ ] In compliance with https://www.python.org/dev/peps/pep-0440/, update version identifier in `PIL/version.py`
+* [ ] In compliance with https://www.python.org/dev/peps/pep-0440/, update version identifier in `src/PIL/_version.py`
 * [ ] Run pre-release check via `make release-test`.
 * [ ] Create tag for release e.g.:
 ```

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ def _read(file):
 
 
 def get_version():
-    version_file = 'src/PIL/version.py'
+    version_file = 'src/PIL/_version.py'
     with open(version_file, 'r') as f:
         exec(compile(f.read(), version_file, 'exec'))
     return locals()['__version__']

--- a/src/PIL/__init__.py
+++ b/src/PIL/__init__.py
@@ -11,12 +11,12 @@
 
 # ;-)
 
-from . import version
+from . import _version
 
 VERSION = '1.1.7'  # PIL Version
-PILLOW_VERSION = version.__version__
+PILLOW_VERSION = __version__ = _version.__version__
 
-__version__ = PILLOW_VERSION
+del _version
 
 _plugins = ['BlpImagePlugin',
             'BmpImagePlugin',

--- a/src/PIL/_version.py
+++ b/src/PIL/_version.py
@@ -1,2 +1,2 @@
 # Master version for Pillow
-__version__ = '5.1.0'
+__version__ = '5.2.0.dev0'


### PR DESCRIPTION
Partially fixes #3082.

It is really confusing for people to find three different constants in PIL module: `VERSION`, `PILLOW_VERSION`, `__version__` and `version`. While `VERSION` is here for historical reasons and does matter, `version` is module is not required to end user at all. My suggestion is to hide it from users by removing from namespace:

```python
In [1]: from PIL import _version
ImportError: cannot import name _version  # Python 2 only

In [2]: import PIL

In [3]: PIL._version
AttributeError: 'module' object has no attribute '_version'
```