### PR TITLE
Skip TestFromQPixmap on Arch + QT5

### DIFF
--- a/Tests/test_qt_image_fromqpixmap.py
+++ b/Tests/test_qt_image_fromqpixmap.py
@@ -1,9 +1,13 @@
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, distro, hopper, unittest
 from .test_imageqt import PillowQPixmapTestCase
 
 from PIL import ImageQt
 
 
+@unittest.skipIf(
+    ImageQt.qt_version == "5" and distro() == "arch",
+    "TestFromQPixmap fails on Arch + QT5",
+)
 class TestFromQPixmap(PillowQPixmapTestCase, PillowTestCase):
 
     def roundtrip(self, expected):


### PR DESCRIPTION
Fixes #3641.

Changes proposed in this pull request:

 * When Arch was added in https://github.com/python-pillow/Pillow/pull/2394, `TestFromQPixmap` and `TestToQPixmap` were skipped for Arch and Qt5: https://github.com/python-pillow/Pillow/pull/2394/commits/1b94ff81feab659605c09507bf5aafcaa7b0743f
 * They were re-enabled a couple of days later in https://github.com/python-pillow/Pillow/pull/2420 after adding the `QT_QPA_PLATFORM=offscreen` env var for Arch in https://github.com/python-pillow/docker-images/pull/4
* Only the `TestFromQPixmap` tests are segfaulting now, I don't know what triggered this, but skipping them allows us to unblock the CI for now