### PR TITLE
Optimise ImageOps.fit by combining resize and crop

### DIFF
--- a/docs/releasenotes/5.4.0.rst
+++ b/docs/releasenotes/5.4.0.rst
@@ -1,0 +1,14 @@
+5.4.0 (unreleased)
+-----
+
+
+Other Changes
+=============
+
+ImageOps.fit
+^^^^^^^^^^^^
+
+Now uses the one resize operation with ``box`` argument internally
+instead of the crop and scale operations sequence.
+This improves the performance and accuracy of cropping since
+``box`` parameter accepts float values.

--- a/docs/releasenotes/5.4.0.rst
+++ b/docs/releasenotes/5.4.0.rst
@@ -8,7 +8,7 @@ Other Changes
 ImageOps.fit
 ^^^^^^^^^^^^
 
-Now uses the one resize operation with ``box`` argument internally
-instead of the crop and scale operations sequence.
+Now uses one resize operation with ``box`` parameter internally
+instead of a crop and scale operations sequence.
 This improves the performance and accuracy of cropping since
-``box`` parameter accepts float values.
+the ``box`` parameter accepts float values.

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -6,6 +6,7 @@ Release Notes
 .. toctree::
   :maxdepth: 2
 
+  5.4.0
   5.3.0
   5.2.0
   5.1.0

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -380,9 +380,10 @@ def fit(image, size, method=Image.NEAREST, bleed=0.0, centering=(0.5, 0.5)):
                  (width, height) tuple.
     :param method: What resampling method to use. Default is
                    :py:attr:`PIL.Image.NEAREST`.
-    :param bleed: Remove a border around the outside of the image (from all
+    :param bleed: Remove a border around the outside of the image from all
                   four edges. The value is a decimal percentage (use 0.01 for
                   one percent). The default value is 0 (no border).
+                  Cannot be greater than or equal to 0.5.
     :param centering: Control the cropping position.  Use (0.5, 0.5) for
                       center cropping (e.g. if cropping the width, take 50% off
                       of the left side, and therefore 50% off the right side).
@@ -400,66 +401,50 @@ def fit(image, size, method=Image.NEAREST, bleed=0.0, centering=(0.5, 0.5)):
     # kevin@cazabon.com
     # http://www.cazabon.com
 
-    # ensure inputs are valid
-    if not isinstance(centering, list):
-        centering = [centering[0], centering[1]]
+    # ensure centering is mutable
+    centering = list(centering)
 
-    if centering[0] > 1.0 or centering[0] < 0.0:
-        centering[0] = 0.50
-    if centering[1] > 1.0 or centering[1] < 0.0:
-        centering[1] = 0.50
+    if not 0.0 <= centering[0] <= 1.0:
+        centering[0] = 0.5
+    if not 0.0 <= centering[1] <= 1.0:
+        centering[1] = 0.5
 
-    if bleed > 0.49999 or bleed < 0.0:
+    if not 0.0 <= bleed < 0.5:
         bleed = 0.0
 
     # calculate the area to use for resizing and cropping, subtracting
     # the 'bleed' around the edges
 
     # number of pixels to trim off on Top and Bottom, Left and Right
-    bleedPixels = (
-        int((float(bleed) * float(image.size[0])) + 0.5),
-        int((float(bleed) * float(image.size[1])) + 0.5)
-        )
+    bleed_pixels = (bleed * image.size[0], bleed * image.size[1])
 
-    liveArea = (0, 0, image.size[0], image.size[1])
-    if bleed > 0.0:
-        liveArea = (
-            bleedPixels[0], bleedPixels[1], image.size[0] - bleedPixels[0] - 1,
-            image.size[1] - bleedPixels[1] - 1
-            )
+    live_size = (image.size[0] - bleed_pixels[0] * 2,
+                image.size[1] - bleed_pixels[1] * 2)
 
-    liveSize = (liveArea[2] - liveArea[0], liveArea[3] - liveArea[1])
-
-    # calculate the aspect ratio of the liveArea
-    liveAreaAspectRatio = float(liveSize[0])/float(liveSize[1])
+    # calculate the aspect ratio of the live_size
+    live_size_ratio = float(live_size[0]) / live_size[1]
 
     # calculate the aspect ratio of the output image
-    aspectRatio = float(size[0]) / float(size[1])
+    output_ratio = float(size[0]) / size[1]
 
     # figure out if the sides or top/bottom will be cropped off
-    if liveAreaAspectRatio >= aspectRatio:
-        # liveArea is wider than what's needed, crop the sides
-        cropWidth = int((aspectRatio * float(liveSize[1])) + 0.5)
-        cropHeight = liveSize[1]
+    if live_size_ratio >= output_ratio:
+        # live_size is wider than what's needed, crop the sides
+        crop_width = output_ratio * live_size[1]
+        crop_height = live_size[1]
     else:
-        # liveArea is taller than what's needed, crop the top and bottom
-        cropWidth = liveSize[0]
-        cropHeight = int((float(liveSize[0])/aspectRatio) + 0.5)
+        # live_size is taller than what's needed, crop the top and bottom
+        crop_width = live_size[0]
+        crop_height = live_size[0] / output_ratio
 
     # make the crop
-    leftSide = int(liveArea[0] + (float(liveSize[0]-cropWidth) * centering[0]))
-    if leftSide < 0:
-        leftSide = 0
-    topSide = int(liveArea[1] + (float(liveSize[1]-cropHeight) * centering[1]))
-    if topSide < 0:
-        topSide = 0
+    crop_left = bleed_pixels[0] + (live_size[0]-crop_width) * centering[0]
+    crop_top = bleed_pixels[1] + (live_size[1]-crop_height) * centering[1]
 
-    out = image.crop(
-        (leftSide, topSide, leftSide + cropWidth, topSide + cropHeight)
-        )
+    crop = (crop_left, crop_top, crop_left + crop_width, crop_top + crop_height)
 
     # resize the image and return it
-    return out.resize(size, method)
+    return image.resize(size, method, box=crop)
 
 
 def flip(image):

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -419,7 +419,7 @@ def fit(image, size, method=Image.NEAREST, bleed=0.0, centering=(0.5, 0.5)):
     bleed_pixels = (bleed * image.size[0], bleed * image.size[1])
 
     live_size = (image.size[0] - bleed_pixels[0] * 2,
-                image.size[1] - bleed_pixels[1] * 2)
+                 image.size[1] - bleed_pixels[1] * 2)
 
     # calculate the aspect ratio of the live_size
     live_size_ratio = float(live_size[0]) / live_size[1]


### PR DESCRIPTION
This optimises crop+resize operations sequence by using `box` parameter of `resize` function. This gives us:

1. Performance. Results for [lilliput-bench](
https://github.com/discordapp/lilliput-bench):

Before:

```
JPEG 256x256 => 32x32:  1109 Bytes,     avg: 1.43 ms    min: 0.92 ms    max: 4.43 ms
PNG 256x256 => 32x32:   2603 Bytes,     avg: 3.70 ms    min: 3.62 ms    max: 7.14 ms
WEBP 256x256 => 32x32:  654 Bytes,      avg: 2.77 ms    min: 2.48 ms    max: 6.30 ms
GIF 256x256 => 32x32:   1897 Bytes,     avg: 4.89 ms    min: 4.51 ms    max: 11.58 ms
JPEG 1920x1080 => 800x600:      107480 Bytes,   avg: 26.28 ms   min: 24.90 ms   max: 37.08 ms
PNG 1920x1080 => 800x600:       810489 Bytes,   avg: 282.60 ms  min: 277.43 ms  max: 377.78 ms
WEBP 1920x1080 => 800x600:      84960 Bytes,    avg: 126.52 ms  min: 123.86 ms  max: 149.28 ms
GIF 1920x1080 => 800x600:       411470 Bytes,   avg: 102.40 ms  min: 95.52 ms   max: 126.27 ms
```

After:

```
JPEG 256x256 => 32x32:	1109 Bytes,	avg: 0.95 ms	min: 0.74 ms	max: 4.93 ms
PNG 256x256 => 32x32:	2603 Bytes,	avg: 3.56 ms	min: 3.45 ms	max: 7.60 ms
WEBP 256x256 => 32x32:	654 Bytes,	avg: 2.77 ms	min: 2.47 ms	max: 6.36 ms
GIF 256x256 => 32x32:	1897 Bytes,	avg: 4.73 ms	min: 4.37 ms	max: 11.39 ms
JPEG 1920x1080 => 800x600:	107450 Bytes,	avg: 21.36 ms	min: 20.99 ms	max: 27.02 ms
PNG 1920x1080 => 800x600:	810516 Bytes,	avg: 277.31 ms	min: 272.55 ms	max: 328.37 ms
WEBP 1920x1080 => 800x600:	84952 Bytes,	avg: 125.57 ms	min: 121.98 ms	max: 154.98 ms
GIF 1920x1080 => 800x600:	411470 Bytes,	avg: 98.35 ms	min: 94.72 ms	max: 117.11 ms
```

2. Accuracy. Unlike crop method, `box` for resize method accepts float coordinates. For example:

```python
from PIL import Image, ImageOps
dot = Image.open('../dot.png')
ImageOps.fit(dot, (220, 200), Image.BICUBIC).save('../_out.png')
```

Source image (50x30px), processed image before, processed image after:

![screenshot 2018-10-17 at 02 30 15](https://user-images.githubusercontent.com/128982/47053429-8b3b3880-d1b5-11e8-8db6-8ec915a50ecd.png)
![screenshot 2018-10-17 at 02 30 04](https://user-images.githubusercontent.com/128982/47053438-91c9b000-d1b5-11e8-986b-7574d75a4466.png)
![screenshot 2018-10-17 at 02 31 40](https://user-images.githubusercontent.com/128982/47053439-92fadd00-d1b5-11e8-928f-31456d3cd8f3.png)
