### PR TITLE
Hide the Ghostscript progress dialog popup on Windows

### DIFF
--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -135,6 +135,8 @@ def Ghostscript(tile, size, fp, scale=1):
         if not gs_windows_binary:
             raise WindowsError('Unable to locate Ghostscript on paths')
         command[0] = gs_windows_binary
+        # Hide the progress dialog
+        command.append("-dNoCancel")
 
     # push data through ghostscript
     try:

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -41,7 +41,7 @@ if sys.platform.startswith('win'):
     if hasattr(shutil, 'which'):
         which = shutil.which
     else:
-        # Python < 3.3
+        # Python 2
         import distutils.spawn
         which = distutils.spawn.find_executable
     for binary in ('gswin32c', 'gswin64c', 'gs'):
@@ -62,7 +62,7 @@ def has_ghostscript():
                 subprocess.check_call(['gs', '--version'], stdout=devnull)
             return True
         except OSError:
-            # no ghostscript
+            # no Ghostscript
             pass
     return False
 
@@ -98,8 +98,8 @@ def Ghostscript(tile, size, fp, scale=1):
         infile = infile_temp
 
         # ignore length and offset!
-        # ghostscript can read it
-        # copy whole file to read in ghostscript
+        # Ghostscript can read it
+        # copy whole file to read in Ghostscript
         with open(infile_temp, 'wb') as f:
             # fetch length of fp
             fp.seek(0, 2)
@@ -115,13 +115,13 @@ def Ghostscript(tile, size, fp, scale=1):
                 lengthfile -= len(s)
                 f.write(s)
 
-    # Build ghostscript command
+    # Build Ghostscript command
     command = ["gs",
                "-q",                         # quiet mode
                "-g%dx%d" % size,             # set output geometry (pixels)
                "-r%fx%f" % res,              # set input DPI (dots per inch)
                "-dBATCH",                    # exit after processing
-               "-dNOPAUSE",                  # don't pause between pages,
+               "-dNOPAUSE",                  # don't pause between pages
                "-dSAFER",                    # safe mode
                "-sDEVICE=ppmraw",            # ppm driver
                "-sOutputFile=%s" % outfile,  # output file
@@ -138,7 +138,7 @@ def Ghostscript(tile, size, fp, scale=1):
         # Hide the progress dialog
         command.append("-dNoCancel")
 
-    # push data through ghostscript
+    # push data through Ghostscript
     try:
         with open(os.devnull, 'w+b') as devnull:
             subprocess.check_call(command, stdin=devnull, stdout=devnull)
@@ -229,7 +229,7 @@ class EpsImageFile(ImageFile.ImageFile):
 
                 try:
                     m = split.match(s)
-                except re.error as v:
+                except re.error:
                     raise SyntaxError("not an EPS file")
 
                 if m:
@@ -244,7 +244,7 @@ class EpsImageFile(ImageFile.ImageFile):
                             self.size = box[2] - box[0], box[3] - box[1]
                             self.tile = [("eps", (0, 0) + self.size, offset,
                                           (length, box))]
-                        except:
+                        except Exception:
                             pass
 
                 else:


### PR DESCRIPTION
Fixes #3371.

Changes proposed in this pull request:

 * Use the `-dNoCancel` on Windows

The docs say:

> The mswinpr2 device supports a limited number of command-line parameters (e.g. it does not support setting the printer resolution). The recognized parameters are the following:
...
> `-dNoCancel`
> Hides the progress dialog, which shows the percent of the document page already processed and also provides a _cancel_ button. This option is useful if GS is intended to print pages in the background, without any user intervention.

https://www.ghostscript.com/doc/9.23/Devices.htm#Win