### PR TITLE
Copy info in Image.transform

### DIFF
--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -1,14 +1,12 @@
 import math
 
-from PIL import Image
+from PIL import Image, ImageTransform
 
 from .helper import PillowTestCase, hopper
 
 
 class TestImageTransform(PillowTestCase):
     def test_sanity(self):
-        from PIL import ImageTransform
-
         im = Image.new("L", (100, 100))
 
         seq = tuple(range(10))
@@ -21,6 +19,16 @@ class TestImageTransform(PillowTestCase):
         im.transform((100, 100), transform)
         transform = ImageTransform.MeshTransform([(seq[:4], seq[:8])])
         im.transform((100, 100), transform)
+
+    def test_info(self):
+        comment = b"File written by Adobe Photoshop\xa8 4.0"
+
+        im = Image.open("Tests/images/hopper.gif")
+        self.assertEqual(im.info["comment"], comment)
+
+        transform = ImageTransform.ExtentTransform((0, 0, 0, 0))
+        new_im = im.transform((100, 100), transform)
+        self.assertEqual(new_im.info["comment"], comment)
 
     def test_extent(self):
         im = hopper("RGB")

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2293,6 +2293,7 @@ class Image(object):
             raise ValueError("missing method data")
 
         im = new(self.mode, size, fillcolor)
+        im.info = self.info.copy()
         if method == MESH:
             # list of quads
             for box, quad in data:


### PR DESCRIPTION
```python
from PIL import Image
im = Image.open("Tests/images/hopper.gif")

print(im.rotate(180).info)  # {'version': b'GIF89a', 'background': 0, 'duration': 0, 'comment': b'File written by Adobe Photoshop\xa8 4.0'}
print(im.rotate(181).info)  # {}
```

This inconsistency is because for some angles, `rotate` will `copy` or `transpose` for the sake of efficiency

https://github.com/python-pillow/Pillow/blob/8c94f01842ba3f0c473e3279df2425c0683bffe2/src/PIL/Image.py#L1924-L1932

instead of its usual `transform`.

https://github.com/python-pillow/Pillow/blob/8c94f01842ba3f0c473e3279df2425c0683bffe2/src/PIL/Image.py#L2001

`transpose` uses `_new` to create the new image, while `transform` uses `new`.

This PR resolves the inconsistent behaviour by ensuring that `info` is copied into `transform` images.