### PR TITLE
Use pillow-depends on HTTPError

### DIFF
--- a/winbuild/build_dep.py
+++ b/winbuild/build_dep.py
@@ -45,9 +45,7 @@ def extract(src, dest):
 
 def extract_libs():
     for name, lib in libs.items():
-        filename = lib["filename"]
-        if not os.path.exists(filename):
-            filename = fetch(lib["url"])
+        filename = fetch(lib["url"])
         if name == "openjpeg":
             for compiler in all_compilers():
                 if not os.path.exists(

--- a/winbuild/config.py
+++ b/winbuild/config.py
@@ -28,96 +28,95 @@ libs = {
     # },
     "zlib": {
         "url": "http://zlib.net/zlib1211.zip",
-        "filename": PILLOW_DEPENDS_DIR + "zlib1211.zip",
+        "filename": "zlib1211.zip",
         "dir": "zlib-1.2.11",
     },
     "jpeg": {
         "url": "http://www.ijg.org/files/jpegsr9c.zip",
-        "filename": PILLOW_DEPENDS_DIR + "jpegsr9c.zip",
+        "filename": "jpegsr9c.zip",
         "dir": "jpeg-9c",
     },
     "tiff": {
         "url": "ftp://download.osgeo.org/libtiff/tiff-4.0.10.tar.gz",
-        "filename": PILLOW_DEPENDS_DIR + "tiff-4.0.10.tar.gz",
+        "filename": "tiff-4.0.10.tar.gz",
         "dir": "tiff-4.0.10",
     },
     "freetype": {
         "url": "https://download.savannah.gnu.org/releases/freetype/freetype-2.10.1.tar.gz",  # noqa: E501
-        "filename": PILLOW_DEPENDS_DIR + "freetype-2.10.1.tar.gz",
+        "filename": "freetype-2.10.1.tar.gz",
         "dir": "freetype-2.10.1",
     },
     "lcms-2.7": {
         "url": SF_MIRROR + "/project/lcms/lcms/2.7/lcms2-2.7.zip",
-        "filename": PILLOW_DEPENDS_DIR + "lcms2-2.7.zip",
+        "filename": "lcms2-2.7.zip",
         "dir": "lcms2-2.7",
     },
     "lcms-2.8": {
         "url": SF_MIRROR + "/project/lcms/lcms/2.8/lcms2-2.8.zip",
-        "filename": PILLOW_DEPENDS_DIR + "lcms2-2.8.zip",
+        "filename": "lcms2-2.8.zip",
         "dir": "lcms2-2.8",
     },
     "ghostscript": {
         "url": "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs927/ghostscript-9.27.tar.gz",  # noqa: E501
-        "filename": PILLOW_DEPENDS_DIR + "ghostscript-9.27.tar.gz",
+        "filename": "ghostscript-9.27.tar.gz",
         "dir": "ghostscript-9.27",
     },
     "tcl-8.5": {
         "url": SF_MIRROR + "/project/tcl/Tcl/8.5.19/tcl8519-src.zip",
-        "filename": PILLOW_DEPENDS_DIR + "tcl8519-src.zip",
+        "filename": "tcl8519-src.zip",
         "dir": "",
     },
     "tk-8.5": {
         "url": SF_MIRROR + "/project/tcl/Tcl/8.5.19/tk8519-src.zip",
-        "filename": PILLOW_DEPENDS_DIR + "tk8519-src.zip",
+        "filename": "tk8519-src.zip",
         "dir": "",
         "version": "8.5.19",
     },
     "tcl-8.6": {
         "url": SF_MIRROR + "/project/tcl/Tcl/8.6.9/tcl869-src.zip",
-        "filename": PILLOW_DEPENDS_DIR + "tcl869-src.zip",
+        "filename": "tcl869-src.zip",
         "dir": "",
     },
     "tk-8.6": {
         "url": SF_MIRROR + "/project/tcl/Tcl/8.6.9/tk869-src.zip",
-        "filename": PILLOW_DEPENDS_DIR + "tk869-src.zip",
+        "filename": "tk869-src.zip",
         "dir": "",
         "version": "8.6.9",
     },
     "webp": {
         "url": "http://downloads.webmproject.org/releases/webp/libwebp-1.0.3.tar.gz",
-        "filename": PILLOW_DEPENDS_DIR + "libwebp-1.0.3.tar.gz",
+        "filename": "libwebp-1.0.3.tar.gz",
         "dir": "libwebp-1.0.3",
     },
     "openjpeg": {
         "url": "https://github.com/uclouvain/openjpeg/archive/v2.3.1.tar.gz",
-        "filename": PILLOW_DEPENDS_DIR + "openjpeg-2.3.1.tar.gz",
+        "filename": "openjpeg-2.3.1.tar.gz",
         "dir": "openjpeg-2.3.1",
     },
     "jpeg-turbo": {
         "url": SF_MIRROR + "/project/libjpeg-turbo/2.0.3/libjpeg-turbo-2.0.3.tar.gz",
-        "filename": PILLOW_DEPENDS_DIR + "libjpeg-turbo-2.0.3.tar.gz",
+        "filename": "libjpeg-turbo-2.0.3.tar.gz",
         "dir": "libjpeg-turbo-2.0.3",
     },
     # ba653c8: Merge tag '2.12.5' into msvc
     "imagequant": {
         "url": "https://github.com/ImageOptim/libimagequant/archive/ba653c8ccb34dde4e21c6076d85a72d21ed9d971.zip",  # noqa: E501
-        "filename": PILLOW_DEPENDS_DIR
-        + "libimagequant-ba653c8ccb34dde4e21c6076d85a72d21ed9d971.zip",
+        "filename": "libimagequant-ba653c8ccb34dde4e21c6076d85a72d21ed9d971.zip",
         "dir": "libimagequant-ba653c8ccb34dde4e21c6076d85a72d21ed9d971",
     },
     "harfbuzz": {
         "url": "https://github.com/harfbuzz/harfbuzz/archive/2.6.1.zip",
-        "filename": PILLOW_DEPENDS_DIR + "harfbuzz-2.6.1.zip",
+        "filename": "harfbuzz-2.6.1.zip",
         "dir": "harfbuzz-2.6.1",
     },
     "fribidi": {
         "url": "https://github.com/fribidi/fribidi/archive/v1.0.7.zip",
-        "filename": PILLOW_DEPENDS_DIR + "fribidi-1.0.7.zip",
+        "filename": "fribidi-1.0.7.zip",
         "dir": "fribidi-1.0.7",
     },
     "libraqm": {
         "url": "https://github.com/HOST-Oman/libraqm/archive/v0.7.0.zip",
-        "filename": PILLOW_DEPENDS_DIR + "libraqm-0.7.0.zip",
+        "filename": "libraqm-0.7.0.zip",
         "dir": "libraqm-0.7.0",
     },
 }

--- a/winbuild/fetch.py
+++ b/winbuild/fetch.py
@@ -3,16 +3,37 @@ import sys
 import urllib.parse
 import urllib.request
 
+from config import libs
+
 
 def fetch(url):
+    depends_filename = None
+    for lib in libs.values():
+        if lib["url"] == url:
+            depends_filename = lib["filename"]
+            break
+    if depends_filename and os.path.exists(depends_filename):
+        return depends_filename
     name = urllib.parse.urlsplit(url)[2].split("/")[-1]
 
     if not os.path.exists(name):
-        print("Fetching", url)
+
+        def retrieve(request_url):
+            print("Fetching", request_url)
+            try:
+                return urllib.request.urlopen(request_url)
+            except urllib.error.URLError:
+                return urllib.request.urlopen(request_url)
+
         try:
-            r = urllib.request.urlopen(url)
-        except urllib.error.URLError:
-            r = urllib.request.urlopen(url)
+            r = retrieve(url)
+        except urllib.error.HTTPError:
+            if depends_filename:
+                r = retrieve(
+                    "https://github.com/python-pillow/pillow-depends/raw/master/"
+                    + depends_filename
+                )
+                name = depends_filename
         content = r.read()
         with open(name, "wb") as fd:
             fd.write(content)


### PR DESCRIPTION
#4127 attempts to solve the problem of retrieving a dependency blocked by a lack of User-Agent by adding a User-Agent.

This PR instead retrieves the file from pillow-depends on User Agent failure.