### PR TITLE
Remove deprecated __version__ from plugins

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -22,31 +22,6 @@ Python 2.7 reaches end-of-life on 2020-01-01.
 Pillow 7.0.0 will be released on 2020-01-01 and will drop support for Python 2.7, making
 Pillow 6.x the last series to support Python 2.
 
-PIL.*ImagePlugin.__version__ attributes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. deprecated:: 6.0.0
-
-The version constants of individual plugins have been deprecated and will be removed in
-a future version. Use ``PIL.__version__`` instead.
-
-===============================  =================================  ==================================
-Deprecated                       Deprecated                         Deprecated
-===============================  =================================  ==================================
-``BmpImagePlugin.__version__``   ``Jpeg2KImagePlugin.__version__``  ``PngImagePlugin.__version__``
-``CurImagePlugin.__version__``   ``JpegImagePlugin.__version__``    ``PpmImagePlugin.__version__``
-``DcxImagePlugin.__version__``   ``McIdasImagePlugin.__version__``  ``PsdImagePlugin.__version__``
-``EpsImagePlugin.__version__``   ``MicImagePlugin.__version__``     ``SgiImagePlugin.__version__``
-``FliImagePlugin.__version__``   ``MpegImagePlugin.__version__``    ``SunImagePlugin.__version__``
-``FpxImagePlugin.__version__``   ``MpoImagePlugin.__version__``     ``TgaImagePlugin.__version__``
-``GdImageFile.__version__``      ``MspImagePlugin.__version__``     ``TiffImagePlugin.__version__``
-``GifImagePlugin.__version__``   ``PalmImagePlugin.__version__``    ``WmfImagePlugin.__version__``
-``IcoImagePlugin.__version__``   ``PcdImagePlugin.__version__``     ``XbmImagePlugin.__version__``
-``ImImagePlugin.__version__``    ``PcxImagePlugin.__version__``     ``XpmImagePlugin.__version__``
-``ImtImagePlugin.__version__``   ``PdfImagePlugin.__version__``     ``XVThumbImagePlugin.__version__``
-``IptcImagePlugin.__version__``  ``PixarImagePlugin.__version__``
-===============================  =================================  ==================================
-
 ImageCms.CmsProfile attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -102,6 +77,31 @@ PILLOW_VERSION constant
 *Removed in version 7.0.0.*
 
 ``PILLOW_VERSION`` has been removed. Use ``__version__`` instead.
+
+PIL.*ImagePlugin.__version__ attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+*Removed in version 7.0.0.*
+
+The version constants of individual plugins have been removed. Use ``PIL.__version__``
+instead.
+
+===============================  =================================  ==================================
+Deprecated                       Deprecated                         Deprecated
+===============================  =================================  ==================================
+``BmpImagePlugin.__version__``   ``Jpeg2KImagePlugin.__version__``  ``PngImagePlugin.__version__``
+``CurImagePlugin.__version__``   ``JpegImagePlugin.__version__``    ``PpmImagePlugin.__version__``
+``DcxImagePlugin.__version__``   ``McIdasImagePlugin.__version__``  ``PsdImagePlugin.__version__``
+``EpsImagePlugin.__version__``   ``MicImagePlugin.__version__``     ``SgiImagePlugin.__version__``
+``FliImagePlugin.__version__``   ``MpegImagePlugin.__version__``    ``SunImagePlugin.__version__``
+``FpxImagePlugin.__version__``   ``MpoImagePlugin.__version__``     ``TgaImagePlugin.__version__``
+``GdImageFile.__version__``      ``MspImagePlugin.__version__``     ``TiffImagePlugin.__version__``
+``GifImagePlugin.__version__``   ``PalmImagePlugin.__version__``    ``WmfImagePlugin.__version__``
+``IcoImagePlugin.__version__``   ``PcdImagePlugin.__version__``     ``XbmImagePlugin.__version__``
+``ImImagePlugin.__version__``    ``PcxImagePlugin.__version__``     ``XpmImagePlugin.__version__``
+``ImtImagePlugin.__version__``   ``PdfImagePlugin.__version__``     ``XVThumbImagePlugin.__version__``
+``IptcImagePlugin.__version__``  ``PixarImagePlugin.__version__``
+===============================  =================================  ==================================
 
 PyQt4 and PySide
 ~~~~~~~~~~~~~~~~

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -87,7 +87,7 @@ The version constants of individual plugins have been removed. Use ``PIL.__versi
 instead.
 
 ===============================  =================================  ==================================
-Deprecated                       Deprecated                         Deprecated
+Removed                          Removed                            Removed
 ===============================  =================================  ==================================
 ``BmpImagePlugin.__version__``   ``Jpeg2KImagePlugin.__version__``  ``PngImagePlugin.__version__``
 ``CurImagePlugin.__version__``   ``JpegImagePlugin.__version__``    ``PpmImagePlugin.__version__``

--- a/docs/releasenotes/7.0.0.rst
+++ b/docs/releasenotes/7.0.0.rst
@@ -9,6 +9,29 @@ PILLOW_VERSION constant
 
 ``PILLOW_VERSION`` has been removed. Use ``__version__`` instead.
 
+PIL.*ImagePlugin.__version__ attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The version constants of individual plugins have been removed. Use ``PIL.__version__``
+instead.
+
+===============================  =================================  ==================================
+Removed                          Removed                            Removed
+===============================  =================================  ==================================
+``BmpImagePlugin.__version__``   ``Jpeg2KImagePlugin.__version__``  ``PngImagePlugin.__version__``
+``CurImagePlugin.__version__``   ``JpegImagePlugin.__version__``    ``PpmImagePlugin.__version__``
+``DcxImagePlugin.__version__``   ``McIdasImagePlugin.__version__``  ``PsdImagePlugin.__version__``
+``EpsImagePlugin.__version__``   ``MicImagePlugin.__version__``     ``SgiImagePlugin.__version__``
+``FliImagePlugin.__version__``   ``MpegImagePlugin.__version__``    ``SunImagePlugin.__version__``
+``FpxImagePlugin.__version__``   ``MpoImagePlugin.__version__``     ``TgaImagePlugin.__version__``
+``GdImageFile.__version__``      ``MspImagePlugin.__version__``     ``TiffImagePlugin.__version__``
+``GifImagePlugin.__version__``   ``PalmImagePlugin.__version__``    ``WmfImagePlugin.__version__``
+``IcoImagePlugin.__version__``   ``PcdImagePlugin.__version__``     ``XbmImagePlugin.__version__``
+``ImImagePlugin.__version__``    ``PcxImagePlugin.__version__``     ``XpmImagePlugin.__version__``
+``ImtImagePlugin.__version__``   ``PdfImagePlugin.__version__``     ``XVThumbImagePlugin.__version__``
+``IptcImagePlugin.__version__``  ``PixarImagePlugin.__version__``
+===============================  =================================  ==================================
+
 PyQt4 and PySide
 ^^^^^^^^^^^^^^^^
 

--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -27,10 +27,6 @@
 from . import Image, ImageFile, ImagePalette
 from ._binary import i8, i16le as i16, i32le as i32, o8, o16le as o16, o32le as o32
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.7"
-
 #
 # --------------------------------------------------------------------
 # Read BMP file

--- a/src/PIL/CurImagePlugin.py
+++ b/src/PIL/CurImagePlugin.py
@@ -21,10 +21,6 @@ from __future__ import print_function
 from . import BmpImagePlugin, Image
 from ._binary import i8, i16le as i16, i32le as i32
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.1"
-
 #
 # --------------------------------------------------------------------
 

--- a/src/PIL/DcxImagePlugin.py
+++ b/src/PIL/DcxImagePlugin.py
@@ -25,10 +25,6 @@ from . import Image
 from ._binary import i32le as i32
 from .PcxImagePlugin import PcxImageFile
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.2"
-
 MAGIC = 0x3ADE68B1  # QUIZ: what's this value, then?
 
 

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -30,10 +30,6 @@ import tempfile
 from . import Image, ImageFile
 from ._binary import i32le as i32
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.5"
-
 #
 # --------------------------------------------------------------------
 

--- a/src/PIL/FliImagePlugin.py
+++ b/src/PIL/FliImagePlugin.py
@@ -19,11 +19,6 @@
 from . import Image, ImageFile, ImagePalette
 from ._binary import i8, i16le as i16, i32le as i32, o8
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.2"
-
-
 #
 # decoder
 

--- a/src/PIL/FpxImagePlugin.py
+++ b/src/PIL/FpxImagePlugin.py
@@ -22,10 +22,6 @@ import olefile
 from . import Image, ImageFile
 from ._binary import i8, i32le as i32
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.1"
-
 # we map from colour field tuples to (mode, rawmode) descriptors
 MODES = {
     # opacity

--- a/src/PIL/GdImageFile.py
+++ b/src/PIL/GdImageFile.py
@@ -26,11 +26,6 @@
 from . import ImageFile, ImagePalette
 from ._binary import i8, i16be as i16, i32be as i32
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.1"
-
-
 ##
 # Image plugin for the GD uncompressed format.  Note that this format
 # is not supported by the standard <b>Image.open</b> function.  To use

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -31,11 +31,6 @@ import subprocess
 from . import Image, ImageChops, ImageFile, ImagePalette, ImageSequence
 from ._binary import i8, i16le as i16, o8, o16le as o16
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.9"
-
-
 # --------------------------------------------------------------------
 # Identify/read GIF files
 

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -30,10 +30,6 @@ from math import ceil, log
 from . import BmpImagePlugin, Image, ImageFile, PngImagePlugin
 from ._binary import i8, i16le as i16, i32le as i32
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.1"
-
 #
 # --------------------------------------------------------------------
 

--- a/src/PIL/ImImagePlugin.py
+++ b/src/PIL/ImImagePlugin.py
@@ -31,11 +31,6 @@ import re
 from . import Image, ImageFile, ImagePalette
 from ._binary import i8
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.7"
-
-
 # --------------------------------------------------------------------
 # Standard tags
 

--- a/src/PIL/ImtImagePlugin.py
+++ b/src/PIL/ImtImagePlugin.py
@@ -19,11 +19,6 @@ import re
 
 from . import Image, ImageFile
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.2"
-
-
 #
 # --------------------------------------------------------------------
 

--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -23,10 +23,6 @@ import tempfile
 from . import Image, ImageFile
 from ._binary import i8, i16be as i16, i32be as i32, o8
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.3"
-
 COMPRESSION = {1: "raw", 5: "jpeg"}
 
 PAD = o8(0) * 4

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -18,10 +18,6 @@ import struct
 
 from . import Image, ImageFile
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.1"
-
 
 def _parse_codestream(fp):
     """Parse the JPEG 2000 codestream to extract the size and component

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -47,11 +47,6 @@ from ._binary import i8, i16be as i16, i32be as i32, o8
 from ._util import isStringType
 from .JpegPresets import presets
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.6"
-
-
 #
 # Parser
 

--- a/src/PIL/McIdasImagePlugin.py
+++ b/src/PIL/McIdasImagePlugin.py
@@ -20,10 +20,6 @@ import struct
 
 from . import Image, ImageFile
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.2"
-
 
 def _accept(s):
     return s[:8] == b"\x00\x00\x00\x00\x00\x00\x00\x04"

--- a/src/PIL/MicImagePlugin.py
+++ b/src/PIL/MicImagePlugin.py
@@ -21,11 +21,6 @@ import olefile
 
 from . import Image, TiffImagePlugin
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.1"
-
-
 #
 # --------------------------------------------------------------------
 

--- a/src/PIL/MpegImagePlugin.py
+++ b/src/PIL/MpegImagePlugin.py
@@ -17,11 +17,6 @@
 from . import Image, ImageFile
 from ._binary import i8
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.1"
-
-
 #
 # Bitstream parser
 

--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -21,10 +21,6 @@
 from . import Image, ImageFile, JpegImagePlugin
 from ._binary import i16be as i16
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.1"
-
 
 def _accept(prefix):
     return JpegImagePlugin._accept(prefix)

--- a/src/PIL/MspImagePlugin.py
+++ b/src/PIL/MspImagePlugin.py
@@ -29,11 +29,6 @@ import struct
 from . import Image, ImageFile
 from ._binary import i8, i16le as i16, o16le as o16
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.1"
-
-
 #
 # read MSP files
 

--- a/src/PIL/PalmImagePlugin.py
+++ b/src/PIL/PalmImagePlugin.py
@@ -10,10 +10,6 @@
 from . import Image, ImageFile
 from ._binary import o8, o16be as o16b
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "1.0"
-
 # fmt: off
 _Palm8BitColormapValues = (  # noqa: E131
     (255, 255, 255), (255, 204, 255), (255, 153, 255), (255, 102, 255),

--- a/src/PIL/PcdImagePlugin.py
+++ b/src/PIL/PcdImagePlugin.py
@@ -18,11 +18,6 @@
 from . import Image, ImageFile
 from ._binary import i8
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.1"
-
-
 ##
 # Image plugin for PhotoCD images.  This plugin only reads the 768x512
 # image from the file; higher resolutions are encoded in a proprietary

--- a/src/PIL/PcxImagePlugin.py
+++ b/src/PIL/PcxImagePlugin.py
@@ -33,10 +33,6 @@ from ._binary import i8, i16le as i16, o8, o16le as o16
 
 logger = logging.getLogger(__name__)
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.6"
-
 
 def _accept(prefix):
     return i8(prefix[0]) == 10 and i8(prefix[1]) in [0, 2, 3, 5]

--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -24,12 +24,7 @@ import io
 import os
 import time
 
-from . import Image, ImageFile, ImageSequence, PdfParser
-
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.5"
-
+from . import Image, ImageFile, ImageSequence, PdfParser, __version__
 
 #
 # --------------------------------------------------------------------
@@ -82,7 +77,7 @@ def _save(im, fp, filename, save_all=False):
 
     existing_pdf.start_writing()
     existing_pdf.write_header()
-    existing_pdf.write_comment("created by PIL PDF driver " + __version__)
+    existing_pdf.write_comment("created by Pillow PDF driver " + __version__)
 
     #
     # pages

--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -77,7 +77,7 @@ def _save(im, fp, filename, save_all=False):
 
     existing_pdf.start_writing()
     existing_pdf.write_header()
-    existing_pdf.write_comment("created by Pillow PDF driver " + __version__)
+    existing_pdf.write_comment("created by Pillow {} PDF driver".format(__version__))
 
     #
     # pages

--- a/src/PIL/PixarImagePlugin.py
+++ b/src/PIL/PixarImagePlugin.py
@@ -22,11 +22,6 @@
 from . import Image, ImageFile
 from ._binary import i16le as i16
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.1"
-
-
 #
 # helpers
 

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -40,10 +40,6 @@ from . import Image, ImageFile, ImagePalette
 from ._binary import i8, i16be as i16, i32be as i32, o16be as o16, o32be as o32
 from ._util import py3
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.9"
-
 logger = logging.getLogger(__name__)
 
 is_cid = re.compile(br"\w\w\w\w").match

--- a/src/PIL/PpmImagePlugin.py
+++ b/src/PIL/PpmImagePlugin.py
@@ -17,10 +17,6 @@
 
 from . import Image, ImageFile
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.2"
-
 #
 # --------------------------------------------------------------------
 

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -16,10 +16,6 @@
 # See the README file for information on usage and redistribution.
 #
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.4"
-
 import io
 
 from . import Image, ImageFile, ImagePalette

--- a/src/PIL/SgiImagePlugin.py
+++ b/src/PIL/SgiImagePlugin.py
@@ -29,10 +29,6 @@ from . import Image, ImageFile
 from ._binary import i8, i16be as i16, o8
 from ._util import py3
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.3"
-
 
 def _accept(prefix):
     return len(prefix) >= 2 and i16(prefix) == 474

--- a/src/PIL/SunImagePlugin.py
+++ b/src/PIL/SunImagePlugin.py
@@ -20,10 +20,6 @@
 from . import Image, ImageFile, ImagePalette
 from ._binary import i32be as i32
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.3"
-
 
 def _accept(prefix):
     return len(prefix) >= 4 and i32(prefix) == 0x59A66A95

--- a/src/PIL/TgaImagePlugin.py
+++ b/src/PIL/TgaImagePlugin.py
@@ -22,11 +22,6 @@ import warnings
 from . import Image, ImageFile, ImagePalette
 from ._binary import i8, i16le as i16, o8, o16le as o16
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.3"
-
-
 #
 # --------------------------------------------------------------------
 # Read RGA file

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -64,9 +64,6 @@ except ImportError:
     from collections import MutableMapping
 
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "1.3.5"
 DEBUG = False  # Needs to be merged with the new logging approach.
 
 # Set these to true to force use of libtiff for reading or writing.

--- a/src/PIL/WmfImagePlugin.py
+++ b/src/PIL/WmfImagePlugin.py
@@ -25,10 +25,6 @@ from . import Image, ImageFile
 from ._binary import i16le as word, i32le as dword, si16le as short, si32le as _long
 from ._util import py3
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.2"
-
 _handler = None
 
 if py3:

--- a/src/PIL/XVThumbImagePlugin.py
+++ b/src/PIL/XVThumbImagePlugin.py
@@ -20,10 +20,6 @@
 from . import Image, ImageFile, ImagePalette
 from ._binary import i8, o8
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.1"
-
 _MAGIC = b"P7 332"
 
 # standard color palette for thumbnails (RGB332)

--- a/src/PIL/XbmImagePlugin.py
+++ b/src/PIL/XbmImagePlugin.py
@@ -23,10 +23,6 @@ import re
 
 from . import Image, ImageFile
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.6"
-
 # XBM header
 xbm_head = re.compile(
     br"\s*#define[ \t]+.*_width[ \t]+(?P<width>[0-9]+)[\r\n]+"

--- a/src/PIL/XpmImagePlugin.py
+++ b/src/PIL/XpmImagePlugin.py
@@ -20,10 +20,6 @@ import re
 from . import Image, ImageFile, ImagePalette
 from ._binary import i8, o8
 
-# __version__ is deprecated and will be removed in a future version. Use
-# PIL.__version__ instead.
-__version__ = "0.2"
-
 # XPM header
 xpm_head = re.compile(b'"([0-9]*) ([0-9]*) ([0-9]*) ([0-9]*)')
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * Remove deprecated `__version__` from plugins
 * Deprecated in Pillow 6.0.0 https://github.com/python-pillow/Pillow/pull/3628
 