### PR TITLE
Removed unnecessary setUp calls

### DIFF
--- a/Tests/test_qt_image_fromqpixmap.py
+++ b/Tests/test_qt_image_fromqpixmap.py
@@ -1,5 +1,5 @@
 from helper import unittest, PillowTestCase, hopper
-from test_imageqt import PillowQtTestCase, PillowQPixmapTestCase
+from test_imageqt import PillowQPixmapTestCase
 
 from PIL import ImageQt
 
@@ -7,7 +7,6 @@ from PIL import ImageQt
 class TestFromQPixmap(PillowQPixmapTestCase, PillowTestCase):
 
     def roundtrip(self, expected):
-        PillowQtTestCase.setUp(self)
         result = ImageQt.fromqpixmap(ImageQt.toqpixmap(expected))
         # Qt saves all pixmaps as rgb
         self.assert_image_equal(result, expected.convert('RGB'))

--- a/Tests/test_qt_image_toqimage.py
+++ b/Tests/test_qt_image_toqimage.py
@@ -25,7 +25,6 @@ if ImageQt.qt_is_installed:
 class TestToQImage(PillowQtTestCase, PillowTestCase):
 
     def test_sanity(self):
-        PillowQtTestCase.setUp(self)
         for mode in ('RGB', 'RGBA', 'L', 'P', '1'):
             src = hopper(mode)
             data = ImageQt.toqimage(src)
@@ -61,8 +60,6 @@ class TestToQImage(PillowQtTestCase, PillowTestCase):
             self.assert_image_equal(reloaded, src)
 
     def test_segfault(self):
-        PillowQtTestCase.setUp(self)
-
         app = QApplication([])
         ex = Example()
         assert(app)  # Silence warning

--- a/Tests/test_qt_image_toqpixmap.py
+++ b/Tests/test_qt_image_toqpixmap.py
@@ -1,5 +1,5 @@
 from helper import unittest, PillowTestCase, hopper
-from test_imageqt import PillowQtTestCase, PillowQPixmapTestCase
+from test_imageqt import PillowQPixmapTestCase
 
 from PIL import ImageQt
 
@@ -10,8 +10,6 @@ if ImageQt.qt_is_installed:
 class TestToQPixmap(PillowQPixmapTestCase, PillowTestCase):
 
     def test_sanity(self):
-        PillowQtTestCase.setUp(self)
-
         for mode in ('1', 'RGB', 'RGBA', 'L', 'P'):
             data = ImageQt.toqpixmap(hopper(mode))
 


### PR DESCRIPTION
There are a few tests which call `PillowQtTestCase.setUp`. However, this is unnecessary in these cases, as those test classes inherit from `PillowQtTestCase`, and so the `setUp` method is already called.

The best evidence that this is unnecessary is that this PR passes, as most of the test environments do not have Qt installed.