### PR TITLE
GHA: Test Python 3.8 on Linux/macOS

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.8"]
 
     name: Python ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,10 @@ jobs:
         ]
         python-version: [
           "pypy3",
+          "3.8",
           "3.7",
-          "3.5",
           "3.6",
+          "3.5",
         ]
         include:
         - python-version: "3.5"
@@ -53,7 +54,7 @@ jobs:
         .travis/test.sh
 
     - name: Docs
-      if: matrix.python-version == 3.7
+      if: matrix.python-version == 3.8
       run: |
         pip install sphinx-rtd-theme
         make doccheck


### PR DESCRIPTION
Python 3.8 is finally available on GitHub Actions, 21 days after release.

(Travis CI was available 21 hours after release.)
