### PR TITLE
[QuantOctree.c] Remove further attempts to average over empty buckets

### DIFF
--- a/src/libImaging/QuantOctree.c
+++ b/src/libImaging/QuantOctree.c
@@ -296,6 +296,7 @@ void add_lookup_buckets(ColorCube cube, ColorBucket palette, long nColors, long 
    long i;
    Pixel p;
    for (i=offset; i<offset+nColors; i++) {
+      if (palette[i].count == 0) continue;
       avg_color_from_color_bucket(&palette[i], &p);
       set_lookup_value(cube, &p, i);
    }
@@ -328,6 +329,7 @@ create_palette_array(const ColorBucket palette, unsigned int paletteLength) {
    if (!paletteArray) return NULL;
 
    for (i=0; i<paletteLength; i++) {
+      if (palette[i].count == 0) continue;
       avg_color_from_color_bucket(&palette[i], &paletteArray[i]);
    }
    return paletteArray;


### PR DESCRIPTION
Fixes #3031.

Changes proposed in this pull request:

* Skip cube updates for empty buckets in "add_lookup_buckets".

* Don't explicitly set pixel value in create_palette_array;
  the array is already zero-initialized, and zero is as good as
  any value for the average over nothing.

*Important:* Please review these two changes very carefully. There is obviously some sort of logic error if you ever need to *consume* the "average over an empty range", so what I'd like you to confirm is that the values that we stop writing in this change have never actually been read, or at least if they've been read they've not been used further.