### PR TITLE
_util.isPath returns True for pathlib.Path objects

### DIFF
--- a/Tests/test_util.py
+++ b/Tests/test_util.py
@@ -4,8 +4,6 @@ from helper import unittest, PillowTestCase
 
 from PIL import _util
 
-py36 = sys.version_info.major >= 3 and sys.version_info.minor >= 6
-
 
 class TestUtil(PillowTestCase):
 
@@ -39,7 +37,7 @@ class TestUtil(PillowTestCase):
         # Assert
         self.assertTrue(it_is)
 
-    @unittest.skipIf(not py36, 'os.path support for Paths added in 3.6')
+    @unittest.skipIf(not _util.py36, 'os.path support for Paths added in 3.6')
     def test_path_obj_is_path(self):
         # Arrange
         from pathlib import Path

--- a/Tests/test_util.py
+++ b/Tests/test_util.py
@@ -39,10 +39,10 @@ class TestUtil(PillowTestCase):
     def test_path_obj_is_path(self):
         # Arrange
         from pathlib import Path
-        fp = Path('filename.ext')
+        test_path = Path('filename.ext')
 
         # Act
-        it_is = _util.isPath(fp)
+        it_is = _util.isPath(test_path)
 
         # Assert
         self.assertTrue(it_is)

--- a/Tests/test_util.py
+++ b/Tests/test_util.py
@@ -1,5 +1,3 @@
-import sys
-
 from helper import unittest, PillowTestCase
 
 from PIL import _util

--- a/Tests/test_util.py
+++ b/Tests/test_util.py
@@ -1,6 +1,10 @@
+import sys
+
 from helper import unittest, PillowTestCase
 
 from PIL import _util
+
+py36 = sys.version_info.major >= 3 and sys.version_info.minor >= 6
 
 
 class TestUtil(PillowTestCase):
@@ -31,6 +35,18 @@ class TestUtil(PillowTestCase):
 
         # Act
         it_is = _util.isStringType(fp)
+
+        # Assert
+        self.assertTrue(it_is)
+
+    @unittest.skipIf(not py36, 'os.path support for Paths added in 3.6')
+    def test_path_obj_is_path(self):
+        # Arrange
+        from pathlib import Path
+        fp = Path('filename.ext')
+
+        # Act
+        it_is = _util.isPath(fp)
 
         # Assert
         self.assertTrue(it_is)

--- a/src/PIL/_util.py
+++ b/src/PIL/_util.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 py3 = sys.version_info.major >= 3
-py36 = py3 and sys.version_info.minor >= 6
+py36 = sys.version_info[0:2] >= (3, 6)
 
 if py3:
     def isStringType(t):

--- a/src/PIL/_util.py
+++ b/src/PIL/_util.py
@@ -2,13 +2,20 @@ import os
 import sys
 
 py3 = sys.version_info.major >= 3
+py36 = py3 and sys.version_info.minor >= 6
 
 if py3:
     def isStringType(t):
         return isinstance(t, str)
 
-    def isPath(f):
-        return isinstance(f, (bytes, str))
+    if py36:
+        from pathlib import Path
+
+        def isPath(f):
+            return isinstance(f, (bytes, str, Path))
+    else:
+        def isPath(f):
+            return isinstance(f, (bytes, str))
 else:
     def isStringType(t):
         return isinstance(t, basestring)  # noqa: F821


### PR DESCRIPTION
Now, for functions which accept either a path or file object, the
predicate will pass on Paths and not attempt to call .read on them
before opening.

The pathlib module was added in 3.4 but os.path functions did not start
accepting path-like objects until 3.6, so that is the version after
which this implementation is defined.

Added a unit test to make sure isPath accepts Path objects. The unit
test is skipped if python version is not 3.6 or later.