### PR TITLE
 Moved QApplication and QGuiApplication testing into separate threads

### DIFF
--- a/Tests/test_image_fromqpixmap.py
+++ b/Tests/test_image_fromqpixmap.py
@@ -1,5 +1,5 @@
 from helper import unittest, PillowTestCase, hopper
-from test_imageqt import PillowQtTestCase, PillowQPixmapTestCase
+from test_imageqt import PillowQPixmapTestCase
 
 from PIL import ImageQt
 
@@ -7,7 +7,6 @@ from PIL import ImageQt
 class TestFromQPixmap(PillowQPixmapTestCase, PillowTestCase):
 
     def roundtrip(self, expected):
-        PillowQtTestCase.setUp(self)
         result = ImageQt.fromqpixmap(ImageQt.toqpixmap(expected))
         # Qt saves all pixmaps as rgb
         self.assert_image_equal(result, expected.convert('RGB'))

--- a/Tests/test_image_fromqpixmap.py
+++ b/Tests/test_image_fromqpixmap.py
@@ -7,9 +7,11 @@ from PIL import ImageQt
 class TestFromQPixmap(PillowQPixmapTestCase, PillowTestCase):
 
     def roundtrip(self, expected):
-        result = ImageQt.fromqpixmap(ImageQt.toqpixmap(expected))
-        # Qt saves all pixmaps as rgb
-        self.assert_image_equal(result, expected.convert('RGB'))
+        def test():
+            result = ImageQt.fromqpixmap(ImageQt.toqpixmap(expected))
+            # Qt saves all pixmaps as rgb
+            self.assert_image_equal(result, expected.convert('RGB'))
+        self.executeInSeparateProcess(test)
 
     def test_sanity_1(self):
         self.roundtrip(hopper('1'))

--- a/Tests/test_image_toqimage.py
+++ b/Tests/test_image_toqimage.py
@@ -25,7 +25,6 @@ if ImageQt.qt_is_installed:
 class TestToQImage(PillowQtTestCase, PillowTestCase):
 
     def test_sanity(self):
-        PillowQtTestCase.setUp(self)
         for mode in ('RGB', 'RGBA', 'L', 'P', '1'):
             src = hopper(mode)
             data = ImageQt.toqimage(src)
@@ -61,8 +60,6 @@ class TestToQImage(PillowQtTestCase, PillowTestCase):
             self.assert_image_equal(reloaded, src)
 
     def test_segfault(self):
-        PillowQtTestCase.setUp(self)
-
         app = QApplication([])
         ex = Example()
         assert(app)  # Silence warning

--- a/Tests/test_image_toqimage.py
+++ b/Tests/test_image_toqimage.py
@@ -60,10 +60,12 @@ class TestToQImage(PillowQtTestCase, PillowTestCase):
             self.assert_image_equal(reloaded, src)
 
     def test_segfault(self):
-        app = QApplication([])
-        ex = Example()
-        assert(app)  # Silence warning
-        assert(ex)   # Silence warning
+        def test():
+            app = QApplication([])
+            ex = Example()
+            assert(app)  # Silence warning
+            assert(ex)   # Silence warning
+        self.executeInSeparateProcess(test)
 
 
 if ImageQt.qt_is_installed:

--- a/Tests/test_image_toqpixmap.py
+++ b/Tests/test_image_toqpixmap.py
@@ -1,5 +1,5 @@
 from helper import unittest, PillowTestCase, hopper
-from test_imageqt import PillowQtTestCase, PillowQPixmapTestCase
+from test_imageqt import PillowQPixmapTestCase
 
 from PIL import ImageQt
 
@@ -10,8 +10,6 @@ if ImageQt.qt_is_installed:
 class TestToQPixmap(PillowQPixmapTestCase, PillowTestCase):
 
     def test_sanity(self):
-        PillowQtTestCase.setUp(self)
-
         for mode in ('1', 'RGB', 'RGBA', 'L', 'P'):
             data = ImageQt.toqpixmap(hopper(mode))
 

--- a/Tests/test_image_toqpixmap.py
+++ b/Tests/test_image_toqpixmap.py
@@ -10,15 +10,17 @@ if ImageQt.qt_is_installed:
 class TestToQPixmap(PillowQPixmapTestCase, PillowTestCase):
 
     def test_sanity(self):
-        for mode in ('1', 'RGB', 'RGBA', 'L', 'P'):
-            data = ImageQt.toqpixmap(hopper(mode))
+        def test():
+            for mode in ('1', 'RGB', 'RGBA', 'L', 'P'):
+                data = ImageQt.toqpixmap(hopper(mode))
 
-            self.assertIsInstance(data, QPixmap)
-            self.assertFalse(data.isNull())
+                self.assertIsInstance(data, QPixmap)
+                self.assertFalse(data.isNull())
 
-            # Test saving the file
-            tempfile = self.tempfile('temp_{}.png'.format(mode))
-            data.save(tempfile)
+                # Test saving the file
+                tempfile = self.tempfile('temp_{}.png'.format(mode))
+                data.save(tempfile)
+        self.executeInSeparateProcess(test)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Using pytest to run all of the tests in a macOS 10.13 environment with PyQt5 installed, I find that test_imagetk.py exits with an 'Abort trap: 6'.

Investigating, I conclude that this is because QGuiApplication is not responding to the 'quit' method as it should, and then Tkinter dies when it runs at the same time.

For a simple example to demonstrate the problem, in running the following code, QGuiApplication does not quit, and I can't figure out how to persuade it to do so, short of exiting Python.

```
from PyQt5.QtGui import QGuiApplication
app = QGuiApplication([])
app.quit()
```

The simplest solution would be to rename the three test scripts that use QGuiApplication, so that they run after test_imagetk.py in the test suite. However, this is not very future proof. So instead, this PR uses multiprocessing to isolate QGuiApplication and QApplication.