### PR TITLE
Print winbuild compile output properly in Python 3.x

### DIFF
--- a/winbuild/build.py
+++ b/winbuild/build.py
@@ -50,9 +50,9 @@ def run_script(params):
         (trace, stderr) = proc.communicate()
         status = proc.returncode
         print("-- stderr --")
-        print(stderr)
+        print(stderr.decode())
         print("-- stdout --")
-        print(trace)
+        print(trace.decode())
         print("Done with %s: %s" % (version, status))
         return (version, status, trace, stderr)
     except Exception as msg:


### PR DESCRIPTION
Before: https://ci.appveyor.com/project/Python-pillow/pillow/builds/25757495/job/t36i34fncfksisx3?fullLog=true#L5829
After: https://ci.appveyor.com/project/nulano/pillow/builds/25759303/job/2d5cy0hle6whgaau?fullLog=true#L5808