### PR TITLE
Use travis_retry for docker pull to avoid occasional network timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - if [ "$DOCKER" == "" ]; then .travis/install.sh; fi
 
 before_install:
-  - if [ "$DOCKER" ]; then docker pull pythonpillow/$DOCKER:$DOCKER_TAG; fi
+  - if [ "$DOCKER" ]; then travis_retry docker pull pythonpillow/$DOCKER:$DOCKER_TAG; fi
 
 before_script:
 # Qt needs a display for some of the tests, and it's only run on the system site packages install


### PR DESCRIPTION
Just occasionally a single build job fails and I hit the rebuild button and it passes.

Recently `docker pull` failed for a single job:

```console
$ if [ "$DOCKER" ]; then docker pull pythonpillow/$DOCKER:$DOCKER_TAG; fi
Error response from daemon: Get https://registry-1.docker.io/v2/pythonpillow/debian-stretch-x86/manifests/pytest: Get https://auth.docker.io/token?scope=repository%3Apythonpillow%2Fdebian-stretch-x86%3Apull&service=registry.docker.io: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
The command "if [ "$DOCKER" ]; then docker pull pythonpillow/$DOCKER:$DOCKER_TAG; fi" failed and exited with 1 during .
Your build has been stopped.
```

https://travis-ci.org/python-pillow/Pillow/jobs/389764869

---

Let's use the `travis_retry` function to avoid these red herrings:

> For commands which do not have a built in retry feature, use the `travis_retry` function to retry it up three times if the return code is non-zero:
>
```yaml
install: travis_retry pip install myawesomepackage
```
>  Most of our internal build commands are wrapped with `travis_retry` to reduce the impact of network timeouts.
>
> Note that `travis_retry` does not work in the `deploy` step of the build, although it does work in the other steps.

https://docs.travis-ci.com/user/common-build-problems/#travis_retry