### PR TITLE
Note a Windows limit on opening fonts

### DIFF
--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -549,8 +549,12 @@ def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):
     This function requires the _imagingft service.
 
     :param font: A filename or file-like object containing a TrueType font.
-                     Under Windows, if the file is not found in this filename,
-                     the loader also looks in Windows :file:`fonts/` directory.
+                 If the file is not found in this filename, the loader may also
+                 search in other directories, such as the :file:`fonts/`
+                 directory on Windows or :file:`/Library/Fonts/`,
+                 :file:`/System/Library/Fonts/` and :file:`~/Library/Fonts/` on
+                 macOS.
+
     :param size: The requested size, in points.
     :param index: Which font face to load (default is first available face).
     :param encoding: Which font encoding to use (default is Unicode). Common

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -546,7 +546,7 @@ def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):
     This function loads a font object from the given file or file-like
     object, and creates a font object for a font of the given size.
 
-    Note that Pillow uses FreeType to open font files. If you are opening many
+   Pillow uses FreeType to open font files. If you are opening many
     fonts simultaneously on Windows, be aware that Windows limits the number of
     files that can be open in C at once to 512. If you approach that limit, an
     ``OSError`` may be thrown, reporting that FreeType "cannot open resource".

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -546,9 +546,9 @@ def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):
     This function loads a font object from the given file or file-like
     object, and creates a font object for a font of the given size.
 
-   Pillow uses FreeType to open font files. If you are opening many
-    fonts simultaneously on Windows, be aware that Windows limits the number of
-    files that can be open in C at once to 512. If you approach that limit, an
+    Pillow uses FreeType to open font files. If you are opening many fonts
+    simultaneously on Windows, be aware that Windows limits the number of files
+    that can be open in C at once to 512. If you approach that limit, an
     ``OSError`` may be thrown, reporting that FreeType "cannot open resource".
 
     This function requires the _imagingft service.

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -546,6 +546,11 @@ def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):
     This function loads a font object from the given file or file-like
     object, and creates a font object for a font of the given size.
 
+    Note that Pillow uses FreeType to open font files. If you are opening many
+    fonts simultaneously on Windows, be aware that Windows limits the number of
+    files that can be open in C at once to 512. If you approach that limit, an
+    ``OSError`` may be thrown, reporting that FreeType "cannot open resource".
+
     This function requires the _imagingft service.
 
     :param font: A filename or file-like object containing a TrueType font.


### PR DESCRIPTION
Resolves #3730

The issue reports `OSError: cannot open resource` when opening many fonts on Windows. This is a FreeType error that is thrown, presumably because on Windows, ['The C run-time libraries have a 512 limit for the number of files that can be open at any one time.'](https://docs.microsoft.com/en-us/cpp/c-runtime-library/file-handling?view=vs-2017)

This PR suggests resolving this situation by simply documenting the limitation.

Also improved some other FreeType documentation while I'm here.