### PR TITLE
Corrected test

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -63,8 +63,11 @@ class TestFileTiff(PillowTestCase):
         im.load()
 
     def test_set_legacy_api(self):
-        with self.assertRaises(Exception):
-            ImageFileDirectory_v2.legacy_api = None
+        ifd = TiffImagePlugin.ImageFileDirectory_v2()
+        with self.assertRaises(Exception) as e:
+            ifd.legacy_api = None
+        self.assertEqual(str(e.exception),
+                         "Not allowing setting of legacy api")
 
     def test_xyres_tiff(self):
         filename = "Tests/images/pil168.tif"


### PR DESCRIPTION
Instead of raising the `Exception` at https://github.com/python-pillow/Pillow/blob/master/src/PIL/TiffImagePlugin.py#L484 as intended, this test was raising a `NameError` because `ImageFileDirectory_v2` is not imported.