### PR TITLE
Fix MicImagePlugin unclosed file warning

### DIFF
--- a/Tests/test_file_mic.py
+++ b/Tests/test_file_mic.py
@@ -54,6 +54,9 @@ class TestFileMic(PillowTestCase):
         self.assertRaises(EOFError, im.seek, 99)
         self.assertEqual(im.tell(), 0)
 
+    def test_unclosed_file(self):
+        self.assert_warning(None, Image.open, TEST_FILE)
+
     def test_invalid_file(self):
         # Test an invalid OLE file
         invalid_file = "Tests/images/flower.jpg"

--- a/src/PIL/MicImagePlugin.py
+++ b/src/PIL/MicImagePlugin.py
@@ -88,7 +88,9 @@ class MicImageFile(TiffImagePlugin.TiffImageFile):
         except IndexError:
             raise EOFError("no such frame")
 
+        prev_fp = self.fp
         self.fp = self.ole.openstream(filename)
+        prev_fp.close()
 
         TiffImagePlugin.TiffImageFile._open(self)
 


### PR DESCRIPTION
Note that the warning only appears for Python 3.4.