### PR TITLE
Adding an upper limit for blocks_max in _set_blocks_max

### DIFF
--- a/Tests/32bit_overflow_check.py
+++ b/Tests/32bit_overflow_check.py
@@ -1,0 +1,6 @@
+from PIL import Image
+import sys
+
+
+if sys.maxsize < 2**32:
+    Image.core.set_blocks_max(2**29)

--- a/Tests/32bit_overflow_check.py
+++ b/Tests/32bit_overflow_check.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from PIL import Image
 import sys
 

--- a/Tests/32bit_overflow_check.py
+++ b/Tests/32bit_overflow_check.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-
-from PIL import Image
-import sys
-
-
-if sys.maxsize < 2**32:
-    Image.core.set_blocks_max(2**29)

--- a/Tests/test_core_resources.py
+++ b/Tests/test_core_resources.py
@@ -105,6 +105,7 @@ class TestCoreMemory(PillowTestCase):
             Image.new("RGB", (10, 10))
 
         self.assertRaises(ValueError, Image.core.set_blocks_max, -1)
+        self.assertRaises(ValueError, Image.core.set_blocks_max, 2**29)
 
     @unittest.skipIf(is_pypy, "images are not collected")
     def test_set_blocks_max_stats(self):

--- a/Tests/test_core_resources.py
+++ b/Tests/test_core_resources.py
@@ -105,7 +105,8 @@ class TestCoreMemory(PillowTestCase):
             Image.new("RGB", (10, 10))
 
         self.assertRaises(ValueError, Image.core.set_blocks_max, -1)
-        self.assertRaises(ValueError, Image.core.set_blocks_max, 2**29)
+        if sys.maxsize < 2**32:
+            self.assertRaises(ValueError, Image.core.set_blocks_max, 2**29)
 
     @unittest.skipIf(is_pypy, "images are not collected")
     def test_set_blocks_max_stats(self):

--- a/Tests/test_core_resources.py
+++ b/Tests/test_core_resources.py
@@ -105,8 +105,8 @@ class TestCoreMemory(PillowTestCase):
             Image.new("RGB", (10, 10))
 
         self.assertRaises(ValueError, Image.core.set_blocks_max, -1)
-        if sys.maxsize < 2**32:
-            self.assertRaises(ValueError, Image.core.set_blocks_max, 2**29)
+        if sys.maxsize < 2 ** 32:
+            self.assertRaises(ValueError, Image.core.set_blocks_max, 2 ** 29)
 
     @unittest.skipIf(is_pypy, "images are not collected")
     def test_set_blocks_max_stats(self):

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -3625,6 +3625,12 @@ _set_blocks_max(PyObject* self, PyObject* args)
             "blocks_max should be greater than 0");
         return NULL;
     }
+    else if ( blocks_max > SIZE_MAX/sizeof(ImagingDefaultArena.blocks_pool[0])) {
+        PyErr_SetString(PyExc_ValueError,
+            "blocks_max is too large");
+        return NULL;
+    }
+
 
     if ( ! ImagingMemorySetBlocksMax(&ImagingDefaultArena, blocks_max)) {
         ImagingError_MemoryError();


### PR DESCRIPTION
Changes proposed in this pull request:

 * Fixing a potential integer overflow in ImagingMemorySetBlocksMax

The integer blocks_max is properly sanitized before being used in an arithmetic operation.
This PR should fix this issue by adding an upper limit to this variable.

If the error message is not appropriate, please do let me know and I will fix it accordingly.