### PR TITLE
 Fixed TIFF bug when seeking backwards and then forwards

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -263,6 +263,11 @@ class TestFileTiff(PillowTestCase):
         self.assertEqual(im.size, (10, 10))
         self.assertEqual(im.convert('RGB').getpixel((0, 0)), (255, 0, 0))
 
+        im.seek(0)
+        im.load()
+        self.assertEqual(im.size, (10, 10))
+        self.assertEqual(im.convert('RGB').getpixel((0, 0)), (0, 128, 0))
+
         im.seek(2)
         im.load()
         self.assertEqual(im.size, (20, 20))

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1056,7 +1056,6 @@ class TiffImageFile(ImageFile.ImageFile):
             self.__frame += 1
         self.fp.seek(self._frame_pos[frame])
         self.tag_v2.load(self.fp)
-        self.__next = self.tag_v2.next
         # fill the legacy tag/ifd entries
         self.tag = self.ifd = ImageFileDirectory_v1.from_v2(self.tag_v2)
         self.__frame = frame
@@ -1087,7 +1086,7 @@ class TiffImageFile(ImageFile.ImageFile):
     def load_end(self):
         # allow closing if we're on the first frame, there's no next
         # This is the ImageFile.load path only, libtiff specific below.
-        if self.__frame == 0 and not self.__next:
+        if len(self._frame_pos) == 1 and not self.__next:
             self._close_exclusive_fp_after_loading = True
 
     def _load_libtiff(self):
@@ -1168,7 +1167,7 @@ class TiffImageFile(ImageFile.ImageFile):
         self.readonly = 0
         # libtiff closed the fp in a, we need to close self.fp, if possible
         if self._exclusive_fp:
-            if self.__frame == 0 and not self.__next:
+            if len(self._frame_pos) == 1 and not self.__next:
                 self.fp.close()
                 self.fp = None  # might be shared
 


### PR DESCRIPTION
Resolves #3712

Currently, `__next` is the position of the next frame after the current one. If a backwards seek has been made, then when `_seek` skips past all the frame positions it knows about, [it goes to the next frame](https://github.com/python-pillow/Pillow/blob/3e9457a034736cd4e320cfcddbc2de7cd4f4d7e5/src/PIL/TiffImagePlugin.py#L1050) after the frame it started at, instead of the next frame at the end.

This PR changes `__next` to be the position of the next frame after the furthest frame that has been seeked to, fixing this bug.