### PR TITLE
Cache EXIF information

### DIFF
--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -455,6 +455,12 @@ def _getexif(self):
     # and is likely to be replaced with something better in a future
     # version.
 
+    # Use the cached version if possible
+    try:
+        return self.info["parsed_exif"]
+    except KeyError:
+        pass
+
     # The EXIF record consists of a TIFF file embedded in a JPEG
     # application marker (!).
     try:
@@ -493,6 +499,8 @@ def _getexif(self):
         info.load(fp)
         exif[0x8825] = _fixup_dict(info)
 
+    # Cache the result for future use
+    self.info["parsed_exif"] = exif
     return exif
 
 


### PR DESCRIPTION
In case we need to call _getexif from the outside, since it's already called while parsing.

This give a great improvement in my test using [sigal](saimn/sigal): parsing a library of 379 photos (without resizing, only metadata reading) went from 2.36295 seconds down to 1.92881 (mean time over 3 rounds).

Caching costs memory though. But this small PR is here to start the discussion.