### PR TITLE
Read textual chunks located after IDAT chunks for PNG

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -482,7 +482,7 @@ The :py:meth:`~PIL.Image.Image.open` method sets the following
 
     This key is omitted if the image is not a transparent palette image.
 
-``Open`` also sets ``Image.text`` to a list of the values of the
+``Open`` also sets ``Image.text`` to a dictionary of the values of the
 ``tEXt``, ``zTXt``, and ``iTXt`` chunks of the PNG image. Individual
 compressed chunks are limited to a decompressed size of
 ``PngImagePlugin.MAX_TEXT_CHUNK``, by default 1MB, to prevent


### PR DESCRIPTION
Resolves #2908 

The issue requires reading text from chunks located after the main image data. Rather than loading the entire image during `open`, this PR instead uses a decorator to call `load()` when the text data is accessed.

There is also a commit to correct a type in the documentation as noted in the initial issue comment - https://github.com/python-pillow/Pillow/issues/2908#issue-284636458