### PR TITLE
Revert "Add updated submodule in pillow-wheels [ci skip]"

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -94,7 +94,6 @@ Released as needed privately to individual vendors for critical security-related
     $ git fetch --all
     $ git checkout [[release tag]]
     $ cd ..
-    $ git add Pillow
     $ git commit -m "Pillow -> 5.2.0" Pillow
     $ git push
 ```


### PR DESCRIPTION
I was wrong in #3320 - `git add Pillow` is not necessary, as the following line - `git commit -m "Pillow -> 5.2.0" Pillow` lists `Pillow` as it's last argument, meaning that it will add Pillow.