### PR TITLE
AppVeyor: upgrade to PyPy 6.0.0

### DIFF
--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -360,8 +360,6 @@ class TestImageDraw(PillowTestCase):
         ImageDraw.floodfill(im, (W, H), red)
         self.assert_image_equal(im, im_floodfill)
 
-    @unittest.skipIf(hasattr(sys, 'pypy_version_info'),
-                     "Causes fatal RPython error on PyPy")
     def test_floodfill_border(self):
         # floodfill() is experimental
 

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -1,11 +1,7 @@
-from helper import unittest, PillowTestCase, hopper
-
-from PIL import Image
-from PIL import ImageColor
-from PIL import ImageDraw
 import os.path
 
-import sys
+from helper import PillowTestCase, hopper, unittest
+from PIL import Image, ImageColor, ImageDraw
 
 BLACK = (0, 0, 0)
 WHITE = (255, 255, 255)

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
-import sys
-from helper import unittest, PillowTestCase, hopper
 
+from helper import PillowTestCase, hopper, unittest
 from PIL import Image
 
 try:
@@ -14,13 +13,6 @@ except ImportError:
     pass
 
 TEST_IMAGE_SIZE = (10, 10)
-
-# Numpy on pypy as of pypy 5.3.1 is corrupting the numpy.array(Image)
-# call such that it's returning a object of type numpy.ndarray, but
-# the repr is that of a PIL.Image. Size and shape are 1 and (), not the
-# size and shape of the array. This causes failures in several tests.
-SKIP_NUMPY_ON_PYPY = hasattr(sys, 'pypy_version_info') and (
-    sys.pypy_version_info <= (5, 3, 1, 'final', 0))
 
 
 class TestNumpy(PillowTestCase):
@@ -121,7 +113,6 @@ class TestNumpy(PillowTestCase):
             for y in range(0, img.size[1], int(img.size[1]/10)):
                 self.assert_deep_equal(px[x, y], np[y, x])
 
-    @unittest.skipIf(SKIP_NUMPY_ON_PYPY, "numpy.array(Image) is flaky on PyPy")
     def test_16bit(self):
         img = Image.open('Tests/images/16bit.cropped.tif')
         np_img = numpy.array(img)
@@ -152,7 +143,6 @@ class TestNumpy(PillowTestCase):
         img_px = img.load()
         self.assertEqual(img_px[0, 0], pixel_value)
 
-    @unittest.skipIf(SKIP_NUMPY_ON_PYPY, "numpy.array(Image) is flaky on PyPy")
     def test_to_array(self):
 
         def _to_array(mode, dtype):

--- a/winbuild/appveyor_install_pypy.cmd
+++ b/winbuild/appveyor_install_pypy.cmd
@@ -1,3 +1,3 @@
-curl -fsSL -o pypy2.zip https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-win32.zip
+curl -fsSL -o pypy2.zip https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-win32.zip
 7z x pypy2.zip -oc:\
-c:\Python34\Scripts\virtualenv.exe -p c:\pypy2-v5.10.0-win32\pypy.exe c:\vp\pypy2
+c:\Python34\Scripts\virtualenv.exe -p c:\pypy2-v6.0.0-win32\pypy.exe c:\vp\pypy2


### PR DESCRIPTION
It was released in April 2018:

https://morepypy.blogspot.com/2018/04/pypy27-and-pypy35-v60-dual-release.html

We can also re-enable some tests which were a problem with older versions of PyPy.