### PR TITLE
Revert #3780 for PyPy3 as it hasn't been updated yet.

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -465,8 +465,10 @@ class TestImageFont(PillowTestCase):
             font.getsize(u"’")
 
     @unittest.skipIf(
-        sys.platform.startswith("win32") and sys.version.startswith("2"),
-        "requires Python 3.x on Windows",
+        sys.platform.startswith("win32") and (
+            sys.version.startswith("2") or hasattr(sys, "pypy_translation_info")
+        ),
+        "requires CPython 3.x on Windows",
     )
     def test_unicode_extended(self):
         # issue #3777

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -465,9 +465,8 @@ class TestImageFont(PillowTestCase):
             font.getsize(u"’")
 
     @unittest.skipIf(
-        sys.platform.startswith("win32") and (
-            sys.version.startswith("2") or hasattr(sys, "pypy_translation_info")
-        ),
+        sys.platform.startswith("win32")
+        and (sys.version.startswith("2") or hasattr(sys, "pypy_translation_info")),
         "requires CPython 3.x on Windows",
     )
     def test_unicode_extended(self):

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -327,7 +327,7 @@ getfont(PyObject* self_, PyObject* args, PyObject* kw)
 static int
 font_getchar(PyObject* string, int index, FT_ULong* char_out)
 {
-#if PY_VERSION_HEX < 0x03000000
+#if (PY_VERSION_HEX < 0x03030000) || (defined(PYPY_VERSION_NUM))
     if (PyUnicode_Check(string)) {
         Py_UNICODE* p = PyUnicode_AS_UNICODE(string);
         int size = PyUnicode_GET_SIZE(string);
@@ -336,7 +336,7 @@ font_getchar(PyObject* string, int index, FT_ULong* char_out)
         *char_out = p[index];
         return 1;
     }
-
+#if PY_VERSION_HEX < 0x03000000
     if (PyString_Check(string)) {
         unsigned char* p = (unsigned char*) PyString_AS_STRING(string);
         int size = PyString_GET_SIZE(string);
@@ -345,6 +345,7 @@ font_getchar(PyObject* string, int index, FT_ULong* char_out)
         *char_out = (unsigned char) p[index];
         return 1;
     }
+#endif
 #else
     if (PyUnicode_Check(string)) {
         if (index >= PyUnicode_GET_LENGTH(string))
@@ -373,7 +374,7 @@ text_layout_raqm(PyObject* string, FontObject* self, const char* dir, PyObject *
         goto failed;
     }
 
-#if PY_VERSION_HEX < 0x03000000
+#if (PY_VERSION_HEX < 0x03030000) || (defined(PYPY_VERSION_NUM))
     if (PyUnicode_Check(string)) {
         Py_UNICODE *text = PyUnicode_AS_UNICODE(string);
         Py_ssize_t size = PyUnicode_GET_SIZE(string);
@@ -392,8 +393,9 @@ text_layout_raqm(PyObject* string, FontObject* self, const char* dir, PyObject *
                 goto failed;
             }
         }
-
-    } else if (PyString_Check(string)) {
+    }
+#if PY_VERSION_HEX < 0x03000000
+    else if (PyString_Check(string)) {
         char *text = PyString_AS_STRING(string);
         int size = PyString_GET_SIZE(string);
         if (! size) {
@@ -410,6 +412,7 @@ text_layout_raqm(PyObject* string, FontObject* self, const char* dir, PyObject *
             }
         }
     }
+#endif
 #else
     if (PyUnicode_Check(string)) {
         Py_UCS4 *text = PyUnicode_AsUCS4Copy(string);


### PR DESCRIPTION
Should fix the PyPy3 build failure introduced in 8d4bb339a6ec55ff5ddfc61aafc2dc50bb4cbf6c.

This disables the fix for #3777 for PyPy3, as PyPy's cpyext module hasn't been updated to support the new PyUnicode functions yet.

From [#3835 (comment)](https://github.com/python-pillow/Pillow/issues/3835#issuecomment-507408755):

> Our tests didn't pick it up because ... whilst we do test PyPy3 on Travis CI, there is a ["implicit declaration of function ‘PyUnicode_AsUCS4Copy’" warning](https://travis-ci.org/python-pillow/Pillow/jobs/552842796#L2596) we didn't notice as all the [`test_imagefont` tests are skipped because there's no FreeType (or RAQM)](https://travis-ci.org/python-pillow/Pillow/jobs/552842796#L4209) on PyPy3. We should improve these testing gaps.

The FreeType library was probably disabled due to a dynamic link error, not because it's not installed. FreeType works again with this PR: https://travis-ci.org/nulano/Pillow/jobs/553153042#L2976