### PR TITLE
Don't try to hash value if enum is empty

### DIFF
--- a/src/PIL/TiffTags.py
+++ b/src/PIL/TiffTags.py
@@ -29,7 +29,7 @@ class TagInfo(namedtuple("_TagInfo", "value name type length enum")):
             cls, value, name, type, length, enum or {})
 
     def cvt_enum(self, value):
-        return self.enum.get(value, value)
+        return self.enum.get(value, value) if self.enum else value
 
 
 def lookup(tag):

--- a/src/PIL/TiffTags.py
+++ b/src/PIL/TiffTags.py
@@ -29,6 +29,9 @@ class TagInfo(namedtuple("_TagInfo", "value name type length enum")):
             cls, value, name, type, length, enum or {})
 
     def cvt_enum(self, value):
+        # Using get will call hash(value), which can be expensive
+        # for some types (e.g. Fraction). Since self.enum is rarely
+        # used, it's usually better to test it first.
         return self.enum.get(value, value) if self.enum else value
 
 


### PR DESCRIPTION
Very few tags have an enum, and for those who don't, computing the hash value can be very expensive, e.g. instances of `fractions.Fraction` as mentioned in [the source](https://github.com/python/cpython/blob/master/Lib/fractions.py#L543).

Using [sigal](https://github.com/saimn/sigal) with a collections of 2000 JPEG images with EXIF leads to a performance improvement of 8% (`Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz` with an SSD).

I used `cProfile` and [snakeviz](https://github.com/jiffyclub/snakeviz) to track down this to calling `__hash__` of `fractions.Fraction` from `TagInfo.cvt_enum`.
