### PR TITLE
Upload image errors to GitHub Actions

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -349,6 +349,13 @@ jobs:
         %PYTHON%\python.exe -m pytest -vx --cov PIL --cov-report term --cov-report xml Tests
       shell: cmd
 
+    - name: Upload errors
+      uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: errors
+        path: Tests/errors
+
     - name: Upload coverage
       run: 'codecov --file "%GITHUB_WORKSPACE%\coverage.xml" --name "%pythonLocation%"'
       shell: cmd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,13 @@ jobs:
       run: |
         .travis/test.sh
 
+    - name: Upload errors
+      uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: errors
+        path: Tests/errors
+
     - name: Docs
       if: matrix.python-version == 3.8
       run: |

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -24,10 +24,24 @@ if os.environ.get("SHOW_ERRORS", None):
     HAS_UPLOADER = True
 
     class test_image_results:
-        @classmethod
-        def upload(self, a, b):
+        @staticmethod
+        def upload(a, b):
             a.show()
             b.show()
+
+
+elif "GITHUB_ACTIONS" in os.environ:
+    HAS_UPLOADER = True
+
+    class test_image_results:
+        @staticmethod
+        def upload(a, b):
+            dir_errors = os.path.join(os.path.dirname(__file__), "errors")
+            os.makedirs(dir_errors, exist_ok=True)
+            tmpdir = tempfile.mkdtemp(dir=dir_errors)
+            a.save(os.path.join(tmpdir, "a.png"))
+            b.save(os.path.join(tmpdir, "b.png"))
+            return tmpdir
 
 
 else:


### PR DESCRIPTION
As GitHub Actions allows direct artifact uploads, failed image comparisons can now be uploaded directly, instead of using an external server (unlike in #2862).

The failed comparisons are saved in a randomly named directory (from `tempfile.mdktemp`), which is then uploaded in an artifact named `errors.zip`.

Test Docker is not included in this, as this is a bit more complicated there.

Sample commit with failing test: https://github.com/nulano/Pillow/commit/165d457b67de4f4dcdc39880fa3439969376c62c
Test (Ubuntu and macOS): https://github.com/nulano/Pillow/runs/257598825
Test Windows: https://github.com/nulano/Pillow/runs/257598798