### PR TITLE
Fixed implicit conversion warnings

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -552,7 +552,7 @@ getink(PyObject* color, Imaging im, char* ink)
                     return NULL;
                 }
             }
-            ink[0] = CLIP8(r);
+            ink[0] = (char) CLIP8(r);
             ink[1] = ink[2] = ink[3] = 0;
         } else {
             a = 255;
@@ -572,10 +572,10 @@ getink(PyObject* color, Imaging im, char* ink)
                         return NULL;
                 }
             }
-            ink[0] = CLIP8(r);
-            ink[1] = CLIP8(g);
-            ink[2] = CLIP8(b);
-            ink[3] = CLIP8(a);
+            ink[0] = (char) CLIP8(r);
+            ink[1] = (char) CLIP8(g);
+            ink[2] = (char) CLIP8(b);
+            ink[3] = (char) CLIP8(a);
         }
         return ink;
     case IMAGING_TYPE_INT32:


### PR DESCRIPTION
When I compile on macOS, I get
```
src/_imaging.c:555:22: warning: implicit conversion from 'int' to 'char' changes value from 255 to -1
      [-Wconstant-conversion]
            ink[0] = CLIP8(r);
                   ~ ^~~~~~~~
src/libImaging/ImagingUtils.h:33:52: note: expanded from macro 'CLIP8'
#define CLIP8(v) ((v) <= 0 ? 0 : (v) < 256 ? (v) : 255)
                                                   ^~~
src/_imaging.c:575:22: warning: implicit conversion from 'int' to 'char' changes value from 255 to -1
      [-Wconstant-conversion]
            ink[0] = CLIP8(r);
                   ~ ^~~~~~~~
src/libImaging/ImagingUtils.h:33:52: note: expanded from macro 'CLIP8'
#define CLIP8(v) ((v) <= 0 ? 0 : (v) < 256 ? (v) : 255)
                                                   ^~~
src/_imaging.c:576:22: warning: implicit conversion from 'int' to 'char' changes value from 255 to -1
      [-Wconstant-conversion]
            ink[1] = CLIP8(g);
                   ~ ^~~~~~~~
src/libImaging/ImagingUtils.h:33:52: note: expanded from macro 'CLIP8'
#define CLIP8(v) ((v) <= 0 ? 0 : (v) < 256 ? (v) : 255)
                                                   ^~~
src/_imaging.c:577:22: warning: implicit conversion from 'int' to 'char' changes value from 255 to -1
      [-Wconstant-conversion]
            ink[2] = CLIP8(b);
                   ~ ^~~~~~~~
src/libImaging/ImagingUtils.h:33:52: note: expanded from macro 'CLIP8'
#define CLIP8(v) ((v) <= 0 ? 0 : (v) < 256 ? (v) : 255)
                                                   ^~~
src/_imaging.c:578:22: warning: implicit conversion from 'int' to 'char' changes value from 255 to -1
      [-Wconstant-conversion]
            ink[3] = CLIP8(a);
                   ~ ^~~~~~~~
src/libImaging/ImagingUtils.h:33:52: note: expanded from macro 'CLIP8'
#define CLIP8(v) ((v) <= 0 ? 0 : (v) < 256 ? (v) : 255)
                                                   ^~~
```