### PR TITLE
Updated lcms tested versions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -151,7 +151,7 @@ Many of Pillow's features require external libraries:
 * **littlecms** provides color management
 
   * Pillow version 2.2.1 and below uses liblcms1, Pillow 2.3.0 and
-    above uses liblcms2. Tested with **1.19** and **2.7**.
+    above uses liblcms2. Tested with **1.19** and **2.7-2.9**.
 
 * **libwebp** provides the WebP format.
 


### PR DESCRIPTION
pillow-wheels now tests LCMS 2.9 - https://github.com/python-pillow/pillow-wheels/blob/0070db36ee8ef06aa9d3adc2296241bf1cafb01f/config.sh#L14