### PR TITLE
Test Linux and macOS with GitHub Actions

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,4 +6,6 @@ codecov:
   # https://docs.codecov.io/v4.3.6/docs/comparing-commits
   allow_coverage_offsets: true
 
+  token: 6dafc396-e7f5-4221-a38a-8b07a49fbdae
+
 comment: off

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,17 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7]
+        python-version: ["3.7"]
 
-    name: Python ${{ matrix.python }}
+    name: Python ${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v1
 
-    - name: Set up Python ${{ matrix.python }}
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
-        python-version: ${{ matrix.python }}
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
+
+brew install libtiff libjpeg webp little-cms2
+
+PYTHONOPTIMIZE=0 pip install cffi
+pip install coverage
+pip install olefile
+pip install -U pytest
+pip install -U pytest-cov
+pip install pyroma
+pip install test-image-results
+pip install numpy
+
+# extra test images
+pushd depends && ./install_extra_test_images.sh && popd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ jobs:
   build:
 
     strategy:
+      fail-fast: false
       matrix:
         os: [
           "ubuntu-18.04",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,7 @@ jobs:
         ]
         python-version: [
           "pypy3",
-          "pypy2",
           "3.7",
-          "2.7",
           "3.5",
           "3.6",
         ]
@@ -54,7 +52,7 @@ jobs:
         .travis/test.sh
 
     - name: Docs
-      if: matrix.python-version == 2.7
+      if: matrix.python-version == 3.7
       run: |
         pip install sphinx-rtd-theme
         make doccheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,9 +45,13 @@ jobs:
       run: |
         .github/workflows/macos-install.sh
 
+    - name: Build
+      run: |
+        .travis/build.sh
+
     - name: Test
       run: |
-        .travis/script.sh
+        .travis/test.sh
 
     - name: Docs
       if: matrix.python-version == 2.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,12 +34,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Linux dependencies
-      if: matrix.os == 'ubuntu-18.04'
+      if: startsWith(matrix.os, 'ubuntu')
       run: |
         .travis/install.sh
 
     - name: Install macOS dependencies
-      if: matrix.os == 'macOS-10.14'
+      if: startsWith(matrix.os, 'macOS')
       run: |
         .github/workflows/macos-install.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,54 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [
+          "pypy3",
+          "pypy2",
+          "3.7",
+          "2.7",
+          "3.5",
+          "3.6",
+        ]
+        include:
+        - python-version: "3.5"
+          env: PYTHONOPTIMIZE=2
+        - python-version: "3.6"
+          env: PYTHONOPTIMIZE=1
+    name: Python ${{ matrix.python-version }}
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        .travis/install.sh
+
+    - name: Test
+      run: |
+        .travis/script.sh
+
+    - name: Docs
+      if: matrix.python-version == 2.7
+      run: |
+        pip install sphinx-rtd-theme
+        make doccheck
+
+    - name: After success
+      if: success()
+      run: |
+        .travis/after_success.sh
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,12 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [
+          "ubuntu-18.04",
+          "macOS-10.14",
+        ]
         python-version: [
           "pypy3",
           "pypy2",
@@ -21,7 +24,8 @@ jobs:
           env: PYTHONOPTIMIZE=2
         - python-version: "3.6"
           env: PYTHONOPTIMIZE=1
-    name: Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} Python ${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v1
@@ -31,9 +35,15 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
+    - name: Install Linux dependencies
+      if: matrix.os == 'ubuntu-18.04'
       run: |
         .travis/install.sh
+
+    - name: Install macOS dependencies
+      if: matrix.os == 'macOS-10.14'
+      run: |
+        .github/workflows/macos-install.sh
 
     - name: Test
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,8 @@ script:
   if [ "$LINT" == "true" ]; then
     tox -e lint
   elif [ "$DOCKER" == "" ]; then
-    .travis/script.sh
+    .travis/build.sh
+    .travis/test.sh
   elif [ "$DOCKER" ]; then
     # the Pillow user in the docker container is UID 1000
     sudo chown -R 1000 $TRAVIS_BUILD_DIR

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+coverage erase
+make clean
+make install-coverage

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-coverage erase
-make clean
-make install-coverage
-
 python -m pytest -v -x --cov PIL --cov-report term Tests
 
 # Docs


### PR DESCRIPTION
For #3606.

Changes proposed in this pull request:

 * This does the same tests as the "native" (ie. non-Docker) builds on Travis CI:
   * pypy3
   * ~pypy2~
   * 3.7
   * 3.6 `PYTHONOPTIMIZE=1`
   * 3.5 `PYTHONOPTIMIZE=2`
   * ~2.7~
 * Not available on GitHub Actions:
   * ~`"2.7_with_system_site_packages" # For PyQt4`~
   * `3.8-dev`

 * Also rename some variables in `lint.yml` for consistency

## Travis scripts

Happily GitHub Actions runs the `.travis/*.sh` scripts with no problems. There's an `if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then make doccheck; fi` in one, I've added the same doccheck as its own step here for GHA.

## Linux

This only runs on `ubuntu-latest`, currently `ubuntu-18.04` Bionic. `ubuntu-16.04` Xenial is also available.

* https://help.github.com/en/articles/virtual-environments-for-github-actions#supported-virtual-environments-and-hardware-resources

* [x] Should we explicitly say `ubuntu-18.04` instead of `ubuntu-latest`? I'm thinking yes.

* [ ] Should we also test Xenial? (If so, this will be a follow-up.)

## Coverage

This does coverage.

TODO

* [n/a] Save the token at https://codecov.io/gh/python-pillow/Pillow/settings as `CODECOV_TOKEN` at https://github.com/python-pillow/Pillow/settings/secrets
* [n/a] Save the token at https://coveralls.io/github/python-pillow/Pillow/settings as `COVERALLS_REPO_TOKEN` at https://github.com/python-pillow/Pillow/settings/secrets
  * It might be we don't really need this, but it complains about it in the logs during `coveralls-merge`, so let's silence it

Now, unfortunately these tokens are not yet available for forks. Travis and AppVeyor don't use tokens because Codecov can autodetect those. That's not yet the case for Azure Pipelines and GitHub Actions. There's a [workaround for AZP](https://hynek.me/articles/simple-python-azure-pipelines/#coverage) to make secrets available to forks. I've requested it for GHA and [they said they'll take a look](https://github.community/t5/GitHub-Actions/Make-secrets-available-to-builds-of-forks/m-p/30685#M511).

Downsides of this:
* It's not ready yet
* It would be possible for people to find out these tokens, but as Hynek mentions in his [AZP workaround](https://hynek.me/articles/simple-python-azure-pipelines/#fn:leak): "However, the token is worthless for anything except uploading coverage and it’s easy to see when someone does it."
* It would make other secrets available to forks (eg. #4071)

* [x] Alternatively, how about we just include them as plaintext in the YAML?

Downsides:
* Visible to others. Probably not a big deal, would still be able to find out from env vars; Codecov themselves suggest adding it to YML ("How do I use this token?"  
https://codecov.io/gh/python-pillow/Pillow/settings)

