### PR TITLE
AppVeyor build improvements

### DIFF
--- a/winbuild/build.py
+++ b/winbuild/build.py
@@ -84,7 +84,8 @@ def vc_setup(compiler, bit):
         arch = "x86" if bit == 32 else "x86_amd64"
         script = (
             r"""
-call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %s"""
+call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %s
+echo on"""
             % arch
         )
     return script

--- a/winbuild/build_dep.py
+++ b/winbuild/build_dep.py
@@ -67,7 +67,6 @@ def extract_openjpeg(compiler):
         r"""
 rem build openjpeg
 setlocal
-@echo on
 cd %%BUILD%%
 mkdir %%INCLIB%%\openjpeg-2.0
 copy /Y /B openjpeg-2.0.0-win32-x86\include\openjpeg-2.0  %%INCLIB%%\openjpeg-2.0
@@ -140,7 +139,6 @@ setlocal
 """
         + vc_setup(compiler, bit)
         + r"""
-@echo on
 cd /D %%OPENJPEG%%%(inc_dir)s
 
 %%CMAKE%% -DBUILD_THIRDPARTY:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=OFF -DCMAKE_BUILD_TYPE=Release -G "NMake Makefiles" .

--- a/winbuild/build_dep.py
+++ b/winbuild/build_dep.py
@@ -143,8 +143,8 @@ setlocal
 cd /D %%OPENJPEG%%%(inc_dir)s
 
 %%CMAKE%% -DBUILD_THIRDPARTY:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=OFF -G "NMake Makefiles" .
-nmake -f Makefile clean
-nmake -f Makefile
+nmake -nologo -f Makefile clean
+nmake -nologo -f Makefile
 copy /Y /B bin\* %%INCLIB%%
 mkdir %%INCLIB%%\openjpeg-%(op_ver)s
 copy /Y /B src\lib\openjp2\*.h %%INCLIB%%\openjpeg-%(op_ver)s
@@ -164,9 +164,9 @@ setlocal
         + vc_setup(compiler, bit)
         + r"""
 cd /D %%JPEG%%
-nmake -f makefile.vc setup-vc6
-nmake -f makefile.vc clean
-nmake -f makefile.vc libjpeg.lib
+nmake -nologo -f makefile.vc setup-vc6
+nmake -nologo -f makefile.vc clean
+nmake -nologo -f makefile.vc libjpeg.lib
 copy /Y /B *.dll %%INCLIB%%
 copy /Y /B *.lib %%INCLIB%%
 copy /Y /B j*.h %%INCLIB%%
@@ -175,8 +175,8 @@ endlocal
 rem Build zlib
 setlocal
 cd /D %%ZLIB%%
-nmake -f win32\Makefile.msc clean
-nmake -f win32\Makefile.msc zlib.lib
+nmake -nologo -f win32\Makefile.msc clean
+nmake -nologo -f win32\Makefile.msc zlib.lib
 copy /Y /B *.dll %%INCLIB%%
 copy /Y /B *.lib %%INCLIB%%
 copy /Y /B zlib.lib %%INCLIB%%\z.lib
@@ -191,7 +191,7 @@ setlocal
         + r"""
 cd /D %%WEBP%%
 rd /S /Q %%WEBP%%\output\release-static
-nmake -f Makefile.vc CFG=release-static RTLIBCFG=static OBJDIR=output all
+nmake -nologo -f Makefile.vc CFG=release-static RTLIBCFG=static OBJDIR=output all
 copy /Y /B output\release-static\%(webp_platform)s\lib\* %%INCLIB%%
 mkdir %%INCLIB%%\webp
 copy /Y /B src\webp\*.h %%INCLIB%%\\webp
@@ -206,8 +206,8 @@ rem do after building jpeg and zlib
 copy %%~dp0\nmake.opt %%TIFF%%
 
 cd /D %%TIFF%%
-nmake -f makefile.vc clean
-nmake -f makefile.vc lib
+nmake -nologo -f makefile.vc clean
+nmake -nologo -f makefile.vc lib
 copy /Y /B libtiff\*.dll %%INCLIB%%
 copy /Y /B libtiff\*.lib %%INCLIB%%
 copy /Y /B libtiff\tiff*.h %%INCLIB%%
@@ -320,7 +320,7 @@ cd /D %%GHOSTSCRIPT%%
 set WIN64=""
 """
     script += r"""
-nmake -f psi/msvc.mak
+nmake -nologo -f psi/msvc.mak
 copy /Y /B bin\ C:\Python27\
 endlocal
 """

--- a/winbuild/build_dep.py
+++ b/winbuild/build_dep.py
@@ -143,7 +143,7 @@ setlocal
 @echo on
 cd /D %%OPENJPEG%%%(inc_dir)s
 
-%%CMAKE%% -DBUILD_THIRDPARTY:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=OFF -G "NMake Makefiles" .
+%%CMAKE%% -DBUILD_THIRDPARTY:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=OFF -DCMAKE_BUILD_TYPE=Release -G "NMake Makefiles" .
 nmake -nologo -f Makefile clean
 nmake -nologo -f Makefile
 copy /Y /B bin\* %%INCLIB%%

--- a/winbuild/build_dep.py
+++ b/winbuild/build_dep.py
@@ -114,6 +114,7 @@ def setup_compiler(compiler):
     return (
         r"""setlocal EnableDelayedExpansion
 call "%%ProgramFiles%%\Microsoft SDKs\Windows\%(env_version)s\Bin\SetEnv.Cmd" /Release %(env_flags)s
+echo on
 set INCLIB=%%INCLIB%%\%(inc_dir)s
 """  # noqa: E501
         % compiler

--- a/winbuild/build_dep.py
+++ b/winbuild/build_dep.py
@@ -167,7 +167,7 @@ setlocal
 cd /D %%JPEG%%
 nmake -nologo -f makefile.vc setup-vc6
 nmake -nologo -f makefile.vc clean
-nmake -nologo -f makefile.vc libjpeg.lib
+nmake -nologo -f makefile.vc nodebug=1 libjpeg.lib
 copy /Y /B *.dll %%INCLIB%%
 copy /Y /B *.lib %%INCLIB%%
 copy /Y /B j*.h %%INCLIB%%


### PR DESCRIPTION
While trying to add PyPy3 to AppVeyor, I found and fixed several winbuild issues, including these:

Log changes:

 * `SetEnv.Cmd` and `vcvarsall.bat` both disable `echo`. Turning it back on improves readability of the build log.
 * `nmake` copyright message was messy (around 30 lines long). Adding `-nologo` turns it off.

Compare before: https://ci.appveyor.com/project/Python-pillow/pillow/builds/27337992/job/ni8rcc28utx9baq6?fullLog=true#L367
Compare after: https://ci.appveyor.com/project/nulano/pillow/builds/27571987/job/cojejreprth4khia?fullLog=true#L367

Build changes:

 * Build libjpeg in release mode, not debug mode, by adding `nodebug=1`. See `jpeg-9c\makefile.vc` line 9 for more info.
* Build openjp2 in release mode, not default mode, by adding `-DCMAKE_BUILD_TYPE=Release`. See e.g. https://codeyarns.com/2015/05/14/build-types-in-cmake/ for more info.

These changes also seem to decrease build times by about 10%:
Before: https://ci.appveyor.com/project/Python-pillow/pillow/builds/27337992
After: https://ci.appveyor.com/project/nulano/pillow/builds/27571987
