### PR TITLE
Fixes for issues reported by static code analysis

### DIFF
--- a/src/Tk/tkImaging.c
+++ b/src/Tk/tkImaging.c
@@ -425,6 +425,7 @@ int load_tkinter_funcs(void)
     /* Try loading from the main program namespace first */
     main_program = dlopen(NULL, RTLD_LAZY);
     if (_func_loader(main_program) == 0) {
+        dlclose(main_program);
         return 0;
     }
     /* Clear exception triggered when we didn't find symbols above */
@@ -453,6 +454,7 @@ int load_tkinter_funcs(void)
     /* dlclose probably safe because tkinter has been imported. */
     dlclose(tkinter_lib);
 exit:
+    dlclose(main_program);
     Py_XDECREF(pModule);
     Py_XDECREF(pString);
     return ret;

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1042,8 +1042,10 @@ _gaussian_blur(ImagingObject* self, PyObject* args)
     if (!imOut)
         return NULL;
 
-    if (!ImagingGaussianBlur(imOut, imIn, radius, passes))
+    if (!ImagingGaussianBlur(imOut, imIn, radius, passes)) {
+        ImagingDelete(imOut);
         return NULL;
+    }
 
     return PyImagingNew(imOut);
 }
@@ -1931,8 +1933,10 @@ _box_blur(ImagingObject* self, PyObject* args)
     if (!imOut)
         return NULL;
 
-    if (!ImagingBoxBlur(imOut, imIn, radius, n))
+    if (!ImagingBoxBlur(imOut, imIn, radius, n)) {
+        ImagingDelete(imOut);
         return NULL;
+    }
 
     return PyImagingNew(imOut);
 }
@@ -2578,6 +2582,7 @@ _draw_arc(ImagingDrawObject* self, PyObject* args)
         return NULL;
     if (n != 2) {
         PyErr_SetString(PyExc_TypeError, must_be_two_coordinates);
+        free(xy);
         return NULL;
     }
 
@@ -2615,6 +2620,7 @@ _draw_bitmap(ImagingDrawObject* self, PyObject* args)
         PyErr_SetString(PyExc_TypeError,
                         "coordinate list must contain exactly 1 coordinate"
                         );
+        free(xy);
         return NULL;
     }
 
@@ -2651,6 +2657,7 @@ _draw_chord(ImagingDrawObject* self, PyObject* args)
         return NULL;
     if (n != 2) {
         PyErr_SetString(PyExc_TypeError, must_be_two_coordinates);
+        free(xy);
         return NULL;
     }
 
@@ -2687,6 +2694,7 @@ _draw_ellipse(ImagingDrawObject* self, PyObject* args)
         return NULL;
     if (n != 2) {
         PyErr_SetString(PyExc_TypeError, must_be_two_coordinates);
+        free(xy);
         return NULL;
     }
 
@@ -2838,6 +2846,7 @@ _draw_pieslice(ImagingDrawObject* self, PyObject* args)
         return NULL;
     if (n != 2) {
         PyErr_SetString(PyExc_TypeError, must_be_two_coordinates);
+        free(xy);
         return NULL;
     }
 
@@ -2876,6 +2885,7 @@ _draw_polygon(ImagingDrawObject* self, PyObject* args)
         PyErr_SetString(PyExc_TypeError,
                         "coordinate list must contain at least 2 coordinates"
                         );
+        free(xy);
         return NULL;
     }
 
@@ -2919,6 +2929,7 @@ _draw_rectangle(ImagingDrawObject* self, PyObject* args)
         return NULL;
     if (n != 2) {
         PyErr_SetString(PyExc_TypeError, must_be_two_coordinates);
+        free(xy);
         return NULL;
     }
 

--- a/src/encode.c
+++ b/src/encode.c
@@ -584,11 +584,15 @@ PyImaging_ZipEncoderNew(PyObject* self, PyObject* args)
         dictionary = NULL;
 
     encoder = PyImaging_EncoderNew(sizeof(ZIPSTATE));
-    if (encoder == NULL)
+    if (encoder == NULL) {
+        free(dictionary);
         return NULL;
+    }
 
-    if (get_packer(encoder, mode, rawmode) < 0)
+    if (get_packer(encoder, mode, rawmode) < 0) {
+        free(dictionary);
         return NULL;
+    }
 
     encoder->encode = ImagingZipEncode;
     encoder->cleanup = ImagingZipEncodeCleanup;
@@ -749,8 +753,10 @@ PyImaging_JpegEncoderNew(PyObject* self, PyObject* args)
     if (rawExif && rawExifLen > 0) {
         /* malloc check ok, length is from python parsearg */
         char* pp = malloc(rawExifLen); // Freed in JpegEncode, Case 5
-        if (!pp)
+        if (!pp) {
+            if (extra) free(extra);
             return PyErr_NoMemory();
+        }
         memcpy(pp, rawExif, rawExifLen);
         rawExif = pp;
     } else

--- a/src/libImaging/Histo.c
+++ b/src/libImaging/Histo.c
@@ -82,8 +82,10 @@ ImagingGetHistogram(Imaging im, Imaging imMask, void* minmax)
 			h->histogram[im->image8[y][x]]++;
             ImagingSectionLeave(&cookie);
 	} else { /* yes, we need the braces. C isn't Python! */
-            if (im->type != IMAGING_TYPE_UINT8)
+            if (im->type != IMAGING_TYPE_UINT8) {
+                ImagingHistogramDelete(h);
                 return ImagingError_ModeError();
+            }
             ImagingSectionEnter(&cookie);
 	    for (y = 0; y < im->ysize; y++) {
 		UINT8* in = (UINT8*) im->image32[y];
@@ -122,8 +124,10 @@ ImagingGetHistogram(Imaging im, Imaging imMask, void* minmax)
                 ImagingSectionLeave(&cookie);
                 break;
             case IMAGING_TYPE_INT32:
-                if (!minmax)
+                if (!minmax) {
+                    ImagingHistogramDelete(h);
                     return ImagingError_ValueError("min/max not given");
+                }
                 if (!im->xsize || !im->ysize)
                     break;
                 imin = ((INT32*) minmax)[0];
@@ -143,8 +147,10 @@ ImagingGetHistogram(Imaging im, Imaging imMask, void* minmax)
                 ImagingSectionLeave(&cookie);
                 break;
             case IMAGING_TYPE_FLOAT32:
-                if (!minmax)
+                if (!minmax) {
+                    ImagingHistogramDelete(h);
                     return ImagingError_ValueError("min/max not given");
+                }
                 if (!im->xsize || !im->ysize)
                     break;
                 fmin = ((FLOAT32*) minmax)[0];

--- a/src/libImaging/Histo.c
+++ b/src/libImaging/Histo.c
@@ -41,7 +41,9 @@ ImagingHistogramNew(Imaging im)
 
     /* Create histogram descriptor */
     h = calloc(1, sizeof(struct ImagingHistogramInstance));
-    strncpy(h->mode, im->mode, IMAGING_MODE_LENGTH);
+    strncpy(h->mode, im->mode, IMAGING_MODE_LENGTH-1);
+    h->mode[IMAGING_MODE_LENGTH-1] = 0;
+
     h->bands = im->bands;
     h->histogram = calloc(im->pixelsize, 256 * sizeof(long));
 

--- a/src/libImaging/Palette.c
+++ b/src/libImaging/Palette.c
@@ -37,7 +37,8 @@ ImagingPaletteNew(const char* mode)
     if (!palette)
         return (ImagingPalette) ImagingError_MemoryError();
 
-    strncpy(palette->mode, mode, IMAGING_MODE_LENGTH);
+    strncpy(palette->mode, mode, IMAGING_MODE_LENGTH-1);
+    palette->mode[IMAGING_MODE_LENGTH-1] = 0;
 
     /* Initialize to ramp */
     for (i = 0; i < 256; i++) {

--- a/src/libImaging/Quant.c
+++ b/src/libImaging/Quant.c
@@ -568,6 +568,8 @@ split(BoxNode *node)
    left=malloc(sizeof(BoxNode));
    right=malloc(sizeof(BoxNode));
    if (!left||!right) {
+      free(left);
+      free(right);
       return 0;
    }
    for(i=0;i<3;i++) {

--- a/src/libImaging/QuantOctree.c
+++ b/src/libImaging/QuantOctree.c
@@ -481,6 +481,7 @@ error:
    free(qp);
    free_color_cube(lookupCube);
    free_color_cube(coarseLookupCube);
+   free(paletteBuckets);
    free(paletteBucketsCoarse);
    free(paletteBucketsFine);
    free_color_cube(coarseCube);

--- a/src/libImaging/Resample.c
+++ b/src/libImaging/Resample.c
@@ -621,6 +621,8 @@ ImagingResampleInner(Imaging imIn, int xsize, int ysize,
     if ( ! ksize_vert) {
         free(bounds_horiz);
         free(kk_horiz);
+        free(bounds_vert);
+        free(kk_vert);
         return NULL;
     }
 

--- a/src/path.c
+++ b/src/path.c
@@ -82,12 +82,16 @@ path_new(Py_ssize_t count, double* xy, int duplicate)
         xy = p;
     }
 
-    if (PyType_Ready(&PyPathType) < 0)
+    if (PyType_Ready(&PyPathType) < 0) {
+        free(xy);
         return NULL;
+    }
 
     path = PyObject_New(PyPathObject, &PyPathType);
-    if (path == NULL)
+    if (path == NULL) {
+        free(xy);
         return NULL;
+    }
 
     path->count = count;
     path->xy = xy;


### PR DESCRIPTION
Hello.

With our instance of static analysis software, we found some issues which may cause some troubles with un-terminated buffers and potential leaked storage.

Pages with problems description:
* [CWE-120: Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')](https://cwe.mitre.org/data/definitions/120.html)
* [CWE-772: Missing Release of Resource after Effective Lifetime](https://cwe.mitre.org/data/definitions/772.html)

This PR contains fixes for almost all of the reported issue (some were false-positives) and it doesn't change any functionality. Also, all test should pass.