### PR TITLE
Fast MPO open

### DIFF
--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -786,7 +786,8 @@ def jpeg_factory(fp=None, filename=None):
         if mpheader[45057] > 1:
             # It's actually an MPO
             from .MpoImagePlugin import MpoImageFile
-            im = MpoImageFile(fp, filename)
+            # Don't reload everything, just convert it.
+            im = MpoImageFile.adopt(im, mpheader)
     except (TypeError, IndexError):
         # It is really a JPEG
         pass

--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -46,10 +46,10 @@ class MpoImageFile(JpegImagePlugin.JpegImageFile):
     def _open(self):
         self.fp.seek(0)  # prep the fp in order to pass the JPEG test
         JpegImagePlugin.JpegImageFile._open(self)
-        self._after_jpeg_open(self._getmp())
+        self._after_jpeg_open()
 
-    def _after_jpeg_open(self, mpheader):
-        self.mpinfo = mpheader
+    def _after_jpeg_open(self, mpheader=None):
+        self.mpinfo = mpheader if mpheader is not None else self._getmp()
         self.__framecount = self.mpinfo[0xB001]
         self.__mpoffsets = [mpent['DataOffset'] + self.info['mpoffset']
                             for mpent in self.mpinfo[0xB002]]

--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -46,7 +46,10 @@ class MpoImageFile(JpegImagePlugin.JpegImageFile):
     def _open(self):
         self.fp.seek(0)  # prep the fp in order to pass the JPEG test
         JpegImagePlugin.JpegImageFile._open(self)
-        self.mpinfo = self._getmp()
+        self._after_jpeg_open(self._getmp())
+
+    def _after_jpeg_open(self, mpheader):
+        self.mpinfo = mpheader
         self.__framecount = self.mpinfo[0xB001]
         self.__mpoffsets = [mpent['DataOffset'] + self.info['mpoffset']
                             for mpent in self.mpinfo[0xB002]]

--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -98,6 +98,22 @@ class MpoImageFile(JpegImagePlugin.JpegImageFile):
         finally:
             self.__fp = None
 
+    @staticmethod
+    def adopt(jpeg_instance, mpheader=None):
+        '''
+        Transform the instance of JpegImageFile into
+        instance of MpoImageFile.
+        After the call, the JpegImageFile is extended
+        to be an MpoImageFile.
+
+        This is essentially useful when opening a JPEG
+        file that reveals itself as an MPO, to avoid
+        double call to _open.
+        '''
+        jpeg_instance.__class__ = MpoImageFile
+        jpeg_instance._after_jpeg_open(mpheader)
+        return jpeg_instance
+
 
 # ---------------------------------------------------------------------
 # Registry stuff


### PR DESCRIPTION
Changes proposed in this pull request:

 * Multiply the performance of opening an MPO file by two.

Before:
```py
%timeit Image.open('Tests/images/frozenpond.mpo')
1000 loops, best of 5: 1.51 ms per loop
```
After:
```py
%timeit Image.open('Tests/images/frozenpond.mpo')
1000 loops, best of 5: 779 µs per loop
```

I thought about multiple strategies to avoid a double call to `JpegImageFile._open` that is costly in this use case:
* `__init__` with JpegInstanceFile object. This is the cleanest, by very difficult to achieve, since an instance has at least three inherited classes with many attributes that can be initialized.
* Delegate. Same as above. A delegate is nice, but it should be done in `ImageFile` itself, and it renders every method call more costly.
* Downcasting. This is maybe the dirtiest method from a computer science point-of-view. This is also the most efficient and easy to read.

I chose the last, but I'm completely opened to constructive critics.

I've explained some performance figures in https://github.com/saimn/sigal/pull/363. The gain is really obvious when you have a range of images that are recognized as MPO, but the only thing you want is reading their EXIF data.