### PR TITLE
Test Python 3.8-dev ahead of 3.8.0's expected 2019-10-20 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ matrix:
       name: "3.5 Trusty PYTHONOPTIMIZE=2"
       dist: trusty
       env: PYTHONOPTIMIZE=2
+    - python: "3.8-dev"
+      name: "3.8-dev Xenial"
     - env: DOCKER="alpine" DOCKER_TAG="master"
     - env: DOCKER="arch" DOCKER_TAG="master" # contains PyQt5
     - env: DOCKER="ubuntu-trusty-x86" DOCKER_TAG="master"


### PR DESCRIPTION
Changes proposed in this pull request:

 * Test Python 3.8-dev on Travis CI
 * Python 3.8.0 is due out on 2019-10-20, or after three Pillow releases.
 * https://www.python.org/dev/peps/pep-0569/#release-schedule

