### PR TITLE
Updated libtiff to 4.0.10

### DIFF
--- a/winbuild/config.py
+++ b/winbuild/config.py
@@ -29,9 +29,9 @@ libs = {
         'dir': 'jpeg-9c',
     },
     'tiff': {
-        'url': 'ftp://download.osgeo.org/libtiff/tiff-4.0.9.zip',
-        'filename': PILLOW_DEPENDS_DIR + 'tiff-4.0.9.zip',
-        'dir': 'tiff-4.0.9',
+        'url': 'ftp://download.osgeo.org/libtiff/tiff-4.0.10.zip',
+        'filename': PILLOW_DEPENDS_DIR + 'tiff-4.0.10.zip',
+        'dir': 'tiff-4.0.10',
     },
     'freetype': {
         'url': 'https://download.savannah.gnu.org/releases/freetype/freetype-2.9.1.tar.gz',

--- a/winbuild/config.py
+++ b/winbuild/config.py
@@ -29,8 +29,8 @@ libs = {
         'dir': 'jpeg-9c',
     },
     'tiff': {
-        'url': 'ftp://download.osgeo.org/libtiff/tiff-4.0.10.zip',
-        'filename': PILLOW_DEPENDS_DIR + 'tiff-4.0.10.zip',
+        'url': 'ftp://download.osgeo.org/libtiff/tiff-4.0.10.tar.gz',
+        'filename': PILLOW_DEPENDS_DIR + 'tiff-4.0.10.tar.gz',
         'dir': 'tiff-4.0.10',
     },
     'freetype': {


### PR DESCRIPTION
As per https://github.com/python-pillow/Pillow/pull/3442#issuecomment-433849065, It's fine to wait until #3441 is resolved.

Also changes it to use .tar.gz instead of .zip, in order to use the same pillow-depends file as pillow-wheels