### PR TITLE
Use a newer Python for the virtualenv for PyPy

### DIFF
--- a/winbuild/appveyor_install_pypy.cmd
+++ b/winbuild/appveyor_install_pypy.cmd
@@ -1,3 +1,3 @@
 curl -fsSL -o pypy2.zip https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-win32.zip
 7z x pypy2.zip -oc:\
-c:\Python34\Scripts\virtualenv.exe -p c:\pypy2-v6.0.0-win32\pypy.exe c:\vp\pypy2
+c:\Python37\Scripts\virtualenv.exe -p c:\pypy2-v6.0.0-win32\pypy.exe c:\vp\pypy2


### PR DESCRIPTION
Changes proposed in this pull request:

 * Python 3.4 -> 3.7
 * Python 3.4 will be going EOL soon on 2019-03-16
 * https://devguide.python.org/#status-of-python-branches
