### PR TITLE
Corrected context manager test

### DIFF
--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -36,9 +36,8 @@ class TestImagePsd(PillowTestCase):
 
     def test_context_manager(self):
         def open():
-            im = Image.open(test_file)
-            im.load()
-            im.close()
+            with Image.open(test_file) as im:
+                im.load()
 
         self.assert_warning(None, open)
 


### PR DESCRIPTION
Fixed context manager test to actually use a context manager.

This also brings the test into line with https://github.com/python-pillow/Pillow/blob/ce8c944525083c6629b08c7b1dc3f8b7cce1982c/Tests/test_file_tiff.py#L64-L69
https://github.com/python-pillow/Pillow/blob/ce8c944525083c6629b08c7b1dc3f8b7cce1982c/Tests/test_file_gif.py#L52-L57
https://github.com/python-pillow/Pillow/blob/ce8c944525083c6629b08c7b1dc3f8b7cce1982c/Tests/test_file_dcx.py#L40-L45
and others.