### PR TITLE
Update links to new PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
    :target: https://zenodo.org/badge/latestdoi/17549/python-pillow/Pillow
 
 .. |version| image:: https://img.shields.io/pypi/v/pillow.svg
-   :target: https://pypi.python.org/pypi/Pillow/
+   :target: https://pypi.org/project/Pillow/
    :alt: Latest PyPI version
 
 .. |gitter| image:: https://badges.gitter.im/python-pillow/Pillow.svg

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,7 +24,7 @@ Released quarterly on the first day of January, April, July, October.
 ```
 * [ ] Create [binary distributions](#binary-distributions)
 * [ ] Upload all binaries and source distributions with ``twine upload dist/Pillow-4.1.0-*``
-* [ ] Manually hide old versions on PyPI such that only the latest major release is visible when viewing https://pypi.python.org/pypi/Pillow (https://pypi.python.org/pypi?:action=pkg_edit&name=Pillow)
+* [ ] Manually hide old versions on PyPI such that only the latest major release is visible when viewing https://pypi.org/project/Pillow/ (https://pypi.org/manage/project/Pillow/releases/)
 
 ## Point Release
 

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -13,7 +13,7 @@ The fork author's goal is to foster and support active development of PIL throug
 .. _Travis CI: https://travis-ci.org/python-pillow/Pillow
 .. _AppVeyor: https://ci.appveyor.com/project/Python-pillow/pillow
 .. _GitHub: https://github.com/python-pillow/Pillow
-.. _Python Package Index: https://pypi.python.org/pypi/Pillow
+.. _Python Package Index: https://pypi.org/project/Pillow/
 
 License
 -------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
    :alt: AppVeyor CI build status (Windows)
 
 .. image:: https://img.shields.io/pypi/v/pillow.svg
-   :target: https://pypi.python.org/pypi/Pillow/
+   :target: https://pypi.org/project/Pillow/
    :alt: Latest PyPI version
 
 .. image:: https://coveralls.io/repos/python-pillow/Pillow/badge.svg?branch=master

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -96,7 +96,7 @@ Building From Source
 
 Download and extract the `compressed archive from PyPI`_.
 
-.. _compressed archive from PyPI: https://pypi.python.org/pypi/Pillow
+.. _compressed archive from PyPI: https://pypi.org/project/Pillow/
 
 .. _external-libraries:
 
@@ -467,7 +467,7 @@ Old Versions
 ------------
 
 You can download old distributions from `PyPI
-<https://pypi.python.org/pypi/Pillow>`_. Only the latest major
+<https://pypi.org/project/Pillow/>`_. Only the latest major
 releases for Python 2.x and 3.x are visible, but all releases are
 available by direct URL access
-e.g. https://pypi.python.org/pypi/Pillow/1.0.
+e.g. https://pypi.org/project/Pillow/1.0/.


### PR DESCRIPTION
The new PyPI (Warehouse) has been launched, with redirected links.

https://pypi.org/

https://wiki.python.org/psf/WarehouseRoadmap