### PR TITLE
Improve handling of PSD frames

### DIFF
--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -17,6 +17,12 @@ class TestImagePsd(PillowTestCase):
         im2 = hopper()
         self.assert_image_similar(im, im2, 4.8)
 
+    def test_unclosed_file(self):
+        def open():
+            im = Image.open(test_file)
+            im.load()
+        self.assert_warning(None, open)
+
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -65,6 +65,12 @@ class TestImagePsd(PillowTestCase):
 
         self.assertRaises(EOFError, im.seek, -1)
 
+    def test_open_after_exclusive_load(self):
+        im = Image.open(test_file)
+        im.load()
+        im.seek(im.tell()+1)
+        im.load()
+
     def test_icc_profile(self):
         im = Image.open(test_file)
         self.assertIn("icc_profile", im.info)

--- a/Tests/test_imagesequence.py
+++ b/Tests/test_imagesequence.py
@@ -32,6 +32,12 @@ class TestImageSequence(PillowTestCase):
         self.assertRaises(IndexError, lambda: i[index+1])
         self.assertRaises(StopIteration, next, i)
 
+    def test_iterator_min_frame(self):
+        im = Image.open('Tests/images/hopper.psd')
+        i = ImageSequence.Iterator(im)
+        for index in range(1, im.n_frames):
+            self.assertEqual(i[index], next(i))
+
     def _test_multipage_tiff(self):
         im = Image.open('Tests/images/multipage.tiff')
         for index, frame in enumerate(ImageSequence.Iterator(im)):

--- a/src/PIL/ImageSequence.py
+++ b/src/PIL/ImageSequence.py
@@ -32,7 +32,7 @@ class Iterator(object):
         if not hasattr(im, "seek"):
             raise AttributeError("im must have seek method")
         self.im = im
-        self.position = 0
+        self.position = getattr(self.im, "_min_frame", 0)
 
     def __getitem__(self, ix):
         try:

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -129,7 +129,7 @@ class PsdImageFile(ImageFile.ImageFile):
         self.tile = _maketile(self.fp, mode, (0, 0) + self.size, channels)
 
         # keep the file open
-        self._fp = self.fp
+        self.__fp = self.fp
         self.frame = 1
         self._min_frame = 1
 
@@ -151,7 +151,7 @@ class PsdImageFile(ImageFile.ImageFile):
             self.mode = mode
             self.tile = tile
             self.frame = layer
-            self.fp = self._fp
+            self.fp = self.__fp
             return name, bbox
         except IndexError:
             raise EOFError("no such layer")
@@ -167,6 +167,15 @@ class PsdImageFile(ImageFile.ImageFile):
         # create palette (optional)
         if self.mode == "P":
             Image.Image.load(self)
+
+    def _close__fp(self):
+        try:
+            if self.__fp != self.fp:
+                self.__fp.close()
+        except AttributeError:
+            pass
+        finally:
+            self.__fp = None
 
 
 def _layerinfo(file):

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -54,6 +54,7 @@ class PsdImageFile(ImageFile.ImageFile):
 
     format = "PSD"
     format_description = "Adobe Photoshop"
+    _close_exclusive_fp_after_loading = False
 
     def _open(self):
 


### PR DESCRIPTION
* PSD frames start from 1, not 0. This PR changes `ImageSequence` to use this.
* PSD was closing the file pointer after load. This is not correct, as it is a multiframe format. This is because it was missing `_close_exclusive_fp_after_loading = False`.