### PR TITLE
Fix Travis CI: Only start Xvfb for Qt builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,11 @@ before_install:
 
 before_script:
 # Qt needs a display for some of the tests, and it's only run on the system site packages install
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+- |
+  if [ "$TRAVIS_PYTHON_VERSION" == "2.7_with_system_site_packages" ]; then
+    export DISPLAY=:99.0
+    sh -e /etc/init.d/xvfb start
+  fi
 
 script:
 - |


### PR DESCRIPTION
WIP, fixes all build jobs except one: `2.7_with_system_site_packages Xenial`.

---

Changes proposed in this pull request:

 * Only start Xvfb for Qt, and Qt is only available with the system site packages installs

---

Yesterday Travis CI released a new build image for Xenial:

https://changelog.travis-ci.com/ubuntu-xenial-16-04-build-environment-update-86123

Unfortunately that broke our Xenial builds. Trusty still works.

* Last master pass: https://travis-ci.org/python-pillow/Pillow/builds/479135721
* First master error: https://travis-ci.org/python-pillow/Pillow/builds/479763270

The Travis changelog says:

> The Xenial build environment now comes with PhamtomJS2, a new way to define headless browser testing, via `services: xvfb`, and improved Java language support.

https://changelog.travis-ci.com/ubuntu-xenial-16-04-build-environment-update-86123

The update history says:

> Xvfb init file is removed in favor of a systemd unit file. Xvfb can be set up with `services: xvfb`. The matching DISPLAY environment variable is made available when you do that.

https://docs.travis-ci.com/user/build-environment-updates/2019-01-14/

---

We need to find a way to start Xvfb on Xenial. 

I tried with these but it didn't help [[1](https://travis-ci.org/hugovk/Pillow/builds/479796492)] [[2](https://travis-ci.org/hugovk/Pillow/builds/479801821)]:
```diff
    - python:  "2.7_with_system_site_packages" # For PyQt4
      name: "2.7_with_system_site_packages Xenial"
+      services: xvfb
```
```diff
services:
  - docker
+  - xvfb
```
