### PR TITLE
Fixed typos

### DIFF
--- a/docs/handbook/writing-your-own-file-decoder.rst
+++ b/docs/handbook/writing-your-own-file-decoder.rst
@@ -171,7 +171,6 @@ The fields are used as follows:
     stride defaults to 0.
 
 **orientation**
-
     Whether the first line in the image is the top line on the screen (1), or
     the bottom line (-1). If omitted, the orientation defaults to 1.
 

--- a/docs/handbook/writing-your-own-file-decoder.rst
+++ b/docs/handbook/writing-your-own-file-decoder.rst
@@ -204,7 +204,7 @@ table describes some commonly used **raw modes**:
 +-----------+-----------------------------------------------------------------+
 | ``RGBX``  | 24-bit true colour, stored as (red, green, blue, pad).          |
 +-----------+-----------------------------------------------------------------+
-| ``RGB;L`` | 24-bit true colour, line interleaved (first all red pixels, the |
+| ``RGB;L`` | 24-bit true colour, line interleaved (first all red pixels, then|
 |           | all green pixels, finally all blue pixels).                     |
 +-----------+-----------------------------------------------------------------+
 


### PR DESCRIPTION
With regards to the blank line, here is what it currently looks like -

![screen shot 2018-09-05 at 9 06 29 pm](https://user-images.githubusercontent.com/3112309/45089453-95e2c680-b14f-11e8-8d3e-5410b9becf90.png)
