### PR TITLE
Added ImageFile get_format_mimetype method

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -48,6 +48,7 @@ class TestFileJpeg(PillowTestCase):
         self.assertEqual(im.mode, "RGB")
         self.assertEqual(im.size, (128, 128))
         self.assertEqual(im.format, "JPEG")
+        self.assertEqual(im.get_format_mimetype(), "image/jpeg")
 
     def test_app(self):
         # Test APP/COM reader (@PIL135)

--- a/Tests/test_file_pixar.py
+++ b/Tests/test_file_pixar.py
@@ -13,6 +13,7 @@ class TestFilePixar(PillowTestCase):
         self.assertEqual(im.mode, "RGB")
         self.assertEqual(im.size, (128, 128))
         self.assertEqual(im.format, "PIXAR")
+        self.assertIsNone(im.get_format_mimetype())
 
         im2 = hopper()
         self.assert_image_similar(im, im2, 4.8)

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -223,6 +223,13 @@ class TestPyDecoder(PillowTestCase):
         im.tile = [("MOCK", (xoff, yoff, xoff+xsize, yoff+ysize + 100), 32, None)]
         self.assertRaises(ValueError, im.load)
 
+    def test_no_format(self):
+        buf = BytesIO(b'\x00'*255)
+
+        im = MockImageFile(buf)
+        self.assertIsNone(im.format)
+        self.assertIsNone(im.get_format_mimetype())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -118,6 +118,11 @@ class ImageFile(Image.Image):
 
         pass
 
+    def get_format_mimetype(self):
+        if self.format is None:
+            return
+        return Image.MIME.get(self.format.upper())
+
     def verify(self):
         "Check file integrity"
 


### PR DESCRIPTION
This is a suggestion for #2065, but also allows users to retrieve the mimetype in more general situations.