### PR TITLE
Fix transform fill color for alpha images

### DIFF
--- a/Tests/test_image_rotate.py
+++ b/Tests/test_image_rotate.py
@@ -109,6 +109,19 @@ class TestImageRotate(PillowTestCase):
         im = im.rotate(45, fillcolor='white')
         self.assert_image_equal(im, target)
 
+    def test_alpha_rotate_no_fill(self):
+        # Alpha images are handled differently internally
+        im = Image.new('RGBA', (10, 10), 'green')
+        im = im.rotate(45, expand=1)
+        corner = im.getpixel((0,0))
+        self.assertEqual(corner, (0, 0, 0, 0))
+
+    def test_alpha_rotate_with_fill(self):
+        # Alpha images are handled differently internally
+        im = Image.new('RGBA', (10, 10), 'green')
+        im = im.rotate(45, expand=1, fillcolor=(255, 0, 0, 255))
+        corner = im.getpixel((0,0))
+        self.assertEqual(corner, (255, 0, 0, 255))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2115,11 +2115,11 @@ class Image(object):
 
         if self.mode == 'LA':
             return self.convert('La').transform(
-                size, method, data, resample, fill).convert('LA')
+                size, method, data, resample, fill, fillcolor).convert('LA')
 
         if self.mode == 'RGBA':
             return self.convert('RGBa').transform(
-                size, method, data, resample, fill).convert('RGBA')
+                size, method, data, resample, fill, fillcolor).convert('RGBA')
 
         if isinstance(method, ImageTransformHandler):
             return method.transform(size, self, resample=resample, fill=fill)


### PR DESCRIPTION
This is a small code change to fix missing parameters when the `transform` function recurses.  Without this, alpha images (LA and RGBA) always have a transparent background regardless of the passed in fill color.

Changes proposed in this pull request:

 * Pass through the `fillcolor` parameter when recursing

Tests all pass on Python 2.7 and 3.5.