### PR TITLE
Added `image.entropy()` method

### DIFF
--- a/Tests/test_image_entropy.py
+++ b/Tests/test_image_entropy.py
@@ -1,0 +1,23 @@
+from helper import unittest, PillowTestCase, hopper
+
+
+class TestImageEntropy(PillowTestCase):
+
+    def test_entropy(self):
+
+        def entropy(mode):
+            return hopper(mode).entropy()
+
+        self.assertAlmostEqual(entropy("1"), 0.9138803254693582)
+        self.assertAlmostEqual(entropy("L"), 7.06650513081286)
+        self.assertAlmostEqual(entropy("I"), 7.06650513081286)
+        self.assertAlmostEqual(entropy("F"), 7.06650513081286)
+        self.assertAlmostEqual(entropy("P"), 5.0530452472519745)
+        self.assertAlmostEqual(entropy("RGB"), 8.821286587714319)
+        self.assertAlmostEqual(entropy("RGBA"), 7.42724306524488)
+        self.assertAlmostEqual(entropy("CMYK"), 7.4272430652448795)
+        self.assertAlmostEqual(entropy("YCbCr"), 7.698360534903628)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftest.py
+++ b/selftest.py
@@ -90,6 +90,8 @@ def testimage():
     2
     >>> len(im.histogram())
     768
+    >>> '%.7f' % im.entropy()
+    '8.8212866'
     >>> _info(im.point(list(range(256))*3))
     (None, 'RGB', (128, 128))
     >>> _info(im.resize((64, 64)))

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1361,6 +1361,7 @@ class Image(object):
         bi-level image (mode "1") or a greyscale image ("L").
 
         :param mask: An optional mask.
+        :param extrema: An optional tuple of manually-specified extrema.
         :returns: A list containing pixel counts.
         """
         self.load()
@@ -1372,6 +1373,36 @@ class Image(object):
                 extrema = self.getextrema()
             return self.im.histogram(extrema)
         return self.im.histogram()
+
+    def entropy(self, mask=None, extrema=None):
+        """
+        Returns the histogram entropy. The histogram is returned as
+        a list of pixel counts, one for each pixel value in the source
+        image. If the image has more than one band, the histograms for
+        all bands are concatenated (for example, the histogram for an
+        "RGB" image contains 768 values).
+
+        A bilevel image (mode "1") is treated as a greyscale ("L") image
+        by this method.
+
+        If a mask is provided, the method returns a histogram for those
+        parts of the image where the mask image is non-zero. The mask
+        image must have the same size as the image, and be either a
+        bi-level image (mode "1") or a greyscale image ("L").
+
+        :param mask: An optional mask.
+        :param extrema: An optional tuple of manually-specified extrema.
+        :returns: A float value measuring the image entropy.
+        """
+        self.load()
+        if mask:
+            mask.load()
+            return self.im.entropy((0, 0), mask.im)
+        if self.mode in ("I", "F"):
+            if extrema is None:
+                extrema = self.getextrema()
+            return self.im.entropy(extrema)
+        return self.im.entropy()
 
     def offset(self, xoffset, yoffset=None):
         raise NotImplementedError("offset() has been removed. "


### PR DESCRIPTION
This calculates the entropy for the image, based on the histogram.

Because this uses image histogram data directly, the existing C function underpinning the `image.histogram()` method was abstracted into a macro, and a new C function was added that uses this macro.

The new `image.entropy()` method is based on `image.histogram()`, and will accept the same arguments to calculate the histogram data it will use to assess the entropy of the image.

The algorithm and methodology is based on existing Python code:
* https://git.io/fhmIU

... A test case in the `Tests/` directory, and doctest lines in `selftest.py`, have both been added and checked.

Changes proposed in this pull request:

 * The addition of an `image.entropy()` method,
 * The abstraction of the prologue of the C function `_histogram` into a macro, and
 * The use of that macro in both `_histogram` and `_entropy`.
 * Minor documentation addenda in the docstrings for both `image.entropy()` and `image.histogram()`