### PR TITLE
Removed deprecated setting of TIFF image sizes

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -73,15 +73,6 @@ class TestFileTiff(PillowTestCase):
             ifd.legacy_api = None
         self.assertEqual(str(e.exception), "Not allowing setting of legacy api")
 
-    def test_size(self):
-        filename = "Tests/images/pil168.tif"
-        im = Image.open(filename)
-
-        def set_size():
-            im.size = (256, 256)
-
-        self.assert_warning(DeprecationWarning, set_size)
-
     def test_xyres_tiff(self):
         filename = "Tests/images/pil168.tif"
         im = Image.open(filename)

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -81,19 +81,6 @@ Deprecated                       Deprecated                         Deprecated
 ``IptcImagePlugin.__version__``  ``PixarImagePlugin.__version__``
 ===============================  =================================  ==================================
 
-Setting the size of TIFF images
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. deprecated:: 5.3.0
-
-Setting the image size of a TIFF image (eg. ``im.size = (256, 256)``) issues
-a ``DeprecationWarning``:
-
-.. code-block:: none
-
-    Setting the size of a TIFF image directly is deprecated, and will
-    be removed in a future version. Use the resize method instead.
-
 ImageCms.CmsProfile attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -126,6 +113,14 @@ PILLOW_VERSION constant
 *Removed in version 7.0.0.*
 
 ``PILLOW_VERSION`` has been removed. Use ``__version__`` instead.
+
+Setting the size of TIFF images
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+*Removed in version 7.0.0.*
+
+Setting the size of a TIFF image directly (eg. ``im.size = (256, 256)``) throws
+an error. Use ``Image.resize`` instead.
 
 VERSION constant
 ~~~~~~~~~~~~~~~~

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1079,19 +1079,6 @@ class TiffImageFile(ImageFile.ImageFile):
         """Return the current frame number"""
         return self.__frame
 
-    @property
-    def size(self):
-        return self._size
-
-    @size.setter
-    def size(self, value):
-        warnings.warn(
-            "Setting the size of a TIFF image directly is deprecated, and will"
-            " be removed in a future version. Use the resize method instead.",
-            DeprecationWarning,
-        )
-        self._size = value
-
     def load(self):
         if self.use_load_libtiff:
             return self._load_libtiff()


### PR DESCRIPTION
Setting TIFF image size was deprecated in Pillow 5.3.0 (https://github.com/python-pillow/Pillow/pull/3203/commits/6f44ae1d27fa89a9e313e0da9dbfe3d129bb0763). This PR removes it for 7.0.0.