### PR TITLE
Performance improvement of ImageDraw.floodfill() 

### DIFF
--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -325,21 +325,21 @@ def getdraw(im=None, hints=None):
 
 def floodfill(image, xy, value, border=None, thresh=0):
     """
-        (experimental) Fills a bounded region with a given color.
+    (experimental) Fills a bounded region with a given color.
 
-        :param image: Target image.
-        :param xy: Seed position (a 2-item coordinate tuple). See
-            :ref:`coordinate-system`.
-        :param value: Fill color.
-        :param border: Optional border value.  If given, the region consists of
-            pixels with a color different from the border color.  If not given,
-            the region consists of pixels having the same color as the seed
-            pixel.
-        :param thresh: Optional threshold value which specifies a maximum
-            tolerable difference of a pixel value from the 'background' in
-            order for it to be replaced. Useful for filling regions of non-
-            homogeneous, but similar, colors.
-        """
+    :param image: Target image.
+    :param xy: Seed position (a 2-item coordinate tuple). See
+        :ref:`coordinate-system`.
+    :param value: Fill color.
+    :param border: Optional border value.  If given, the region consists of
+        pixels with a color different from the border color.  If not given,
+        the region consists of pixels having the same color as the seed
+        pixel.
+    :param thresh: Optional threshold value which specifies a maximum
+        tolerable difference of a pixel value from the 'background' in
+        order for it to be replaced. Useful for filling regions of non-
+        homogeneous, but similar, colors.
+    """
     # based on an implementation by Eric S. Raymond
     # amended by yo1995 @20180806
     pixel = image.load()

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -352,7 +352,7 @@ def floodfill(image, xy, value, border=None, thresh=0):
     except (ValueError, IndexError):
         return  # seed point outside image
     edge = {(x, y)}
-    full_edge = set()  # use a set to record each unique pixel processed
+    full_edge = set()  # use a set to keep record of current and previous edge pixels to reduce memory consumption
     while edge:
         new_edge = set()
         for (x, y) in edge:  # 4 adjacent method
@@ -364,6 +364,7 @@ def floodfill(image, xy, value, border=None, thresh=0):
                 except (ValueError, IndexError):
                     pass
                 else:
+                    full_edge.add((s, t))
                     if border is None:
                         fill = _color_diff(p, background) <= thresh
                     else:
@@ -371,8 +372,7 @@ def floodfill(image, xy, value, border=None, thresh=0):
                     if fill:
                         pixel[s, t] = value
                         new_edge.add((s, t))
-                        full_edge.add((s, t))
-        full_edge = edge  # do not record useless pixels to reduce memory consumption
+        full_edge = edge  # discard pixels proceeded
         edge = new_edge
 
 

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -388,7 +388,7 @@ def floodfill(image, xy, value, border=None, thresh=0):
                             new_edge.add((s, t))
                             full_edge.add((s, t))
             full_edge = edge
-            edge = newedge
+            edge = new_edge
 
 
 def _color_diff(rgb1, rgb2):

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -372,7 +372,7 @@ def floodfill(image, xy, value, border=None, thresh=0):
                     if fill:
                         pixel[s, t] = value
                         new_edge.add((s, t))
-        full_edge = edge  # discard pixels proceeded
+        full_edge = edge  # discard pixels processed
         edge = new_edge
 
 

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -325,22 +325,23 @@ def getdraw(im=None, hints=None):
 
 def floodfill(image, xy, value, border=None, thresh=0):
     """
-    (experimental) Fills a bounded region with a given color.
+        (experimental) Fills a bounded region with a given color.
 
-    :param image: Target image.
-    :param xy: Seed position (a 2-item coordinate tuple). See
-        :ref:`coordinate-system`.
-    :param value: Fill color.
-    :param border: Optional border value.  If given, the region consists of
-        pixels with a color different from the border color.  If not given,
-        the region consists of pixels having the same color as the seed
-        pixel.
-    :param thresh: Optional threshold value which specifies a maximum
-        tolerable difference of a pixel value from the 'background' in
-        order for it to be replaced. Useful for filling regions of non-
-        homogeneous, but similar, colors.
-    """
+        :param image: Target image.
+        :param xy: Seed position (a 2-item coordinate tuple). See
+            :ref:`coordinate-system`.
+        :param value: Fill color.
+        :param border: Optional border value.  If given, the region consists of
+            pixels with a color different from the border color.  If not given,
+            the region consists of pixels having the same color as the seed
+            pixel.
+        :param thresh: Optional threshold value which specifies a maximum
+            tolerable difference of a pixel value from the 'background' in
+            order for it to be replaced. Useful for filling regions of non-
+            homogeneous, but similar, colors.
+        """
     # based on an implementation by Eric S. Raymond
+    # amended by yo1995 @20180806
     pixel = image.load()
     x, y = xy
     try:
@@ -350,12 +351,15 @@ def floodfill(image, xy, value, border=None, thresh=0):
         pixel[x, y] = value
     except (ValueError, IndexError):
         return  # seed point outside image
-    edge = [(x, y)]
+    edge = {(x, y)}
+    full_edge = set()  # use a set to record each unique pixel processed
     if border is None:
         while edge:
-            newedge = []
-            for (x, y) in edge:
+            new_edge = set()
+            for (x, y) in edge:  # 4 adjacent method
                 for (s, t) in ((x+1, y), (x-1, y), (x, y+1), (x, y-1)):
+                    if (s, t) in full_edge:
+                        continue  # if already processed, skip
                     try:
                         p = pixel[s, t]
                     except IndexError:
@@ -363,13 +367,17 @@ def floodfill(image, xy, value, border=None, thresh=0):
                     else:
                         if _color_diff(p, background) <= thresh:
                             pixel[s, t] = value
-                            newedge.append((s, t))
-            edge = newedge
+                            new_edge.add((s, t))
+                            full_edge.add((s, t))
+            full_edge = edge  # do not record useless pixels to reduce memory consumption
+            edge = new_edge
     else:
         while edge:
-            newedge = []
+            new_edge = set()
             for (x, y) in edge:
                 for (s, t) in ((x+1, y), (x-1, y), (x, y+1), (x, y-1)):
+                    if (s, t) in full_edge:
+                        continue
                     try:
                         p = pixel[s, t]
                     except IndexError:
@@ -377,7 +385,9 @@ def floodfill(image, xy, value, border=None, thresh=0):
                     else:
                         if p != value and p != border:
                             pixel[s, t] = value
-                            newedge.append((s, t))
+                            new_edge.add((s, t))
+                            full_edge.add((s, t))
+            full_edge = edge
             edge = newedge
 
 


### PR DESCRIPTION

- Feature improvement: improved performance of `ImageDraw.floodfill()` with  Python built-in `set()` datatype. reduce run time while maintaining memory consumption.

## Changes proposed in this pull request:

 * under `ImageDraw Module`: `ImageDraw.floodfill()`
    - changed original *list* datatype to *set* in order to handle pixels in a more efficient manner.

## unittest result

![pytest-result](https://user-images.githubusercontent.com/9660181/43712850-292b38f4-99aa-11e8-81db-b2f06dd6b286.png)

## test result

![test-result](https://user-images.githubusercontent.com/9660181/43712978-9ce70a48-99aa-11e8-9b9b-e6e13119550e.png)

by implementing this change, the floodfill() method is around 40% faster on both of the test cases. The result highly depends on the amount of the pixels to fill. The pixels to be filled are only iterated once, rather than 4 times with original method.

## test-case-files

[PR-testcases.zip](https://github.com/python-pillow/Pillow/files/2262254/PR-testcases.zip)

run test.sh to see comparison between methods.

