### PR TITLE
Replace non-ascii quotes from docstring

### DIFF
--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -284,8 +284,8 @@ class FreeTypeFont(object):
         """
         Create a bitmap for the text.
 
-        If the font uses antialiasing, the bitmap should have mode “L” and use a
-        maximum value of 255. Otherwise, it should have mode “1”.
+        If the font uses antialiasing, the bitmap should have mode ``L`` and use a
+        maximum value of 255. Otherwise, it should have mode ``1``.
 
         :param text: Text to render.
         :param mode: Used by some graphics drivers to indicate what mode the
@@ -335,8 +335,8 @@ class FreeTypeFont(object):
         """
         Create a bitmap for the text.
 
-        If the font uses antialiasing, the bitmap should have mode “L” and use a
-        maximum value of 255. Otherwise, it should have mode “1”.
+        If the font uses antialiasing, the bitmap should have mode ``L`` and use a
+        maximum value of 255. Otherwise, it should have mode ``1``.
 
         :param text: Text to render.
         :param mode: Used by some graphics drivers to indicate what mode the


### PR DESCRIPTION
This gave me encoding warnings when running pytest on Python 2.7.
