### PR TITLE
Remove unused C hashtable functions

### DIFF
--- a/src/libImaging/QuantHash.h
+++ b/src/libImaging/QuantHash.h
@@ -22,8 +22,6 @@ typedef uint32_t (*HashFunc)(const HashTable *,const HashKey_t);
 typedef int (*HashCmpFunc)(const HashTable *,const HashKey_t,const HashKey_t);
 typedef void (*IteratorFunc)(const HashTable *,const HashKey_t,const HashVal_t,void *);
 typedef void (*IteratorUpdateFunc)(const HashTable *,const HashKey_t,HashVal_t *,void *);
-typedef void (*KeyDestroyFunc)(const HashTable *,HashKey_t);
-typedef void (*ValDestroyFunc)(const HashTable *,HashVal_t);
 typedef void (*ComputeFunc)(const HashTable *,const HashKey_t,HashVal_t *);
 typedef void (*CollisionFunc)(const HashTable *,HashKey_t *,HashVal_t *,HashKey_t,HashVal_t);
 
@@ -40,8 +38,6 @@ int hashtable_delete(HashTable *h,const HashKey_t key);
 int hashtable_remove(HashTable *h,const HashKey_t key,HashKey_t *keyRet,HashVal_t *valRet);
 void *hashtable_set_user_data(HashTable *h,void *data);
 void *hashtable_get_user_data(const HashTable *h);
-KeyDestroyFunc hashtable_set_key_destroy_func(HashTable *,KeyDestroyFunc d);
-ValDestroyFunc hashtable_set_value_destroy_func(HashTable *,ValDestroyFunc d);
 uint32_t hashtable_get_count(const HashTable *h);
 void hashtable_rehash(HashTable *h);
 void hashtable_rehash_compute(HashTable *h,CollisionFunc cf);

--- a/src/libImaging/QuantHash.h
+++ b/src/libImaging/QuantHash.h
@@ -30,16 +30,11 @@ void hashtable_free(HashTable *h);
 void hashtable_foreach(HashTable *h,IteratorFunc i,void *u);
 void hashtable_foreach_update(HashTable *h,IteratorUpdateFunc i,void *u);
 int hashtable_insert(HashTable *h,HashKey_t key,HashVal_t val);
-int hashtable_update(HashTable *h,HashKey_t key,HashVal_t val);
 int hashtable_lookup(const HashTable *h,const HashKey_t key,HashVal_t *valp);
-int hashtable_lookup_or_insert(HashTable *h,HashKey_t key,HashVal_t *valp,HashVal_t val);
 int hashtable_insert_or_update_computed(HashTable *h,HashKey_t key,ComputeFunc newFunc,ComputeFunc existsFunc);
-int hashtable_delete(HashTable *h,const HashKey_t key);
-int hashtable_remove(HashTable *h,const HashKey_t key,HashKey_t *keyRet,HashVal_t *valRet);
 void *hashtable_set_user_data(HashTable *h,void *data);
 void *hashtable_get_user_data(const HashTable *h);
 uint32_t hashtable_get_count(const HashTable *h);
-void hashtable_rehash(HashTable *h);
 void hashtable_rehash_compute(HashTable *h,CollisionFunc cf);
 
 #endif // __QUANTHASH_H__


### PR DESCRIPTION
Fixes #3546.

Alternative to and closes https://github.com/python-pillow/Pillow/pull/3550.

Changes proposed in this pull request:

 * https://github.com/python-pillow/Pillow/issues/3546 points out a suspicious expression which checks the same thing twice:
   `if (h->keyDestroyFunc || h->keyDestroyFunc) {`

 * One option is to fix it. See PR #3550 for:
   `if (h->keyDestroyFunc || h->valDestroyFunc) {`

 * However, the expression can never be True (and [isn't covered by tests](https://codecov.io/gh/python-pillow/Pillow/src/7447b44edfe152a8c6857f417f85219a3c450625/src/libImaging/QuantHash.c#L318)), because the only place these functions are set are in `hashtable_set_value_destroy_func` and `hashtable_set_key_destroy_func`

* These functions are never called, and aren't exposed to the Python layer, so can be removed

* There's a number of other unused and unexposed functions in this file which can be likewise removed

* Helps towards #722: QuantHash.c coverage 59% -> 84%


---


The file header says it was created in 1998, and this line has been there since at least [PIL 1.1.1](https://github.com/hugovk/PIL/blame/master/libImaging/QuantHash.c#L345) (released in 2000), so we can use [`Hasn't worked in 20 years`](https://github.com/python-pillow/Pillow/labels/Hasn%27t%20worked%20in%2020%20years) label!


