### PR TITLE
Updated ImageOps documentation

### DIFF
--- a/docs/reference/ImageOps.rst
+++ b/docs/reference/ImageOps.rst
@@ -8,13 +8,13 @@ The :py:mod:`ImageOps` module contains a number of ‘ready-made’ image
 processing operations. This module is somewhat experimental, and most operators
 only work on L and RGB images.
 
-Only bug fixes have been added since the Pillow fork.
-
 .. versionadded:: 1.1.3
 
 .. autofunction:: autocontrast
 .. autofunction:: colorize
+.. autofunction:: pad
 .. autofunction:: crop
+.. autofunction:: scale
 .. autofunction:: deform
 .. autofunction:: equalize
 .. autofunction:: expand
@@ -25,3 +25,4 @@ Only bug fixes have been added since the Pillow fork.
 .. autofunction:: mirror
 .. autofunction:: posterize
 .. autofunction:: solarize
+.. autofunction:: exif_transpose


### PR DESCRIPTION
* Add functions to the documentation
* 'Only bug fixes have been added since the Pillow fork.' - This is no longer true. There is at least #3687 and #3364, 