### PR TITLE
Fixed saving a multiframe image as a single frame PDF

### DIFF
--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -104,6 +104,16 @@ class TestFilePdf(PillowTestCase):
         self.assertTrue(os.path.isfile(outfile))
         self.assertGreater(os.path.getsize(outfile), 0)
 
+    def test_multiframe_normal_save(self):
+        # Test saving a multiframe image without save_all
+        im = Image.open("Tests/images/dispose_bgnd.gif")
+
+        outfile = self.tempfile('temp.pdf')
+        im.save(outfile)
+
+        self.assertTrue(os.path.isfile(outfile))
+        self.assertGreater(os.path.getsize(outfile), 0)
+
     def test_pdf_open(self):
         # fail on a buffer full of null bytes
         self.assertRaises(PdfParser.PdfFormatError, PdfParser.PdfParser, buf=bytearray(65536))

--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -113,7 +113,8 @@ def _save(im, fp, filename, save_all=False):
 
     pageNumber = 0
     for imSequence in ims:
-        for im in ImageSequence.Iterator(imSequence):
+        im_pages = ImageSequence.Iterator(imSequence) if save_all else [imSequence]
+        for im in im_pages:
             # FIXME: Should replace ASCIIHexDecode with RunLengthDecode (packbits)
             # or LZWDecode (tiff/lzw compression).  Note that PDF 1.2 also supports
             # Flatedecode (zip compression).


### PR DESCRIPTION
This is mirroring the logic from https://github.com/radarhere/Pillow/blob/3bbd0a58109c840a8895f364ffc7127cee04a30b/src/PIL/PdfImagePlugin.py#L96, so that this loop, which uses the values in the `image_refs` array, operates the same as the previous loop, which set the values in the array.