### PR TITLE
Fixed crash when loading non-font bytes

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -420,6 +420,10 @@ class TestImageFont(PillowTestCase):
         self.assertRaises(IOError, ImageFont.load_path, filename)
         self.assertRaises(IOError, ImageFont.truetype, filename)
 
+    def test_load_non_font_bytes(self):
+        with open("Tests/images/hopper.jpg", "rb") as f:
+            self.assertRaises(IOError, ImageFont.truetype, f)
+
     def test_default_font(self):
         # Arrange
         txt = 'This is a "better than nothing" default font.'

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -545,6 +545,8 @@ def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):
     try:
         return freetype(font)
     except IOError:
+        if not isPath(font):
+            raise
         ttf_filename = os.path.basename(font)
 
         dirs = []

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -315,6 +315,7 @@ getfont(PyObject* self_, PyObject* args, PyObject* kw)
     if (error) {
         if (self->font_bytes) {
             PyMem_Free(self->font_bytes);
+            self->font_bytes = NULL;
         }
         Py_DECREF(self);
         return geterror(error);


### PR DESCRIPTION
Resolves #3853, alternative to #3854

The issue reports that loading a non-font as bytes into `ImageFont.truetype` causes a crash. The alternative PR concludes that it is because of memory being free twice - one in `getfont`, and once in `font_dealloc`.

https://github.com/python-pillow/Pillow/blob/9d5a50a0fd12f6ed0feae39d5602d33857febaa5/src/_imagingft.c#L316-L318

https://github.com/python-pillow/Pillow/blob/9d5a50a0fd12f6ed0feae39d5602d33857febaa5/src/_imagingft.c#L1034-L1041

The alternative PR solves this by removing the `PyMem_Free` from `getfont`. This PR suggests instead setting `self->font_bytes` to null after the memory is freed the first time.

Also, the alternative PR points out that once the error is raised, `os.path.basename(font)` is called - which doesn't work if `font` is a file-like object. So this PR also fixes that.