### PR TITLE
Travis CI: Remove 'sudo' config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: required
 language: python
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ matrix:
     - python: "3.6"
       name: "Lint"
       env: LINT="true"
-      sudo: false
     - python: "pypy"
       name: "PyPy Trusty"
       dist: trusty


### PR DESCRIPTION
Changes proposed in this pull request:

 * Travis CI is removing the `sudo` config option and all builds will soon be on VM-based infrastructure
   * https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
 * In December, `sudo` won't have any affect
 * Now, `sudo: required` is no longer needed
 * Now, `sudo: false` can already be removed
   * It's only used for the lint job and can already be safely removed
