### PR TITLE
Docs: Remove redundant module skipping

### DIFF
--- a/docs/PIL.rst
+++ b/docs/PIL.rst
@@ -62,8 +62,6 @@ can be found here.
     :undoc-members:
     :show-inheritance:
 
-.. intentionally skipped documenting this because it's deprecated
-
 :mod:`ImageShow` Module
 -----------------------
 


### PR DESCRIPTION
The skipping originally applied to ImageFileIO (#375), and ImageFileIO was later removed (#1343) but this line was missed.

(It wasn't obvious as the skipping line comes before the module.)