### PR TITLE
Lazily use ImageFileDirectory_v1 values from Exif

### DIFF
--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -321,3 +321,13 @@ class TestPyDecoder(PillowTestCase):
         self.assertEqual(
             exif.get_ifd(0xA005), {1: "R98", 2: b"0100", 4097: 2272, 4098: 1704}
         )
+
+    def test_exif_shared(self):
+        im = Image.open("Tests/images/exif.png")
+        exif = im.getexif()
+        self.assertIs(im.getexif(), exif)
+
+    def test_exif_str(self):
+        im = Image.open("Tests/images/exif.png")
+        exif = im.getexif()
+        self.assertEqual(str(exif), "{274: 1}")

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3327,19 +3327,13 @@ class Exif(MutableMapping):
             return tag in self
 
     def __setitem__(self, tag, value):
-        if self._info is not None:
-            try:
-                del self._info[tag]
-            except KeyError:
-                pass
+        if self._info is not None and tag in self._info:
+            del self._info[tag]
         self._data[tag] = value
 
     def __delitem__(self, tag):
-        if self._info is not None:
-            try:
-                del self._info[tag]
-            except KeyError:
-                pass
+        if self._info is not None and tag in self._info:
+            del self._info[tag]
         del self._data[tag]
 
     def __iter__(self):

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -158,7 +158,7 @@ def APP(self, marker):
     # If DPI isn't in JPEG header, fetch from EXIF
     if "dpi" not in self.info and "exif" in self.info:
         try:
-            exif = self._getexif()
+            exif = self.getexif()
             resolution_unit = exif[0x0128]
             x_resolution = exif[0x011A]
             try:

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -485,19 +485,9 @@ def _fixup_dict(src_dict):
 
 
 def _getexif(self):
-    # Use the cached version if possible
-    try:
-        return self.info["parsed_exif"]
-    except KeyError:
-        pass
-
     if "exif" not in self.info:
         return None
-    exif = dict(self.getexif())
-
-    # Cache the result for future use
-    self.info["parsed_exif"] = exif
-    return exif
+    return dict(self.getexif())
 
 
 def _getmp(self):

--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -86,8 +86,6 @@ class MpoImageFile(JpegImagePlugin.JpegImageFile):
         self.offset = self.__mpoffsets[frame]
 
         self.fp.seek(self.offset + 2)  # skip SOI marker
-        if "parsed_exif" in self.info:
-            del self.info["parsed_exif"]
         if i16(self.fp.read(2)) == 0xFFE1:  # APP1
             n = i16(self.fp.read(2)) - 2
             self.info["exif"] = ImageFile._safe_read(self.fp, n)

--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -92,7 +92,7 @@ class MpoImageFile(JpegImagePlugin.JpegImageFile):
             n = i16(self.fp.read(2)) - 2
             self.info["exif"] = ImageFile._safe_read(self.fp, n)
 
-            exif = self._getexif()
+            exif = self.getexif()
             if 40962 in exif and 40963 in exif:
                 self._size = (exif[40962], exif[40963])
         elif "exif" in self.info:


### PR DESCRIPTION
ImageFileDirectory_v1 is lazy, [performing operations when a value is accessed](https://github.com/python-pillow/Pillow/blob/cb7d8d622a3c17aea55d2f989f89300532161120/src/PIL/TiffImagePlugin.py#L968).

However, [accessing all of those values to create a dictionary](https://github.com/python-pillow/Pillow/blob/cb7d8d622a3c17aea55d2f989f89300532161120/src/PIL/Image.py#L3152) when [loading the data](https://github.com/python-pillow/Pillow/blob/cb7d8d622a3c17aea55d2f989f89300532161120/src/PIL/Image.py#L3184) undoes that speed increase.

#3663 set out to fix this by adding a new class - however, it had conflicts once #3625 was merged and a different class was added to deal with Exif data. This PR takes a different approach towards the original goal, for the new context.

It also uses this change by swapping calls in JpegImagePlugin and MpoImagePlugin from `_getexif` to `getexif`, switching from [JpegImagePlugin creating a dict of all the values](https://github.com/python-pillow/Pillow/blob/cb7d8d622a3c17aea55d2f989f89300532161120/src/PIL/JpegImagePlugin.py#L496) to using the now-lazy Exif class.