### PR TITLE
Fix Qt segfault: Only create QGuiApplication once for the test class, not every test case

### DIFF
--- a/Tests/test_imageqt.py
+++ b/Tests/test_imageqt.py
@@ -1,4 +1,4 @@
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, hopper, unittest
 
 from PIL import ImageQt
 
@@ -6,26 +6,22 @@ from PIL import ImageQt
 if ImageQt.qt_is_installed:
     from PIL.ImageQt import qRgba
 
-    def skip_if_qt_is_not_installed(_):
-        pass
-else:
-    def skip_if_qt_is_not_installed(test_case):
-        test_case.skipTest('Qt bindings are not installed')
-
 
 class PillowQtTestCase(object):
-
-    def setUp(self):
-        skip_if_qt_is_not_installed(self)
+    @classmethod
+    def setUpClass(cls):
+        if not ImageQt.qt_is_installed:
+            raise unittest.SkipTest('Qt bindings are not installed')
 
     def tearDown(self):
         pass
 
 
 class PillowQPixmapTestCase(PillowQtTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(PillowQPixmapTestCase, cls).setUpClass()
 
-    def setUp(self):
-        PillowQtTestCase.setUp(self)
         try:
             if ImageQt.qt_version == '5':
                 from PyQt5.QtGui import QGuiApplication
@@ -36,9 +32,9 @@ class PillowQPixmapTestCase(PillowQtTestCase):
             elif ImageQt.qt_version == 'side2':
                 from PySide2.QtGui import QGuiApplication
         except ImportError:
-            self.skipTest('QGuiApplication not installed')
+            raise unittest.SkipTest('QGuiApplication not installed')
 
-        self.app = QGuiApplication([])
+        cls.app = QGuiApplication([])
 
     def tearDown(self):
         PillowQtTestCase.tearDown(self)


### PR DESCRIPTION
Fixes #3641.

Alternative to and closes https://github.com/python-pillow/Pillow/pull/3649.

I was able to reproduce this on macOS High Sierra with PyQt5 (`pip install pyqt5`). Segfault pasted down below.

Changes proposed in this pull request:

 * The segfault happens in `TestFromQPixmap` but not `TestToQPixmap`, because there's several tests cases in the former and only one test case in the latter. Editing `TestFromQPixmap` to have one test case makes it pass.

 * Before, a `self.app = QGuiApplication([])` was created for every test case in `setUp`, and at the end of the test case `self.app.quit()` in `tearDown`

 * This seems to cause a mixup in resource ownership when the next test case is run and a new `setUp` called

 * Moving the `QGuiApplication([])` creation up a level from `setUp` to `setUpClass`, which is called just once for all tests in the class, allows the tests to pass

```
Process:               Python [77792]
Path:                  /usr/local/Cellar/python/3.7.2/Frameworks/Python.framework/Versions/3.7/Resources/Python.app/Contents/MacOS/Python
Identifier:            org.python.python
Version:               3.7.2 (3.7.2)
Code Type:             X86-64 (Native)
Parent Process:        zsh [757]
Responsible:           Python [77792]
User ID:               501

Date/Time:             2019-02-14 20:23:29.957 +0200
OS Version:            Mac OS X 10.13.6 (17G4015)
Report Version:        12
Anonymous UUID:        238DC13B-0E3F-6168-C43B-DAE2E7F81768

Sleep/Wake UUID:       3E6A493B-443F-4007-BAC5-D16B469B4F0D

Time Awake Since Boot: 2200000 seconds
Time Since Wake:       4100 seconds

System Integrity Protection: enabled

Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY

Termination Signal:    Segmentation fault: 11
Termination Reason:    Namespace SIGNAL, Code 0xb
Terminating Process:   exc handler [0]

VM Regions Near 0:
--> 
    __TEXT                 0000000104ee6000-0000000104ee8000 [    8K] r-x/rwx SM=COW  /usr/local/Cellar/python/3.7.2/Frameworks/Python.framework/Versions/3.7/Resources/Python.app/Contents/MacOS/Python

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   QtGui                         	0x0000000107482275 QGuiApplication::~QGuiApplication() + 37
1   QtGui.so                      	0x00000001071ae87c sipQGuiApplication::~sipQGuiApplication() + 44
2   QtGui.so                      	0x00000001071af18d dealloc_QGuiApplication(_sipSimpleWrapper*) + 173
3   sip.so                        	0x0000000107f991de forgetObject + 174
4   sip.so                        	0x0000000107f98f5a sipWrapper_dealloc + 14
5   org.python.python             	0x0000000104f3cb6b subtype_dealloc + 907
6   org.python.python             	0x0000000104f258db dict_dealloc + 124
7   org.python.python             	0x0000000104f3cc11 subtype_dealloc + 1073
8   org.python.python             	0x0000000104f055d3 method_dealloc + 109
9   org.python.python             	0x0000000104f3aeef tupledealloc + 94
10  org.python.python             	0x0000000104ff03c6 partial_dealloc + 71
11  org.python.python             	0x0000000104f1499c frame_dealloc + 161
12  org.python.python             	0x0000000104f99c44 _PyEval_EvalCodeWithName + 1740
13  org.python.python             	0x0000000104f03369 _PyFunction_FastCallDict + 441
14  org.python.python             	0x0000000104f04499 _PyObject_Call_Prepend + 150
15  org.python.python             	0x0000000104f03849 PyObject_Call + 136
16  org.python.python             	0x0000000104ff068d partial_call + 239
17  org.python.python             	0x0000000104f035a1 _PyObject_FastCallKeywords + 359
18  org.python.python             	0x0000000104f9940a call_function + 746
19  org.python.python             	0x0000000104f9207b _PyEval_EvalFrameDefault + 7174
20  org.python.python             	0x0000000104f03b16 function_code_fastcall + 112
21  org.python.python             	0x0000000104f99411 call_function + 753
22  org.python.python             	0x0000000104f91fc4 _PyEval_EvalFrameDefault + 6991
23  org.python.python             	0x0000000104f03b16 function_code_fastcall + 112
24  org.python.python             	0x0000000104f99411 call_function + 753
25  org.python.python             	0x0000000104f91fc4 _PyEval_EvalFrameDefault + 6991
26  org.python.python             	0x0000000104f03b16 function_code_fastcall + 112
27  org.python.python             	0x0000000104f99411 call_function + 753
28  org.python.python             	0x0000000104f91fc4 _PyEval_EvalFrameDefault + 6991
29  org.python.python             	0x0000000104f03b16 function_code_fastcall + 112
30  org.python.python             	0x0000000104f99411 call_function + 753
31  org.python.python             	0x0000000104f91fc4 _PyEval_EvalFrameDefault + 6991
32  org.python.python             	0x0000000104f03b16 function_code_fastcall + 112
33  org.python.python             	0x0000000104f99411 call_function + 753
34  org.python.python             	0x0000000104f91fc4 _PyEval_EvalFrameDefault + 6991
35  org.python.python             	0x0000000104f03b16 function_code_fastcall + 112
36  org.python.python             	0x0000000104f922f4 _PyEval_EvalFrameDefault + 7807
37  org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
38  org.python.python             	0x0000000104f03700 _PyFunction_FastCallKeywords + 225
39  org.python.python             	0x0000000104f99411 call_function + 753
40  org.python.python             	0x0000000104f92121 _PyEval_EvalFrameDefault + 7340
41  org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
42  org.python.python             	0x0000000104f03700 _PyFunction_FastCallKeywords + 225
43  org.python.python             	0x0000000104f99411 call_function + 753
44  org.python.python             	0x0000000104f91fdd _PyEval_EvalFrameDefault + 7016
45  org.python.python             	0x0000000104f03b16 function_code_fastcall + 112
46  org.python.python             	0x0000000104f99411 call_function + 753
47  org.python.python             	0x0000000104f91fdd _PyEval_EvalFrameDefault + 7016
48  org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
49  org.python.python             	0x0000000104f03369 _PyFunction_FastCallDict + 441
50  org.python.python             	0x0000000104f04499 _PyObject_Call_Prepend + 150
51  org.python.python             	0x0000000104f413e9 slot_tp_call + 71
52  org.python.python             	0x0000000104f03849 PyObject_Call + 136
53  org.python.python             	0x0000000104f922f4 _PyEval_EvalFrameDefault + 7807
54  org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
55  org.python.python             	0x0000000104f03700 _PyFunction_FastCallKeywords + 225
56  org.python.python             	0x0000000104f99411 call_function + 753
57  org.python.python             	0x0000000104f9207b _PyEval_EvalFrameDefault + 7174
58  org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
59  org.python.python             	0x0000000104f03700 _PyFunction_FastCallKeywords + 225
60  org.python.python             	0x0000000104f99411 call_function + 753
61  org.python.python             	0x0000000104f92121 _PyEval_EvalFrameDefault + 7340
62  org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
63  org.python.python             	0x0000000104f03369 _PyFunction_FastCallDict + 441
64  org.python.python             	0x0000000104f04499 _PyObject_Call_Prepend + 150
65  org.python.python             	0x0000000104f03849 PyObject_Call + 136
66  org.python.python             	0x0000000104f922f4 _PyEval_EvalFrameDefault + 7807
67  org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
68  org.python.python             	0x0000000104f03700 _PyFunction_FastCallKeywords + 225
69  org.python.python             	0x0000000104f99411 call_function + 753
70  org.python.python             	0x0000000104f92121 _PyEval_EvalFrameDefault + 7340
71  org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
72  org.python.python             	0x0000000104f03700 _PyFunction_FastCallKeywords + 225
73  org.python.python             	0x0000000104f99411 call_function + 753
74  org.python.python             	0x0000000104f92121 _PyEval_EvalFrameDefault + 7340
75  org.python.python             	0x0000000104f03b16 function_code_fastcall + 112
76  org.python.python             	0x0000000104f99411 call_function + 753
77  org.python.python             	0x0000000104f91fdd _PyEval_EvalFrameDefault + 7016
78  org.python.python             	0x0000000104f03b16 function_code_fastcall + 112
79  org.python.python             	0x0000000104f04499 _PyObject_Call_Prepend + 150
80  org.python.python             	0x0000000104f03849 PyObject_Call + 136
81  org.python.python             	0x0000000104f922f4 _PyEval_EvalFrameDefault + 7807
82  org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
83  org.python.python             	0x0000000104f03700 _PyFunction_FastCallKeywords + 225
84  org.python.python             	0x0000000104f99411 call_function + 753
85  org.python.python             	0x0000000104f92121 _PyEval_EvalFrameDefault + 7340
86  org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
87  org.python.python             	0x0000000104f03700 _PyFunction_FastCallKeywords + 225
88  org.python.python             	0x0000000104f99411 call_function + 753
89  org.python.python             	0x0000000104f91fdd _PyEval_EvalFrameDefault + 7016
90  org.python.python             	0x0000000104f03b16 function_code_fastcall + 112
91  org.python.python             	0x0000000104f99411 call_function + 753
92  org.python.python             	0x0000000104f91fdd _PyEval_EvalFrameDefault + 7016
93  org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
94  org.python.python             	0x0000000104f03369 _PyFunction_FastCallDict + 441
95  org.python.python             	0x0000000104f04499 _PyObject_Call_Prepend + 150
96  org.python.python             	0x0000000104f413e9 slot_tp_call + 71
97  org.python.python             	0x0000000104f035a1 _PyObject_FastCallKeywords + 359
98  org.python.python             	0x0000000104f9940a call_function + 746
99  org.python.python             	0x0000000104f92121 _PyEval_EvalFrameDefault + 7340
100 org.python.python             	0x0000000104f03b16 function_code_fastcall + 112
101 org.python.python             	0x0000000104f922f4 _PyEval_EvalFrameDefault + 7807
102 org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
103 org.python.python             	0x0000000104f03700 _PyFunction_FastCallKeywords + 225
104 org.python.python             	0x0000000104f99411 call_function + 753
105 org.python.python             	0x0000000104f92121 _PyEval_EvalFrameDefault + 7340
106 org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
107 org.python.python             	0x0000000104f03700 _PyFunction_FastCallKeywords + 225
108 org.python.python             	0x0000000104f99411 call_function + 753
109 org.python.python             	0x0000000104f91fdd _PyEval_EvalFrameDefault + 7016
110 org.python.python             	0x0000000104f03b16 function_code_fastcall + 112
111 org.python.python             	0x0000000104f99411 call_function + 753
112 org.python.python             	0x0000000104f91fdd _PyEval_EvalFrameDefault + 7016
113 org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
114 org.python.python             	0x0000000104f03369 _PyFunction_FastCallDict + 441
115 org.python.python             	0x0000000104f04499 _PyObject_Call_Prepend + 150
116 org.python.python             	0x0000000104f413e9 slot_tp_call + 71
117 org.python.python             	0x0000000104f035a1 _PyObject_FastCallKeywords + 359
118 org.python.python             	0x0000000104f9940a call_function + 746
119 org.python.python             	0x0000000104f92121 _PyEval_EvalFrameDefault + 7340
120 org.python.python             	0x0000000104f03b16 function_code_fastcall + 112
121 org.python.python             	0x0000000104f99411 call_function + 753
122 org.python.python             	0x0000000104f9207b _PyEval_EvalFrameDefault + 7174
123 org.python.python             	0x0000000104f03b16 function_code_fastcall + 112
124 org.python.python             	0x0000000104f99411 call_function + 753
125 org.python.python             	0x0000000104f9207b _PyEval_EvalFrameDefault + 7174
126 org.python.python             	0x0000000104f03b16 function_code_fastcall + 112
127 org.python.python             	0x0000000104f922f4 _PyEval_EvalFrameDefault + 7807
128 org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
129 org.python.python             	0x0000000104f03700 _PyFunction_FastCallKeywords + 225
130 org.python.python             	0x0000000104f99411 call_function + 753
131 org.python.python             	0x0000000104f92121 _PyEval_EvalFrameDefault + 7340
132 org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
133 org.python.python             	0x0000000104f03700 _PyFunction_FastCallKeywords + 225
134 org.python.python             	0x0000000104f99411 call_function + 753
135 org.python.python             	0x0000000104f91fdd _PyEval_EvalFrameDefault + 7016
136 org.python.python             	0x0000000104f03b16 function_code_fastcall + 112
137 org.python.python             	0x0000000104f99411 call_function + 753
138 org.python.python             	0x0000000104f91fdd _PyEval_EvalFrameDefault + 7016
139 org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
140 org.python.python             	0x0000000104f03369 _PyFunction_FastCallDict + 441
141 org.python.python             	0x0000000104f04499 _PyObject_Call_Prepend + 150
142 org.python.python             	0x0000000104f413e9 slot_tp_call + 71
143 org.python.python             	0x0000000104f035a1 _PyObject_FastCallKeywords + 359
144 org.python.python             	0x0000000104f9940a call_function + 746
145 org.python.python             	0x0000000104f92121 _PyEval_EvalFrameDefault + 7340
146 org.python.python             	0x0000000104f03b16 function_code_fastcall + 112
147 org.python.python             	0x0000000104f99411 call_function + 753
148 org.python.python             	0x0000000104f91fdd _PyEval_EvalFrameDefault + 7016
149 org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
150 org.python.python             	0x0000000104f903ed PyEval_EvalCode + 42
151 org.python.python             	0x0000000104f8de9c builtin_exec + 554
152 org.python.python             	0x0000000104f0419f _PyMethodDef_RawFastCallKeywords + 496
153 org.python.python             	0x0000000104f0373b _PyCFunction_FastCallKeywords + 44
154 org.python.python             	0x0000000104f9939c call_function + 636
155 org.python.python             	0x0000000104f9207b _PyEval_EvalFrameDefault + 7174
156 org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
157 org.python.python             	0x0000000104f03700 _PyFunction_FastCallKeywords + 225
158 org.python.python             	0x0000000104f99411 call_function + 753
159 org.python.python             	0x0000000104f9207b _PyEval_EvalFrameDefault + 7174
160 org.python.python             	0x0000000104f99ca3 _PyEval_EvalCodeWithName + 1835
161 org.python.python             	0x0000000104f03369 _PyFunction_FastCallDict + 441
162 org.python.python             	0x0000000104fd6fc2 pymain_run_module + 147
163 org.python.python             	0x0000000104fd610d pymain_main + 4407
164 org.python.python             	0x0000000104fd6c1b _Py_UnixMain + 75
165 libdyld.dylib                 	0x00007fff6bd17015 start + 1

Thread 1:
0   libsystem_kernel.dylib        	0x00007fff6be6828a __workq_kernreturn + 10
1   libsystem_pthread.dylib       	0x00007fff6c02f009 _pthread_wqthread + 1035
2   libsystem_pthread.dylib       	0x00007fff6c02ebe9 start_wqthread + 13

Thread 2:
0   libsystem_pthread.dylib       	0x00007fff6c02ebdc start_wqthread + 0
1   ???                           	0x007865646e496d65 0 + 33888479226719589

Thread 3:
0   libsystem_pthread.dylib       	0x00007fff6c02ebdc start_wqthread + 0
1   ???                           	0x0000000000060002 0 + 393218

Thread 4:
0   libsystem_kernel.dylib        	0x00007fff6be6828a __workq_kernreturn + 10
1   libsystem_pthread.dylib       	0x00007fff6c02f009 _pthread_wqthread + 1035
2   libsystem_pthread.dylib       	0x00007fff6c02ebe9 start_wqthread + 13

Thread 5:
0   libsystem_pthread.dylib       	0x00007fff6c02ebdc start_wqthread + 0

Thread 0 crashed with X86 Thread State (64-bit):
  rax: 0x0000000107897af0  rbx: 0x0000000107f0a468  rcx: 0x00ce070000ce0801  rdx: 0x00ce080000ce0800
  rdi: 0x0000000000000000  rsi: 0x0000000000ce0700  rbp: 0x00007ffeead10890  rsp: 0x00007ffeead10870
   r8: 0x00000001050f6bd8   r9: 0xffffffff00000000  r10: 0x0000000000000000  r11: 0x00000001050f6bd8
  r12: 0x00007f873f8dfaa8  r13: 0x0000000107f98f4c  r14: 0x00007f873f8a0390  r15: 0x00007f873f8f2e70
  rip: 0x0000000107482275  rfl: 0x0000000000010202  cr2: 0x0000000000000000
  
Logical CPU:     0
Error Code:      0x00000004
Trap Number:     14
```