### PR TITLE
Test ImageShow.show on CIs

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -355,6 +355,12 @@ def on_appveyor():
     return "APPVEYOR" in os.environ
 
 
+def on_ci():
+    # Travis and AppVeyor have "CI"
+    # Azure Pipelines has "TF_BUILD"
+    return "CI" in os.environ or "TF_BUILD" in os.environ
+
+
 if sys.platform == "win32":
     IMCONVERT = os.environ.get("MAGICK_HOME", "")
     if IMCONVERT:

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -1,6 +1,6 @@
 from PIL import Image, ImageShow
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, hopper, on_ci, unittest
 
 
 class TestImageShow(PillowTestCase):
@@ -15,7 +15,7 @@ class TestImageShow(PillowTestCase):
         # Restore original state
         ImageShow._viewers.pop()
 
-    def test_show(self):
+    def test_viewer_show(self):
         class TestViewer(ImageShow.Viewer):
             methodCalled = False
 
@@ -33,6 +33,12 @@ class TestImageShow(PillowTestCase):
 
         # Restore original state
         ImageShow._viewers.pop(0)
+
+    @unittest.skipUnless(on_ci(), "Only run on CIs")
+    def test_show(self):
+        for mode in ("1", "I;16", "LA", "RGB", "RGBA"):
+            im = hopper(mode)
+            self.assertTrue(ImageShow.show(im))
 
     def test_viewer(self):
         viewer = ImageShow.Viewer()


### PR DESCRIPTION
This PR adds a test that actually runs the `ImageShow.show` method, opening the image. However, to be neat, it only runs on the CIs, where the shown images won't bother users.