### PR TITLE
GitHub Actions: include `pull_request` so PRs from forks run

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Fixes #4060.

This reverts commit f6eb0f77027bb105ae99d87759acbcee262bc03f.

> A workflow that specifies a pull_request as the event will always run in the repository that contains that pull_request.  So when I raise a pull_request to the upstream repo from a fork of that repo the workflow run will be in that upstream repo.  

https://github.community/t5/GitHub-Actions/Run-a-GitHub-action-on-pull-request-for-PR-opened-from-a-forked/td-p/15426

> **Pull request events for forked repositories**
>
> When you open a pull request from a forked repository, the pull request opens on the base repository by default. In this scenario, GitHub sends the `pull_request` event to the base repository and no pull request events occur on the forked repository because the webhook configuration of the original base repository doesn't apply to forked repositories.
...
> If you intend to use the `pull_request` event to trigger CI tests, we recommend that you set up your workflow configuration to listen to the `push` event.

https://help.github.com/en/articles/events-that-trigger-workflows#pull-request-events-for-forked-repositories