### PR TITLE
Add feature: ImageOps.colorize to support three colors

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -94,6 +94,22 @@ class TestImageOps(PillowTestCase):
         newimg = ImageOps.scale(i, 0.5)
         self.assertEqual(newimg.size, (25, 25))
 
+    def test_colorize(self):
+        # Test the colorizing function
+
+        # Grab test image
+        i = hopper("L").resize((15, 16))
+
+        # Test original 2-color functionality
+        ImageOps.colorize(i, 'green', 'red')
+
+        # Test new three color functionality (cyanotype colors)
+        ImageOps.colorize(i,
+                          (32, 37, 79),
+                          (255, 255, 255),
+                          (35, 52, 121),
+                          40)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -136,28 +136,50 @@ def autocontrast(image, cutoff=0, ignore=None):
     return _lut(image, lut)
 
 
-def colorize(image, black, white):
+def colorize(image, black, white, mid=None, midpoint=128):
     """
-    Colorize grayscale image.  The **black** and **white**
-    arguments should be RGB tuples; this function calculates a color
-    wedge mapping all black pixels in the source image to the first
-    color, and all white pixels to the second color.
+    Colorize grayscale image.
+    This function calculates a color wedge mapping all
+    black pixels in the source image to the first
+    color, and all white pixels to the second color. If
+    mid is specified, it uses three color mapping.
+    The **black** and **white**
+    arguments should be RGB tuples; optionally you can use
+    three color mapping by also specifying **mid**, and
+    optionally, **midpoint** (which is the integer value
+    in [0, 255] corresponding to the midpoint color,
+    default 128).
 
     :param image: The image to colorize.
     :param black: The color to use for black input pixels.
     :param white: The color to use for white input pixels.
+    :param mid: The color to use for midtone input pixels.
+    :param midpoint: the int value [0, 255] for the mid color.
     :return: An image.
     """
     assert image.mode == "L"
     black = _color(black, "RGB")
+    if mid is not None:
+        mid = _color(mid, "RGB")
     white = _color(white, "RGB")
     red = []
     green = []
     blue = []
-    for i in range(256):
-        red.append(black[0]+i*(white[0]-black[0])//255)
-        green.append(black[1]+i*(white[1]-black[1])//255)
-        blue.append(black[2]+i*(white[2]-black[2])//255)
+    if mid is None:
+        for i in range(256):
+            red.append(black[0] + i * (white[0] - black[0]) // 255)
+            green.append(black[1] + i * (white[1] - black[1]) // 255)
+            blue.append(black[2] + i * (white[2] - black[2]) // 255)
+    else:
+        for i in range(0, midpoint):
+            red.append(black[0] + i * (mid[0] - black[0]) // 255)
+            green.append(black[1] + i * (mid[1] - black[1]) // 255)
+            blue.append(black[2] + i * (mid[2] - black[2]) // 255)
+        for i in range(0, 256 - midpoint):
+            red.append(mid[0] + i * (white[0] - mid[0]) // 255)
+            green.append(mid[1] + i * (white[1] - mid[1]) // 255)
+            blue.append(mid[2] + i * (white[2] - mid[2]) // 255)
+
     image = image.convert("RGB")
     return _lut(image, red + green + blue)
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -154,10 +154,11 @@ def colorize(image, black, white, mid=None, midpoint=128):
     :param black: The color to use for black input pixels.
     :param white: The color to use for white input pixels.
     :param mid: The color to use for midtone input pixels.
-    :param midpoint: the int value [0, 255] for the mid color.
+    :param midpoint: the int value in [1, 254] for the mid color.
     :return: An image.
     """
     assert image.mode == "L"
+    assert 1 <= midpoint <= 254
 
     # Define colors from arguments
     black = _color(black, "RGB")

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -147,8 +147,8 @@ def colorize(image, black, white, mid=None, midpoint=128):
     arguments should be RGB tuples; optionally you can use
     three color mapping by also specifying **mid**, and
     optionally, **midpoint** (which is the integer value
-    in [0, 255] corresponding to the midpoint color,
-    default 128).
+    in [1, 254] corresponding to where the midpoint color
+    should be mapped (0 being black and 255 being white).
 
     :param image: The image to colorize.
     :param black: The color to use for black input pixels.
@@ -158,10 +158,14 @@ def colorize(image, black, white, mid=None, midpoint=128):
     :return: An image.
     """
     assert image.mode == "L"
+
+    # Define colors from arguments
     black = _color(black, "RGB")
     if mid is not None:
         mid = _color(mid, "RGB")
     white = _color(white, "RGB")
+
+    # Create the mapping
     red = []
     green = []
     blue = []

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -136,7 +136,7 @@ def autocontrast(image, cutoff=0, ignore=None):
     return _lut(image, lut)
 
 
-def colorize(image, black, white, mid=None, midpoint=128):
+def colorize(image, black, white, mid=None, midpoint=127):
     """
     Colorize grayscale image.
     This function calculates a color wedge mapping all
@@ -176,14 +176,16 @@ def colorize(image, black, white, mid=None, midpoint=128):
             green.append(black[1] + i * (white[1] - black[1]) // 255)
             blue.append(black[2] + i * (white[2] - black[2]) // 255)
     else:
-        for i in range(0, midpoint):
-            red.append(black[0] + i * (mid[0] - black[0]) // 255)
-            green.append(black[1] + i * (mid[1] - black[1]) // 255)
-            blue.append(black[2] + i * (mid[2] - black[2]) // 255)
-        for i in range(0, 256 - midpoint):
-            red.append(mid[0] + i * (white[0] - mid[0]) // 255)
-            green.append(mid[1] + i * (white[1] - mid[1]) // 255)
-            blue.append(mid[2] + i * (white[2] - mid[2]) // 255)
+        range1 = range(0, midpoint)
+        range2 = range(0, 256 - midpoint)
+        for i in range1:
+            red.append(black[0] + i * (mid[0] - black[0]) // len(range1))
+            green.append(black[1] + i * (mid[1] - black[1]) // len(range1))
+            blue.append(black[2] + i * (mid[2] - black[2]) // len(range1))
+        for i in range2:
+            red.append(mid[0] + i * (white[0] - mid[0]) // len(range2))
+            green.append(mid[1] + i * (white[1] - mid[1]) // len(range2))
+            blue.append(mid[2] + i * (white[2] - mid[2]) // len(range2))
 
     image = image.convert("RGB")
     return _lut(image, red + green + blue)


### PR DESCRIPTION
Changes proposed in this pull request:
 * Added optional arguments to allow for a third color (`mid`) to be specified in `ImageOps.colorize()`, and the ability to choose where this color is applied in the [black, white] range (`midpoint`)
* While re-writing `colorize`, I formatted that function to pep8

 Comments:
* I was using `ImageOps.colorize()` to try to generate a image resembling a cyanotype, and found the two colors for mapping limiting. See attached images for a sense of how the change allows a more dynamic mapping
* I added the test `test_imageops.test_colorize()` to test the functionality and it is passing on Travis. However I'm not sure how to automatically test the gradient mapping without a test image, so I attached an image showing a stoplight gradient with a slight offset in the midpoint, demonstrating that the effect works smoothly. Test code to generate this is `ImageOps.colorize3(image_gradient, 'red', 'green', 'yellow', 100)` where `image_gradient` is a black to white gradient image
* I tested the docs and they seem to be building fine with my updated docstring

Two-color:
![test_2color](https://user-images.githubusercontent.com/28113523/42406121-8008009c-8156-11e8-8ea1-081f1418c451.jpg)
Three color:
![test_3color](https://user-images.githubusercontent.com/28113523/42406120-7feec2a8-8156-11e8-866e-c612c44fc0fd.jpg)
Gradient test:
![test_gradient_offset](https://user-images.githubusercontent.com/28113523/42406123-802040a8-8156-11e8-8c8d-0e7bcf3685ba.jpg)
