### PR TITLE
Clean up several Sphinx warnings

### DIFF
--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -132,11 +132,11 @@ Methods
     Draws an arc (a portion of a circle outline) between the start and end
     angles, inside the given bounding box.
 
-    :param xy: Two points to define the bounding box. Sequence of
-            ``[(x0, y0), (x1, y1)]`` or ``[x0, y0, x1, y1]``,
-             where ``x1 >= x0`` and ``y1 >= y0``.
-    :param start: Starting angle, in degrees. Angles are measured from
-            3 o'clock, increasing clockwise.
+    :param xy: Two points to define the bounding box. Sequence of ``[(x0, y0),
+        (x1, y1)]`` or ``[x0, y0, x1, y1]``, where ``x1 >= x0`` and ``y1 >=
+        y0``.
+    :param start: Starting angle, in degrees. Angles are measured from 3
+        o'clock, increasing clockwise.
     :param end: Ending angle, in degrees.
     :param fill: Color to use for the arc.
     :param width: The line width, in pixels.
@@ -159,9 +159,9 @@ Methods
     Same as :py:meth:`~PIL.ImageDraw.ImageDraw.arc`, but connects the end points
     with a straight line.
 
-    :param xy: Two points to define the bounding box. Sequence of
-            ``[(x0, y0), (x1, y1)]`` or ``[x0, y0, x1, y1]``,
-             where ``x1 >= x0`` and ``y1 >= y0``.
+    :param xy: Two points to define the bounding box. Sequence of ``[(x0, y0),
+        (x1, y1)]`` or ``[x0, y0, x1, y1]``, where ``x1 >= x0`` and ``y1 >=
+        y0``.
     :param outline: Color to use for the outline.
     :param fill: Color to use for the fill.
     :param width: The line width, in pixels.
@@ -173,8 +173,8 @@ Methods
     Draws an ellipse inside the given bounding box.
 
     :param xy: Two points to define the bounding box. Sequence of either
-            ``[(x0, y0), (x1, y1)]`` or ``[x0, y0, x1, y1]``,
-             where ``x1 >= x0`` and ``y1 >= y0``.
+        ``[(x0, y0), (x1, y1)]`` or ``[x0, y0, x1, y1]``, where ``x1 >= x0``
+        and ``y1 >= y0``.
     :param outline: Color to use for the outline.
     :param fill: Color to use for the fill.
     :param width: The line width, in pixels.
@@ -203,11 +203,11 @@ Methods
     Same as arc, but also draws straight lines between the end points and the
     center of the bounding box.
 
-    :param xy: Two points to define the bounding box. Sequence of
-            ``[(x0, y0), (x1, y1)]`` or ``[x0, y0, x1, y1]``,
-             where ``x1 >= x0`` and ``y1 >= y0``.
-    :param start: Starting angle, in degrees. Angles are measured from
-            3 o'clock, increasing clockwise.
+    :param xy: Two points to define the bounding box. Sequence of ``[(x0, y0),
+        (x1, y1)]`` or ``[x0, y0, x1, y1]``, where ``x1 >= x0`` and ``y1 >=
+        y0``.
+    :param start: Starting angle, in degrees. Angles are measured from 3
+        o'clock, increasing clockwise.
     :param end: Ending angle, in degrees.
     :param fill: Color to use for the fill.
     :param outline: Color to use for the outline.

--- a/docs/reference/ImageStat.rst
+++ b/docs/reference/ImageStat.rst
@@ -20,12 +20,13 @@ for a region of an image.
 
         Min/max values for each band in the image.
 
-        .. Note:: This relies on the :py:meth:`~PIL.Image.histogram` method, and simply
-        returns the low and high bins used. This is correct for images with 8 bits per
-        channel, but fails for other modes such as ``I`` or ``F``. Instead, use
-        :py:meth:`~PIL.Image.getextrema` to return per-band extrema for the image.
-        This is more correct and efficient because, for non-8-bit modes, the histogram
-        method uses :py:meth:`~PIL.Image.getextrema` to determine the bins used.
+        .. Note:: This relies on the :py:meth:`~PIL.Image.histogram` method,
+            and simply returns the low and high bins used. This is correct for
+            images with 8 bits per channel, but fails for other modes such as
+            ``I`` or ``F``. Instead, use :py:meth:`~PIL.Image.getextrema` to
+            return per-band extrema for the image. This is more correct and
+            efficient because, for non-8-bit modes, the histogram method uses
+            :py:meth:`~PIL.Image.getextrema` to determine the bins used.
 
     .. py:attribute:: count
 


### PR DESCRIPTION
Appeared as:

    Pillow/docs/reference/ImageDraw.rst:137: WARNING: Unexpected indentation.
    Pillow/docs/reference/ImageDraw.rst:164: WARNING: Unexpected indentation.
    Pillow/docs/reference/ImageDraw.rst:177: WARNING: Unexpected indentation.
    Pillow/docs/reference/ImageDraw.rst:208: WARNING: Unexpected indentation.
    Pillow/docs/reference/ImageStat.rst:24: WARNING: Explicit markup ends without a blank line; unexpected unindent.