### PR TITLE
Revert "Update epsilon for FreeType 2.10 with eg. Unicode width 16" and skip test_unicode_extended on Python 2.x instead

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -463,10 +463,7 @@ class TestImageFont(PillowTestCase):
         with self.assertRaises(UnicodeEncodeError):
             font.getsize(u"’")
 
-    @unittest.skipIf(
-        sys.platform.startswith("win32") and sys.version.startswith("2"),
-        "requires Python 3.x on Windows",
-    )
+    @unittest.skipIf(sys.version.startswith("2"), "requires Python 3.3+")
     def test_unicode_extended(self):
         # issue #3777
         text = u"A\u278A\U0001F12B"

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -53,8 +53,7 @@ class TestImageFont(PillowTestCase):
     # (and, other things, but first things first)
     METRICS = {
         (">=2.3", "<2.4"): {"multiline": 30, "textsize": 12, "getters": (13, 16)},
-        (">=2.7", "<2.10"): {"multiline": 6.2, "textsize": 2.5, "getters": (12, 16)},
-        (">=2.10",): {"multiline": 14.8, "textsize": 2.5, "getters": (12, 16)},
+        (">=2.7",): {"multiline": 6.2, "textsize": 2.5, "getters": (12, 16)},
         "Default": {"multiline": 0.5, "textsize": 0.5, "getters": (12, 16)},
     }
 


### PR DESCRIPTION
I suspect [#3835 (comment)](https://github.com/python-pillow/Pillow/issues/3835#issuecomment-507260313) is actually a real failure. When I tried the test on Windows without the #3780 fix, I got the same values:
`E AssertionError: 2.5 not greater than or equal to 14.728 : average pixel value difference 14.7280 > epsilon 2.5000`
https://ci.appveyor.com/project/nulano/pillow/builds/23676028/job/jjd897m8b68sx96a#L6647.

Reverts python-pillow/Pillow#3931
Skips test_unicode_extended on all platforms when running Python 2.