### PR TITLE
Update RELEASING example

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -94,7 +94,7 @@ Released as needed privately to individual vendors for critical security-related
     $ git fetch --all
     $ git checkout [[release tag]]
     $ cd ..
-    $ git commit -m "Pillow -> 2.9.0" Pillow
+    $ git commit -m "Pillow -> 5.2.0" Pillow
     $ git push
 ```
 * [ ] Download distributions from the [Pillow Wheel Builder container](http://a365fff413fe338398b6-1c8a9b3114517dc5fe17b7c3f8c63a43.r19.cf2.rackcdn.com/).


### PR DESCRIPTION
Looks like this was missed in https://github.com/python-pillow/Pillow/commit/937443f2a64564335b6e7439160742bc5939fd0c