### PR TITLE
Report details about Pillow when running tests

### DIFF
--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -1,0 +1,40 @@
+def pytest_report_header(config):
+    import os
+
+    report = []
+
+    def append(*args):
+        report.append(" ".join(args))
+
+    try:
+        from PIL import Image, features
+
+        append("-" * 68)
+        append("Pillow", Image.__version__)
+        append("-" * 68)
+        append("Python modules loaded from", os.path.dirname(Image.__file__))
+        append("Binary modules loaded from", os.path.dirname(Image.core.__file__))
+        append("-" * 68)
+        for name, feature in [
+            ("pil", "PIL CORE"),
+            ("tkinter", "TKINTER"),
+            ("freetype2", "FREETYPE2"),
+            ("littlecms2", "LITTLECMS2"),
+            ("webp", "WEBP"),
+            ("transp_webp", "WEBP Transparency"),
+            ("webp_mux", "WEBPMUX"),
+            ("webp_anim", "WEBP Animation"),
+            ("jpg", "JPEG"),
+            ("jpg_2000", "OPENJPEG (JPEG2000)"),
+            ("zlib", "ZLIB (PNG/ZIP)"),
+            ("libtiff", "LIBTIFF"),
+            ("raqm", "RAQM (Bidirectional Text)"),
+        ]:
+            if features.check(name):
+                append("---", feature, "support ok")
+            else:
+                append("***", feature, "support not installed")
+        append("-" * 68)
+    except Exception as e:
+        return "pytest_report_header failed: %s" % str(e)
+    return "\n".join(report)

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -1,40 +1,11 @@
 def pytest_report_header(config):
-    import os
-
-    report = []
-
-    def append(*args):
-        report.append(" ".join(args))
+    import io
 
     try:
-        from PIL import Image, features
+        from PIL import features
 
-        append("-" * 68)
-        append("Pillow", Image.__version__)
-        append("-" * 68)
-        append("Python modules loaded from", os.path.dirname(Image.__file__))
-        append("Binary modules loaded from", os.path.dirname(Image.core.__file__))
-        append("-" * 68)
-        for name, feature in [
-            ("pil", "PIL CORE"),
-            ("tkinter", "TKINTER"),
-            ("freetype2", "FREETYPE2"),
-            ("littlecms2", "LITTLECMS2"),
-            ("webp", "WEBP"),
-            ("transp_webp", "WEBP Transparency"),
-            ("webp_mux", "WEBPMUX"),
-            ("webp_anim", "WEBP Animation"),
-            ("jpg", "JPEG"),
-            ("jpg_2000", "OPENJPEG (JPEG2000)"),
-            ("zlib", "ZLIB (PNG/ZIP)"),
-            ("libtiff", "LIBTIFF"),
-            ("raqm", "RAQM (Bidirectional Text)"),
-        ]:
-            if features.check(name):
-                append("---", feature, "support ok")
-            else:
-                append("***", feature, "support not installed")
-        append("-" * 68)
+        with io.StringIO() as out:
+            features.pilinfo(out=out, supported_formats=False)
+            return out.getvalue()
     except Exception as e:
         return "pytest_report_header failed: %s" % str(e)
-    return "\n".join(report)


### PR DESCRIPTION
This change will print version, installation directory, and features of the Pillow installation being tested. I found this helpful when building and testing Pillow locally. For example:
```
> py -3.8 -m pytest Tests
================================================================= test session starts ==================================================================
platform win32 -- Python 3.8.0, pytest-5.2.2, py-1.8.0, pluggy-0.13.0
--------------------------------------------------------------------
Pillow 6.2.1
--------------------------------------------------------------------
Python modules loaded from X:\Python38\lib\site-packages\PIL
Binary modules loaded from X:\Python38\lib\site-packages\PIL
--------------------------------------------------------------------
--- PIL CORE support ok
--- TKINTER support ok
--- FREETYPE2 support ok
--- LITTLECMS2 support ok
--- WEBP support ok
--- WEBP Transparency support ok
--- WEBPMUX support ok
--- WEBP Animation support ok
--- JPEG support ok
--- OPENJPEG (JPEG2000) support ok
--- ZLIB (PNG/ZIP) support ok
--- LIBTIFF support ok
--- RAQM (Bidirectional Text) support ok
--------------------------------------------------------------------
rootdir: D:\Build\Pillow\Pillow.git, inifile: setup.cfg
plugins: hypothesis-4.41.3, palladium-1.2.2, cov-2.8.1, forked-1.1.3, xdist-1.30.0
collected 1393 items

Tests\test_000_sanity.py .                                                                                                                        [  0%]
<snip>
```
