### PR TITLE
Do not down-convert if image is LA when showing with PNG format

### DIFF
--- a/Tests/test_image_mode.py
+++ b/Tests/test_image_mode.py
@@ -26,6 +26,17 @@ class TestImageMode(PillowTestCase):
         self.assertEqual(m.basemode, "L")
         self.assertEqual(m.basetype, "L")
 
+        for mode in ("I;16", "I;16S",
+                     "I;16L", "I;16LS",
+                     "I;16B", "I;16BS",
+                     "I;16N", "I;16NS"):
+            m = ImageMode.getmode(mode)
+            self.assertEqual(m.mode, mode)
+            self.assertEqual(str(m), mode)
+            self.assertEqual(m.bands, ("I",))
+            self.assertEqual(m.basemode, "L")
+            self.assertEqual(m.basetype, "L")
+
         m = ImageMode.getmode("RGB")
         self.assertEqual(m.mode, "RGB")
         self.assertEqual(str(m), "RGB")

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -18,18 +18,19 @@ class TestImageShow(PillowTestCase):
         ImageShow._viewers.pop()
 
     def test_show(self):
-        class TestViewer:
+        class TestViewer(ImageShow.Viewer):
             methodCalled = False
 
-            def show(self, image, title=None, **options):
+            def show_image(self, image, **options):
                 self.methodCalled = True
                 return True
         viewer = TestViewer()
         ImageShow.register(viewer, -1)
 
-        im = hopper()
-        self.assertTrue(ImageShow.show(im))
-        self.assertTrue(viewer.methodCalled)
+        for mode in ("1", "I;16", "LA", "RGB", "RGBA"):
+            im = hopper(mode)
+            self.assertTrue(ImageShow.show(im))
+            self.assertTrue(viewer.methodCalled)
 
         # Restore original state
         ImageShow._viewers.pop(0)

--- a/src/PIL/ImageMode.py
+++ b/src/PIL/ImageMode.py
@@ -48,9 +48,17 @@ def getmode(mode):
         modes["La"] = ModeDescriptor("La", ("L", "a"), "L", "L")
         modes["PA"] = ModeDescriptor("PA", ("P", "A"), "RGB", "L")
         # mapping modes
-        modes["I;16"] = ModeDescriptor("I;16", "I", "L", "L")
-        modes["I;16L"] = ModeDescriptor("I;16L", "I", "L", "L")
-        modes["I;16B"] = ModeDescriptor("I;16B", "I", "L", "L")
+        for i16mode in (
+            "I;16",
+            "I;16S",
+            "I;16L",
+            "I;16LS",
+            "I;16B",
+            "I;16BS",
+            "I;16N",
+            "I;16NS",
+        ):
+            modes[i16mode] = ModeDescriptor(i16mode, ("I",), "L", "L")
         # set global mode cache atomically
         _modes = modes
     return _modes[mode]

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -71,7 +71,9 @@ class Viewer(object):
             # FIXME: auto-contrast if max() > 255?
         else:
             base = Image.getmodebase(image.mode)
-        if base != image.mode and image.mode != "1" and image.mode != "RGBA":
+        if not (base == image.mode or
+                image.mode in ("1", "RGBA") or
+                (self.format == "PNG" and image.mode == "LA")):
             image = image.convert(base)
 
         return self.show_image(image, **options)

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -63,18 +63,12 @@ class Viewer(object):
     def show(self, image, **options):
 
         # save temporary image to disk
-        if image.mode[:4] == "I;16":
-            # @PIL88 @PIL101
-            # "I;16" isn't an 'official' mode, but we still want to
-            # provide a simple way to show 16-bit images.
-            base = "L"
-            # FIXME: auto-contrast if max() > 255?
-        else:
+        if not (
+            image.mode in ("1", "RGBA") or (self.format == "PNG" and image.mode == "LA")
+        ):
             base = Image.getmodebase(image.mode)
-        if not (base == image.mode or
-                image.mode in ("1", "RGBA") or
-                (self.format == "PNG" and image.mode == "LA")):
-            image = image.convert(base)
+            if image.mode != base:
+                image = image.convert(base)
 
         return self.show_image(image, **options)
 


### PR DESCRIPTION
Resolves #3868. ImageShow converts images to their base mode, unless they are 1 or RGBA. The issue reports that LA images lose their transparency - this is because the base mode is L. This PR resolves the issue by adding an exception for LA, adding to the existing exceptions for 1 and RGBA - although only if the output image format is PNG, since BMP cannot save in LA.

Unrelated to that problem, but around the same code, ImageShow has a condition to test for 'I;16' modes, stating that L is to be used instead of the base mode in those cases. However, `Image.getmodebase("I;16")` is L, so there is no difference. I have added a commit to add more mode descriptors to cover all I;16 modes, so that the ImageShow condition can be removed.

In doing that, I did find that ImageMode was listing the bands for the I;16 modes as a string, rather than as a tuple. When adding testing code to Tests/test_image_mode.py, it became apparent that this was inconsistent with other modes, so I have also fixed that.