### PR TITLE
Update CONTRIBUTING from ISSUE_TEMPLATE

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,7 +21,9 @@ Please send a pull request to the master branch. Please include [documentation](
 
 ## Reporting Issues
 
-When reporting issues, please include code that reproduces the issue and whenever possible, an image that demonstrates the issue. The best reproductions are self-contained scripts with minimal dependencies.
+When reporting issues, please include code that reproduces the issue and whenever possible, an image that demonstrates the issue. Please upload images to GitHub, not to third-party file hosting sites. If necessary, add the image to a zip or tar archive.
+
+The best reproductions are self-contained scripts with minimal dependencies. If you are using a framework such as plone, Django, or buildout, try to replicate the issue just using Pillow.
 
 ### Provide details
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/master/.github/ISSUE_TEMPLATE.md originally mirrored CONTRIBUTING. It has since received updates - https://github.com/python-pillow/Pillow/commits/master/.github/ISSUE_TEMPLATE.md - so this PR copies those changes back to CONTRIBUTING.