### PR TITLE
Update epsilon for FreeType 2.10 with eg. Unicode width 16

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -53,7 +53,8 @@ class TestImageFont(PillowTestCase):
     # (and, other things, but first things first)
     METRICS = {
         (">=2.3", "<2.4"): {"multiline": 30, "textsize": 12, "getters": (13, 16)},
-        (">=2.7",): {"multiline": 6.2, "textsize": 2.5, "getters": (12, 16)},
+        (">=2.7", "<2.10"): {"multiline": 6.2, "textsize": 2.5, "getters": (12, 16)},
+        (">=2.10",): {"multiline": 14.8, "textsize": 2.5, "getters": (12, 16)},
         "Default": {"multiline": 0.5, "textsize": 0.5, "getters": (12, 16)},
     }
 


### PR DESCRIPTION
Potential fix for https://github.com/python-pillow/Pillow/issues/3835#issuecomment-507260313:

> Some new failures on pillow-wheels, `TestImageFont.test_unicode_extended` failed:
> 
> * Mac MB_PYTHON_VERSION=2.7
> * Linux MB_PYTHON_VERSION=2.7 UNICODE_WIDTH=16
> * Linux MB_PYTHON_VERSION=2.7 PLAT=i686 UNICODE_WIDTH=16
> 
> With:
> 
> * `AssertionError:  average pixel value difference 14.7190 > epsilon 6.2000`
> * `AssertionError:  average pixel value difference 14.7190 > epsilon 6.2000`
> * `AssertionError:  average pixel value difference 14.7280 > epsilon 6.2000`
> 
> https://travis-ci.org/python-pillow/pillow-wheels/builds/552752918
> 
![image](https://user-images.githubusercontent.com/1324225/60439158-f4b38800-9c1a-11e9-8cf4-1b9c09e98920.png)




