### PR TITLE
Avoid potential downscaling artifacts by cropping

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -581,6 +581,11 @@ class TestFileJpeg(PillowTestCase):
         # OSError for unidentified image.
         self.assertEqual(im.info.get("dpi"), (72, 72))
 
+    def test_partial_mcu_draft(self):
+        im = Image.open("Tests/images/flower2.jpg")
+        im.draft(im.mode, (100, 100))
+        self.assertEqual(im.size, (146, 109))
+
 
 @unittest.skipUnless(sys.platform.startswith('win32'), "Windows only")
 class TestFileCloseW32(PillowTestCase):


### PR DESCRIPTION
Resolves #3419 

The problem in that issue is that JPEGs are composed of MCUs (Minimum Coded Units). If a JPEG image is not made up of a whole number of MCUs, the encoder must fill in the leftover part of the last MCUs with something - it is not reliable what. When decoding the image, downscaling can make this unreliable image data become visible.

The docstring for `draft` states that it ['returns a version of the image that as closely as possible matches the given mode and size'](https://github.com/python-pillow/Pillow/blob/2e17e0f618eb8b9e3decd0a586e79cdfdbea4baf/src/PIL/Image.py#L1154-L1156).

Since accuracy of size is by no means guaranteed with when using `draft`, my suggestion to resolve the potential artifacts is to crop them out.