### PR TITLE
Fix Flake8

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -205,7 +205,7 @@ class TestFileLibTiff(LibTiffTestCase):
         #     4: "long",
         #     5: "rational",
         #     12: "double",
-        # type: dummy value
+        # Type: dummy value
         values = {2: 'test',
                   3: 1,
                   4: 2**20,

--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -393,8 +393,6 @@ class PdfParser:
 
     def __init__(self, filename=None, f=None,
                  buf=None, start_offset=0, mode="rb"):
-        # type: (PdfParser, str, file, Union[bytes, bytearray], int, str)
-        #       -> None
         if buf and f:
             raise RuntimeError(
                 "specify buf or f or filename, but not both buf and f")

--- a/winbuild/build_dep.py
+++ b/winbuild/build_dep.py
@@ -307,7 +307,7 @@ if 'PYTHON' in os.environ:
     add_compiler(compiler_from_env(), bit_from_env())
 else:
     # for compiler in all_compilers():
-        # add_compiler(compiler)
+    #     add_compiler(compiler)
     add_compiler(compilers[7.0][2008][32], 32)
 
 with open('build_deps.cmd', 'w') as f:


### PR DESCRIPTION
There's a new release of Flake8 (3.7.1), including a new release of pyflakes (2.1.0), which brings in some new tests which fail:

https://travis-ci.org/python-pillow/Pillow/jobs/486309539#L224

```
./winbuild/build_dep.py:310:9: E117 over-indented (comment)
```
Simple comment indentation.

```
./Tests/test_file_libtiff.py:196:9: F723 syntax error in type comment 'dummy value'
```
It now checks mypy type comments. This one isn't a real mypy type comment, so change `type:` to `Type:`.

```
./src/PIL/PdfParser.py:396:9: F821 undefined name 'file'
./src/PIL/PdfParser.py:396:9: F821 undefined name 'Union'
```

The `Union` one can be fixed with `from typing import Union`, but that introduces a dependency on the mypy `typing` module. We have issue https://github.com/python-pillow/Pillow/issues/2625 to add typing support, so I've removed it from here.
