### PR TITLE
Corrected installation doc syntax

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -175,7 +175,7 @@ Many of Pillow's features require external libraries:
   * setting text direction or font features is not supported without
     libraqm.
   * libraqm is dynamically loaded in Pillow 5.0.0 and above, so support
-	is available if all the libraries are installed.
+    is available if all the libraries are installed.
   * Windows support: Raqm support is currently unsupported on Windows.
 
 Once you have installed the prerequisites, run::


### PR DESCRIPTION
Replaced tab with spaces.

Before

![screen shot 2018-04-14 at 10 18 37 pm](https://user-images.githubusercontent.com/3112309/38768110-e40cc3a4-4031-11e8-9ca9-fd8b803a3004.png)

After

![screen shot 2018-04-14 at 10 19 02 pm](https://user-images.githubusercontent.com/3112309/38768111-e69e3b52-4031-11e8-910c-d142a9a0e00c.png)