### PR TITLE
Corrected remap_palette documentation

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1688,7 +1688,7 @@ class Image(object):
         Rewrites the image to reorder the palette.
 
         :param dest_map: A list of indexes into the original palette.
-           e.g. [1,0] would swap a two item palette, and list(range(255))
+           e.g. [1,0] would swap a two item palette, and list(range(256))
            is the identity transform.
         :param source_palette: Bytes or None.
         :returns:  An :py:class:`~PIL.Image.Image` object.


### PR DESCRIPTION
![documentation](https://user-images.githubusercontent.com/3112309/54856598-655f2480-4d4f-11e9-82d0-1038f83e24b0.png)

This is incorrect. It should be 256, not 255.

```python
>>> from PIL import Image, ImagePalette
>>> im = Image.open("Tests/images/hopper.gif")
>>> im.load()
<PixelAccess object at 0x10eee3790>
>>> original = im.palette.palette
>>> new = im.remap_palette(list(range(255))).palette.palette
>>> print("same" if new == original else "changed")
changed
>>> new = im.remap_palette(list(range(256))).palette.palette
>>> print("same" if new == original else "changed")
same
```

Just to demonstrate that 257 is too far -

```python
>>> new = im.remap_palette(list(range(257))).palette.palette
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/Image.py", line 1715, in remap_palette
    new_positions[oldPosition] = i
IndexError: list assignment index out of range
>>> 
```