### PR TITLE
Increased tolerance for stroke test comparison

### DIFF
--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -831,7 +831,7 @@ class TestImageDraw(PillowTestCase):
 
             # Assert
             self.assert_image_similar(
-                im, Image.open("Tests/images/imagedraw_stroke_" + suffix + ".png"), 2.8
+                im, Image.open("Tests/images/imagedraw_stroke_" + suffix + ".png"), 3.1
             )
 
     @unittest.skipUnless(HAS_FREETYPE, "ImageFont not available")


### PR DESCRIPTION
Since merging #3978, I've been seeing some intermittent failures from Travis and Azure.

For example,
- https://travis-ci.org/python-pillow/Pillow/jobs/583125917 - but if you rerun the build, there is a decent chance it will pass.
- https://dev.azure.com/python-pillow/pillow/_build/results?buildId=806
- https://dev.azure.com/python-pillow/pillow/_build/results?buildId=812
- https://dev.azure.com/python-pillow/pillow/_build/results?buildId=817

This PR increases the tolerance of that test.