### PR TITLE
Skip broken install of coveralls-merge on 2.7_with_system_site_packages

### DIFF
--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -11,8 +11,11 @@ coveralls-lcov -v -n coverage.filtered.info > coverage.c.json
 
 coverage report
 pip install codecov
-pip install coveralls-merge
-coveralls-merge coverage.c.json
+if [[ $TRAVIS_PYTHON_VERSION != "2.7_with_system_site_packages" ]]; then
+    # Not working here. Just skip it, it's being removed soon.
+    pip install coveralls-merge
+    coveralls-merge coverage.c.json
+fi
 codecov
 
 if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ] && [ "$DOCKER" == "" ]; then


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/3934.

The `2.7_with_system_site_packages` build has outdated or missing dependencies when installing `coveralls-merge`. From the latest `master` build:

```
Collecting coveralls-merge
  Downloading https://files.pythonhosted.org/packages/1f/4a/af2413b78ba9361a3e18a58788e745c89772325b100d62a3bc217c295f15/coveralls-merge-0.0.3.tar.gz
Collecting coveralls>=0.4.2 (from coveralls-merge)
  Downloading https://files.pythonhosted.org/packages/7c/f0/80c6957c3e88981d608681568460972156b5b2b870c76ab976b909e0003f/coveralls-1.8.1-py2.py3-none-any.whl
Requirement already satisfied: requests>=1.0.0 in /usr/lib/python2.7/dist-packages (from coveralls-merge) (2.9.1)
Requirement already satisfied: coverage<5.0,>=3.6 in /home/travis/virtualenv/python2.7_with_system_site_packages/lib/python2.7/site-packages (from coveralls>=0.4.2->coveralls-merge) (4.5.3)
Collecting docopt>=0.6.1 (from coveralls>=0.4.2->coveralls-merge)
  Downloading https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz
Collecting urllib3[secure]<1.25,>=1.21.1; python_version < "3" (from coveralls>=0.4.2->coveralls-merge)
  Downloading https://files.pythonhosted.org/packages/01/11/525b02e4acc0c747de8b6ccdab376331597c569c42ea66ab0a1dbd36eca2/urllib3-1.24.3-py2.py3-none-any.whl (118kB)
Requirement already satisfied: pyOpenSSL>=0.14; extra == "secure" in /usr/lib/python2.7/dist-packages (from urllib3[secure]<1.25,>=1.21.1; python_version < "3"->coveralls>=0.4.2->coveralls-merge) (0.15.1)
Requirement already satisfied: idna>=2.0.0; extra == "secure" in /usr/lib/python2.7/dist-packages (from urllib3[secure]<1.25,>=1.21.1; python_version < "3"->coveralls>=0.4.2->coveralls-merge) (2.0)
Collecting cryptography>=1.3.4; extra == "secure" (from urllib3[secure]<1.25,>=1.21.1; python_version < "3"->coveralls>=0.4.2->coveralls-merge)
  Downloading https://files.pythonhosted.org/packages/e6/68/50698ce24c61db7d44d93a5043c621a0ca7839d4ef9dff913e6ab465fc92/cryptography-2.7-cp27-cp27mu-manylinux1_x86_64.whl (2.3MB)
Collecting certifi; extra == "secure" (from urllib3[secure]<1.25,>=1.21.1; python_version < "3"->coveralls>=0.4.2->coveralls-merge)
  Downloading https://files.pythonhosted.org/packages/69/1b/b853c7a9d4f6a6d00749e94eb6f3a041e342a885b87340b79c1ef73e3a78/certifi-2019.6.16-py2.py3-none-any.whl (157kB)
Requirement already satisfied: ipaddress; extra == "secure" in /usr/lib/python2.7/dist-packages (from urllib3[secure]<1.25,>=1.21.1; python_version < "3"->coveralls>=0.4.2->coveralls-merge) (1.0.16)
Requirement already satisfied: enum34; python_version < "3" in /usr/lib/python2.7/dist-packages (from cryptography>=1.3.4; extra == "secure"->urllib3[secure]<1.25,>=1.21.1; python_version < "3"->coveralls>=0.4.2->coveralls-merge) (1.1.2)
Requirement already satisfied: cffi!=1.11.3,>=1.8 in /home/travis/virtualenv/python2.7_with_system_site_packages/lib/python2.7/site-packages (from cryptography>=1.3.4; extra == "secure"->urllib3[secure]<1.25,>=1.21.1; python_version < "3"->coveralls>=0.4.2->coveralls-merge) (1.12.3)
Requirement already satisfied: six>=1.4.1 in /usr/lib/python2.7/dist-packages (from cryptography>=1.3.4; extra == "secure"->urllib3[secure]<1.25,>=1.21.1; python_version < "3"->coveralls>=0.4.2->coveralls-merge) (1.10.0)
Collecting asn1crypto>=0.21.0 (from cryptography>=1.3.4; extra == "secure"->urllib3[secure]<1.25,>=1.21.1; python_version < "3"->coveralls>=0.4.2->coveralls-merge)
  Downloading https://files.pythonhosted.org/packages/ea/cd/35485615f45f30a510576f1a56d1e0a7ad7bd8ab5ed7cdc600ef7cd06222/asn1crypto-0.24.0-py2.py3-none-any.whl (101kB)
Requirement already satisfied: pycparser in /home/travis/virtualenv/python2.7_with_system_site_packages/lib/python2.7/site-packages (from cffi!=1.11.3,>=1.8->cryptography>=1.3.4; extra == "secure"->urllib3[secure]<1.25,>=1.21.1; python_version < "3"->coveralls>=0.4.2->coveralls-merge) (2.19)
Building wheels for collected packages: coveralls-merge, docopt
  Building wheel for coveralls-merge (setup.py): started
  Building wheel for coveralls-merge (setup.py): finished with status 'done'
  Stored in directory: /home/travis/.cache/pip/wheels/89/8b/06/63d890dc5b20ec17485a4aa038b9a53fad83525afdb076ea26
  Building wheel for docopt (setup.py): started
  Building wheel for docopt (setup.py): finished with status 'done'
  Stored in directory: /home/travis/.cache/pip/wheels/9b/04/dd/7daf4150b6d9b12949298737de9431a324d4b797ffd63f526e
Successfully built coveralls-merge docopt
Installing collected packages: docopt, asn1crypto, cryptography, certifi, urllib3, coveralls, coveralls-merge
  Found existing installation: cryptography 1.2.3
    Not uninstalling cryptography at /usr/lib/python2.7/dist-packages, outside environment /home/travis/virtualenv/python2.7_with_system_site_packages
    Can't uninstall 'cryptography'. No files were found to uninstall.
  Found existing installation: urllib3 1.13.1
    Not uninstalling urllib3 at /usr/lib/python2.7/dist-packages, outside environment /home/travis/virtualenv/python2.7_with_system_site_packages
    Can't uninstall 'urllib3'. No files were found to uninstall.
Successfully installed asn1crypto-0.24.0 certifi-2019.6.16 coveralls-1.8.1 coveralls-merge-0.0.3 cryptography-2.7 docopt-0.6.2 urllib3-1.24.3
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7_with_system_site_packages/bin/coveralls-merge", line 6, in <module>
    from coveralls_merge.core import main
  File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/coveralls_merge/core.py", line 14, in <module>
    import requests
  File "/usr/lib/python2.7/dist-packages/requests/__init__.py", line 53, in <module>
    from .packages.urllib3.contrib import pyopenssl
  File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/urllib3/contrib/pyopenssl.py", line 46, in <module>
    import OpenSSL.SSL
  File "/usr/lib/python2.7/dist-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import rand, crypto, SSL
  File "/usr/lib/python2.7/dist-packages/OpenSSL/SSL.py", line 118, in <module>
    SSL_ST_INIT = _lib.SSL_ST_INIT
AttributeError: 'module' object has no attribute 'SSL_ST_INIT'
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7_with_system_site_packages/bin/codecov", line 6, in <module>
    from codecov import main
  File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/codecov/__init__.py", line 7, in <module>
    import requests
  File "/usr/lib/python2.7/dist-packages/requests/__init__.py", line 53, in <module>
    from .packages.urllib3.contrib import pyopenssl
  File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/urllib3/contrib/pyopenssl.py", line 46, in <module>
    import OpenSSL.SSL
  File "/usr/lib/python2.7/dist-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import rand, crypto, SSL
  File "/usr/lib/python2.7/dist-packages/OpenSSL/SSL.py", line 118, in <module>
    SSL_ST_INIT = _lib.SSL_ST_INIT
AttributeError: 'module' object has no attribute 'SSL_ST_INIT'
```

https://travis-ci.org/python-pillow/Pillow/jobs/562465420#L4404

This particular job is for testing PyQt4 on Python 2.7, both of which are being dropped after the next release.

I propose we just skip `coveralls-merge` here, which means we only get Python coverage and not C coverage for this one job.

---

This is one of two problems related to getting Codecov checks on PRs (https://github.com/python-pillow/Pillow/issues/3934), the other is an S3 timeout with the `codecov` tool (see https://community.codecov.io/t/missing-checks-on-github/361).

This will help narrow down the problem.