### PR TITLE
Remove deprecated PILLOW_VERSION

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -94,14 +94,6 @@ a ``DeprecationWarning``:
     Setting the size of a TIFF image directly is deprecated, and will
     be removed in a future version. Use the resize method instead.
 
-PILLOW_VERSION constant
-~~~~~~~~~~~~~~~~~~~~~~~
-
-.. deprecated:: 5.2.0
-
-``PILLOW_VERSION`` has been deprecated and will be removed in 7.0.0. Use ``__version__``
-instead.
-
 ImageCms.CmsProfile attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -127,6 +119,13 @@ Removed features
 
 Deprecated features are only removed in major releases after an appropriate
 period of deprecation has passed.
+
+PILLOW_VERSION constant
+~~~~~~~~~~~~~~~~~~~~~~~
+
+*Removed in version 7.0.0.*
+
+``PILLOW_VERSION`` has been removed. Use ``__version__`` instead.
 
 VERSION constant
 ~~~~~~~~~~~~~~~~

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -35,9 +35,9 @@ import sys
 import warnings
 
 # VERSION was removed in Pillow 6.0.0.
-# PILLOW_VERSION is deprecated and will be removed in Pillow 7.0.0.
+# PILLOW_VERSION was removed in Pillow 7.0.0.
 # Use __version__ instead.
-from . import PILLOW_VERSION, ImageMode, TiffTags, __version__, _plugins
+from . import ImageMode, TiffTags, __version__, _plugins
 from ._binary import i8, i32le
 from ._util import deferred_error, isPath, isStringType, py3
 
@@ -56,9 +56,6 @@ except ImportError:
     # Python 2.7
     from collections import Callable, MutableMapping
 
-
-# Silence warning
-assert PILLOW_VERSION
 
 logger = logging.getLogger(__name__)
 

--- a/src/PIL/__init__.py
+++ b/src/PIL/__init__.py
@@ -17,9 +17,9 @@ PIL.VERSION is the old PIL version and will be removed in the future.
 from . import _version
 
 # VERSION was removed in Pillow 6.0.0.
-# PILLOW_VERSION is deprecated and will be removed in Pillow 7.0.0.
+# PILLOW_VERSION was removed in Pillow 7.0.0.
 # Use __version__ instead.
-PILLOW_VERSION = __version__ = _version.__version__
+__version__ = _version.__version__
 
 del _version
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * `PILLOW_VERSION` was deprecated in 5.2.0 (https://github.com/python-pillow/Pillow/pull/3090) and is removed in 7.0.0
