### PR TITLE
Remove deprecated PIL.OleFileIO in favour of olefile Python package

### DIFF
--- a/src/PIL/OleFileIO.py
+++ b/src/PIL/OleFileIO.py
@@ -1,4 +1,0 @@
-raise ImportError(
-    'PIL.OleFileIO is deprecated. Use the olefile Python package '
-    'instead. This module will be removed in a future version.'
-)


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/3581.

The vendored version was removed in #2199, on 13 Dec 2016, in favour of the olefile Python package and replaced with a deprecation warning that PIL.OleFileIO would be removed in a future version.

We've had nine quarterly releases since then (4.0.0, 4.1.0, 4.2.0, 4.3.0, 5.0.0, 5.1.0, 5.2.0, 5.3.0, 5.4.0), let's remove the deprecation.