### PR TITLE
Make ContainerIO.isatty() return a bool, not int

### DIFF
--- a/Tests/test_file_container.py
+++ b/Tests/test_file_container.py
@@ -16,7 +16,7 @@ class TestFileContainer(PillowTestCase):
         im = hopper()
         container = ContainerIO.ContainerIO(im, 0, 0)
 
-        self.assertEqual(container.isatty(), 0)
+        self.assertFalse(container.isatty())
 
     def test_seek_mode_0(self):
         # Arrange

--- a/src/PIL/ContainerIO.py
+++ b/src/PIL/ContainerIO.py
@@ -39,7 +39,7 @@ class ContainerIO(object):
     # Always false.
 
     def isatty(self):
-        return 0
+        return False
 
     def seek(self, offset, mode=0):
         """


### PR DESCRIPTION
Better follows the interface of `IOBase.isatty`:

https://docs.python.org/3/library/io.html#io.IOBase.isatty