### PR TITLE
From KeyError to ValueError when saving image

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1894,7 +1894,7 @@ class Image(object):
            parameter should always be used.
         :param params: Extra parameters to the image writer.
         :returns: None
-        :exception KeyError: If the output format could not be determined
+        :exception ValueError: If the output format could not be determined
            from the file name.  Use the format option to solve this.
         :exception IOError: If the file could not be written.  The file
            may have been created, and may contain partial data.


### PR DESCRIPTION
When saving an image, if the extension is not determined it raises a ValueError (while internally it manages a KeyError) so I propose this change

Changes proposed in this pull request:

 * Image.save raises a ValueError and not a KeyError