### PR TITLE
Fix mismatched function name, add explanation

### DIFF
--- a/src/PIL/JpegPresets.py
+++ b/src/PIL/JpegPresets.py
@@ -33,7 +33,10 @@ Possible subsampling values are 0, 1 and 2 that correspond to 4:4:4, 4:2:2 and
 4:2:0.
 
 You can get the subsampling of a JPEG with the
-`JpegImagePlugin.get_subsampling(im)` function.
+`JpegImagePlugin.get_sampling(im)` function.
+
+In JPEG compressed data a JPEG marker is used instead of an EXIF tag.
+(ref.: https://www.exiv2.org/tags.html)
 
 
 Quantization tables


### PR DESCRIPTION
Mention why this information is not available in the EXIF tag specified for this purpose.

Changes proposed in this pull request:

 * Fix mismatched function name
 * Add explanation why current subsampling value is not set to the EXIF tag for this purpose.