### PR TITLE
Cache the result of _getexif()

### DIFF
--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -430,7 +430,11 @@ class JpegImageFile(ImageFile.ImageFile):
         self.tile = []
 
     def _getexif(self):
-        return _getexif(self)
+        try:
+            return self._exif
+        except AttributeError:
+            self._exif = _getexif(self)
+            return self._exif
 
     def _getmp(self):
         return _getmp(self)


### PR DESCRIPTION
Changes proposed in this pull request:

 * Cache the result of the first call to `_getexif()`

When using Pillow to read EXIF data, the `_getexif()` is called twice per images, since it's already called in `APP()`. Caching the result improves a lot EXIF reading in that case, at the expense of a little bit more memory.

But maybe the `info["exif"]` could be drop in case of a sucessful call to `_getexif()`?
