### PR TITLE
Fix double free in font loading failure

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -420,6 +420,10 @@ class TestImageFont(PillowTestCase):
         self.assertRaises(IOError, ImageFont.load_path, filename)
         self.assertRaises(IOError, ImageFont.truetype, filename)
 
+    def test_load_non_font_bytes(self):
+        with open("Tests/images/hopper.jpg", "rb") as f:
+            self.assertRaises(IOError, ImageFont.truetype, f)
+
     def test_default_font(self):
         # Arrange
         txt = 'This is a "better than nothing" default font.'

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -545,6 +545,8 @@ def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):
     try:
         return freetype(font)
     except IOError:
+        if not isPath(font):
+            raise
         ttf_filename = os.path.basename(font)
 
         dirs = []

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -313,9 +313,6 @@ getfont(PyObject* self_, PyObject* args, PyObject* kw)
       PyMem_Free(filename);
 
     if (error) {
-        if (self->font_bytes) {
-            PyMem_Free(self->font_bytes);
-        }
         Py_DECREF(self);
         return geterror(error);
     }


### PR DESCRIPTION
The memory is freeed in font_dealloc, doing that again leads to SIGABRT.

Fixes #3853.

Changes proposed in this pull request:

 * it removes double free in error handling path

I wanted to add test for this, but the error handling futher is broken as well (the invalid font raises IOError, which is later intepreted as missing file and loader tries to do `os.path.basename` on a file like object), so I ended up fixing the crash only for now.