### PR TITLE
Revert "Use bare 'raise' to re-raise exceptions"

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -140,14 +140,14 @@ class PillowTestCase(unittest.TestCase):
                 (msg or '') +
                 " average pixel value difference %.4f > epsilon %.4f" % (
                     ave_diff, epsilon))
-        except Exception:
+        except Exception as e:
             if HAS_UPLOADER:
                 try:
                     url = test_image_results.upload(a, b)
                     logger.error("Url for test images: %s" % url)
                 except Exception:
                     pass
-            raise
+            raise e
 
     def assert_image_similar_tofile(self, a, filename, epsilon, msg=None,
                                     mode=None):


### PR DESCRIPTION
Revert #3575

Now that the PR is merged to master, '2.7_with_system_site_packages Trusty' is failing.

Investigating, I find that the following script raises `NameError: name 'first' is not defined` on Python 3, but  `NameError: name 'second' is not defined` on Python 2. So the original code was not identical to the new code.

```
try:
	first
except Exception:
	try:
		second
	except Exception:
		pass
	raise
```