### PR TITLE
test_is_path calls the correct function

### DIFF
--- a/Tests/test_util.py
+++ b/Tests/test_util.py
@@ -30,7 +30,7 @@ class TestUtil(PillowTestCase):
         fp = "filename.ext"
 
         # Act
-        it_is = _util.isStringType(fp)
+        it_is = _util.isPath(fp)
 
         # Assert
         self.assertTrue(it_is)


### PR DESCRIPTION
Before, the test called the isStringType utility, which has its own,
separate test.

Changes proposed in this pull request:

 * `test_is_path` unit test calls the correct function
