### PR TITLE
Fixed freeing unallocated pointer when resizing with height too large

### DIFF
--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -11,11 +11,15 @@ class TestImagingResampleVulnerability(PillowTestCase):
     # see https://github.com/python-pillow/Pillow/issues/1710
     def test_overflow(self):
         im = hopper("L")
-        xsize = 0x100000008 // 4
-        ysize = 1000  # unimportant
-        with self.assertRaises(MemoryError):
-            # any resampling filter will do here
-            im.im.resize((xsize, ysize), Image.BILINEAR)
+        size_too_large = 0x100000008 // 4
+        size_normal = 1000  # unimportant
+        for xsize, ysize in (
+            (size_too_large, size_normal),
+            (size_normal, size_too_large),
+        ):
+            with self.assertRaises(MemoryError):
+                # any resampling filter will do here
+                im.im.resize((xsize, ysize), Image.BILINEAR)
 
     def test_invalid_size(self):
         im = hopper()

--- a/src/libImaging/Resample.c
+++ b/src/libImaging/Resample.c
@@ -627,8 +627,6 @@ ImagingResampleInner(Imaging imIn, int xsize, int ysize,
     if ( ! ksize_vert) {
         free(bounds_horiz);
         free(kk_horiz);
-        free(bounds_vert);
-        free(kk_vert);
         return NULL;
     }
 


### PR DESCRIPTION
Resolves #4115

#3393 added two `free` lines that should not be present. `bounds_vert` and `kk_vert` are assigned by `precompute_coeffs`. If `precompute_coeffs` returns `0`, then they were not assigned, and should not be freed.

I have added a test that fails without this PR to demonstrate.