### PR TITLE
Use OpenJPEG package

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -3,9 +3,9 @@
 set -e
 
 sudo apt-get update
-sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-tk\
-			 python-qt4 ghostscript libffi-dev libjpeg-turbo-progs cmake imagemagick\
-             libharfbuzz-dev libfribidi-dev
+sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-tk python-qt4\
+                         ghostscript libffi-dev libjpeg-turbo-progs libopenjp2-7-dev\
+                         cmake imagemagick libharfbuzz-dev libfribidi-dev
 
 PYTHONOPTIMIZE=0 pip install cffi
 pip install coverage
@@ -21,9 +21,6 @@ if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then pip install -r requirements.txt ;
 
 # webp
 pushd depends && ./install_webp.sh && popd
-
-# openjpeg
-pushd depends && ./install_openjpeg.sh && popd
 
 # libimagequant
 pushd depends && ./install_imagequant.sh && popd

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -332,19 +332,19 @@ Or for Python 3::
 
 .. Note:: ``redhat-rpm-config`` is required on Fedora 23, but not earlier versions.
 
-Prerequisites are installed on **Ubuntu 14.04 LTS** with::
+Prerequisites are installed on **Ubuntu 16.04 LTS** with::
 
-    $ sudo apt-get install libtiff5-dev libjpeg8-dev zlib1g-dev \
-        libfreetype6-dev liblcms2-dev libwebp-dev libharfbuzz-dev libfribidi-dev \
-        tcl8.6-dev tk8.6-dev python-tk
+    $ sudo apt-get install libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev \
+        libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python-tk \
+        libharfbuzz-dev libfribidi-dev
 
 Then see ``depends/install_raqm.sh`` to install libraqm.
 
 Prerequisites are installed on recent **RedHat** **Centos** or **Fedora** with::
 
-    $ sudo dnf install libtiff-devel libjpeg-devel zlib-devel freetype-devel \
-        lcms2-devel libwebp-devel tcl-devel tk-devel libraqm-devel \
-        libimagequant-devel
+    $ sudo dnf install libtiff-devel libjpeg-devel openjpeg2-devel zlib-devel \
+        freetype-devel lcms2-devel libwebp-devel tcl-devel tk-devel \
+        harfbuzz-devel fribidi-devel libraqm-devel libimagequant-devel
 
 Note that the package manager may be yum or dnf, depending on the
 exact distribution.


### PR DESCRIPTION
Resolves #1757, together with https://github.com/python-pillow/docker-images/pull/67 - used package OpenJPEG instead of compiling it.

Also updates the Ubuntu version in the documentation from 14.04 to 16.04 - partly because 14.04 is now rather old, and partly because 'libopenjp2-7-dev' can't be found in 14.04.

Also adds 'harfbuzz-devel' and 'fribidi-devel' to the Fedora prerequistes, as seen in https://github.com/python-pillow/Pillow/blob/master/depends/fedora_23.sh