### PR TITLE
Fix bug when merging identical images to GIF with a list of durations

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -514,10 +514,16 @@ class TestFileGif(PillowTestCase):
             frames.append(Image.alpha_composite(mask, image))
 
         # duration as list
-        frames[0].save(out,
-                       save_all=True, append_images=frames[1:], optimize=False, duration=duration_list, loop=0,
-                       transparency=0)
-
+        frames[0].save(
+            out,
+            save_all=True,
+            append_images=frames[1:],
+            optimize=False,
+            duration=duration_list,
+            loop=0,
+            transparency=0,
+        )
+        
         reread = Image.open(out)
 
         # Assert that the first three frames were combined

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -523,7 +523,6 @@ class TestFileGif(PillowTestCase):
             loop=0,
             transparency=0,
         )
-        
         reread = Image.open(out)
 
         # Assert that the first three frames were combined

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -472,7 +472,7 @@ class TestFileGif(PillowTestCase):
             except EOFError:
                 pass
 
-    def test_partially_identical_frames(self):
+    def test_identical_frames(self):
         duration_list = [1000, 1500, 2000, 4000]
 
         out = self.tempfile("temp.gif")
@@ -495,41 +495,25 @@ class TestFileGif(PillowTestCase):
         # Assert that the new duration is the total of the identical frames
         self.assertEqual(reread.info["duration"], 4500)
 
-    def test_totally_identical_frames(self):
-        duration_list = [1000, 1500, 2000, 4000]
+    def test_identical_frames_to_single_frame(self):
+        for duration in ([1000, 1500, 2000, 4000], (1000, 1500, 2000, 4000), 8500):
+            out = self.tempfile("temp.gif")
+            im_list = [
+                Image.new("L", (100, 100), "#000"),
+                Image.new("L", (100, 100), "#000"),
+                Image.new("L", (100, 100), "#000"),
+            ]
 
-        out = self.tempfile("temp.gif")
+            im_list[0].save(
+                out, save_all=True, append_images=im_list[1:], duration=duration
+            )
+            reread = Image.open(out)
 
-        image_path = "Tests/images/bc7-argb-8bpp_MipMaps-1.png"
-        im_list = [
-            Image.open(image_path),
-            Image.open(image_path),
-            Image.open(image_path),
-            Image.open(image_path),
-        ]
-        mask = Image.new("RGBA", im_list[0].size, (255, 255, 255, 0))
+            # Assert that all frames were combined
+            self.assertEqual(reread.n_frames, 1)
 
-        frames = []
-        for image in im_list:
-            frames.append(Image.alpha_composite(mask, image))
-
-        # duration as list
-        frames[0].save(
-            out,
-            save_all=True,
-            append_images=frames[1:],
-            optimize=False,
-            duration=duration_list,
-            loop=0,
-            transparency=0,
-        )
-        reread = Image.open(out)
-
-        # Assert that all four frames were combined
-        self.assertEqual(reread.n_frames, 1)
-
-        # Assert that the new duration is the total of the identical frames
-        self.assertEqual(reread.info["duration"], 8500)
+            # Assert that the new duration is the total of the identical frames
+            self.assertEqual(reread.info["duration"], 8500)
 
     def test_number_of_loops(self):
         number_of_loops = 2

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -525,7 +525,7 @@ class TestFileGif(PillowTestCase):
         )
         reread = Image.open(out)
 
-        # Assert that the first three frames were combined
+        # Assert that all four frames were combined
         self.assertEqual(reread.n_frames, 1)
 
         # Assert that the new duration is the total of the identical frames

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -472,9 +472,6 @@ def _write_multiple_frames(im, fp, palette):
             else:
                 bbox = None
             im_frames.append({"im": im_frame, "bbox": bbox, "encoderinfo": encoderinfo})
-    # see: https://github.com/python-pillow/Pillow/issues/4002
-    if len(im_frames) == 1 and "duration" in im_frames[0]["encoderinfo"]:
-        im.encoderinfo["duration"] = im_frames[0]["encoderinfo"]["duration"]
 
     if len(im_frames) > 1:
         for frame_data in im_frames:
@@ -492,6 +489,11 @@ def _write_multiple_frames(im, fp, palette):
                 offset = frame_data["bbox"][:2]
             _write_frame_data(fp, im_frame, offset, frame_data["encoderinfo"])
         return True
+    elif "duration" in im.encoderinfo and isinstance(
+        im.encoderinfo["duration"], (list, tuple)
+    ):
+        # Since multiple frames will not be written, add together the frame durations
+        im.encoderinfo["duration"] = sum(im.encoderinfo["duration"])
 
 
 def _save_all(im, fp, filename):

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -474,8 +474,8 @@ def _write_multiple_frames(im, fp, palette):
             im_frames.append({"im": im_frame, "bbox": bbox, "encoderinfo": encoderinfo})
     
     # see: https://github.com/python-pillow/Pillow/issues/4002
-    if len(im_frames) == 1 and 'duration' in im_frames[0]['encoderinfo']:
-        im.encoderinfo['duration'] = im_frames[0]['encoderinfo']['duration']
+    if len(im_frames) == 1 and "duration" in im_frames[0]["encoderinfo"]:
+        im.encoderinfo["duration"] = im_frames[0]["encoderinfo"]["duration"]
 
     if len(im_frames) > 1:
         for frame_data in im_frames:

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -472,7 +472,6 @@ def _write_multiple_frames(im, fp, palette):
             else:
                 bbox = None
             im_frames.append({"im": im_frame, "bbox": bbox, "encoderinfo": encoderinfo})
-    
     # see: https://github.com/python-pillow/Pillow/issues/4002
     if len(im_frames) == 1 and "duration" in im_frames[0]["encoderinfo"]:
         im.encoderinfo["duration"] = im_frames[0]["encoderinfo"]["duration"]

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -472,6 +472,10 @@ def _write_multiple_frames(im, fp, palette):
             else:
                 bbox = None
             im_frames.append({"im": im_frame, "bbox": bbox, "encoderinfo": encoderinfo})
+    
+    # see: https://github.com/python-pillow/Pillow/issues/4002
+    if len(im_frames) == 1 and 'duration' in im_frames[0]['encoderinfo']:
+        im.encoderinfo['duration'] = im_frames[0]['encoderinfo']['duration']
 
     if len(im_frames) > 1:
         for frame_data in im_frames:


### PR DESCRIPTION
Fixes #4002

Changes proposed in this pull request:

 * copy `duration` from `im_frames` to `im.encoderinfo`

