### PR TITLE
Slightly simplify Image.__eq__

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -655,8 +655,7 @@ class Image(object):
         return filename
 
     def __eq__(self, other):
-        return (isinstance(other, Image) and
-                self.__class__.__name__ == other.__class__.__name__ and
+        return (self.__class__ is other.__class__ and
                 self.mode == other.mode and
                 self.size == other.size and
                 self.info == other.info and


### PR DESCRIPTION
Two identical types can be compared using the `is` operator. Object identity is slightly faster than a string comparison as well.