### PR TITLE
Move "Image size" under "API Changes"

### DIFF
--- a/docs/releasenotes/5.3.0.rst
+++ b/docs/releasenotes/5.3.0.rst
@@ -1,6 +1,24 @@
 5.3.0
 -----
 
+API Changes
+===========
+
+Image size
+^^^^^^^^^^
+
+If you attempt to set the size of an image directly, e.g.
+``im.size = (100, 100)``, you will now receive an ``AttributeError``. This is
+not about removing existing functionality, but instead about raising an
+explicit error to prevent later consequences. The ``resize`` method is the
+correct way to change an image's size.
+
+The exceptions to this are:
+
+* The ICO and ICNS image formats, which use ``im.size = (100, 100)`` to select a subimage.
+* The TIFF image format, which now has a ``DeprecationWarning`` for this action, as direct image size setting was previously necessary to work around an issue with tile extents.
+
+
 API Additions
 =============
 
@@ -28,6 +46,7 @@ Now it supports three-color mapping with the optional ``mid`` parameter, and
 the positions for all three color arguments can each be optionally specified
 (``blackpoint``, ``whitepoint`` and ``midpoint``).
 For example, with all optional arguments::
+
     ImageOps.colorize(im, black=(32, 37, 79), white='white', mid=(59, 101, 175),
                           blackpoint=15, whitepoint=240, midpoint=100)
 
@@ -38,20 +57,6 @@ While ``ImageOps.fit`` allows users to crop images to a requested aspect ratio
 and size, new method ``ImageOps.pad`` pads images to fill a requested aspect
 ratio and size, filling new space with a provided ``color`` and positioning the
 image within the new area through a ``centering`` argument.
-
-Image Size
-==========
-
-If you attempt to set the size of an image directly, e.g.
-``im.size = (100, 100)``, you will now receive an ``AttributeError``. This is
-not about removing existing functionality, but instead about raising an
-explicit error to prevent later consequences. The ``resize`` method is the
-correct way to change an image's size.
-
-The exceptions to this are:
-
-* The ICO and ICNS image formats, which use ``im.size = (100, 100)`` to select a subimage.
-* The TIFF image format, which now has a ``DeprecationWarning`` for this action, as direct image size setting was previously necessary to work around an issue with tile extents.
 
 Other Changes
 =============


### PR DESCRIPTION
To try to keep the headings consistent with recent releases:

![image](https://user-images.githubusercontent.com/1324225/46258479-21900e80-c4d4-11e8-94b4-48fe9758fbdc.png)


https://pillow.readthedocs.io/en/5.2.x/releasenotes/index.html
