### PR TITLE
Added UnidentifiedImageError

### DIFF
--- a/Tests/test_file_gd.py
+++ b/Tests/test_file_gd.py
@@ -1,4 +1,4 @@
-from PIL import GdImageFile
+from PIL import GdImageFile, UnidentifiedImageError
 
 from .helper import PillowTestCase
 
@@ -17,4 +17,4 @@ class TestFileGd(PillowTestCase):
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
 
-        self.assertRaises(IOError, GdImageFile.open, invalid_file)
+        self.assertRaises(UnidentifiedImageError, GdImageFile.open, invalid_file)

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import tempfile
 
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 from PIL._util import py3
 
 from .helper import PillowTestCase, hopper, is_win32, unittest
@@ -48,6 +48,9 @@ class TestImage(PillowTestCase):
                 Image.new(mode, (1, 1))
             self.assertEqual(str(e.exception), "unrecognized image mode")
 
+    def test_exception_inheritance(self):
+        self.assertTrue(issubclass(UnidentifiedImageError, IOError))
+
     def test_sanity(self):
 
         im = Image.new("L", (100, 100))
@@ -88,7 +91,7 @@ class TestImage(PillowTestCase):
             import StringIO
 
             im = StringIO.StringIO("")
-        self.assertRaises(IOError, Image.open, im)
+        self.assertRaises(UnidentifiedImageError, Image.open, im)
 
     def test_bad_mode(self):
         self.assertRaises(ValueError, Image.open, "filename", "bad mode")

--- a/docs/releasenotes/7.0.0.rst
+++ b/docs/releasenotes/7.0.0.rst
@@ -66,8 +66,8 @@ API Additions
 Custom unidentified image error
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Pillow will now throw a custom UnidentifiedImageError when an image cannot be
-identified. For backwards compatibility, this will inherit from IOError.
+Pillow will now throw a custom ``UnidentifiedImageError`` when an image cannot be
+identified. For backwards compatibility, this will inherit from ``IOError``.
 
 Other Changes
 =============

--- a/docs/releasenotes/7.0.0.rst
+++ b/docs/releasenotes/7.0.0.rst
@@ -63,11 +63,11 @@ TODO
 API Additions
 =============
 
-TODO
-^^^^
+Custom unidentified image error
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-TODO
-
+Pillow will now throw a custom UnidentifiedImageError when an image cannot be
+identified. For backwards compatibility, this will inherit from IOError.
 
 Other Changes
 =============

--- a/src/PIL/GdImageFile.py
+++ b/src/PIL/GdImageFile.py
@@ -23,7 +23,7 @@
 # purposes only.
 
 
-from . import ImageFile, ImagePalette
+from . import ImageFile, ImagePalette, UnidentifiedImageError
 from ._binary import i8, i16be as i16, i32be as i32
 
 ##
@@ -82,4 +82,4 @@ def open(fp, mode="r"):
     try:
         return GdImageFile(fp)
     except SyntaxError:
-        raise IOError("cannot identify this image file")
+        raise UnidentifiedImageError("cannot identify this image file")

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -38,7 +38,7 @@ import warnings
 # VERSION was removed in Pillow 6.0.0.
 # PILLOW_VERSION was removed in Pillow 7.0.0.
 # Use __version__ instead.
-from . import ImageMode, TiffTags, __version__, _plugins
+from . import ImageMode, TiffTags, UnidentifiedImageError, __version__, _plugins
 from ._binary import i8, i32le
 from ._util import deferred_error, isPath, isStringType, py3
 
@@ -2794,7 +2794,9 @@ def open(fp, mode="r"):
         fp.close()
     for message in accept_warnings:
         warnings.warn(message)
-    raise IOError("cannot identify image file %r" % (filename if filename else fp))
+    raise UnidentifiedImageError(
+        "cannot identify image file %r" % (filename if filename else fp)
+    )
 
 
 #

--- a/src/PIL/__init__.py
+++ b/src/PIL/__init__.py
@@ -70,3 +70,7 @@ _plugins = [
     "XpmImagePlugin",
     "XVThumbImagePlugin",
 ]
+
+
+class UnidentifiedImageError(IOError):
+    pass


### PR DESCRIPTION
Resolves #3892

See how this goes. Pillow 7.0.0 seems like a good time for such changes.

As suggested there, this is a custom error, that inherits from the previous type for backwards compatibility.

See also the related issues #1643 and #2339