### PR TITLE
CI: Stop testing Python 2.7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,13 +13,7 @@ environment:
   TEST_OPTIONS:
   DEPLOY: YES
   matrix:
-  - PYTHON: C:/vp/pypy2
-    EXECUTABLE: bin/pypy.exe
-    PIP_DIR: bin
-    VENV: YES
-  - PYTHON: C:/Python27-x64
   - PYTHON: C:/Python37
-  - PYTHON: C:/Python27
   - PYTHON: C:/Python37-x64
   - PYTHON: C:/Python36
   - PYTHON: C:/Python36-x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,11 @@ matrix:
     - python: "3.6"
       name: "Lint"
       env: LINT="true"
-    - python: "pypy"
-      name: "PyPy2 Xenial"
     - python: "pypy3"
       name: "PyPy3 Xenial"
     - python: '3.7'
       name: "3.7 Xenial"
       services: xvfb
-    - python: '2.7'
-      name: "2.7 Xenial"
     - python: '3.6'
       name: "3.6 Xenial PYTHONOPTIMIZE=1"
       env: PYTHONOPTIMIZE=1


### PR DESCRIPTION
For #3642 

Changes proposed in this pull request:

 * Whilst https://github.com/python-pillow/Pillow/pull/4109 is still in review, minimal changes to stop testing Python 2.7 and benefit immediately from CI time saved
 * Savings:
   * Travis CI: ~9 minutes
   * AppVeyor: ~16 minutes
