### PR TITLE
Fix some tests

### DIFF
--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -24,19 +24,19 @@ class TestFeatures(PillowTestCase):
                              features.check(feature))
 
     @unittest.skipUnless(HAVE_WEBP, "WebP not available")
-    def check_webp_transparency(self):
+    def test_webp_transparency(self):
         self.assertEqual(features.check('transp_webp'),
                          not _webp.WebPDecoderBuggyAlpha())
         self.assertEqual(features.check('transp_webp'),
                          _webp.HAVE_TRANSPARENCY)
 
     @unittest.skipUnless(HAVE_WEBP, "WebP not available")
-    def check_webp_mux(self):
+    def test_webp_mux(self):
         self.assertEqual(features.check('webp_mux'),
                          _webp.HAVE_WEBPMUX)
 
     @unittest.skipUnless(HAVE_WEBP, "WebP not available")
-    def check_webp_anim(self):
+    def test_webp_anim(self):
         self.assertEqual(features.check('webp_anim'),
                          _webp.HAVE_WEBPANIM)
 

--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -23,19 +23,19 @@ class TestFeatures(PillowTestCase):
             self.assertEqual(features.check_feature(feature),
                              features.check(feature))
 
-    @unittest.skipUnless(HAVE_WEBP, True)
+    @unittest.skipUnless(HAVE_WEBP, "WebP not available")
     def check_webp_transparency(self):
         self.assertEqual(features.check('transp_webp'),
                          not _webp.WebPDecoderBuggyAlpha())
         self.assertEqual(features.check('transp_webp'),
                          _webp.HAVE_TRANSPARENCY)
 
-    @unittest.skipUnless(HAVE_WEBP, True)
+    @unittest.skipUnless(HAVE_WEBP, "WebP not available")
     def check_webp_mux(self):
         self.assertEqual(features.check('webp_mux'),
                          _webp.HAVE_WEBPMUX)
 
-    @unittest.skipUnless(HAVE_WEBP, True)
+    @unittest.skipUnless(HAVE_WEBP, "WebP not available")
     def check_webp_anim(self):
         self.assertEqual(features.check('webp_anim'),
                          _webp.HAVE_WEBPANIM)

--- a/Tests/test_format_hsv.py
+++ b/Tests/test_format_hsv.py
@@ -13,11 +13,7 @@ class TestFormatHSV(PillowTestCase):
         return float(i)/255.0
 
     def str_to_float(self, i):
-
         return float(ord(i))/255.0
-
-    def to_int(self, f):
-        return int(f*255.0)
 
     def tuple_to_ints(self, tp):
         x, y, z = tp

--- a/Tests/test_format_hsv.py
+++ b/Tests/test_format_hsv.py
@@ -17,7 +17,7 @@ class TestFormatHSV(PillowTestCase):
 
     def tuple_to_ints(self, tp):
         x, y, z = tp
-        return (int(x*255.0), int(y*255.0), int(z*255.0))
+        return int(x*255.0), int(y*255.0), int(z*255.0)
 
     def test_sanity(self):
         Image.new('HSV', (100, 100))

--- a/Tests/test_pyroma.py
+++ b/Tests/test_pyroma.py
@@ -5,19 +5,12 @@ from PIL import __version__
 try:
     import pyroma
 except ImportError:
-    # Skip via setUp()
-    pass
+    pyroma = None
 
 
 class TestPyroma(PillowTestCase):
 
-    def setUp(self):
-        try:
-            import pyroma
-            assert pyroma  # Ignore warning
-        except ImportError:
-            self.skipTest("ImportError")
-
+    @unittest.skipUnless(pyroma, "Pyroma is not installed")
     def test_pyroma(self):
         # Arrange
         data = pyroma.projectdata.get_data(".")


### PR DESCRIPTION
Changes proposed in this pull request:

 * test_features.py: Some tests were named `check_*` so aren't run. Probably a mistake, as they were bookended by `test_check` and `test_check_features`. Switch to `test_*` so they're run.

 * test_features.py: `@unittest.skipUnless` takes a condition and _reason_.

 * test_format_hsv.py: Remove unused helper method and redundant parentheses.

 * test_pyroma.py: Simplify skipping and remove `setUp`.
