### PR TITLE
Raise error if it is occurred during conversion in getlist

### DIFF
--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -66,7 +66,7 @@ class TestColorLut3DCoreAPI(PillowTestCase):
             im.im.color_lut_3d('RGB', Image.LINEAR,
                 3, 2, 2, 2, [0, 0, 0] * 9)
 
-        with self.assertRaisesRegexp(TypeError, "a float is required"):
+        with self.assertRaises(TypeError):
             im.im.color_lut_3d('RGB', Image.LINEAR,
                 3, 2, 2, 2, [0, 0, "0"] * 8)
 

--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -66,6 +66,10 @@ class TestColorLut3DCoreAPI(PillowTestCase):
             im.im.color_lut_3d('RGB', Image.LINEAR,
                 3, 2, 2, 2, [0, 0, 0] * 9)
 
+        with self.assertRaisesRegexp(TypeError, "a float is required"):
+            im.im.color_lut_3d('RGB', Image.LINEAR,
+                3, 2, 2, 2, [0, 0, "0"] * 8)
+
     def test_correct_args(self):
         im = Image.new('RGB', (10, 10), 0)
 

--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -70,6 +70,10 @@ class TestColorLut3DCoreAPI(PillowTestCase):
             im.im.color_lut_3d('RGB', Image.LINEAR,
                 3, 2, 2, 2, [0, 0, "0"] * 8)
 
+        with self.assertRaises(TypeError):
+            im.im.color_lut_3d('RGB', Image.LINEAR,
+                3, 2, 2, 2, 16)
+
     def test_correct_args(self):
         im = Image.new('RGB', (10, 10), 0)
 

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -379,12 +379,12 @@ getlist(PyObject* arg, Py_ssize_t* length, const char* wrong_length, int type)
     PyObject* seq;
     PyObject* op;
 
-    if (!PySequence_Check(arg)) {
+    if ( ! PySequence_Check(arg)) {
         PyErr_SetString(PyExc_TypeError, must_be_sequence);
         return NULL;
     }
 
-    n = PyObject_Length(arg);
+    n = PySequence_Size(arg);
     if (length && wrong_length && n != *length) {
         PyErr_SetString(PyExc_ValueError, wrong_length);
         return NULL;
@@ -393,13 +393,12 @@ getlist(PyObject* arg, Py_ssize_t* length, const char* wrong_length, int type)
     /* malloc check ok, type & ff is just a sizeof(something)
        calloc checks for overflow */
     list = calloc(n, type & 0xff);
-    if (!list)
+    if ( ! list)
         return PyErr_NoMemory();
 
     seq = PySequence_Fast(arg, must_be_sequence);
-    if (!seq) {
+    if ( ! seq) {
         free(list);
-        PyErr_SetString(PyExc_TypeError, must_be_sequence);
         return NULL;
     }
 
@@ -427,11 +426,15 @@ getlist(PyObject* arg, Py_ssize_t* length, const char* wrong_length, int type)
         }
     }
 
+    Py_DECREF(seq);
+
+    if (PyErr_Occurred()) {
+        free(list);
+        return NULL;
+    }
+
     if (length)
         *length = n;
-
-    PyErr_Clear();
-    Py_DECREF(seq);
 
     return list;
 }


### PR DESCRIPTION
From [`PyInt_AsLong()`](https://docs.python.org/3/c-api/long.html#c.PyLong_AsLong) and [`PyFloat_AsDouble()`](https://docs.python.org/3/c-api/float.html#c.PyFloat_AsDouble) docs:

```
Returns -1 on error. Use PyErr_Occurred() to disambiguate.
```
```
This method returns -1.0 upon failure, so one should call PyErr_Occurred() to check for errors.
```