### PR TITLE
Remove unnecessary unittest.main() boilerplate from test files

### DIFF
--- a/Tests/README.rst
+++ b/Tests/README.rst
@@ -13,28 +13,20 @@ Install::
 Execution
 ---------
 
-**If Pillow has been built in-place**
-
 To run an individual test::
 
-    python Tests/test_image.py
+    pytest Tests/test_image.py
 
-Run all the tests from the root of the Pillow source distribution::
+Or::
 
-    pytest -vx Tests
-
-Or with coverage::
-
-    pytest -vx --cov PIL --cov-report term Tests
-    coverage html
-    open htmlcov/index.html
-
-**If Pillow has been installed**
-
-To run an individual test::
-
-    pytest -k Tests/test_image.py
+    pytest -k test_image.py
 
 Run all the tests from the root of the Pillow source distribution::
 
     pytest
+
+Or with coverage::
+
+    pytest --cov PIL --cov-report term
+    coverage html
+    open htmlcov/index.html

--- a/Tests/test_000_sanity.py
+++ b/Tests/test_000_sanity.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 import PIL
 import PIL.Image
@@ -24,7 +24,3 @@ class TestSanity(PillowTestCase):
         PIL.Image.new("RGB", (100, 100))
         PIL.Image.new("I", (100, 100))
         PIL.Image.new("F", (100, 100))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_binary.py
+++ b/Tests/test_binary.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import _binary
 
@@ -22,7 +22,3 @@ class TestBinary(PillowTestCase):
 
         self.assertEqual(_binary.o16be(65535), b'\xff\xff')
         self.assertEqual(_binary.o32be(65535), b'\x00\x00\xff\xff')
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image
 import os
@@ -103,7 +103,3 @@ class TestBmpReference(PillowTestCase):
                                os.path.join(base, 'g', 'pal4rle.bmp'))
                 if f not in unsupported:
                     self.fail("Unsupported Image %s: %s" % (f, msg))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_box_blur.py
+++ b/Tests/test_box_blur.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image, ImageFilter
 
@@ -215,7 +215,3 @@ class TestBoxBlur(PillowTestCase):
             passes=3,
             delta=1,
         )
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -519,7 +519,3 @@ class TestTransformColorLut3D(PillowTestCase):
         self.assertEqual(lut.table[0:16], [
             0.0, 0.0, 0.0, 0.5,  0.25, 0.0, 0.0, 0.5,
             0.0, 0.0, 0.0, 0.5,  0.0, 0.16, 0.0, 0.5])
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_core_resources.py
+++ b/Tests/test_core_resources.py
@@ -179,7 +179,3 @@ class TestEnvVars(PillowTestCase):
         self.assert_warning(
             UserWarning, Image._apply_env_variables,
             {'PILLOW_BLOCKS_MAX': 'wat'})
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 
@@ -83,7 +83,3 @@ class TestDecompressionCrop(PillowTestCase):
         for value in error_values:
             with self.assertRaises(Image.DecompressionBombError):
                 im.crop(value)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -63,7 +63,3 @@ class TestFeatures(PillowTestCase):
         module = "unsupported_module"
         # Act / Assert
         self.assertRaises(ValueError, features.check_module, module)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_blp.py
+++ b/Tests/test_file_blp.py
@@ -1,6 +1,6 @@
 from PIL import Image
 
-from .helper import PillowTestCase, unittest
+from .helper import PillowTestCase
 
 
 class TestFileBlp(PillowTestCase):
@@ -18,7 +18,3 @@ class TestFileBlp(PillowTestCase):
         im = Image.open("Tests/images/blp/blp2_dxt1a.blp")
         target = Image.open("Tests/images/blp/blp2_dxt1a.png")
         self.assert_image_equal(im, target)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image, BmpImagePlugin
 import io
@@ -75,7 +75,3 @@ class TestFileBmp(PillowTestCase):
         im = BmpImagePlugin.DibImageFile('Tests/images/clipboard.dib')
         target = Image.open('Tests/images/clipboard_target.png')
         self.assert_image_equal(im, target)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_bufrstub.py
+++ b/Tests/test_file_bufrstub.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import BufrStubImagePlugin, Image
 
@@ -40,7 +40,3 @@ class TestFileBufrStub(PillowTestCase):
 
         # Act / Assert: stub cannot save without an implemented handler
         self.assertRaises(IOError, im.save, tmpfile)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_container.py
+++ b/Tests/test_file_container.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 from PIL import ContainerIO
@@ -123,7 +123,3 @@ class TestFileContainer(PillowTestCase):
             # Assert
 
             self.assertEqual(data, expected)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_cur.py
+++ b/Tests/test_file_cur.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image, CurImagePlugin
 
@@ -29,7 +29,3 @@ class TestFileCur(PillowTestCase):
         cur.fp.close()
         with open(no_cursors_file, "rb") as cur.fp:
             self.assertRaises(TypeError, cur._open)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_dcx.py
+++ b/Tests/test_file_dcx.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image, DcxImagePlugin
 
@@ -64,7 +64,3 @@ class TestFileDcx(PillowTestCase):
 
         # Act / Assert
         self.assertRaises(EOFError, im.seek, frame)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_dds.py
+++ b/Tests/test_file_dds.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 from PIL import Image, DdsImagePlugin
 
 TEST_FILE_DXT1 = "Tests/images/dxt1-rgb-4bbp-noalpha_MipMaps-1.dds"
@@ -110,7 +110,3 @@ class TestFileDds(PillowTestCase):
             im.load()
 
         self.assertRaises(IOError, short_file)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -251,7 +251,3 @@ class TestFileEps(PillowTestCase):
         self.assertEqual(image.mode, "RGB")
         self.assertEqual(image.size, (460, 352))
         self.assertEqual(image.format, "EPS")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_fitsstub.py
+++ b/Tests/test_file_fitsstub.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import FitsStubImagePlugin, Image
 
@@ -44,7 +44,3 @@ class TestFileFitsStub(PillowTestCase):
         self.assertRaises(
             IOError,
             FitsStubImagePlugin._save, im, dummy_fp, dummy_filename)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image, FliImagePlugin
 
@@ -97,7 +97,3 @@ class TestFileFli(PillowTestCase):
 
         expected = Image.open("Tests/images/a_fli.png")
         self.assert_image_equal(im, expected)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_fpx.py
+++ b/Tests/test_file_fpx.py
@@ -21,7 +21,3 @@ class TestFileFpx(PillowTestCase):
         ole_file = "Tests/images/test-ole-file.doc"
         self.assertRaises(SyntaxError,
                           FpxImagePlugin.FpxImageFile, ole_file)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_ftex.py
+++ b/Tests/test_file_ftex.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 from PIL import Image
 
 
@@ -14,7 +14,3 @@ class TestFileFtex(PillowTestCase):
         im = Image.open('Tests/images/ftex_dxt1.ftc')
         target = Image.open('Tests/images/ftex_dxt1.png')
         self.assert_image_similar(im, target.convert('RGBA'), 15)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_gbr.py
+++ b/Tests/test_file_gbr.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image, GbrImagePlugin
 
@@ -17,7 +17,3 @@ class TestFileGbr(PillowTestCase):
         target = Image.open('Tests/images/gbr.png')
 
         self.assert_image_equal(target, im)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_gd.py
+++ b/Tests/test_file_gd.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import GdImageFile
 
@@ -20,7 +20,3 @@ class TestFileGd(PillowTestCase):
         invalid_file = "Tests/images/flower.jpg"
 
         self.assertRaises(IOError, GdImageFile.open, invalid_file)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -654,7 +654,3 @@ class TestFileGif(PillowTestCase):
         self.assertEqual(im.tile[0][3][0], 11)  # LZW bits
         # codec error prepatch
         im.load()
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_gimpgradient.py
+++ b/Tests/test_file_gimpgradient.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import GimpGradientFile
 
@@ -119,7 +119,3 @@ class TestImage(PillowTestCase):
         # load returns raw palette information
         self.assertEqual(len(palette[0]), 1024)
         self.assertEqual(palette[1], "RGBA")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_gimppalette.py
+++ b/Tests/test_file_gimppalette.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL.GimpPaletteFile import GimpPaletteFile
 
@@ -28,7 +28,3 @@ class TestImage(PillowTestCase):
 
         # Assert
         self.assertEqual(mode, "RGB")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_gribstub.py
+++ b/Tests/test_file_gribstub.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import GribStubImagePlugin, Image
 
@@ -40,7 +40,3 @@ class TestFileGribStub(PillowTestCase):
 
         # Act / Assert: stub cannot save without an implemented handler
         self.assertRaises(IOError, im.save, tmpfile)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_hdf5stub.py
+++ b/Tests/test_file_hdf5stub.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Hdf5StubImagePlugin, Image
 
@@ -44,7 +44,3 @@ class TestFileHdf5Stub(PillowTestCase):
         self.assertRaises(
             IOError,
             Hdf5StubImagePlugin._save, im, dummy_fp, dummy_filename)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -121,7 +121,3 @@ class TestFileIcns(PillowTestCase):
         with io.BytesIO(b'invalid\n') as fp:
             self.assertRaises(SyntaxError,
                               IcnsImagePlugin.IcnsFile, fp)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 import io
 from PIL import Image, IcoImagePlugin
@@ -82,7 +82,3 @@ class TestFileIco(PillowTestCase):
         self.assertEqual(
             im_saved.info['sizes'],
             {(16, 16), (24, 24), (32, 32), (48, 48)})
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image, ImImagePlugin
 
@@ -69,7 +69,3 @@ class TestFileIm(PillowTestCase):
 
     def test_number(self):
         self.assertEqual(1.2, ImImagePlugin.number("1.2"))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_iptc.py
+++ b/Tests/test_file_iptc.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image, IptcImagePlugin
 
@@ -69,7 +69,3 @@ class TestFileIptc(PillowTestCase):
 
         # Assert
         self.assertEqual(mystdout.getvalue(), "61 62 63 \n")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -602,7 +602,3 @@ class TestFileCloseW32(PillowTestCase):
         self.assertTrue(fp.closed)
         # this should not fail, as load should have closed the file.
         os.remove(tmpfile)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image, Jpeg2KImagePlugin
 from io import BytesIO
@@ -210,7 +210,3 @@ class TestFileJpeg2k(PillowTestCase):
 
         # Assert
         self.assertEqual(p.image.size, (640, 480))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 from PIL import features
 from PIL._util import py3
 
@@ -700,7 +700,3 @@ class TestFileLibTiff(LibTiffTestCase):
         im = Image.open(infile)
 
         self.assert_image_similar_tofile(im, "Tests/images/flower.jpg", 0.5)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_libtiff_small.py
+++ b/Tests/test_file_libtiff_small.py
@@ -1,5 +1,3 @@
-from .helper import unittest
-
 from PIL import Image
 
 from .test_file_libtiff import LibTiffTestCase
@@ -46,7 +44,3 @@ class TestFileLibTiffSmall(LibTiffTestCase):
 
         self.assertEqual(im.size, (128, 128))
         self._assert_noerr(im)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_mcidas.py
+++ b/Tests/test_file_mcidas.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image, McIdasImagePlugin
 
@@ -28,7 +28,3 @@ class TestFileMcIdas(PillowTestCase):
         self.assertEqual(im.size, (1800, 400))
         im2 = Image.open(saved_file)
         self.assert_image_equal(im, im2)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_mic.py
+++ b/Tests/test_file_mic.py
@@ -64,7 +64,3 @@ class TestFileMic(PillowTestCase):
         ole_file = "Tests/images/test-ole-file.doc"
         self.assertRaises(SyntaxError,
                           MicImagePlugin.MicImageFile, ole_file)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 from io import BytesIO
 from PIL import Image
 
@@ -142,7 +142,3 @@ class TestFileMpo(PillowTestCase):
             self.assertEqual(im.tell(), 1)
             jpg1 = self.frame_roundtrip(im)
             self.assert_image_similar(im, jpg1, 30)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_msp.py
+++ b/Tests/test_file_msp.py
@@ -78,7 +78,3 @@ class TestFileMsp(PillowTestCase):
 
         # Act/Assert
         self.assertRaises(IOError, im.save, filename)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_palm.py
+++ b/Tests/test_file_palm.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper, imagemagick_available
+from .helper import PillowTestCase, hopper, imagemagick_available
 
 import os.path
 
@@ -52,7 +52,3 @@ class TestFilePalm(PillowTestCase):
 
         # Act / Assert
         self.assertRaises(IOError, self.helper_save_as_palm, mode)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_pcd.py
+++ b/Tests/test_file_pcd.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 from PIL import Image
 
 
@@ -16,7 +16,3 @@ class TestFilePcd(PillowTestCase):
 
         # target = hopper().resize((768,512))
         # self.assert_image_similar(im, target, 10)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_pcx.py
+++ b/Tests/test_file_pcx.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image, ImageFile, PcxImagePlugin
 
@@ -128,7 +128,3 @@ class TestFilePcx(PillowTestCase):
         for x in range(5):
             px[x, 3] = 0
         self._test_buffer_overflow(im)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 from PIL import Image, PdfParser
 import io
 import os
@@ -266,7 +266,3 @@ class TestFilePdf(PillowTestCase):
         f = io.BytesIO(f.getvalue())
         im.save(f, format="PDF", append=True)
         self.assertGreater(len(f.getvalue()), initial_size)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_pixar.py
+++ b/Tests/test_file_pixar.py
@@ -1,4 +1,4 @@
-from .helper import hopper, unittest, PillowTestCase
+from .helper import hopper, PillowTestCase
 
 from PIL import Image, PixarImagePlugin
 
@@ -24,7 +24,3 @@ class TestFilePixar(PillowTestCase):
         self.assertRaises(
             SyntaxError,
             PixarImagePlugin.PixarImageFile, invalid_file)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -626,7 +626,3 @@ class TestTruncatedPngPLeaks(PillowLeakTestCase):
             self._test_leak(core)
         finally:
             ImageFile.LOAD_TRUNCATED_IMAGES = False
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image
 
@@ -49,7 +49,3 @@ class TestFilePpm(PillowTestCase):
 
         with self.assertRaises(IOError):
             Image.open('Tests/images/negative_size.ppm')
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -1,4 +1,4 @@
-from .helper import hopper, unittest, PillowTestCase
+from .helper import hopper, PillowTestCase
 
 from PIL import Image, PsdImagePlugin
 
@@ -76,7 +76,3 @@ class TestImagePsd(PillowTestCase):
         im = Image.open("Tests/images/hopper_merged.psd")
 
         self.assertNotIn("icc_profile", im.info)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_sgi.py
+++ b/Tests/test_file_sgi.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image, SgiImagePlugin
 
@@ -89,7 +89,3 @@ class TestFileSgi(PillowTestCase):
         out = self.tempfile('temp.sgi')
 
         self.assertRaises(ValueError, im.save, out, format='sgi')
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 from PIL import ImageSequence
@@ -119,7 +119,3 @@ class TestImageSpider(PillowTestCase):
         for i, frame in enumerate(ImageSequence.Iterator(im)):
             if i > 1:
                 self.fail("Non-stack DOS file test failed")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_sun.py
+++ b/Tests/test_file_sun.py
@@ -45,7 +45,3 @@ class TestFileSun(PillowTestCase):
                 # im.save(target_file)
                 with Image.open(target_path) as target:
                     self.assert_image_equal(im, target)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_tar.py
+++ b/Tests/test_file_tar.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image, TarIO
 
@@ -34,7 +34,3 @@ class TestFileTar(PillowTestCase):
     def test_contextmanager(self):
         with TarIO.TarIO(TEST_TAR_FILE, 'hopper.jpg'):
             pass
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_tga.py
+++ b/Tests/test_file_tga.py
@@ -2,7 +2,7 @@ import os
 from glob import glob
 from itertools import product
 
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image
 
@@ -201,7 +201,3 @@ class TestFileTga(PillowTestCase):
             test_im.getchannel("A").getcolors()[0][0], num_transparent)
 
         self.assert_image_equal(im, test_im)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -565,7 +565,3 @@ class TestFileTiffW32(PillowTestCase):
         # this should not fail, as load should have closed the file pointer,
         # and close should have closed the mmap
         os.remove(tmpfile)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -1,7 +1,7 @@
 import io
 import struct
 
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image, TiffImagePlugin, TiffTags
 from PIL.TiffImagePlugin import _limit_rational, IFDRational
@@ -247,7 +247,3 @@ class TestFileTiffMetadata(PillowTestCase):
 
         # Should not raise ValueError.
         self.assert_warning(UserWarning, lambda: ifd[277])
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_wal.py
+++ b/Tests/test_file_wal.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import WalImageFile
 
@@ -17,7 +17,3 @@ class TestFileWal(PillowTestCase):
         self.assertEqual(im.format_description, "Quake2 Texture")
         self.assertEqual(im.mode, "P")
         self.assertEqual(im.size, (128, 128))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -172,7 +172,3 @@ class TestFileWebp(PillowTestCase):
         difference = sum([abs(original_value[i] - reread_value[i])
                           for i in range(0, 3)])
         self.assertLess(difference, 5)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_webp_alpha.py
+++ b/Tests/test_file_webp_alpha.py
@@ -115,7 +115,3 @@ class TestFileWebpAlpha(PillowTestCase):
         target = Image.open(file_path).convert("RGBA")
 
         self.assert_image_similar(image, target, 25.0)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_webp_animated.py
+++ b/Tests/test_file_webp_animated.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image
 
@@ -151,7 +151,3 @@ class TestFileWebpAnimation(PillowTestCase):
             self.assertEqual(im.info["duration"], dur)
             self.assertEqual(im.info["timestamp"], ts)
             ts -= dur
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_webp_lossless.py
+++ b/Tests/test_file_webp_lossless.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 
@@ -36,7 +36,3 @@ class TestFileWebpLossless(PillowTestCase):
         image.getdata()
 
         self.assert_image_equal(image, hopper(self.rgb_mode))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_webp_metadata.py
+++ b/Tests/test_file_webp_metadata.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image
 
@@ -133,7 +133,3 @@ class TestFileWebpMetadata(PillowTestCase):
         self.assertEqual(iccp_data, image.info.get('icc_profile', None))
         self.assertEqual(exif_data, image.info.get('exif', None))
         self.assertEqual(xmp_data, image.info.get('xmp', None))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 from PIL import WmfImagePlugin
@@ -51,7 +51,3 @@ class TestFileWmf(PillowTestCase):
         for ext in [".wmf", ".emf"]:
             tmpfile = self.tempfile("temp"+ext)
             self.assertRaises(IOError, im.save, tmpfile)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_xbm.py
+++ b/Tests/test_file_xbm.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image
 
@@ -60,7 +60,3 @@ class TestFileXbm(PillowTestCase):
         # Assert
         self.assertEqual(im.mode, '1')
         self.assertEqual(im.size, (128, 128))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_xpm.py
+++ b/Tests/test_file_xpm.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image, XpmImagePlugin
 
@@ -33,7 +33,3 @@ class TestFileXpm(PillowTestCase):
 
         # Assert
         self.assertEqual(len(data), 16384)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_file_xvthumb.py
+++ b/Tests/test_file_xvthumb.py
@@ -1,4 +1,4 @@
-from .helper import hopper, unittest, PillowTestCase
+from .helper import hopper, PillowTestCase
 
 from PIL import Image, XVThumbImagePlugin
 
@@ -34,7 +34,3 @@ class TestFileXVThumb(PillowTestCase):
         # Act / Assert
         self.assertRaises(SyntaxError,
                           XVThumbImagePlugin.XVThumbImageFile, invalid_file)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_font_bdf.py
+++ b/Tests/test_font_bdf.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import FontFile, BdfFontFile
 
@@ -18,7 +18,3 @@ class TestFontBdf(PillowTestCase):
     def test_invalid_file(self):
         with open("Tests/images/flower.jpg", "rb") as fp:
             self.assertRaises(SyntaxError, BdfFontFile.BdfFontFile, fp)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_font_leaks.py
+++ b/Tests/test_font_leaks.py
@@ -31,7 +31,3 @@ class TestDefaultFontLeak(TestTTypeFontLeak):
     def test_leak(self):
         default_font = ImageFont.load_default()
         self._test_font(default_font)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_font_pcf.py
+++ b/Tests/test_font_pcf.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image, FontFile, PcfFontFile
 from PIL import ImageFont, ImageDraw
@@ -79,7 +79,3 @@ class TestFontPcf(PillowTestCase):
         # accept bytes instances in Py3.
         if py3:
             self._test_high_characters(message.encode('latin1'))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_format_hsv.py
+++ b/Tests/test_format_hsv.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 from PIL._util import py3
@@ -129,7 +129,3 @@ class TestFormatHSV(PillowTestCase):
         self.assert_image_similar(converted.getchannel(2),
                                   comparable.getchannel(2),
                                   3, "B conversion is wrong")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_format_lab.py
+++ b/Tests/test_format_lab.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image
 
@@ -40,7 +40,3 @@ class TestFormatLab(PillowTestCase):
 
         k = i.getpixel((0, 0))
         self.assertEqual(k, (128, 228, 128))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -560,7 +560,3 @@ class TestRegistry(PillowTestCase):
                                                       'DoesNotExist',
                                                       ('args',),
                                                       extra=('extra',))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -366,7 +366,3 @@ int main(int argc, char* argv[])
         process = subprocess.Popen(['embed_pil.exe'], env=env)
         process.communicate()
         self.assertEqual(process.returncode, 0)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_array.py
+++ b/Tests/test_image_array.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 
@@ -55,7 +55,3 @@ class TestImageArray(PillowTestCase):
         self.assertEqual(test("RGB"), ("RGB", (128, 100), True))
         self.assertEqual(test("RGBA"), ("RGBA", (128, 100), True))
         self.assertEqual(test("RGBX"), ("RGBA", (128, 100), True))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 
@@ -230,7 +230,3 @@ class TestImageConvert(PillowTestCase):
         # Assert
         # No change
         self.assert_image_equal(converted_im, im)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_copy.py
+++ b/Tests/test_image_copy.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 
@@ -40,7 +40,3 @@ class TestImageCopy(PillowTestCase):
         out = im.copy()
         self.assertEqual(out.mode, im.mode)
         self.assertEqual(out.size, im.size)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_crop.py
+++ b/Tests/test_image_crop.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 
@@ -102,7 +102,3 @@ class TestImageCrop(PillowTestCase):
         cropped = im.crop((10, 10, 20, 20))
         self.assertEqual(cropped.size, (10, 10))
         self.assertEqual(cropped.getdata()[2], (0, 0, 0))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_draft.py
+++ b/Tests/test_image_draft.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, fromstring, tostring
+from .helper import PillowTestCase, fromstring, tostring
 
 from PIL import Image
 
@@ -69,7 +69,3 @@ class TestImageDraft(PillowTestCase):
         im = self.draft_roundtrip('L', (128, 128), None, (64, 64))
         im.draft(None, (64, 64))
         im.load()
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image, ImageFilter
 
@@ -136,7 +136,3 @@ class TestImageFilter(PillowTestCase):
                 Image.merge(mode, source[:len(mode)]).filter(kernel),
                 Image.merge(mode, reference[:len(mode)]),
             )
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_frombytes.py
+++ b/Tests/test_image_frombytes.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 
@@ -13,7 +13,3 @@ class TestImageFromBytes(PillowTestCase):
 
     def test_not_implemented(self):
         self.assertRaises(NotImplementedError, Image.fromstring)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_fromqimage.py
+++ b/Tests/test_image_fromqimage.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 from .test_imageqt import PillowQtTestCase
 
 from PIL import ImageQt, Image
@@ -42,7 +42,3 @@ class TestFromQImage(PillowQtTestCase, PillowTestCase):
     def test_sanity_p(self):
         for im in self.files_to_test:
             self.roundtrip(im.convert('P'))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_getbands.py
+++ b/Tests/test_image_getbands.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image
 
@@ -18,7 +18,3 @@ class TestImageGetBands(PillowTestCase):
             Image.new("CMYK", (1, 1)).getbands(), ("C", "M", "Y", "K"))
         self.assertEqual(
             Image.new("YCbCr", (1, 1)).getbands(), ("Y", "Cb", "Cr"))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_getbbox.py
+++ b/Tests/test_image_getbbox.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 
@@ -37,7 +37,3 @@ class TestImageGetBbox(PillowTestCase):
 
         im.paste(255, (-10, -10, 110, 110))
         self.assertEqual(im.getbbox(), (0, 0, 100, 100))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_getcolors.py
+++ b/Tests/test_image_getcolors.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 
 class TestImageGetColors(PillowTestCase):
@@ -65,7 +65,3 @@ class TestImageGetColors(PillowTestCase):
         A = im.getcolors(maxcolors=16)
         A.sort()
         self.assertEqual(A, expected)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_getdata.py
+++ b/Tests/test_image_getdata.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 
 class TestImageGetData(PillowTestCase):
@@ -27,7 +27,3 @@ class TestImageGetData(PillowTestCase):
         self.assertEqual(getdata("RGBA"), ((11, 13, 52, 255), 960, 960))
         self.assertEqual(getdata("CMYK"), ((244, 242, 203, 0), 960, 960))
         self.assertEqual(getdata("YCbCr"), ((16, 147, 123), 960, 960))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_getextrema.py
+++ b/Tests/test_image_getextrema.py
@@ -1,5 +1,5 @@
 from PIL import Image
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 
 class TestImageGetExtrema(PillowTestCase):
@@ -27,7 +27,3 @@ class TestImageGetExtrema(PillowTestCase):
         self.assertEqual(im.mode, 'I;16')
         extrema = im.getextrema()
         self.assertEqual(extrema, (106, 285))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_getim.py
+++ b/Tests/test_image_getim.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 from PIL._util import py3
 
 
@@ -12,7 +12,3 @@ class TestImageGetIm(PillowTestCase):
             self.assertIn("PyCapsule", type_repr)
 
         self.assertIsInstance(im.im.id, int)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_getpalette.py
+++ b/Tests/test_image_getpalette.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 
 class TestImageGetPalette(PillowTestCase):
@@ -18,7 +18,3 @@ class TestImageGetPalette(PillowTestCase):
         self.assertIsNone(palette("RGBA"))
         self.assertIsNone(palette("CMYK"))
         self.assertIsNone(palette("YCbCr"))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_getprojection.py
+++ b/Tests/test_image_getprojection.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 
@@ -30,7 +30,3 @@ class TestImageGetProjection(PillowTestCase):
         im.paste(255, (2, 4, 8, 6))
         self.assertEqual(im.getprojection()[0], [0, 0, 1, 1, 1, 1, 1, 1, 0, 0])
         self.assertEqual(im.getprojection()[1], [0, 0, 0, 0, 1, 1, 0, 0, 0, 0])
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_histogram.py
+++ b/Tests/test_image_histogram.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 
 class TestImageHistogram(PillowTestCase):
@@ -18,7 +18,3 @@ class TestImageHistogram(PillowTestCase):
         self.assertEqual(histogram("RGBA"), (1024, 0, 16384))
         self.assertEqual(histogram("CMYK"), (1024, 0, 16384))
         self.assertEqual(histogram("YCbCr"), (768, 0, 1908))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_load.py
+++ b/Tests/test_image_load.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 
@@ -28,7 +28,3 @@ class TestImageLoad(PillowTestCase):
             os.fstat(fn)
 
         self.assertRaises(OSError, os.fstat, fn)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_mode.py
+++ b/Tests/test_image_mode.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 
@@ -51,7 +51,3 @@ class TestImageMode(PillowTestCase):
         check("RGBX", "RGB", "L", 4, ("R", "G", "B", "X"))
         check("CMYK", "RGB", "L", 4, ("C", "M", "Y", "K"))
         check("YCbCr", "RGB", "L", 3, ("Y", "Cb", "Cr"))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_paste.py
+++ b/Tests/test_image_paste.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, cached_property
+from .helper import PillowTestCase, cached_property
 
 from PIL import Image
 
@@ -250,7 +250,3 @@ class TestImagingPaste(PillowTestCase):
 
         im.copy().paste(im2)
         im.copy().paste(im2, (0, 0))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_point.py
+++ b/Tests/test_image_point.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 
 class TestImagePoint(PillowTestCase):
@@ -38,7 +38,3 @@ class TestImagePoint(PillowTestCase):
     def test_f_mode(self):
         im = hopper('F')
         self.assertRaises(ValueError, im.point, None)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_putalpha.py
+++ b/Tests/test_image_putalpha.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image
 
@@ -44,7 +44,3 @@ class TestImagePutAlpha(PillowTestCase):
         self.assertFalse(im.readonly)
         self.assertEqual(im.mode, 'RGBA')
         self.assertEqual(im.getpixel((0, 0)), (1, 2, 3, 4))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_putdata.py
+++ b/Tests/test_image_putdata.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 from array import array
 
 import sys
@@ -83,7 +83,3 @@ class TestImagePutData(PillowTestCase):
         im.putdata(arr)
 
         self.assertEqual(len(im.getdata()), len(arr))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_putpalette.py
+++ b/Tests/test_image_putpalette.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import ImagePalette
 
@@ -28,7 +28,3 @@ class TestImagePutPalette(PillowTestCase):
         im.putpalette(ImagePalette.random())
         im.putpalette(ImagePalette.sepia())
         im.putpalette(ImagePalette.wedge())
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 
@@ -46,7 +46,3 @@ class TestImageQuantize(PillowTestCase):
         converted = image.quantize()
         self.assert_image(converted, 'P', converted.size)
         self.assert_image_similar(converted.convert('RGB'), image, 1)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -544,7 +544,3 @@ class CoreResampleBoxTest(PillowTestCase):
                 except AssertionError:
                     print('>>>', size, box, flt)
                     raise
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -3,7 +3,7 @@ Tests for resize functionality.
 """
 from itertools import permutations
 
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 
@@ -115,7 +115,3 @@ class TestImageResize(PillowTestCase):
         # Test unknown resampling filter
         im = hopper()
         self.assertRaises(ValueError, im.resize, (10, 10), "unknown")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_rotate.py
+++ b/Tests/test_image_rotate.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 from PIL import Image
 
 
@@ -123,7 +123,3 @@ class TestImageRotate(PillowTestCase):
         im = im.rotate(45, expand=1, fillcolor=(255, 0, 0, 255))
         corner = im.getpixel((0, 0))
         self.assertEqual(corner, (255, 0, 0, 255))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_split.py
+++ b/Tests/test_image_split.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 
@@ -59,7 +59,3 @@ class TestImageSplit(PillowTestCase):
         self.assertEqual(split_open("RGB"), 3)
         if 'zip_encoder' in codecs:
             self.assertEqual(split_open("RGBA"), 4)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 
 class TestImageThumbnail(PillowTestCase):
@@ -35,7 +35,3 @@ class TestImageThumbnail(PillowTestCase):
         im = hopper().resize((128, 128))
         im.thumbnail((100, 100))
         self.assert_image(im, im.mode, (100, 100))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_tobitmap.py
+++ b/Tests/test_image_tobitmap.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper, fromstring
+from .helper import PillowTestCase, hopper, fromstring
 
 
 class TestImageToBitmap(PillowTestCase):
@@ -13,7 +13,3 @@ class TestImageToBitmap(PillowTestCase):
 
         self.assertIsInstance(bitmap, bytes)
         self.assert_image_equal(im1, fromstring(bitmap))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_tobytes.py
+++ b/Tests/test_image_tobytes.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 
 class TestImageToBytes(PillowTestCase):
@@ -6,7 +6,3 @@ class TestImageToBytes(PillowTestCase):
     def test_sanity(self):
         data = hopper().tobytes()
         self.assertIsInstance(data, bytes)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -1,6 +1,6 @@
 import math
 
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 
@@ -271,7 +271,3 @@ class TestImageTransformAffine(PillowTestCase):
 class TestImageTransformPerspective(TestImageTransformAffine):
     # Repeat all tests for AFFINE transformations with PERSPECTIVE
     transform = Image.PERSPECTIVE
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_image_transpose.py
+++ b/Tests/test_image_transpose.py
@@ -1,5 +1,5 @@
 from . import helper
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL.Image import (FLIP_LEFT_RIGHT, FLIP_TOP_BOTTOM, ROTATE_90, ROTATE_180,
                        ROTATE_270, TRANSPOSE, TRANSVERSE)
@@ -146,7 +146,3 @@ class TestImageTranspose(PillowTestCase):
             im.transpose(TRANSVERSE), transpose(ROTATE_270, FLIP_TOP_BOTTOM))
         self.assert_image_equal(
             im.transpose(TRANSVERSE), transpose(ROTATE_180, TRANSPOSE))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagechops.py
+++ b/Tests/test_imagechops.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 from PIL import ImageChops
@@ -373,7 +373,3 @@ class TestImageChops(PillowTestCase):
             table(ImageChops.logical_or, 0, 255), (0, 255, 255, 255))
         self.assertEqual(
             table(ImageChops.logical_xor, 0, 255), (0, 255, 255, 0))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 import datetime
 
 from PIL import Image, ImageMode
@@ -514,7 +514,3 @@ class TestImageCms(PillowTestCase):
 
                     self.assert_image_equal(test_image.convert(dst_format[2]),
                                             reference_image)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagecolor.py
+++ b/Tests/test_imagecolor.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image
 from PIL import ImageColor
@@ -192,7 +192,3 @@ class TestImageColor(PillowTestCase):
         self.assertEqual(
             (162, 33), ImageColor.getcolor("rgba(0, 255, 115, 33)", "LA"))
         Image.new("LA", (1, 1), "white")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -1,6 +1,6 @@
 import os.path
 
-from .helper import PillowTestCase, hopper, unittest
+from .helper import PillowTestCase, hopper
 from PIL import Image, ImageColor, ImageDraw
 
 BLACK = (0, 0, 0)
@@ -762,7 +762,3 @@ class TestImageDraw(PillowTestCase):
                     expected = ("Tests/images/imagedraw_outline"
                                 "_{}_{}.png".format(operation, mode))
                     self.assert_image_similar(im, Image.open(expected), 1)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagedraw2.py
+++ b/Tests/test_imagedraw2.py
@@ -223,7 +223,3 @@ class TestImageDraw(PillowTestCase):
 
         # Assert
         self.assert_image_equal(im, im2)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/Tests/test_imageenhance.py
+++ b/Tests/test_imageenhance.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 from PIL import ImageEnhance
@@ -48,7 +48,3 @@ class TestImageEnhance(PillowTestCase):
                 self._check_alpha(
                     getattr(ImageEnhance, op)(original).enhance(amount),
                     original, op, amount)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper, fromstring, tostring
+from .helper import PillowTestCase, hopper, fromstring, tostring
 
 from io import BytesIO
 
@@ -233,7 +233,3 @@ class TestPyDecoder(PillowTestCase):
         im = MockImageFile(buf)
         self.assertIsNone(im.format)
         self.assertIsNone(im.get_format_mimetype())
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -529,7 +529,3 @@ class TestImageFont(PillowTestCase):
 @unittest.skipUnless(HAS_RAQM, "Raqm not Available")
 class TestImageFont_RaqmLayout(TestImageFont):
     LAYOUT_ENGINE = ImageFont.LAYOUT_RAQM
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagefont_bitmap.py
+++ b/Tests/test_imagefont_bitmap.py
@@ -34,7 +34,3 @@ class TestImageFontBitmap(PillowTestCase):
         draw_outline.text((0, size_final[1] - size_outline[1]),
                           text, fill=(0, 0, 0), font=font_outline)
         self.assert_image_similar(im_bitmap, im_outline, 20)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagefontctl.py
+++ b/Tests/test_imagefontctl.py
@@ -130,9 +130,3 @@ class TestImagecomplextext(PillowTestCase):
         target_img = Image.open(target)
 
         self.assert_image_similar(im, target_img, .5)
-
-
-if __name__ == '__main__':
-    unittest.main()
-
-# End of file

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 import sys
 import subprocess
@@ -53,7 +53,3 @@ class TestImageGrabImport(PillowTestCase):
             self.assertIsInstance(exception, ImportError)
             self.assertEqual(str(exception),
                              "ImageGrab is macOS and Windows only")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagemath.py
+++ b/Tests/test_imagemath.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image
 from PIL import ImageMath
@@ -182,7 +182,3 @@ class TestImageMath(PillowTestCase):
             pixel(ImageMath.eval("notequal(B, A)", A=A, B=B)), "I 1")
         self.assertEqual(
             pixel(ImageMath.eval("notequal(A, Z)", A=A, Z=Z)), "I 1")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagemorph.py
+++ b/Tests/test_imagemorph.py
@@ -1,5 +1,5 @@
 # Test the ImageMorphology functionality
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image, ImageMorph, _imagingmorph
 
@@ -321,7 +321,3 @@ class MorphTests(PillowTestCase):
 
         # Should not raise
         _imagingmorph.match(bytes(lut), iml.im.id)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import ImageOps
 from PIL import Image
@@ -218,7 +218,3 @@ class TestImageOps(PillowTestCase):
                                        (0, 127, 0),
                                        threshold=1,
                                        msg='white test pixel incorrect')
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imageops_usm.py
+++ b/Tests/test_imageops_usm.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image
 from PIL import ImageFilter
@@ -73,7 +73,3 @@ class TestImageOpsUsm(PillowTestCase):
         self.assertTrue(236 <= gp(8, 5)[2] <= 239)
         self.assertTrue(236 <= gp(8, 6)[2] <= 239)
         self.assertTrue(236 <= gp(8, 7)[1] <= 239)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import ImagePalette, Image
 
@@ -134,7 +134,3 @@ class TestImagePalette(PillowTestCase):
     def test_invalid_palette(self):
         self.assertRaises(IOError,
                           ImagePalette.load, "Tests/images/hopper.jpg")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagepath.py
+++ b/Tests/test_imagepath.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import ImagePath, Image
 from PIL._util import py3
@@ -94,7 +94,3 @@ class evil:
 
     def __setitem__(self, i, x):
         self.corrupt[i] = struct.unpack("dd", x)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imageqt.py
+++ b/Tests/test_imageqt.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import ImageQt
 
@@ -78,7 +78,3 @@ class TestImageQt(PillowQtTestCase, PillowTestCase):
     def test_image(self):
         for mode in ('1', 'RGB', 'RGBA', 'L', 'P'):
             ImageQt.ImageQt(hopper(mode))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagesequence.py
+++ b/Tests/test_imagesequence.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image, ImageSequence, TiffImagePlugin
 
@@ -69,7 +69,3 @@ class TestImageSequence(PillowTestCase):
         im.seek(0)
         color2 = im.getpalette()[0:3]
         self.assertEqual(color1, color2)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 from PIL import ImageShow
@@ -44,7 +44,3 @@ class TestImageShow(PillowTestCase):
     def test_viewers(self):
         for viewer in ImageShow._viewers:
             viewer.get_command('test.jpg')
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagestat.py
+++ b/Tests/test_imagestat.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 from PIL import ImageStat
@@ -55,7 +55,3 @@ class TestImageStat(PillowTestCase):
         self.assertEqual(st.rms[0], 128)
         self.assertEqual(st.var[0], 0)
         self.assertEqual(st.stddev[0], 0)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagetk.py
+++ b/Tests/test_imagetk.py
@@ -87,7 +87,3 @@ class TestImageTk(PillowTestCase):
 
         # reloaded = ImageTk.getimage(im_tk)
         # self.assert_image_equal(reloaded, im)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagewin.py
+++ b/Tests/test_imagewin.py
@@ -106,7 +106,3 @@ class TestImageWinDib(PillowTestCase):
         # Assert
         # Confirm they're the same
         self.assertEqual(dib1.tobytes(), dib2.tobytes())
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_imagewin_pointers.py
+++ b/Tests/test_imagewin_pointers.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 from PIL import Image, ImageWin
 
 import sys
@@ -107,6 +107,3 @@ if sys.platform.startswith('win32'):
             DeleteDC(hdc)
 
             Image.open(BytesIO(bitmap)).save(opath)
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_lib_pack.py
+++ b/Tests/test_lib_pack.py
@@ -1,6 +1,6 @@
 import sys
 
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image
 
@@ -620,7 +620,3 @@ class TestLibUnpack(PillowTestCase):
         self.assertRaises(ValueError, self.assert_unpack, "L", "L", 0, 0)
         self.assertRaises(ValueError, self.assert_unpack, "RGB", "RGB", 2, 0)
         self.assertRaises(ValueError, self.assert_unpack, "CMYK", "CMYK", 2, 0)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_locale.py
+++ b/Tests/test_locale.py
@@ -32,7 +32,3 @@ class TestLocale(PillowTestCase):
         except locale.Error:
             unittest.skip('Polish locale not available')
         Image.open(path)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_map.py
+++ b/Tests/test_map.py
@@ -23,7 +23,3 @@ class TestMap(PillowTestCase):
             im.load()
 
         Image.MAX_IMAGE_PIXELS = max_pixels
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_mode_i16.py
+++ b/Tests/test_mode_i16.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import Image
 
@@ -105,7 +105,3 @@ class TestModeI16(PillowTestCase):
         self.verify(im.convert("I;16B"))
         self.verify(im.convert("I;16B").convert("L"))
         self.verify(im.convert("I;16B").convert("I"))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -208,7 +208,3 @@ class TestNumpy(PillowTestCase):
 
         # Act/Assert
         self.assert_warning(None, lambda: array(im))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_pdfparser.py
+++ b/Tests/test_pdfparser.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL.PdfParser import IndirectObjectDef, IndirectReference, PdfBinary, \
                           PdfDict, PdfFormatError, PdfName, PdfParser, \
@@ -122,7 +122,3 @@ class TestPdfParser(PillowTestCase):
         self.assertEqual(pdf_repr([123, True, {"a": PdfName(b"b")}]),
                          b"[ 123 true <<\n/a /b\n>> ]")
         self.assertEqual(pdf_repr(PdfBinary(b"\x90\x1F\xA0")), b"<901FA0>")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image
 
@@ -91,7 +91,3 @@ class TestPickle(PillowTestCase):
         for protocol in range(0, cPickle.HIGHEST_PROTOCOL + 1):
             self.helper_pickle_string(cPickle, protocol, mode="L")
             self.helper_pickle_file(cPickle, protocol, mode="L")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_psdraw.py
+++ b/Tests/test_psdraw.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import Image, PSDraw
 import os
@@ -61,7 +61,3 @@ class TestPsDraw(PillowTestCase):
         sys.stdout = old_stdout
 
         self.assertNotEqual(mystdout.getvalue(), "")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_pyroma.py
+++ b/Tests/test_pyroma.py
@@ -28,7 +28,3 @@ class TestPyroma(PillowTestCase):
         else:
             # Should have a perfect score
             self.assertEqual(rating, (10, []))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_qt_image_fromqpixmap.py
+++ b/Tests/test_qt_image_fromqpixmap.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 from .test_imageqt import PillowQPixmapTestCase
 
 from PIL import ImageQt
@@ -25,7 +25,3 @@ class TestFromQPixmap(PillowQPixmapTestCase, PillowTestCase):
 
     def test_sanity_p(self):
         self.roundtrip(hopper('P'))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_qt_image_toqimage.py
+++ b/Tests/test_qt_image_toqimage.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 from .test_imageqt import PillowQtTestCase
 
 from PIL import ImageQt, Image
@@ -91,7 +91,3 @@ if ImageQt.qt_is_installed:
             lbl = QLabel(self)
             # Segfault in the problem
             lbl.setPixmap(pixmap1.copy())
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_qt_image_toqpixmap.py
+++ b/Tests/test_qt_image_toqpixmap.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 from .test_imageqt import PillowQPixmapTestCase
 
 from PIL import ImageQt
@@ -19,7 +19,3 @@ class TestToQPixmap(PillowQPixmapTestCase, PillowTestCase):
             # Test saving the file
             tempfile = self.tempfile('temp_{}.png'.format(mode))
             data.save(tempfile)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_shell_injection.py
+++ b/Tests/test_shell_injection.py
@@ -51,7 +51,3 @@ class TestShellInjection(PillowTestCase):
     def test_save_netpbm_filename_l_mode(self):
         im = Image.open(TEST_GIF).convert("L")
         self.assert_save_filename_check(im, GifImagePlugin._save_netpbm)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_tiff_ifdrational.py
+++ b/Tests/test_tiff_ifdrational.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 from PIL import TiffImagePlugin, Image
 from PIL.TiffImagePlugin import IFDRational
@@ -58,7 +58,3 @@ class Test_IFDRational(PillowTestCase):
             reloaded = Image.open(out)
             self.assertEqual(float(IFDRational(301, 1)),
                              float(reloaded.tag_v2[282]))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_uploader.py
+++ b/Tests/test_uploader.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase, hopper
+from .helper import PillowTestCase, hopper
 
 
 class TestUploader(PillowTestCase):
@@ -11,7 +11,3 @@ class TestUploader(PillowTestCase):
         result = hopper('P').convert('RGB')
         target = hopper('RGB')
         self.assert_image_similar(result, target, 0)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_util.py
+++ b/Tests/test_util.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase
 
 from PIL import _util
 
@@ -74,7 +74,3 @@ class TestUtil(PillowTestCase):
 
         # Assert
         self.assertRaises(ValueError, lambda: thing.some_attr)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Tests/test_webp_leaks.py
+++ b/Tests/test_webp_leaks.py
@@ -20,7 +20,3 @@ class TestWebPLeaks(PillowLeakTestCase):
                 im.load()
 
         self._test_leak(core)
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
With the introduction and use of pytest, it is simple and easy to execute specific tests in isolation through documented command line arguments. Either by specifying the module path or through the `-k
EXPRESSION` argument. There is no longer any need to provide the boilerplate:

```py
if __name__ == '__main__':
    unittest.main()
```

To every test file. It is simply noise.

The pattern remains in test files that aren't named with `test_*` as those files are not discovered and executed by pytest by default.