### PR TITLE
Deprecate support for PyQt4 and PySide

### DIFF
--- a/Tests/test_imageqt.py
+++ b/Tests/test_imageqt.py
@@ -2,6 +2,12 @@ from .helper import PillowTestCase, hopper
 
 from PIL import ImageQt
 
+try:
+    # Python 3
+    from importlib import reload
+except ImportError:
+    # Python 2.7
+    pass
 
 if ImageQt.qt_is_installed:
     from PIL.ImageQt import qRgba
@@ -78,3 +84,7 @@ class TestImageQt(PillowQtTestCase, PillowTestCase):
     def test_image(self):
         for mode in ('1', 'RGB', 'RGBA', 'L', 'P'):
             ImageQt.ImageQt(hopper(mode))
+
+    def test_deprecated(self):
+        expected = DeprecationWarning if ImageQt.qt_version in ["4", "side"] else None
+        self.assert_warning(expected, reload, ImageQt)

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -12,6 +12,18 @@ Deprecated features
 Below are features which are considered deprecated. Where appropriate,
 a ``DeprecationWarning`` is issued.
 
+
+PyQt4 and PySide
+~~~~~~~~~~~~~~~~
+
+.. deprecated:: 6.0.0
+
+Qt 4 reached end-of-life on 2015-12-19. Its Python bindings are also EOL: PyQt4 since
+2018-08-31 and PySide since 2015-10-14.
+
+Support for PyQt4 and PySide has been deprecated from ``ImageQt`` and will be removed in
+a future version. Please upgrade to PyQt5 or PySide2.
+
 Setting the size of TIFF images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -12,6 +12,17 @@ Deprecated features
 Below are features which are considered deprecated. Where appropriate,
 a ``DeprecationWarning`` is issued.
 
+PyQt4 and PySide
+~~~~~~~~~~~~~~~~
+
+.. deprecated:: 6.0.0
+
+Qt 4 reached end-of-life on 2015-12-19. Its Python bindings are also EOL: PyQt4 since
+2018-08-31 and PySide since 2015-10-14.
+
+Support for PyQt4 and PySide has been deprecated from ``ImageQt`` and will be removed in
+a future version. Please upgrade to PyQt5 or PySide2.
+
 PIL.*ImagePlugin.__version__ attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -36,17 +47,6 @@ Deprecated                       Deprecated                         Deprecated
 ``ImtImagePlugin.__version__``   ``PdfImagePlugin.__version__``     ``XVThumbImagePlugin.__version__``
 ``IptcImagePlugin.__version__``  ``PixarImagePlugin.__version__``
 ===============================  =================================  ==================================
-
-PyQt4 and PySide
-~~~~~~~~~~~~~~~~
-
-.. deprecated:: 6.0.0
-
-Qt 4 reached end-of-life on 2015-12-19. Its Python bindings are also EOL: PyQt4 since
-2018-08-31 and PySide since 2015-10-14.
-
-Support for PyQt4 and PySide has been deprecated from ``ImageQt`` and will be removed in
-a future version. Please upgrade to PyQt5 or PySide2.
 
 Setting the size of TIFF images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/reference/ImageQt.rst
+++ b/docs/reference/ImageQt.rst
@@ -7,6 +7,12 @@
 The :py:mod:`ImageQt` module contains support for creating PyQt4, PyQt5, PySide or
 PySide2 QImage objects from PIL images.
 
+Qt 4 reached end-of-life on 2015-12-19. Its Python bindings are also EOL: PyQt4 since
+2018-08-31 and PySide since 2015-10-14.
+
+Support for PyQt4 and PySide is deprecated since Pillow 6.0.0 and will be removed in a
+future version. Please upgrade to PyQt5 or PySide2.
+
 .. versionadded:: 1.1.6
 
 .. py:class:: ImageQt.ImageQt(image)

--- a/docs/releasenotes/6.0.0.rst
+++ b/docs/releasenotes/6.0.0.rst
@@ -32,6 +32,18 @@ API Changes
 Deprecations
 ^^^^^^^^^^^^
 
+PyQt4 and PySide
+~~~~~~~~~~~~~~~~
+
+Qt 4 reached end-of-life on 2015-12-19. Its Python bindings are also EOL: PyQt4 since
+2018-08-31 and PySide since 2015-10-14.
+
+Support for PyQt4 and PySide has been deprecated from ``ImageQt`` and will be removed in
+a future version. Please upgrade to PyQt5 or PySide2.
+
+PIL.*ImagePlugin.__version__ attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 These version constants have been deprecated and will be removed in a future
 version.
 

--- a/src/PIL/ImageQt.py
+++ b/src/PIL/ImageQt.py
@@ -20,6 +20,7 @@ from . import Image
 from ._util import isPath, py3
 from io import BytesIO
 import sys
+import warnings
 
 qt_versions = [
     ['5', 'PyQt5'],
@@ -27,6 +28,12 @@ qt_versions = [
     ['4', 'PyQt4'],
     ['side', 'PySide']
 ]
+
+WARNING_TEXT = (
+    "Support for EOL {} is deprecated and will be removed in a future version. "
+    "Please upgrade to PyQt5 or PySide2."
+)
+
 # If a version has already been imported, attempt it first
 qt_versions.sort(key=lambda qt_version: qt_version[1] in sys.modules,
                  reverse=True)
@@ -41,9 +48,13 @@ for qt_version, qt_module in qt_versions:
         elif qt_module == 'PyQt4':
             from PyQt4.QtGui import QImage, qRgba, QPixmap
             from PyQt4.QtCore import QBuffer, QIODevice
+
+            warnings.warn(WARNING_TEXT.format(qt_module), DeprecationWarning)
         elif qt_module == 'PySide':
             from PySide.QtGui import QImage, qRgba, QPixmap
             from PySide.QtCore import QBuffer, QIODevice
+
+            warnings.warn(WARNING_TEXT.format(qt_module), DeprecationWarning)
     except (ImportError, RuntimeError):
         continue
     qt_is_installed = True
@@ -67,7 +78,7 @@ def fromqimage(im):
     """
     buffer = QBuffer()
     buffer.open(QIODevice.ReadWrite)
-    # preserve alha channel with png
+    # preserve alpha channel with png
     # otherwise ppm is more friendly with Image.open
     if im.hasAlphaChannel():
         im.save(buffer, 'png')


### PR DESCRIPTION
Changes proposed in this pull request:

 * Qt 4 reached end-of-life on [2015-12-19](https://blog.qt.io/blog/2015/05/26/qt-4-8-7-released/). Its Python bindings are also EOL: PyQt4 since [2018-08-31](https://www.riverbankcomputing.com/news) and PySide since [2015-10-14](https://en.wikipedia.org/wiki/PySide).

 * Deprecate support for PyQt4 and PySide

 * Please upgrade to PyQt5 or PySide2
