### PR TITLE
Replace copy operations with memcpy()

### DIFF
--- a/src/libImaging/Access.c
+++ b/src/libImaging/Access.c
@@ -94,11 +94,11 @@ static void
 get_pixel_16L(Imaging im, int x, int y, void* color)
 {
     UINT8* in = (UINT8*) &im->image[y][x+x];
-    UINT16* out = color;
 #ifdef WORDS_BIGENDIAN
+    UINT16* out = color;
     out[0] = in[0] + (in[1]<<8);
 #else
-    out[0] = *(UINT16*) in;
+    memcpy(color, in, sizeof(UINT16));
 #endif
 }
 
@@ -106,10 +106,10 @@ static void
 get_pixel_16B(Imaging im, int x, int y, void* color)
 {
     UINT8* in = (UINT8*) &im->image[y][x+x];
-    UINT16* out = color;
 #ifdef WORDS_BIGENDIAN
-    out[0] = *(UINT16*) in;
+    memcpy(color, in, sizeof(UINT16));
 #else
+    UINT16* out = color;
     out[0] = in[1] + (in[0]<<8);
 #endif
 }
@@ -117,19 +117,18 @@ get_pixel_16B(Imaging im, int x, int y, void* color)
 static void
 get_pixel_32(Imaging im, int x, int y, void* color)
 {
-    INT32* out = color;
-    out[0] = im->image32[y][x];
+    memcpy(color, &im->image32[y][x], sizeof(INT32));
 }
 
 static void
 get_pixel_32L(Imaging im, int x, int y, void* color)
 {
     UINT8* in = (UINT8*) &im->image[y][x*4];
-    INT32* out = color;
 #ifdef WORDS_BIGENDIAN
+    INT32* out = color;
     out[0] = in[0] + (in[1]<<8) + (in[2]<<16) + (in[3]<<24);
 #else
-    out[0] = *(INT32*) in;
+    memcpy(color, in, sizeof(INT32));
 #endif
 }
 
@@ -137,10 +136,10 @@ static void
 get_pixel_32B(Imaging im, int x, int y, void* color)
 {
     UINT8* in = (UINT8*) &im->image[y][x*4];
-    INT32* out = color;
 #ifdef WORDS_BIGENDIAN
-    out[0] = *(INT32*) in;
+    memcpy(color, in, sizeof(INT32));
 #else
+    INT32* out = color;
     out[0] = in[3] + (in[2]<<8) + (in[1]<<16) + (in[0]<<24);
 #endif
 }
@@ -153,7 +152,7 @@ put_pixel(Imaging im, int x, int y, const void* color)
     if (im->image8)
         im->image8[y][x] = *((UINT8*) color);
     else
-        im->image32[y][x] = *((INT32*) color);
+        memcpy(&im->image32[y][x], color, sizeof(INT32));
 }
 
 static void
@@ -165,10 +164,7 @@ put_pixel_8(Imaging im, int x, int y, const void* color)
 static void
 put_pixel_16L(Imaging im, int x, int y, const void* color)
 {
-    const char* in = color;
-    UINT8* out = (UINT8*) &im->image8[y][x+x];
-    out[0] = in[0];
-    out[1] = in[1];
+    memcpy(&im->image8[y][x+x], color, 2);
 }
 
 static void
@@ -183,12 +179,7 @@ put_pixel_16B(Imaging im, int x, int y, const void* color)
 static void
 put_pixel_32L(Imaging im, int x, int y, const void* color)
 {
-    const char* in = color;
-    UINT8* out = (UINT8*) &im->image8[y][x*4];
-    out[0] = in[0];
-    out[1] = in[1];
-    out[2] = in[2];
-    out[3] = in[3];
+    memcpy(&im->image8[y][x*4], color, 4);
 }
 
 static void
@@ -205,7 +196,7 @@ put_pixel_32B(Imaging im, int x, int y, const void* color)
 static void
 put_pixel_32(Imaging im, int x, int y, const void* color)
 {
-    im->image32[y][x] = *((INT32*) color);
+    memcpy(&im->image32[y][x], color, sizeof(INT32));
 }
 
 void

--- a/src/libImaging/Draw.c
+++ b/src/libImaging/Draw.c
@@ -40,7 +40,6 @@
 #define FLOOR(v) ((v) >= 0.0 ? (int) (v) : (int) floor(v))
 
 #define INK8(ink) (*(UINT8*)ink)
-#define INK32(ink) (*(INT32*)ink)
 
 /*
  * Rounds around zero (up=away from zero, down=torwards zero)
@@ -555,7 +554,7 @@ DRAW draw32rgba = { point32rgba, hline32rgba, line32rgba, polygon32rgba };
         ink = INK8(ink_);\
     } else {\
         draw = (op) ? &draw32rgba : &draw32;    \
-        ink = INK32(ink_);\
+        memcpy(&ink, ink_, sizeof(ink)); \
     }
 
 int

--- a/src/libImaging/Filter.c
+++ b/src/libImaging/Filter.c
@@ -124,7 +124,7 @@ ImagingFilter3x3(Imaging imOut, Imaging im, const float* kernel,
             UINT8* in1 = (UINT8*) im->image[y+1];
             UINT32* out = (UINT32*) imOut->image[y];
 
-            out[0] = ((UINT32*) in0)[0];
+            memcpy(out, in0, sizeof(UINT32));
             if (im->bands == 2) {
                 for (x = 1; x < im->xsize-1; x++) {
                     float ss0 = offset;
@@ -234,8 +234,7 @@ ImagingFilter5x5(Imaging imOut, Imaging im, const float* kernel,
             UINT8* in2 = (UINT8*) im->image[y+2];
             UINT32* out = (UINT32*) imOut->image[y];
 
-            out[0] = ((UINT32*) in0)[0];
-            out[1] = ((UINT32*) in0)[1];
+            memcpy(out, in0, sizeof(UINT32) * 2);
             if (im->bands == 2) {
                 for (x = 2; x < im->xsize-2; x++) {
                     float ss0 = offset;

--- a/src/libImaging/Geometry.c
+++ b/src/libImaging/Geometry.c
@@ -407,7 +407,7 @@ nearest_filter32(void* out, Imaging im, double xin, double yin)
     int y = COORD(yin);
     if (x < 0 || x >= im->xsize || y < 0 || y >= im->ysize)
         return 0;
-    ((INT32*)out)[0] = im->image32[y][x];
+    memcpy(out, &im->image32[y][x], sizeof(INT32));
     return 1;
 }
 

--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -146,7 +146,7 @@ ImagingGetExtrema(Imaging im, void *extrema)
                     imax = in[x];
             }
         }
-        ((INT32*) extrema)[0] = imin;
+        memcpy(extrema, &imin, sizeof(imin));
         ((INT32*) extrema)[1] = imax;
         break;
     case IMAGING_TYPE_FLOAT32:
@@ -160,7 +160,7 @@ ImagingGetExtrema(Imaging im, void *extrema)
                     fmax = in[x];
             }
         }
-        ((FLOAT32*) extrema)[0] = fmin;
+        memcpy(extrema, &fmin, sizeof(fmin));
         ((FLOAT32*) extrema)[1] = fmax;
         break;
     case IMAGING_TYPE_SPECIAL:

--- a/src/libImaging/Histo.c
+++ b/src/libImaging/Histo.c
@@ -124,7 +124,7 @@ ImagingGetHistogram(Imaging im, Imaging imMask, void* minmax)
                     return ImagingError_ValueError("min/max not given");
                 if (!im->xsize || !im->ysize)
                     break;
-                imin = ((INT32*) minmax)[0];
+                memcpy(&imin, minmax, sizeof(imin));
                 imax = ((INT32*) minmax)[1];
                 if (imin >= imax)
                     break;
@@ -145,7 +145,7 @@ ImagingGetHistogram(Imaging im, Imaging imMask, void* minmax)
                     return ImagingError_ValueError("min/max not given");
                 if (!im->xsize || !im->ysize)
                     break;
-                fmin = ((FLOAT32*) minmax)[0];
+                memcpy(&fmin, minmax, sizeof(fmin));
                 fmax = ((FLOAT32*) minmax)[1];
                 if (fmin >= fmax)
                     break;

--- a/src/libImaging/Unpack.c
+++ b/src/libImaging/Unpack.c
@@ -995,7 +995,7 @@ unpackI12_I16(UINT8* out, const UINT8* in, int pixels){
 #ifdef WORDS_BIGENDIAN
         out[0] = tmp[1];  out[1] = tmp[0];
 #else
-        out16[0] = pixel;
+        memcpy(out, &pixel, sizeof(pixel));
 #endif
 
         pixel = (((UINT16) (in[1] & 0x0F)) << 8) + in[2];
@@ -1012,7 +1012,7 @@ unpackI12_I16(UINT8* out, const UINT8* in, int pixels){
 #ifdef WORDS_BIGENDIAN
         out[0] = tmp[1];  out[1] = tmp[0];
 #else
-        out16[0] = pixel;
+        memcpy(out, &pixel, sizeof(pixel));
 #endif
     }
 }


### PR DESCRIPTION
This replaces trivial instances where a copy from one pointer to the other involves no further calculations or casts. The compiler will optimize this to whatever the platform offers.

This is a first step in direction of a fix for #3213.
