### PR TITLE
Update docstrings

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -35,7 +35,7 @@ What about PIL?
     Prior to Pillow 2.0.0, very few image code changes were made. Pillow 2.0.0
     added Python 3 support and includes many bug fixes from many contributors.
 
-As more time passes since the last PIL release, the likelihood of a new PIL release decreases. However, we've yet to hear an official "PIL is dead" announcement. So if you still want to support PIL, please `report issues here first`_, then `open corresponding Pillow tickets here`_.
+As more time passes since the last PIL release (1.1.7 in 2009), the likelihood of a new PIL release decreases. However, we've yet to hear an official "PIL is dead" announcement. So if you still want to support PIL, please `report issues here first`_, then `open corresponding Pillow tickets here`_.
 
 .. _report issues here first: https://bitbucket.org/effbot/pil-2009-raclette/issues
 

--- a/src/PIL/__init__.py
+++ b/src/PIL/__init__.py
@@ -1,15 +1,18 @@
-#
-# The Python Imaging Library.
-# $Id$
-#
-# package placeholder
-#
-# Copyright (c) 1999 by Secret Labs AB.
-#
-# See the README file for information on usage and redistribution.
-#
+"""Pillow {} (Fork of the Python Imaging Library)
 
-# ;-)
+Pillow is the friendly PIL fork by Alex Clark and Contributors.
+    https://github.com/python-pillow/Pillow/
+
+Pillow is forked from PIL 1.1.7.
+
+PIL is the Python Imaging Library by Fredrik Lundh and Contributors.
+Copyright (c) 1999 by Secret Labs AB.
+
+Use PIL.__version__ for this Pillow version.
+PIL.VERSION is the old PIL version and will be removed in the future.
+
+;-)
+"""
 
 from . import _version
 
@@ -20,6 +23,9 @@ VERSION = '1.1.7'  # PIL Version
 PILLOW_VERSION = __version__ = _version.__version__
 
 del _version
+
+__doc__ = __doc__.format(__version__)  # include version in docstring
+
 
 _plugins = ['BlpImagePlugin',
             'BmpImagePlugin',


### PR DESCRIPTION
Fixes #3082.

Changes proposed in this pull request:

 * about.rst: add last PIL release version and date
 * PIL/\_\_init__.py: update package and version module docstrings

```python
Python 3.7.0 (default, Jun 29 2018, 20:13:13)
[Clang 9.1.0 (clang-902.0.39.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import PIL
>>> help(PIL)
```
Gives:
![image](https://user-images.githubusercontent.com/1324225/42132247-f0b58c3a-7d1c-11e8-902b-997193235f4b.png)
...
![image](https://user-images.githubusercontent.com/1324225/42132252-fc9c2ebe-7d1c-11e8-8cca-9a8291bf7969.png)
