### PR TITLE
Catch BaseException for resource cleanup handlers

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2663,7 +2663,7 @@ def open(fp, mode="r"):
                 # opening failures that are entirely expected.
                 # logger.debug("", exc_info=True)
                 continue
-            except Exception:
+            except BaseException:
                 if exclusive_fp:
                     fp.close()
                 raise


### PR DESCRIPTION
In the event of a `SystemExit` or `KeyboardInterrupt`, file resources should still be cleaned up before re-raising the exception.

https://docs.python.org/3/library/exceptions.html#exception-hierarchy