### PR TITLE
No more deprecated bdist_wininst .exe installers

### DIFF
--- a/winbuild/build.py
+++ b/winbuild/build.py
@@ -191,16 +191,14 @@ def run_one(op):
 
 
 if __name__ == "__main__":
-    opts, args = getopt.getopt(sys.argv[1:], "", ["clean", "dist", "wheel"])
+    opts, args = getopt.getopt(sys.argv[1:], "", ["clean", "wheel"])
     opts = dict(opts)
 
     if "--clean" in opts:
         clean()
 
     op = "install"
-    if "--dist" in opts:
-        op = "bdist_wininst --user-access-control=auto"
-    elif "--wheel" in opts:
+    if "--wheel" in opts:
         op = "bdist_wheel"
 
     if "PYTHON" in os.environ:

--- a/winbuild/build.rst
+++ b/winbuild/build.rst
@@ -79,8 +79,8 @@ Building Pillow
 ---------------
 
 Once the dependencies are built, run `python build.py --clean` to
-build and install Pillow in virtualenvs for each python
-build. `build.py --dist` will build Windows installers instead of
+build and install Pillow in virtualenvs for each Python
+build. `build.py --wheel` will build wheels instead of
 installing into virtualenvs.
 
 UNDONE -- suppressed output, what about failures.


### PR DESCRIPTION
 `bdist_wininst` (`.exe` installers) has been deprecated in Python 3.8, and `bdist_wheel` (wheel packages) should be used instead:
 
  * https://discuss.python.org/t/deprecate-bdist-wininst/1929?u=hugovk
  * https://github.com/python/cpython/pull/14553

As far as I can see in the codebase, it's only used in `build.py --dist` to create Windows installers for testing dev builds. There's already a `build.py --wheel` option for `bdist_wheel` packages. So let's remove `--dist`.

---


In https://discuss.python.org/t/deprecate-bdist-wininst/1929/12?u=hugovk, @cgohlke pointed out:

> > PyPI doesn’t even allow you to upload bdist_wininst (See [PEP 527 ](https://www.python.org/dev/peps/pep-0527/)) anymore
>
> Maybe a bug: [Pillow](https://pypi.org/project/Pillow/#files) still uploads `bdist_wininst` installers for Windows.

@cgohlke Are those `.exe` installers something you normally send over each release day? If so, we can just skip those.

---

Any objections to stop distributing `.exe` installers for the next release?



Here's the output of `pypinfo --limit 10 pillow file`, showing the download count for the Pillow files on PyPI over the last 30 days: 

Served from cache: True
Data processed: 0.00 B
Data billed: 0.00 B
Estimated cost: $0.00

| file                                           | download_count |
| ---------------------------------------------- | -------------- |
| Pillow-6.1.0-cp27-cp27mu-manylinux1_x86_64.whl |      1,747,882 |
| Pillow-6.1.0-cp36-cp36m-manylinux1_x86_64.whl  |        961,926 |
| Pillow-6.1.0-cp35-cp35m-manylinux1_x86_64.whl  |        531,485 |
| Pillow-6.1.0-cp37-cp37m-manylinux1_x86_64.whl  |        438,457 |
| Pillow-6.1.0-cp37-cp37m-win_amd64.whl          |        146,346 |
| Pillow-6.1.0.tar.gz                            |        133,063 |
| Pillow-6.0.0-cp36-cp36m-manylinux1_x86_64.whl  |        131,780 |
| Pillow-5.4.1-cp36-cp36m-manylinux1_x86_64.whl  |        123,360 |
| Pillow-6.1.0-cp37-cp37m-win32.whl              |        113,811 |
| Pillow-5.3.0-cp27-cp27mu-manylinux1_x86_64.whl |        104,872 |
| Total                                          |      4,432,982 |

And attached for `pypinfo --limit 1000 pillow file`, which contains no `.exe` and the last 56 rows are all for a single download.
