### PR TITLE
CI: Temporarily pin pytest to prevent scandir non-compilation

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -71,7 +71,7 @@ build_script:
 
 test_script:
 - cd c:\pillow
-- '%PYTHON%\%PIP_DIR%\pip.exe install pytest pytest-cov'
+- '%PYTHON%\%PIP_DIR%\pip.exe install "pytest<3.7" pytest-cov'
 - '%PYTHON%\%EXECUTABLE% -m pytest -vx --cov PIL --cov-report term --cov-report xml Tests'
 #- '%PYTHON%\%EXECUTABLE% test-installed.py -v -s %TEST_OPTIONS%' TODO TEST_OPTIONS with pytest?
 


### PR DESCRIPTION
A temporary fix for #3284, but let's keep that open until this workaround can be removed.

The new pytest 3.7.1 (and 3.7.0) now depends on pathlib2 for Python < 3.4, which depends upon scandir, which doesn't build for PyPy on Windows.

Changes proposed in this pull request:

* Temporarily pin `pytest<3.7` on AppVeyor to prevent scandir non-compilation.