### PR TITLE
Remove duplicate run of selftest.py

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -6,7 +6,6 @@ coverage erase
 make clean
 make install-coverage
 
-python selftest.py
 python -m pytest -v -x --cov PIL --cov-report term Tests
 
 pushd /tmp/check-manifest && check-manifest --ignore ".coveragerc,.editorconfig,*.yml,*.yaml,tox.ini" && popd


### PR DESCRIPTION
The make target 'install-coverage' already runs selftest.py. Avoid
running the same script a second time to slightly speed up builds.