### PR TITLE
Improve configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,15 +147,20 @@ LCMS_ROOT = None
 
 def _pkg_config(name):
     try:
-        command = [
+        command_libs = [
             'pkg-config',
             '--libs-only-L', name,
+        ]
+        command_cflags = [
+            'pkg-config',
             '--cflags-only-I', name,
         ]
         if not DEBUG:
-            command.append('--silence-errors')
-        libs = subprocess.check_output(command).decode('utf8').split(' ')
-        return libs[1][2:].strip(), libs[0][2:].strip()
+            command_libs.append('--silence-errors')
+            command_cflags.append('--silence-errors')
+        libs = subprocess.check_output(command_libs).decode('utf8').strip().replace('-L', '')
+        cflags = subprocess.check_output(command_cflags).decode('utf8').strip().replace('-I', '')
+        return (libs, cflags)
     except Exception:
         pass
 

--- a/setup.py
+++ b/setup.py
@@ -245,6 +245,11 @@ class pil_build_ext(build_ext):
                                         IMAGEQUANT_ROOT="libimagequant"
                                         ).items():
             root = globals()[root_name]
+
+            if root is None and root_name in os.environ:
+                prefix = os.environ[root_name]
+                root = (os.path.join(prefix, 'lib'), os.path.join(prefix, 'include'))
+
             if root is None and pkg_config:
                 if isinstance(lib_name, tuple):
                     for lib_name2 in lib_name:


### PR DESCRIPTION
Fix pkg-config call: If there is multiple spaces between pkg-config output elements the indexing is not correct ([1] can be an empty string and the value is in [2])
The second commit allow to define *_ROOT using environment variables