### PR TITLE
Catch CalledProcessError when checking for Ghostscript

### DIFF
--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -61,7 +61,7 @@ def has_ghostscript():
             with open(os.devnull, 'wb') as devnull:
                 subprocess.check_call(['gs', '--version'], stdout=devnull)
             return True
-        except OSError:
+        except (OSError, subprocess.CalledProcessError):
             # no ghostscript
             pass
     return False


### PR DESCRIPTION
`CalledProcessError` is thrown in https://travis-ci.org/python-pillow/docker-images/jobs/421960744#L2136. This PR catches it.