### PR TITLE
Changed condition to use DEBUG as a boolean

### DIFF
--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -854,7 +854,7 @@ class ImageFileDirectory_v2(MutableMapping):
 
         # pass 2: write entries to file
         for tag, typ, count, value, data in entries:
-            if DEBUG > 1:
+            if DEBUG:
                 print(tag, typ, count, repr(value), repr(data))
             result += self._pack("HHL4s", tag, typ, count, value)
 


### PR DESCRIPTION
TiffImagePlugin sets `DEBUG` to `False` initially, and checks for a truthy value in various places, except for

https://github.com/python-pillow/Pillow/blob/59153f5e125bf677b257b0310e710583a62506cf/src/PIL/TiffImagePlugin.py#L857

This is an  artifact of #1207, when `DEBUG` changed from `0` by default to `False`. This PR changes it to just check for a truthy value.