### PR TITLE
Use bytes literals instead of bytes(str)

### DIFF
--- a/Tests/check_icns_dos.py
+++ b/Tests/check_icns_dos.py
@@ -4,9 +4,5 @@
 from io import BytesIO
 
 from PIL import Image
-from PIL._util import py3
 
-if py3:
-    Image.open(BytesIO(bytes("icns\x00\x00\x00\x10hang\x00\x00\x00\x00", "latin-1")))
-else:
-    Image.open(BytesIO(bytes("icns\x00\x00\x00\x10hang\x00\x00\x00\x00")))
+Image.open(BytesIO(b"icns\x00\x00\x00\x10hang\x00\x00\x00\x00"))

--- a/Tests/check_j2k_dos.py
+++ b/Tests/check_j2k_dos.py
@@ -4,19 +4,5 @@
 from io import BytesIO
 
 from PIL import Image
-from PIL._util import py3
 
-if py3:
-    Image.open(
-        BytesIO(
-            bytes(
-                "\x00\x00\x00\x0cjP\x20\x20\x0d\x0a\x87\x0a\x00\x00\x00\x00hang",
-                "latin-1",
-            )
-        )
-    )
-
-else:
-    Image.open(
-        BytesIO(bytes("\x00\x00\x00\x0cjP\x20\x20\x0d\x0a\x87\x0a\x00\x00\x00\x00hang"))
-    )
+Image.open(BytesIO(b"\x00\x00\x00\x0cjP\x20\x20\x0d\x0a\x87\x0a\x00\x00\x00\x00hang"))


### PR DESCRIPTION
Bytes literals are available on all supported Python versions. Rather
than convert strings literals to bytes at runtime, simply use a bytes
literal.