### PR TITLE
AppVeyor: Upgrade to PyPy 7.1.0

### DIFF
--- a/winbuild/appveyor_install_pypy.cmd
+++ b/winbuild/appveyor_install_pypy.cmd
@@ -1,3 +1,3 @@
-curl -fsSL -o pypy2.zip https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.0.0-win32.zip
+curl -fsSL -o pypy2.zip https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.0-win32.zip
 7z x pypy2.zip -oc:\
-c:\Python37\Scripts\virtualenv.exe -p c:\pypy2.7-v7.0.0-win32\pypy.exe c:\vp\pypy2
+c:\Python37\Scripts\virtualenv.exe -p c:\pypy2.7-v7.1.0-win32\pypy.exe c:\vp\pypy2


### PR DESCRIPTION
Changes proposed in this pull request:

 * PyPy 7.1.0 is out, let's use it on AppVeyor 
 * https://morepypy.blogspot.com/2019/03/pypy-v71-released-now-uses-utf-8.html
