### PR TITLE
Remove unused docs/_templates directory

### DIFF
--- a/docs/Guardfile
+++ b/docs/Guardfile
@@ -5,6 +5,5 @@ from livereload.compiler import shell
 Task.add('*.rst', shell('make html'))
 Task.add('*/*.rst', shell('make html'))
 Task.add('_static/*.css', shell('make clean html'))
-Task.add('_templates/*', shell('make clean html'))
 Task.add('Makefile', shell('make html'))
 Task.add('conf.py', shell('make html'))

--- a/docs/_templates/.gitignore
+++ b/docs/_templates/.gitignore
@@ -1,1 +1,0 @@
-# Empty file, to make the directory available in the repository

--- a/docs/_templates/sidebarhelp.html
+++ b/docs/_templates/sidebarhelp.html
@@ -1,4 +1,0 @@
-<h3>Need help?</h3>
-<p>
-    You can get help via IRC at <a href="irc://irc.freenode.net#pil">irc://irc.freenode.net#pil</a>, <a href="https://gitter.im/python-pillow/Pillow">Gitter</a> or <a href="https://stackoverflow.com/questions/tagged/python-imaging-library">Stack Overflow</a>. Please <a href="https://github.com/python-pillow/Pillow/issues/new">report issues on GitHub</a>.
-</p>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,9 +31,6 @@ import PIL
 # ones.
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode", "sphinx.ext.intersphinx"]
 
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ["_templates"]
-
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']


### PR DESCRIPTION
The only file, `sidebarhelp.html`, applies to the sphinx-better-theme which is unused and was removed in
02f3685b2d0f96cbe7028d45c0564efb0c5349ad.