### PR TITLE
Replaced macOS Command Line Tools install with miniconda path

### DIFF
--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
-
 brew install libtiff libjpeg webp little-cms2
 
 PYTHONOPTIMIZE=0 pip install cffi

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -3,5 +3,8 @@
 set -e
 
 coverage erase
+if [ $(uname) == "Darwin" ]; then
+    export CPPFLAGS="-I/usr/local/miniconda/include";
+fi
 make clean
 make install-coverage


### PR DESCRIPTION
Suggestion to resolve #4166