### PR TITLE
Fixed GIF bug when rewinding to a non-zero frame

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -230,6 +230,15 @@ class TestFileGif(PillowTestCase):
 
         self.assertEqual(im.info, info)
 
+    def test_seek_rewind(self):
+        im = Image.open("Tests/images/iss634.gif")
+        im.seek(2)
+        im.seek(1)
+
+        expected = Image.open("Tests/images/iss634.gif")
+        expected.seek(1)
+        self.assert_image_equal(im, expected)
+
     def test_n_frames(self):
         for path, n_frames in [
             [TEST_GIF, 1],

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -122,6 +122,8 @@ class GifImageFile(ImageFile.ImageFile):
         if not self._seek_check(frame):
             return
         if frame < self.__frame:
+            if frame != 0:
+                self.im = None
             self._seek(0)
 
         last_frame = self.__frame


### PR DESCRIPTION
Seen in #3629

```python
from PIL import Image
im = Image.open("Tests/images/iss634.gif")
im.seek(2)
im.seek(1)
```

Expected

![expected](https://user-images.githubusercontent.com/3112309/54325093-a458f000-4654-11e9-86a6-26cd347eda9a.gif)

Result without the fix

![result](https://user-images.githubusercontent.com/3112309/54325100-a8850d80-4654-11e9-9e2a-7a4d07ae0817.gif)