### PR TITLE
Changed Kernel to subclass BuiltinFilter

### DIFF
--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -94,14 +94,14 @@ class TestImageFilter(PillowTestCase):
         self.assertEqual(rankfilter.size, 1)
         self.assertEqual(rankfilter.rank, 2)
 
+    def test_builtinfilter_p(self):
+        builtinFilter = ImageFilter.BuiltinFilter()
+
+        self.assertRaises(ValueError, builtinFilter.filter, hopper("P"))
+
     def test_kernel_not_enough_coefficients(self):
         self.assertRaises(ValueError,
                           lambda: ImageFilter.Kernel((3, 3), (0, 0)))
-
-    def test_kernel_filter_p(self):
-        kernel = ImageFilter.Kernel((2, 2), (0, 0, 0, 0))
-
-        self.assertRaises(ValueError, kernel.filter, hopper("P"))
 
     def test_consistency_3x3(self):
         source = Image.open("Tests/images/hopper.bmp")

--- a/src/PIL/ImageFilter.py
+++ b/src/PIL/ImageFilter.py
@@ -33,7 +33,14 @@ class MultibandFilter(Filter):
     pass
 
 
-class Kernel(MultibandFilter):
+class BuiltinFilter(MultibandFilter):
+    def filter(self, image):
+        if image.mode == "P":
+            raise ValueError("cannot filter palette images")
+        return image.filter(*self.filterargs)
+
+
+class Kernel(BuiltinFilter):
     """
     Create a convolution kernel.  The current version only
     supports 3x3 and 5x5 integer and floating point kernels.
@@ -59,16 +66,6 @@ class Kernel(MultibandFilter):
         if size[0] * size[1] != len(kernel):
             raise ValueError("not enough coefficients in kernel")
         self.filterargs = size, scale, offset, kernel
-
-    def filter(self, image):
-        if image.mode == "P":
-            raise ValueError("cannot filter palette images")
-        return image.filter(*self.filterargs)
-
-
-class BuiltinFilter(Kernel):
-    def __init__(self):
-        pass
 
 
 class RankFilter(Filter):


### PR DESCRIPTION
Changed Kernel to subclass BuiltinFilter, instead of the other way around.

Before, BuiltinFilter overrides Kernel's init method with a simple pass statement -
```
class Kernel(MultibandFilter):
    name = "Kernel"
    def __init__(self, size, kernel, scale=None, offset=0):
        ...
    def filter(self, image):
        ...

class BuiltinFilter(Kernel):
    def __init__(self):
        pass
```

After, Kernel adds an init method -
```
class BuiltinFilter(MultibandFilter):
    def filter(self, image):
        ...

class Kernel(BuiltinFilter):
    name = "Kernel"
    def __init__(self, size, kernel, scale=None, offset=0):
        ...
```

This should have no effect, it just seems like a nicer way to organise the code.