### PR TITLE
Added GitHub release to release checklist

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,6 +24,7 @@ Released quarterly on the first day of January, April, July, October.
 ```
 * [ ] Create [binary distributions](#binary-distributions)
 * [ ] Upload all binaries and source distributions e.g. ``twine upload dist/Pillow-5.2.0-*``
+* [ ] Create a [new release on GitHub](https://github.com/python-pillow/Pillow/releases/new)
 * [ ] In compliance with [PEP 440](https://www.python.org/dev/peps/pep-0440/), append `.dev0` to version identifier in `src/PIL/_version.py`
 
 ## Point Release
@@ -50,6 +51,7 @@ Released as needed for security, installation or critical bug fixes.
     $ make sdist
 ```
 * [ ] Create [binary distributions](#binary-distributions)
+* [ ] Create a [new release on GitHub](https://github.com/python-pillow/Pillow/releases/new)
 
 ## Embargoed Release
 
@@ -73,6 +75,7 @@ Released as needed privately to individual vendors for critical security-related
     $ make sdist
 ```
 * [ ] Create [binary distributions](#binary-distributions)
+* [ ] Create a [new release on GitHub](https://github.com/python-pillow/Pillow/releases/new)
 
 ## Binary Distributions
 


### PR DESCRIPTION
5.2.0 wasn't added as a release to https://github.com/python-pillow/Pillow/releases until I did it just now - so this PR adds it to the release checklist.