### PR TITLE
Ignore UserWarnings in TestFileTiff::test_string_dimension

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -2,6 +2,7 @@ import logging
 import os
 from io import BytesIO
 
+import pytest
 from PIL import Image, TiffImagePlugin
 from PIL._util import py3
 from PIL.TiffImagePlugin import RESOLUTION_UNIT, X_RESOLUTION, Y_RESOLUTION
@@ -594,6 +595,9 @@ class TestFileTiff(PillowTestCase):
             im.load()
             self.assertFalse(fp.closed)
 
+    # Ignore this UserWarning which triggers for four tags:
+    # "Possibly corrupt EXIF data.  Expecting to read 50404352 bytes but..."
+    @pytest.mark.filterwarnings("ignore:Possibly corrupt EXIF data")
     def test_string_dimension(self):
         # Assert that an error is raised if one of the dimensions is a string
         with self.assertRaises(ValueError):


### PR DESCRIPTION
For consideration, here's an alternative way to accomplish #4184

See https://docs.pytest.org/en/latest/warnings.html#pytest-mark-filterwarnings for documentation.