### PR TITLE
Tighten fixed pyroma test

### DIFF
--- a/Tests/test_pyroma.py
+++ b/Tests/test_pyroma.py
@@ -26,5 +26,5 @@ class TestPyroma(PillowTestCase):
             )
 
         else:
-            # Should have a near-perfect score
-            self.assertEqual(rating, (9, ["Your package does not have license data."]))
+            # Should have a perfect score
+            self.assertEqual(rating, (10, []))


### PR DESCRIPTION
PR https://github.com/python-pillow/Pillow/pull/3752 relaxed a Pyroma test because (https://github.com/python-pillow/Pillow/pull/3752#issuecomment-476852312):

> Pyroma was failing because "Your package does not have license data". When there's a known Trove licence, `licence` can and should be omitted, according to https://github.com/pypa/packaging.python.org/pull/492.
> 
> I've reported this to pyroma (https://github.com/regebro/pyroma/issues/38) and relaxed our test in the meantime.

Pyroma has now fixed https://github.com/regebro/pyroma/issues/38 and released it in version 2.5, which means Pillow again scores a 10.

Let's undo the workaround (also fixes the build eg. https://travis-ci.org/python-pillow/Pillow/builds/540460207).