### PR TITLE
AppVeyor improvements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -52,7 +52,7 @@ install:
       }
       else
       {
-        c:\python34\python.exe c:\pillow\winbuild\build_dep.py
+        c:\python37\python.exe c:\pillow\winbuild\build_dep.py
         c:\pillow\winbuild\build_deps.cmd
         $host.SetShouldExit(0)
       }

--- a/winbuild/build.py
+++ b/winbuild/build.py
@@ -109,6 +109,7 @@ set INCLUDE=%%INCLUDE%%;%%INCLIB%%\%(inc_dir)s;%%INCLIB%%\tcl%(tcl_ver)s\include
 setlocal
 set LIB=%%LIB%%;C:\Python%(py_ver)s\tcl%(vc_setup)s
 call %(python_path)s\%(executable)s setup.py %(imaging_libs)s %%BLDOPT%%
+call %(python_path)s\%(executable)s -c "from PIL import _webp;import os, shutil;shutil.copy('%%INCLIB%%\\freetype.dll', os.path.dirname(_webp.__file__));"
 endlocal
 
 endlocal

--- a/winbuild/build_dep.py
+++ b/winbuild/build_dep.py
@@ -238,9 +238,9 @@ setlocal
 rd /S /Q %%LCMS%%\Lib
 rd /S /Q %%LCMS%%\Projects\VC%(vc_version)s\Release
 %%MSBUILD%% %%LCMS%%\Projects\VC%(vc_version)s\lcms2.sln /t:Clean /p:Configuration="Release" /p:Platform=Win32 /m
-%%MSBUILD%% %%LCMS%%\Projects\VC%(vc_version)s\lcms2.sln /t:lcms2_static /p:Configuration="Release" /p:Platform=Win32 /m
+%%MSBUILD%% %%LCMS%%\Projects\VC%(vc_version)s\lcms2.sln /t:lcms2_static /p:Configuration="Release" /p:Platform=Win32 /p:PlatformToolset=v90 /m
 xcopy /Y /E /Q %%LCMS%%\include %%INCLIB%%
-copy /Y /B %%LCMS%%\Projects\VC%(vc_version)s\Release\*.lib %%INCLIB%%
+copy /Y /B %%LCMS%%\Lib\MS\*.lib %%INCLIB%%
 endlocal
 """ % compiler  # noqa: E501
 
@@ -265,7 +265,7 @@ rem Build gs
 setlocal
 """ + vc_setup(compiler, bit) + r"""
 set MSVC_VERSION=""" + {
-        "2008": "9",
+        "2010": "90",
         "2015": "14"
     }[compiler['vc_version']] + r"""
 set RCOMP="C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\Bin\RC.Exe"
@@ -308,7 +308,7 @@ if 'PYTHON' in os.environ:
 else:
     # for compiler in all_compilers():
     #     add_compiler(compiler)
-    add_compiler(compilers[7.0][2008][32], 32)
+    add_compiler(compilers[7.0][2010][32], 32)
 
 with open('build_deps.cmd', 'w') as f:
     f.write("\n".join(script))

--- a/winbuild/config.py
+++ b/winbuild/config.py
@@ -43,9 +43,9 @@ libs = {
         'dir': 'lcms2-2.7',
     },
     'ghostscript': {
-        'url': 'https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs926/ghostscript-9.26.tar.gz',  # noqa: E501
-        'filename': PILLOW_DEPENDS_DIR + 'ghostscript-9.26.tar.gz',
-        'dir': 'ghostscript-9.26',
+        'url': 'https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs927/ghostscript-9.27.tar.gz',  # noqa: E501
+        'filename': PILLOW_DEPENDS_DIR + 'ghostscript-9.27.tar.gz',
+        'dir': 'ghostscript-9.27',
     },
     'tcl-8.5': {
         'url': SF_MIRROR+'/project/tcl/Tcl/8.5.19/tcl8519-src.zip',

--- a/winbuild/config.py
+++ b/winbuild/config.py
@@ -3,8 +3,8 @@ import os
 SF_MIRROR = 'http://iweb.dl.sourceforge.net'
 PILLOW_DEPENDS_DIR = 'C:\\pillow-depends\\'
 
-pythons = {'27': {'compiler': 7, 'vc': 2008},
-           'pypy2': {'compiler': 7, 'vc': 2008},
+pythons = {'27': {'compiler': 7, 'vc': 2010},
+           'pypy2': {'compiler': 7, 'vc': 2010},
            '35': {'compiler': 7.1, 'vc': 2015},
            '36': {'compiler': 7.1, 'vc': 2015},
            '37': {'compiler': 7.1, 'vc': 2015}}
@@ -83,10 +83,10 @@ libs = {
 
 compilers = {
     7: {
-        2008: {
+        2010: {
             64: {
                 'env_version': 'v7.0',
-                'vc_version': '2008',
+                'vc_version': '2010',
                 'env_flags': '/x64 /xp',
                 'inc_dir': 'msvcr90-x64',
                 'platform': 'x64',
@@ -94,7 +94,7 @@ compilers = {
             },
             32: {
                 'env_version': 'v7.0',
-                'vc_version': '2008',
+                'vc_version': '2010',
                 'env_flags': '/x86 /xp',
                 'inc_dir': 'msvcr90-x32',
                 'platform': 'Win32',


### PR DESCRIPTION
* Added Freetype to all AppVeyor builds except Mingw
* Removed use of Python 3.4
* Updated Ghostscript to 9.27
* Changed Visual Studio 2008 to 2010, as Visual Studio 2008 reached end of support on April 10, 2018 - https://support.microsoft.com/en-au/help/4043450/products-reaching-end-of-support-for-2018