### PR TITLE
Changed overflow check to use PY_SSIZE_T_MAX

### DIFF
--- a/Tests/test_map.py
+++ b/Tests/test_map.py
@@ -4,6 +4,11 @@ from PIL import Image
 
 from .helper import PillowTestCase, unittest
 
+try:
+    import numpy
+except ImportError:
+    numpy = None
+
 
 @unittest.skipIf(sys.platform.startswith("win32"), "Win32 does not call map_buffer")
 class TestMap(PillowTestCase):
@@ -23,3 +28,10 @@ class TestMap(PillowTestCase):
             im.load()
 
         Image.MAX_IMAGE_PIXELS = max_pixels
+
+    @unittest.skipIf(sys.maxsize <= 2 ** 32, "requires 64-bit system")
+    @unittest.skipIf(numpy is None, "Numpy is not installed")
+    def test_ysize(self):
+        # Should not raise 'Integer overflow in ysize'
+        arr = numpy.zeros((46341, 46341), dtype=numpy.uint8)
+        Image.fromarray(arr)

--- a/src/map.c
+++ b/src/map.c
@@ -339,7 +339,7 @@ PyImaging_MapBuffer(PyObject* self, PyObject* args)
             stride = xsize * 4;
     }
 
-    if (stride > 0 && ysize > INT_MAX / stride) {
+    if (stride > 0 && ysize > PY_SSIZE_T_MAX / stride) {
         PyErr_SetString(PyExc_MemoryError, "Integer overflow in ysize");
         return NULL;
     }


### PR DESCRIPTION
Resolves #3963

The check was added in https://github.com/python-pillow/Pillow/commit/c50ebe6459a131a1ea8ca531f10da616d3 to fix #2105. This PR should be updating the range for 64-bit systems.