### PR TITLE
Added seek 0 and Jpeg for multiframe MPO

### DIFF
--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -80,6 +80,8 @@ class MpoImageFile(JpegImagePlugin.JpegImageFile):
             ("jpeg", (0, 0) + self.size, self.offset, (self.mode, ""))
         ]
         self.__frame = frame
+        self.fp.seek(0)
+        JpegImagePlugin.JpegImageFile._open(self)
 
     def tell(self):
         return self.__frame


### PR DESCRIPTION
Fixes #1631 issue when loading multiple frames of MPO.

Changes proposed in this pull request:

 * Added seek(0) and JpegImagePlugin.JpegImageFile._open(self) after each seek

This works to reinitialise the fp. 