### PR TITLE
Added getsize_multiline support for PIL.ImageFont

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -509,12 +509,12 @@ class TestImageFont(PillowTestCase):
         self.assertEqual(t.getsize('M'), self.metrics['getters'])
         self.assertEqual(t.getsize('y'), (12, 20))
         self.assertEqual(t.getsize('a'), (12, 16))
-        self.assertEqual(t.getsize_multiline('A'),(12,16))
-        self.assertEqual(t.getsize_multiline('AB'),(24,16))
-        self.assertEqual(t.getsize_multiline('a'),(12,16))
-        self.assertEqual(t.getsize_multiline('ABC\n'),(36,36))
-        self.assertEqual(t.getsize_multiline('ABC\nA'),(36,36))
-        self.assertEqual(t.getsize_multiline('ABC\nAaaa'),(48,36))
+        self.assertEqual(t.getsize_multiline('A'), (12, 16))
+        self.assertEqual(t.getsize_multiline('AB'), (24, 16))
+        self.assertEqual(t.getsize_multiline('a'), (12, 16))
+        self.assertEqual(t.getsize_multiline('ABC\n'), (36, 36))
+        self.assertEqual(t.getsize_multiline('ABC\nA'), (36, 36))
+        self.assertEqual(t.getsize_multiline('ABC\nAaaa'), (48, 36))
 
 
 @unittest.skipUnless(HAS_RAQM, "Raqm not Available")

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -509,6 +509,12 @@ class TestImageFont(PillowTestCase):
         self.assertEqual(t.getsize('M'), self.metrics['getters'])
         self.assertEqual(t.getsize('y'), (12, 20))
         self.assertEqual(t.getsize('a'), (12, 16))
+        self.assertEqual(t.getsize_multiline('A'),(12,16))
+        self.assertEqual(t.getsize_multiline('AB'),(24,16))
+        self.assertEqual(t.getsize_multiline('a'),(12,16))
+        self.assertEqual(t.getsize_multiline('ABC\n'),(36,36))
+        self.assertEqual(t.getsize_multiline('ABC\nA'),(36,36))
+        self.assertEqual(t.getsize_multiline('ABC\nAaaa'),(48,36))
 
 
 @unittest.skipUnless(HAS_RAQM, "Raqm not Available")

--- a/docs/reference/ImageFont.rst
+++ b/docs/reference/ImageFont.rst
@@ -51,6 +51,10 @@ Methods
 
     :return: (width, height)
 
+.. py:method:: PIL.ImageFont.ImageFont.getsize_multiline(text)
+
+    :return: (width, height)
+
 .. py:method:: PIL.ImageFont.ImageFont.getmask(text, mode='', direction=None, features=[])
 
     Create a bitmap for the text.

--- a/docs/reference/ImageFont.rst
+++ b/docs/reference/ImageFont.rst
@@ -51,10 +51,6 @@ Methods
 
     :return: (width, height)
 
-.. py:method:: PIL.ImageFont.ImageFont.getsize_multiline(text)
-
-    :return: (width, height)
-
 .. py:method:: PIL.ImageFont.ImageFont.getmask(text, mode='', direction=None, features=[])
 
     Create a bitmap for the text.

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -147,6 +147,10 @@ class FreeTypeFont(object):
             self.font = core.getfont(
                 "", size, index, encoding, self.font_bytes, layout_engine)
 
+    def _multiline_split(self, text):
+        split_character = "\n" if isinstance(text, str) else b"\n"
+        return text.split(split_character)
+
     def getname(self):
         return self.font.family, self.font.style
 
@@ -156,6 +160,16 @@ class FreeTypeFont(object):
     def getsize(self, text, direction=None, features=None):
         size, offset = self.font.getsize(text, direction, features)
         return (size[0] + offset[0], size[1] + offset[1])
+
+    def getsize_multiline(self, text, direction=None, spacing=4, features=None):
+        max_width = 0
+        lines = self._multiline_split(text)
+        line_spacing = self.getsize('A')[1] + spacing
+        for line in lines:
+            line_width, line_height = self.getsize(line, direction, features)
+            max_width = max(max_width, line_width)
+
+        return max_width, len(lines)*line_spacing - spacing
 
     def getoffset(self, text):
         return self.font.getsize(text)[1]


### PR DESCRIPTION
New feature: getsize_multiline in PIL.ImageFont to return multiline textsize

Changes proposed in this pull request:

 * src/PIL/ImageFont.py: Added getsize_multiline() 
 * Tests/test_imagefont.py: Added test for multiline textsize
 * docs/reference/ImageFont.rst: Added documentation for getsize_multiline
