### PR TITLE
ImageShow improvements

### DIFF
--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -14,6 +14,9 @@ class TestImageShow(PillowTestCase):
         # Test registering a viewer that is not a class
         ImageShow.register("not a class")
 
+        # Restore original state
+        ImageShow._viewers.pop()
+
     def test_show(self):
         class TestViewer:
             methodCalled = False
@@ -28,12 +31,19 @@ class TestImageShow(PillowTestCase):
         self.assertTrue(ImageShow.show(im))
         self.assertTrue(viewer.methodCalled)
 
+        # Restore original state
+        ImageShow._viewers.pop(0)
+
     def test_viewer(self):
         viewer = ImageShow.Viewer()
 
         self.assertIsNone(viewer.get_format(None))
 
         self.assertRaises(NotImplementedError, viewer.get_command, None)
+
+    def test_viewers(self):
+        for viewer in ImageShow._viewers:
+            viewer.get_command('test.jpg')
 
 
 if __name__ == '__main__':

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -148,12 +148,9 @@ else:
         format = "PNG"
         options = {'compress_level': 1}
 
-        def show_file(self, file, **options):
-            command, executable = self.get_command_ex(file, **options)
-            command = "(%s %s; rm -f %s)&" % (command, quote(file),
-                                              quote(file))
-            os.system(command)
-            return 1
+        def get_command(self, file, **options):
+            command = self.get_command_ex(file, **options)[0]
+            return "(%s %s; rm -f %s)&" % (command, quote(file), quote(file))
 
     # implementations
 

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -17,6 +17,8 @@ from __future__ import print_function
 from PIL import Image
 import os
 import sys
+import subprocess
+import tempfile
 
 if sys.version_info.major >= 3:
     from shlex import quote
@@ -128,6 +130,21 @@ elif sys.platform == "darwin":
                                                         quote(file))
             return command
 
+        def show_file(self, file, **options):
+            """Display given file"""
+            f, path = tempfile.mkstemp()
+            f.write(file)
+            f.close()
+            with open(path, "r") as f:
+                subprocess.Popen([
+                    'im=$(cat);'
+                    'open -a /Applications/Preview.app $im;'
+                    'sleep 20;'
+                    'rm -f $im'
+                ], shell=True, stdin=f)
+            os.remove(path)
+            return 1
+
     register(MacViewer)
 
 else:
@@ -151,6 +168,21 @@ else:
         def get_command(self, file, **options):
             command = self.get_command_ex(file, **options)[0]
             return "(%s %s; rm -f %s)&" % (command, quote(file), quote(file))
+
+        def show_file(self, file, **options):
+            """Display given file"""
+            f, path = tempfile.mkstemp()
+            f.write(file)
+            f.close()
+            with open(path, "r") as f:
+                command = self.get_command_ex(file, **options)[0]
+                subprocess.Popen([
+                    'im=$(cat);' +
+                    command+' $im;'
+                    'rm -f $im'
+                ], shell=True, stdin=f)
+            os.remove(path)
+            return 1
 
     # implementations
 


### PR DESCRIPTION
* Added UnixViewer implementation of the `get_command` method
* Supply filename through stdin instead of inline in Mac and Unix viewers. This is for the sake of security - rather than simply being quoted through shlex/pipes, the filename is now a variable. Feel free to tell me that this is more convoluted than necessary though, given that the filename being passed in does not originate externally.