### PR TITLE
Test on latest available macOS and Ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-          "ubuntu-18.04",
-          "macOS-10.14",
+          "ubuntu-latest",
+          "macOS-latest",
         ]
         python-version: [
           "pypy3",


### PR DESCRIPTION
Changes proposed in this pull request:

 * Looks like macOS-10.14 is being removed, 4 have "This check failed", 1 has "This check was neutral" and no further info:
   * https://github.com/python-pillow/Pillow/pull/4195/checks?check_run_id=288243449

 * In https://github.com/actions/virtual-environments/issues/53, GitHub said it would be replaced with macOS 10.15

 * Using `-latest` will use whatever the latest version is
   * For macOS, GitHub say "at this point in time don't have enough VM capacity to support multiple versions of macOS" https://github.com/actions/virtual-environments/issues/53#issuecomment-549954507

Should we use explicit versions or implicit `-latest` versions? At least if we test on multiple Ubuntu versions, using explicit versions would be clearer.
