### PR TITLE
Fix 'BytesWarning: Comparison between bytes and string' in PdfDict

### DIFF
--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -269,18 +269,13 @@ class PdfDict(UserDict):
             else:
                 self.__dict__[key] = value
         else:
-            if isinstance(key, str):
-                key = key.encode("us-ascii")
-            self[key] = value
+            self[key.encode("us-ascii")] = value
 
     def __getattr__(self, key):
         try:
-            value = self[key]
+            value = self[key.encode("us-ascii")]
         except KeyError:
-            try:
-                value = self[key.encode("us-ascii")]
-            except KeyError:
-                raise AttributeError(key)
+            raise AttributeError(key)
         if isinstance(value, bytes):
             value = decode_text(value)
         if key.endswith("Date"):


### PR DESCRIPTION
When bytes warnings are enabled with the `-b` argument, the `PdfDict` class would emit a warning.

https://docs.python.org/3/using/cmdline.html#miscellaneous-options

> -b
>
> Issue a warning when comparing `bytes` or `bytearray` with `str` or `bytes` with `int`.

Object attributes are always type str, so can safely encode them without a type check. Observe:

```
    $ python3
    >>> o = object()
    >>> setattr(o, b'foo', b'bar')
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    TypeError: attribute name must be string, not 'bytes'
```