### PR TITLE
Add linting to the tox matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ services:
 install:
   - |
     if [ "$LINT" == "true" ]; then
-      pip install -U check-manifest flake8
+      pip install tox
     elif [ "$DOCKER" == "" ]; then
       .travis/install.sh;
     fi
@@ -83,8 +83,7 @@ before_script:
 script:
 - |
   if [ "$LINT" == "true" ]; then
-    flake8 --statistics --count
-    check-manifest
+    tox -e lint
   elif [ "$DOCKER" == "" ]; then
     .travis/script.sh
   elif [ "$DOCKER" ]; then

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,10 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36, py37
+envlist =
+    lint
+    py{27,34,35,36,37}
+minversion = 1.9
 
 [testenv]
 commands =
@@ -18,3 +21,12 @@ deps =
     olefile
     pyroma
     pytest
+
+[testenv:lint]
+commands =
+    flake8 --statistics --count
+    check-manifest
+deps =
+    check-manifest
+    flake8
+skip_install = true


### PR DESCRIPTION
Allows contributors to easily run the lint stage with a single command: `tox -e lint`. This creates shorter round trips with CI in case of an error.

Update the Travis configuration to use the new environment to run lint.This allows using a single/common source of truth to reduce differences between Travis and local testing.

The tox environment uses the skip_install feature as static analysis doesn't requiring install the Pillow package itself to run. This feature requires tox 1.9 (2015-02-24), so a minimum tox version was added to the configuration.

https://tox.readthedocs.io/en/latest/config.html#conf-skip_install
