### PR TITLE
Remove indirect dependencies from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,26 +1,13 @@
 # Development, documentation & testing requirements.
--e .
-alabaster
-Babel
 black; python_version >= '3.6'
 check-manifest
-cov-core
 coverage
 coveralls
-docopt
-docutils
 jarn.viewdoc
-Jinja2
-MarkupSafe
 olefile
 pycodestyle
 pyflakes
-Pygments
 pyroma
 pytest
 pytest-cov
-pytz
-requests
-snowballstemmer
-Sphinx
 sphinx-rtd-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ pytest
 pytest-cov
 pytz
 requests
-six
 snowballstemmer
 Sphinx
 sphinx-rtd-theme


### PR DESCRIPTION
This is mostly just to create a new PR to see if the Codecov checks are now working, and we don't explicitly use `six` anyway.