### PR TITLE
Read parallax data from MPO files

### DIFF
--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -55,6 +55,16 @@ class TestFileMpo(PillowTestCase):
             self.assertEqual(info[296], 2)
             self.assertEqual(info[34665], 188)
 
+    def test_parallax(self):
+        # Nintendo
+        im = Image.open("Tests/images/sugarshack.mpo")
+        self.assertEqual(im._getexif()["makernote"]["Parallax"], -44.798187255859375)
+
+        # Fujifilm
+        im = Image.open("Tests/images/fujifilm.mpo")
+        im.seek(1)
+        self.assertEqual(im._getexif()["makernote"][0xb211], -3.125)
+
     def test_mp(self):
         for test_file in test_files:
             im = Image.open(test_file)

--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -18,7 +18,8 @@
 # See the README file for information on usage and redistribution.
 #
 
-from . import Image, JpegImagePlugin
+from . import Image, ImageFile, JpegImagePlugin
+from ._binary import i16be as i16
 
 __version__ = "0.1"
 
@@ -76,6 +77,14 @@ class MpoImageFile(JpegImagePlugin.JpegImageFile):
             return
         self.fp = self.__fp
         self.offset = self.__mpoffsets[frame]
+
+        self.fp.seek(self.offset + 2)  # skip SOI marker
+        if i16(self.fp.read(2)) == 0xFFE1:  # APP1
+            n = i16(self.fp.read(2))-2
+            self.info["exif"] = ImageFile._safe_read(self.fp, n)
+        else:
+            del self.info["exif"]
+
         self.tile = [
             ("jpeg", (0, 0) + self.size, self.offset, (self.mode, ""))
         ]


### PR DESCRIPTION
Resolves #2081

MPO files can have EXIF data for separate images (Page 9 of http://www.cipa.jp/std/documents/e/DC-007_E.pdf). This PR adds reading of that exif data.

Within the EXIF data of the second image in files in #2081, there is a Makernote EXIF tag containing parallax data. However, the MakerNote tag does not have consistent structure across MPO images - it is manufacturer specific. See https://www.awaresystems.be/imaging/tiff/tifftags/privateifd/exif/makernote.html and http://www.exiv2.org/makernote.html.

The issue provides Fujifilm MPO images. The specification of the Fujifilm MakerNote tag can be found at http://www.ozhiker.com/electronics/pjmt/jpeg_info/fujifilm_mn.html#Fujifilm_Tags, and the parallax tag value can be found at https://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/FujiFilm.html. I have added one of the images from the issue.

Within the test suite, there are Nintendo MPO images. See https://3dbrew.org/wiki/MPO and http://owl.phy.queensu.ca/~phil/exiftool/TagNames/Nintendo.html for information about their MakerNote tag.

The test added in this PR reads parallax data from both types of files.