### PR TITLE
CI: Retry SVN checkout to mitigate temporary network problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ services:
   - docker
 
 install:
-  - if [ "$DOCKER" == "" ]; then .travis/install.sh; fi
+  - if [ "$DOCKER" == "" ]; then travis_retry .travis/install.sh; fi
 
 before_install:
   - if [ "$DOCKER" ]; then travis_retry docker pull pythonpillow/$DOCKER:$DOCKER_TAG; fi

--- a/depends/install_extra_test_images.sh
+++ b/depends/install_extra_test_images.sh
@@ -3,7 +3,7 @@
 
 rm -rf test_images
 
-# Use SVN to just fetch a single git subdirectory
-svn checkout https://github.com/python-pillow/pillow-depends/trunk/test_images
+# Use SVN to just fetch a single Git subdirectory
+travis_retry svn checkout https://github.com/python-pillow/pillow-depends/trunk/test_images
 
 cp -r test_images/* ../Tests/images

--- a/depends/install_extra_test_images.sh
+++ b/depends/install_extra_test_images.sh
@@ -4,6 +4,6 @@
 rm -rf test_images
 
 # Use SVN to just fetch a single Git subdirectory
-travis_retry svn checkout https://github.com/python-pillow/pillow-depends/trunk/test_images
+svn checkout https://github.com/python-pillow/pillow-depends/trunk/test_images
 
 cp -r test_images/* ../Tests/images


### PR DESCRIPTION
Here's a recent one-off build failure on Travis CI during `svn checkout` in the installation phase:

```
svn: E175002: Unexpected HTTP status 429 'Too Many Requests' on '/python-pillow/pillow-depends/!svn/vcc/default'
cp: cannot stat 'test_images/*': No such file or directory
The command "if [ "$DOCKER" == "" ]; then .travis/install.sh; fi" failed and exited with 1 during .
```
https://travis-ci.org/python-pillow/Pillow/jobs/430241230#L2608

Let's make the build a bit more resilient by retrying up to 3 times using `travis_retry`:

https://docs.travis-ci.com/user/common-build-problems/#travis_retry

It's possible subsequent attempts right after a `429 'Too Many Requests'` won't work, but let's give this a shot. This should help with other temporary network problems.

---

Checking other network installation things, `wget` already defaults to 20 retries:

https://www.gnu.org/software/wget/manual/wget.html#Download-Options