### PR TITLE
Use the already imported io

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -679,8 +679,7 @@ class Image(object):
 
         :returns: png version of the image as bytes
         """
-        from io import BytesIO
-        b = BytesIO()
+        b = io.BytesIO()
         self.save(b, 'PNG')
         return b.getvalue()
 


### PR DESCRIPTION
instead of importing again from io (lgtm suggestion)

Fixes # .

Changes proposed in this pull request:

 * remove an import from io, as io is globally imported on top of the module
 * 
 * 
