### PR TITLE
Do not play sound when running screencapture command

### DIFF
--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -14,7 +14,7 @@ try:
 
         def test_grabclipboard(self):
             if sys.platform == "darwin":
-                subprocess.call(['screencapture', '-c'])
+                subprocess.call(['screencapture', '-cx'])
             else:
                 p = subprocess.Popen(['powershell', '-command', '-'],
                                      stdin=subprocess.PIPE)


### PR DESCRIPTION
This PR changes the ImageGrab test to run screencapture silently. Without it, a sound plays when running the test.