### PR TITLE
Move several imports to the top-level of the file

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -5,9 +5,11 @@ from __future__ import print_function
 
 import logging
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
+from io import BytesIO
 
 from PIL import Image, ImageMath
 from PIL._util import py3
@@ -284,14 +286,10 @@ if not py3:
 
 
 def fromstring(data):
-    from io import BytesIO
-
     return Image.open(BytesIO(data))
 
 
 def tostring(im, string_format, **options):
-    from io import BytesIO
-
     out = BytesIO()
     im.save(out, string_format, **options)
     return out.getvalue()
@@ -323,8 +321,6 @@ def command_succeeds(cmd):
     Runs the command, which must be a list of strings. Returns True if the
     command succeeds, or False if an OSError was raised by subprocess.Popen.
     """
-    import subprocess
-
     with open(os.devnull, "wb") as f:
         try:
             subprocess.call(cmd, stdout=f, stderr=subprocess.STDOUT)

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import base64
 import distutils.version
 import io
 import itertools
@@ -852,8 +853,6 @@ class TestFileLibTiff(LibTiffTestCase):
         # Assert that a TIFF image with SampleFormat=UINT tag is not corrupted
         # when saving to a new file.
         # Pillow 6.0 fails with "OSError: cannot identify image file".
-        import base64
-
         tiff = io.BytesIO(
             base64.b64decode(
                 b"SUkqAAgAAAAPAP4ABAABAAAAAAAAAAABBAABAAAAAQAAAAEBBAABAAAAAQAA"

--- a/Tests/test_file_libtiff_small.py
+++ b/Tests/test_file_libtiff_small.py
@@ -1,3 +1,5 @@
+from io import BytesIO
+
 from PIL import Image
 
 from .test_file_libtiff import LibTiffTestCase
@@ -25,8 +27,6 @@ class TestFileLibTiffSmall(LibTiffTestCase):
 
     def test_g4_hopper_bytesio(self):
         """Testing the bytesio loading code path"""
-        from io import BytesIO
-
         test_file = "Tests/images/hopper_g4.tif"
         s = BytesIO()
         with open(test_file, "rb") as f:

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 from io import BytesIO
 
@@ -504,10 +505,7 @@ class TestFileTiff(PillowTestCase):
             self.assert_image_equal(im.convert("RGB"), reloaded.convert("RGB"))
 
     def test_tiff_save_all(self):
-        import io
-        import os
-
-        mp = io.BytesIO()
+        mp = BytesIO()
         with Image.open("Tests/images/multipage.tiff") as im:
             im.save(mp, format="tiff", save_all=True)
 
@@ -516,7 +514,7 @@ class TestFileTiff(PillowTestCase):
             self.assertEqual(im.n_frames, 3)
 
         # Test appending images
-        mp = io.BytesIO()
+        mp = BytesIO()
         im = Image.new("RGB", (100, 100), "#f00")
         ims = [Image.new("RGB", (100, 100), color) for color in ["#0f0", "#00f"]]
         im.copy().save(mp, format="TIFF", save_all=True, append_images=ims)
@@ -530,7 +528,7 @@ class TestFileTiff(PillowTestCase):
             for im in ims:
                 yield im
 
-        mp = io.BytesIO()
+        mp = BytesIO()
         im.save(mp, format="TIFF", save_all=True, append_images=imGenerator(ims))
 
         mp.seek(0, os.SEEK_SET)
@@ -588,7 +586,6 @@ class TestFileTiff(PillowTestCase):
 class TestFileTiffW32(PillowTestCase):
     def test_fd_leak(self):
         tmpfile = self.tempfile("temp.tif")
-        import os
 
         # this is an mmaped file.
         with Image.open("Tests/images/uint16_1_4660.tif") as im:

--- a/Tests/test_file_webp_metadata.py
+++ b/Tests/test_file_webp_metadata.py
@@ -1,3 +1,5 @@
+from io import BytesIO
+
 from PIL import Image
 
 from .helper import PillowTestCase
@@ -39,8 +41,6 @@ class TestFileWebpMetadata(PillowTestCase):
         self.assertEqual(exif_data, expected_exif)
 
     def test_write_exif_metadata(self):
-        from io import BytesIO
-
         file_path = "Tests/images/flower.jpg"
         image = Image.open(file_path)
         expected_exif = image.info["exif"]
@@ -73,8 +73,6 @@ class TestFileWebpMetadata(PillowTestCase):
         self.assertEqual(icc, expected_icc)
 
     def test_write_icc_metadata(self):
-        from io import BytesIO
-
         file_path = "Tests/images/flower2.jpg"
         image = Image.open(file_path)
         expected_icc_profile = image.info["icc_profile"]
@@ -95,8 +93,6 @@ class TestFileWebpMetadata(PillowTestCase):
             )
 
     def test_read_no_exif(self):
-        from io import BytesIO
-
         file_path = "Tests/images/flower.jpg"
         image = Image.open(file_path)
         self.assertIn("exif", image.info)

--- a/Tests/test_file_xbm.py
+++ b/Tests/test_file_xbm.py
@@ -1,3 +1,5 @@
+from io import BytesIO
+
 from PIL import Image
 
 from .helper import PillowTestCase
@@ -28,8 +30,6 @@ static char basic_bits[] = {
 
 class TestFileXbm(PillowTestCase):
     def test_pil151(self):
-        from io import BytesIO
-
         im = Image.open(BytesIO(PIL151))
 
         im.load()

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import sys
+import tempfile
 
 from PIL import Image
 from PIL._util import py3
@@ -126,8 +127,6 @@ class TestImage(PillowTestCase):
     def test_tempfile(self):
         # see #1460, pathlib support breaks tempfile.TemporaryFile on py27
         # Will error out on save on 3.0.0
-        import tempfile
-
         im = hopper()
         with tempfile.TemporaryFile() as fp:
             im.save(fp, "JPEG")

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -1,5 +1,8 @@
+import ctypes
 import os
+import subprocess
 import sys
+from distutils import ccompiler, sysconfig
 
 from PIL import Image
 
@@ -337,10 +340,6 @@ class TestEmbeddable(unittest.TestCase):
         "Failing on AppVeyor when run from subprocess, not from shell",
     )
     def test_embeddable(self):
-        import subprocess
-        import ctypes
-        from distutils import ccompiler, sysconfig
-
         with open("embed_pil.c", "w") as fh:
             fh.write(
                 """

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -23,7 +23,9 @@
 import io
 import os
 import re
+import subprocess
 import sys
+import tempfile
 
 from . import Image, ImageFile
 from ._binary import i32le as i32
@@ -61,8 +63,6 @@ def has_ghostscript():
     if gs_windows_binary:
         return True
     if not sys.platform.startswith("win"):
-        import subprocess
-
         try:
             with open(os.devnull, "wb") as devnull:
                 subprocess.check_call(["gs", "--version"], stdout=devnull)
@@ -90,9 +90,6 @@ def Ghostscript(tile, size, fp, scale=1):
         float((72.0 * size[0]) / (bbox[2] - bbox[0])),
         float((72.0 * size[1]) / (bbox[3] - bbox[1])),
     )
-
-    import subprocess
-    import tempfile
 
     out_fd, outfile = tempfile.mkstemp()
     os.close(out_fd)

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -25,6 +25,8 @@
 #
 
 import itertools
+import os
+import subprocess
 
 from . import Image, ImageChops, ImageFile, ImagePalette, ImageSequence
 from ._binary import i8, i16le as i16, o8, o16le as o16
@@ -617,24 +619,22 @@ def _save_netpbm(im, fp, filename):
     # If you need real GIF compression and/or RGB quantization, you
     # can use the external NETPBM/PBMPLUS utilities.  See comments
     # below for information on how to enable this.
-
-    import os
-    from subprocess import Popen, check_call, PIPE, CalledProcessError
-
     tempfile = im._dump()
 
     with open(filename, "wb") as f:
         if im.mode != "RGB":
             with open(os.devnull, "wb") as devnull:
-                check_call(["ppmtogif", tempfile], stdout=f, stderr=devnull)
+                subprocess.check_call(["ppmtogif", tempfile], stdout=f, stderr=devnull)
         else:
             # Pipe ppmquant output into ppmtogif
             # "ppmquant 256 %s | ppmtogif > %s" % (tempfile, filename)
             quant_cmd = ["ppmquant", "256", tempfile]
             togif_cmd = ["ppmtogif"]
             with open(os.devnull, "wb") as devnull:
-                quant_proc = Popen(quant_cmd, stdout=PIPE, stderr=devnull)
-                togif_proc = Popen(
+                quant_proc = subprocess.Popen(
+                    quant_cmd, stdout=subprocess.PIPE, stderr=devnull
+                )
+                togif_proc = subprocess.Popen(
                     togif_cmd, stdin=quant_proc.stdout, stdout=f, stderr=devnull
                 )
 
@@ -643,11 +643,11 @@ def _save_netpbm(im, fp, filename):
 
             retcode = quant_proc.wait()
             if retcode:
-                raise CalledProcessError(retcode, quant_cmd)
+                raise subprocess.CalledProcessError(retcode, quant_cmd)
 
             retcode = togif_proc.wait()
             if retcode:
-                raise CalledProcessError(retcode, togif_cmd)
+                raise subprocess.CalledProcessError(retcode, togif_cmd)
 
     try:
         os.unlink(tempfile)

--- a/src/PIL/IcnsImagePlugin.py
+++ b/src/PIL/IcnsImagePlugin.py
@@ -19,6 +19,7 @@ import io
 import os
 import shutil
 import struct
+import subprocess
 import sys
 import tempfile
 
@@ -333,11 +334,12 @@ def _save(im, fp, filename):
         last_w = w * 2
 
     # iconutil -c icns -o {} {}
-    from subprocess import Popen, PIPE, CalledProcessError
 
     convert_cmd = ["iconutil", "-c", "icns", "-o", filename, iconset]
     with open(os.devnull, "wb") as devnull:
-        convert_proc = Popen(convert_cmd, stdout=PIPE, stderr=devnull)
+        convert_proc = subprocess.Popen(
+            convert_cmd, stdout=subprocess.PIPE, stderr=devnull
+        )
 
     convert_proc.stdout.close()
 
@@ -347,7 +349,7 @@ def _save(im, fp, filename):
     shutil.rmtree(iconset)
 
     if retcode:
-        raise CalledProcessError(retcode, convert_cmd)
+        raise subprocess.CalledProcessError(retcode, convert_cmd)
 
 
 Image.register_open(IcnsImageFile.format, IcnsImageFile, lambda x: x[:4] == b"icns")

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -32,6 +32,7 @@ import numbers
 import os
 import struct
 import sys
+import tempfile
 import warnings
 
 # VERSION was removed in Pillow 6.0.0.
@@ -639,8 +640,6 @@ class Image(object):
             self.load()
 
     def _dump(self, file=None, format=None, **options):
-        import tempfile
-
         suffix = ""
         if format:
             suffix = "." + format

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -25,8 +25,10 @@
 # See the README file for information on usage and redistribution.
 #
 
+import base64
 import os
 import sys
+from io import BytesIO
 
 from . import Image
 from ._util import isDirectory, isPath, py3
@@ -713,9 +715,6 @@ def load_default():
 
     :return: A font object.
     """
-    from io import BytesIO
-    import base64
-
     f = ImageFont()
     f._load_pilfont_data(
         # courB08

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -15,17 +15,14 @@
 # See the README file for information on usage and redistribution.
 #
 
+import os
+import subprocess
 import sys
+import tempfile
 
 from . import Image
 
-if sys.platform == "win32":
-    grabber = Image.core.grabscreen
-elif sys.platform == "darwin":
-    import os
-    import tempfile
-    import subprocess
-else:
+if sys.platform not in ["win32", "darwin"]:
     raise ImportError("ImageGrab is macOS and Windows only")
 
 
@@ -40,7 +37,7 @@ def grab(bbox=None, include_layered_windows=False, all_screens=False):
         if bbox:
             im = im.crop(bbox)
     else:
-        offset, size, data = grabber(include_layered_windows, all_screens)
+        offset, size, data = Image.core.grabscreen(include_layered_windows, all_screens)
         im = Image.frombytes(
             "RGB",
             size,

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -36,7 +36,10 @@ from __future__ import print_function
 
 import array
 import io
+import os
 import struct
+import subprocess
+import tempfile
 import warnings
 
 from . import Image, ImageFile, TiffImagePlugin
@@ -444,10 +447,6 @@ class JpegImageFile(ImageFile.ImageFile):
 
         # ALTERNATIVE: handle JPEGs via the IJG command line utilities
 
-        import subprocess
-        import tempfile
-        import os
-
         f, path = tempfile.mkstemp()
         os.close(f)
         if os.path.exists(self.filename):
@@ -772,9 +771,6 @@ def _save(im, fp, filename):
 
 def _save_cjpeg(im, fp, filename):
     # ALTERNATIVE: handle JPEGs via the IJG command line utilities.
-    import os
-    import subprocess
-
     tempfile = im._dump()
     subprocess.check_call(["cjpeg", "-outfile", filename, tempfile])
     try:


### PR DESCRIPTION
This better follows PEP 8 style guide:

https://www.python.org/dev/peps/pep-0008/#imports

> Imports are always put at the top of the file, just after any module
> comments and docstrings, and before module globals and constants.

This also avoids duplicate import code within the same file.