### PR TITLE
Docs: Link to Codecov rather than Coveralls

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Please send a pull request to the master branch. Please include [documentation](
 - Fork the Pillow repository.
 - Create a branch from master.
 - Develop bug fixes, features, tests, etc.
-- Run the test suite on Python 2.7 and 3.x. You can enable [Travis CI](https://travis-ci.org/profile/) and [AppVeyor](https://ci.appveyor.com/projects/new) on your repo to catch test failures prior to the pull request, and [Coveralls](https://coveralls.io/repos/new) to see if the changed code is covered by tests.
+- Run the test suite on Python 2.7 and 3.x. You can enable [Travis CI](https://travis-ci.org/profile/) and [AppVeyor](https://ci.appveyor.com/projects/new) on your repo to catch test failures prior to the pull request, and [Codecov](https://codecov.io/gh) to see if the changed code is covered by tests.
 - Create a pull request to pull the changes from your branch to the Pillow master.
 
 ### Guidelines

--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,8 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
    :target: https://ci.appveyor.com/project/python-pillow/Pillow
    :alt: AppVeyor CI build status (Windows)
 
-.. |coverage| image:: https://coveralls.io/repos/python-pillow/Pillow/badge.svg?branch=master&service=github
-   :target: https://coveralls.io/github/python-pillow/Pillow?branch=master
+.. |coverage| image:: https://codecov.io/gh/python-pillow/Pillow/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/python-pillow/Pillow
    :alt: Code coverage
 
 .. |zenodo| image:: https://zenodo.org/badge/17549/python-pillow/Pillow.svg

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,8 +30,8 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
    :target: https://pypi.org/project/Pillow/
    :alt: Number of PyPI downloads
 
-.. image:: https://coveralls.io/repos/python-pillow/Pillow/badge.svg?branch=master&service=github
-   :target: https://coveralls.io/github/python-pillow/Pillow?branch=master
+.. |coverage| image:: https://codecov.io/gh/python-pillow/Pillow/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/python-pillow/Pillow
    :alt: Code coverage
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.
    :target: https://pypi.org/project/Pillow/
    :alt: Number of PyPI downloads
 
-.. |coverage| image:: https://codecov.io/gh/python-pillow/Pillow/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/python-pillow/Pillow/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/python-pillow/Pillow
    :alt: Code coverage
 


### PR DESCRIPTION
Codecov is our primary coverage tool.