### PR TITLE
Remove Python.h where not needed

### DIFF
--- a/src/libImaging/BoxBlur.c
+++ b/src/libImaging/BoxBlur.c
@@ -1,4 +1,3 @@
-#include "Python.h"
 #include "Imaging.h"
 
 

--- a/src/libImaging/UnsharpMask.c
+++ b/src/libImaging/UnsharpMask.c
@@ -6,7 +6,6 @@
 /* Originally released under LGPL.  Graciously donated to PIL
    for distribution under the standard PIL license in 2009." */
 
-#include "Python.h"
 #include "Imaging.h"
 
 


### PR DESCRIPTION
* Removes Python.h header from a couple of python-free libImaging files.