### PR TITLE
Changed rm command to use force

### DIFF
--- a/depends/install_extra_test_images.sh
+++ b/depends/install_extra_test_images.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # install extra test images
 
-rm -r test_images
+rm -rf test_images
 
 # Use SVN to just fetch a single git subdirectory
 svn checkout https://github.com/python-pillow/pillow-depends/trunk/test_images


### PR DESCRIPTION
Running the following commands -
```
svn checkout https://github.com/python-pillow/pillow-depends/trunk/test_images
rm -r test_images
```

I get asked if I want to override for .svn files. This PR changes it to `rm -rf` to fix this.