### PR TITLE
Changed GIF seek to remove previous info items

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -134,13 +134,15 @@ class TestFileGif(PillowTestCase):
         # Multiframe image
         im = Image.open("Tests/images/dispose_bgnd.gif")
 
+        info = im.info.copy()
+
         out = self.tempfile('temp.gif')
         im.save(out, save_all=True)
         reread = Image.open(out)
 
         for header in important_headers:
             self.assertEqual(
-                im.info[header],
+                info[header],
                 reread.info[header]
             )
 
@@ -206,6 +208,15 @@ class TestFileGif(PillowTestCase):
                 img.seek(img.tell() + 1)
         except EOFError:
             self.assertEqual(framecount, 5)
+
+    def test_seek_info(self):
+        im = Image.open("Tests/images/iss634.gif")
+        info = im.info.copy()
+
+        im.seek(1)
+        im.seek(0)
+
+        self.assertEqual(im.info, info)
 
     def test_n_frames(self):
         for path, n_frames in [


### PR DESCRIPTION
Resolves #3315

That issue calls `is_animated` on a GIF, and finds that afterwards, `im.info` now has `comment` with value `None`. `is_animated` should not mutate the value of `im.info` in this way. It happens because the `EOFError` 'frame' has `comment` with value `None`, and it is not removed when `is_animated` seeks back to original frame.

So this PR solves the more general case - subsequent GIF seeks should not just accumulate `info` items.

Note: The following code currently reports `0` loops after the `seek`, but with this PR, it raises a `KeyError`.
```python
from PIL import Image
im = Image.open('Tests/images/iss634.gif')
print(im.info['loop'])
im.seek(1)
print(im.info['loop'])
```