### PR TITLE
Remove deprecated VERSION

### DIFF
--- a/Tests/test_000_sanity.py
+++ b/Tests/test_000_sanity.py
@@ -11,8 +11,6 @@ class TestSanity(PillowTestCase):
         # Make sure we have the binary extension
         PIL.Image.core.new("L", (100, 100))
 
-        self.assertEqual(PIL.Image.VERSION[:3], '1.1')
-
         # Create an image and do stuff with it.
         im = PIL.Image.new("1", (100, 100))
         self.assertEqual((im.mode, im.size), ('1', (100, 100)))

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -205,7 +205,7 @@ class TestFileLibTiff(LibTiffTestCase):
         #     4: "long",
         #     5: "rational",
         #     12: "double",
-        # type: dummy value
+        # Type: dummy value
         values = {2: 'test',
                   3: 1,
                   4: 2**20,

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -24,10 +24,10 @@
 # See the README file for information on usage and redistribution.
 #
 
-# VERSION is deprecated and will be removed in Pillow 6.0.0.
-# PILLOW_VERSION is deprecated and will be removed after that.
+# VERSION was removed in Pillow 6.0.0.
+# PILLOW_VERSION is deprecated and will be removed in Pillow 7.0.0.
 # Use __version__ instead.
-from . import VERSION, PILLOW_VERSION, __version__, _plugins
+from . import PILLOW_VERSION, __version__, _plugins
 from ._util import py3
 
 import logging
@@ -60,8 +60,7 @@ except ImportError:
     from collections import Callable
 
 
-# Silence warnings
-assert VERSION
+# Silence warning
 assert PILLOW_VERSION
 
 logger = logging.getLogger(__name__)

--- a/src/PIL/ImageCms.py
+++ b/src/PIL/ImageCms.py
@@ -950,5 +950,5 @@ def versions():
 
     return (
         VERSION, core.littlecms_version,
-        sys.version.split()[0], Image.VERSION
+        sys.version.split()[0], Image.__version__
     )

--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -393,8 +393,6 @@ class PdfParser:
 
     def __init__(self, filename=None, f=None,
                  buf=None, start_offset=0, mode="rb"):
-        # type: (PdfParser, str, file, Union[bytes, bytearray], int, str)
-        #       -> None
         if buf and f:
             raise RuntimeError(
                 "specify buf or f or filename, but not both buf and f")

--- a/src/PIL/__init__.py
+++ b/src/PIL/__init__.py
@@ -16,10 +16,9 @@ PIL.VERSION is the old PIL version and will be removed in the future.
 
 from . import _version
 
-# VERSION is deprecated and will be removed in Pillow 6.0.0.
-# PILLOW_VERSION is deprecated and will be removed after that.
+# VERSION was removed in Pillow 6.0.0.
+# PILLOW_VERSION is deprecated and will be removed in Pillow 7.0.0.
 # Use __version__ instead.
-VERSION = '1.1.7'  # PIL Version
 PILLOW_VERSION = __version__ = _version.__version__
 
 del _version

--- a/winbuild/build_dep.py
+++ b/winbuild/build_dep.py
@@ -307,7 +307,7 @@ if 'PYTHON' in os.environ:
     add_compiler(compiler_from_env(), bit_from_env())
 else:
     # for compiler in all_compilers():
-        # add_compiler(compiler)
+    #     add_compiler(compiler)
     add_compiler(compilers[7.0][2008][32], 32)
 
 with open('build_deps.cmd', 'w') as f:


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/3581.

Changes proposed in this pull request:

 * Includes PR https://github.com/python-pillow/Pillow/pull/3623 to fix unrelated lint warnings
 * Remove deprecated `VERSION`, the old forked PIL version number 1.1.7
