### PR TITLE
Raise the same error if a truncated image is loaded a second time

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -372,6 +372,10 @@ class TestFileJpeg(PillowTestCase):
         with self.assertRaises(IOError):
             im.load()
 
+        # Test that the error is raised if loaded a second time
+        with self.assertRaises(IOError):
+            im.load()
+
     def _n_qtables_helper(self, n, test_file):
         im = Image.open(test_file)
         f = self.tempfile("temp.jpg")

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -113,6 +113,10 @@ class TestImageFile(PillowTestCase):
         with self.assertRaises(IOError):
             im.load()
 
+        # Test that the error is raised if loaded a second time
+        with self.assertRaises(IOError):
+            im.load()
+
     def test_truncated_without_errors(self):
         if "zip_encoder" not in codecs:
             self.skipTest("PNG (zlib) encoder not available")

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -243,7 +243,6 @@ class ImageFile(Image.Image):
                                 if LOAD_TRUNCATED_IMAGES:
                                     break
                                 else:
-                                    self.tile = []
                                     raise IOError(
                                         "image file is truncated "
                                         "(%d bytes not processed)" % len(b)

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -612,7 +612,7 @@ class PngImageFile(ImageFile.ImageFile):
             rawmode, data = self.png.im_palette
             self.palette = ImagePalette.raw(rawmode, data)
 
-        self.__idat = length  # used by load_read()
+        self.__prepare_idat = length  # used by load_prepare()
 
     @property
     def text(self):
@@ -645,6 +645,7 @@ class PngImageFile(ImageFile.ImageFile):
         if self.info.get("interlace"):
             self.decoderconfig = self.decoderconfig + (1,)
 
+        self.__idat = self.__prepare_idat  # used by load_read()
         ImageFile.ImageFile.load_prepare(self)
 
     def load_read(self, read_bytes):


### PR DESCRIPTION
Resolves #3863, and see also #2977, two issues that find it strange that Pillow is inconsistent between the first `load()` of a truncated image, and the second.

After `load()` is called on a truncated image, an error is raised and there is a line - `self.tile = []`. This means that when `load()` is called a second time, [it thinks there is nothing to do](https://github.com/python-pillow/Pillow/blob/1c57a41ececc4529520a423b9bec13c78927cb25/src/PIL/ImageFile.py#L148) and does not return the same truncated error. This logic has been present since the fork.

Instead, this PR removes that line, causing the same error to be raised on subsequent loads. It also resets an internal variable of PngImagePlugin, to fix an error that was raised when changing the tests for this, also providing consistency by resetting the image to it's initial state.