### PR TITLE
Allow for unknown PNG chunks after image data

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -596,6 +596,7 @@ class TestFilePng(PillowTestCase):
         im = Image.open("Tests/images/iss634.apng")
         self.assertEqual(im.get_format_mimetype(), 'image/apng')
 
+        # This also tests reading unknown PNG chunks (fcTL and fdAT) in load_end
         expected = Image.open("Tests/images/iss634.webp")
         self.assert_image_similar(im, expected, 0.23)
 

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -533,14 +533,6 @@ class PngStream(ChunkStream):
         self.im_custom_mimetype = 'image/apng'
         return s
 
-    def chunk_fcTL(self, pos, length):
-        s = ImageFile._safe_read(self.fp, length)
-        return s
-
-    def chunk_fdAT(self, pos, length):
-        s = ImageFile._safe_read(self.fp, length)
-        return s
-
 
 # --------------------------------------------------------------------
 # PNG reader
@@ -681,6 +673,9 @@ class PngImageFile(ImageFile.ImageFile):
             except UnicodeDecodeError:
                 break
             except EOFError:
+                ImageFile._safe_read(self.fp, length)
+            except AttributeError:
+                logger.debug("%r %s %s (unknown)", cid, pos, length)
                 ImageFile._safe_read(self.fp, length)
         self._text = self.png.im_text
         self.png.close()


### PR DESCRIPTION
Resolves #3557

This copies the logic for handling unknown PNG chunks in `_open` - https://github.com/python-pillow/Pillow/blob/7bf5246b93cc89cfb9d6cca78c4719a943b10585/src/PIL/PngImagePlugin.py#L581-L583