### PR TITLE
Revert "CI: Temporarily pin pytest to prevent scandir non-compilation"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -71,7 +71,7 @@ build_script:
 
 test_script:
 - cd c:\pillow
-- '%PYTHON%\%PIP_DIR%\pip.exe install "pytest<3.7" pytest-cov'
+- '%PYTHON%\%PIP_DIR%\pip.exe install pytest pytest-cov'
 - '%PYTHON%\%EXECUTABLE% -m pytest -vx --cov PIL --cov-report term --cov-report xml Tests'
 #- '%PYTHON%\%EXECUTABLE% test-installed.py -v -s %TEST_OPTIONS%' TODO TEST_OPTIONS with pytest?
 


### PR DESCRIPTION
Reverts python-pillow/Pillow#3285

Fixes https://github.com/python-pillow/Pillow/issues/3284

Re: https://github.com/pytest-dev/pytest/issues/3750#issuecomment-412093501