### PR TITLE
Qualify reference to LOAD_TRUNCATED_IMAGES

### DIFF
--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -221,13 +221,13 @@ class ImageFile(Image.Image):
                                 s = read(self.decodermaxblock)
                             except (IndexError, struct.error):
                                 # truncated png/gif
-                                if LOAD_TRUNCATED_IMAGES:
+                                if ImageFile.LOAD_TRUNCATED_IMAGES:
                                     break
                                 else:
                                     raise IOError("image file is truncated")
 
                             if not s:  # truncated jpeg
-                                if LOAD_TRUNCATED_IMAGES:
+                                if ImageFile.LOAD_TRUNCATED_IMAGES:
                                     break
                                 else:
                                     self.tile = []


### PR DESCRIPTION
Setting ImageFile.LOAD_TRUNCATED_IMAGES = True had no effect in loading JPEG images with "extra" data after the end of image marker in a Zope application. Tracing the code showed that although ImageFile.LOAD_TRUNCATED_IMAGES was True, the unqualified reference in ImageFile.py to LOAD_TRUNCATED_IMAGES returned False, and so the load failed.

Changes proposed in this pull request:

* Add ImageFile. qualifier to LOAD_TRUNCATED_IMAGES references