### PR TITLE
Removed unused function

### DIFF
--- a/winbuild/build_dep.py
+++ b/winbuild/build_dep.py
@@ -121,24 +121,6 @@ rem build openjpeg
 setlocal
 @echo on
 cd /D %%OPENJPEG%%%(inc_dir)s
-%%CMAKE%% -DBUILD_THIRDPARTY:BOOL=OFF -G "NMake Makefiles" .
-nmake -f Makefile clean
-nmake -f Makefile
-copy /Y /B bin\* %%INCLIB%%
-mkdir %%INCLIB%%\openjpeg-%(op_ver)s
-copy /Y /B src\lib\openjp2\*.h %%INCLIB%%\openjpeg-%(op_ver)s
-endlocal
-""" % atts
-
-
-def msbuild_openjpeg(compiler):
-    atts = {'op_ver': '2.1'}
-    atts.update(compiler)
-    return r"""
-rem build openjpeg
-setlocal
-@echo on
-cd /D %%OPENJPEG%%%(inc_dir)s
 
 %%CMAKE%% -DBUILD_THIRDPARTY:BOOL=OFF -G "NMake Makefiles" .
 nmake -f Makefile clean


### PR DESCRIPTION
`msbuild_openjpeg` is unused. Also, `nmake_openjpeg` and `msbuild_openjpeg` are identical, so removing the function is not losing any information.