### PR TITLE
Docs: Release history is visible at PyPI

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -478,8 +478,6 @@ These platforms have been reported to work at the versions mentioned.
 Old Versions
 ------------
 
-You can download old distributions from `PyPI
-<https://pypi.org/project/Pillow/>`_. Only the latest major
-releases for Python 2.x and 3.x are visible, but all releases are
-available by direct URL access
-e.g. https://pypi.org/project/Pillow/1.0/.
+You can download old distributions from the `release history at PyPI
+<https://pypi.org/project/Pillow/#history>`_ and by direct URL access
+eg. https://pypi.org/project/Pillow/1.0/.


### PR DESCRIPTION
Now available at https://pypi.org/project/Pillow/#history since the PyPI (aka Warehouse) redesign.