### PR TITLE
Improved get_format_mimetype logic

### DIFF
--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -120,9 +120,10 @@ class ImageFile(Image.Image):
         pass
 
     def get_format_mimetype(self):
-        if self.format is None:
-            return
-        return self.custom_mimetype or Image.MIME.get(self.format.upper())
+        if self.custom_mimetype:
+            return self.custom_mimetype
+        if self.format is not None:
+            return Image.MIME.get(self.format.upper())
 
     def verify(self):
         "Check file integrity"


### PR DESCRIPTION
This has no practical value at the moment, this is just allowing for the possibility of an image having a `custom_mimetype` without having a `format`.