### PR TITLE
Wait until mode is normalized to copy im.info into encoderinfo

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -491,6 +491,27 @@ class TestFileGif(PillowTestCase):
 
         self.assertEqual(reloaded.info['transparency'], 253)
 
+    def test_rgb_transparency(self):
+        out = self.tempfile('temp.gif')
+
+        # Single frame
+        im = Image.new('RGB', (1, 1))
+        im.info['transparency'] = (255, 0, 0)
+        self.assert_warning(UserWarning, im.save, out)
+
+        reloaded = Image.open(out)
+        self.assertNotIn('transparency', reloaded.info)
+
+        # Multiple frames
+        im = Image.new('RGB', (1, 1))
+        im.info['transparency'] = b""
+        ims = [Image.new('RGB', (1, 1))]
+        self.assert_warning(UserWarning,
+                            im.save, out, save_all=True, append_images=ims)
+
+        reloaded = Image.open(out)
+        self.assertNotIn('transparency', reloaded.info)
+
     def test_bbox(self):
         out = self.tempfile('temp.gif')
 

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -372,6 +372,8 @@ def _normalize_palette(im, palette, info):
 
 def _write_single_frame(im, fp, palette):
     im_out = _normalize_mode(im, True)
+    for k, v in im_out.info.items():
+        im.encoderinfo.setdefault(k, v)
     im_out = _normalize_palette(im_out, palette, im.encoderinfo)
 
     for s in _get_global_header(im_out, im.encoderinfo):
@@ -392,8 +394,8 @@ def _write_single_frame(im, fp, palette):
 
 def _write_multiple_frames(im, fp, palette):
 
-    duration = im.encoderinfo.get("duration", None)
-    disposal = im.encoderinfo.get('disposal', None)
+    duration = im.encoderinfo.get("duration", im.info.get("duration"))
+    disposal = im.encoderinfo.get("disposal", im.info.get("disposal"))
 
     im_frames = []
     frame_count = 0
@@ -402,6 +404,9 @@ def _write_multiple_frames(im, fp, palette):
         for im_frame in ImageSequence.Iterator(imSequence):
             # a copy is required here since seek can still mutate the image
             im_frame = _normalize_mode(im_frame.copy())
+            if frame_count == 0:
+                for k, v in im_frame.info.items():
+                    im.encoderinfo.setdefault(k, v)
             im_frame = _normalize_palette(im_frame, palette, im.encoderinfo)
 
             encoderinfo = im.encoderinfo.copy()
@@ -460,12 +465,10 @@ def _save_all(im, fp, filename):
 
 
 def _save(im, fp, filename, save_all=False):
-    for k, v in im.info.items():
-        im.encoderinfo.setdefault(k, v)
     # header
-    try:
-        palette = im.encoderinfo["palette"]
-    except KeyError:
+    if "palette" in im.encoderinfo or "palette" in im.info:
+        palette = im.encoderinfo.get("palette", im.info.get("palette"))
+    else:
         palette = None
         im.encoderinfo["optimize"] = im.encoderinfo.get("optimize", True)
 


### PR DESCRIPTION
When saving a GIF, any values in `im.info` are added to `im.encoderinfo` if the key does not already exist there - https://github.com/python-pillow/Pillow/blob/master/src/PIL/GifImagePlugin.py#L460

In #2803, an RGB image is saved to GIF. GifImagePlugin has a method, `_normalize_mode`, that converts an RGB mode to P. For the image in that issue, Image's `convert` method runs `del(new.info['transparency'])` - https://github.com/python-pillow/Pillow/blob/master/src/PIL/Image.py#L973, deleting the transparency info for the converted image. However, GifImagePlugin has already copied the transparency value from `im.info` to `im.encoderinfo` for later use, so the `del` operation does not have the intended effect.

To fix this, this PR postpones the merging of `im.info` into `im.encoderinfo` until after `_normalize_mode` is run.