### PR TITLE
Fix code for PYTHONOPTIMIZE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,10 @@ matrix:
     - python: '3.5'
     - python: '3.5'
       dist: trusty
+      env: PYTHONOPTIMIZE=1
     - python: '3.4'
       dist: trusty
+      env: PYTHONOPTIMIZE=2
     - env: DOCKER="alpine" DOCKER_TAG="pytest"
     - env: DOCKER="arch" DOCKER_TAG="pytest" # contains PyQt5
     - env: DOCKER="ubuntu-trusty-x86" DOCKER_TAG="pytest"

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -14,7 +14,6 @@ else:
         import cffi
     except ImportError:
         cffi = None
-        pass
 
 
 class AccessTest(PillowTestCase):

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -1,15 +1,20 @@
 from helper import unittest, PillowTestCase, hopper, on_appveyor
 
-try:
-    from PIL import PyAccess
-    import cffi
-except ImportError:
-    cffi = None
-    pass
-
 from PIL import Image
 import sys
 import os
+
+# CFFI imports pycparser which doesn't support PYTHONOPTIMIZE=2
+# https://github.com/eliben/pycparser/pull/198#issuecomment-317001670
+if os.environ.get("PYTHONOPTIMIZE") == "2":
+    cffi = None
+else:
+    try:
+        from PIL import PyAccess
+        import cffi
+    except ImportError:
+        cffi = None
+        pass
 
 
 class AccessTest(PillowTestCase):

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -2,8 +2,9 @@ from helper import unittest, PillowTestCase, hopper, on_appveyor
 
 try:
     from PIL import PyAccess
+    import cffi
 except ImportError:
-    # Skip in setUp()
+    cffi = None
     pass
 
 from PIL import Image
@@ -113,37 +114,19 @@ class TestImageGetPixel(AccessTest):
             self.check(mode, 2**16-1)
 
 
+@unittest.skipIf(cffi is None, "No cffi")
 class TestCffiPutPixel(TestImagePutPixel):
     _need_cffi_access = True
 
-    def setUp(self):
-        try:
-            import cffi
-            assert cffi  # silence warning
-        except ImportError:
-            self.skipTest("No cffi")
 
-
+@unittest.skipIf(cffi is None, "No cffi")
 class TestCffiGetPixel(TestImageGetPixel):
     _need_cffi_access = True
 
-    def setUp(self):
-        try:
-            import cffi
-            assert cffi  # silence warning
-        except ImportError:
-            self.skipTest("No cffi")
 
-
+@unittest.skipIf(cffi is None, "No cffi")
 class TestCffi(AccessTest):
     _need_cffi_access = True
-
-    def setUp(self):
-        try:
-            import cffi
-            assert cffi  # silence warning
-        except ImportError:
-            self.skipTest("No cffi")
 
     def _test_get_access(self, im):
         """Do we get the same thing as the old pixel access

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -215,7 +215,7 @@ class TestImageFont(PillowTestCase):
 
         # Act/Assert
         self.assertRaises(
-            AssertionError,
+            ValueError,
             draw.multiline_text, (0, 0), TEST_TEXT, font=ttf, align="unknown")
 
     def test_draw_align(self):

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -246,7 +246,7 @@ class ImageDraw(object):
             elif align == "right":
                 left += (max_width - widths[idx])
             else:
-                assert False, 'align must be "left", "center" or "right"'
+                raise ValueError('align must be "left", "center" or "right"')
             self.text((left, top), line, fill, font, anchor,
                       direction=direction, features=features)
             top += line_spacing

--- a/src/PIL/ImageTk.py
+++ b/src/PIL/ImageTk.py
@@ -32,13 +32,6 @@ if sys.version_info.major > 2:
 else:
     import Tkinter as tkinter
 
-# required for pypy, which always has cffi installed
-try:
-    from cffi import FFI
-    ffi = FFI()
-except ImportError:
-    pass
-
 from . import Image
 from io import BytesIO
 
@@ -192,7 +185,11 @@ class PhotoImage(object):
                 from . import _imagingtk
                 try:
                     if hasattr(tk, 'interp'):
-                        # Pypy is using a ffi cdata element
+                        # Required for PyPy, which always has CFFI installed
+                        from cffi import FFI
+                        ffi = FFI()
+
+                        # Pypy is using an FFI cdata element
                         # (Pdb) self.tk.interp
                         #  <cdata 'Tcl_Interp *' 0x3061b50>
                         _imagingtk.tkinit(

--- a/src/PIL/ImageTk.py
+++ b/src/PIL/ImageTk.py
@@ -189,7 +189,7 @@ class PhotoImage(object):
                         from cffi import FFI
                         ffi = FFI()
 
-                        # Pypy is using an FFI cdata element
+                        # PyPy is using an FFI CDATA element
                         # (Pdb) self.tk.interp
                         #  <cdata 'Tcl_Interp *' 0x3061b50>
                         _imagingtk.tkinit(

--- a/src/PIL/__init__.py
+++ b/src/PIL/__init__.py
@@ -1,4 +1,4 @@
-"""Pillow {} (Fork of the Python Imaging Library)
+"""Pillow (Fork of the Python Imaging Library)
 
 Pillow is the friendly PIL fork by Alex Clark and Contributors.
     https://github.com/python-pillow/Pillow/
@@ -23,8 +23,6 @@ VERSION = '1.1.7'  # PIL Version
 PILLOW_VERSION = __version__ = _version.__version__
 
 del _version
-
-__doc__ = __doc__.format(__version__)  # include version in docstring
 
 
 _plugins = ['BlpImagePlugin',


### PR DESCRIPTION
Fixes #3231.

 * Fix bug introduced by https://github.com/python-pillow/Pillow/pull/3218 with `PYTHONOPTIMIZE=2`, because that level strips away docstrings resulting in '`NoneType' object has no attribute 'format'`

---

https://ziade.org/2015/11/25/should-i-use-pythonoptimize/ says:

> So yeah, **even if you don't use yourself those options, it's good practice to make sure that your python code is tested with all possible values for PYTHONOPTIMIZE.**
> 
> It's easy enough, just run your tests with **-O** and **-OO** and without, and make sure your code does not depend on docstrings or assertions.

---

Changes proposed in this pull request:

 * Test two build jobs (chosen arbitrarily) with the two different `PYTHONOPTIMIZE` levels to ensure this stays fixed

 * Running `PYTHONOPTIMIZE=1` (same as `-O`) identified code depending on an assert. Convert it to an exception.

 * Running `PYTHONOPTIMIZE=2` (same as `-OO`) identified code depending on docstrings in `pycparser`, imported by `cffi`. `pycparser` doesn't support `PYTHONOPTIMIZE=2`:  https://github.com/eliben/pycparser/pull/198#issuecomment-317001670.

   * When `PYTHONOPTIMIZE=2`, skip tests that require `cffi`

   * ImageTk.py only needs `cffi` for PyPy. Import it only where needed, to avoid problems when `PYTHONOPTIMIZE=2`.

