### PR TITLE
Minor ImageDraw documentation improvement

### DIFF
--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -391,8 +391,8 @@ def floodfill(image, xy, value, border=None, thresh=0):
         pixel.
     :param thresh: Optional threshold value which specifies a maximum
         tolerable difference of a pixel value from the 'background' in
-        order for it to be replaced. Useful for filling regions of non-
-        homogeneous, but similar, colors.
+        order for it to be replaced. Useful for filling regions of
+        non-homogeneous, but similar, colors.
     """
     # based on an implementation by Eric S. Raymond
     # amended by yo1995 @20180806


### PR DESCRIPTION
Removes the space between 'non-' and 'homogeneous' - while this looks fine in it's raw form, on Read The Docs is rendered as -
![imagedraw](https://user-images.githubusercontent.com/3112309/46791617-45353d80-cd8d-11e8-9e37-ec9e619483ae.png)
