### PR TITLE
Updated ImageShow documentation

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2110,7 +2110,7 @@ class Image(object):
         debugging purposes.
 
         On Unix platforms, this method saves the image to a temporary
-        PPM file, and calls the **display**, **eog** or **xv**
+        PNG file, and calls the **display**, **eog** or **xv**
         utility, depending on which one can be found.
 
         On macOS, this method saves the image to a temporary PNG file, and


### PR DESCRIPTION
ImageShow uses PNG for Unix platforms - see #2527 and https://github.com/python-pillow/Pillow/blob/master/src/PIL/ImageShow.py#L167