### PR TITLE
Document format limitations of ImageStat.Stat.extrema

### DIFF
--- a/docs/reference/ImageStat.rst
+++ b/docs/reference/ImageStat.rst
@@ -20,6 +20,14 @@ for a region of an image.
 
         Min/max values for each band in the image.
 
+        .. Note:: This relies on the :py:meth:`~PIL.Image.histogram` method, and simply
+        returns the low and high bins used. This is correct for images with 8 bits per
+        channel, but fails for other modes such as ``I`` or ``F``. Instead, use
+        :py:meth:`~PIL.Image.getextrema` to return per-band extrema for the image.
+        This is more correct and efficient because :py:meth:`~PIL.Image.getextrema` is
+        used by the histogram method for non-8-bit modes to return extrema to define the
+        bins used in the histogram.
+
     .. py:attribute:: count
 
         Total number of pixels for each band in the image.


### PR DESCRIPTION
Fixes #1606.

Changes proposed in this pull request:

 * Document format limitations of `ImageStat.Stat.extrema`
 * And recommend more efficient `Image.getextrema`
