### PR TITLE
Fix coverage paths

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,7 +72,7 @@ build_script:
 test_script:
 - cd c:\pillow
 - '%PYTHON%\%PIP_DIR%\pip.exe install pytest pytest-cov'
-- '%PYTHON%\%EXECUTABLE% -m pytest -vx --cov PIL --cov-report term --cov-report xml Tests'
+- '%PYTHON%\%EXECUTABLE% -m pytest -vx --cov src/PIL --cov-report term --cov-report xml Tests'
 #- '%PYTHON%\%EXECUTABLE% test-installed.py -v -s %TEST_OPTIONS%' TODO TEST_OPTIONS with pytest?
 
 after_test:

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -7,7 +7,7 @@ make clean
 make install-coverage
 
 python selftest.py
-python -m pytest -vx --cov PIL --cov-report term Tests
+python -m pytest -vx --cov src/PIL --cov-report term Tests
 
 pushd /tmp/check-manifest && check-manifest --ignore ".coveragerc,.editorconfig,*.yml,*.yaml,tox.ini" && popd
 

--- a/Tests/README.rst
+++ b/Tests/README.rst
@@ -25,7 +25,7 @@ Run all the tests from the root of the Pillow source distribution::
 
 Or with coverage::
 
-    pytest -vx --cov PIL --cov-report term Tests
+    pytest -vx --cov src/PIL --cov-report term Tests
     coverage html
     open htmlcov/index.html
 


### PR DESCRIPTION
This should fix coveralls reporting with duplicated long file names

<img width="905" alt="screen shot 2018-04-11 at 19 55 45" src="https://user-images.githubusercontent.com/128982/38631416-5fd9cf8a-3dc2-11e8-8fd7-786588d7d46e.png">
