### PR TITLE
Add option to capture all monitors on Windows

### DIFF
--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -8,7 +8,11 @@ try:
 
     class TestImageGrab(PillowTestCase):
         def test_grab(self):
-            for im in [ImageGrab.grab(), ImageGrab.grab(include_layered_windows=True)]:
+            for im in [
+                ImageGrab.grab(),
+                ImageGrab.grab(include_layered_windows=True),
+                ImageGrab.grab(multimonitor=True),
+            ]:
                 self.assert_image(im, im.mode, im.size)
 
         def test_grabclipboard(self):

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -11,7 +11,7 @@ try:
             for im in [
                 ImageGrab.grab(),
                 ImageGrab.grab(include_layered_windows=True),
-                ImageGrab.grab(multimonitor=True),
+                ImageGrab.grab(all_screens=True),
             ]:
                 self.assert_image(im, im.mode, im.size)
 

--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -22,7 +22,11 @@ or the clipboard to a PIL image memory.
     :param bbox: What region to copy. Default is the entire screen.
                  Note that on Windows OS, the top-left point may be negative if ``all_screens=True`` is used.
     :param include_layered_windows: Includes layered windows. Windows OS only.
+
+        .. versionadded:: 6.1.0
     :param all_screens: Capture all monitors. Windows OS only.
+
+        .. versionadded:: 6.2.0
     :return: An image
 
 .. py:function:: PIL.ImageGrab.grabclipboard()

--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -11,7 +11,7 @@ or the clipboard to a PIL image memory.
 
 .. versionadded:: 1.1.3
 
-.. py:function:: PIL.ImageGrab.grab(bbox=None, include_layered_windows=False, multimonitor=False)
+.. py:function:: PIL.ImageGrab.grab(bbox=None, include_layered_windows=False, all_screens=False)
 
     Take a snapshot of the screen. The pixels inside the bounding box are
     returned as an "RGB" image on Windows or "RGBA" on macOS.
@@ -20,8 +20,9 @@ or the clipboard to a PIL image memory.
     .. versionadded:: 1.1.3 (Windows), 3.0.0 (macOS)
 
     :param bbox: What region to copy. Default is the entire screen.
+                 Note that on Windows OS, the top-left point may be negative if ``all_screens=True`` is used.
     :param include_layered_windows: Includes layered windows. Windows OS only.
-    :param multimonitor: Capture all monitors. Windows OS only.
+    :param all_screens: Capture all monitors. Windows OS only.
     :return: An image
 
 .. py:function:: PIL.ImageGrab.grabclipboard()

--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -11,7 +11,7 @@ or the clipboard to a PIL image memory.
 
 .. versionadded:: 1.1.3
 
-.. py:function:: PIL.ImageGrab.grab(bbox=None, include_layered_windows=False)
+.. py:function:: PIL.ImageGrab.grab(bbox=None, include_layered_windows=False, multimonitor=False)
 
     Take a snapshot of the screen. The pixels inside the bounding box are
     returned as an "RGB" image on Windows or "RGBA" on macOS.
@@ -21,6 +21,7 @@ or the clipboard to a PIL image memory.
 
     :param bbox: What region to copy. Default is the entire screen.
     :param include_layered_windows: Includes layered windows. Windows OS only.
+    :param multimonitor: Capture all monitors. Windows OS only.
     :return: An image
 
 .. py:function:: PIL.ImageGrab.grabclipboard()

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -29,7 +29,7 @@ else:
     raise ImportError("ImageGrab is macOS and Windows only")
 
 
-def grab(bbox=None, include_layered_windows=False):
+def grab(bbox=None, include_layered_windows=False, multimonitor=False):
     if sys.platform == "darwin":
         fh, filepath = tempfile.mkstemp(".png")
         os.close(fh)
@@ -37,8 +37,10 @@ def grab(bbox=None, include_layered_windows=False):
         im = Image.open(filepath)
         im.load()
         os.unlink(filepath)
+        if bbox:
+            im = im.crop(bbox)
     else:
-        size, data = grabber(include_layered_windows)
+        offset, size, data = grabber(include_layered_windows, multimonitor)
         im = Image.frombytes(
             "RGB",
             size,
@@ -49,8 +51,10 @@ def grab(bbox=None, include_layered_windows=False):
             (size[0] * 3 + 3) & -4,
             -1,
         )
-    if bbox:
-        im = im.crop(bbox)
+        if bbox:
+            x0, y0 = offset
+            left, top, right, bottom = bbox
+            im = im.crop((left - x0, top - y0, right - x0, bottom - y0))
     return im
 
 

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -29,7 +29,7 @@ else:
     raise ImportError("ImageGrab is macOS and Windows only")
 
 
-def grab(bbox=None, include_layered_windows=False, multimonitor=False):
+def grab(bbox=None, include_layered_windows=False, all_screens=False):
     if sys.platform == "darwin":
         fh, filepath = tempfile.mkstemp(".png")
         os.close(fh)
@@ -40,7 +40,7 @@ def grab(bbox=None, include_layered_windows=False, multimonitor=False):
         if bbox:
             im = im.crop(bbox)
     else:
-        offset, size, data = grabber(include_layered_windows, multimonitor)
+        offset, size, data = grabber(include_layered_windows, all_screens)
         im = Image.frombytes(
             "RGB",
             size,

--- a/src/display.c
+++ b/src/display.c
@@ -323,14 +323,14 @@ PyObject*
 PyImaging_GrabScreenWin32(PyObject* self, PyObject* args)
 {
     int x = 0, y = 0, width, height;
-    int includeLayeredWindows = 0, multimonitor = 0;
+    int includeLayeredWindows = 0, all_screens = 0;
     HBITMAP bitmap;
     BITMAPCOREHEADER core;
     HDC screen, screen_copy;
     DWORD rop;
     PyObject* buffer;
 
-    if (!PyArg_ParseTuple(args, "|ii", &includeLayeredWindows, &multimonitor))
+    if (!PyArg_ParseTuple(args, "|ii", &includeLayeredWindows, &all_screens))
         return NULL;
 
     /* step 1: create a memory DC large enough to hold the
@@ -339,7 +339,7 @@ PyImaging_GrabScreenWin32(PyObject* self, PyObject* args)
     screen = CreateDC("DISPLAY", NULL, NULL, NULL);
     screen_copy = CreateCompatibleDC(screen);
 
-    if (multimonitor) {
+    if (all_screens) {
         x = GetSystemMetrics(SM_XVIRTUALSCREEN);
         y = GetSystemMetrics(SM_YVIRTUALSCREEN);
         width = GetSystemMetrics(SM_CXVIRTUALSCREEN);

--- a/src/display.c
+++ b/src/display.c
@@ -345,8 +345,8 @@ PyImaging_GrabScreenWin32(PyObject* self, PyObject* args)
         width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
         height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
     } else {
-        width = GetSystemMetrics(SM_CXSCREEN);
-        height = GetSystemMetrics(SM_CYSCREEN);
+        width = GetDeviceCaps(screen, HORZRES);
+        height = GetDeviceCaps(screen, VERTRES);
     }
 
     bitmap = CreateCompatibleBitmap(screen, width, height);


### PR DESCRIPTION
Resolves #1547

~~Provides workaround for #2438, #3432, #3626:
For some reason grabbing a screenshot of the whole screen with the new `ImageGrab.grab(multimonitor=True)` ignores DPI scaling properly.~~
Edit: I didn't look at the screenshot closely enough.