### PR TITLE
Remove unused PillowTestCase.__str__

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -53,10 +53,6 @@ class PillowTestCase(unittest.TestCase):
         # holds last result object passed to run method:
         self.currentResult = None
 
-    # Nicer output for --verbose
-    def __str__(self):
-        return self.__class__.__name__ + "." + self._testMethodName
-
     def run(self, result=None):
         self.currentResult = result  # remember result for use later
         unittest.TestCase.run(self, result)  # call superclass run method


### PR DESCRIPTION
With the move to pytest, the class's string method is unused. pytest has its own test progress outputter.