### PR TITLE
Changed URL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3898,7 +3898,7 @@ Pre-fork
     (1.1.3 final released)
 
     + Made setup.py look for old versions of zlib.  For some back-
-      ground, see: http://www.gzip.org/zlib/advisory-2002-03-11.txt
+      ground, see: https://zlib.net/advisory-2002-03-11.txt
 
     (1.1.3c2 released)
 


### PR DESCRIPTION
Since the URL no longer works, this PR updates it.

I found https://zlib.net/advisory-2002-03-11.txt, which matches to https://web.archive.org/web/20170120044244/http://www.gzip.org/zlib/advisory-2002-03-11.txt