### PR TITLE
GitHub Action to add issue or PR to project

### DIFF
--- a/.github/workflows/issue-or-pr-opened.yml
+++ b/.github/workflows/issue-or-pr-opened.yml
@@ -1,0 +1,15 @@
+name: Issue or PR opened
+on: [issues, pull_request]
+
+jobs:
+  assign:
+    name: Add issue/PR to project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue/PR to project
+        if: github.event.action == 'opened'
+        uses: alex-page/github-project-automation-plus@v0.0.3
+        with:
+          project: Pillow
+          column: New Issues
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-or-pr-opened.yml
+++ b/.github/workflows/issue-or-pr-opened.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           project: Pillow
           column: New Issues
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/3844.

Changes proposed in this pull request:

 * When a PR or issue is opened, automatically add it to the "New Issues" column of the [Pillow](https://github.com/python-pillow/Pillow/projects/1) board
