### PR TITLE
Update issue template for community profile checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: Issue report
 about: Create a report to help us improve Pillow
 ---
 ### What did you do?

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,7 @@
+---
+name: Bug report
+about: Create a report to help us improve Pillow
+---
 ### What did you do?
 
 ### What did you expect to happen?
@@ -12,7 +16,7 @@
 
 Please include **code** that reproduces the issue and whenever possible, an **image** that demonstrates the issue. Please upload images to GitHub, not to third-party file hosting sites. If necessary, add the image to a zip or tar archive.
 
-The best reproductions are self-contained scripts with minimal dependencies. If you are using a framework such as plone, Django, or buildout, try to replicate the issue just using Pillow. 
+The best reproductions are self-contained scripts with minimal dependencies. If you are using a framework such as plone, Django, or buildout, try to replicate the issue just using Pillow.
 
 ```python
 code goes here


### PR DESCRIPTION
While Pillow currently has an issue template, the community profile checklist is not detecting this.

![Screen Shot 2019-05-19 at 10 23 30 pm](https://user-images.githubusercontent.com/3112309/57987542-0f47fc80-7ac6-11e9-9890-1342d79b6217.png)

https://help.github.com/en/articles/about-issue-and-pull-request-templates
> To be included in the community profile checklist, issue templates must be located in the .github/ISSUE_TEMPLATE folder and contain valid name: and about: YAML front matter.

So this PR adds those variables. I've based the values here on one of the standards.

![Screen Shot 2019-05-19 at 10 25 49 pm](https://user-images.githubusercontent.com/3112309/57987549-2edf2500-7ac6-11e9-9621-3161be9e51b7.png)