### PR TITLE
Add option to set dither param on quantize

### DIFF
--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -46,3 +46,19 @@ class TestImageQuantize(PillowTestCase):
         converted = image.quantize()
         self.assert_image(converted, 'P', converted.size)
         self.assert_image_similar(converted.convert('RGB'), image, 1)
+
+    def test_quantize_no_dither(self):
+        image = hopper()
+        palette = Image.open('Tests/images/caption_6_33_22.png').convert('P')
+
+        converted = image.quantize(dither=0, palette=palette)
+        self.assert_image(converted, 'P', converted.size)
+
+    def test_quantize_dither_diff(self):
+        image = hopper()
+        palette = Image.open('Tests/images/caption_6_33_22.png').convert('P')
+
+        dither = image.quantize(dither=1, palette=palette)
+        nodither = image.quantize(dither=0, palette=palette)
+
+        self.assertNotEqual(dither.tobytes(), nodither.tobytes())

--- a/docs/releasenotes/6.0.0.rst
+++ b/docs/releasenotes/6.0.0.rst
@@ -107,6 +107,11 @@ DIB File Format
 
 Pillow now supports reading and writing the DIB "Device Independent Bitmap" file format.
 
+Image.quantize
+^^^^^^^^^^^^^^
+
+The `dither` option is now a customisable parameter (was previously hardcoded to `1`). This parameter takes the same values used in `Image.convert`
+
 Other Changes
 =============
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1049,7 +1049,7 @@ class Image(object):
                 new_im.info['transparency'] = trns
         return new_im
 
-    def quantize(self, colors=256, method=None, kmeans=0, palette=None):
+    def quantize(self, colors=256, method=None, kmeans=0, palette=None, dither=1):
         """
         Convert the image to 'P' mode with the specified number
         of colors.
@@ -1062,6 +1062,10 @@ class Image(object):
         :param kmeans: Integer
         :param palette: Quantize to the palette of given
                         :py:class:`PIL.Image.Image`.
+        :param dither: Dithering method, used when converting from
+           mode "RGB" to "P" or from "RGB" or "L" to "1".
+           Available methods are NONE or FLOYDSTEINBERG (default).
+           Default: 1 (legacy setting)
         :returns: A new image
 
         """
@@ -1089,7 +1093,7 @@ class Image(object):
                 raise ValueError(
                     "only RGB or L mode images can be quantized to a palette"
                     )
-            im = self.im.convert("P", 1, palette.im)
+            im = self.im.convert("P", dither, palette.im)
             return self._new(im)
 
         return self._new(self.im.quantize(colors, method, kmeans))


### PR DESCRIPTION
Default the option to `1`, as per original setting

Changes proposed in this pull request:

 * Allow `Image.quantize` to supply it's own `dither` keyword argument. 
 * Defaults to `1`, to ensure backward compatibility. 
