### PR TITLE
Capture pkg-config output even if only one component returned

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,8 +154,8 @@ def _pkg_config(name):
         ]
         if not DEBUG:
             command.append('--silence-errors')
-        libs = subprocess.check_output(command).decode('utf8').split(' ')
-        return libs[1][2:].strip(), libs[0][2:].strip()
+        libs = subprocess.check_output(command).decode('utf8')
+        return re.match(r'(?:-L([^\s]+))?\s*(?:-I([^\s]+))?', libs).groups()
     except Exception:
         pass
 


### PR DESCRIPTION
Changing pkg-config output parser in case it returns only one component
(only -I or only -L)

Currently an issue with libtiff in official python container:
```
> docker run --rm -it --entrypoint=bash python:3
# pkg-config --libs-only-L libtiff-4 --cflags-only-I libtiff-4
 -I/usr/include/x86_64-linux-gnu 
# pip install pillow --global-option="build_ext" --global-option="--disable-zlib" \
 --global-option="build_ext" --global-option="--disable-jpeg" \
 --global-option="build_ext" --global-option="--enable-tiff"

...
    The headers or library files could not be found for tiff,
    which was requested by the option flag --enable-tiff
```