### PR TITLE
Install project using pip in ReadTheDocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,2 @@
+python:
+    pip_install: true


### PR DESCRIPTION
Possible solution for #2763 

Given the intermittent nature of the problem, I can't say anything definitively, but here is my evidence that it might solve it - testing builds of the 5.3.x branch against this, 5.3.x fails 3 out of 6, and this fails 0 out of 6.

![readthedocs](https://user-images.githubusercontent.com/3112309/47422539-9520f500-d7ce-11e8-9e0f-45ffdecc7c3e.png)