### PR TITLE
FIX: fix PngImageFile.load_end

### DIFF
--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -677,6 +677,11 @@ class PngImageFile(ImageFile.ImageFile):
                 self.png.call(cid, pos, length)
             except UnicodeDecodeError:
                 break
+            except EOFError:
+                # call dispatches out to chunk_* methods which
+                # mutate the internal state and then raise EOFError
+                # for a chunk that must be last.
+                break
         self._text = self.png.im_text
         self.png.close()
         self.png = None


### PR DESCRIPTION
Ensure that the flow-control EOFError exceptions are properly handled.

closes #3527


Fixes # .

Changes proposed in this pull request:

 * 
 * 
 *