### PR TITLE
Correct libimagequant installation requirements

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -173,7 +173,7 @@ Many of Pillow's features require external libraries:
   * Libimagequant is licensed GPLv3, which is more restrictive than
     the Pillow license, therefore we will not be distributing binaries
     with libimagequant support enabled.
-  * Windows support: Libimagequant requires VS2013/MSVC 18 to compile,
+  * Windows support: Libimagequant requires VS2015/MSVC 19 to compile,
     so it is unlikely to work with Python 2.7 on Windows.
 
 * **libraqm** provides complex text layout support.


### PR DESCRIPTION
Our docs currently state that 'Windows support: Libimagequant requires VS2013/MSVC 18 to compile'.

However, https://pngquant.org/lib/ instructs users to 'Use Visual Studio 2015', so I have changed it to 'VS2015/MSVC 19'. The updated MSVC number comes from looking up Visual Studio 2015 in https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering