### PR TITLE
Added EXIF class

### DIFF
--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -64,6 +64,18 @@ class TestFileMpo(PillowTestCase):
         im.seek(1)
         self.assertEqual(im.size, (680, 480))
 
+    def test_parallax(self):
+        # Nintendo
+        im = Image.open("Tests/images/sugarshack.mpo")
+        exif = im.getexif()
+        self.assertEqual(exif.get_ifd(0x927c)[0x1101]["Parallax"], -44.798187255859375)
+
+        # Fujifilm
+        im = Image.open("Tests/images/fujifilm.mpo")
+        im.seek(1)
+        exif = im.getexif()
+        self.assertEqual(exif.get_ifd(0x927c)[0xb211], -3.125)
+
     def test_mp(self):
         for test_file in test_files:
             im = Image.open(test_file)

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -284,7 +284,7 @@ class TestPyDecoder(PillowTestCase):
     @unittest.skipIf(not HAVE_WEBP or not _webp.HAVE_WEBPANIM,
                      "WebP support not installed with animation")
     def test_exif_webp(self):
-        im = Image.open("Tests/images/hopper.webp")  # WebP
+        im = Image.open("Tests/images/hopper.webp")
         exif = im.getexif()
         self.assertEqual(exif, {})
 
@@ -321,5 +321,15 @@ class TestPyDecoder(PillowTestCase):
         self.assertEqual(reloaded_exif, {
             258: 8,
             40963: 455,
-            305: 'Pillow test'
+            305: 'Pillow test',
+        })
+
+    def test_exif_interop(self):
+        im = Image.open("Tests/images/flower.jpg")
+        exif = im.getexif()
+        self.assertEqual(exif.get_ifd(0xa005), {
+            1: 'R98',
+            2: b'0100',
+            4097: 2272,
+            4098: 1704,
         })

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -1,10 +1,16 @@
-from .helper import PillowTestCase, hopper, fromstring, tostring
+from .helper import unittest, PillowTestCase, hopper, fromstring, tostring
 
 from io import BytesIO
 
 from PIL import Image
 from PIL import ImageFile
 from PIL import EpsImagePlugin
+
+try:
+    from PIL import _webp
+    HAVE_WEBP = True
+except ImportError:
+    HAVE_WEBP = False
 
 
 codecs = dir(Image.core)
@@ -233,3 +239,87 @@ class TestPyDecoder(PillowTestCase):
         im = MockImageFile(buf)
         self.assertIsNone(im.format)
         self.assertIsNone(im.get_format_mimetype())
+
+    def test_exif_jpeg(self):
+        im = Image.open("Tests/images/exif-72dpi-int.jpg")  # Little endian
+        exif = im.getexif()
+        self.assertNotIn(258, exif)
+        self.assertIn(40960, exif)
+        self.assertEqual(exif[40963], 450)
+        self.assertEqual(exif[11], "gThumb 3.0.1")
+
+        out = self.tempfile('temp.jpg')
+        exif[258] = 8
+        del exif[40960]
+        exif[40963] = 455
+        exif[11] = "Pillow test"
+        im.save(out, exif=exif)
+        reloaded = Image.open(out)
+        reloaded_exif = reloaded.getexif()
+        self.assertEqual(reloaded_exif[258], 8)
+        self.assertNotIn(40960, exif)
+        self.assertEqual(reloaded_exif[40963], 455)
+        self.assertEqual(exif[11], "Pillow test")
+
+        im = Image.open("Tests/images/no-dpi-in-exif.jpg")  # Big endian
+        exif = im.getexif()
+        self.assertNotIn(258, exif)
+        self.assertIn(40962, exif)
+        self.assertEqual(exif[40963], 200)
+        self.assertEqual(exif[305], "Adobe Photoshop CC 2017 (Macintosh)")
+
+        out = self.tempfile('temp.jpg')
+        exif[258] = 8
+        del exif[34665]
+        exif[40963] = 455
+        exif[305] = "Pillow test"
+        im.save(out, exif=exif)
+        reloaded = Image.open(out)
+        reloaded_exif = reloaded.getexif()
+        self.assertEqual(reloaded_exif[258], 8)
+        self.assertNotIn(40960, exif)
+        self.assertEqual(reloaded_exif[40963], 455)
+        self.assertEqual(exif[305], "Pillow test")
+
+    @unittest.skipIf(not HAVE_WEBP or not _webp.HAVE_WEBPANIM,
+                     "WebP support not installed with animation")
+    def test_exif_webp(self):
+        im = Image.open("Tests/images/hopper.webp")  # WebP
+        exif = im.getexif()
+        self.assertEqual(exif, {})
+
+        out = self.tempfile('temp.webp')
+        exif[258] = 8
+        exif[40963] = 455
+        exif[305] = "Pillow test"
+
+        def check_exif():
+            reloaded = Image.open(out)
+            reloaded_exif = reloaded.getexif()
+            self.assertEqual(reloaded_exif[258], 8)
+            self.assertEqual(reloaded_exif[40963], 455)
+            self.assertEqual(exif[305], "Pillow test")
+        im.save(out, exif=exif)
+        check_exif()
+        im.save(out, exif=exif, save_all=True)
+        check_exif()
+
+    def test_exif_png(self):
+        im = Image.open("Tests/images/exif.png")
+        exif = im.getexif()
+        self.assertEqual(exif, {274: 1})
+
+        out = self.tempfile('temp.png')
+        exif[258] = 8
+        del exif[274]
+        exif[40963] = 455
+        exif[305] = "Pillow test"
+        im.save(out, exif=exif)
+
+        reloaded = Image.open(out)
+        reloaded_exif = reloaded.getexif()
+        self.assertEqual(reloaded_exif, {
+            258: 8,
+            40963: 455,
+            305: 'Pillow test'
+        })

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -707,7 +707,7 @@ class Exif(MutableMapping):
 
     def _get_ifd_dict(self, fp, head, tag):
         try:
-            # an offset pointer to the location of the nested embedded ifd.
+            # an offset pointer to the location of the nested embedded IFD.
             # It should be a long, but may be corrupted.
             fp.seek(self._data[tag])
         except (KeyError, TypeError):

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -751,7 +751,7 @@ class Exif(MutableMapping):
             self._data[0x8825] = ifd
             self._ifds[0x8825] = ifd
 
-    def toBytes(self, offset=0):
+    def tobytes(self, offset=0):
         from . import TiffImagePlugin
         if self.endian == "<":
             head = b"II\x2A\x00\x08\x00\x00\x00"
@@ -760,7 +760,7 @@ class Exif(MutableMapping):
         ifd = TiffImagePlugin.ImageFileDirectory_v2(ifh=head)
         for tag, value in self._data.items():
             ifd[tag] = value
-        return b"Exif\x00\x00"+head+ifd.toBytes(offset)
+        return b"Exif\x00\x00"+head+ifd.tobytes(offset)
 
     def get_ifd(self, tag):
         if tag not in self._ifds and tag in self._data:

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -735,7 +735,7 @@ class Exif(MutableMapping):
         info.load(fp)
         self._data = dict(self._fixup_dict(info))
 
-        # get exif extension
+        # get EXIF extension
         ifd = self._get_ifd_dict(fp, head, 0x8769)
         if ifd:
             self._data.update(ifd)

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -726,7 +726,7 @@ def _save(im, fp, filename):
 
     exif = info.get("exif", b"")
     if isinstance(exif, ImageFile.Exif):
-        exif = exif.toBytes()
+        exif = exif.tobytes()
 
     # get keyword arguments
     im.encoderconfig = (

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -472,65 +472,20 @@ class JpegImageFile(ImageFile.ImageFile):
 def _fixup_dict(src_dict):
     # Helper function for _getexif()
     # returns a dict with any single item tuples/lists as individual values
-    def _fixup(value):
-        try:
-            if len(value) == 1 and not isinstance(value, dict):
-                return value[0]
-        except Exception:
-            pass
-        return value
-
-    return {k: _fixup(v) for k, v in src_dict.items()}
+    exif = ImageFile.Exif()
+    return exif._fixup_dict(src_dict)
 
 
 def _getexif(self):
-    # Extract EXIF information.  This method is highly experimental,
-    # and is likely to be replaced with something better in a future
-    # version.
-
     # Use the cached version if possible
     try:
         return self.info["parsed_exif"]
     except KeyError:
         pass
 
-    # The EXIF record consists of a TIFF file embedded in a JPEG
-    # application marker (!).
-    try:
-        data = self.info["exif"]
-    except KeyError:
+    if "exif" not in self.info:
         return None
-    fp = io.BytesIO(data[6:])
-    head = fp.read(8)
-    # process dictionary
-    info = TiffImagePlugin.ImageFileDirectory_v1(head)
-    fp.seek(info.next)
-    info.load(fp)
-    exif = dict(_fixup_dict(info))
-    # get exif extension
-    try:
-        # exif field 0x8769 is an offset pointer to the location
-        # of the nested embedded exif ifd.
-        # It should be a long, but may be corrupted.
-        fp.seek(exif[0x8769])
-    except (KeyError, TypeError):
-        pass
-    else:
-        info = TiffImagePlugin.ImageFileDirectory_v1(head)
-        info.load(fp)
-        exif.update(_fixup_dict(info))
-    # get gpsinfo extension
-    try:
-        # exif field 0x8825 is an offset pointer to the location
-        # of the nested embedded gps exif ifd.
-        # It should be a long, but may be corrupted.
-        fp.seek(exif[0x8825])
-    except (KeyError, TypeError):
-        pass
-    else:
-        info = TiffImagePlugin.ImageFileDirectory_v1(head)
-        info.load(fp)
-        exif[0x8825] = _fixup_dict(info)
+    exif = dict(self.getexif())
 
     # Cache the result for future use
     self.info["parsed_exif"] = exif
@@ -769,6 +724,10 @@ def _save(im, fp, filename):
 
     optimize = info.get("optimize", False)
 
+    exif = info.get("exif", b"")
+    if isinstance(exif, ImageFile.Exif):
+        exif = exif.toBytes()
+
     # get keyword arguments
     im.encoderconfig = (
         quality,
@@ -780,7 +739,7 @@ def _save(im, fp, filename):
         subsampling,
         qtables,
         extra,
-        info.get("exif", b"")
+        exif
         )
 
     # if we optimize, libjpeg needs a buffer big enough to hold the whole image
@@ -800,7 +759,7 @@ def _save(im, fp, filename):
 
     # The exif info needs to be written as one block, + APP1, + one spare byte.
     # Ensure that our buffer is big enough. Same with the icc_profile block.
-    bufsize = max(ImageFile.MAXBLOCK, bufsize, len(info.get("exif", b"")) + 5,
+    bufsize = max(ImageFile.MAXBLOCK, bufsize, len(exif) + 5,
                   len(extra) + 1)
 
     ImageFile._save(im, fp, [("jpeg", (0, 0)+im.size, 0, rawmode)], bufsize)

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -86,7 +86,7 @@ def APP(self, marker):
             self.info["jfif_density"] = jfif_density
     elif marker == 0xFFE1 and s[:5] == b"Exif\0":
         if "exif" not in self.info:
-            # extract Exif information (incomplete)
+            # extract EXIF information (incomplete)
             self.info["exif"] = s  # FIXME: value will change
     elif marker == 0xFFE2 and s[:5] == b"FPXR\0":
         # extract FlashPix information (incomplete)
@@ -168,7 +168,7 @@ def APP(self, marker):
                 dpi *= 2.54
             self.info["dpi"] = dpi, dpi
         except (KeyError, SyntaxError, ZeroDivisionError):
-            # SyntaxError for invalid/unreadable exif
+            # SyntaxError for invalid/unreadable EXIF
             # KeyError for dpi not included
             # ZeroDivisionError for invalid dpi rational value
             self.info["dpi"] = 72, 72
@@ -757,7 +757,7 @@ def _save(im, fp, filename):
         else:
             bufsize = im.size[0] * im.size[1]
 
-    # The exif info needs to be written as one block, + APP1, + one spare byte.
+    # The EXIF info needs to be written as one block, + APP1, + one spare byte.
     # Ensure that our buffer is big enough. Same with the icc_profile block.
     bufsize = max(ImageFile.MAXBLOCK, bufsize, len(exif) + 5,
                   len(extra) + 1)

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -696,8 +696,14 @@ class PngImageFile(ImageFile.ImageFile):
     def _getexif(self):
         if "exif" not in self.info:
             self.load()
-        from .JpegImagePlugin import _getexif
-        return _getexif(self)
+        if "exif" not in self.info:
+            return None
+        return dict(self.getexif())
+
+    def getexif(self):
+        if "exif" not in self.info:
+            self.load()
+        return ImageFile.ImageFile.getexif(self)
 
 
 # --------------------------------------------------------------------
@@ -880,6 +886,8 @@ def _save(im, fp, filename, chunk=putchunk):
 
     exif = im.encoderinfo.get("exif", im.info.get("exif"))
     if exif:
+        if isinstance(exif, ImageFile.Exif):
+            exif = exif.toBytes(8)
         if exif.startswith(b"Exif\x00\x00"):
             exif = exif[6:]
         chunk(fp, b"eXIf", exif)

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -887,7 +887,7 @@ def _save(im, fp, filename, chunk=putchunk):
     exif = im.encoderinfo.get("exif", im.info.get("exif"))
     if exif:
         if isinstance(exif, ImageFile.Exif):
-            exif = exif.toBytes(8)
+            exif = exif.tobytes(8)
         if exif.startswith(b"Exif\x00\x00"):
             exif = exif[6:]
         chunk(fp, b"eXIf", exif)

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -785,7 +785,7 @@ class ImageFileDirectory_v2(MutableMapping):
             warnings.warn(str(msg))
             return
 
-    def toBytes(self, offset=0):
+    def tobytes(self, offset=0):
         # FIXME What about tagdata?
         result = self._pack("H", len(self._tags_v2))
 
@@ -859,7 +859,7 @@ class ImageFileDirectory_v2(MutableMapping):
             fp.write(self._prefix + self._pack("HL", 42, 8))
 
         offset = fp.tell()
-        result = self.toBytes(offset)
+        result = self.tobytes(offset)
         fp.write(result)
         return offset + len(result)
 

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -218,7 +218,7 @@ def _save_all(im, fp, filename):
     icc_profile = im.encoderinfo.get("icc_profile", "")
     exif = im.encoderinfo.get("exif", "")
     if isinstance(exif, ImageFile.Exif):
-        exif = exif.toBytes()
+        exif = exif.tobytes()
     xmp = im.encoderinfo.get("xmp", "")
     if allow_mixed:
         lossless = False
@@ -319,7 +319,7 @@ def _save(im, fp, filename):
     icc_profile = im.encoderinfo.get("icc_profile", "")
     exif = im.encoderinfo.get("exif", "")
     if isinstance(exif, ImageFile.Exif):
-        exif = exif.toBytes()
+        exif = exif.tobytes()
     xmp = im.encoderinfo.get("xmp", "")
 
     if im.mode not in _VALID_WEBP_LEGACY_MODES:

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -93,8 +93,9 @@ class WebPImageFile(ImageFile.ImageFile):
         self.seek(0)
 
     def _getexif(self):
-        from .JpegImagePlugin import _getexif
-        return _getexif(self)
+        if "exif" not in self.info:
+            return None
+        return dict(self.getexif())
 
     @property
     def n_frames(self):
@@ -216,6 +217,8 @@ def _save_all(im, fp, filename):
     method = im.encoderinfo.get("method", 0)
     icc_profile = im.encoderinfo.get("icc_profile", "")
     exif = im.encoderinfo.get("exif", "")
+    if isinstance(exif, ImageFile.Exif):
+        exif = exif.toBytes()
     xmp = im.encoderinfo.get("xmp", "")
     if allow_mixed:
         lossless = False
@@ -315,6 +318,8 @@ def _save(im, fp, filename):
     quality = im.encoderinfo.get("quality", 80)
     icc_profile = im.encoderinfo.get("icc_profile", "")
     exif = im.encoderinfo.get("exif", "")
+    if isinstance(exif, ImageFile.Exif):
+        exif = exif.toBytes()
     xmp = im.encoderinfo.get("xmp", "")
 
     if im.mode not in _VALID_WEBP_LEGACY_MODES:


### PR DESCRIPTION
Resolves #520

In addition to the methods described in that issue, I have also added `get_ifd()`, for reading specified subdirectories -
* The Interop EXIF subdirectory, to help #3270. Reference documentation -https://www.awaresystems.be/imaging/tiff/tifftags/interoperabilityifd.html
* The Makernote subdirectory, to resolve #2081

---

Regarding #2081 -

MPO files can have EXIF data for separate images (Page 9 of http://www.cipa.jp/std/documents/e/DC-007_E.pdf). This PR changes `im.info["exif"]` to be specific to the current MPO frame.

Within the EXIF data of the second image in files in #2081, there is a Makernote EXIF tag containing parallax data. However, the MakerNote tag does not have consistent structure across MPO images - it is manufacturer specific. See https://www.awaresystems.be/imaging/tiff/tifftags/privateifd/exif/makernote.html and http://www.exiv2.org/makernote.html.

The issue provides Fujifilm MPO images. The specification of the Fujifilm MakerNote tag can be found at http://www.ozhiker.com/electronics/pjmt/jpeg_info/fujifilm_mn.html#Fujifilm_Tags, and the parallax tag value can be found at https://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/FujiFilm.html. I have added one of the images from the issue.

Within the test suite, there are Nintendo MPO images. See https://3dbrew.org/wiki/MPO and http://owl.phy.queensu.ca/~phil/exiftool/TagNames/Nintendo.html for information about their MakerNote tag.

The test added in this PR reads parallax data from both types of files.