### PR TITLE
Include tox.ini in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-
 include *.c
 include *.h
 include *.in
@@ -9,6 +8,7 @@ include *.sh
 include *.txt
 include LICENSE
 include Makefile
+include tox.ini
 graft Tests
 graft src
 graft depends
@@ -24,7 +24,6 @@ exclude .editorconfig
 exclude .landscape.yaml
 exclude .readthedocs.yml
 exclude azure-pipelines.yml
-exclude tox.ini
 global-exclude .git*
 global-exclude *.pyc
 global-exclude *.so


### PR DESCRIPTION
It is considered good practice to include test files in the source
distribution, as well as the files used to run them. It allows packagers
and users to run the tests locally to ensure the package is complete and
working.