### PR TITLE
Update Python 2 doc URLs to Python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ sdist:
 test:
 	pytest -qq
 
-# https://docs.python.org/2/distutils/packageindex.html#the-pypirc-file
+# https://docs.python.org/3/distutils/packageindex.html#the-pypirc-file
 upload-test:
 #       [test]
 #       username:

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -59,7 +59,7 @@ Functions
         documentation`_ to have warnings output to the logging facility instead of stderr.
 
 	.. _decompression bombs: https://en.wikipedia.org/wiki/Zip_bomb
-	.. _the logging documentation: https://docs.python.org/2/library/logging.html?highlight=logging#integration-with-the-warnings-module
+	.. _the logging documentation: https://docs.python.org/3/library/logging.html#integration-with-the-warnings-module
 
 Image processing
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Python 3 docs are more actively maintained and are the future.