### PR TITLE
Add TIFFTAG_SAMPLEFORMAT to blocklist

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -587,6 +587,28 @@ class TestFileTiff(PillowTestCase):
             im.load()
             self.assertFalse(fp.closed)
 
+    def test_sampleformat_not_corrupted(self):
+        # Assert that a TIFF image with SampleFormat=UINT tag is not corrupted
+        # when saving to a new file.
+        # Pillow 6.0 fails with "OSError: cannot identify image file".
+        import base64
+        tiff = BytesIO(
+            base64.b64decode(
+                b'SUkqAAgAAAAPAP4ABAABAAAAAAAAAAABBAABAAAAAQAAAAEBBAABAAAAAQAA'
+                b'AAIBAwADAAAAwgAAAAMBAwABAAAACAAAAAYBAwABAAAAAgAAABEBBAABAAAA'
+                b'4AAAABUBAwABAAAAAwAAABYBBAABAAAAAQAAABcBBAABAAAACwAAABoBBQAB'
+                b'AAAAyAAAABsBBQABAAAA0AAAABwBAwABAAAAAQAAACgBAwABAAAAAQAAAFMB'
+                b'AwADAAAA2AAAAAAAAAAIAAgACAABAAAAAQAAAAEAAAABAAAAAQABAAEAAAB4'
+                b'nGNgYAAAAAMAAQ=='
+            )
+        )
+        out = BytesIO()
+        with Image.open(tiff) as im:
+            im.save(out, format='tiff')
+        out.seek(0)
+        with Image.open(out) as im:
+            im.load()
+
 
 @unittest.skipUnless(sys.platform.startswith("win32"), "Windows only")
 class TestFileTiffW32(PillowTestCase):

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1540,7 +1540,7 @@ def _save(im, fp, filename):
 
         # STRIPOFFSETS and STRIPBYTECOUNTS are added by the library
         # based on the data in the strip.
-        blocklist = [STRIPOFFSETS, STRIPBYTECOUNTS]
+        blocklist = [STRIPOFFSETS, STRIPBYTECOUNTS, SAMPLEFORMAT]
         atts = {}
         # bits per sample is a single short in the tiff directory, not a list.
         atts[BITSPERSAMPLE] = bits[0]


### PR DESCRIPTION
The `SAMPLEFORMAT` tag is determined by the image format and should not be copied from `legacy_ifd`.

Fixes the wrong `SampleFormat` tag noted in https://github.com/python-pillow/Pillow/issues/3919#issuecomment-506533103.

Alternatively, the `SAMPLEFORMAT` tag could always be written explicitly instead of relying on the TIFF default.

Probably needs a test.