### PR TITLE
Improvements to TIFF is_animated and n_frames

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -229,11 +229,6 @@ class TestFileTiff(PillowTestCase):
             ['Tests/images/multipage-lastframe.tif', 1],
             ['Tests/images/multipage.tiff', 3]
         ]:
-            # Test is_animated before n_frames
-            im = Image.open(path)
-            self.assertEqual(im.is_animated, n_frames != 1)
-
-            # Test is_animated after n_frames
             im = Image.open(path)
             self.assertEqual(im.n_frames, n_frames)
             self.assertEqual(im.is_animated, n_frames != 1)

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -998,11 +998,8 @@ class TiffImageFile(ImageFile.ImageFile):
     def n_frames(self):
         if self._n_frames is None:
             current = self.tell()
-            try:
-                while True:
-                    self._seek(self.tell() + 1)
-            except EOFError:
-                self._n_frames = self.tell() + 1
+            while self._n_frames is None:
+                self._seek(self.tell() + 1)
             self.seek(current)
         return self._n_frames
 
@@ -1039,6 +1036,8 @@ class TiffImageFile(ImageFile.ImageFile):
                 print("Loading tags, location: %s" % self.fp.tell())
             self.tag_v2.load(self.fp)
             self.__next = self.tag_v2.next
+            if self.__next == 0:
+                self._n_frames = frame + 1
             if len(self._frame_pos) == 1:
                 self._is_animated = self.__next != 0
             self.__frame += 1

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -998,6 +998,7 @@ class TiffImageFile(ImageFile.ImageFile):
     def n_frames(self):
         if self._n_frames is None:
             current = self.tell()
+            self._seek(len(self._frame_pos))
             while self._n_frames is None:
                 self._seek(self.tell() + 1)
             self.seek(current)


### PR DESCRIPTION
* Because `__next` reveals if there is a next frame or not, `_is_animated` can be determined on the initial seek. That also means that the tests can be simplified slightly, because `is_animated` no longer interacts with `_n_frames`. You might think that this means that the `is_animated` decorator can be replaced with just a variable. However, `MicImageFile` inherits `TiffImageFile`, and `is_animated` can't be set directly in that circumstance.
* Because `__next` reveals if there is a next frame or not, `_n_frames` can be populated automatically if seeking to the last frame.
* The search in `n_frames` for the last frame can be made faster by starting from the last frame ever seeked, rather than just from the current position.