### PR TITLE
Test ImageChops

### DIFF
--- a/Tests/test_imagechops.py
+++ b/Tests/test_imagechops.py
@@ -3,6 +3,16 @@ from helper import unittest, PillowTestCase, hopper
 from PIL import Image
 from PIL import ImageChops
 
+BLACK = (0, 0, 0)
+BROWN = (127, 64, 0)
+CYAN = (0, 255, 255)
+DARK_GREEN = (0, 128, 0)
+GREEN = (0, 255, 0)
+ORANGE = (255, 128, 0)
+WHITE = (255, 255, 255)
+
+GREY = 128
+
 
 class TestImageChops(PillowTestCase):
 
@@ -34,6 +44,200 @@ class TestImageChops(PillowTestCase):
 
         ImageChops.offset(im, 10)
         ImageChops.offset(im, 10, 20)
+
+    def test_add(self):
+        # Arrange
+        im1 = Image.open("Tests/images/imagedraw_ellipse_RGB.png")
+        im2 = Image.open("Tests/images/imagedraw_floodfill.png")
+
+        # Act
+        new = ImageChops.add(im1, im2)
+
+        # Assert
+        self.assertEqual(new.getbbox(), (25, 25, 76, 76))
+        self.assertEqual(new.getpixel((50, 50)), ORANGE)
+
+    def test_add_modulo(self):
+        # Arrange
+        im1 = Image.open("Tests/images/imagedraw_ellipse_RGB.png")
+        im2 = Image.open("Tests/images/imagedraw_floodfill.png")
+
+        # Act
+        new = ImageChops.add_modulo(im1, im2)
+
+        # Assert
+        self.assertEqual(new.getbbox(), (25, 25, 76, 76))
+        self.assertEqual(new.getpixel((50, 50)), ORANGE)
+
+    def test_blend(self):
+        # Arrange
+        im1 = Image.open("Tests/images/imagedraw_ellipse_RGB.png")
+        im2 = Image.open("Tests/images/imagedraw_floodfill.png")
+
+        # Act
+        new = ImageChops.blend(im1, im2, 0.5)
+
+        # Assert
+        self.assertEqual(new.getbbox(), (25, 25, 76, 76))
+        self.assertEqual(new.getpixel((50, 50)), BROWN)
+
+    def test_constant(self):
+        # Arrange
+        im = Image.new("RGB", (20, 10))
+
+        # Act
+        new = ImageChops.constant(im, GREY)
+
+        # Assert
+        self.assertEqual(new.size, im.size)
+        self.assertEqual(new.getpixel((0, 0)), GREY)
+        self.assertEqual(new.getpixel((19, 9)), GREY)
+
+    def test_darker(self):
+        # Arrange
+        im1 = Image.open("Tests/images/imagedraw_chord_RGB.png")
+        im2 = Image.open("Tests/images/imagedraw_outline_chord_RGB.png")
+
+        # Act
+        new = ImageChops.darker(im1, im2)
+
+        # Assert
+        self.assert_image_equal(new, im2)
+
+    def test_difference(self):
+        # Arrange
+        im1 = Image.open("Tests/images/imagedraw_arc_end_le_start.png")
+        im2 = Image.open("Tests/images/imagedraw_arc_no_loops.png")
+
+        # Act
+        new = ImageChops.difference(im1, im2)
+
+        # Assert
+        self.assertEqual(new.getbbox(), (25, 25, 76, 76))
+
+    def test_duplicate(self):
+        # Arrange
+        im = hopper()
+
+        # Act
+        new = ImageChops.duplicate(im)
+
+        # Assert
+        self.assert_image_equal(new, im)
+
+    def test_invert(self):
+        # Arrange
+        im = Image.open("Tests/images/imagedraw_floodfill.png")
+
+        # Act
+        new = ImageChops.invert(im)
+
+        # Assert
+        self.assertEqual(new.getbbox(), (0, 0, 100, 100))
+        self.assertEqual(new.getpixel((0, 0)), WHITE)
+        self.assertEqual(new.getpixel((50, 50)), CYAN)
+
+    def test_lighter(self):
+        # Arrange
+        im1 = Image.open("Tests/images/imagedraw_chord_RGB.png")
+        im2 = Image.open("Tests/images/imagedraw_outline_chord_RGB.png")
+
+        # Act
+        new = ImageChops.darker(im1, im2)
+
+        # Assert
+        self.assert_image_equal(new, im2)
+
+    def test_multiply_black(self):
+        """If you multiply an image with a solid black image,
+        the result is black."""
+        # Arrange
+        im1 = hopper()
+        black = Image.new("RGB", im1.size, "black")
+
+        # Act
+        new = ImageChops.multiply(im1, black)
+
+        # Assert
+        self.assert_image_equal(new, black)
+
+    def test_multiply_green(self):
+        # Arrange
+        im = Image.open("Tests/images/imagedraw_floodfill.png")
+        green = Image.new("RGB", im.size, "green")
+
+        # Act
+        new = ImageChops.multiply(im, green)
+
+        # Assert
+        self.assertEqual(new.getbbox(), (25, 25, 76, 76))
+        self.assertEqual(new.getpixel((25, 25)), DARK_GREEN)
+        self.assertEqual(new.getpixel((50, 50)), BLACK)
+
+    def test_multiply_white(self):
+        """If you multiply with a solid white image,
+        the image is unaffected."""
+        # Arrange
+        im1 = hopper()
+        white = Image.new("RGB", im1.size, "white")
+
+        # Act
+        new = ImageChops.multiply(im1, white)
+
+        # Assert
+        self.assert_image_equal(new, im1)
+
+    def test_offset(self):
+        # Arrange
+        im = Image.open("Tests/images/imagedraw_ellipse_RGB.png")
+        xoffset = 45
+        yoffset = 20
+
+        # Act
+        new = ImageChops.offset(im, xoffset, yoffset)
+
+        # Assert
+        self.assertEqual(new.getbbox(), (0, 45, 100, 96))
+        self.assertEqual(new.getpixel((50, 50)), BLACK)
+        self.assertEqual(new.getpixel((50+xoffset, 50+yoffset)), DARK_GREEN)
+
+    def test_screen(self):
+        # Arrange
+        im1 = Image.open("Tests/images/imagedraw_ellipse_RGB.png")
+        im2 = Image.open("Tests/images/imagedraw_floodfill.png")
+
+        # Act
+        new = ImageChops.screen(im1, im2)
+
+        # Assert
+        self.assertEqual(new.getbbox(), (25, 25, 76, 76))
+        self.assertEqual(new.getpixel((50, 50)), ORANGE)
+
+    def test_subtract(self):
+        # Arrange
+        im1 = Image.open("Tests/images/imagedraw_chord_RGB.png")
+        im2 = Image.open("Tests/images/imagedraw_outline_chord_RGB.png")
+
+        # Act
+        new = ImageChops.subtract(im1, im2)
+
+        # Assert
+        self.assertEqual(new.getbbox(), (25, 50, 76, 76))
+        self.assertEqual(new.getpixel((50, 50)), GREEN)
+        self.assertEqual(new.getpixel((50, 51)), BLACK)
+
+    def test_subtract_modulo(self):
+        # Arrange
+        im1 = Image.open("Tests/images/imagedraw_chord_RGB.png")
+        im2 = Image.open("Tests/images/imagedraw_outline_chord_RGB.png")
+
+        # Act
+        new = ImageChops.subtract_modulo(im1, im2)
+
+        # Assert
+        self.assertEqual(new.getbbox(), (25, 50, 76, 76))
+        self.assertEqual(new.getpixel((50, 50)), GREEN)
+        self.assertEqual(new.getpixel((50, 51)), BLACK)
 
     def test_logical(self):
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * `ImageChops` has just two tests in [test_imagechops.py](https://github.com/python-pillow/Pillow/blob/master/Tests/test_imagechops.py):
   * `test_logical` tests `logical_* methods
   * `test_sanity` only checks methods can run
 * This PR adds cases to test the output of methods
