### PR TITLE
Use unsigned int to store TIFF IFD offsets

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -503,9 +503,9 @@ PyImaging_LibTiffDecoderNew(PyObject* self, PyObject* args)
     char* rawmode;
     char* compname;
     int fp;
-    int ifdoffset;
+    uint32 ifdoffset;
 
-    if (! PyArg_ParseTuple(args, "sssii", &mode, &rawmode, &compname, &fp, &ifdoffset))
+    if (! PyArg_ParseTuple(args, "sssiI", &mode, &rawmode, &compname, &fp, &ifdoffset))
         return NULL;
 
     TRACE(("new tiff decoder %s\n", compname));

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -147,7 +147,7 @@ void _tiffUnmapProc(thandle_t hdata, tdata_t base, toff_t size) {
     (void) hdata; (void) base; (void) size;
 }
 
-int ImagingLibTiffInit(ImagingCodecState state, int fp, int offset) {
+int ImagingLibTiffInit(ImagingCodecState state, int fp, uint32 offset) {
     TIFFSTATE *clientstate = (TIFFSTATE *)state->context;
 
     TRACE(("initing libtiff\n"));

--- a/src/libImaging/TiffDecode.h
+++ b/src/libImaging/TiffDecode.h
@@ -43,7 +43,7 @@ typedef struct {
 
 
 
-extern int ImagingLibTiffInit(ImagingCodecState state, int fp, int offset);
+extern int ImagingLibTiffInit(ImagingCodecState state, int fp, uint32 offset);
 extern int ImagingLibTiffEncodeInit(ImagingCodecState state, char *filename, int fp);
 extern int ImagingLibTiffMergeFieldInfo(ImagingCodecState state, TIFFDataType field_type, int key);
 extern int ImagingLibTiffSetField(ImagingCodecState state, ttag_t tag, ...);


### PR DESCRIPTION
Fixes #3919.
