### PR TITLE
CI: Fix diff-cover, move linting to own job, name the jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,18 @@ cache: pip
 notifications:
   irc: "chat.freenode.net#pil"
 
-# Run slow PyPy* first, to give them a headstart and reduce waiting time.
+# Run fast lint first to get fast feedback.
+# Run slow PyPy* next, to give them a headstart and reduce waiting time.
 # Run latest 3.x and 2.x next, to get quick compatibility results.
 # Then run the remainder, with fastest Docker jobs last.
 
 matrix:
   fast_finish: true
   include:
+    - python: "3.6"
+      name: "Lint"
+      env: LINT="true"
+      sudo: false
     - python: "pypy"
       name: "PyPy Trusty"
       dist: trusty
@@ -62,7 +67,12 @@ services:
   - docker
 
 install:
-  - if [ "$DOCKER" == "" ]; then .travis/install.sh; fi
+  - |
+    if [ "$LINT" == "true" ]; then
+      pip install -U flake8
+    elif [ "$DOCKER" == "" ]; then
+      .travis/install.sh;
+    fi
 
 before_install:
   - if [ "$DOCKER" ]; then travis_retry docker pull pythonpillow/$DOCKER:$DOCKER_TAG; fi
@@ -73,14 +83,19 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
 
 script:
-  - |
-       if [ "$DOCKER" == "" ]; then
-          .travis/script.sh
-       else
-          # the Pillow user in the docker container is UID 1000
-          sudo chown -R 1000 $TRAVIS_BUILD_DIR
-          docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/$DOCKER:$DOCKER_TAG
-       fi
+- |
+  if [ "$DOCKER" == "" ] && [ "$LINT" == "" ]; then
+    .travis/script.sh
+  elif [ "$DOCKER" ]; then
+    # the Pillow user in the docker container is UID 1000
+    sudo chown -R 1000 $TRAVIS_BUILD_DIR
+    docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/$DOCKER:$DOCKER_TAG
+  fi
 
 after_success:
-  - .travis/after_success.sh
+- |
+  if [ "$LINT" == "true" ]; then
+    flake8 --statistics --count
+  else
+    .travis/after_success.sh
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,25 +14,37 @@ matrix:
   fast_finish: true
   include:
     - python: "pypy"
+      name: "PyPy Trusty"
       dist: trusty
     - python: "pypy3"
+      name: "PyPy3 Trusty"
       dist: trusty
     - python: '3.7'
+      name: "3.7 Xenial"
     - python: '2.7'
+      name: "2.7 Xenial"
     - python: '2.7'
+      name: "2.7 Trusty"
       dist: trusty
     - python:  "2.7_with_system_site_packages" # For PyQt4
+      name: "2.7_with_system_site_packages Xenial"
     - python:  "2.7_with_system_site_packages" # For PyQt4
+      name: "2.7_with_system_site_packages Trusty"
       dist: trusty
     - python: '3.6'
+      name: "3.6 Xenial"
     - python: '3.6'
+      name: "3.6 Trusty PYTHONOPTIMIZE=1"
       dist: trusty
       env: PYTHONOPTIMIZE=1
     - python: '3.5'
+      name: "3.5 Xenial"
     - python: '3.5'
+      name: "3.5 Trusty PYTHONOPTIMIZE=2"
       dist: trusty
       env: PYTHONOPTIMIZE=2
     - python: '3.4'
+      name: "3.4 Trusty"
       dist: trusty
     - env: DOCKER="alpine" DOCKER_TAG="pytest"
     - env: DOCKER="arch" DOCKER_TAG="pytest" # contains PyQt5

--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -15,15 +15,6 @@ pip install coveralls-merge
 coveralls-merge coverage.c.json
 codecov
 
-if [ "$DOCKER" == "" ]; then
-    pip install pyflakes pycodestyle
-    pyflakes *.py | tee >(wc -l)
-    pyflakes src/PIL/*.py | tee >(wc -l)
-    pyflakes Tests/*.py | tee >(wc -l)
-    pycodestyle --statistics --count src/PIL/*.py
-    pycodestyle --statistics --count Tests/*.py
-fi
-
 if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ] && [ "$DOCKER" == "" ]; then
     # Coverage and quality reports on just the latest diff.
     # (Installation is very slow on Py3, so just do it for Py2.)

--- a/depends/diffcover-install.sh
+++ b/depends/diffcover-install.sh
@@ -4,4 +4,4 @@ git fetch origin master:refs/remotes/origin/master
 
 # CFLAGS=-O0 means build with no optimisation.
 # Makes build much quicker for lxml and other dependencies.
-time CFLAGS=-O0 pip install --use-wheel diff_cover
+time CFLAGS=-O0 pip install diff_cover

--- a/depends/diffcover-install.sh
+++ b/depends/diffcover-install.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Fetch the remote master branch before running diff-cover on Travis CI.
 # https://github.com/Bachmann1234/diff-cover#troubleshooting
 git fetch origin master:refs/remotes/origin/master

--- a/depends/diffcover-run.sh
+++ b/depends/diffcover-run.sh
@@ -1,4 +1,4 @@
 coverage xml
 diff-cover coverage.xml
 diff-quality --violation=pyflakes
-diff-quality --violation=pep8
+diff-quality --violation=pycodestyle

--- a/depends/diffcover-run.sh
+++ b/depends/diffcover-run.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 coverage xml
 diff-cover coverage.xml
 diff-quality --violation=pyflakes


### PR DESCRIPTION
Changes proposed in this pull request:

 * Fix diff-cover checks: 
   * Fix install `no such option: --use-wheel`
   * It tried to use the old pep8 tool, which is now pycodestyle

 * Move the linting to its own job, but do it inside `after_success` so it won't fail the build. This makes it easier to find. I chose 3.6 as the base Python, as it's the newest that doesn't need to download the Python archive, so is faster. It runs first to get fast feedback.

 * Name the non-Docker build jobs, so we can clearly see which are Trusty and which are Xenial.

# Before

![image](https://user-images.githubusercontent.com/1324225/47113318-5d133280-d261-11e8-9eef-076e1db34dc3.png)

# After

![image](https://user-images.githubusercontent.com/1324225/47113289-4967cc00-d261-11e8-8a54-1ed875fdc69c.png)
