### PR TITLE
Fixed bug in ImageDraw.multiline_textsize()

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -230,7 +230,10 @@ class TestImageFont(PillowTestCase):
         # Test that textsize() correctly connects to multiline_textsize()
         self.assertEqual(draw.textsize(TEST_TEXT, font=ttf),
                          draw.multiline_textsize(TEST_TEXT, font=ttf))
-
+        # Test that multiline_textsize corresponds to ImageFont.textsize()
+        # for single line text
+        self.assertEqual(ttf.getsize('A'),
+                         draw.multiline_textsize('A', font=ttf))
         # Test that textsize() can pass on additional arguments
         # to multiline_textsize()
         draw.textsize(TEST_TEXT, font=ttf, spacing=4)

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -230,10 +230,12 @@ class TestImageFont(PillowTestCase):
         # Test that textsize() correctly connects to multiline_textsize()
         self.assertEqual(draw.textsize(TEST_TEXT, font=ttf),
                          draw.multiline_textsize(TEST_TEXT, font=ttf))
+
         # Test that multiline_textsize corresponds to ImageFont.textsize()
         # for single line text
         self.assertEqual(ttf.getsize('A'),
                          draw.multiline_textsize('A', font=ttf))
+
         # Test that textsize() can pass on additional arguments
         # to multiline_textsize()
         draw.textsize(TEST_TEXT, font=ttf, spacing=4)

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -271,7 +271,7 @@ class ImageDraw(object):
             line_width, line_height = self.textsize(line, font, spacing,
                                                     direction, features)
             max_width = max(max_width, line_width)
-        return max_width, len(lines)*line_spacing
+        return max_width, len(lines)*line_spacing - spacing
 
 
 def Draw(im, mode=None):


### PR DESCRIPTION
Fixes bug in ImageDraw.multiline_textsize()

Changes proposed in this pull request:

 * ImageDraw.multiline_textsize() previously returns a multiline_textsize height value includes one extra 'spacing' value than required. Fixed to ignore last added spacing
 * Added necessary test to ensure ImageDraw.multiline_textsize() returns the same value as ImageFont.getsize() for single line text

