### PR TITLE
Move security policy to show up more clearly in the GitHub UI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,6 +34,4 @@ The best reproductions are self-contained scripts with minimal dependencies. If 
 
 ## Security vulnerabilities
 
-To report sensitive vulnerability information, please use the [Tidelift security contact](https://tidelift.com/security). Tidelift will coordinate the fix and disclosure.
-
-If your organisation/employer is a distributor of Pillow and would like advance notification of security-related bugs, please let us know your preferred contact method.
+Please see our [security policy](https://github.com/python-pillow/Pillow/blob/master/.github/SECURITY.md).

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,5 @@
+# Security policy
+
+To report sensitive vulnerability information, please use the [Tidelift security contact](https://tidelift.com/security). Tidelift will coordinate the fix and disclosure.
+
+If your organisation/employer is a distributor of Pillow and would like advance notification of security-related bugs, please let us know your preferred contact method.


### PR DESCRIPTION
Changes proposed in this pull request:

![image](https://user-images.githubusercontent.com/1324225/58328675-60941b00-7e3b-11e9-9cf8-ee8771a89980.png)


 * GitHub have a new way to show the security policy under a dedicated "Security" tab
 * Move the info to the new file (avoid duplication)
 * Link from the old place to the new place
 * More info:
   * https://github.blog/2019-05-23-introducing-new-ways-to-keep-your-code-secure/#open-source-security
   * https://help.github.com/en/articles/adding-a-security-policy-to-your-repository
 
