### PR TITLE
Corrected note syntax

### DIFF
--- a/docs/reference/ImageStat.rst
+++ b/docs/reference/ImageStat.rst
@@ -20,8 +20,10 @@ for a region of an image.
 
         Min/max values for each band in the image.
 
-        .. Note:: This relies on the :py:meth:`~PIL.Image.histogram` method,
-            and simply returns the low and high bins used. This is correct for
+        .. note::
+
+            This relies on the :py:meth:`~PIL.Image.histogram` method, and
+            simply returns the low and high bins used. This is correct for
             images with 8 bits per channel, but fails for other modes such as
             ``I`` or ``F``. Instead, use :py:meth:`~PIL.Image.getextrema` to
             return per-band extrema for the image. This is more correct and


### PR DESCRIPTION
Before: https://pillow.readthedocs.io/en/stable/reference/ImageStat.html#PIL.ImageStat.PIL.ImageStat.Stat.extrema

After: https://pillow-radarhere.readthedocs.io/en/imagestat/reference/ImageStat.html#PIL.ImageStat.PIL.ImageStat.Stat.extrema