### PR TITLE
Documented OS support for ICO saved files

### DIFF
--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -263,6 +263,9 @@ class IcoImageFile(ImageFile.ImageFile):
 
     Handles classic, XP and Vista icon formats.
 
+    When saving, PNG compression is used. Support for this was only added in
+    Windows Vista.
+
     This plugin is a refactored version of Win32IconImagePlugin by Bryan Davis
     <casadebender@gmail.com>.
     https://code.google.com/archive/p/casadebender/wikis/Win32IconImagePlugin.wiki


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/issues/3773#issuecomment-509160651

> it should also mention that the current Pillow implementation saves ICOs internally as PNGs, not DIBs (support was only added in Windows Vista).

See https://github.com/python-pillow/Pillow/blob/cb7d8d622a3c17aea55d2f989f89300532161120/src/PIL/IcoImagePlugin.py#L72

and

https://en.wikipedia.org/wiki/ICO_(file_format)
> The ability to read PNG images from ICO and CUR format images was introduced in Windows Vista.