### PR TITLE
Update release notes for 5.3.0

### DIFF
--- a/docs/releasenotes/5.3.0.rst
+++ b/docs/releasenotes/5.3.0.rst
@@ -4,6 +4,15 @@
 API Additions
 =============
 
+Curved joints for line sequences
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``ImageDraw.Draw.line`` draws a line, or lines, between points. Previously,
+when multiple points are given, for a larger ``width``, the joints between
+these lines looked unsightly. There is now an additional optional argument,
+``joint``, defaulting to ``None``. When it is set to ``curved``, the joints
+between the lines will become rounded.
+
 ImageOps.colorize
 ^^^^^^^^^^^^^^^^^
 
@@ -13,17 +22,8 @@ Now it supports three-color mapping with the optional ``mid`` parameter, and
 the positions for all three color arguments can each be optionally specified
 (``blackpoint``, ``whitepoint`` and ``midpoint``).
 For example, with all optional arguments::
-	ImageOps.colorize(im, black=(32, 37, 79), white='white', mid=(59, 101, 175),
+    ImageOps.colorize(im, black=(32, 37, 79), white='white', mid=(59, 101, 175),
                           blackpoint=15, whitepoint=240, midpoint=100)
-
-Curved joints for line sequences
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-``ImageDraw.Draw.line`` draws a line, or lines, between points. Previously,
-when multiple points are given, for a larger ``width``, the joints between
-these lines looked unsightly. There is now an additional optional argument,
-``joint``, defaulting to ``None``. When it is set to ``curved``, the joints
-between the lines will become rounded.
 
 ImageOps.pad
 ^^^^^^^^^^^^

--- a/docs/releasenotes/5.3.0.rst
+++ b/docs/releasenotes/5.3.0.rst
@@ -4,6 +4,12 @@
 API Additions
 =============
 
+Add line width parameter to rectangle and ellipse-based shapes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A line ``width`` parameter has been added to ``ImageDraw.Draw.arc``,
+``chord``, ``ellipse``, ``pieslice`` and ``rectangle``.
+
 Curved joints for line sequences
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/releasenotes/5.3.0.rst
+++ b/docs/releasenotes/5.3.0.rst
@@ -28,6 +28,7 @@ Now it supports three-color mapping with the optional ``mid`` parameter, and
 the positions for all three color arguments can each be optionally specified
 (``blackpoint``, ``whitepoint`` and ``midpoint``).
 For example, with all optional arguments::
+
     ImageOps.colorize(im, black=(32, 37, 79), white='white', mid=(59, 101, 175),
                           blackpoint=15, whitepoint=240, midpoint=100)
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * Add https://github.com/python-pillow/Pillow/pull/3094 to release notes
 * Put both the `ImageOps` additions next to each other
 * Fix "unexpected indentation" error in PyCharm's RST preview:

<img src="https://user-images.githubusercontent.com/1324225/46246467-c3492a00-c406-11e8-8717-e82a408d9a8e.png" width=65%>

