### PR TITLE
Update docs: macOS saves to a temp PNG before showing

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2024,7 +2024,7 @@ class Image(object):
         PPM file, and calls either the **xv** utility or the **display**
         utility, depending on which one can be found.
 
-        On macOS, this method saves the image to a temporary BMP file, and
+        On macOS, this method saves the image to a temporary PNG file, and
         opens it with the native Preview application.
 
         On Windows, it saves the image to a temporary BMP file, and uses


### PR DESCRIPTION
Changes proposed in this pull request:

 * Since #2527, macOS saves to a temp PNG before showing, not a temp BMP
