### PR TITLE
Ensure image is mutable before saving

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -3,6 +3,8 @@ from .helper import unittest, PillowTestCase, hopper
 from PIL import Image
 from PIL._util import py3
 import os
+import sys
+import shutil
 
 
 class TestImage(PillowTestCase):
@@ -120,6 +122,16 @@ class TestImage(PillowTestCase):
         im.readonly = 1
         im.paste(0, (0, 0, 100, 100))
         self.assertFalse(im.readonly)
+
+    @unittest.skipIf(sys.platform.startswith('win32'),
+                     "Test requires opening tempfile twice")
+    def test_readonly_save(self):
+        temp_file = self.tempfile("temp.bmp")
+        shutil.copy("Tests/images/rgb32bf-rgba.bmp", temp_file)
+
+        im = Image.open(temp_file)
+        self.assertTrue(im.readonly)
+        im.save(temp_file)
 
     def test_dump(self):
         im = Image.new("L", (10, 10))

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1958,7 +1958,7 @@ class Image(object):
             filename = fp.name
 
         # may mutate self!
-        self.load()
+        self._ensure_mutable()
 
         save_all = params.pop('save_all', False)
         self.encoderinfo = params


### PR DESCRIPTION
Resolves #3496

In that issue, a bus error occurs when opening an image and saving it back to the same location. It was described as relating to mmap. Investigating, I find that the bus error occurs at https://github.com/python-pillow/Pillow/blob/d1f865e02ae1731eb41a981ea9a45613e0b91ddc/src/libImaging/Pack.c#L459

So presumably that is conflicting with mmap.

The same block of code that sets up mmap also marks the image as readonly.

https://github.com/python-pillow/Pillow/blob/d1f865e02ae1731eb41a981ea9a45613e0b91ddc/src/PIL/ImageFile.py#L185-L191

https://pillow.readthedocs.io/en/5.4.1/releasenotes/3.3.2.html

> The image was marked readonly, so Pillow would not ordinarily write to that memory without duplicating the image first.

Given the general testing requirement of operating on temp files, and since the test involves opening and saving back the same file, the test can't be run on Windows, as temp files can't be opened twice on that operating system - https://docs.python.org/2/library/tempfile.html
> Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; it cannot on Windows NT or later).