### PR TITLE
Corrected documentation of TIFF saving arguments

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -759,18 +759,21 @@ using the general tags available through tiffinfo.
     Strings
 
 **resolution_unit**
-    A string of "inch", "centimeter" or "cm"
+    An integer. 1 for no unit, 2 for inches and 3 for centimeters.
 
 **resolution**
+    Either an integer or a float, used for both the x and y resolution.
 
 **x_resolution**
+    Either an integer or a float.
 
 **y_resolution**
+    Either an integer or a float.
 
 **dpi**
-    Either a Float, 2 tuple of (numerator, denominator) or a
-    :py:class:`~PIL.TiffImagePlugin.IFDRational`. Resolution implies
-    an equal x and y resolution, dpi also implies a unit of inches.
+    A tuple of (x_resolution, y_resolution), with inches as the resolution
+    unit. For consistency with other image formats, the x and y resolutions
+    of the dpi will be rounded to the nearest integer.
 
 
 WebP


### PR DESCRIPTION
Resolves #4013, which reports that the `dpi` argument in TIFF saving doesn't support '(numerator, denominator)' values as the documentation claims.

The documentation was added in #369

Looking at code, this functionality was removed in #1419, where 'A tuple of more than one rational tuples' 'flatten to floats' was removed, along with `ifd[X_RESOLUTION] = _cvt_res(dpi[0])` being changed to `ifd[X_RESOLUTION] = dpi[0]`.

While updating this, I also note that we round the dpi - that was added in #3709

Also removed in #1419 was the use of "inch", "cm" and "centimeter" for `resolution_unit`, so I'm fixing that as well.