### PR TITLE
Download lib if not present in pillow-depends

### DIFF
--- a/winbuild/build_dep.py
+++ b/winbuild/build_dep.py
@@ -2,6 +2,7 @@ from unzip import unzip
 from untar import untar
 import os
 
+from fetch import fetch
 from config import compilers, compiler_from_env, libs
 
 
@@ -44,6 +45,8 @@ def extract(src, dest):
 def extract_libs():
     for name, lib in libs.items():
         filename = lib['filename']
+        if not os.path.exists(filename):
+            filename = fetch(lib['url'])
         if name == 'openjpeg':
             for compiler in compilers.values():
                 if not os.path.exists(os.path.join(


### PR DESCRIPTION
I know this was considered in #2095. It was declined at the time because SourceForge wasn't working, but that is no longer the case.