### PR TITLE
Pillow 6.2.1 is the last to support Python 2.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,16 +20,16 @@ Changelog (Pillow)
 - Changed default frombuffer raw decoder args #1730
   [radarhere]
 
-6.2.1 (unreleased)
+6.2.1 (2019-10-20)
 ------------------
+
+- This is the last Pillow release to support Python 2.7 #3642
 
 - Add support for Python 3.8 #4141
   [hugovk]
 
 6.2.0 (2019-10-01)
 ------------------
-
-- This is the last Pillow release to support Python 2.7 #3642
 
 - Catch buffer overruns #4104
   [radarhere]

--- a/docs/releasenotes/6.2.0.rst
+++ b/docs/releasenotes/6.2.0.rst
@@ -62,14 +62,6 @@ shared instance of ``Image.Exif``.
 Deprecations
 ^^^^^^^^^^^^
 
-Python 2.7
-~~~~~~~~~~
-
-Python 2.7 reaches end-of-life on 2020-01-01.
-
-Pillow 7.0.0 will be released on 2020-01-01 and will drop support for Python
-2.7, making Pillow 6.2.x the last release series to support Python 2.
-
 Image.frombuffer
 ~~~~~~~~~~~~~~~~
 

--- a/docs/releasenotes/6.2.1.rst
+++ b/docs/releasenotes/6.2.1.rst
@@ -1,7 +1,26 @@
 6.2.1
 -----
 
+API Changes
+===========
+
+Deprecations
+^^^^^^^^^^^^
+
+Python 2.7
+~~~~~~~~~~
+
+Python 2.7 reaches end-of-life on 2020-01-01.
+
+Pillow 7.0.0 will be released on 2020-01-01 and will drop support for Python
+2.7, making Pillow 6.2.x the last release series to support Python 2.
+
+Other Changes
+=============
+
+
+
 Support added for Python 3.8
-============================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Pillow 6.2.1 supports Python 3.8.


### PR DESCRIPTION
For #4152.
