### PR TITLE
Stable is now the default ReadTheDocs version

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -102,4 +102,4 @@ Released as needed privately to individual vendors for critical security-related
 
 ## Documentation
 
-* [ ] Make sure the default version for Read the Docs is the latest tagged release e.g. `d2d43879` (5.4.0)
+* [ ] Make sure the [default version for Read the Docs](https://pillow.readthedocs.io/en/stable/) is up-to-date with the release changes


### PR DESCRIPTION
Updating the release checklist after the default ReadTheDocs was changed to stable in https://github.com/python-pillow/Pillow/issues/3391#issuecomment-451302427