### PR TITLE
Fix bug in TIFF loading of BufferedReader

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -81,6 +81,19 @@ class TestFileLibTiff(LibTiffTestCase):
         self.assertEqual(im.size, (500, 500))
         self._assert_noerr(im)
 
+    def test_g4_non_disk_file_object(self):
+        """Testing loading from non-disk non-bytesio file object"""
+        test_file = "Tests/images/hopper_g4_500.tif"
+        s = io.BytesIO()
+        with open(test_file, "rb") as f:
+            s.write(f.read())
+            s.seek(0)
+        r = io.BufferedReader(s)
+        im = Image.open(r)
+
+        self.assertEqual(im.size, (500, 500))
+        self._assert_noerr(im)
+
     def test_g4_eq_png(self):
         """ Checking that we're actually getting the data that we expect"""
         png = Image.open("Tests/images/hopper_bw_500.png")

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -82,7 +82,7 @@ class TestFileLibTiff(LibTiffTestCase):
         self._assert_noerr(im)
 
     def test_g4_non_disk_file_object(self):
-        """Testing loading from non-disk non-bytesio file object"""
+        """Testing loading from non-disk non-BytesIO file object"""
         test_file = "Tests/images/hopper_g4_500.tif"
         s = io.BytesIO()
         with open(test_file, "rb") as f:

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1175,6 +1175,7 @@ class TiffImageFile(ImageFile.ImageFile):
             # we have something else.
             if DEBUG:
                 print("don't have fileno or getvalue. just reading")
+            self.fp.seek(0)
             # UNDONE -- so much for that buffer size thing.
             n, err = decoder.decode(self.fp.read())
 

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1164,7 +1164,7 @@ class TiffImageFile(ImageFile.ImageFile):
             if DEBUG:
                 print("have getvalue. just sending in a string from getvalue")
             n, err = decoder.decode(self.fp.getvalue())
-        elif hasattr(self.fp, "fileno"):
+        elif fp:
             # we've got a actual file on disk, pass in the fp.
             if DEBUG:
                 print("have fileno, calling fileno version of the decoder.")


### PR DESCRIPTION
Fixes #3996.

Changes proposed in this pull request:

 * There is an existing fp value that is safely created before the call to Image._getdecoder. The same value should just be used again in the logic surrounding the actual decode.
 * For the case of "we have something else" (no getvalue or fileno) it should seek to the beginning as it does in other cases.