### PR TITLE
Temporarily use --no-cache-dir for pip on mingw32

### DIFF
--- a/winbuild/appveyor_install_msys2_deps.sh
+++ b/winbuild/appveyor_install_msys2_deps.sh
@@ -6,7 +6,7 @@ pacman -S --noconfirm mingw32/mingw-w64-i686-python3-pip \
 	   mingw32/mingw-w64-i686-python2-setuptools \
 	   mingw-w64-i686-libjpeg-turbo
 
-C:/msys64/mingw32/bin/python3 -m pip install --upgrade pip
+C:/msys64/mingw32/bin/python3 -m pip install --upgrade --no-cache-dir pip
 
-/mingw32/bin/pip install pytest pytest-cov olefile
-/mingw32/bin/pip3 install pytest pytest-cov olefile
+/mingw32/bin/pip install --no-cache-dir pytest pytest-cov olefile
+/mingw32/bin/pip3 install --no-cache-dir pytest pytest-cov olefile


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/3156.

mingw32 builds fail like this:

```
Collecting pytest
c:\msys64\usr\bin\bash :   Cache entry deserialization failed, entry ignored
At line:3 char:3
+   c:\msys64\usr\bin\bash -l -c c:\\pillow\\winbuild\\appveyor_install ...
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (  Cache entry d..., entry ignored:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
 
  Using cached https://files.pythonhosted.org/packages/d3/75/e79b66c9fe6166a90004bb8fb02bab06213c3348e93f3be41d7eaf625554/pytest-3.6.1-py2.py3-none-any.whl
Collecting pytest-cov
  Cache entry deserialization failed, entry ignored
  Using cached https://files.pythonhosted.org/packages/30/7d/7f6a78ae44a1248ee28cc777586c18b28a1df903470e5d34a6e25712b8aa/pytest_cov-2.5.1-py2.py3-none-any.whl
Collecting olefile
  Cache entry deserialization failed, entry ignored
  Using cached https://files.pythonhosted.org/packages/d3/8a/e0f0e56d6a542dd987f9290ef7b5164636ee597ce8c2932c19c78292d5ec/olefile-0.45.1.zip
Collecting atomicwrites>=1.0 (from pytest)
  Cache entry deserialization failed, entry ignored
  Using cached https://files.pythonhosted.org/packages/0a/e8/cd6375e7a59664eeea9e1c77a766eeac0fc3083bb958c2b41ec46b95f29c/atomicwrites-1.1.5-py2.py3-none-any.whl
Collecting py>=1.5.0 (from pytest)
  Cache entry deserialization failed, entry ignored
  Using cached https://files.pythonhosted.org/packages/67/a5/f77982214dd4c8fd104b066f249adea2c49e25e8703d284382eb5e9ab35a/py-1.5.3-py2.py3-none-any.whl
Collecting six>=1.10.0 (from pytest)
  Cache entry deserialization failed, entry ignored
  Using cached https://files.pythonhosted.org/packages/67/4b/141a581104b1f6397bfa78ac9d43d8ad29a7ca43ea90a2d863fe3056e86a/six-1.11.0-py2.py3-none-any.whl
Collecting colorama; sys_platform == "win32" (from pytest)
  Cache entry deserialization failed, entry ignored
  Using cached https://files.pythonhosted.org/packages/db/c8/7dcf9dbcb22429512708fe3a547f8b6101c0d02137acbd892505aee57adf/colorama-0.3.9-py2.py3-none-any.whl
Collecting more-itertools>=4.0.0 (from pytest)
  Cache entry deserialization failed, entry ignored
  Using cached https://files.pythonhosted.org/packages/85/40/90c3b0393e12b9827381004224de8814686e3d7182f9d4182477f600826d/more_itertools-4.2.0-py3-none-any.whl
Requirement already satisfied: setuptools in c:/msys64/mingw32/lib/python3.6/site-packages (from pytest) (39.2.0.post20180521)
Collecting pluggy<0.7,>=0.5 (from pytest)
  Cache entry deserialization failed, entry ignored
  Using cached https://files.pythonhosted.org/packages/ba/65/ded3bc40bbf8d887f262f150fbe1ae6637765b5c9534bd55690ed2c0b0f7/pluggy-0.6.0-py3-none-any.whl
Collecting attrs>=17.4.0 (from pytest)
  Cache entry deserialization failed, entry ignored
  Using cached https://files.pythonhosted.org/packages/41/59/cedf87e91ed541be7957c501a92102f9cc6363c623a7666d69d51c78ac5b/attrs-18.1.0-py2.py3-none-any.whl
Collecting coverage>=3.7.1 (from pytest-cov)
  Cache entry deserialization failed, entry ignored
  Using cached https://files.pythonhosted.org/packages/35/fe/e7df7289d717426093c68d156e0fd9117c8f4872b6588e8a8928a0f68424/coverage-4.5.1.tar.gz
Installing collected packages: atomicwrites, py, six, colorama, more-itertools, pluggy, attrs, pytest, coverage, pytest-cov, olefile
  Running setup.py install for coverage: started
    Running setup.py install for coverage: finished with status 'done'
  Running setup.py install for olefile: started
    Running setup.py install for olefile: finished with status 'done'
Successfully installed atomicwrites-1.1.5 attrs-18.1.0 colorama-0.3.9 coverage-4.5.1 more-itertools-4.2.0 olefile-0.45.1 pluggy-0.6.0 py-1.5.3 pytest-3.6.1 pytest-cov-2.5.1 six-1.11.0
Command executed with exception: 
 
```
https://ci.appveyor.com/project/Python-pillow/pillow/build/3763/job/kx8amjf3srp21560

This looks like this is caused by a caching bug in a vendored dependency of pip 10 (https://github.com/pypa/pip/issues/5250), which already has a released fix (https://github.com/ionrock/cachecontrol/pull/190). 

The next pip 18 (yes, 18, they've switched to [CalVer](https://calver.org/)) is due for release in July (https://github.com/pypa/pip/pull/5324)

In the meantime, let's skip pip caching for this particular job to get the CI back to green.

Changes proposed in this pull request:

 * Run `pip` with `--no-cache-dir` for mingw32

Let's keep https://github.com/python-pillow/Pillow/issues/3156 open so we remember to revert this when pip 18 is out.