### PR TITLE
Improve pytest configuration to allow specific tests as CLI args

### DIFF
--- a/Tests/bench_cffi_access.py
+++ b/Tests/bench_cffi_access.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 # Not running this test by default. No DOS against Travis CI.
 

--- a/Tests/bench_get.py
+++ b/Tests/bench_get.py
@@ -1,4 +1,4 @@
-import helper
+from . import helper
 import timeit
 
 import sys

--- a/Tests/check_fli_overflow.py
+++ b/Tests/check_fli_overflow.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 from PIL import Image
 
 TEST_FILE = "Tests/images/fli_overflow.fli"

--- a/Tests/check_imaging_leaks.py
+++ b/Tests/check_imaging_leaks.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import division
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 import sys
 from PIL import Image
 

--- a/Tests/check_j2k_leaks.py
+++ b/Tests/check_j2k_leaks.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 import sys
 from PIL import Image
 from io import BytesIO

--- a/Tests/check_j2k_overflow.py
+++ b/Tests/check_j2k_overflow.py
@@ -1,5 +1,5 @@
 from PIL import Image
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 
 class TestJ2kEncodeOverflow(PillowTestCase):

--- a/Tests/check_jpeg_leaks.py
+++ b/Tests/check_jpeg_leaks.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 from io import BytesIO
 import sys
 

--- a/Tests/check_large_memory.py
+++ b/Tests/check_large_memory.py
@@ -1,6 +1,6 @@
 import sys
 
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 # This test is not run automatically.
 #

--- a/Tests/check_large_memory_numpy.py
+++ b/Tests/check_large_memory_numpy.py
@@ -1,6 +1,6 @@
 import sys
 
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 # This test is not run automatically.
 #

--- a/Tests/check_libtiff_segfault.py
+++ b/Tests/check_libtiff_segfault.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 from PIL import Image
 
 TEST_FILE = "Tests/images/libtiff_segfault.tif"

--- a/Tests/check_png_dos.py
+++ b/Tests/check_png_dos.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 from PIL import Image, PngImagePlugin, ImageFile
 from io import BytesIO
 import zlib

--- a/Tests/test_000_sanity.py
+++ b/Tests/test_000_sanity.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 import PIL
 import PIL.Image

--- a/Tests/test_binary.py
+++ b/Tests/test_binary.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import _binary
 

--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image
 import os

--- a/Tests/test_box_blur.py
+++ b/Tests/test_box_blur.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image, ImageFilter
 

--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -3,7 +3,7 @@ from __future__ import division
 from array import array
 
 from PIL import Image, ImageFilter
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 try:
     import numpy

--- a/Tests/test_core_resources.py
+++ b/Tests/test_core_resources.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function
 
 import sys
 
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 from PIL import Image
 
 

--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 

--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import features
 

--- a/Tests/test_file_blp.py
+++ b/Tests/test_file_blp.py
@@ -1,6 +1,6 @@
 from PIL import Image
 
-from helper import PillowTestCase, unittest
+from .helper import PillowTestCase, unittest
 
 
 class TestFileBlp(PillowTestCase):

--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, BmpImagePlugin
 import io

--- a/Tests/test_file_bufrstub.py
+++ b/Tests/test_file_bufrstub.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import BufrStubImagePlugin, Image
 

--- a/Tests/test_file_container.py
+++ b/Tests/test_file_container.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 from PIL import ContainerIO

--- a/Tests/test_file_cur.py
+++ b/Tests/test_file_cur.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image, CurImagePlugin
 

--- a/Tests/test_file_dcx.py
+++ b/Tests/test_file_dcx.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, DcxImagePlugin
 

--- a/Tests/test_file_dds.py
+++ b/Tests/test_file_dds.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 from PIL import Image, DdsImagePlugin
 
 TEST_FILE_DXT1 = "Tests/images/dxt1-rgb-4bbp-noalpha_MipMaps-1.dds"

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, EpsImagePlugin
 import io

--- a/Tests/test_file_fitsstub.py
+++ b/Tests/test_file_fitsstub.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import FitsStubImagePlugin, Image
 

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image, FliImagePlugin
 

--- a/Tests/test_file_fpx.py
+++ b/Tests/test_file_fpx.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 try:
     from PIL import FpxImagePlugin

--- a/Tests/test_file_ftex.py
+++ b/Tests/test_file_ftex.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 from PIL import Image
 
 

--- a/Tests/test_file_gbr.py
+++ b/Tests/test_file_gbr.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image, GbrImagePlugin
 

--- a/Tests/test_file_gd.py
+++ b/Tests/test_file_gd.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import GdImageFile
 

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper, netpbm_available
+from .helper import unittest, PillowTestCase, hopper, netpbm_available
 
 from PIL import Image, ImagePalette, GifImagePlugin
 

--- a/Tests/test_file_gimpgradient.py
+++ b/Tests/test_file_gimpgradient.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import GimpGradientFile
 

--- a/Tests/test_file_gimppalette.py
+++ b/Tests/test_file_gimppalette.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL.GimpPaletteFile import GimpPaletteFile
 

--- a/Tests/test_file_gribstub.py
+++ b/Tests/test_file_gribstub.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import GribStubImagePlugin, Image
 

--- a/Tests/test_file_hdf5stub.py
+++ b/Tests/test_file_hdf5stub.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Hdf5StubImagePlugin, Image
 

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image, IcnsImagePlugin
 

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 import io
 from PIL import Image, IcoImagePlugin

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, ImImagePlugin
 

--- a/Tests/test_file_iptc.py
+++ b/Tests/test_file_iptc.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, IptcImagePlugin
 

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -1,5 +1,5 @@
-from helper import unittest, PillowTestCase, hopper
-from helper import djpeg_available, cjpeg_available
+from .helper import unittest, PillowTestCase, hopper
+from .helper import djpeg_available, cjpeg_available
 
 from io import BytesIO
 import os

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image, Jpeg2KImagePlugin
 from io import BytesIO

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 from PIL import features
 from PIL._util import py3
 

--- a/Tests/test_file_libtiff_small.py
+++ b/Tests/test_file_libtiff_small.py
@@ -1,8 +1,8 @@
-from helper import unittest
+from .helper import unittest
 
 from PIL import Image
 
-from test_file_libtiff import LibTiffTestCase
+from .test_file_libtiff import LibTiffTestCase
 
 
 class TestFileLibTiffSmall(LibTiffTestCase):

--- a/Tests/test_file_mcidas.py
+++ b/Tests/test_file_mcidas.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image, McIdasImagePlugin
 

--- a/Tests/test_file_mic.py
+++ b/Tests/test_file_mic.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, ImagePalette, features
 

--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 from io import BytesIO
 from PIL import Image
 

--- a/Tests/test_file_msp.py
+++ b/Tests/test_file_msp.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, MspImagePlugin
 

--- a/Tests/test_file_palm.py
+++ b/Tests/test_file_palm.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper, imagemagick_available
+from .helper import unittest, PillowTestCase, hopper, imagemagick_available
 
 import os.path
 

--- a/Tests/test_file_pcd.py
+++ b/Tests/test_file_pcd.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 from PIL import Image
 
 

--- a/Tests/test_file_pcx.py
+++ b/Tests/test_file_pcx.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, ImageFile, PcxImagePlugin
 

--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 from PIL import Image, PdfParser
 import io
 import os

--- a/Tests/test_file_pixar.py
+++ b/Tests/test_file_pixar.py
@@ -1,4 +1,4 @@
-from helper import hopper, unittest, PillowTestCase
+from .helper import hopper, unittest, PillowTestCase
 
 from PIL import Image, PixarImagePlugin
 

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, PillowLeakTestCase, hopper
+from .helper import unittest, PillowTestCase, PillowLeakTestCase, hopper
 from PIL import Image, ImageFile, PngImagePlugin
 from PIL._util import py3
 

--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -1,4 +1,4 @@
-from helper import hopper, unittest, PillowTestCase
+from .helper import hopper, unittest, PillowTestCase
 
 from PIL import Image, PsdImagePlugin
 

--- a/Tests/test_file_sgi.py
+++ b/Tests/test_file_sgi.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, SgiImagePlugin
 

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 from PIL import ImageSequence

--- a/Tests/test_file_sun.py
+++ b/Tests/test_file_sun.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, SunImagePlugin
 

--- a/Tests/test_file_tar.py
+++ b/Tests/test_file_tar.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image, TarIO
 

--- a/Tests/test_file_tga.py
+++ b/Tests/test_file_tga.py
@@ -2,7 +2,7 @@ import os
 from glob import glob
 from itertools import product
 
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -2,7 +2,7 @@ import logging
 from io import BytesIO
 import sys
 
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, TiffImagePlugin
 from PIL._util import py3

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -1,7 +1,7 @@
 import io
 import struct
 
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, TiffImagePlugin, TiffTags
 from PIL.TiffImagePlugin import _limit_rational, IFDRational

--- a/Tests/test_file_wal.py
+++ b/Tests/test_file_wal.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import WalImageFile
 

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, WebPImagePlugin
 

--- a/Tests/test_file_webp_alpha.py
+++ b/Tests/test_file_webp_alpha.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 

--- a/Tests/test_file_webp_animated.py
+++ b/Tests/test_file_webp_animated.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_file_webp_lossless.py
+++ b/Tests/test_file_webp_lossless.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 

--- a/Tests/test_file_webp_metadata.py
+++ b/Tests/test_file_webp_metadata.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 from PIL import WmfImagePlugin

--- a/Tests/test_file_xbm.py
+++ b/Tests/test_file_xbm.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_file_xpm.py
+++ b/Tests/test_file_xpm.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, XpmImagePlugin
 

--- a/Tests/test_file_xvthumb.py
+++ b/Tests/test_file_xvthumb.py
@@ -1,4 +1,4 @@
-from helper import hopper, unittest, PillowTestCase
+from .helper import hopper, unittest, PillowTestCase
 
 from PIL import Image, XVThumbImagePlugin
 

--- a/Tests/test_font_bdf.py
+++ b/Tests/test_font_bdf.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import FontFile, BdfFontFile
 

--- a/Tests/test_font_leaks.py
+++ b/Tests/test_font_leaks.py
@@ -1,5 +1,5 @@
 from __future__ import division
-from helper import unittest, PillowLeakTestCase
+from .helper import unittest, PillowLeakTestCase
 import sys
 from PIL import Image, features, ImageDraw, ImageFont
 

--- a/Tests/test_font_pcf.py
+++ b/Tests/test_font_pcf.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image, FontFile, PcfFontFile
 from PIL import ImageFont, ImageDraw

--- a/Tests/test_format_hsv.py
+++ b/Tests/test_format_hsv.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 from PIL._util import py3

--- a/Tests/test_format_lab.py
+++ b/Tests/test_format_lab.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 from PIL._util import py3

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper, on_appveyor
+from .helper import unittest, PillowTestCase, hopper, on_appveyor
 
 from PIL import Image
 import sys

--- a/Tests/test_image_array.py
+++ b/Tests/test_image_array.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 

--- a/Tests/test_image_copy.py
+++ b/Tests/test_image_copy.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 

--- a/Tests/test_image_crop.py
+++ b/Tests/test_image_crop.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 

--- a/Tests/test_image_draft.py
+++ b/Tests/test_image_draft.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, fromstring, tostring
+from .helper import unittest, PillowTestCase, fromstring, tostring
 
 from PIL import Image
 

--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, ImageFilter
 

--- a/Tests/test_image_frombytes.py
+++ b/Tests/test_image_frombytes.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 

--- a/Tests/test_image_fromqimage.py
+++ b/Tests/test_image_fromqimage.py
@@ -1,5 +1,5 @@
-from helper import unittest, PillowTestCase, hopper
-from test_imageqt import PillowQtTestCase
+from .helper import unittest, PillowTestCase, hopper
+from .test_imageqt import PillowQtTestCase
 
 from PIL import ImageQt, Image
 

--- a/Tests/test_image_getbands.py
+++ b/Tests/test_image_getbands.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_image_getbbox.py
+++ b/Tests/test_image_getbbox.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 

--- a/Tests/test_image_getcolors.py
+++ b/Tests/test_image_getcolors.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 
 class TestImageGetColors(PillowTestCase):

--- a/Tests/test_image_getdata.py
+++ b/Tests/test_image_getdata.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 
 class TestImageGetData(PillowTestCase):

--- a/Tests/test_image_getextrema.py
+++ b/Tests/test_image_getextrema.py
@@ -1,5 +1,5 @@
 from PIL import Image
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 
 class TestImageGetExtrema(PillowTestCase):

--- a/Tests/test_image_getim.py
+++ b/Tests/test_image_getim.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 from PIL._util import py3
 
 

--- a/Tests/test_image_getpalette.py
+++ b/Tests/test_image_getpalette.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 
 class TestImageGetPalette(PillowTestCase):

--- a/Tests/test_image_getprojection.py
+++ b/Tests/test_image_getprojection.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 

--- a/Tests/test_image_histogram.py
+++ b/Tests/test_image_histogram.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 
 class TestImageHistogram(PillowTestCase):

--- a/Tests/test_image_load.py
+++ b/Tests/test_image_load.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 

--- a/Tests/test_image_mode.py
+++ b/Tests/test_image_mode.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 

--- a/Tests/test_image_paste.py
+++ b/Tests/test_image_paste.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, cached_property
+from .helper import unittest, PillowTestCase, cached_property
 
 from PIL import Image
 

--- a/Tests/test_image_point.py
+++ b/Tests/test_image_point.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 
 class TestImagePoint(PillowTestCase):

--- a/Tests/test_image_putalpha.py
+++ b/Tests/test_image_putalpha.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_image_putdata.py
+++ b/Tests/test_image_putdata.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 from array import array
 
 import sys

--- a/Tests/test_image_putpalette.py
+++ b/Tests/test_image_putpalette.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import ImagePalette
 

--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function
 
 from contextlib import contextmanager
 
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 from PIL import Image, ImageDraw
 
 

--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -3,7 +3,7 @@ Tests for resize functionality.
 """
 from itertools import permutations
 
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 

--- a/Tests/test_image_rotate.py
+++ b/Tests/test_image_rotate.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 from PIL import Image
 
 

--- a/Tests/test_image_split.py
+++ b/Tests/test_image_split.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 
 class TestImageThumbnail(PillowTestCase):

--- a/Tests/test_image_tobitmap.py
+++ b/Tests/test_image_tobitmap.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper, fromstring
+from .helper import unittest, PillowTestCase, hopper, fromstring
 
 
 class TestImageToBitmap(PillowTestCase):

--- a/Tests/test_image_tobytes.py
+++ b/Tests/test_image_tobytes.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 
 class TestImageToBytes(PillowTestCase):

--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -1,6 +1,6 @@
 import math
 
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 

--- a/Tests/test_image_transpose.py
+++ b/Tests/test_image_transpose.py
@@ -1,5 +1,5 @@
-import helper
-from helper import unittest, PillowTestCase
+from . import helper
+from .helper import unittest, PillowTestCase
 
 from PIL.Image import (FLIP_LEFT_RIGHT, FLIP_TOP_BOTTOM, ROTATE_90, ROTATE_180,
                        ROTATE_270, TRANSPOSE, TRANSVERSE)

--- a/Tests/test_imagechops.py
+++ b/Tests/test_imagechops.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 from PIL import ImageChops

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 import datetime
 
 from PIL import Image, ImageMode

--- a/Tests/test_imagecolor.py
+++ b/Tests/test_imagecolor.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image
 from PIL import ImageColor

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -1,6 +1,6 @@
 import os.path
 
-from helper import PillowTestCase, hopper, unittest
+from .helper import PillowTestCase, hopper, unittest
 from PIL import Image, ImageColor, ImageDraw
 
 BLACK = (0, 0, 0)

--- a/Tests/test_imagedraw2.py
+++ b/Tests/test_imagedraw2.py
@@ -1,6 +1,6 @@
 import os.path
 
-from helper import PillowTestCase, hopper, unittest
+from .helper import PillowTestCase, hopper, unittest
 from PIL import Image, ImageDraw2, features
 
 BLACK = (0, 0, 0)

--- a/Tests/test_imageenhance.py
+++ b/Tests/test_imageenhance.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 from PIL import ImageEnhance

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper, fromstring, tostring
+from .helper import unittest, PillowTestCase, hopper, fromstring, tostring
 
 from io import BytesIO
 

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image, ImageDraw, ImageFont, features
 from io import BytesIO

--- a/Tests/test_imagefont_bitmap.py
+++ b/Tests/test_imagefont_bitmap.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 from PIL import Image, ImageFont, ImageDraw
 
 

--- a/Tests/test_imagefontctl.py
+++ b/Tests/test_imagefontctl.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 from PIL import Image, ImageDraw, ImageFont, features
 
 

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 import sys
 import subprocess

--- a/Tests/test_imagemath.py
+++ b/Tests/test_imagemath.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image
 from PIL import ImageMath

--- a/Tests/test_imagemorph.py
+++ b/Tests/test_imagemorph.py
@@ -1,5 +1,5 @@
 # Test the ImageMorphology functionality
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, ImageMorph, _imagingmorph
 

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import ImageOps
 from PIL import Image

--- a/Tests/test_imageops_usm.py
+++ b/Tests/test_imageops_usm.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image
 from PIL import ImageOps

--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import ImagePalette, Image
 

--- a/Tests/test_imagepath.py
+++ b/Tests/test_imagepath.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import ImagePath, Image
 from PIL._util import py3

--- a/Tests/test_imageqt.py
+++ b/Tests/test_imageqt.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import ImageQt
 

--- a/Tests/test_imagesequence.py
+++ b/Tests/test_imagesequence.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image, ImageSequence, TiffImagePlugin
 

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 from PIL import ImageShow

--- a/Tests/test_imagestat.py
+++ b/Tests/test_imagestat.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 from PIL import ImageStat

--- a/Tests/test_imagetk.py
+++ b/Tests/test_imagetk.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 from PIL import Image
 from PIL._util import py3
 

--- a/Tests/test_imagewin.py
+++ b/Tests/test_imagewin.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import ImageWin
 import sys

--- a/Tests/test_imagewin_pointers.py
+++ b/Tests/test_imagewin_pointers.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 from PIL import Image, ImageWin
 
 import sys

--- a/Tests/test_lib_image.py
+++ b/Tests/test_lib_image.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_lib_pack.py
+++ b/Tests/test_lib_pack.py
@@ -1,6 +1,6 @@
 import sys
 
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_locale.py
+++ b/Tests/test_locale.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_map.py
+++ b/Tests/test_map.py
@@ -1,4 +1,4 @@
-from helper import PillowTestCase, unittest
+from .helper import PillowTestCase, unittest
 import sys
 
 from PIL import Image

--- a/Tests/test_mode_i16.py
+++ b/Tests/test_mode_i16.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import Image
 

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-from helper import PillowTestCase, hopper, unittest
+from .helper import PillowTestCase, hopper, unittest
 from PIL import Image
 
 try:

--- a/Tests/test_pdfparser.py
+++ b/Tests/test_pdfparser.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL.PdfParser import IndirectObjectDef, IndirectReference, PdfBinary, \
                           PdfDict, PdfFormatError, PdfName, PdfParser, \

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image
 

--- a/Tests/test_psdraw.py
+++ b/Tests/test_psdraw.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import Image, PSDraw
 import os

--- a/Tests/test_pyroma.py
+++ b/Tests/test_pyroma.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import __version__
 

--- a/Tests/test_qt_image_fromqpixmap.py
+++ b/Tests/test_qt_image_fromqpixmap.py
@@ -1,5 +1,5 @@
-from helper import unittest, PillowTestCase, hopper
-from test_imageqt import PillowQPixmapTestCase
+from .helper import unittest, PillowTestCase, hopper
+from .test_imageqt import PillowQPixmapTestCase
 
 from PIL import ImageQt
 

--- a/Tests/test_qt_image_toqimage.py
+++ b/Tests/test_qt_image_toqimage.py
@@ -1,5 +1,5 @@
-from helper import unittest, PillowTestCase, hopper
-from test_imageqt import PillowQtTestCase
+from .helper import unittest, PillowTestCase, hopper
+from .test_imageqt import PillowQtTestCase
 
 from PIL import ImageQt, Image
 

--- a/Tests/test_qt_image_toqpixmap.py
+++ b/Tests/test_qt_image_toqpixmap.py
@@ -1,5 +1,5 @@
-from helper import unittest, PillowTestCase, hopper
-from test_imageqt import PillowQPixmapTestCase
+from .helper import unittest, PillowTestCase, hopper
+from .test_imageqt import PillowQPixmapTestCase
 
 from PIL import ImageQt
 

--- a/Tests/test_shell_injection.py
+++ b/Tests/test_shell_injection.py
@@ -1,5 +1,5 @@
-from helper import unittest, PillowTestCase
-from helper import djpeg_available, cjpeg_available, netpbm_available
+from .helper import unittest, PillowTestCase
+from .helper import djpeg_available, cjpeg_available, netpbm_available
 
 import sys
 import shutil

--- a/Tests/test_tiff_ifdrational.py
+++ b/Tests/test_tiff_ifdrational.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 from PIL import TiffImagePlugin, Image
 from PIL.TiffImagePlugin import IFDRational

--- a/Tests/test_uploader.py
+++ b/Tests/test_uploader.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase, hopper
+from .helper import unittest, PillowTestCase, hopper
 
 
 class TestUploader(PillowTestCase):

--- a/Tests/test_util.py
+++ b/Tests/test_util.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowTestCase
+from .helper import unittest, PillowTestCase
 
 from PIL import _util
 

--- a/Tests/test_webp_leaks.py
+++ b/Tests/test_webp_leaks.py
@@ -1,4 +1,4 @@
-from helper import unittest, PillowLeakTestCase
+from .helper import unittest, PillowLeakTestCase
 from PIL import Image, features
 from io import BytesIO
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,8 +4,5 @@ test=pytest
 [metadata]
 license_file = LICENSE
 
-[tool:pytest]
-addopts = -vx Tests
-
 [flake8]
 max-line-length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands =
     {envpython} setup.py clean
     {envpython} setup.py build_ext --inplace
     {envpython} selftest.py
-    {envpython} -m pytest -qq {posargs}
+    {envpython} -m pytest {posargs}
 deps =
     cffi
     numpy


### PR DESCRIPTION
The previous test configuration made it difficult to run a single test with the pytest CLI. There were two major issues: 

- The `Tests` directory was not a package. It now includes a `__init__.py` file and imports from other tests modules are done with relative imports.

- `setup.cfg` always specified the `Tests` directory. So even if a specific test were specified as a CLI arg, this configuration would also always include all tests. This configuration has been removed to allow specifying a single test on the command line.

Contributors can now run specific tests with a single command such as:

```
$ tox -e py37 -- Tests/test_file_pdf.py::TestFilePdf.test_rgb
```

This makes it easy and faster to iterate on a single test failure and is very familiar to those that have previously used tox and pytest.

When running tox or pytest with no arguments, they still discover and runs all tests in the Tests directory.