### PR TITLE
Fix _crop and tests

### DIFF
--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -6,7 +6,6 @@ TEST_FILE = "Tests/images/hopper.ppm"
 
 ORIGINAL_LIMIT = Image.MAX_IMAGE_PIXELS
 
-from PIL.Image import DecompressionBombWarning, DecompressionBombError
 
 class TestDecompressionBomb(PillowTestCase):
 
@@ -67,7 +66,7 @@ class TestDecompressionCrop(PillowTestCase):
         im = Image.new("RGB", (100, 100))
 
         good_values = ((-9999, -9999, -9990, -9990),
-                        (-999, -999, -990, -990))
+                       (-999, -999, -990, -990))
 
         warning_values = ((-160, -160, 99, 99),
                           (160, 160, -99, -99))
@@ -76,14 +75,15 @@ class TestDecompressionCrop(PillowTestCase):
                         (99909, 99990, -99999, -99999))
 
         for value in good_values:
-            self.assertEqual(im.crop(value).size, (9,9))
+            self.assertEqual(im.crop(value).size, (9, 9))
 
         for value in warning_values:
-            self.assert_warning(DecompressionBombWarning, im.crop, value)
+            self.assert_warning(Image.DecompressionBombWarning, im.crop, value)
 
         for value in error_values:
-            with self.assertRaises(DecompressionBombError):
+            with self.assertRaises(Image.DecompressionBombError):
                 im.crop(value)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -6,6 +6,7 @@ TEST_FILE = "Tests/images/hopper.ppm"
 
 ORIGINAL_LIMIT = Image.MAX_IMAGE_PIXELS
 
+from PIL.Image import DecompressionBombWarning, DecompressionBombError
 
 class TestDecompressionBomb(PillowTestCase):
 
@@ -61,6 +62,28 @@ class TestDecompressionCrop(PillowTestCase):
         self.assert_warning(Image.DecompressionBombWarning,
                             self.src.crop, box)
 
+    def test_crop_decompression_checks(self):
+
+        im = Image.new("RGB", (100, 100))
+
+        good_values = ((-9999, -9999, -9990, -9990),
+                        (-999, -999, -990, -990))
+
+        warning_values = ((-160, -160, 99, 99),
+                          (160, 160, -99, -99))
+
+        error_values = ((-99909, -99990, 99999, 99999),
+                        (99909, 99990, -99999, -99999))
+
+        for value in good_values:
+            self.assertEqual(im.crop(value).size, (9,9))
+
+        for value in warning_values:
+            self.assert_warning(DecompressionBombWarning, im.crop, value)
+
+        for value in error_values:
+            with self.assertRaises(DecompressionBombError):
+                im.crop(value)
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_image_crop.py
+++ b/Tests/test_image_crop.py
@@ -2,7 +2,6 @@ from helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 
-
 class TestImageCrop(PillowTestCase):
 
     def test_crop(self):

--- a/Tests/test_image_crop.py
+++ b/Tests/test_image_crop.py
@@ -2,6 +2,7 @@ from helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 
+
 class TestImageCrop(PillowTestCase):
 
     def test_crop(self):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1104,12 +1104,9 @@ class Image(object):
 
         x0, y0, x1, y1 = map(int, map(round, box))
 
-        if x1 < x0:
-            x1 = x0
-        if y1 < y0:
-            y1 = y0
+        absolute_values = (abs(x1 - x0), abs(y1 - y0))
 
-        _decompression_bomb_check((x1, y1))
+        _decompression_bomb_check(absolute_values)
 
         return im.crop((x0, y0, x1, y1))
 


### PR DESCRIPTION
Issue being fixed:
DecompressionBombWarning/Error caused by wrong values passed to it in Image._crop

_bomb_decompression_check checks if the size of the image is larger than a certain value.
In Image._crop which is called from Image.crop x1 and y1 are passed to check the size of the crop.
abs(x1 - x0) and abs(y1-y0) should be passed instead, since that represents the size of the crop not just x1 and y1.

Changes proposed in this pull request:
* Use absolute value of (x1-x0) and (y1-y0) instead of the existing check
* Pas those values which represent the width and height instead just the location of x1, y1, which is not correct in the context of _decompression_bomb_check


Pull request is solving this issue: https://github.com/python-pillow/Pillow/issues/3312