### PR TITLE
Documented more encoding values

### DIFF
--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -529,7 +529,8 @@ def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):
     :param size: The requested size, in points.
     :param index: Which font face to load (default is first available face).
     :param encoding: Which font encoding to use (default is Unicode). Possible
-                     encodings include:
+                     encodings include (see the FreeType documentation for more
+                     information):
 
                      * "unic" (Unicode)
                      * "symb" (Microsoft Symbol)
@@ -544,7 +545,8 @@ def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):
                      * "joha" (Johab)
                      * "lat1" (Latin-1)
 
-                     See the FreeType documentation for more information.
+                     This specifies the character set to use. It does not alter the
+                     encoding of any text provided in subsequent operations.
     :param layout_engine: Which layout engine to use, if available:
                      `ImageFont.LAYOUT_BASIC` or `ImageFont.LAYOUT_RAQM`.
     :return: A font object.

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -528,11 +528,23 @@ def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):
                      the loader also looks in Windows :file:`fonts/` directory.
     :param size: The requested size, in points.
     :param index: Which font face to load (default is first available face).
-    :param encoding: Which font encoding to use (default is Unicode). Common
-                     encodings are "unic" (Unicode), "symb" (Microsoft
-                     Symbol), "ADOB" (Adobe Standard), "ADBE" (Adobe Expert),
-                     and "armn" (Apple Roman). See the FreeType documentation
-                     for more information.
+    :param encoding: Which font encoding to use (default is Unicode). Possible
+                     encodings include:
+
+                     * "unic" (Unicode)
+                     * "symb" (Microsoft Symbol)
+                     * "ADOB" (Adobe Standard)
+                     * "ADBE" (Adobe Expert)
+                     * "ADBC" (Adobe Custom)
+                     * "armn" (Apple Roman)
+                     * "sjis" (Shift JIS)
+                     * "gb  " (PRC)
+                     * "big5"
+                     * "wans" (Extended Wansung)
+                     * "joha" (Johab)
+                     * "lat1" (Latin-1)
+
+                     See the FreeType documentation for more information.
     :param layout_engine: Which layout engine to use, if available:
                      `ImageFont.LAYOUT_BASIC` or `ImageFont.LAYOUT_RAQM`.
     :return: A font object.


### PR DESCRIPTION
Resolves #3345 by listing more encoding values, and adding a note that the `encoding` parameter does not change the encoding of text from later operations.

See https://www.freetype.org/freetype2/docs/reference/ft2-base_interface.html#ft_encoding for the list of encoding values added.