### PR TITLE
Drop support for EOL Ubuntu 14.04 (Trusty Tahr)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,8 @@ matrix:
       env: LINT="true"
     - python: "pypy2.7-6.0"
       name: "PyPy2 Xenial"
-      dist: xenial
     - python: "pypy3.5-6.0"
       name: "PyPy3 Xenial"
-      dist: xenial
     - python: '3.7'
       name: "3.7 Xenial"
     - python: '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,32 +26,19 @@ matrix:
       name: "3.7 Xenial"
     - python: '2.7'
       name: "2.7 Xenial"
-    - python: '2.7'
-      name: "2.7 Trusty"
-      dist: trusty
     - python:  "2.7_with_system_site_packages" # For PyQt4
       name: "2.7_with_system_site_packages Xenial"
       services: xvfb
-    - python:  "2.7_with_system_site_packages" # For PyQt4
-      name: "2.7_with_system_site_packages Trusty"
-      dist: trusty
     - python: '3.6'
-      name: "3.6 Xenial"
-    - python: '3.6'
-      name: "3.6 Trusty PYTHONOPTIMIZE=1"
-      dist: trusty
+      name: "3.6 Xenial PYTHONOPTIMIZE=1"
       env: PYTHONOPTIMIZE=1
     - python: '3.5'
-      name: "3.5 Xenial"
-    - python: '3.5'
-      name: "3.5 Trusty PYTHONOPTIMIZE=2"
-      dist: trusty
+      name: "3.5 Xenial PYTHONOPTIMIZE=2"
       env: PYTHONOPTIMIZE=2
     - python: "3.8-dev"
       name: "3.8-dev Xenial"
     - env: DOCKER="alpine" DOCKER_TAG="master"
     - env: DOCKER="arch" DOCKER_TAG="master" # contains PyQt5
-    - env: DOCKER="ubuntu-trusty-x86" DOCKER_TAG="master"
     - env: DOCKER="ubuntu-xenial-amd64" DOCKER_TAG="master"
     - env: DOCKER="debian-stretch-x86" DOCKER_TAG="master"
     - env: DOCKER="centos-6-amd64" DOCKER_TAG="master"
@@ -78,7 +65,7 @@ install:
 before_script:
 # Qt needs a display for some of the tests, and it's only run on the system site packages install
 - |
-  if [ "$TRAVIS_JOB_NAME" == "2.7_with_system_site_packages Trusty" ]; then
+  if [ "$TRAVIS_JOB_NAME" == "2.7_with_system_site_packages Xenial" ]; then
     export DISPLAY=:99.0
     sh -e /etc/init.d/xvfb start
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,14 +60,6 @@ install:
       .travis/install.sh;
     fi
 
-before_script:
-# Qt needs a display for some of the tests, and it's only run on the system site packages install
-- |
-  if [ "$TRAVIS_JOB_NAME" == "2.7_with_system_site_packages Xenial" ]; then
-    export DISPLAY=:99.0
-    sh -e /etc/init.d/xvfb start
-  fi
-
 script:
 - |
   if [ "$LINT" == "true" ]; then

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -113,12 +113,7 @@ class TestNumpy(PillowTestCase):
         img = Image.fromarray(arr * 255).convert('1')
         self.assertEqual(img.mode, '1')
         arr_back = numpy.array(img)
-        # numpy 1.8 and earlier return this as a boolean. (trusty/precise)
-        if arr_back.dtype == numpy.bool:
-            arr_bool = numpy.array([[1, 0, 0, 1, 0], [0, 1, 0, 0, 0]], numpy.bool)
-            numpy.testing.assert_array_equal(arr_bool, arr_back)
-        else:
-            numpy.testing.assert_array_equal(arr, arr_back)
+        numpy.testing.assert_array_equal(arr, arr_back)
 
     def test_save_tiff_uint16(self):
         # Tests that we're getting the pixel value in the right byte order.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,11 +23,6 @@ jobs:
 
 - template: .azure-pipelines/jobs/test-docker.yml
   parameters:
-    docker: 'ubuntu-trusty-x86'
-    name:   'ubuntu_trusty_x86'
-
-- template: .azure-pipelines/jobs/test-docker.yml
-  parameters:
     docker: 'ubuntu-xenial-amd64'
     name:   'ubuntu_xenial_amd64'
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -165,7 +165,7 @@ Many of Pillow's features require external libraries:
 
   * Pillow has been tested with openjpeg **2.0.0** and **2.1.0**.
   * Pillow does **not** support the earlier **1.5** series which ships
-    with Ubuntu <= 14.04 and Debian Jessie.
+    with Debian Jessie.
 
 * **libimagequant** provides improved color quantization
 
@@ -402,10 +402,6 @@ These platforms are built and tested for every change.
 +----------------------------------+-------------------------------+-----------------------+
 | Ubuntu Linux 16.04 LTS           | 2.7, 3.5, 3.6, 3.7,           |x86-64                 |
 |                                  | PyPy, PyPy3                   |                       |
-+----------------------------------+-------------------------------+-----------------------+
-| Ubuntu Linux 14.04 LTS           | 2.7, 3.5, 3.6                 |x86-64                 |
-|                                  +-------------------------------+-----------------------+
-|                                  | 2.7                           |x86                    |
 +----------------------------------+-------------------------------+-----------------------+
 | Windows Server 2012 R2           | 2.7, 3.5, 3.6, 3.7            |x86, x86-64            |
 |                                  +-------------------------------+-----------------------+


### PR DESCRIPTION
Changes proposed in this pull request:

 * Trusty is EOL this month https://linuxlifecycle.com/
 * Remove from CIs
 * Switch `PYTHONOPTIMIZE` jobs to Xenial
 * We no longer need the `before_script:` section, Xenial uses `services: xvfb` instead of explicit `xvfb start` https://blog.travis-ci.com/2018-11-08-xenial-release
 * Remove a NumPy workaround for Trusty and already dropped Precise

Related: https://github.com/python-pillow/docker-images/pull/54 and https://github.com/python-pillow/pillow-wheels/pull/115.
