### PR TITLE
Do not download dev wheels

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -92,7 +92,7 @@ Released as needed privately to individual vendors for critical security-related
   ```
 * [ ] Download distributions from the [Pillow Wheel Builder container](http://a365fff413fe338398b6-1c8a9b3114517dc5fe17b7c3f8c63a43.r19.cf2.rackcdn.com/).
   ```bash
-  wget -m -A 'Pillow-<VERSION>*' \
+  wget -m -A 'Pillow-<VERSION>-*' \
   http://a365fff413fe338398b6-1c8a9b3114517dc5fe17b7c3f8c63a43.r19.cf2.rackcdn.com
   ```
 


### PR DESCRIPTION
Added dash to regex in command for downloading wheels, so that
- Pillow-6.2.0-cp37-cp37m-manylinux1_x86_64.whl

is matched, while

- Pillow-6.2.0.dev0+20190902192556-cp27-cp27mu-manylinux1_x86_64.whl

is not.

![image](https://user-images.githubusercontent.com/3112309/65954425-4f15ec00-e489-11e9-8943-24c90503424b.png)