### PR TITLE
Introduce isort to automate import ordering and formatting

### DIFF
--- a/Tests/32bit_segfault_check.py
+++ b/Tests/32bit_segfault_check.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-from PIL import Image
 import sys
 
+from PIL import Image
 
 if sys.maxsize < 2 ** 32:
     im = Image.new("L", (999999, 999999), 0)

--- a/Tests/bench_cffi_access.py
+++ b/Tests/bench_cffi_access.py
@@ -1,10 +1,10 @@
-from .helper import unittest, PillowTestCase, hopper
-
-# Not running this test by default. No DOS against Travis CI.
+import time
 
 from PIL import PyAccess
 
-import time
+from .helper import PillowTestCase, hopper, unittest
+
+# Not running this test by default. No DOS against Travis CI.
 
 
 def iterate_get(size, access):

--- a/Tests/bench_get.py
+++ b/Tests/bench_get.py
@@ -1,7 +1,7 @@
-from . import helper
+import sys
 import timeit
 
-import sys
+from . import helper
 
 sys.path.insert(0, ".")
 

--- a/Tests/check_fli_overflow.py
+++ b/Tests/check_fli_overflow.py
@@ -1,5 +1,6 @@
-from .helper import unittest, PillowTestCase
 from PIL import Image
+
+from .helper import PillowTestCase, unittest
 
 TEST_FILE = "Tests/images/fli_overflow.fli"
 

--- a/Tests/check_icns_dos.py
+++ b/Tests/check_icns_dos.py
@@ -1,9 +1,10 @@
 # Tests potential DOS of IcnsImagePlugin with 0 length block.
 # Run from anywhere that PIL is importable.
 
+from io import BytesIO
+
 from PIL import Image
 from PIL._util import py3
-from io import BytesIO
 
 if py3:
     Image.open(BytesIO(bytes("icns\x00\x00\x00\x10hang\x00\x00\x00\x00", "latin-1")))

--- a/Tests/check_imaging_leaks.py
+++ b/Tests/check_imaging_leaks.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 
 from __future__ import division
-from .helper import unittest, PillowTestCase
+
 import sys
+
 from PIL import Image
+
+from .helper import PillowTestCase, unittest
 
 min_iterations = 100
 max_iterations = 10000

--- a/Tests/check_j2k_dos.py
+++ b/Tests/check_j2k_dos.py
@@ -1,9 +1,10 @@
 # Tests potential DOS of Jpeg2kImagePlugin with 0 length block.
 # Run from anywhere that PIL is importable.
 
+from io import BytesIO
+
 from PIL import Image
 from PIL._util import py3
-from io import BytesIO
 
 if py3:
     Image.open(

--- a/Tests/check_j2k_leaks.py
+++ b/Tests/check_j2k_leaks.py
@@ -1,7 +1,9 @@
-from .helper import unittest, PillowTestCase
 import sys
-from PIL import Image
 from io import BytesIO
+
+from PIL import Image
+
+from .helper import PillowTestCase, unittest
 
 # Limits for testing the leak
 mem_limit = 1024 * 1048576

--- a/Tests/check_j2k_overflow.py
+++ b/Tests/check_j2k_overflow.py
@@ -1,5 +1,6 @@
 from PIL import Image
-from .helper import unittest, PillowTestCase
+
+from .helper import PillowTestCase, unittest
 
 
 class TestJ2kEncodeOverflow(PillowTestCase):

--- a/Tests/check_jpeg_leaks.py
+++ b/Tests/check_jpeg_leaks.py
@@ -1,6 +1,7 @@
-from .helper import unittest, PillowTestCase, hopper
-from io import BytesIO
 import sys
+from io import BytesIO
+
+from .helper import PillowTestCase, hopper, unittest
 
 iterations = 5000
 

--- a/Tests/check_large_memory.py
+++ b/Tests/check_large_memory.py
@@ -1,6 +1,8 @@
 import sys
 
-from .helper import unittest, PillowTestCase
+from PIL import Image
+
+from .helper import PillowTestCase, unittest
 
 # This test is not run automatically.
 #
@@ -11,7 +13,6 @@ from .helper import unittest, PillowTestCase
 # Raspberry Pis). It does succeed on a 3gb Ubuntu 12.04x64 VM on Python
 # 2.7 and 3.2.
 
-from PIL import Image
 
 try:
     import numpy

--- a/Tests/check_large_memory_numpy.py
+++ b/Tests/check_large_memory_numpy.py
@@ -1,6 +1,8 @@
 import sys
 
-from .helper import unittest, PillowTestCase
+from PIL import Image
+
+from .helper import PillowTestCase, unittest
 
 # This test is not run automatically.
 #
@@ -10,7 +12,6 @@ from .helper import unittest, PillowTestCase
 # on any 32-bit machine, as well as any smallish things (like
 # Raspberry Pis).
 
-from PIL import Image
 
 try:
     import numpy as np

--- a/Tests/check_libtiff_segfault.py
+++ b/Tests/check_libtiff_segfault.py
@@ -1,5 +1,6 @@
-from .helper import unittest, PillowTestCase
 from PIL import Image
+
+from .helper import PillowTestCase, unittest
 
 TEST_FILE = "Tests/images/libtiff_segfault.tif"
 

--- a/Tests/check_png_dos.py
+++ b/Tests/check_png_dos.py
@@ -1,7 +1,9 @@
-from .helper import unittest, PillowTestCase
-from PIL import Image, PngImagePlugin, ImageFile
-from io import BytesIO
 import zlib
+from io import BytesIO
+
+from PIL import Image, ImageFile, PngImagePlugin
+
+from .helper import PillowTestCase, unittest
 
 TEST_FILE = "Tests/images/png_decompression_dos.png"
 

--- a/Tests/createfontdatachunk.py
+++ b/Tests/createfontdatachunk.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+
 import base64
 import os
 

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -2,15 +2,15 @@
 Helper functions.
 """
 from __future__ import print_function
+
+import logging
+import os
 import sys
 import tempfile
-import os
 import unittest
 
 from PIL import Image, ImageMath
 from PIL._util import py3
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/Tests/import_all.py
+++ b/Tests/import_all.py
@@ -2,9 +2,8 @@ from __future__ import print_function
 
 import glob
 import os
-import traceback
-
 import sys
+import traceback
 
 sys.path.insert(0, ".")
 

--- a/Tests/test_000_sanity.py
+++ b/Tests/test_000_sanity.py
@@ -1,7 +1,7 @@
-from .helper import PillowTestCase
-
 import PIL
 import PIL.Image
+
+from .helper import PillowTestCase
 
 
 class TestSanity(PillowTestCase):

--- a/Tests/test_binary.py
+++ b/Tests/test_binary.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
-
 from PIL import _binary
+
+from .helper import PillowTestCase
 
 
 class TestBinary(PillowTestCase):

--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -1,8 +1,10 @@
 from __future__ import print_function
-from .helper import PillowTestCase
+
+import os
 
 from PIL import Image
-import os
+
+from .helper import PillowTestCase
 
 base = os.path.join("Tests", "images", "bmp")
 

--- a/Tests/test_box_blur.py
+++ b/Tests/test_box_blur.py
@@ -1,7 +1,6 @@
-from .helper import PillowTestCase
-
 from PIL import Image, ImageFilter
 
+from .helper import PillowTestCase
 
 sample = Image.new("L", (7, 5))
 # fmt: off

--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -3,7 +3,8 @@ from __future__ import division
 from array import array
 
 from PIL import Image, ImageFilter
-from .helper import unittest, PillowTestCase
+
+from .helper import PillowTestCase, unittest
 
 try:
     import numpy

--- a/Tests/test_core_resources.py
+++ b/Tests/test_core_resources.py
@@ -2,9 +2,9 @@ from __future__ import division, print_function
 
 import sys
 
-from .helper import unittest, PillowTestCase
 from PIL import Image
 
+from .helper import PillowTestCase, unittest
 
 is_pypy = hasattr(sys, "pypy_version_info")
 

--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 TEST_FILE = "Tests/images/hopper.ppm"
 

--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -2,9 +2,9 @@ from __future__ import unicode_literals
 
 import io
 
-from .helper import unittest, PillowTestCase
-
 from PIL import features
+
+from .helper import PillowTestCase, unittest
 
 try:
     from PIL import _webp

--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -1,7 +1,8 @@
-from .helper import PillowTestCase, hopper
-
-from PIL import Image, BmpImagePlugin
 import io
+
+from PIL import BmpImagePlugin, Image
+
+from .helper import PillowTestCase, hopper
 
 
 class TestFileBmp(PillowTestCase):

--- a/Tests/test_file_bufrstub.py
+++ b/Tests/test_file_bufrstub.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import BufrStubImagePlugin, Image
+
+from .helper import PillowTestCase, hopper
 
 TEST_FILE = "Tests/images/gfs.t06z.rassda.tm00.bufr_d"
 

--- a/Tests/test_file_container.py
+++ b/Tests/test_file_container.py
@@ -1,7 +1,6 @@
-from .helper import PillowTestCase, hopper
+from PIL import ContainerIO, Image
 
-from PIL import Image
-from PIL import ContainerIO
+from .helper import PillowTestCase, hopper
 
 TEST_FILE = "Tests/images/dummy.container"
 

--- a/Tests/test_file_cur.py
+++ b/Tests/test_file_cur.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
+from PIL import CurImagePlugin, Image
 
-from PIL import Image, CurImagePlugin
+from .helper import PillowTestCase
 
 TEST_FILE = "Tests/images/deerstalker.cur"
 

--- a/Tests/test_file_dcx.py
+++ b/Tests/test_file_dcx.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
+from PIL import DcxImagePlugin, Image
 
-from PIL import Image, DcxImagePlugin
+from .helper import PillowTestCase, hopper
 
 # Created with ImageMagick: convert hopper.ppm hopper.dcx
 TEST_FILE = "Tests/images/hopper.dcx"

--- a/Tests/test_file_dds.py
+++ b/Tests/test_file_dds.py
@@ -1,7 +1,8 @@
 from io import BytesIO
 
+from PIL import DdsImagePlugin, Image
+
 from .helper import PillowTestCase
-from PIL import Image, DdsImagePlugin
 
 TEST_FILE_DXT1 = "Tests/images/dxt1-rgb-4bbp-noalpha_MipMaps-1.dds"
 TEST_FILE_DXT3 = "Tests/images/dxt3-argb-8bbp-explicitalpha_MipMaps-1.dds"

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -1,7 +1,8 @@
-from .helper import unittest, PillowTestCase, hopper
-
-from PIL import Image, EpsImagePlugin
 import io
+
+from PIL import EpsImagePlugin, Image
+
+from .helper import PillowTestCase, hopper, unittest
 
 HAS_GHOSTSCRIPT = EpsImagePlugin.has_ghostscript()
 

--- a/Tests/test_file_fitsstub.py
+++ b/Tests/test_file_fitsstub.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
-
 from PIL import FitsStubImagePlugin, Image
+
+from .helper import PillowTestCase
 
 TEST_FILE = "Tests/images/hopper.fits"
 

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
+from PIL import FliImagePlugin, Image
 
-from PIL import Image, FliImagePlugin
+from .helper import PillowTestCase
 
 # created as an export of a palette image from Gimp2.6
 # save as...-> hopper.fli, default options.

--- a/Tests/test_file_fpx.py
+++ b/Tests/test_file_fpx.py
@@ -1,4 +1,4 @@
-from .helper import unittest, PillowTestCase
+from .helper import PillowTestCase, unittest
 
 try:
     from PIL import FpxImagePlugin

--- a/Tests/test_file_ftex.py
+++ b/Tests/test_file_ftex.py
@@ -1,5 +1,6 @@
-from .helper import PillowTestCase
 from PIL import Image
+
+from .helper import PillowTestCase
 
 
 class TestFileFtex(PillowTestCase):

--- a/Tests/test_file_gbr.py
+++ b/Tests/test_file_gbr.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
+from PIL import GbrImagePlugin, Image
 
-from PIL import Image, GbrImagePlugin
+from .helper import PillowTestCase
 
 
 class TestFileGbr(PillowTestCase):

--- a/Tests/test_file_gd.py
+++ b/Tests/test_file_gd.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
-
 from PIL import GdImageFile
+
+from .helper import PillowTestCase
 
 TEST_GD_FILE = "Tests/images/hopper.gd"
 

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1,8 +1,8 @@
-from .helper import unittest, PillowTestCase, hopper, netpbm_available
-
-from PIL import Image, ImagePalette, GifImagePlugin, ImageDraw
-
 from io import BytesIO
+
+from PIL import GifImagePlugin, Image, ImageDraw, ImagePalette
+
+from .helper import PillowTestCase, hopper, netpbm_available, unittest
 
 try:
     from PIL import _webp

--- a/Tests/test_file_gimpgradient.py
+++ b/Tests/test_file_gimpgradient.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
-
 from PIL import GimpGradientFile
+
+from .helper import PillowTestCase
 
 
 class TestImage(PillowTestCase):

--- a/Tests/test_file_gimppalette.py
+++ b/Tests/test_file_gimppalette.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
-
 from PIL.GimpPaletteFile import GimpPaletteFile
+
+from .helper import PillowTestCase
 
 
 class TestImage(PillowTestCase):

--- a/Tests/test_file_gribstub.py
+++ b/Tests/test_file_gribstub.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import GribStubImagePlugin, Image
+
+from .helper import PillowTestCase, hopper
 
 TEST_FILE = "Tests/images/WAlaska.wind.7days.grb"
 

--- a/Tests/test_file_hdf5stub.py
+++ b/Tests/test_file_hdf5stub.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
-
 from PIL import Hdf5StubImagePlugin, Image
+
+from .helper import PillowTestCase
 
 TEST_FILE = "Tests/images/hdf5.h5"
 

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -1,9 +1,9 @@
-from .helper import unittest, PillowTestCase
-
-from PIL import Image, IcnsImagePlugin
-
 import io
 import sys
+
+from PIL import IcnsImagePlugin, Image
+
+from .helper import PillowTestCase, unittest
 
 # sample icon file
 TEST_FILE = "Tests/images/pillow.icns"

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -1,7 +1,8 @@
-from .helper import PillowTestCase, hopper
-
 import io
-from PIL import Image, ImageDraw, IcoImagePlugin
+
+from PIL import IcoImagePlugin, Image, ImageDraw
+
+from .helper import PillowTestCase, hopper
 
 TEST_ICO_FILE = "Tests/images/hopper.ico"
 

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image, ImImagePlugin
+
+from .helper import PillowTestCase, hopper
 
 # sample im
 TEST_IM = "Tests/images/hopper.im"

--- a/Tests/test_file_iptc.py
+++ b/Tests/test_file_iptc.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image, IptcImagePlugin
+
+from .helper import PillowTestCase, hopper
 
 TEST_FILE = "Tests/images/iptc.jpg"
 

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -1,13 +1,10 @@
-from .helper import unittest, PillowTestCase, hopper
-from .helper import djpeg_available, cjpeg_available
-
-from io import BytesIO
 import os
 import sys
+from io import BytesIO
 
-from PIL import Image
-from PIL import ImageFile
-from PIL import JpegImagePlugin
+from PIL import Image, ImageFile, JpegImagePlugin
+
+from .helper import PillowTestCase, cjpeg_available, djpeg_available, hopper, unittest
 
 codecs = dir(Image.core)
 

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -1,7 +1,8 @@
-from .helper import PillowTestCase
+from io import BytesIO
 
 from PIL import Image, Jpeg2KImagePlugin
-from io import BytesIO
+
+from .helper import PillowTestCase
 
 codecs = dir(Image.core)
 

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -1,17 +1,17 @@
 from __future__ import print_function
-from .helper import PillowTestCase, hopper
-from PIL import features
-from PIL._util import py3
 
+import distutils.version
+import io
+import itertools
+import logging
+import os
 from collections import namedtuple
 from ctypes import c_float
-import io
-import logging
-import itertools
-import os
-import distutils.version
 
-from PIL import Image, TiffImagePlugin, TiffTags
+from PIL import Image, TiffImagePlugin, TiffTags, features
+from PIL._util import py3
+
+from .helper import PillowTestCase, hopper
 
 logger = logging.getLogger(__name__)
 

--- a/Tests/test_file_mcidas.py
+++ b/Tests/test_file_mcidas.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
-
 from PIL import Image, McIdasImagePlugin
+
+from .helper import PillowTestCase
 
 
 class TestFileMcIdas(PillowTestCase):

--- a/Tests/test_file_mic.py
+++ b/Tests/test_file_mic.py
@@ -1,6 +1,6 @@
-from .helper import unittest, PillowTestCase, hopper
-
 from PIL import Image, ImagePalette, features
+
+from .helper import PillowTestCase, hopper, unittest
 
 try:
     from PIL import MicImagePlugin

--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -1,7 +1,8 @@
-from .helper import PillowTestCase
 from io import BytesIO
+
 from PIL import Image
 
+from .helper import PillowTestCase
 
 test_files = ["Tests/images/sugarshack.mpo", "Tests/images/frozenpond.mpo"]
 

--- a/Tests/test_file_msp.py
+++ b/Tests/test_file_msp.py
@@ -1,8 +1,8 @@
-from .helper import unittest, PillowTestCase, hopper
+import os
 
 from PIL import Image, MspImagePlugin
 
-import os
+from .helper import PillowTestCase, hopper, unittest
 
 TEST_FILE = "Tests/images/hopper.msp"
 EXTRA_DIR = "Tests/images/picins"

--- a/Tests/test_file_palm.py
+++ b/Tests/test_file_palm.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper, imagemagick_available
-
 import os.path
+
+from .helper import PillowTestCase, hopper, imagemagick_available
 
 
 class TestFilePalm(PillowTestCase):

--- a/Tests/test_file_pcd.py
+++ b/Tests/test_file_pcd.py
@@ -1,5 +1,6 @@
-from .helper import PillowTestCase
 from PIL import Image
+
+from .helper import PillowTestCase
 
 
 class TestFilePcd(PillowTestCase):

--- a/Tests/test_file_pcx.py
+++ b/Tests/test_file_pcx.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image, ImageFile, PcxImagePlugin
+
+from .helper import PillowTestCase, hopper
 
 
 class TestFilePcx(PillowTestCase):

--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -1,10 +1,12 @@
-from .helper import PillowTestCase, hopper
-from PIL import Image, PdfParser
 import io
 import os
 import os.path
 import tempfile
 import time
+
+from PIL import Image, PdfParser
+
+from .helper import PillowTestCase, hopper
 
 
 class TestFilePdf(PillowTestCase):

--- a/Tests/test_file_pixar.py
+++ b/Tests/test_file_pixar.py
@@ -1,6 +1,6 @@
-from .helper import hopper, PillowTestCase
-
 from PIL import Image, PixarImagePlugin
+
+from .helper import PillowTestCase, hopper
 
 TEST_FILE = "Tests/images/hopper.pxr"
 

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -1,10 +1,11 @@
-from .helper import unittest, PillowTestCase, PillowLeakTestCase, hopper
+import sys
+import zlib
+from io import BytesIO
+
 from PIL import Image, ImageFile, PngImagePlugin
 from PIL._util import py3
 
-from io import BytesIO
-import zlib
-import sys
+from .helper import PillowLeakTestCase, PillowTestCase, hopper, unittest
 
 try:
     from PIL import _webp

--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 # sample ppm stream
 test_file = "Tests/images/hopper.ppm"

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -1,6 +1,6 @@
-from .helper import hopper, PillowTestCase
-
 from PIL import Image, PsdImagePlugin
+
+from .helper import PillowTestCase, hopper
 
 test_file = "Tests/images/hopper.psd"
 

--- a/Tests/test_file_sgi.py
+++ b/Tests/test_file_sgi.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image, SgiImagePlugin
+
+from .helper import PillowTestCase, hopper
 
 
 class TestFileSgi(PillowTestCase):

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -1,10 +1,8 @@
-from .helper import PillowTestCase, hopper
-
-from PIL import Image
-from PIL import ImageSequence
-from PIL import SpiderImagePlugin
-
 import tempfile
+
+from PIL import Image, ImageSequence, SpiderImagePlugin
+
+from .helper import PillowTestCase, hopper
 
 TEST_FILE = "Tests/images/hopper.spider"
 

--- a/Tests/test_file_sun.py
+++ b/Tests/test_file_sun.py
@@ -1,8 +1,8 @@
-from .helper import unittest, PillowTestCase, hopper
+import os
 
 from PIL import Image, SunImagePlugin
 
-import os
+from .helper import PillowTestCase, hopper, unittest
 
 EXTRA_DIR = "Tests/images/sunraster"
 

--- a/Tests/test_file_tar.py
+++ b/Tests/test_file_tar.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
-
 from PIL import Image, TarIO
+
+from .helper import PillowTestCase
 
 codecs = dir(Image.core)
 

--- a/Tests/test_file_tga.py
+++ b/Tests/test_file_tga.py
@@ -2,10 +2,9 @@ import os
 from glob import glob
 from itertools import product
 
-from .helper import PillowTestCase
-
 from PIL import Image
 
+from .helper import PillowTestCase
 
 _TGA_DIR = os.path.join("Tests", "images", "tga")
 _TGA_DIR_COMMON = os.path.join(_TGA_DIR, "common")

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -1,12 +1,12 @@
 import logging
-from io import BytesIO
 import sys
-
-from .helper import unittest, PillowTestCase, hopper
+from io import BytesIO
 
 from PIL import Image, TiffImagePlugin, features
 from PIL._util import py3
-from PIL.TiffImagePlugin import X_RESOLUTION, Y_RESOLUTION, RESOLUTION_UNIT
+from PIL.TiffImagePlugin import RESOLUTION_UNIT, X_RESOLUTION, Y_RESOLUTION
+
+from .helper import PillowTestCase, hopper, unittest
 
 logger = logging.getLogger(__name__)
 

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -1,10 +1,10 @@
 import io
 import struct
 
-from .helper import PillowTestCase, hopper
-
 from PIL import Image, TiffImagePlugin, TiffTags
-from PIL.TiffImagePlugin import _limit_rational, IFDRational
+from PIL.TiffImagePlugin import IFDRational, _limit_rational
+
+from .helper import PillowTestCase, hopper
 
 tag_ids = {info.name: info.value for info in TiffTags.TAGS_V2.values()}
 

--- a/Tests/test_file_wal.py
+++ b/Tests/test_file_wal.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
-
 from PIL import WalImageFile
+
+from .helper import PillowTestCase
 
 
 class TestFileWal(PillowTestCase):

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -1,6 +1,6 @@
-from .helper import unittest, PillowTestCase, hopper
-
 from PIL import Image, WebPImagePlugin
+
+from .helper import PillowTestCase, hopper, unittest
 
 try:
     from PIL import _webp

--- a/Tests/test_file_webp_alpha.py
+++ b/Tests/test_file_webp_alpha.py
@@ -1,6 +1,6 @@
-from .helper import unittest, PillowTestCase, hopper
-
 from PIL import Image
+
+from .helper import PillowTestCase, hopper, unittest
 
 try:
     from PIL import _webp

--- a/Tests/test_file_webp_animated.py
+++ b/Tests/test_file_webp_animated.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
-
 from PIL import Image
+
+from .helper import PillowTestCase
 
 try:
     from PIL import _webp

--- a/Tests/test_file_webp_lossless.py
+++ b/Tests/test_file_webp_lossless.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 try:
     from PIL import _webp

--- a/Tests/test_file_webp_metadata.py
+++ b/Tests/test_file_webp_metadata.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
-
 from PIL import Image
+
+from .helper import PillowTestCase
 
 try:
     from PIL import _webp

--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -1,7 +1,6 @@
-from .helper import PillowTestCase, hopper
+from PIL import Image, WmfImagePlugin
 
-from PIL import Image
-from PIL import WmfImagePlugin
+from .helper import PillowTestCase, hopper
 
 
 class TestFileWmf(PillowTestCase):

--- a/Tests/test_file_xbm.py
+++ b/Tests/test_file_xbm.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
-
 from PIL import Image
+
+from .helper import PillowTestCase
 
 PIL151 = b"""
 #define basic_width 32

--- a/Tests/test_file_xpm.py
+++ b/Tests/test_file_xpm.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image, XpmImagePlugin
+
+from .helper import PillowTestCase, hopper
 
 TEST_FILE = "Tests/images/hopper.xpm"
 

--- a/Tests/test_file_xvthumb.py
+++ b/Tests/test_file_xvthumb.py
@@ -1,6 +1,6 @@
-from .helper import hopper, PillowTestCase
-
 from PIL import Image, XVThumbImagePlugin
+
+from .helper import PillowTestCase, hopper
 
 TEST_FILE = "Tests/images/hopper.p7"
 

--- a/Tests/test_font_bdf.py
+++ b/Tests/test_font_bdf.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
+from PIL import BdfFontFile, FontFile
 
-from PIL import FontFile, BdfFontFile
+from .helper import PillowTestCase
 
 filename = "Tests/images/courB08.bdf"
 

--- a/Tests/test_font_leaks.py
+++ b/Tests/test_font_leaks.py
@@ -1,7 +1,10 @@
 from __future__ import division
-from .helper import unittest, PillowLeakTestCase
+
 import sys
-from PIL import Image, features, ImageDraw, ImageFont
+
+from PIL import Image, ImageDraw, ImageFont, features
+
+from .helper import PillowLeakTestCase, unittest
 
 
 @unittest.skipIf(sys.platform.startswith("win32"), "requires Unix or macOS")

--- a/Tests/test_font_pcf.py
+++ b/Tests/test_font_pcf.py
@@ -1,8 +1,7 @@
-from .helper import PillowTestCase
-
-from PIL import Image, FontFile, PcfFontFile
-from PIL import ImageFont, ImageDraw
+from PIL import FontFile, Image, ImageDraw, ImageFont, PcfFontFile
 from PIL._util import py3
+
+from .helper import PillowTestCase
 
 codecs = dir(Image.core)
 

--- a/Tests/test_format_hsv.py
+++ b/Tests/test_format_hsv.py
@@ -1,10 +1,10 @@
-from .helper import PillowTestCase, hopper
+import colorsys
+import itertools
 
 from PIL import Image
 from PIL._util import py3
 
-import colorsys
-import itertools
+from .helper import PillowTestCase, hopper
 
 
 class TestFormatHSV(PillowTestCase):

--- a/Tests/test_format_lab.py
+++ b/Tests/test_format_lab.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
-
 from PIL import Image
+
+from .helper import PillowTestCase
 
 
 class TestFormatLab(PillowTestCase):

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1,10 +1,11 @@
-from .helper import unittest, PillowTestCase, hopper
+import os
+import shutil
+import sys
 
 from PIL import Image
 from PIL._util import py3
-import os
-import sys
-import shutil
+
+from .helper import PillowTestCase, hopper, unittest
 
 
 class TestImage(PillowTestCase):

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -1,8 +1,9 @@
-from .helper import unittest, PillowTestCase, hopper, on_appveyor
+import os
+import sys
 
 from PIL import Image
-import sys
-import os
+
+from .helper import PillowTestCase, hopper, on_appveyor, unittest
 
 # CFFI imports pycparser which doesn't support PYTHONOPTIMIZE=2
 # https://github.com/eliben/pycparser/pull/198#issuecomment-317001670

--- a/Tests/test_image_array.py
+++ b/Tests/test_image_array.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 im = hopper().resize((128, 100))
 

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 
 class TestImageConvert(PillowTestCase):

--- a/Tests/test_image_copy.py
+++ b/Tests/test_image_copy.py
@@ -1,8 +1,8 @@
-from .helper import PillowTestCase, hopper
+import copy
 
 from PIL import Image
 
-import copy
+from .helper import PillowTestCase, hopper
 
 
 class TestImageCopy(PillowTestCase):

--- a/Tests/test_image_crop.py
+++ b/Tests/test_image_crop.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 
 class TestImageCrop(PillowTestCase):

--- a/Tests/test_image_draft.py
+++ b/Tests/test_image_draft.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, fromstring, tostring
-
 from PIL import Image
+
+from .helper import PillowTestCase, fromstring, tostring
 
 
 class TestImageDraft(PillowTestCase):

--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image, ImageFilter
+
+from .helper import PillowTestCase, hopper
 
 
 class TestImageFilter(PillowTestCase):

--- a/Tests/test_image_frombytes.py
+++ b/Tests/test_image_frombytes.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 
 class TestImageFromBytes(PillowTestCase):

--- a/Tests/test_image_fromqimage.py
+++ b/Tests/test_image_fromqimage.py
@@ -1,7 +1,7 @@
+from PIL import Image, ImageQt
+
 from .helper import PillowTestCase, hopper
 from .test_imageqt import PillowQtTestCase
-
-from PIL import ImageQt, Image
 
 
 class TestFromQImage(PillowQtTestCase, PillowTestCase):

--- a/Tests/test_image_getbands.py
+++ b/Tests/test_image_getbands.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
-
 from PIL import Image
+
+from .helper import PillowTestCase
 
 
 class TestImageGetBands(PillowTestCase):

--- a/Tests/test_image_getbbox.py
+++ b/Tests/test_image_getbbox.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 
 class TestImageGetBbox(PillowTestCase):

--- a/Tests/test_image_getextrema.py
+++ b/Tests/test_image_getextrema.py
@@ -1,4 +1,5 @@
 from PIL import Image
+
 from .helper import PillowTestCase, hopper
 
 

--- a/Tests/test_image_getim.py
+++ b/Tests/test_image_getim.py
@@ -1,5 +1,6 @@
-from .helper import PillowTestCase, hopper
 from PIL._util import py3
+
+from .helper import PillowTestCase, hopper
 
 
 class TestImageGetIm(PillowTestCase):

--- a/Tests/test_image_getprojection.py
+++ b/Tests/test_image_getprojection.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 
 class TestImageGetProjection(PillowTestCase):

--- a/Tests/test_image_load.py
+++ b/Tests/test_image_load.py
@@ -1,8 +1,8 @@
-from .helper import PillowTestCase, hopper
+import os
 
 from PIL import Image
 
-import os
+from .helper import PillowTestCase, hopper
 
 
 class TestImageLoad(PillowTestCase):

--- a/Tests/test_image_mode.py
+++ b/Tests/test_image_mode.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 
 class TestImageMode(PillowTestCase):

--- a/Tests/test_image_paste.py
+++ b/Tests/test_image_paste.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, cached_property
-
 from PIL import Image
+
+from .helper import PillowTestCase, cached_property
 
 
 class TestImagingPaste(PillowTestCase):

--- a/Tests/test_image_putalpha.py
+++ b/Tests/test_image_putalpha.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
-
 from PIL import Image
+
+from .helper import PillowTestCase
 
 
 class TestImagePutAlpha(PillowTestCase):

--- a/Tests/test_image_putdata.py
+++ b/Tests/test_image_putdata.py
@@ -1,9 +1,9 @@
-from .helper import PillowTestCase, hopper
+import sys
 from array import array
 
-import sys
-
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 
 class TestImagePutData(PillowTestCase):

--- a/Tests/test_image_putpalette.py
+++ b/Tests/test_image_putpalette.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import ImagePalette
+
+from .helper import PillowTestCase, hopper
 
 
 class TestImagePutPalette(PillowTestCase):

--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 
 class TestImageQuantize(PillowTestCase):

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -2,8 +2,9 @@ from __future__ import division, print_function
 
 from contextlib import contextmanager
 
-from .helper import unittest, PillowTestCase, hopper
 from PIL import Image, ImageDraw
+
+from .helper import PillowTestCase, hopper, unittest
 
 
 class TestImagingResampleVulnerability(PillowTestCase):

--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -3,9 +3,9 @@ Tests for resize functionality.
 """
 from itertools import permutations
 
-from .helper import PillowTestCase, hopper
-
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 
 class TestImagingCoreResize(PillowTestCase):

--- a/Tests/test_image_rotate.py
+++ b/Tests/test_image_rotate.py
@@ -1,5 +1,6 @@
-from .helper import PillowTestCase, hopper
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 
 class TestImageRotate(PillowTestCase):

--- a/Tests/test_image_split.py
+++ b/Tests/test_image_split.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 
 class TestImageSplit(PillowTestCase):

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -1,5 +1,6 @@
-from .helper import PillowTestCase, hopper
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 
 class TestImageThumbnail(PillowTestCase):

--- a/Tests/test_image_tobitmap.py
+++ b/Tests/test_image_tobitmap.py
@@ -1,4 +1,4 @@
-from .helper import PillowTestCase, hopper, fromstring
+from .helper import PillowTestCase, fromstring, hopper
 
 
 class TestImageToBitmap(PillowTestCase):

--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -1,8 +1,8 @@
 import math
 
-from .helper import PillowTestCase, hopper
-
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 
 class TestImageTransform(PillowTestCase):

--- a/Tests/test_image_transpose.py
+++ b/Tests/test_image_transpose.py
@@ -1,6 +1,3 @@
-from . import helper
-from .helper import PillowTestCase
-
 from PIL.Image import (
     FLIP_LEFT_RIGHT,
     FLIP_TOP_BOTTOM,
@@ -10,6 +7,9 @@ from PIL.Image import (
     TRANSPOSE,
     TRANSVERSE,
 )
+
+from . import helper
+from .helper import PillowTestCase
 
 
 class TestImageTranspose(PillowTestCase):

--- a/Tests/test_imagechops.py
+++ b/Tests/test_imagechops.py
@@ -1,7 +1,6 @@
-from .helper import PillowTestCase, hopper
+from PIL import Image, ImageChops
 
-from PIL import Image
-from PIL import ImageChops
+from .helper import PillowTestCase, hopper
 
 BLACK = (0, 0, 0)
 BROWN = (127, 64, 0)

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -1,10 +1,10 @@
-from .helper import PillowTestCase, hopper
 import datetime
+import os
+from io import BytesIO
 
 from PIL import Image, ImageMode
 
-from io import BytesIO
-import os
+from .helper import PillowTestCase, hopper
 
 try:
     from PIL import ImageCms

--- a/Tests/test_imagecolor.py
+++ b/Tests/test_imagecolor.py
@@ -1,7 +1,6 @@
-from .helper import PillowTestCase
+from PIL import Image, ImageColor
 
-from PIL import Image
-from PIL import ImageColor
+from .helper import PillowTestCase
 
 
 class TestImageColor(PillowTestCase):

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -1,7 +1,8 @@
 import os.path
 
-from .helper import PillowTestCase, hopper
 from PIL import Image, ImageColor, ImageDraw
+
+from .helper import PillowTestCase, hopper
 
 BLACK = (0, 0, 0)
 WHITE = (255, 255, 255)

--- a/Tests/test_imagedraw2.py
+++ b/Tests/test_imagedraw2.py
@@ -1,7 +1,8 @@
 import os.path
 
-from .helper import PillowTestCase, hopper, unittest
 from PIL import Image, ImageDraw2, features
+
+from .helper import PillowTestCase, hopper, unittest
 
 BLACK = (0, 0, 0)
 WHITE = (255, 255, 255)

--- a/Tests/test_imageenhance.py
+++ b/Tests/test_imageenhance.py
@@ -1,7 +1,6 @@
-from .helper import PillowTestCase, hopper
+from PIL import Image, ImageEnhance
 
-from PIL import Image
-from PIL import ImageEnhance
+from .helper import PillowTestCase, hopper
 
 
 class TestImageEnhance(PillowTestCase):

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -1,10 +1,8 @@
-from .helper import unittest, PillowTestCase, hopper, fromstring, tostring
-
 from io import BytesIO
 
-from PIL import Image
-from PIL import ImageFile
-from PIL import EpsImagePlugin
+from PIL import EpsImagePlugin, Image, ImageFile
+
+from .helper import PillowTestCase, fromstring, hopper, tostring, unittest
 
 try:
     from PIL import _webp

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
-from .helper import unittest, PillowTestCase
-
-from PIL import Image, ImageDraw, ImageFont, features
-from io import BytesIO
-import os
-import sys
 import copy
+import distutils.version
+import os
 import re
 import shutil
-import distutils.version
+import sys
+from io import BytesIO
+
+from PIL import Image, ImageDraw, ImageFont, features
+
+from .helper import PillowTestCase, unittest
 
 FONT_PATH = "Tests/fonts/FreeMono.ttf"
 FONT_SIZE = 20

--- a/Tests/test_imagefont_bitmap.py
+++ b/Tests/test_imagefont_bitmap.py
@@ -1,6 +1,6 @@
-from .helper import unittest, PillowTestCase
-from PIL import Image, ImageFont, ImageDraw
+from PIL import Image, ImageDraw, ImageFont
 
+from .helper import PillowTestCase, unittest
 
 image_font_installed = True
 try:

--- a/Tests/test_imagefontctl.py
+++ b/Tests/test_imagefontctl.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-from .helper import unittest, PillowTestCase
 from PIL import Image, ImageDraw, ImageFont, features
 
+from .helper import PillowTestCase, unittest
 
 FONT_SIZE = 20
 FONT_PATH = "Tests/fonts/DejaVuSans.ttf"

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -1,7 +1,7 @@
-from .helper import PillowTestCase
-
-import sys
 import subprocess
+import sys
+
+from .helper import PillowTestCase
 
 try:
     from PIL import ImageGrab

--- a/Tests/test_imagemath.py
+++ b/Tests/test_imagemath.py
@@ -1,8 +1,8 @@
 from __future__ import print_function
-from .helper import PillowTestCase
 
-from PIL import Image
-from PIL import ImageMath
+from PIL import Image, ImageMath
+
+from .helper import PillowTestCase
 
 
 def pixel(im):

--- a/Tests/test_imagemorph.py
+++ b/Tests/test_imagemorph.py
@@ -1,7 +1,7 @@
 # Test the ImageMorphology functionality
-from .helper import PillowTestCase, hopper
-
 from PIL import Image, ImageMorph, _imagingmorph
+
+from .helper import PillowTestCase, hopper
 
 
 class MorphTests(PillowTestCase):

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -1,7 +1,6 @@
-from .helper import PillowTestCase, hopper
+from PIL import Image, ImageOps
 
-from PIL import Image
-from PIL import ImageOps
+from .helper import PillowTestCase, hopper
 
 try:
     from PIL import _webp

--- a/Tests/test_imageops_usm.py
+++ b/Tests/test_imageops_usm.py
@@ -1,7 +1,6 @@
-from .helper import PillowTestCase
+from PIL import Image, ImageFilter
 
-from PIL import Image
-from PIL import ImageFilter
+from .helper import PillowTestCase
 
 im = Image.open("Tests/images/hopper.ppm")
 snakes = Image.open("Tests/images/color_snakes.png")

--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
+from PIL import Image, ImagePalette
 
-from PIL import ImagePalette, Image
+from .helper import PillowTestCase
 
 
 class TestImagePalette(PillowTestCase):

--- a/Tests/test_imagepath.py
+++ b/Tests/test_imagepath.py
@@ -1,10 +1,10 @@
-from .helper import PillowTestCase
-
-from PIL import ImagePath, Image
-from PIL._util import py3
-
 import array
 import struct
+
+from PIL import Image, ImagePath
+from PIL._util import py3
+
+from .helper import PillowTestCase
 
 
 class TestImagePath(PillowTestCase):

--- a/Tests/test_imagesequence.py
+++ b/Tests/test_imagesequence.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image, ImageSequence, TiffImagePlugin
+
+from .helper import PillowTestCase, hopper
 
 
 class TestImageSequence(PillowTestCase):

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -1,7 +1,6 @@
-from .helper import PillowTestCase, hopper
+from PIL import Image, ImageShow
 
-from PIL import Image
-from PIL import ImageShow
+from .helper import PillowTestCase, hopper
 
 
 class TestImageShow(PillowTestCase):

--- a/Tests/test_imagestat.py
+++ b/Tests/test_imagestat.py
@@ -1,7 +1,6 @@
-from .helper import PillowTestCase, hopper
+from PIL import Image, ImageStat
 
-from PIL import Image
-from PIL import ImageStat
+from .helper import PillowTestCase, hopper
 
 
 class TestImageStat(PillowTestCase):

--- a/Tests/test_imagetk.py
+++ b/Tests/test_imagetk.py
@@ -1,7 +1,7 @@
-from .helper import unittest, PillowTestCase, hopper
 from PIL import Image
 from PIL._util import py3
 
+from .helper import PillowTestCase, hopper, unittest
 
 try:
     from PIL import ImageTk

--- a/Tests/test_imagewin.py
+++ b/Tests/test_imagewin.py
@@ -1,7 +1,8 @@
-from .helper import unittest, PillowTestCase, hopper
+import sys
 
 from PIL import ImageWin
-import sys
+
+from .helper import PillowTestCase, hopper, unittest
 
 
 class TestImageWin(PillowTestCase):

--- a/Tests/test_imagewin_pointers.py
+++ b/Tests/test_imagewin_pointers.py
@@ -1,9 +1,10 @@
-from .helper import PillowTestCase, hopper
+import ctypes
+import sys
+from io import BytesIO
+
 from PIL import Image, ImageWin
 
-import sys
-import ctypes
-from io import BytesIO
+from .helper import PillowTestCase, hopper
 
 # see https://github.com/python-pillow/Pillow/pull/1431#issuecomment-144692652
 

--- a/Tests/test_lib_image.py
+++ b/Tests/test_lib_image.py
@@ -1,6 +1,6 @@
-from .helper import unittest, PillowTestCase
-
 from PIL import Image
+
+from .helper import PillowTestCase, unittest
 
 
 class TestLibImage(PillowTestCase):

--- a/Tests/test_lib_pack.py
+++ b/Tests/test_lib_pack.py
@@ -1,9 +1,8 @@
 import sys
 
-from .helper import PillowTestCase
-
 from PIL import Image
 
+from .helper import PillowTestCase
 
 X = 255
 

--- a/Tests/test_locale.py
+++ b/Tests/test_locale.py
@@ -1,9 +1,10 @@
 from __future__ import print_function
-from .helper import unittest, PillowTestCase
+
+import locale
 
 from PIL import Image
 
-import locale
+from .helper import PillowTestCase, unittest
 
 # ref https://github.com/python-pillow/Pillow/issues/272
 # on windows, in polish locale:

--- a/Tests/test_map.py
+++ b/Tests/test_map.py
@@ -1,7 +1,8 @@
-from .helper import PillowTestCase, unittest
 import sys
 
 from PIL import Image
+
+from .helper import PillowTestCase, unittest
 
 
 @unittest.skipIf(sys.platform.startswith("win32"), "Win32 does not call map_buffer")

--- a/Tests/test_mode_i16.py
+++ b/Tests/test_mode_i16.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase, hopper
-
 from PIL import Image
+
+from .helper import PillowTestCase, hopper
 
 
 class TestModeI16(PillowTestCase):

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
 
-from .helper import PillowTestCase, hopper, unittest
 from PIL import Image
+
+from .helper import PillowTestCase, hopper, unittest
 
 try:
     import numpy

--- a/Tests/test_pdfparser.py
+++ b/Tests/test_pdfparser.py
@@ -1,4 +1,4 @@
-from .helper import PillowTestCase
+import time
 
 from PIL.PdfParser import (
     IndirectObjectDef,
@@ -13,7 +13,8 @@ from PIL.PdfParser import (
     encode_text,
     pdf_repr,
 )
-import time
+
+from .helper import PillowTestCase
 
 
 class TestPdfParser(PillowTestCase):

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -1,6 +1,6 @@
-from .helper import PillowTestCase
-
 from PIL import Image
+
+from .helper import PillowTestCase
 
 
 class TestPickle(PillowTestCase):

--- a/Tests/test_psdraw.py
+++ b/Tests/test_psdraw.py
@@ -1,8 +1,9 @@
-from .helper import PillowTestCase
-
-from PIL import Image, PSDraw
 import os
 import sys
+
+from PIL import Image, PSDraw
+
+from .helper import PillowTestCase
 
 
 class TestPsDraw(PillowTestCase):

--- a/Tests/test_pyroma.py
+++ b/Tests/test_pyroma.py
@@ -1,6 +1,6 @@
-from .helper import unittest, PillowTestCase
-
 from PIL import __version__
+
+from .helper import PillowTestCase, unittest
 
 try:
     import pyroma

--- a/Tests/test_qt_image_fromqpixmap.py
+++ b/Tests/test_qt_image_fromqpixmap.py
@@ -1,7 +1,7 @@
+from PIL import ImageQt
+
 from .helper import PillowTestCase, hopper
 from .test_imageqt import PillowQPixmapTestCase
-
-from PIL import ImageQt
 
 
 class TestFromQPixmap(PillowQPixmapTestCase, PillowTestCase):

--- a/Tests/test_qt_image_toqimage.py
+++ b/Tests/test_qt_image_toqimage.py
@@ -1,8 +1,7 @@
+from PIL import Image, ImageQt
+
 from .helper import PillowTestCase, hopper
 from .test_imageqt import PillowQtTestCase
-
-from PIL import ImageQt, Image
-
 
 if ImageQt.qt_is_installed:
     from PIL.ImageQt import QImage

--- a/Tests/test_qt_image_toqpixmap.py
+++ b/Tests/test_qt_image_toqpixmap.py
@@ -1,7 +1,7 @@
+from PIL import ImageQt
+
 from .helper import PillowTestCase, hopper
 from .test_imageqt import PillowQPixmapTestCase
-
-from PIL import ImageQt
 
 if ImageQt.qt_is_installed:
     from PIL.ImageQt import QPixmap

--- a/Tests/test_shell_injection.py
+++ b/Tests/test_shell_injection.py
@@ -1,10 +1,15 @@
-from .helper import unittest, PillowTestCase
-from .helper import djpeg_available, cjpeg_available, netpbm_available
-
-import sys
 import shutil
+import sys
 
-from PIL import Image, JpegImagePlugin, GifImagePlugin
+from PIL import GifImagePlugin, Image, JpegImagePlugin
+
+from .helper import (
+    PillowTestCase,
+    cjpeg_available,
+    djpeg_available,
+    netpbm_available,
+    unittest,
+)
 
 TEST_JPG = "Tests/images/hopper.jpg"
 TEST_GIF = "Tests/images/hopper.gif"

--- a/Tests/test_tiff_ifdrational.py
+++ b/Tests/test_tiff_ifdrational.py
@@ -1,9 +1,9 @@
-from .helper import PillowTestCase, hopper
+from fractions import Fraction
 
-from PIL import TiffImagePlugin, Image
+from PIL import Image, TiffImagePlugin
 from PIL.TiffImagePlugin import IFDRational
 
-from fractions import Fraction
+from .helper import PillowTestCase, hopper
 
 
 class Test_IFDRational(PillowTestCase):

--- a/Tests/test_util.py
+++ b/Tests/test_util.py
@@ -1,6 +1,6 @@
-from .helper import unittest, PillowTestCase
-
 from PIL import _util
+
+from .helper import PillowTestCase, unittest
 
 
 class TestUtil(PillowTestCase):

--- a/Tests/test_webp_leaks.py
+++ b/Tests/test_webp_leaks.py
@@ -1,6 +1,8 @@
-from .helper import unittest, PillowLeakTestCase
-from PIL import Image, features
 from io import BytesIO
+
+from PIL import Image, features
+
+from .helper import PillowLeakTestCase, unittest
 
 test_file = "Tests/images/hopper.webp"
 

--- a/Tests/threaded_save.py
+++ b/Tests/threaded_save.py
@@ -1,11 +1,12 @@
 from __future__ import print_function
-from PIL import Image
 
 import io
 import queue
 import sys
 import threading
 import time
+
+from PIL import Image
 
 test_format = sys.argv[1] if len(sys.argv) > 1 else "PNG"
 

--- a/Tests/versions.py
+++ b/Tests/versions.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+
 from PIL import Image
 
 

--- a/docs/Guardfile
+++ b/docs/Guardfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-from livereload.task import Task
 from livereload.compiler import shell
+from livereload.task import Task
 
 Task.add('*.rst', shell('make html'))
 Task.add('*/*.rst', shell('make html'))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,8 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath('.'))
 
-import sphinx_rtd_theme
-
 import PIL
+import sphinx_rtd_theme
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/example/DdsImagePlugin.py
+++ b/docs/example/DdsImagePlugin.py
@@ -12,8 +12,8 @@ Full text of the CC0 license:
 
 import struct
 from io import BytesIO
-from PIL import Image, ImageFile
 
+from PIL import Image, ImageFile
 
 # Magic ("DDS ")
 DDS_MAGIC = 0x20534444

--- a/mp_compile.py
+++ b/mp_compile.py
@@ -4,10 +4,11 @@
 # own newly-added support for parallel builds.
 
 from __future__ import print_function
-from multiprocessing import Pool, cpu_count
-from distutils.ccompiler import CCompiler
+
 import os
 import sys
+from distutils.ccompiler import CCompiler
+from multiprocessing import Pool, cpu_count
 
 try:
     MAX_PROCS = int(os.environ.get("MAX_CONCURRENCY", min(4, cpu_count())))

--- a/selftest.py
+++ b/selftest.py
@@ -2,11 +2,10 @@
 # minimal sanity check
 from __future__ import print_function
 
-import sys
 import os
+import sys
 
-from PIL import Image
-from PIL import features
+from PIL import Image, features
 
 try:
     Image.core.ping

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,11 @@ test=pytest
 extend-ignore = E203, W503
 max-line-length = 88
 
+[isort]
+combine_as_imports = True
+include_trailing_comma = True
+line_length = 88
+multi_line_output = 3
+
 [tool:pytest]
 addopts = -rs

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ from setuptools import Extension, setup
 # comment this out to disable multi threaded builds.
 import mp_compile
 
-
 if sys.platform == "win32" and sys.version_info >= (3, 8):
     warnings.warn(
         "Pillow does not yet support Python {}.{} and does not yet provide "

--- a/src/PIL/BdfFontFile.py
+++ b/src/PIL/BdfFontFile.py
@@ -19,8 +19,7 @@
 
 from __future__ import print_function
 
-from . import Image, FontFile
-
+from . import FontFile, Image
 
 # --------------------------------------------------------------------
 # parse X Bitmap Distribution Format (BDF)

--- a/src/PIL/BlpImagePlugin.py
+++ b/src/PIL/BlpImagePlugin.py
@@ -34,7 +34,6 @@ from io import BytesIO
 
 from . import Image, ImageFile
 
-
 BLP_FORMAT_JPEG = 0
 
 BLP_ENCODING_UNCOMPRESSED = 1

--- a/src/PIL/CurImagePlugin.py
+++ b/src/PIL/CurImagePlugin.py
@@ -18,7 +18,7 @@
 
 from __future__ import print_function
 
-from . import Image, BmpImagePlugin
+from . import BmpImagePlugin, Image
 from ._binary import i8, i16le as i16, i32le as i32
 
 # __version__ is deprecated and will be removed in a future version. Use

--- a/src/PIL/DdsImagePlugin.py
+++ b/src/PIL/DdsImagePlugin.py
@@ -12,8 +12,8 @@ Full text of the CC0 license:
 
 import struct
 from io import BytesIO
-from . import Image, ImageFile
 
+from . import Image, ImageFile
 
 # Magic ("DDS ")
 DDS_MAGIC = 0x20534444

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -20,10 +20,11 @@
 # See the README file for information on usage and redistribution.
 #
 
-import re
 import io
 import os
+import re
 import sys
+
 from . import Image, ImageFile
 from ._binary import i32le as i32
 

--- a/src/PIL/FontFile.py
+++ b/src/PIL/FontFile.py
@@ -17,6 +17,7 @@
 from __future__ import print_function
 
 import os
+
 from . import Image, _binary
 
 WIDTH = 800

--- a/src/PIL/FpxImagePlugin.py
+++ b/src/PIL/FpxImagePlugin.py
@@ -17,10 +17,10 @@
 
 from __future__ import print_function
 
-from . import Image, ImageFile
-from ._binary import i32le as i32, i8
-
 import olefile
+
+from . import Image, ImageFile
+from ._binary import i8, i32le as i32
 
 # __version__ is deprecated and will be removed in a future version. Use
 # PIL.__version__ instead.

--- a/src/PIL/FtexImagePlugin.py
+++ b/src/PIL/FtexImagePlugin.py
@@ -53,8 +53,8 @@ Note: All data is stored in little-Endian (Intel) byte order.
 
 import struct
 from io import BytesIO
-from . import Image, ImageFile
 
+from . import Image, ImageFile
 
 MAGIC = b"FTEX"
 FORMAT_DXT1 = 0

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -24,10 +24,10 @@
 # See the README file for information on usage and redistribution.
 #
 
-from . import Image, ImageFile, ImagePalette, ImageChops, ImageSequence
-from ._binary import i8, i16le as i16, o8, o16le as o16
-
 import itertools
+
+from . import Image, ImageChops, ImageFile, ImagePalette, ImageSequence
+from ._binary import i8, i16le as i16, o8, o16le as o16
 
 # __version__ is deprecated and will be removed in a future version. Use
 # PIL.__version__ instead.

--- a/src/PIL/GimpGradientFile.py
+++ b/src/PIL/GimpGradientFile.py
@@ -13,7 +13,8 @@
 # See the README file for information on usage and redistribution.
 #
 
-from math import pi, log, sin, sqrt
+from math import log, pi, sin, sqrt
+
 from ._binary import o8
 
 # --------------------------------------------------------------------

--- a/src/PIL/GimpPaletteFile.py
+++ b/src/PIL/GimpPaletteFile.py
@@ -15,8 +15,8 @@
 #
 
 import re
-from ._binary import o8
 
+from ._binary import o8
 
 ##
 # File handler for GIMP's palette format.

--- a/src/PIL/IcnsImagePlugin.py
+++ b/src/PIL/IcnsImagePlugin.py
@@ -15,14 +15,15 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image, ImageFile, PngImagePlugin
-from PIL._binary import i8
 import io
 import os
 import shutil
 import struct
 import sys
 import tempfile
+
+from PIL import Image, ImageFile, PngImagePlugin
+from PIL._binary import i8
 
 enable_jpeg2k = hasattr(Image.core, "jp2klib_version")
 if enable_jpeg2k:

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -25,10 +25,10 @@
 import struct
 import warnings
 from io import BytesIO
+from math import ceil, log
 
-from . import Image, ImageFile, BmpImagePlugin, PngImagePlugin
+from . import BmpImagePlugin, Image, ImageFile, PngImagePlugin
 from ._binary import i8, i16le as i16, i32le as i32
-from math import log, ceil
 
 # __version__ is deprecated and will be removed in a future version. Use
 # PIL.__version__ instead.

--- a/src/PIL/ImImagePlugin.py
+++ b/src/PIL/ImImagePlugin.py
@@ -27,6 +27,7 @@
 
 
 import re
+
 from . import Image, ImageFile, ImagePalette
 from ._binary import i8
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -24,15 +24,22 @@
 # See the README file for information on usage and redistribution.
 #
 
+import atexit
+import io
+import logging
+import math
+import numbers
+import os
+import struct
+import sys
+import warnings
+
 # VERSION was removed in Pillow 6.0.0.
 # PILLOW_VERSION is deprecated and will be removed in Pillow 7.0.0.
 # Use __version__ instead.
-from . import PILLOW_VERSION, __version__, _plugins
-from ._util import py3
-
-import logging
-import warnings
-import math
+from . import PILLOW_VERSION, ImageMode, TiffTags, __version__, _plugins
+from ._binary import i8, i32le
+from ._util import deferred_error, isPath, isStringType, py3
 
 try:
     import builtins
@@ -41,18 +48,6 @@ except ImportError:
 
     builtins = __builtin__
 
-from . import ImageMode, TiffTags
-from ._binary import i8, i32le
-from ._util import isPath, isStringType, deferred_error
-
-import os
-import sys
-import io
-import struct
-import atexit
-
-# type stuff
-import numbers
 
 try:
     # Python 3

--- a/src/PIL/ImageCms.py
+++ b/src/PIL/ImageCms.py
@@ -16,9 +16,11 @@
 # below for the original description.
 
 from __future__ import print_function
+
 import sys
 
 from PIL import Image
+from PIL._util import isStringType
 
 try:
     from PIL import _imagingcms
@@ -28,7 +30,6 @@ except ImportError as ex:
     from ._util import deferred_error
 
     _imagingcms = deferred_error(ex)
-from PIL._util import isStringType
 
 DESCRIPTION = """
 pyCMS

--- a/src/PIL/ImageColor.py
+++ b/src/PIL/ImageColor.py
@@ -17,8 +17,9 @@
 # See the README file for information on usage and redistribution.
 #
 
-from . import Image
 import re
+
+from . import Image
 
 
 def getrgb(color):

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -36,6 +36,7 @@ import numbers
 from . import Image, ImageColor
 from ._util import isStringType
 
+
 """
 A simple 2D drawing interface for PIL images.
 <p>

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -27,11 +27,12 @@
 # See the README file for information on usage and redistribution.
 #
 
+import io
+import struct
+import sys
+
 from . import Image
 from ._util import isPath
-import io
-import sys
-import struct
 
 MAXBLOCK = 65536
 

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -25,10 +25,11 @@
 # See the README file for information on usage and redistribution.
 #
 
-from . import Image
-from ._util import isDirectory, isPath, py3
 import os
 import sys
+
+from . import Image
+from ._util import isDirectory, isPath, py3
 
 LAYOUT_BASIC = 0
 LAYOUT_RAQM = 1

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -15,9 +15,9 @@
 # See the README file for information on usage and redistribution.
 #
 
-from . import Image
-
 import sys
+
+from . import Image
 
 if sys.platform == "win32":
     grabber = Image.core.grabscreen

--- a/src/PIL/ImageMorph.py
+++ b/src/PIL/ImageMorph.py
@@ -7,8 +7,9 @@
 
 from __future__ import print_function
 
-from . import Image, _imagingmorph
 import re
+
+from . import Image, _imagingmorph
 
 LUT_SIZE = 1 << 9
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -17,11 +17,11 @@
 # See the README file for information on usage and redistribution.
 #
 
+import functools
+import operator
+
 from . import Image
 from ._util import isStringType
-import operator
-import functools
-
 
 #
 # helpers

--- a/src/PIL/ImagePalette.py
+++ b/src/PIL/ImagePalette.py
@@ -17,7 +17,8 @@
 #
 
 import array
-from . import ImageColor, GimpPaletteFile, GimpGradientFile, PaletteFile
+
+from . import GimpGradientFile, GimpPaletteFile, ImageColor, PaletteFile
 
 
 class ImagePalette(object):

--- a/src/PIL/ImagePath.py
+++ b/src/PIL/ImagePath.py
@@ -16,5 +16,4 @@
 
 from . import Image
 
-
 Path = Image.core.path

--- a/src/PIL/ImageQt.py
+++ b/src/PIL/ImageQt.py
@@ -16,11 +16,12 @@
 # See the README file for information on usage and redistribution.
 #
 
-from . import Image
-from ._util import isPath, py3
-from io import BytesIO
 import sys
 import warnings
+from io import BytesIO
+
+from . import Image
+from ._util import isPath, py3
 
 qt_versions = [["5", "PyQt5"], ["side2", "PySide2"], ["4", "PyQt4"], ["side", "PySide"]]
 

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -14,11 +14,12 @@
 
 from __future__ import print_function
 
-from PIL import Image
 import os
-import sys
 import subprocess
+import sys
 import tempfile
+
+from PIL import Image
 
 if sys.version_info.major >= 3:
     from shlex import quote

--- a/src/PIL/ImageStat.py
+++ b/src/PIL/ImageStat.py
@@ -21,9 +21,9 @@
 # See the README file for information on usage and redistribution.
 #
 
+import functools
 import math
 import operator
-import functools
 
 
 class Stat(object):

--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -17,10 +17,11 @@
 
 from __future__ import print_function
 
-from . import Image, ImageFile
-from ._binary import i8, i16be as i16, i32be as i32, o8
 import os
 import tempfile
+
+from . import Image, ImageFile
+from ._binary import i8, i16be as i16, i32be as i32, o8
 
 # __version__ is deprecated and will be removed in a future version. Use
 # PIL.__version__ instead.

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -12,10 +12,11 @@
 #
 # See the README file for information on usage and redistribution.
 #
-from . import Image, ImageFile
-import struct
-import os
 import io
+import os
+import struct
+
+from . import Image, ImageFile
 
 # __version__ is deprecated and will be removed in a future version. Use
 # PIL.__version__ instead.

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -35,13 +35,14 @@
 from __future__ import print_function
 
 import array
-import struct
 import io
+import struct
 import warnings
+
 from . import Image, ImageFile, TiffImagePlugin
-from ._binary import i8, o8, i16be as i16, i32be as i32
-from .JpegPresets import presets
+from ._binary import i8, i16be as i16, i32be as i32, o8
 from ._util import isStringType
+from .JpegPresets import presets
 
 # __version__ is deprecated and will be removed in a future version. Use
 # PIL.__version__ instead.

--- a/src/PIL/McIdasImagePlugin.py
+++ b/src/PIL/McIdasImagePlugin.py
@@ -17,6 +17,7 @@
 #
 
 import struct
+
 from . import Image, ImageFile
 
 # __version__ is deprecated and will be removed in a future version. Use

--- a/src/PIL/MicImagePlugin.py
+++ b/src/PIL/MicImagePlugin.py
@@ -17,9 +17,9 @@
 #
 
 
-from . import Image, TiffImagePlugin
-
 import olefile
+
+from . import Image, TiffImagePlugin
 
 # __version__ is deprecated and will be removed in a future version. Use
 # PIL.__version__ instead.

--- a/src/PIL/MspImagePlugin.py
+++ b/src/PIL/MspImagePlugin.py
@@ -23,10 +23,11 @@
 #
 # See also: http://www.fileformat.info/format/mspaint/egff.htm
 
-from . import Image, ImageFile
-from ._binary import i16le as i16, o16le as o16, i8
-import struct
 import io
+import struct
+
+from . import Image, ImageFile
+from ._binary import i8, i16le as i16, o16le as o16
 
 # __version__ is deprecated and will be removed in a future version. Use
 # PIL.__version__ instead.

--- a/src/PIL/PSDraw.py
+++ b/src/PIL/PSDraw.py
@@ -15,9 +15,10 @@
 # See the README file for information on usage and redistribution.
 #
 
+import sys
+
 from . import EpsImagePlugin
 from ._util import py3
-import sys
 
 ##
 # Simple Postscript graphics interface.

--- a/src/PIL/PaletteFile.py
+++ b/src/PIL/PaletteFile.py
@@ -15,7 +15,6 @@
 
 from ._binary import o8
 
-
 ##
 # File handler for Teragon-style palette files.
 

--- a/src/PIL/PcfFontFile.py
+++ b/src/PIL/PcfFontFile.py
@@ -17,8 +17,9 @@
 #
 
 import io
-from . import Image, FontFile
-from ._binary import i8, i16le as l16, i32le as l32, i16be as b16, i32be as b32
+
+from . import FontFile, Image
+from ._binary import i8, i16be as b16, i16le as l16, i32be as b32, i32le as l32
 
 # --------------------------------------------------------------------
 # declarations

--- a/src/PIL/PcxImagePlugin.py
+++ b/src/PIL/PcxImagePlugin.py
@@ -27,6 +27,7 @@
 
 import io
 import logging
+
 from . import Image, ImageFile, ImagePalette
 from ._binary import i8, i16le as i16, o8, o16le as o16
 

--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -20,10 +20,11 @@
 # Image plugin for PDF images (output only).
 ##
 
-from . import Image, ImageFile, ImageSequence, PdfParser
 import io
 import os
 import time
+
+from . import Image, ImageFile, ImageSequence, PdfParser
 
 # __version__ is deprecated and will be removed in a future version. Use
 # PIL.__version__ instead.

--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -6,6 +6,7 @@ import os
 import re
 import time
 import zlib
+
 from ._util import py3
 
 try:

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -33,8 +33,8 @@
 
 import logging
 import re
-import zlib
 import struct
+import zlib
 
 from . import Image, ImageFile, ImagePalette
 from ._binary import i8, i16be as i16, i32be as i32, o16be as o16, o32be as o32

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -21,6 +21,7 @@
 __version__ = "0.4"
 
 import io
+
 from . import Image, ImageFile, ImagePalette
 from ._binary import i8, i16be as i16, i32be as i32
 

--- a/src/PIL/PyAccess.py
+++ b/src/PIL/PyAccess.py
@@ -25,7 +25,6 @@ import sys
 
 from cffi import FFI
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/PIL/SgiImagePlugin.py
+++ b/src/PIL/SgiImagePlugin.py
@@ -22,12 +22,12 @@
 #
 
 
-from . import Image, ImageFile
-from ._binary import i8, o8, i16be as i16
-from ._util import py3
-import struct
 import os
+import struct
 
+from . import Image, ImageFile
+from ._binary import i8, i16be as i16, o8
+from ._util import py3
 
 # __version__ is deprecated and will be removed in a future version. Use
 # PIL.__version__ instead.

--- a/src/PIL/SpiderImagePlugin.py
+++ b/src/PIL/SpiderImagePlugin.py
@@ -35,10 +35,11 @@
 
 from __future__ import print_function
 
-from PIL import Image, ImageFile
 import os
 import struct
 import sys
+
+from PIL import Image, ImageFile
 
 
 def isInt(f):

--- a/src/PIL/TarIO.py
+++ b/src/PIL/TarIO.py
@@ -16,8 +16,8 @@
 
 import io
 import sys
-from . import ContainerIO
 
+from . import ContainerIO
 
 ##
 # A file object that provides read access to a given member of a TAR

--- a/src/PIL/TgaImagePlugin.py
+++ b/src/PIL/TgaImagePlugin.py
@@ -17,10 +17,10 @@
 #
 
 
+import warnings
+
 from . import Image, ImageFile, ImagePalette
 from ._binary import i8, i16le as i16, o8, o16le as o16
-
-import warnings
 
 # __version__ is deprecated and will be removed in a future version. Use
 # PIL.__version__ instead.

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -41,21 +41,19 @@
 
 from __future__ import division, print_function
 
-from . import Image, ImageFile, ImagePalette, TiffTags
-from ._binary import i8, o8
-from ._util import py3
-
-from fractions import Fraction
-from numbers import Number, Rational
-
+import distutils.version
 import io
 import itertools
 import os
 import struct
 import sys
 import warnings
-import distutils.version
+from fractions import Fraction
+from numbers import Number, Rational
 
+from . import Image, ImageFile, ImagePalette, TiffTags
+from ._binary import i8, o8
+from ._util import py3
 from .TiffTags import TYPES
 
 try:

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -1,3 +1,5 @@
+from io import BytesIO
+
 from . import Image, ImageFile
 
 try:
@@ -6,7 +8,6 @@ try:
     SUPPORTED = True
 except ImportError:
     SUPPORTED = False
-from io import BytesIO
 
 
 _VALID_WEBP_MODES = {"RGBX": True, "RGBA": True, "RGB": True}

--- a/src/PIL/WmfImagePlugin.py
+++ b/src/PIL/WmfImagePlugin.py
@@ -22,9 +22,8 @@
 from __future__ import print_function
 
 from . import Image, ImageFile
-from ._binary import i16le as word, si16le as short, i32le as dword, si32le as _long
+from ._binary import i16le as word, i32le as dword, si16le as short, si32le as _long
 from ._util import py3
-
 
 # __version__ is deprecated and will be removed in a future version. Use
 # PIL.__version__ instead.

--- a/src/PIL/XbmImagePlugin.py
+++ b/src/PIL/XbmImagePlugin.py
@@ -20,6 +20,7 @@
 #
 
 import re
+
 from . import Image, ImageFile
 
 # __version__ is deprecated and will be removed in a future version. Use

--- a/src/PIL/XpmImagePlugin.py
+++ b/src/PIL/XpmImagePlugin.py
@@ -16,6 +16,7 @@
 
 
 import re
+
 from . import Image, ImageFile, ImagePalette
 from ._binary import i8, o8
 

--- a/src/PIL/_binary.py
+++ b/src/PIL/_binary.py
@@ -11,7 +11,8 @@
 # See the README file for information on usage and redistribution.
 #
 
-from struct import unpack_from, pack
+from struct import pack, unpack_from
+
 from ._util import py3
 
 if py3:

--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -5,6 +5,7 @@ import os
 import sys
 
 import PIL
+
 from . import Image
 
 modules = {

--- a/tox.ini
+++ b/tox.ini
@@ -26,9 +26,11 @@ deps =
 commands =
     black --check --diff .
     flake8 --statistics --count
+    isort --check-only --diff
     check-manifest
 deps =
     black
     check-manifest
     flake8
+    isort
 skip_install = true

--- a/winbuild/build.py
+++ b/winbuild/build.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
 
-import subprocess
-import shutil
-import sys
 import getopt
 import os
+import shutil
+import subprocess
+import sys
 
 from config import (
-    compilers,
-    compiler_from_env,
-    pythons,
-    pyversion_from_env,
-    bit_from_env,
     VIRT_BASE,
     X64_EXT,
+    bit_from_env,
+    compiler_from_env,
+    compilers,
+    pythons,
+    pyversion_from_env,
 )
 
 

--- a/winbuild/build_dep.py
+++ b/winbuild/build_dep.py
@@ -1,10 +1,10 @@
-from unzip import unzip
-from untar import untar
 import os
 
-from fetch import fetch
-from config import compilers, all_compilers, compiler_from_env, bit_from_env, libs
 from build import vc_setup
+from config import all_compilers, bit_from_env, compiler_from_env, compilers, libs
+from fetch import fetch
+from untar import untar
+from unzip import unzip
 
 
 def _relpath(*args):

--- a/winbuild/get_pythons.py
+++ b/winbuild/get_pythons.py
@@ -1,5 +1,6 @@
-from fetch import fetch
 import os
+
+from fetch import fetch
 
 if __name__ == "__main__":
     for version in ["2.7.15", "3.4.4"]:

--- a/winbuild/test.py
+++ b/winbuild/test.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
-import subprocess
-import os
 import glob
+import os
+import subprocess
 import sys
 
-from config import pythons, VIRT_BASE, X64_EXT
+from config import VIRT_BASE, X64_EXT, pythons
 
 
 def test_one(params):


### PR DESCRIPTION
Similar to the recent adoption of Black. isort is a Python utility to
sort imports alphabetically and automatically separate into sections. By
using isort, contributors can quickly and automatically conform to the
projects style without thinking. Just let the tool do it.

Uses the configuration recommended by the black project to avoid
conflicts of style.