### PR TITLE
Fixed None as TIFF compression argument

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -486,7 +486,7 @@ class TestFileLibTiff(LibTiffTestCase):
             pilim_load = Image.open(buffer_io)
             self.assert_image_similar(pilim, pilim_load, 0)
 
-        # save_bytesio()
+        save_bytesio()
         save_bytesio('raw')
         save_bytesio("packbits")
         save_bytesio("tiff_lzw")

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1396,8 +1396,9 @@ def _save(im, fp, filename):
 
     ifd = ImageFileDirectory_v2(prefix=prefix)
 
-    compression = im.encoderinfo.get('compression',
-                                     im.info.get('compression', 'raw'))
+    compression = im.encoderinfo.get('compression', im.info.get('compression'))
+    if compression is None:
+        compression = 'raw'
 
     libtiff = WRITE_LIBTIFF or compression != 'raw'
 


### PR DESCRIPTION
Resolves #3308

That issue points out that `None` is listed as a `compression` value at https://pillow.readthedocs.io/en/5.2.x/handbook/image-file-formats.html#saving-tiff-images

A commented test for this was added in https://github.com/python-pillow/Pillow/pull/1011