### PR TITLE
Close exclusive fp on open exception

### DIFF
--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -17,11 +17,15 @@ class TestBmpReference(PillowTestCase):
         """ These shouldn't crash/dos, but they shouldn't return anything
         either """
         for f in self.get_files('b'):
-            try:
-                im = Image.open(f)
-                im.load()
-            except Exception:  # as msg:
-                pass
+            def open(f):
+                try:
+                    im = Image.open(f)
+                    im.load()
+                except Exception:  # as msg:
+                    pass
+
+            # Assert that there is no unclosed file warning
+            self.assert_warning(None, open, f)
 
     def test_questionable(self):
         """ These shouldn't crash/dos, but it's not well defined that these

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2641,6 +2641,10 @@ def open(fp, mode="r"):
                 # opening failures that are entirely expected.
                 # logger.debug("", exc_info=True)
                 continue
+            except Exception:
+                if exclusive_fp:
+                    fp.close()
+                raise
         return None
 
     im = _open_core(fp, filename, prefix)


### PR DESCRIPTION
If the image cannot be identified, the exclusive fp is closed - https://github.com/python-pillow/Pillow/blob/master/src/PIL/Image.py#L2656

This PR closes the exclusive fp if an uncaught exception is thrown.