### PR TITLE
Allow asymmetric PDF export resolution

### DIFF
--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -61,7 +61,7 @@ def _save(im, fp, filename, save_all=False):
         resolution2D = (resolution,resolution)
     else:
         resolution2D = resolution
-        
+
     info = {
         "title": None if is_appending else os.path.splitext(
                                                os.path.basename(filename)

--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -56,7 +56,12 @@ def _save(im, fp, filename, save_all=False):
         existing_pdf = PdfParser.PdfParser(f=fp, filename=filename, mode="w+b")
 
     resolution = im.encoderinfo.get("resolution", 72.0)
-
+    # Allows the user to specify either a 1D resolution or 2D resolution.
+    if not isinstance(resolution,(list,tuple)):
+        resolution2D = (resolution,resolution)
+    else:
+        resolution2D = resolution
+        
     info = {
         "title": None if is_appending else os.path.splitext(
                                                os.path.basename(filename)
@@ -211,8 +216,8 @@ def _save(im, fp, filename, save_all=False):
                                     MediaBox=[
                                         0,
                                         0,
-                                        int(width * 72.0 / resolution),
-                                        int(height * 72.0 / resolution)
+                                        int(width * 72.0 / resolution2D[0]),
+                                        int(height * 72.0 / resolution2D[1])
                                     ],
                                     Contents=contents_refs[pageNumber])
 
@@ -221,8 +226,8 @@ def _save(im, fp, filename, save_all=False):
 
             page_contents = PdfParser.make_bytes(
                 "q %d 0 0 %d 0 0 cm /image Do Q\n" % (
-                    int(width * 72.0 / resolution),
-                    int(height * 72.0 / resolution)))
+                    int(width * 72.0 / resolution2D[0]),
+                    int(height * 72.0 / resolution2D[1])))
 
             existing_pdf.write_obj(contents_refs[pageNumber],
                                    stream=page_contents)


### PR DESCRIPTION
Allow PDF exporting resolution to be specified as a tuple too, to get asymmetric DPIs sometimes used by sticker/inkjet printers, e.g 600x1200dpi.