### PR TITLE
Better error messaging in PIL.Image.fromarray

### DIFF
--- a/Tests/test_image_array.py
+++ b/Tests/test_image_array.py
@@ -52,3 +52,8 @@ class TestImageArray(PillowTestCase):
         self.assertEqual(test("RGB"), ("RGB", (128, 100), True))
         self.assertEqual(test("RGBA"), ("RGBA", (128, 100), True))
         self.assertEqual(test("RGBX"), ("RGBA", (128, 100), True))
+
+        # Test mode is None with no "typestr" in the array interface
+        with self.assertRaises(TypeError):
+            wrapped = Wrapper(test("L"), {"shape": (100, 128)})
+            Image.fromarray(wrapped)

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2631,6 +2631,9 @@ def fromarray(obj, mode=None):
     if mode is None:
         try:
             typekey = (1, 1) + shape[2:], arr["typestr"]
+        except KeyError:
+            raise TypeError("Cannot handle this data type")
+        try:
             mode, rawmode = _fromarray_typemap[typekey]
         except KeyError:
             raise TypeError("Cannot handle this data type: %s, %s" % typekey)

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2633,7 +2633,7 @@ def fromarray(obj, mode=None):
             typekey = (1, 1) + shape[2:], arr["typestr"]
             mode, rawmode = _fromarray_typemap[typekey]
         except KeyError:
-            raise TypeError("Cannot handle this data type")
+            raise TypeError("Cannot handle this data type: %s, %s" % typekey)
     else:
         rawmode = mode
     if mode in ["1", "L", "I", "P", "F"]:


### PR DESCRIPTION
Changes proposed in this pull request:
 * Add the type of data that fromarray cannot handle to the error message.
