### PR TITLE
Change tuple background to global color table index when saving as GIF

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -4,6 +4,12 @@ from PIL import Image, ImagePalette, GifImagePlugin
 
 from io import BytesIO
 
+try:
+    from PIL import _webp
+    HAVE_WEBP = True
+except ImportError:
+    HAVE_WEBP = False
+
 codecs = dir(Image.core)
 
 # sample gif stream
@@ -410,6 +416,11 @@ class TestFileGif(PillowTestCase):
         reread = Image.open(out)
 
         self.assertEqual(reread.info['background'], im.info['background'])
+
+        if HAVE_WEBP and _webp.HAVE_WEBPANIM:
+            im = Image.open("Tests/images/hopper.webp")
+            self.assertIsInstance(im.info['background'], tuple)
+            im.save(out)
 
     def test_comment(self):
         im = Image.open(TEST_GIF)

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -711,10 +711,17 @@ def _get_global_header(im, info):
         if im.info.get("version") == b"89a":
             version = b"89a"
 
+    background = 0
+    if "background" in info:
+        background = info["background"]
+        if isinstance(background, tuple):
+            # WebPImagePlugin stores an RGBA value in info["background"]
+            # So it must be converted to the same format as GifImagePlugin's
+            # info["background"] - a global color table index
+            background = im.palette.getcolor(background)
+
     palette_bytes = _get_palette_bytes(im)
     color_table_size = _get_color_table_size(palette_bytes)
-
-    background = info["background"] if "background" in info else 0
 
     return [
         b"GIF"+version +               # signature + version


### PR DESCRIPTION
Suggestion for #2949

WebP sets `im.info['background']` to an RGBA tuple. However, GIF uses background as an ['Index into the Global Color Table'](https://www.w3.org/Graphics/GIF/spec-gif89a.txt). This PR converts the value from the tuple to a global color table index when saving as a GIF.

I will note that this isn't perfect - `ImagePalette.getcolor` ignores the alpha part of the RGBA tuple, and I think there a few things wrong with the way that we are handling GIF backgrounds. However, I don't think there is anything wrong with the code that I am adding in.