### PR TITLE
Add Ubuntu 18.04 Bionic, update 16.04 Xenial filename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,8 @@ matrix:
       name: "3.8-dev Xenial"
     - env: DOCKER="alpine" DOCKER_TAG="master"
     - env: DOCKER="arch" DOCKER_TAG="master" # contains PyQt5
-    - env: DOCKER="ubuntu-xenial-amd64" DOCKER_TAG="master"
+    - env: DOCKER="ubuntu-16.04-xenial-amd64" DOCKER_TAG="master"
+    - env: DOCKER="ubuntu-18.04-bionic-amd64" DOCKER_TAG="master"
     - env: DOCKER="debian-stretch-x86" DOCKER_TAG="master"
     - env: DOCKER="centos-6-amd64" DOCKER_TAG="master"
     - env: DOCKER="centos-7-amd64" DOCKER_TAG="master"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,8 +23,13 @@ jobs:
 
 - template: .azure-pipelines/jobs/test-docker.yml
   parameters:
-    docker: 'ubuntu-xenial-amd64'
-    name:   'ubuntu_xenial_amd64'
+    docker: 'ubuntu-16.04-xenial-amd64'
+    name:   'ubuntu_16_04_xenial_amd64'
+
+- template: .azure-pipelines/jobs/test-docker.yml
+  parameters:
+    docker: 'ubuntu-18.04-bionic-amd64'
+    name:   'ubuntu_18_04_bionic_amd64'
 
 - template: .azure-pipelines/jobs/test-docker.yml
   parameters:


### PR DESCRIPTION
Docker images were updated in https://github.com/python-pillow/docker-images/pull/54.

Changes proposed in this pull request:

 * Add Docker image for Ubuntu 18.04 Bionic
 * Update Docker filename for Ubuntu 16.04 Xenial
 * For both Travis CI and Azure Pipelines

