### PR TITLE
Issue template: add prompts for versions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ### What actually happened?
 
-### What versions of OS, Python and Pillow are you using?
+### What are your OS, Python and Pillow versions?
 
 * OS: 
 * Python: 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,11 @@
 
 ### What actually happened?
 
-### What versions of Pillow and Python are you using?
+### What versions of OS, Python and Pillow are you using?
+
+* OS: 
+* Python: 
+* Pillow: 
 
 Please include **code** that reproduces the issue and whenever possible, an **image** that demonstrates the issue. Please upload images to GitHub, not to third-party file hosting sites. If necessary, add the image to a zip or tar archive.
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * Add OS version to the issue template
 * Prompt for it and Python and Pillow versions
 * This might encourage people to fill in the info in bug reports
