### PR TITLE
Retry svn checkout on failure up to 3 times

### DIFF
--- a/depends/install_extra_test_images.sh
+++ b/depends/install_extra_test_images.sh
@@ -3,7 +3,17 @@
 
 rm -rf test_images
 
-# Use SVN to just fetch a single git subdirectory
-svn checkout https://github.com/python-pillow/pillow-depends/trunk/test_images
+# Use SVN to just fetch a single Git subdirectory
+svn_checkout()
+{
+	if [ ! -z $1 ]; then
+		echo ""
+		echo "Retrying svn checkout..."
+		echo ""
+	fi
+
+	svn checkout https://github.com/python-pillow/pillow-depends/trunk/test_images
+}
+svn_checkout || svn_checkout retry || svn_checkout retry || svn_checkout retry
 
 cp -r test_images/* ../Tests/images


### PR DESCRIPTION
Alternate suggestion for #3367 

As a way of demonstrating what this code does on failure, here is a test script -
```sh
test_count=-1

svn_checkout()
{
	if [ ! -z $1 ]; then
		echo ""
		echo "Retrying svn checkout..."	
		echo ""
	fi
	
	test_count=$(( $test_count + 1 ))
	if [ $test_count = 2 ]; then
		svn checkout https://github.com/python-pillow/pillow-depends/trunk/test_images
	else
		svn checkout blah
	fi
}

svn_checkout || svn_checkout retry || svn_checkout retry || svn_checkout retry
```