### PR TITLE
Remove duplicate cleanup in test_decompression_bomb.py

### DIFF
--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -14,7 +14,6 @@ class TestDecompressionBomb(PillowTestCase):
     def test_no_warning_small_file(self):
         # Implicit assert: no warning.
         # A warning would cause a failure.
-        Image.MAX_IMAGE_PIXELS = ORIGINAL_LIMIT
         Image.open(TEST_FILE)
 
     def test_no_warning_no_limit(self):


### PR DESCRIPTION
The same cleanup is done in the teardDown() method. There is no need to do it a 2nd time.