### PR TITLE
Split pytest flags

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -7,7 +7,7 @@ make clean
 make install-coverage
 
 python selftest.py
-python -m pytest -vx --cov PIL --cov-report term Tests
+python -m pytest -v -x --cov PIL --cov-report term Tests
 
 pushd /tmp/check-manifest && check-manifest --ignore ".coveragerc,.editorconfig,*.yml,*.yaml,tox.ini" && popd
 


### PR DESCRIPTION
The next time that the Python 3.8 job is run, it will fail with

> ERROR: usage: pytest.py [options] [file_or_dir] [file_or_dir] [...]
> pytest.py: error: unrecognized arguments: -vx

This is connected to the recent release of pytest 5.0.

Splitting 'vx' into separate flags, I find that it passes again.