### PR TITLE
Fix collections ABCs DeprecationWarning in Python 3.7

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -121,8 +121,14 @@ import struct
 import atexit
 
 # type stuff
-import collections
 import numbers
+try:
+    # Python 3
+    from collections.abc import Callable
+except ImportError:
+    # Python 2.7
+    from collections import Callable
+
 
 # works everywhere, win for pypy, not cpython
 USE_CFFI_ACCESS = hasattr(sys, 'pypy_version_info')
@@ -1142,7 +1148,7 @@ class Image(object):
 
         self.load()
 
-        if isinstance(filter, collections.Callable):
+        if isinstance(filter, Callable):
             filter = filter()
         if not hasattr(filter, "filter"):
             raise TypeError("filter argument should be ImageFilter.Filter " +

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -58,6 +58,13 @@ import warnings
 
 from .TiffTags import TYPES
 
+try:
+    # Python 3
+    from collections.abc import MutableMapping
+except ImportError:
+    # Python 2.7
+    from collections import MutableMapping
+
 
 __version__ = "1.3.5"
 DEBUG = False  # Needs to be merged with the new logging approach.
@@ -398,7 +405,7 @@ class IFDRational(Rational):
     __round__ = _delegate('__round__')
 
 
-class ImageFileDirectory_v2(collections.MutableMapping):
+class ImageFileDirectory_v2(MutableMapping):
     """This class represents a TIFF tag directory.  To speed things up, we
     don't decode tags unless they're asked for.
 


### PR DESCRIPTION
Fixes #3122.

Changes proposed in this pull request:

 * Prefer `collections.abc` (new in [Python 3.3](https://docs.python.org/3.7/library/collections.abc.html)) over `collections` for abstract base classes
 * "In Python 3.8, the abstract base classes in `collections.abc` will no longer be exposed in the regular `collections` module. This will help create a clearer distinction between the concrete classes and the abstract base classes."
 * https://docs.python.org/3.7/whatsnew/3.7.html#deprecated
