### PR TITLE
CI: Run check-manifest in lint job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ services:
 install:
   - |
     if [ "$LINT" == "true" ]; then
-      pip install -U flake8
+      pip install -U check-manifest flake8
     elif [ "$DOCKER" == "" ]; then
       .travis/install.sh;
     fi
@@ -84,6 +84,7 @@ script:
 - |
   if [ "$LINT" == "true" ]; then
     flake8 --statistics --count
+    check-manifest
   elif [ "$DOCKER" == "" ]; then
     .travis/script.sh
   elif [ "$DOCKER" ]; then


### PR DESCRIPTION
Changes proposed in this pull request:

 * Run `check-manifest` on the CI

During 5.4.0 release, `make release-test` failed on:

```
...
1183 passed, 86 skipped in 27.28 seconds
check-manifest
lists of files in version control and sdist do not match!
missing from sdist:
  .readthedocs.yml
suggested MANIFEST.in rules:
  include *.yml
make: *** [release-test] Error 1
```

The fix was easy (https://github.com/python-pillow/Pillow/commit/d2d438794cdd80bdbc852c884f0473c86fb72ab3), but let's find these sooner, before release day.

Example of a failure without the https://github.com/python-pillow/Pillow/commit/d2d438794cdd80bdbc852c884f0473c86fb72ab3 fix: https://travis-ci.org/hugovk/Pillow/jobs/474177112.