### PR TITLE
Deprecate PIL.*ImagePlugin.__version__ attributes

### DIFF
--- a/docs/releasenotes/6.0.0.rst
+++ b/docs/releasenotes/6.0.0.rst
@@ -29,10 +29,49 @@ and have now been removed: ``gaussian_blur``, ``gblur``, ``unsharp_mask``, ``usm
 API Changes
 ===========
 
-TODO
-^^^^
+Deprecations
+^^^^^^^^^^^^
 
-TODO
+These version constants have been deprecated and will be removed in a future
+version.
+
+* ``BmpImagePlugin.__version__``
+* ``CurImagePlugin.__version__``
+* ``DcxImagePlugin.__version__``
+* ``EpsImagePlugin.__version__``
+* ``FliImagePlugin.__version__``
+* ``FpxImagePlugin.__version__``
+* ``GdImageFile.__version__``
+* ``GifImagePlugin.__version__``
+* ``IcoImagePlugin.__version__``
+* ``ImImagePlugin.__version__``
+* ``ImtImagePlugin.__version__``
+* ``IptcImagePlugin.__version__``
+* ``Jpeg2KImagePlugin.__version__``
+* ``JpegImagePlugin.__version__``
+* ``McIdasImagePlugin.__version__``
+* ``MicImagePlugin.__version__``
+* ``MpegImagePlugin.__version__``
+* ``MpoImagePlugin.__version__``
+* ``MspImagePlugin.__version__``
+* ``PalmImagePlugin.__version__``
+* ``PcdImagePlugin.__version__``
+* ``PcxImagePlugin.__version__``
+* ``PdfImagePlugin.__version__``
+* ``PixarImagePlugin.__version__``
+* ``PngImagePlugin.__version__``
+* ``PpmImagePlugin.__version__``
+* ``PsdImagePlugin.__version__``
+* ``SgiImagePlugin.__version__``
+* ``SunImagePlugin.__version__``
+* ``TgaImagePlugin.__version__``
+* ``TiffImagePlugin.__version__``
+* ``WmfImagePlugin.__version__``
+* ``XbmImagePlugin.__version__``
+* ``XpmImagePlugin.__version__``
+* ``XVThumbImagePlugin.__version__``
+
+Use ``PIL.__version__`` instead.
 
 API Additions
 =============

--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -29,6 +29,8 @@ from ._binary import i8, i16le as i16, i32le as i32, \
                      o8, o16le as o16, o32le as o32
 import math
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.7"
 
 #

--- a/src/PIL/CurImagePlugin.py
+++ b/src/PIL/CurImagePlugin.py
@@ -21,6 +21,8 @@ from __future__ import print_function
 from . import Image, BmpImagePlugin
 from ._binary import i8, i16le as i16, i32le as i32
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.1"
 
 #

--- a/src/PIL/DcxImagePlugin.py
+++ b/src/PIL/DcxImagePlugin.py
@@ -25,6 +25,8 @@ from . import Image
 from ._binary import i32le as i32
 from .PcxImagePlugin import PcxImageFile
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.2"
 
 MAGIC = 0x3ADE68B1  # QUIZ: what's this value, then?

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -27,6 +27,8 @@ import sys
 from . import Image, ImageFile
 from ._binary import i32le as i32
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.5"
 
 #

--- a/src/PIL/FliImagePlugin.py
+++ b/src/PIL/FliImagePlugin.py
@@ -19,6 +19,8 @@
 from . import Image, ImageFile, ImagePalette
 from ._binary import i8, i16le as i16, i32le as i32, o8
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.2"
 
 

--- a/src/PIL/FpxImagePlugin.py
+++ b/src/PIL/FpxImagePlugin.py
@@ -22,6 +22,8 @@ from ._binary import i32le as i32, i8
 
 import olefile
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.1"
 
 # we map from colour field tuples to (mode, rawmode) descriptors

--- a/src/PIL/GdImageFile.py
+++ b/src/PIL/GdImageFile.py
@@ -26,6 +26,8 @@
 from . import ImageFile, ImagePalette
 from ._binary import i8, i16be as i16, i32be as i32
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.1"
 
 

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -29,6 +29,8 @@ from ._binary import i8, i16le as i16, o8, o16le as o16
 
 import itertools
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.9"
 
 

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -29,6 +29,8 @@ from . import Image, ImageFile, BmpImagePlugin, PngImagePlugin
 from ._binary import i8, i16le as i16, i32le as i32
 from math import log, ceil
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.1"
 
 #

--- a/src/PIL/ImImagePlugin.py
+++ b/src/PIL/ImImagePlugin.py
@@ -30,6 +30,8 @@ import re
 from . import Image, ImageFile, ImagePalette
 from ._binary import i8
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.7"
 
 

--- a/src/PIL/ImtImagePlugin.py
+++ b/src/PIL/ImtImagePlugin.py
@@ -19,6 +19,8 @@ import re
 
 from . import Image, ImageFile
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.2"
 
 

--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -22,6 +22,8 @@ from ._binary import i8, i16be as i16, i32be as i32, o8
 import os
 import tempfile
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.3"
 
 COMPRESSION = {

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -17,6 +17,8 @@ import struct
 import os
 import io
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.1"
 
 

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -43,6 +43,8 @@ from ._binary import i8, o8, i16be as i16
 from .JpegPresets import presets
 from ._util import isStringType
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.6"
 
 

--- a/src/PIL/McIdasImagePlugin.py
+++ b/src/PIL/McIdasImagePlugin.py
@@ -19,6 +19,8 @@
 import struct
 from . import Image, ImageFile
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.2"
 
 

--- a/src/PIL/MicImagePlugin.py
+++ b/src/PIL/MicImagePlugin.py
@@ -21,6 +21,8 @@ from . import Image, TiffImagePlugin
 
 import olefile
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.1"
 
 

--- a/src/PIL/MpegImagePlugin.py
+++ b/src/PIL/MpegImagePlugin.py
@@ -17,6 +17,8 @@
 from . import Image, ImageFile
 from ._binary import i8
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.1"
 
 

--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -20,6 +20,8 @@
 
 from . import Image, JpegImagePlugin
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.1"
 
 

--- a/src/PIL/MspImagePlugin.py
+++ b/src/PIL/MspImagePlugin.py
@@ -28,6 +28,8 @@ from ._binary import i16le as i16, o16le as o16, i8
 import struct
 import io
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.1"
 
 

--- a/src/PIL/PalmImagePlugin.py
+++ b/src/PIL/PalmImagePlugin.py
@@ -10,6 +10,8 @@
 from . import Image, ImageFile
 from ._binary import o8, o16be as o16b
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "1.0"
 
 _Palm8BitColormapValues = (  # noqa: E131

--- a/src/PIL/PcdImagePlugin.py
+++ b/src/PIL/PcdImagePlugin.py
@@ -18,6 +18,8 @@
 from . import Image, ImageFile
 from ._binary import i8
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.1"
 
 

--- a/src/PIL/PcxImagePlugin.py
+++ b/src/PIL/PcxImagePlugin.py
@@ -31,6 +31,8 @@ from ._binary import i8, i16le as i16, o8, o16le as o16
 
 logger = logging.getLogger(__name__)
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.6"
 
 

--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -25,6 +25,8 @@ import io
 import os
 import time
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.5"
 
 

--- a/src/PIL/PixarImagePlugin.py
+++ b/src/PIL/PixarImagePlugin.py
@@ -22,6 +22,8 @@
 from . import Image, ImageFile
 from ._binary import i16le as i16
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.1"
 
 

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -40,6 +40,8 @@ from . import Image, ImageFile, ImagePalette
 from ._binary import i8, i16be as i16, i32be as i32, o16be as o16, o32be as o32
 from ._util import py3
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.9"
 
 logger = logging.getLogger(__name__)

--- a/src/PIL/PpmImagePlugin.py
+++ b/src/PIL/PpmImagePlugin.py
@@ -17,6 +17,8 @@
 
 from . import Image, ImageFile
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.2"
 
 #

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -16,6 +16,8 @@
 # See the README file for information on usage and redistribution.
 #
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.4"
 
 from . import Image, ImageFile, ImagePalette

--- a/src/PIL/SgiImagePlugin.py
+++ b/src/PIL/SgiImagePlugin.py
@@ -29,6 +29,8 @@ import struct
 import os
 
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.3"
 
 

--- a/src/PIL/SunImagePlugin.py
+++ b/src/PIL/SunImagePlugin.py
@@ -20,6 +20,8 @@
 from . import Image, ImageFile, ImagePalette
 from ._binary import i32be as i32
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.3"
 
 

--- a/src/PIL/TgaImagePlugin.py
+++ b/src/PIL/TgaImagePlugin.py
@@ -22,6 +22,8 @@ from ._binary import i8, i16le as i16, o8, o16le as o16
 
 import warnings
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.3"
 
 

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -66,6 +66,8 @@ except ImportError:
     from collections import MutableMapping
 
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "1.3.5"
 DEBUG = False  # Needs to be merged with the new logging approach.
 

--- a/src/PIL/WmfImagePlugin.py
+++ b/src/PIL/WmfImagePlugin.py
@@ -27,6 +27,8 @@ from ._binary import i16le as word, si16le as short, \
 from ._util import py3
 
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.2"
 
 _handler = None

--- a/src/PIL/XVThumbImagePlugin.py
+++ b/src/PIL/XVThumbImagePlugin.py
@@ -20,6 +20,8 @@
 from . import Image, ImageFile, ImagePalette
 from ._binary import i8, o8
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.1"
 
 _MAGIC = b"P7 332"

--- a/src/PIL/XbmImagePlugin.py
+++ b/src/PIL/XbmImagePlugin.py
@@ -22,6 +22,8 @@
 import re
 from . import Image, ImageFile
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.6"
 
 # XBM header

--- a/src/PIL/XpmImagePlugin.py
+++ b/src/PIL/XpmImagePlugin.py
@@ -19,6 +19,8 @@ import re
 from . import Image, ImageFile, ImagePalette
 from ._binary import i8, o8
 
+# __version__ is deprecated and will be removed in a future version. Use
+# PIL.__version__ instead.
 __version__ = "0.2"
 
 # XPM header


### PR DESCRIPTION
Use `PIL.__version__` instead.