### PR TITLE
Ignore UserWarning in TestFileTiff::test_string_dimension

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import warnings
 from io import BytesIO
 
 from PIL import Image, TiffImagePlugin
@@ -578,7 +579,11 @@ class TestFileTiff(PillowTestCase):
     def test_string_dimension(self):
         # Assert that an error is raised if one of the dimensions is a string
         with self.assertRaises(ValueError):
-            Image.open("Tests/images/string_dimension.tiff")
+            # Ignore this UserWarning which triggers for four tags:
+            # "Possibly corrupt EXIF data.  Expecting to read 50404352 bytes but..."
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=UserWarning)
+                Image.open("Tests/images/string_dimension.tiff")
 
 
 @unittest.skipUnless(is_win32(), "Windows only")


### PR DESCRIPTION
We should pay attention to and fix warnings in tests. Sometimes we will get deprecation warnings that we need to fix in our code, they shouldn't be lost in a haystack.

There's 5 warnings in the pytest summary, 4 of which are a `UserWarning` in a single test, like:

```
UserWarning: Possibly corrupt EXIF data.  Expecting to read 8587444226 bytes but only got 481. Skipping tag 63749
```

Let's either fix the test file, or ignore this specific warning, it's not relevant to this particular test.


# Before

```
/home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/Pillow-7.0.0.dev0-py3.8-linux-x86_64.egg/PIL/_imaging.py:3
  /home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/Pillow-7.0.0.dev0-py3.8-linux-x86_64.egg/PIL/_imaging.py:3: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
Tests/test_file_tiff.py::TestFileTiff::test_string_dimension
  /home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/Pillow-7.0.0.dev0-py3.8-linux-x86_64.egg/PIL/TiffImagePlugin.py:781: UserWarning: Possibly corrupt EXIF data.  Expecting to read 8587444226 bytes but only got 481. Skipping tag 63749
Tests/test_file_tiff.py::TestFileTiff::test_string_dimension
  /home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/Pillow-7.0.0.dev0-py3.8-linux-x86_64.egg/PIL/TiffImagePlugin.py:781: UserWarning: Possibly corrupt EXIF data.  Expecting to read 8589934082 bytes but only got 0. Skipping tag 278
Tests/test_file_tiff.py::TestFileTiff::test_string_dimension
  /home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/Pillow-7.0.0.dev0-py3.8-linux-x86_64.egg/PIL/TiffImagePlugin.py:781: UserWarning: Possibly corrupt EXIF data.  Expecting to read 83958528 bytes but only got 227. Skipping tag 34304
Tests/test_file_tiff.py::TestFileTiff::test_string_dimension
  /home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/Pillow-7.0.0.dev0-py3.8-linux-x86_64.egg/PIL/TiffImagePlugin.py:781: UserWarning: Possibly corrupt EXIF data.  Expecting to read 50404352 bytes but only got 227. Skipping tag 36352
-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

https://travis-ci.org/python-pillow/Pillow/jobs/605927378#L4156

# After

```
=============================== warnings summary ===============================
/home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/Pillow-7.0.0.dev0-py3.8-linux-x86_64.egg/PIL/_imaging.py:3
  /home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/Pillow-7.0.0.dev0-py3.8-linux-x86_64.egg/PIL/_imaging.py:3: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

https://travis-ci.org/hugovk/Pillow/jobs/605922603#L4052

---

