### PR TITLE
Test pypy3.6-v7.2.0 on Windows

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-  
+
     runs-on: windows-2016
     strategy:
       fail-fast: false
@@ -19,16 +19,15 @@ jobs:
             platform-vcvars: "x86_amd64"
             platform-msbuild: "x64"
           - python-version: "pypy3.6"
-            pypy-version: "pypy-c-jit-97588-7392d01b93d0-win32"
-            pypy-url: "http://buildbot.pypy.org/nightly/py3.6/pypy-c-jit-97588-7392d01b93d0-win32.zip"
-            # pypy-url: "https://bitbucket.org/pypy/pypy/downloads/${{ matrix.pypy-version }}.zip"
+            pypy-version: "pypy3.6-v7.2.0-win32"
+            pypy-url: "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.2.0-win32.zip"
         exclude:
           - python-version: "pypy3.6"
             architecture: "x64"
     timeout-minutes: 30
-    
+
     name: Python ${{ matrix.python-version }} ${{ matrix.architecture }}
-    
+
     steps:
     - uses: actions/checkout@v1
 
@@ -59,7 +58,7 @@ jobs:
       run: |
         "%pythonLocation%\python.exe" -m pip install wheel pytest pytest-cov
         pip install codecov
-    
+
     - name: Fetch dependencies
       run: |
         curl -fsSL -o nasm.zip https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win64/nasm-2.14.02-win64.zip
@@ -324,7 +323,7 @@ jobs:
         rem Add GhostScript and Raqm binaries (copied to INCLIB) to PATH.
         path %INCLIB%;%PATH%
         %PYTHON%\python.exe selftest.py --installed
-    
+
     - name: Test Pillow
       run: |
         set PYTHON=%pythonLocation%
@@ -333,7 +332,7 @@ jobs:
         path %INCLIB%;%PATH%
         cd /D %GITHUB_WORKSPACE%
         %PYTHON%\python.exe -m pytest -vx --cov PIL --cov-report term --cov-report xml Tests
-    
+
     - name: Upload coverage
       run: 'codecov --file "%GITHUB_WORKSPACE%\coverage.xml" --name "%pythonLocation%"'
 

--- a/winbuild/appveyor_install_pypy3.cmd
+++ b/winbuild/appveyor_install_pypy3.cmd
@@ -1,3 +1,3 @@
-curl -fsSL -o pypy3.zip http://buildbot.pypy.org/nightly/py3.6/pypy-c-jit-97588-7392d01b93d0-win32.zip
+curl -fsSL -o pypy3.zip https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.2.0-win32.zip
 7z x pypy3.zip -oc:\
-c:\Python37\Scripts\virtualenv.exe -p c:\pypy-c-jit-97588-7392d01b93d0-win32\pypy3.exe c:\vp\pypy3
+c:\Python37\Scripts\virtualenv.exe -p c:\pypy3.6-v7.2.0-win32\pypy3.exe c:\vp\pypy3


### PR DESCRIPTION
PyPy v7.2 has been released:

* https://morepypy.blogspot.com/2019/10/pypy-v72-released.html

Changes proposed in this pull request:

 * Replace nightly with 7.2 on AppVeyor and GitHub Actions
 * GHA: seems you can't refer to a matrix var whilst also defining a var so `pypy3.6-v7.2.0-win32` comes twice


