### PR TITLE
CI: Allow lint job to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,9 @@ before_script:
 
 script:
 - |
-  if [ "$DOCKER" == "" ] && [ "$LINT" == "" ]; then
+  if [ "$LINT" == "true" ]; then
+    flake8 --statistics --count
+  elif [ "$DOCKER" == "" ]; then
     .travis/script.sh
   elif [ "$DOCKER" ]; then
     # the Pillow user in the docker container is UID 1000
@@ -92,8 +94,6 @@ script:
 
 after_success:
 - |
-  if [ "$LINT" == "true" ]; then
-    flake8 --statistics --count
-  else
+  if [ "$LINT" == "" ]; then
     .travis/after_success.sh
   fi

--- a/Tests/createfontdatachunk.py
+++ b/Tests/createfontdatachunk.py
@@ -2,7 +2,6 @@
 from __future__ import print_function
 import base64
 import os
-import sys
 
 if __name__ == "__main__":
     # create font data chunk for embedding

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -84,7 +84,7 @@ class PillowTestCase(unittest.TestCase):
             self.assertTrue(
                 all(x == y for x, y in zip(a, b)),
                 msg or "got %s, expected %s" % (a, b))
-        except:
+        except Exception:
             self.assertEqual(a, b, msg)
 
     def assert_image(self, im, mode, size, msg=None):
@@ -149,7 +149,7 @@ class PillowTestCase(unittest.TestCase):
                 try:
                     url = test_image_results.upload(a, b)
                     logger.error("Url for test images: %s" % url)
-                except:
+                except Exception:
                     pass
             raise e
 

--- a/Tests/test_imagemath.py
+++ b/Tests/test_imagemath.py
@@ -18,7 +18,7 @@ A = Image.new("L", (1, 1), 1)
 B = Image.new("L", (1, 1), 2)
 Z = Image.new("L", (1, 1), 0)  # Z for zero
 F = Image.new("F", (1, 1), 3)
-I = Image.new("I", (1, 1), 4)
+I = Image.new("I", (1, 1), 4)  # noqa: E741
 
 A2 = A.resize((2, 2))
 B2 = B.resize((2, 2))

--- a/mp_compile.py
+++ b/mp_compile.py
@@ -43,7 +43,7 @@ def _mp_compile(self, sources, output_dir=None, macros=None,
     pool = Pool(MAX_PROCS)
     try:
         print("Building using %d processes" % pool._processes)
-    except:
+    except Exception:
         pass
     arr = [(self, obj, build, cc_args, extra_postargs, pp_opts)
            for obj in objects]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,11 @@
 [aliases]
 test=pytest
+
 [metadata]
 license_file = LICENSE
+
 [tool:pytest]
 addopts = -vx Tests
+
+[flake8]
+max-line-length = 88

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -971,7 +971,7 @@ class Image(object):
                         if isinstance(t, tuple):
                             try:
                                 t = trns_im.palette.getcolor(t)
-                            except:
+                            except Exception:
                                 raise ValueError("Couldn't allocate a palette "
                                                  "color for transparency")
                     trns_im.putpixel((0, 0), t)
@@ -1008,7 +1008,7 @@ class Image(object):
             if trns is not None:
                 try:
                     new.info['transparency'] = new.palette.getcolor(trns)
-                except:
+                except Exception:
                     # if we can't make a transparent color, don't leave the old
                     # transparency hanging around to mess us up.
                     del(new.info['transparency'])
@@ -1038,7 +1038,7 @@ class Image(object):
             if new_im.mode == 'P':
                 try:
                     new_im.info['transparency'] = new_im.palette.getcolor(trns)
-                except:
+                except Exception:
                     del(new_im.info['transparency'])
                     warnings.warn("Couldn't allocate palette entry " +
                                   "for transparency")

--- a/src/PIL/ImageFilter.py
+++ b/src/PIL/ImageFilter.py
@@ -197,7 +197,7 @@ class UnsharpMask(MultibandFilter):
 
     .. _digital unsharp masking: https://en.wikipedia.org/wiki/Unsharp_masking#Digital_unsharp_masking
 
-    """
+    """  # noqa: E501
     name = "UnsharpMask"
 
     def __init__(self, radius=2, percent=150, threshold=3):

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -72,7 +72,7 @@ class ImageFont(object):
                 try:
                     fullname = os.path.splitext(filename)[0] + ext
                     image = Image.open(fullname)
-                except:
+                except Exception:
                     pass
                 else:
                     if image and image.mode in ("1", "L"):

--- a/src/PIL/ImageQt.py
+++ b/src/PIL/ImageQt.py
@@ -140,7 +140,7 @@ def _toqclass_helper(im):
         if py3:
             im = str(im.toUtf8(), "utf-8")
         else:
-            im = unicode(im.toUtf8(), "utf-8")
+            im = unicode(im.toUtf8(), "utf-8")  # noqa: F821
     if isPath(im):
         im = Image.open(im)
 

--- a/src/PIL/ImageTk.py
+++ b/src/PIL/ImageTk.py
@@ -124,7 +124,7 @@ class PhotoImage(object):
         self.__photo.name = None
         try:
             self.__photo.tk.call("image", "delete", name)
-        except:
+        except Exception:
             pass  # ignore internal errors
 
     def __str__(self):
@@ -244,7 +244,7 @@ class BitmapImage(object):
         self.__photo.name = None
         try:
             self.__photo.tk.call("image", "delete", name)
-        except:
+        except Exception:
             pass  # ignore internal errors
 
     def width(self):

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -181,14 +181,14 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
         try:
             fd = self.fp.fileno()
             length = os.fstat(fd).st_size
-        except:
+        except Exception:
             fd = -1
             try:
                 pos = self.fp.tell()
                 self.fp.seek(0, 2)
                 length = self.fp.tell()
                 self.fp.seek(pos, 0)
-            except:
+            except Exception:
                 length = -1
 
         self.tile = [('jpeg2k', (0, 0) + self.size, 0,
@@ -250,7 +250,7 @@ def _save(im, fp, filename):
     if hasattr(fp, "fileno"):
         try:
             fd = fp.fileno()
-        except:
+        except Exception:
             fd = -1
 
     im.encoderconfig = (

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -75,7 +75,7 @@ def APP(self, marker):
         try:
             jfif_unit = i8(s[7])
             jfif_density = i16(s, 8), i16(s, 10)
-        except:
+        except Exception:
             pass
         else:
             if jfif_unit == 1:
@@ -107,7 +107,7 @@ def APP(self, marker):
         # extract Adobe custom properties
         try:
             adobe_transform = i8(s[1])
-        except:
+        except Exception:
             pass
         else:
             self.info["adobe_transform"] = adobe_transform
@@ -441,7 +441,7 @@ def _fixup_dict(src_dict):
         try:
             if len(value) == 1 and not isinstance(value, dict):
                 return value[0]
-        except:
+        except Exception:
             pass
         return value
 
@@ -512,7 +512,7 @@ def _getmp(self):
         info = TiffImagePlugin.ImageFileDirectory_v2(head)
         info.load(file_contents)
         mp = dict(info)
-    except:
+    except Exception:
         raise SyntaxError("malformed MP Index (unreadable directory)")
     # it's an error not to have a number of images
     try:

--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -373,7 +373,7 @@ def pdf_repr(x):
     elif isinstance(x, list):
         return bytes(PdfArray(x))
     elif ((py3 and isinstance(x, str)) or
-          (not py3 and isinstance(x, unicode))):
+          (not py3 and isinstance(x, unicode))):  # noqa: F821
         return pdf_repr(encode_text(x))
     elif isinstance(x, bytes):
         # XXX escape more chars? handle binary garbage

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -340,7 +340,7 @@ class PngStream(ChunkStream):
         self.im_size = i32(s), i32(s[4:])
         try:
             self.im_mode, self.im_rawmode = _MODES[(i8(s[8]), i8(s[9]))]
-        except:
+        except Exception:
             pass
         if i8(s[12]):
             self.im_info["interlace"] = 1

--- a/src/PIL/PyAccess.py
+++ b/src/PIL/PyAccess.py
@@ -231,7 +231,7 @@ class _PyAccessI16_B(PyAccess):
         pixel = self.pixels[y][x]
         try:
             color = min(color, 65535)
-        except:
+        except Exception:
             color = min(color[0], 65535)
 
         pixel.l = color >> 8

--- a/src/PIL/PyAccess.py
+++ b/src/PIL/PyAccess.py
@@ -214,7 +214,7 @@ class _PyAccessI16_L(PyAccess):
         except TypeError:
             color = min(color[0], 65535)
 
-        pixel.l = color & 0xFF
+        pixel.l = color & 0xFF  # noqa: E741
         pixel.r = color >> 8
 
 
@@ -234,7 +234,7 @@ class _PyAccessI16_B(PyAccess):
         except Exception:
             color = min(color[0], 65535)
 
-        pixel.l = color >> 8
+        pixel.l = color >> 8  # noqa: E741
         pixel.r = color & 0xFF
 
 

--- a/src/PIL/SpiderImagePlugin.py
+++ b/src/PIL/SpiderImagePlugin.py
@@ -210,7 +210,7 @@ def loadImageSeries(filelist=None):
             continue
         try:
             im = Image.open(img).convert2byte()
-        except:
+        except Exception:
             if not isSpiderImage(img):
                 print(img + " is not a Spider image file")
             continue

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -541,7 +541,7 @@ class ImageFileDirectory_v2(MutableMapping):
     def _setitem(self, tag, value, legacy_api):
         basetypes = (Number, bytes, str)
         if not py3:
-            basetypes += unicode,
+            basetypes += unicode,  # noqa: F821
 
         info = TiffTags.lookup(tag)
         values = [value] if isinstance(value, basetypes) else value
@@ -623,13 +623,13 @@ class ImageFileDirectory_v2(MutableMapping):
             from .TiffTags import TYPES
             if func.__name__.startswith("load_"):
                 TYPES[idx] = func.__name__[5:].replace("_", " ")
-            _load_dispatch[idx] = size, func
+            _load_dispatch[idx] = size, func  # noqa: F821
             return func
         return decorator
 
     def _register_writer(idx):
         def decorator(func):
-            _write_dispatch[idx] = func
+            _write_dispatch[idx] = func  # noqa: F821
             return func
         return decorator
 
@@ -638,9 +638,9 @@ class ImageFileDirectory_v2(MutableMapping):
         idx, fmt, name = idx_fmt_name
         TYPES[idx] = name
         size = struct.calcsize("=" + fmt)
-        _load_dispatch[idx] = size, lambda self, data, legacy_api=True: (
+        _load_dispatch[idx] = size, lambda self, data, legacy_api=True: (  # noqa: F821
             self._unpack("{}{}".format(len(data) // size, fmt), data))
-        _write_dispatch[idx] = lambda self, *values: (
+        _write_dispatch[idx] = lambda self, *values: (  # noqa: F821
             b"".join(self._pack(fmt, value) for value in values))
 
     list(map(_register_basic,
@@ -1507,7 +1507,7 @@ def _save(im, fp, filename):
             if tag not in TiffTags.LIBTIFF_CORE:
                 continue
             if tag not in atts and tag not in blocklist:
-                if isinstance(value, str if py3 else unicode):
+                if isinstance(value, str if py3 else unicode):  # noqa: F821
                     atts[tag] = value.encode('ascii', 'replace') + b"\0"
                 elif isinstance(value, IFDRational):
                     atts[tag] = float(value)

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -594,7 +594,8 @@ class ImageFileDirectory_v2(MutableMapping):
             except ValueError:
                 # We've got a builtin tag with 1 expected entry
                 warnings.warn(
-                    "Metadata Warning, tag %s had too many entries: %s, expected 1" % (
+                    "Metadata Warning, tag %s had too many entries: "
+                    "%s, expected 1" % (
                         tag, len(values)))
                 dest[tag] = values[0]
 

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1413,7 +1413,7 @@ def _save(im, fp, filename):
         ifd[key] = info.get(key)
         try:
             ifd.tagtype[key] = info.tagtype[key]
-        except:
+        except Exception:
             pass  # might not be an IFD, Might not have populated type
 
     # additions written by Greg Couch, gregc@cgl.ucsf.edu

--- a/src/PIL/_util.py
+++ b/src/PIL/_util.py
@@ -11,10 +11,10 @@ if py3:
         return isinstance(f, (bytes, str))
 else:
     def isStringType(t):
-        return isinstance(t, basestring)
+        return isinstance(t, basestring)  # noqa: F821
 
     def isPath(f):
-        return isinstance(f, basestring)
+        return isinstance(f, basestring)  # noqa: F821
 
 
 # Checks if an object is a string, and that it points to a directory.

--- a/winbuild/build.py
+++ b/winbuild/build.py
@@ -112,7 +112,7 @@ call %(python_path)s\%(executable)s setup.py %(imaging_libs)s %%BLDOPT%%
 endlocal
 
 endlocal
-"""
+"""  # noqa: E501
     return script % args
 
 

--- a/winbuild/build.py
+++ b/winbuild/build.py
@@ -119,7 +119,7 @@ endlocal
 def clean():
     try:
         shutil.rmtree('../build')
-    except:
+    except Exception:
         # could already be removed
         pass
     run_script(('virtualenvs', setup_vms()))

--- a/winbuild/build_dep.py
+++ b/winbuild/build_dep.py
@@ -104,7 +104,7 @@ def setup_compiler(compiler):
     return r"""setlocal EnableDelayedExpansion
 call "%%ProgramFiles%%\Microsoft SDKs\Windows\%(env_version)s\Bin\SetEnv.Cmd" /Release %(env_flags)s
 set INCLIB=%%INCLIB%%\%(inc_dir)s
-""" % compiler
+""" % compiler  # noqa: E501
 
 
 def end_compiler():
@@ -202,7 +202,7 @@ rd /S /Q %%FREETYPE%%\objs
 xcopy /Y /E /Q %%FREETYPE%%\include %%INCLIB%%
 copy /Y /B %%FREETYPE%%\objs\vc%(vc_version)s\%(platform)s\*.lib %%INCLIB%%\freetype.lib
 endlocal
-""" % compiler
+""" % compiler  # noqa: E501
 
 
 def msbuild_freetype_70(compiler):
@@ -217,7 +217,7 @@ xcopy /Y /E /Q %%FREETYPE%%\include %%INCLIB%%
 xcopy /Y /E /Q %%FREETYPE%%\objs\win32\vc%(vc_version)s %%INCLIB%%
 copy /Y /B %%FREETYPE%%\objs\win32\vc%(vc_version)s\*.lib %%INCLIB%%\freetype.lib
 endlocal
-""" % compiler
+""" % compiler  # noqa: E501
 
 
 def build_lcms2(compiler):
@@ -237,12 +237,12 @@ rem Build lcms2
 setlocal
 rd /S /Q %%LCMS%%\Lib
 rd /S /Q %%LCMS%%\Projects\VC%(vc_version)s\Release
-%%MSBUILD%% %%LCMS%%\Projects\VC%(vc_version)s\lcms2.sln  /t:Clean /p:Configuration="Release" /p:Platform=Win32 /m
+%%MSBUILD%% %%LCMS%%\Projects\VC%(vc_version)s\lcms2.sln /t:Clean /p:Configuration="Release" /p:Platform=Win32 /m
 %%MSBUILD%% %%LCMS%%\Projects\VC%(vc_version)s\lcms2.sln /t:lcms2_static /p:Configuration="Release" /p:Platform=Win32 /m
 xcopy /Y /E /Q %%LCMS%%\include %%INCLIB%%
 copy /Y /B %%LCMS%%\Projects\VC%(vc_version)s\Release\*.lib %%INCLIB%%
 endlocal
-""" % compiler
+""" % compiler  # noqa: E501
 
 
 def build_lcms_71(compiler):
@@ -251,12 +251,12 @@ rem Build lcms2
 setlocal
 rd /S /Q %%LCMS%%\Lib
 rd /S /Q %%LCMS%%\Projects\VC%(vc_version)s\Release
-%%MSBUILD%% %%LCMS%%\Projects\VC%(vc_version)s\lcms2.sln  /t:Clean /p:Configuration="Release" /p:Platform=%(platform)s /m
-%%MSBUILD%% %%LCMS%%\Projects\VC%(vc_version)s\lcms2.sln  /t:lcms2_static /p:Configuration="Release" /p:Platform=%(platform)s /m
+%%MSBUILD%% %%LCMS%%\Projects\VC%(vc_version)s\lcms2.sln /t:Clean /p:Configuration="Release" /p:Platform=%(platform)s /m
+%%MSBUILD%% %%LCMS%%\Projects\VC%(vc_version)s\lcms2.sln /t:lcms2_static /p:Configuration="Release" /p:Platform=%(platform)s /m
 xcopy /Y /E /Q %%LCMS%%\include %%INCLIB%%
 copy /Y /B %%LCMS%%\Lib\MS\*.lib %%INCLIB%%
 endlocal
-""" % compiler
+""" % compiler  # noqa: E501
 
 
 def add_compiler(compiler, bit):

--- a/winbuild/config.py
+++ b/winbuild/config.py
@@ -34,7 +34,7 @@ libs = {
         'dir': 'tiff-4.0.10',
     },
     'freetype': {
-        'url': 'https://download.savannah.gnu.org/releases/freetype/freetype-2.9.1.tar.gz',
+        'url': 'https://download.savannah.gnu.org/releases/freetype/freetype-2.9.1.tar.gz',  # noqa: E501
         'filename': PILLOW_DEPENDS_DIR + 'freetype-2.9.1.tar.gz',
         'dir': 'freetype-2.9.1',
     },


### PR DESCRIPTION
Changes proposed in this pull request:

 * The lint job can now fail the build
 * Fix remaining flake8 findings

Here's what `flake8 --statistics --count` reports for master:
```
44    E501 line too long
21    E722 do not use bare 'except'
3     E741 ambiguous variable name 'I'
1     F401 'sys' imported but unused
10    F821 undefined name 'unicode'
```

For each these, we can fix them, ignore on a case-by-case basis (with `noqa`), or exclude the whole check in setup.cfg.

The main decision is:
* do we want to ignore this rule globally but allow new ones in, 
* or let a in a few old exceptions now (possibly fix them later) and prevent new ones coming in

I've gone for the latter, but let me know if there's any you really don't like and would prefer globally ignored.

* E501 line too long: I've increased the max line length to a common-ish value of 88 (=80+10%), fixed a few others, and `noqa`d some really long ones which are mostly long commands exported to scripts during winbuild. We can choose another max length if preferred.

* E722 do not use bare 'except': these have been replaced with `except Exception:`, and new ones can be more precise

* E741 ambiguous variable name: just three which are `noqa`d to prevent new ones

* F401 'sys' imported but unused: simple fix

* F821 undefined name: these are mostly on Python 2/3 compatibility code which we won't need to worry about for too much longer
