### PR TITLE
Link method in docs

### DIFF
--- a/docs/handbook/overview.rst
+++ b/docs/handbook/overview.rst
@@ -33,7 +33,7 @@ DIB interface <PIL.ImageWin>` that can be used with PythonWin and other
 Windows-based toolkits. Many other GUI toolkits come with some kind of PIL
 support.
 
-For debugging, there’s also a :py:meth:`show` method which saves an image to
+For debugging, there’s also a :py:meth:`~PIL.Image.Image.show` method which saves an image to
 disk, and calls an external display utility.
 
 Image Processing


### PR DESCRIPTION
Changes a reference at https://pillow.readthedocs.io/en/latest/handbook/overview.html to link to the method, rather than just being highlighted text.