### PR TITLE
Catch ValueError when processing the edge of an image in ImageDraw.floodfill

### DIFF
--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -366,6 +366,11 @@ class TestImageDraw(PillowTestCase):
         ImageDraw.floodfill(im, (W, H), red)
         self.assert_image_equal(im, im_floodfill)
 
+        # Test filling at the edge of an image
+        im = Image.new("RGB", (1, 1))
+        ImageDraw.floodfill(im, (0, 0), red)
+        self.assert_image_equal(im, Image.new("RGB", (1, 1), red))
+
     def test_floodfill_border(self):
         # floodfill() is experimental
 

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -358,7 +358,7 @@ def floodfill(image, xy, value, border=None, thresh=0):
                 for (s, t) in ((x+1, y), (x-1, y), (x, y+1), (x, y-1)):
                     try:
                         p = pixel[s, t]
-                    except IndexError:
+                    except (ValueError, IndexError):
                         pass
                     else:
                         if _color_diff(p, background) <= thresh:
@@ -372,7 +372,7 @@ def floodfill(image, xy, value, border=None, thresh=0):
                 for (s, t) in ((x+1, y), (x-1, y), (x, y+1), (x, y-1)):
                     try:
                         p = pixel[s, t]
-                    except IndexError:
+                    except (ValueError, IndexError):
                         pass
                     else:
                         if p != value and p != border:


### PR DESCRIPTION
As evidence that ValueError is required - https://ci.appveyor.com/project/Python-pillow/pillow/build/4127/job/4nr0goie5hrk18q6#L3573