### PR TITLE
Avoid potential draft artifacts by resizing

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -581,6 +581,11 @@ class TestFileJpeg(PillowTestCase):
         # OSError for unidentified image.
         self.assertEqual(im.info.get("dpi"), (72, 72))
 
+    def test_partial_mcu(self):
+        im = Image.open("Tests/images/flower2.jpg")
+        im.draft(im.mode, (100, 100))
+        self.assertEqual(im.size, (100, 100))
+
 
 @unittest.skipUnless(sys.platform.startswith('win32'), "Windows only")
 class TestFileCloseW32(PillowTestCase):

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -586,6 +586,10 @@ class TestFileJpeg(PillowTestCase):
         im.draft(im.mode, (100, 100))
         self.assertEqual(im.size, (100, 100))
 
+        im = Image.open("Tests/images/flower2.jpg")
+        im.thumbnail((100, 75))
+        self.assertEqual(im.size, (100, 75))
+
 
 @unittest.skipUnless(sys.platform.startswith('win32'), "Windows only")
 class TestFileCloseW32(PillowTestCase):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2129,11 +2129,12 @@ class Image(object):
 
         self.draft(None, size)
 
-        im = self.resize(size, resample)
+        if self.size != size:
+            im = self.resize(size, resample)
 
-        self.im = im.im
-        self.mode = im.mode
-        self._size = size
+            self.im = im.im
+            self._size = size
+        self.mode = self.im.mode
 
         self.readonly = 0
         self.pyaccess = None

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -396,6 +396,20 @@ class JpegImageFile(ImageFile.ImageFile):
         self.tile = [(d, e, o, a)]
         self.decoderconfig = (scale, 0)
 
+        if scale > 1:
+            sampling = get_sampling(self)
+            if sampling != -1:
+                mcu = [(8, 8), (16, 8), (16, 16)][sampling]
+                for i in range(0, 2):
+                    # If an original image dimension is not a whole number of
+                    # MCUs, then the additional data may not be correct.
+                    if self.size[i] % mcu[i] != 0:
+                        im = self.resize(size)
+
+                        self.im = im.im
+                        self._size = size
+                        break
+
         return self
 
     def load_djpeg(self):


### PR DESCRIPTION
Resolves #3419

The problem in that issue is that JPEGs are composed of MCUs (Minimum Coded Units). If a JPEG image is not made up of a whole number of MCUs, the encoder must fill in the leftover part of the last MCUs with something - it is not reliable what. When decoding the image, downscaling can make this unreliable image data become visible.

Rather than use this unreliable data, this PR switches to using `resize()` instead.