### PR TITLE
Fix segfault: do not destroy glyph while its bitmap is used

### DIFF
--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -791,7 +791,7 @@ font_render(FontObject* self, PyObject* args)
     int index, error, ascender, horizontal_dir;
     int load_flags;
     unsigned char *source;
-    FT_Glyph glyph = NULL;
+    FT_Glyph glyph;
     FT_GlyphSlot glyph_slot;
     FT_Bitmap bitmap;
     FT_BitmapGlyph bitmap_glyph;
@@ -951,9 +951,8 @@ font_render(FontObject* self, PyObject* args)
         }
         x += glyph_info[i].x_advance;
         y -= glyph_info[i].y_advance;
-        if (glyph != NULL) {
+        if (stroker != NULL) {
             FT_Done_Glyph(glyph);
-            glyph = NULL;
         }
     }
 

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -791,7 +791,7 @@ font_render(FontObject* self, PyObject* args)
     int index, error, ascender, horizontal_dir;
     int load_flags;
     unsigned char *source;
-    FT_Glyph glyph;
+    FT_Glyph glyph = NULL;
     FT_GlyphSlot glyph_slot;
     FT_Bitmap bitmap;
     FT_BitmapGlyph bitmap_glyph;
@@ -890,8 +890,6 @@ font_render(FontObject* self, PyObject* args)
 
             bitmap = bitmap_glyph->bitmap;
             left = bitmap_glyph->left;
-
-            FT_Done_Glyph(glyph);
         } else {
             bitmap = glyph_slot->bitmap;
             left = glyph_slot->bitmap_left;
@@ -953,6 +951,10 @@ font_render(FontObject* self, PyObject* args)
         }
         x += glyph_info[i].x_advance;
         y -= glyph_info[i].y_advance;
+        if (glyph != NULL) {
+            FT_Done_Glyph(glyph);
+            glyph = NULL;
+        }
     }
 
     FT_Stroker_Done(stroker);


### PR DESCRIPTION
Fix segfault in `_imagingft.font_render` during `TestImageDraw::test_stroke`.

Fixes #4156 .

Changes proposed in this pull request:

Do not destroy glyph while its bitmap is used.
