### PR TITLE
Add TIFF compression codecs: LZMA, Zstd, WebP

### DIFF
--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -133,6 +133,9 @@ COMPRESSION_INFO = {
     32946: "tiff_deflate",
     34676: "tiff_sgilog",
     34677: "tiff_sgilog24",
+    34925: "lzma",
+    50000: "zstd",
+    50001: "webp",
 }
 
 COMPRESSION_INFO_REV = {v: k for k, v in COMPRESSION_INFO.items()}


### PR DESCRIPTION
Windows binaries are linked to a libtiff library, which has LZMA (Python >=3.5), WebP, and ZStd compression codecs enabled. However, Pillow currently fails to open TIFF files that use these compressions.