### PR TITLE
Changed mmap file pointer to use context manager

### DIFF
--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -174,8 +174,8 @@ class ImageFile(Image.Image):
                     else:
                         # use mmap, if possible
                         import mmap
-                        fp = open(self.filename, "r")
-                        self.map = mmap.mmap(fp.fileno(), 0, access=mmap.ACCESS_READ)
+                        with open(self.filename, "r") as fp:
+                            self.map = mmap.mmap(fp.fileno(), 0, access=mmap.ACCESS_READ)
                         self.im = Image.core.map_buffer(
                             self.map, self.size, decoder_name, extents, offset, args
                             )

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -175,8 +175,7 @@ class ImageFile(Image.Image):
                         # use mmap, if possible
                         import mmap
                         fp = open(self.filename, "r")
-                        size = os.path.getsize(self.filename)
-                        self.map = mmap.mmap(fp.fileno(), size, access=mmap.ACCESS_READ)
+                        self.map = mmap.mmap(fp.fileno(), 0, access=mmap.ACCESS_READ)
                         self.im = Image.core.map_buffer(
                             self.map, self.size, decoder_name, extents, offset, args
                             )


### PR DESCRIPTION
Resolves #3184 

Also stops specifying size to `mmap.mmap` explicitly, since is 0 is supplied, it uses the length of the file. It does raise an exception on Windows if the file is empty, but that sounds reasonable.