### PR TITLE
Fix for Python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -432,7 +432,9 @@ class pil_build_ext(build_ext):
             # pythonX.Y.dll.a is in the /usr/lib/pythonX.Y/config directory
             _add_directory(
                 library_dirs,
-                os.path.join("/usr/lib", "python%s" % sys.version[:3], "config"),
+                os.path.join(
+                    "/usr/lib", "python{}.{}".format(*sys.version_info), "config"
+                ),
             )
 
         elif sys.platform == "darwin":


### PR DESCRIPTION
Changes proposed in this pull request:

 * Fix for Python 3.10
 * Inspired by https://github.com/pypa/setuptools/pull/1824


```python
Python 3.7.4 (default, Jul  9 2019, 18:13:23)
[Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.version
'3.7.4 (default, Jul  9 2019, 18:13:23) \n[Clang 10.0.1 (clang-1001.0.46.4)]'
>>> sys.version[:3]
'3.7'
>>> v310 = '3.10.4 (default, Jul  9 2019, 18:13:23) \n[Clang 10.0.1 (clang-1001.0.46.4)]'
>>> v310[:3]
'3.1'
```

