### PR TITLE
Use double backticks in RST

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -88,7 +88,7 @@ Changelog (Pillow)
 - Updated TIFF tile descriptors to match current decoding functionality #3795
   [dmnisson]
 
-- Added an `image.entropy()` method (second revision) #3608
+- Added an ``image.entropy()`` method (second revision) #3608
   [fish2000]
 
 - Pass the correct types to PyArg_ParseTuple #3880
@@ -724,7 +724,7 @@ Changelog (Pillow)
 - Enable background colour parameter on rotate #3057
   [storesource]
 
-- Remove unnecessary `#if 1` directive #3072
+- Remove unnecessary ``#if 1`` directive #3072
   [jdufresne]
 
 - Remove unused Python class, Path #3070
@@ -1261,7 +1261,7 @@ Changelog (Pillow)
 - Add decompression bomb check to Image.crop #2410
   [wiredfool]
 
-- ImageFile: Ensure that the `err_code` variable is initialized in case of exception. #2363
+- ImageFile: Ensure that the ``err_code`` variable is initialized in case of exception. #2363
   [alexkiro]
 
 - Tiff: Support append_images for saving multipage TIFFs #2406
@@ -1498,7 +1498,7 @@ Changelog (Pillow)
 - Removed PIL 1.0 era TK readme that concerns Windows 95/NT #2360
   [wiredfool]
 
-- Prevent `nose -v` printing docstrings #2369
+- Prevent ``nose -v`` printing docstrings #2369
   [hugovk]
 
 - Replaced absolute PIL imports with relative imports #2349
@@ -1943,7 +1943,7 @@ Changelog (Pillow)
 - Changed depends/install_*.sh urls to point to github pillow-depends repo #1983
   [wiredfool]
 
-- Allow ICC profile from `encoderinfo` while saving PNGs #1909
+- Allow ICC profile from ``encoderinfo`` while saving PNGs #1909
   [homm]
 
 - Fix integer overflow on ILP32 systems (32-bit Linux). #1975
@@ -2386,7 +2386,7 @@ Changelog (Pillow)
 - Added PDF multipage saving #1445
   [radarhere]
 
-- Removed deprecated code, Image.tostring, Image.fromstring, Image.offset, ImageDraw.setink, ImageDraw.setfill, ImageFileIO, ImageFont.FreeTypeFont and ImageFont.truetype `file` kwarg, ImagePalette private _make functions, ImageWin.fromstring and ImageWin.tostring #1343
+- Removed deprecated code, Image.tostring, Image.fromstring, Image.offset, ImageDraw.setink, ImageDraw.setfill, ImageFileIO, ImageFont.FreeTypeFont and ImageFont.truetype ``file`` kwarg, ImagePalette private _make functions, ImageWin.fromstring and ImageWin.tostring #1343
   [radarhere]
 
 - Load more broken images #1428
@@ -2878,7 +2878,7 @@ Changelog (Pillow)
 - Doc cleanup
   [wiredfool]
 
-- Fix `ImageStat` docs #796
+- Fix ``ImageStat`` docs #796
   [akx]
 
 - Added docs for ExifTags #794
@@ -3315,7 +3315,7 @@ Changelog (Pillow)
 - Add RGBA support to ImageColor #309
   [yoavweiss]
 
-- Test for `str`, not `"utf-8"` #306 (fixes #304)
+- Test for ``str``, not ``"utf-8"`` #306 (fixes #304)
   [mjpieters]
 
 - Fix missing import os in _util.py #303
@@ -3421,7 +3421,7 @@ Changelog (Pillow)
 
 - Partial work to add a wrapper for WebPGetFeatures to correctly support #220 (fixes #204)
 
-- Significant performance improvement of `alpha_composite` function #156
+- Significant performance improvement of ``alpha_composite`` function #156
   [homm]
 
 - Support explicitly disabling features via --disable-* options #240

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -389,12 +389,12 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
     image will be saved without tiling.
 
 **quality_mode**
-    Either `"rates"` or `"dB"` depending on the units you want to use to
+    Either ``"rates"`` or ``"dB"`` depending on the units you want to use to
     specify image quality.
 
 **quality_layers**
     A sequence of numbers, each of which represents either an approximate size
-    reduction (if quality mode is `"rates"`) or a signal to noise ratio value
+    reduction (if quality mode is ``"rates"``) or a signal to noise ratio value
     in decibels.  If not specified, defaults to a single layer of full quality.
 
 **num_resolutions**
@@ -811,10 +811,10 @@ Saving sequences
 
     Support for animated WebP files will only be enabled if the system WebP
     library is v0.5.0 or later. You can check webp animation support at
-    runtime by calling `features.check("webp_anim")`.
+    runtime by calling ``features.check("webp_anim")``.
 
 When calling :py:meth:`~PIL.Image.Image.save`, the following options
-are available when the `save_all` argument is present and true.
+are available when the ``save_all`` argument is present and true.
 
 **append_images**
     A list of images to append as additional frames. Each of the

--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -247,7 +247,7 @@ Transposing an image
     out = im.transpose(Image.ROTATE_270)
 
 ``transpose(ROTATE)`` operations can also be performed identically with
-:py:meth:`~PIL.Image.Image.rotate` operations, provided the `expand` flag is
+:py:meth:`~PIL.Image.Image.rotate` operations, provided the ``expand`` flag is
 true, to provide for the same changes to the image's size.
 
 A more general form of image transformations can be carried out via the

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -52,7 +52,7 @@ Functions
     .. warning::
         To protect against potential DOS attacks caused by "`decompression bombs`_" (i.e. malicious files
         which decompress into a huge amount of data and are designed to crash or cause disruption by using up
-        a lot of memory), Pillow will issue a `DecompressionBombWarning` if the image is over a certain
+        a lot of memory), Pillow will issue a ``DecompressionBombWarning`` if the image is over a certain
         limit. If desired, the warning can be turned into an error with
         ``warnings.simplefilter('error', Image.DecompressionBombWarning)`` or suppressed entirely with
         ``warnings.simplefilter('ignore', Image.DecompressionBombWarning)``. See also `the logging
@@ -262,10 +262,10 @@ Instances of the :py:class:`Image` class have the following attributes:
 .. py:attribute:: filename
 
     The filename or path of the source file. Only images created with the
-    factory function `open` have a filename attribute. If the input is a
+    factory function ``open`` have a filename attribute. If the input is a
     file like object, the filename attribute is set to an empty string.
 
-    :type: :py:class: `string`
+    :type: :py:class:`string`
 
 .. py:attribute:: format
 

--- a/docs/reference/ImageCms.rst
+++ b/docs/reference/ImageCms.rst
@@ -33,13 +33,13 @@ can be easily displayed in a chromaticity diagram, for example).
     .. py:attribute:: version
 
         The version number of the ICC standard that this profile follows
-        (e.g. `2.0`).
+        (e.g. ``2.0``).
 
         :type: :py:class:`float`
 
     .. py:attribute:: icc_version
 
-        Same as `version`, but in encoded format (see 7.2.4 of ICC.1:2010).
+        Same as ``version``, but in encoded format (see 7.2.4 of ICC.1:2010).
 
     .. py:attribute:: device_class
 

--- a/docs/reference/ImagePath.rst
+++ b/docs/reference/ImagePath.rst
@@ -53,7 +53,7 @@ vector data. Path objects can be passed to the methods on the
     Converts the path to a Python list [(x, y), …].
 
     :param flat: By default, this function returns a list of 2-tuples
-                 [(x, y), ...].  If this argument is `True`, it
+                 [(x, y), ...].  If this argument is ``True``, it
                  returns a flat list [x, y, ...] instead.
     :return: A list of coordinates. See **flat**.
 

--- a/docs/releasenotes/2.7.0.rst
+++ b/docs/releasenotes/2.7.0.rst
@@ -27,7 +27,7 @@ Image resizing filters
 ----------------------
 
 Image resizing methods :py:meth:`~PIL.Image.Image.resize` and
-:py:meth:`~PIL.Image.Image.thumbnail` take a `resample` argument, which tells
+:py:meth:`~PIL.Image.Image.thumbnail` take a ``resample`` argument, which tells
 which filter should be used for resampling. Possible values are:
 :py:attr:`PIL.Image.NEAREST`, :py:attr:`PIL.Image.BILINEAR`,
 :py:attr:`PIL.Image.BICUBIC` and :py:attr:`PIL.Image.ANTIALIAS`.

--- a/docs/releasenotes/2.8.0.rst
+++ b/docs/releasenotes/2.8.0.rst
@@ -4,18 +4,28 @@
 Open HTTP response objects with Image.open
 ------------------------------------------
 
-HTTP response objects returned from `urllib2.urlopen(url)` or `requests.get(url, stream=True).raw` are 'file-like' but do not support `.seek()` operations. As a result PIL was unable to open them as images, requiring a wrap in `cStringIO` or `BytesIO`.
+HTTP response objects returned from ``urllib2.urlopen(url)`` or
+``requests.get(url, stream=True).raw`` are 'file-like' but do not support ``.seek()``
+operations. As a result PIL was unable to open them as images, requiring a wrap in
+``cStringIO`` or ``BytesIO``.
 
-Now new functionality has been added to `Image.open()` by way of an `.seek(0)` check and catch on exception `AttributeError` or `io.UnsupportedOperation`. If this is caught we attempt to wrap the object using `io.BytesIO` (which will only work on buffer-file-like objects).
+Now new functionality has been added to ``Image.open()`` by way of an ``.seek(0)`` check and
+catch on exception ``AttributeError`` or ``io.UnsupportedOperation``. If this is caught we
+attempt to wrap the object using ``io.BytesIO`` (which will only work on buffer-file-like
+objects).
 
-This allows opening of files using both `urllib2` and `requests`, e.g.::
+This allows opening of files using both ``urllib2`` and ``requests``, e.g.::
 
     Image.open(urllib2.urlopen(url))
     Image.open(requests.get(url, stream=True).raw)
 
-If the response uses content-encoding (compression, either gzip or deflate) then this will fail as both the urllib2 and requests raw file object will produce compressed data in that case. Using Content-Encoding on images is rather non-sensical as most images are already compressed, but it can still happen.
+If the response uses content-encoding (compression, either gzip or deflate) then this
+will fail as both the urllib2 and requests raw file object will produce compressed data
+in that case. Using Content-Encoding on images is rather non-sensical as most images are
+already compressed, but it can still happen.
 
-For requests the work-around is to set the decode_content attribute on the raw object to True::
+For requests the work-around is to set the decode_content attribute on the raw object to
+True::
 
     response = requests.get(url, stream=True)
     response.raw.decode_content = True

--- a/docs/releasenotes/3.0.0.rst
+++ b/docs/releasenotes/3.0.0.rst
@@ -5,8 +5,8 @@
 Saving Multipage Images
 -----------------------
 
-There is now support for saving multipage images in the `GIF` and
-`PDF` formats. To enable this functionality, pass in `save_all=True`
+There is now support for saving multipage images in the ``GIF`` and
+``PDF`` formats. To enable this functionality, pass in ``save_all=True``
 as a keyword argument to the save::
 
     im.save('test.pdf', save_all=True)
@@ -37,7 +37,7 @@ have been removed in this release::
     ImageDraw.setink()
     ImageDraw.setfill()
     The ImageFileIO module
-    The ImageFont.FreeTypeFont and ImageFont.truetype `file` keyword arg
+    The ImageFont.FreeTypeFont and ImageFont.truetype ``file`` keyword arg
     The ImagePalette private _make functions
     ImageWin.fromstring()
     ImageWin.tostring()

--- a/docs/releasenotes/3.1.0.rst
+++ b/docs/releasenotes/3.1.0.rst
@@ -5,8 +5,8 @@
 ImageDraw arc, chord and pieslice can now use floats
 ----------------------------------------------------
 
-There is no longer a need to ensure that the start and end arguments for `arc`,
-`chord` and `pieslice` are integers.
+There is no longer a need to ensure that the start and end arguments for ``arc``,
+``chord`` and ``pieslice`` are integers.
 
 Note that these numbers are not simply rounded internally, but are actually
 utilised in the drawing process.

--- a/winbuild/build.rst
+++ b/winbuild/build.rst
@@ -37,8 +37,8 @@ virtualenv as well, reducing the number of packages that we need to
 install.)
 
 Download the rest of the Pythons by opening a command window, changing
-to the `winbuild` directory, and running `python
-get_pythons.py`.
+to the ``winbuild`` directory, and running ``python
+get_pythons.py``.
 
 UNDONE -- gpg verify the signatures (note that we can download from
 https)
@@ -65,8 +65,8 @@ Dependencies
 ------------
 
 The script 'build_dep.py' downloads and builds the dependencies.  Open
-a command window, change directory into `winbuild` and run `python
-build_dep.py`.
+a command window, change directory into ``winbuild`` and run ``python
+build_dep.py``.
 
 This will download libjpeg, libtiff, libz, and freetype. It will then
 compile 32 and 64-bit versions of the libraries, with both versions of
@@ -78,9 +78,9 @@ UNDONE -- webp, jpeg2k not recognized
 Building Pillow
 ---------------
 
-Once the dependencies are built, run `python build.py --clean` to
+Once the dependencies are built, run ``python build.py --clean`` to
 build and install Pillow in virtualenvs for each Python
-build. `build.py --wheel` will build wheels instead of
+build. ``build.py --wheel`` will build wheels instead of
 installing into virtualenvs.
 
 UNDONE -- suppressed output, what about failures.
@@ -88,6 +88,6 @@ UNDONE -- suppressed output, what about failures.
 Testing Pillow
 --------------
 
-Build and install Pillow, then run `python test.py` from the
-`winbuild` directory.
+Build and install Pillow, then run ``python test.py`` from the
+``winbuild`` directory.
 


### PR DESCRIPTION
reStructuredText uses double backticks for code. Markdown uses single backticks.