### PR TITLE
Added fallback for finding ld on MinGW Cygwin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,18 @@ class RequiredDependencyException(Exception):
 PLATFORM_MINGW = "mingw" in ccompiler.get_default_compiler()
 PLATFORM_PYPY = hasattr(sys, "pypy_version_info")
 
+if sys.platform == "win32" and PLATFORM_MINGW:
+    from distutils import cygwinccompiler
+
+    cygwin_versions = cygwinccompiler.get_versions()
+    if cygwin_versions[1] is None:
+        # ld version is None
+        # distutils cygwinccompiler might fetch the ld path from gcc
+        # Try the normal path instead
+        cygwin_versions = list(cygwin_versions)
+        cygwin_versions[1] = cygwinccompiler._find_exe_version("ld -v")
+        cygwinccompiler.get_versions = lambda: tuple(cygwin_versions)
+
 
 def _dbg(s, tp=None):
     if DEBUG:

--- a/winbuild/appveyor_install_msys2_deps.sh
+++ b/winbuild/appveyor_install_msys2_deps.sh
@@ -3,12 +3,16 @@
 mkdir /var/cache/pacman/pkg
 pacman -S --noconfirm mingw32/mingw-w64-i686-python3-pip \
 	   mingw32/mingw-w64-i686-python3-setuptools \
+	   mingw32/mingw-w64-i686-python3-pytest \
+	   mingw32/mingw-w64-i686-python3-pytest-cov \
 	   mingw32/mingw-w64-i686-python2-pip \
 	   mingw32/mingw-w64-i686-python2-setuptools \
+	   mingw32/mingw-w64-i686-python2-pytest \
+	   mingw32/mingw-w64-i686-python2-pytest-cov \
 	   mingw-w64-i686-libjpeg-turbo \
 	   mingw-w64-i686-libimagequant
 
 C:/msys64/mingw32/bin/python3 -m pip install --upgrade pip
 
-/mingw32/bin/pip install pytest pytest-cov olefile
-/mingw32/bin/pip3 install pytest pytest-cov olefile
+/mingw32/bin/pip install olefile
+/mingw32/bin/pip3 install olefile


### PR DESCRIPTION
Suggestion to resolve #4018

The mingw32 job is currently failing with
```
if self.ld_version >= "2.10.90":
    TypeError: '>=' not supported between instances of 'NoneType' and 'str'
```

Searching, I found that in 'C:/msys64/mingw32/lib/python3.7\\distutils\\cygwinccompiler.py', there is a part where it stops searching for a simple 'ld' executable, instead searching for the path specified by gcc.

```python
ld = 'ld'
out = Popen(gcc+' --print-prog-name ld', shell=True, stdout=PIPE).stdout
try:
	ld = test=str(out.read(),encoding='utf-8').strip()
```

However, I think this path then ends up being /usr/lib/gcc/x86_64-pc-msys/9.1.0/../../../../x86_64-pc-msys/bin/ld.exe

So this PR uses pacman versions of pytest and pytest-cov instead of compiling from source, and adds a fallback when compiling Pillow, trying 'ld' again if the gcc path does not work.