### PR TITLE
Improve PDF document info

### DIFF
--- a/Tests/test_pdfparser.py
+++ b/Tests/test_pdfparser.py
@@ -3,6 +3,7 @@ from helper import unittest, PillowTestCase
 from PIL.PdfParser import IndirectObjectDef, IndirectReference, PdfBinary, \
                           PdfDict, PdfFormatError, PdfName, PdfParser, \
                           PdfStream, decode_text, encode_text, pdf_repr
+import time
 
 
 class TestPdfParser(PillowTestCase):
@@ -76,6 +77,19 @@ class TestPdfParser(PillowTestCase):
         self.assertIsInstance(s, PdfStream)
         self.assertEqual(s.dictionary.Name, "value")
         self.assertEqual(s.decode(), b"abcde")
+        for name in ["CreationDate", "ModDate"]:
+            for date, value in {
+                b"20180729214124": "20180729214124",
+                b"D:20180729214124": "20180729214124",
+                b"D:2018072921": "20180729210000",
+                b"D:20180729214124Z": "20180729214124",
+                b"D:20180729214124+08'00'": "20180729134124",
+                b"D:20180729214124-05'00'": "20180730024124"
+            }.items():
+                d = PdfParser.get_value(
+                    b"<</"+name.encode()+b" ("+date+b")>>", 0)[0]
+                self.assertEqual(
+                    time.strftime("%Y%m%d%H%M%S", getattr(d, name)), value)
 
     def test_pdf_repr(self):
         self.assertEqual(bytes(IndirectReference(1, 2)), b"1 2 R")

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1029,7 +1029,8 @@ The :py:meth:`~PIL.Image.Image.save` method can take the following keyword argum
     saved in the PDF.
 
 **title**
-    The document’s title.
+    The document’s title. If not appending to an existing PDF file, this will
+    default to the filename.
 
     .. versionadded:: 5.1.0
 
@@ -1060,6 +1061,18 @@ The :py:meth:`~PIL.Image.Image.save` method can take the following keyword argum
     conforming product that converted it to PDF.
 
     .. versionadded:: 5.1.0
+
+**creationDate**
+    The creation date of the document. If not appending to an existing PDF
+    file, this will default to the current time.
+
+    .. versionadded:: 5.3.0
+
+**modDate**
+    The modification date of the document. If not appending to an existing PDF
+    file, this will default to the current time.
+
+    .. versionadded:: 5.3.0
 
 XV Thumbnails
 ^^^^^^^^^^^^^

--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -22,6 +22,7 @@
 
 from . import Image, ImageFile, ImageSequence, PdfParser
 import io
+import os
 
 __version__ = "0.5"
 
@@ -47,7 +48,7 @@ def _save_all(im, fp, filename):
 def _save(im, fp, filename, save_all=False):
     resolution = im.encoderinfo.get("resolution", 72.0)
     is_appending = im.encoderinfo.get("append", False)
-    title = im.encoderinfo.get("title", None)
+    title = None if is_appending else im.encoderinfo.get("title", os.path.splitext(filename)[0])
     author = im.encoderinfo.get("author", None)
     subject = im.encoderinfo.get("subject", None)
     keywords = im.encoderinfo.get("keywords", None)


### PR DESCRIPTION
Using https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/pdf_reference_archives/PDFReference.pdf as a reference, this PR suggests two changes -

- By default, set the 'title' field to the filename, minus the extension.
- Add creation and modification dates. Defaults to the current time. This can be read and written as a time.struct_time object