### PR TITLE
Remove unused draw_line, draw_point and getabc

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -2751,21 +2751,6 @@ _draw_lines(ImagingDrawObject* self, PyObject* args)
 }
 
 static PyObject*
-_draw_point(ImagingDrawObject* self, PyObject* args)
-{
-    int x, y;
-    int ink;
-    if (!PyArg_ParseTuple(args, "(ii)i", &x, &y, &ink))
-        return NULL;
-
-    if (ImagingDrawPoint(self->image->image, x, y, &ink, self->blend) < 0)
-        return NULL;
-
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
-static PyObject*
 _draw_points(ImagingDrawObject* self, PyObject* args)
 {
     double *xy;
@@ -2951,7 +2936,6 @@ static struct PyMethodDef _draw_methods[] = {
 #endif
     {"draw_polygon", (PyCFunction)_draw_polygon, 1},
     {"draw_rectangle", (PyCFunction)_draw_rectangle, 1},
-    {"draw_point", (PyCFunction)_draw_point, 1},
     {"draw_points", (PyCFunction)_draw_points, 1},
     {"draw_arc", (PyCFunction)_draw_arc, 1},
     {"draw_bitmap", (PyCFunction)_draw_bitmap, 1},

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -2698,22 +2698,6 @@ _draw_ellipse(ImagingDrawObject* self, PyObject* args)
 }
 
 static PyObject*
-_draw_line(ImagingDrawObject* self, PyObject* args)
-{
-    int x0, y0, x1, y1;
-    int ink;
-    if (!PyArg_ParseTuple(args, "(ii)(ii)i", &x0, &y0, &x1, &y1, &ink))
-        return NULL;
-
-    if (ImagingDrawLine(self->image->image, x0, y0, x1, y1,
-                        &ink, self->blend) < 0)
-        return NULL;
-
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
-static PyObject*
 _draw_lines(ImagingDrawObject* self, PyObject* args)
 {
     double *xy;
@@ -2961,7 +2945,6 @@ _draw_rectangle(ImagingDrawObject* self, PyObject* args)
 static struct PyMethodDef _draw_methods[] = {
 #ifdef WITH_IMAGEDRAW
     /* Graphics (ImageDraw) */
-    {"draw_line", (PyCFunction)_draw_line, 1},
     {"draw_lines", (PyCFunction)_draw_lines, 1},
 #ifdef WITH_ARROW
     {"draw_outline", (PyCFunction)_draw_outline, 1},

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -675,47 +675,6 @@ font_getsize(FontObject* self, PyObject* args)
 }
 
 static PyObject*
-font_getabc(FontObject* self, PyObject* args)
-{
-    FT_ULong ch;
-    FT_Face face;
-    double a, b, c;
-
-    /* calculate ABC values for a given string */
-
-    PyObject* string;
-    if (!PyArg_ParseTuple(args, "O:getabc", &string))
-        return NULL;
-
-#if PY_VERSION_HEX >= 0x03000000
-    if (!PyUnicode_Check(string)) {
-#else
-    if (!PyUnicode_Check(string) && !PyString_Check(string)) {
-#endif
-        PyErr_SetString(PyExc_TypeError, "expected string");
-        return NULL;
-    }
-
-    if (font_getchar(string, 0, &ch)) {
-        int index, error;
-        face = self->face;
-        index = FT_Get_Char_Index(face, ch);
-        /* Note: bitmap fonts within ttf fonts do not work, see #891/pr#960 */
-        error = FT_Load_Glyph(face, index, FT_LOAD_DEFAULT|FT_LOAD_NO_BITMAP);
-        if (error)
-            return geterror(error);
-        a = face->glyph->metrics.horiBearingX / 64.0;
-        b = face->glyph->metrics.width / 64.0;
-        c = (face->glyph->metrics.horiAdvance -
-             face->glyph->metrics.horiBearingX -
-             face->glyph->metrics.width) / 64.0;
-    } else
-        a = b = c = 0.0;
-
-    return Py_BuildValue("ddd", a, b, c);
-}
-
-static PyObject*
 font_render(FontObject* self, PyObject* args)
 {
     int i, x, y;
@@ -854,7 +813,6 @@ font_dealloc(FontObject* self)
 static PyMethodDef font_methods[] = {
     {"render", (PyCFunction) font_render, METH_VARARGS},
     {"getsize", (PyCFunction) font_getsize, METH_VARARGS},
-    {"getabc", (PyCFunction) font_getabc, METH_VARARGS},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * _imaging.c exposes:
   * `_draw_line` as `draw_line`
   * `_draw_lines` as `draw_lines`
   * `_draw_point` as `draw_point`
   * `_draw_points` as `draw_points`
 * However, ImageDraw.py only uses `draw_lines` and `draw_points`
 * _imagingft.c exposes `font_getabc` as `getabc`, but unused by the Python layer
 * This PR removes the unused functions
 * Helps a bit towards #722