### PR TITLE
Performance: Use subclass for parsing EXIF data

### DIFF
--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -493,7 +493,7 @@ class ExifImageFileDirectory(TiffImagePlugin.ImageFileDirectory_v1):
         raise NotImplementedError()
 
     def _setitem(self, tag, value, legacy_api):
-        super()._setitem(tag, value, legacy_api)
+        TiffImagePlugin.ImageFileDirectory_v1._setitem(self, tag, value, legacy_api)
         if legacy_api:
             val = self._tags_v1[tag]
             if not isinstance(val, (tuple, bytes)):
@@ -504,7 +504,7 @@ class ExifImageFileDirectory(TiffImagePlugin.ImageFileDirectory_v1):
         if isinstance(value, TiffImagePlugin.ImageFileDirectory_v2):
             self._tags_v1[tag] = value
         else:
-            super().__setitem__(tag, value)
+            TiffImagePlugin.ImageFileDirectory_v1.__setitem__(self, tag, value)
 
     def __getitem__(self, tag):
         if tag not in self._tags_v1:  # unpack on the fly
@@ -526,7 +526,7 @@ class ExifImageFileDirectory(TiffImagePlugin.ImageFileDirectory_v1):
             self._tagdata.update(other._tagdata)
             self.tagtype.update(other.tagtype)
         else:
-            super().update(*args, **kwds)
+            TiffImagePlugin.ImageFileDirectory_v1.update(self, *args, **kwds)
 
 
 def _getexif(self):

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -479,7 +479,7 @@ def _fixup(value):
 
 
 class ExifImageFileDirectory(TiffImagePlugin.ImageFileDirectory_v1):
-    '''
+    """
     Specialization for parsing EXIF data:
     - Remove support for v2 to avoid useless computations
     - custom __setitem__ to supports IFD values

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -487,7 +487,7 @@ class ExifImageFileDirectory(TiffImagePlugin.ImageFileDirectory_v1):
     - custom update() to avoid iterating and expanding non parsed data
 
     The goal is to use the lazyness of ImageFileDirectory_v1 in _getexif().
-    '''
+    """
 
     def to_v2(self):
         raise NotImplementedError()

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -496,8 +496,6 @@ class ExifImageFileDirectory(TiffImagePlugin.ImageFileDirectory_v1):
         TiffImagePlugin.ImageFileDirectory_v1._setitem(self, tag, value, legacy_api)
         if legacy_api:
             val = self._tags_v1[tag]
-            if not isinstance(val, (tuple, bytes)):
-                val = val,
             self._tags_v1[tag] = _fixup(val)
 
     def __setitem__(self, tag, value):
@@ -514,7 +512,7 @@ class ExifImageFileDirectory(TiffImagePlugin.ImageFileDirectory_v1):
             # We don't support v2
             self._setitem(tag, handler(self, data, True), True)
         val = self._tags_v1[tag]
-        # Don't try to convert as tuple, it is done in _setitem
+        # Don't try to convert as tuple, it is undone by the _fixup function
         return val
 
     def update(self, *args, **kwds):

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -486,7 +486,7 @@ class ExifImageFileDirectory(TiffImagePlugin.ImageFileDirectory_v1):
     - values are "fixed up" so that 1-size tuples are expanded
     - custom update() to avoid iterating and expanding non parsed data
 
-    The goal is to use the lazyness of ImageFileDirectory_v1 in _getexif().
+    The goal is to use the laziness of ImageFileDirectory_v1 in _getexif().
     """
 
     def to_v2(self):


### PR DESCRIPTION
The old method (using dict() and _fixup_dict) create clones from IFD_v1, but it read all items when iterating, losing all benefits from the lazyness of IFD.
The new method use a custom subclass that try to prevent all iterations as much as possible, keeping all tags undecoded.

The return value isn't a dict anymore, but a subclass of ImageFileDirectory_v1 that doesn't support tov2(). All decoded tags are formatted as before.

With a test image, I'm going from:
```py
%timeit Image.open("Tests/images/exif-dpi-zerodivision.jpg") 1000 loops, best of 5: 485 µs per loop
```
to
```py
%timeit Image.open("Tests/images/exif-dpi-zerodivision.jpg") 1000 loops, best of 5: 257 µs per loop
```

With a more common JPEG image from my Panasonic TZ10 camera, I'm going from:
```py
%timeit Image.open("/home/photos/P1040526.JPG") 1000 loops, best of 5: 3.24 ms per loop
```
to
```py
%timeit Image.open("/home/photos/P1040526.JPG") 1000 loops, best of 5: 871 µs per loop
```

I hope that even if the return type of `_getexif` is not the same, its compatibility with the previous format will make it merged.