### PR TITLE
Fix BytesWarning in Tests/test_numpy.py

### DIFF
--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -115,7 +115,7 @@ class TestNumpy(PillowTestCase):
         arr_back = numpy.array(img)
         # numpy 1.8 and earlier return this as a boolean. (trusty/precise)
         if arr_back.dtype == numpy.bool:
-            arr_bool = numpy.array([[1, 0, 0, 1, 0], [0, 1, 0, 0, 0]], 'bool')
+            arr_bool = numpy.array([[1, 0, 0, 1, 0], [0, 1, 0, 0, 0]], numpy.bool)
             numpy.testing.assert_array_equal(arr_bool, arr_back)
         else:
             numpy.testing.assert_array_equal(arr, arr_back)
@@ -143,21 +143,21 @@ class TestNumpy(PillowTestCase):
 
             np_img = numpy.array(img)
             self._test_img_equals_nparray(img, np_img)
-            self.assertEqual(np_img.dtype, numpy.dtype(dtype))
+            self.assertEqual(np_img.dtype, dtype)
 
-        modes = [("L", 'uint8'),
-                 ("I", 'int32'),
-                 ("F", 'float32'),
-                 ("LA", 'uint8'),
-                 ("RGB", 'uint8'),
-                 ("RGBA", 'uint8'),
-                 ("RGBX", 'uint8'),
-                 ("CMYK", 'uint8'),
-                 ("YCbCr", 'uint8'),
+        modes = [("L", numpy.uint8),
+                 ("I", numpy.int32),
+                 ("F", numpy.float32),
+                 ("LA", numpy.uint8),
+                 ("RGB", numpy.uint8),
+                 ("RGBA", numpy.uint8),
+                 ("RGBX", numpy.uint8),
+                 ("CMYK", numpy.uint8),
+                 ("YCbCr", numpy.uint8),
                  ("I;16", '<u2'),
                  ("I;16B", '>u2'),
                  ("I;16L", '<u2'),
-                 ("HSV", 'uint8'),
+                 ("HSV", numpy.uint8),
                  ]
 
         for mode in modes:
@@ -167,7 +167,7 @@ class TestNumpy(PillowTestCase):
         # see https://github.com/python-pillow/Pillow/issues/439
 
         data = list(range(256))*3
-        lut = numpy.array(data, dtype='uint8')
+        lut = numpy.array(data, dtype=numpy.uint8)
 
         im = hopper()
 


### PR DESCRIPTION
When running Python with the `-b` command line argument, fixes warnings:

    Tests/test_numpy.py::TestNumpy::test_1bit
      Pillow/Tests/test_numpy.py:118: BytesWarning: Comparison between bytes and string
        arr_bool = numpy.array([[1, 0, 0, 1, 0], [0, 1, 0, 0, 0]], 'bool')

    Tests/test_numpy.py::TestNumpy::test_point_lut
      Pillow/Tests/test_numpy.py:170: BytesWarning: Comparison between bytes and string
        lut = numpy.array(data, dtype='uint8')

    Tests/test_numpy.py::TestNumpy::test_to_array
      Pillow/Tests/test_numpy.py:146: BytesWarning: Comparison between bytes and string
        self.assertEqual(np_img.dtype, numpy.dtype(dtype))
