### PR TITLE
unpack_from is faster than unpack of slice

### DIFF
--- a/src/PIL/BlpImagePlugin.py
+++ b/src/PIL/BlpImagePlugin.py
@@ -65,7 +65,7 @@ def decode_dxt1(data, alpha=False):
     for block in range(blocks):
         # Decode next 8-byte block.
         idx = block * 8
-        color0, color1, bits = struct.unpack("<HHI", data[idx:idx + 8])
+        color0, color1, bits = struct.unpack_from("<HHI", data, idx)
 
         r0, g0, b0 = unpack_565(color0)
         r1, g1, b1 = unpack_565(color1)
@@ -121,10 +121,10 @@ def decode_dxt3(data):
         idx = block * 16
         block = data[idx:idx + 16]
         # Decode next 16-byte block.
-        bits = struct.unpack("<8B", block[:8])
-        color0, color1 = struct.unpack("<HH", block[8:12])
+        bits = struct.unpack_from("<8B", block)
+        color0, color1 = struct.unpack_from("<HH", block, 8)
 
-        code, = struct.unpack("<I", block[12:])
+        code, = struct.unpack_from("<I", block, 12)
 
         r0, g0, b0 = unpack_565(color0)
         r1, g1, b1 = unpack_565(color1)
@@ -174,17 +174,17 @@ def decode_dxt5(data):
         idx = block * 16
         block = data[idx:idx + 16]
         # Decode next 16-byte block.
-        a0, a1 = struct.unpack("<BB", block[:2])
+        a0, a1 = struct.unpack_from("<BB", block)
 
-        bits = struct.unpack("<6B", block[2:8])
+        bits = struct.unpack_from("<6B", block, 2)
         alphacode1 = (
             bits[2] | (bits[3] << 8) | (bits[4] << 16) | (bits[5] << 24)
         )
         alphacode2 = bits[0] | (bits[1] << 8)
 
-        color0, color1 = struct.unpack("<HH", block[8:12])
+        color0, color1 = struct.unpack_from("<HH", block, 8)
 
-        code, = struct.unpack("<I", block[12:])
+        code, = struct.unpack_from("<I", block, 12)
 
         r0, g0, b0 = unpack_565(color0)
         r1, g1, b1 = unpack_565(color1)

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -29,13 +29,13 @@ def _parse_codestream(fp):
     siz = hdr + fp.read(lsiz - 2)
     lsiz, rsiz, xsiz, ysiz, xosiz, yosiz, xtsiz, ytsiz, \
         xtosiz, ytosiz, csiz \
-        = struct.unpack('>HHIIIIIIIIH', siz[:38])
+        = struct.unpack_from('>HHIIIIIIIIH', siz)
     ssiz = [None]*csiz
     xrsiz = [None]*csiz
     yrsiz = [None]*csiz
     for i in range(csiz):
         ssiz[i], xrsiz[i], yrsiz[i] \
-            = struct.unpack('>BBB', siz[36 + 3 * i:39 + 3 * i])
+            = struct.unpack_from('>BBB', siz, 36 + 3 * i)
 
     size = (xsiz - xosiz, ysiz - yosiz)
     if csiz == 1:
@@ -114,9 +114,9 @@ def _parse_jp2_header(fp):
                     mode = 'RGBA'
                 break
         elif tbox == b'colr':
-            meth, prec, approx = struct.unpack('>BBB', content[:3])
+            meth, prec, approx = struct.unpack_from('>BBB', content)
             if meth == 1:
-                cs = struct.unpack('>I', content[3:7])[0]
+                cs = struct.unpack_from('>I', content, 3)[0]
                 if cs == 16:   # sRGB
                     if nc == 1 and (bpc & 0x7f) > 8:
                         mode = 'I;16'

--- a/src/PIL/MspImagePlugin.py
+++ b/src/PIL/MspImagePlugin.py
@@ -133,7 +133,7 @@ class MspDecoder(ImageFile.PyDecoder):
                     runtype = i8(row[idx])
                     idx += 1
                     if runtype == 0:
-                        (runcount, runval) = struct.unpack("Bc", row[idx:idx+2])
+                        (runcount, runval) = struct.unpack_from("Bc", row, idx)
                         img.write(runval * runcount)
                         idx += 2
                     else:

--- a/src/PIL/_binary.py
+++ b/src/PIL/_binary.py
@@ -11,7 +11,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from struct import unpack, pack
+from struct import unpack_from, pack
 from ._util import py3
 
 if py3:
@@ -36,7 +36,7 @@ def i16le(c, o=0):
     c: string containing bytes to convert
     o: offset of bytes to convert in string
     """
-    return unpack("<H", c[o:o+2])[0]
+    return unpack_from("<H", c, o)[0]
 
 
 def si16le(c, o=0):
@@ -46,7 +46,7 @@ def si16le(c, o=0):
     c: string containing bytes to convert
     o: offset of bytes to convert in string
     """
-    return unpack("<h", c[o:o+2])[0]
+    return unpack_from("<h", c, o)[0]
 
 
 def i32le(c, o=0):
@@ -56,7 +56,7 @@ def i32le(c, o=0):
     c: string containing bytes to convert
     o: offset of bytes to convert in string
     """
-    return unpack("<I", c[o:o+4])[0]
+    return unpack_from("<I", c, o)[0]
 
 
 def si32le(c, o=0):
@@ -66,15 +66,15 @@ def si32le(c, o=0):
     c: string containing bytes to convert
     o: offset of bytes to convert in string
     """
-    return unpack("<i", c[o:o+4])[0]
+    return unpack_from("<i", c, o)[0]
 
 
 def i16be(c, o=0):
-    return unpack(">H", c[o:o+2])[0]
+    return unpack_from(">H", c, o)[0]
 
 
 def i32be(c, o=0):
-    return unpack(">I", c[o:o+4])[0]
+    return unpack_from(">I", c, o)[0]
 
 
 # Output, le = little endian, be = big endian


### PR DESCRIPTION
tiny bit faster
struct.unpack_from just doesn't read the memory further if input data is too long, so slice stops were unneeded
for non-zero slice starts, struct.unpack_from just adds to the memory offset instead of copying like slices
(was 2 commits, rebased to 1 after changing 3 more files)