### PR TITLE
Cleanup by resetting locale

### DIFF
--- a/Tests/test_locale.py
+++ b/Tests/test_locale.py
@@ -31,4 +31,8 @@ class TestLocale(PillowTestCase):
             locale.setlocale(locale.LC_ALL, "polish")
         except locale.Error:
             unittest.skip("Polish locale not available")
-        Image.open(path)
+
+        try:
+            Image.open(path)
+        finally:
+            locale.setlocale(locale.LC_ALL, (None, None))


### PR DESCRIPTION
https://bitbucket.org/pypy/pypy/issues/3079/systemerror-in-timestrptime-with-non#comment-54017374 notes that Pillow does not reset the locale at the end of one of our tests.