### PR TITLE
Set up GitHub Sponsors with Tidelift

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+tidelift: pypi/pillow


### PR DESCRIPTION
GitHub has new ways to sponsor open-source projects, including making Tidelift more visible.

This is the config for Tidelift, which also needs a checkbox ticking under settings (I don't have access) like this:

https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository#displaying-a-sponsor-button-in-your-repository

More info:

* https://github.blog/2019-05-23-announcing-github-sponsors-a-new-way-to-contribute-to-open-source/
* https://blog.tidelift.com/tidelift-partners-with-github-funds-4000-open-source-projects
* https://tidelift.com/subscription/how-to-connect-tidelift-with-github
