### PR TITLE
Install optional dependencies in tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,9 @@ commands =
     {envpython} setup.py build_ext --inplace
     {envpython} selftest.py
     {envpython} -m pytest -qq {posargs}
-deps = pytest
+deps =
+    cffi
+    numpy
+    olefile
+    pyroma
+    pytest


### PR DESCRIPTION
Improves local test coverage by reducing skipped tests when testing through tox.