### PR TITLE
Remove check-manifest from .travis/script.sh

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -8,7 +8,6 @@ sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-tk\
              libharfbuzz-dev libfribidi-dev
 
 PYTHONOPTIMIZE=0 pip install cffi
-pip install check-manifest
 pip install coverage
 pip install olefile
 pip install -U pytest
@@ -19,9 +18,6 @@ pip install numpy
 
 # docs only on Python 2.7
 if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then pip install -r requirements.txt ; fi
-
-# clean checkout for manifest
-mkdir /tmp/check-manifest && cp -a . /tmp/check-manifest
 
 # webp
 pushd depends && ./install_webp.sh && popd
@@ -34,4 +30,3 @@ pushd depends && ./install_imagequant.sh && popd
 
 # extra test images
 pushd depends && ./install_extra_test_images.sh && popd
-

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -9,7 +9,5 @@ make install-coverage
 python selftest.py
 python -m pytest -v -x --cov PIL --cov-report term Tests
 
-pushd /tmp/check-manifest && check-manifest --ignore ".coveragerc,.editorconfig,*.yml,*.yaml,tox.ini" && popd
-
 # Docs
 if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then make doccheck; fi


### PR DESCRIPTION
check-manifest already exists as part of the lint tox target "lint"
which is run by Travis CI. There is no need to re-run the same check as
part of each test run.