### PR TITLE
Changed Preview application path so that it is no longer static

### DIFF
--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -128,7 +128,7 @@ elif sys.platform == "darwin":
         def get_command(self, file, **options):
             # on darwin open returns immediately resulting in the temp
             # file removal while app is opening
-            command = "open -a /Applications/Preview.app"
+            command = "open -a Preview.app"
             command = "(%s %s; sleep 20; rm -f %s)&" % (
                 command,
                 quote(file),
@@ -143,12 +143,7 @@ elif sys.platform == "darwin":
                 f.write(file)
             with open(path, "r") as f:
                 subprocess.Popen(
-                    [
-                        "im=$(cat);"
-                        "open -a /Applications/Preview.app $im;"
-                        "sleep 20;"
-                        "rm -f $im"
-                    ],
+                    ["im=$(cat); open -a Preview.app $im; sleep 20; rm -f $im"],
                     shell=True,
                     stdin=f,
                 )


### PR DESCRIPTION
Resolves #3895

In the issue, it is reported that macOS 10.15 moves Preview from /Applications to /System/Applications. We could instruct Pillow to test for the operating system version, and use the relevant path, but I think it would be simpler to just stop using an absolute path.