### PR TITLE
Re-add the downloads badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
     * - tests
       - |linux| |macos| |windows| |coverage|
     * - package
-      - |zenodo| |version|
+      - |zenodo| |version| |downloads|
     * - social
       - |gitter| |twitter|
 
@@ -46,6 +46,10 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
 .. |version| image:: https://img.shields.io/pypi/v/pillow.svg
    :target: https://pypi.org/project/Pillow/
    :alt: Latest PyPI version
+
+.. |downloads| image:: https://img.shields.io/pypi/dm/pillow.svg
+   :target: https://pypi.python.org/pypi/Pillow/
+   :alt: Number of PyPI downloads
 
 .. |gitter| image:: https://badges.gitter.im/python-pillow/Pillow.svg
    :target: https://gitter.im/python-pillow/Pillow?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,10 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
    :target: https://pypi.org/project/Pillow/
    :alt: Latest PyPI version
 
+.. image:: https://img.shields.io/pypi/dm/pillow.svg
+   :target: https://pypi.python.org/pypi/Pillow/
+   :alt: Number of PyPI downloads
+
 .. image:: https://coveralls.io/repos/python-pillow/Pillow/badge.svg?branch=master
    :target: https://coveralls.io/github/python-pillow/Pillow?branch=master
    :alt: Code coverage


### PR DESCRIPTION
Changes proposed in this pull request:

 * The downloads badge is fixed at Shields.io: https://github.com/badges/shields/pull/2131
 * 4 million downloads per month!

![image](https://user-images.githubusercontent.com/1324225/47655706-455b7880-db96-11e8-92c4-8d5400311cc1.png)

