### PR TITLE
Fix Unicode support for PyPy

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -253,7 +253,6 @@ jobs:
 
     # for Raqm
     - name: Build dependencies / HarfBuzz
-      if: "!contains(matrix.python-version, 'pypy')"
       run: |
         set INCLUDE=C:\Program Files (x86)\Microsoft SDKs\Windows\V7.1A\Include
         set INCLIB=%GITHUB_WORKSPACE%\winbuild\depends\msvcr10-x32
@@ -274,7 +273,6 @@ jobs:
 
     # for Raqm
     - name: Build dependencies / FriBidi
-      if: "!contains(matrix.python-version, 'pypy')"
       run: |
         set INCLUDE=C:\Program Files (x86)\Microsoft SDKs\Windows\V7.1A\Include
         set INCLIB=%GITHUB_WORKSPACE%\winbuild\depends\msvcr10-x32
@@ -292,9 +290,7 @@ jobs:
         copy /Y /B *.lib %INCLIB%
       shell: cmd
 
-    # failing with PyPy3
     - name: Build dependencies / Raqm
-      if: "!contains(matrix.python-version, 'pypy')"
       run: |
         set INCLUDE=C:\Program Files (x86)\Microsoft SDKs\Windows\V7.1A\Include
         set INCLIB=%GITHUB_WORKSPACE%\winbuild\depends\msvcr10-x32

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -463,7 +463,7 @@ class TestImageFont(PillowTestCase):
         with self.assertRaises(UnicodeEncodeError):
             font.getsize("’")
 
-    @unittest.skipIf(is_pypy(), "requires CPython")
+    @unittest.skipIf(is_pypy(), "failing on PyPy")
     def test_unicode_extended(self):
         # issue #3777
         text = "A\u278A\U0001F12B"

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -326,24 +326,12 @@ getfont(PyObject* self_, PyObject* args, PyObject* kw)
 static int
 font_getchar(PyObject* string, int index, FT_ULong* char_out)
 {
-#if (defined(PYPY_VERSION_NUM))
-    if (PyUnicode_Check(string)) {
-        Py_UNICODE* p = PyUnicode_AS_UNICODE(string);
-        int size = PyUnicode_GET_SIZE(string);
-        if (index >= size)
-            return 0;
-        *char_out = p[index];
-        return 1;
-    }
-#else
     if (PyUnicode_Check(string)) {
         if (index >= PyUnicode_GET_LENGTH(string))
             return 0;
         *char_out = PyUnicode_READ_CHAR(string, index);
         return 1;
     }
-#endif
-
     return 0;
 }
 
@@ -363,7 +351,7 @@ text_layout_raqm(PyObject* string, FontObject* self, const char* dir, PyObject *
         goto failed;
     }
 
-#if (defined(PYPY_VERSION_NUM))
+#if (defined(PYPY_VERSION_NUM) && (PYPY_VERSION_NUM < 0x07020000))
     if (PyUnicode_Check(string)) {
         Py_UNICODE *text = PyUnicode_AS_UNICODE(string);
         Py_ssize_t size = PyUnicode_GET_SIZE(string);

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -380,7 +380,7 @@ text_layout_raqm(PyObject* string, FontObject* self, const char* dir, PyObject *
                and raqm fails with empty strings */
             goto failed;
         }
-        int set_text = (*p_raqm.set_text)(rq, (const uint32_t *)(text), size);
+        int set_text = (*p_raqm.set_text)(rq, text, size);
         PyMem_Free(text);
         if (!set_text) {
             PyErr_SetString(PyExc_ValueError, "raqm_set_text() failed");


### PR DESCRIPTION
Depends on #4109.

Reinstates #3780 changes reverted by #3935 for PyPy 7.2.0+.

This change also fixes Raqm support on PyPy (from https://github.com/python-pillow/Pillow/pull/4084#issuecomment-536663835).

There is a bug in PyPy that causes a failure of the test for #3777 when using Raqm, reported here: https://bitbucket.org/pypy/pypy/issues/3095/pyunicode_asucs4copy-fails-with-extended