### PR TITLE
Corrected tag counts

### DIFF
--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -239,11 +239,13 @@ class TestFileTiffMetadata(PillowTestCase):
     def test_PhotoshopInfo(self):
         im = Image.open("Tests/images/issue_2278.tif")
 
-        self.assertIsInstance(im.tag_v2[34377], bytes)
+        self.assertEqual(len(im.tag_v2[34377]), 1)
+        self.assertIsInstance(im.tag_v2[34377][0], bytes)
         out = self.tempfile("temp.tiff")
         im.save(out)
         reloaded = Image.open(out)
-        self.assertIsInstance(reloaded.tag_v2[34377], bytes)
+        self.assertEqual(len(reloaded.tag_v2[34377]), 1)
+        self.assertIsInstance(reloaded.tag_v2[34377][0], bytes)
 
     def test_too_many_entries(self):
         ifd = TiffImagePlugin.ImageFileDirectory_v2()

--- a/src/PIL/TiffTags.py
+++ b/src/PIL/TiffTags.py
@@ -175,9 +175,9 @@ TAGS_V2 = {
     530: ("YCbCrSubSampling", SHORT, 2),
     531: ("YCbCrPositioning", SHORT, 1),
     532: ("ReferenceBlackWhite", RATIONAL, 6),
-    700: ("XMP", BYTE, 1),
+    700: ("XMP", BYTE, 0),
     33432: ("Copyright", ASCII, 1),
-    34377: ("PhotoshopInfo", BYTE, 1),
+    34377: ("PhotoshopInfo", BYTE, 0),
     # FIXME add more tags here
     34665: ("ExifIFD", LONG, 1),
     34675: ("ICCProfile", UNDEFINED, 1),

--- a/src/PIL/TiffTags.py
+++ b/src/PIL/TiffTags.py
@@ -177,6 +177,7 @@ TAGS_V2 = {
     532: ("ReferenceBlackWhite", RATIONAL, 6),
     700: ("XMP", BYTE, 0),
     33432: ("Copyright", ASCII, 1),
+    33723: ("IptcNaaInfo", UNDEFINED, 0),
     34377: ("PhotoshopInfo", BYTE, 0),
     # FIXME add more tags here
     34665: ("ExifIFD", LONG, 1),


### PR DESCRIPTION
Helps #3677. An error is still caused for that issue, but at least it is not a segfault.

Correct tag counts for
- https://www.awaresystems.be/imaging/tiff/tifftags/xmp.html and https://www.awaresystems.be/imaging/tiff/tifftags/photoshop.html - 'Count N'

Add
- https://www.awaresystems.be/imaging/tiff/tifftags/iptc.html