### PR TITLE
Improved ImageFont documentation

### DIFF
--- a/docs/reference/ImageFont.rst
+++ b/docs/reference/ImageFont.rst
@@ -47,90 +47,11 @@ Functions
 Methods
 -------
 
-.. py:method:: PIL.ImageFont.ImageFont.getsize(text, direction=None, features=[], language=None)
-
-    Returns width and height (in pixels) of given text if rendered in font with
-    provided direction, features, and language.
-
-    :param text: Text to measure.
-
-    :param direction: Direction of the text. It can be 'rtl' (right to
-                      left), 'ltr' (left to right) or 'ttb' (top to bottom).
-                      Requires libraqm.
-
-                      .. versionadded:: 4.2.0
-
-    :param features: A list of OpenType font features to be used during text
-                     layout. This is usually used to turn on optional
-                     font features that are not enabled by default,
-                     for example 'dlig' or 'ss01', but can be also
-                     used to turn off default font features for
-                     example '-liga' to disable ligatures or '-kern'
-                     to disable kerning.  To get all supported
-                     features, see
-                     https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist
-                     Requires libraqm.
-
-                     .. versionadded:: 4.2.0
-
-    :param language: Language of the text. Different languages may use
-                     different glyph shapes or ligatures. This parameter tells
-                     the font which language the text is in, and to apply the
-                     correct substitutions as appropriate, if available.
-                     It should be a `BCP 47 language code
-                     <https://www.w3.org/International/articles/language-tags/>`
-                     Requires libraqm.
-
-                     .. versionadded:: 6.0.0
-
-    :return: (width, height)
-
-.. py:method:: PIL.ImageFont.ImageFont.getmask(text, mode='', direction=None, features=[], language=None)
-
-    Create a bitmap for the text.
-
-    If the font uses antialiasing, the bitmap should have mode “L” and use a
-    maximum value of 255. Otherwise, it should have mode “1”.
-
-    :param text: Text to render.
-    :param mode: Used by some graphics drivers to indicate what mode the
-                 driver prefers; if empty, the renderer may return either
-                 mode. Note that the mode is always a string, to simplify
-                 C-level implementations.
-
-                 .. versionadded:: 1.1.5
-
-    :param direction: Direction of the text. It can be 'rtl' (right to
-                      left), 'ltr' (left to right) or 'ttb' (top to bottom).
-                      Requires libraqm.
-
-                      .. versionadded:: 4.2.0
-
-    :param features: A list of OpenType font features to be used during text
-                     layout. This is usually used to turn on optional
-                     font features that are not enabled by default,
-                     for example 'dlig' or 'ss01', but can be also
-                     used to turn off default font features for
-                     example '-liga' to disable ligatures or '-kern'
-                     to disable kerning.  To get all supported
-                     features, see
-                     https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist
-                     Requires libraqm.
-
-                     .. versionadded:: 4.2.0
-
-    :param language: Language of the text. Different languages may use
-                     different glyph shapes or ligatures. This parameter tells
-                     the font which language the text is in, and to apply the
-                     correct substitutions as appropriate, if available.
-                     It should be a `BCP 47 language code
-                     <https://www.w3.org/International/articles/language-tags/>`
-                     Requires libraqm.
-
-                     .. versionadded:: 6.0.0
-
-    :return: An internal PIL storage memory instance as defined by the
-             :py:mod:`PIL.Image.core` interface module.
+.. autoclass:: PIL.ImageFont.ImageFont
+    :members:
 
 .. autoclass:: PIL.ImageFont.FreeTypeFont
+    :members:
+
+.. autoclass:: PIL.ImageFont.TransposedFont
     :members:

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -110,9 +110,33 @@ class ImageFont(object):
         self.font = Image.core.font(image.im, data)
 
     def getsize(self, text, *args, **kwargs):
+        """
+        Returns width and height (in pixels) of given text.
+
+        :param text: Text to measure.
+
+        :return: (width, height)
+        """
         return self.font.getsize(text)
 
     def getmask(self, text, mode="", *args, **kwargs):
+        """
+        Create a bitmap for the text.
+
+        If the font uses antialiasing, the bitmap should have mode ``L`` and use a
+        maximum value of 255. Otherwise, it should have mode ``1``.
+
+        :param text: Text to render.
+        :param mode: Used by some graphics drivers to indicate what mode the
+                     driver prefers; if empty, the renderer may return either
+                     mode. Note that the mode is always a string, to simplify
+                     C-level implementations.
+
+                     .. versionadded:: 1.1.5
+
+        :return: An internal PIL storage memory instance as defined by the
+                 :py:mod:`PIL.Image.core` interface module.
+        """
         return self.font.getmask(text, mode)
 
 


### PR DESCRIPTION
See https://pillow.readthedocs.io/en/latest/reference/ImageFont.html for the current version

This PR
- fixes the documentation for the `getmask` and `getsize` methods of the ImageFont class. Comparing with the source code - https://github.com/python-pillow/Pillow/blob/master/src/PIL/ImageFont.py#L112 - the current documentation is incorrect regarding the arguments for those methods. The new docstrings I've added are copied and altered from the FreeTypeFont `getmask` and `getsize`.
- adds the TransposedFont class to the documentation

See https://pillow-radarhere.readthedocs.io/en/imagefont_docs/reference/ImageFont.html for the improved version.