### PR TITLE
Document clearly PILLOW_VERSION removal

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -76,8 +76,8 @@ PILLOW_VERSION constant
 
 .. deprecated:: 5.2.0
 
-``PILLOW_VERSION`` has been deprecated and will be removed in the next
-major release. Use ``__version__`` instead.
+``PILLOW_VERSION`` has been deprecated and will be removed in 7.0.0. Use ``__version__``
+instead.
 
 ImageCms.CmsProfile attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Changes proposed in this pull request:

 * The source code makes it clear when it will be removed (see below).
 * Do the same in documentation.

https://github.com/python-pillow/Pillow/blob/e8b2da587f721e9e7fee7135dee159b9330098f4/src/PIL/__init__.py#L20

https://github.com/python-pillow/Pillow/blob/e8b2da587f721e9e7fee7135dee159b9330098f4/src/PIL/Image.py#L28