### PR TITLE
Changed EPS subprocess stdin from devnull to None

### DIFF
--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -144,7 +144,7 @@ def Ghostscript(tile, size, fp, scale=1):
             if sys.platform.startswith('win'):
                 startupinfo = subprocess.STARTUPINFO()
                 startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-            subprocess.check_call(command, stdin=devnull, stdout=devnull,
+            subprocess.check_call(command, stdout=devnull,
                                   startupinfo=startupinfo)
         im = Image.open(outfile)
         im.load()


### PR DESCRIPTION
See #3322

This change is discussed in that issue. However, where the issue suggests changing both stdin and stdout, this PR only changes stdin. Changing stdout as well should not be necessary to resolve the issue, and so it is not done here, to avoid potential output.

As for why this code exists in the first place, the duplicate `devnull`s were added in #2253, replacing two `PIPE`s. The reason for the stdin pipe was removed in #506. I look at these series of changes and would believe that the current code is an accident, rather than deliberate. So this PR is a minor cleanup from that angle.

Also, now that #3587 has added Ghostscript to AppVeyor, this PR can said to not cause a failure in Windows CI.