### PR TITLE
Destroy hashtable if either keyDestroyFunc or valDestroyFunc exists

### DIFF
--- a/src/libImaging/QuantHash.c
+++ b/src/libImaging/QuantHash.c
@@ -314,7 +314,7 @@ void hashtable_free(HashTable *h) {
    uint32_t i;
 
    if (h->table) {
-      if (h->keyDestroyFunc || h->keyDestroyFunc) {
+      if (h->keyDestroyFunc || h->valDestroyFunc) {
          hashtable_foreach(h,_hashtable_destroy,NULL);
       }
       for (i=0;i<h->length;i++) {


### PR DESCRIPTION
Fixes #3546.

Changes proposed in this pull request:

 * It was checking the same thing twice: `h->keyDestroyFunc || h->keyDestroyFunc`
 * Makes more sense to check both key and val funcs, as it calls `_hashtable_destroy`:

https://github.com/python-pillow/Pillow/blob/7447b44edfe152a8c6857f417f85219a3c450625/src/libImaging/QuantHash.c#L317-L319

* Which calls both `h->keyDestroyFunc` and `h->valDestroyFunc`, if they exist:

https://github.com/python-pillow/Pillow/blob/7447b44edfe152a8c6857f417f85219a3c450625/src/libImaging/QuantHash.c#L65-L72

---

The file header says it was created in 1998, and this line has been there since at least [PIL 1.1.1](https://github.com/hugovk/PIL/blame/master/libImaging/QuantHash.c#L345) (released in 2000), so we can use [`Hasn't worked in 20 years`](https://github.com/python-pillow/Pillow/labels/Hasn%27t%20worked%20in%2020%20years) label!
