### PR TITLE
Remove additional references to removed handles_eof

### DIFF
--- a/docs/reference/open_files.rst
+++ b/docs/reference/open_files.rst
@@ -89,13 +89,6 @@ Complications
   the file descriptor internally, it is duplicated prior to passing it
   into libtiff.
 
-* ``decoder.handles_eof`` This slightly misnamed flag indicates that
-  the decoder wants to be called with a 0 length buffer when reads are
-  done. Despite the comments in ``ImageFile.load()``, the only decoder
-  that actually uses this flag is the Jpeg2K decoder. The use of this
-  flag in Jpeg2K predated the change to the decoder that added the
-  pulls_fd flag, and is therefore not used.
-
 * I don't think that there's any way to make this safe without
   changing the lazy loading::
 

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -596,8 +596,6 @@ class PyDecoder(object):
         Override to perform the decoding process.
 
         :param buffer: A bytes object with the data to be decoded.
-            If `handles_eof` is set, then `buffer` will be empty and `self.fd`
-            will be set.
         :returns: A tuple of (bytes consumed, errcode).
             If finished with decoding return <0 for the bytes consumed.
             Err codes are from `ERRORS`


### PR DESCRIPTION
`handles_eof` was removed in 90760a5f3020ada06bf752ae6e98dbfafc0aeb48.