### PR TITLE
GitHub Actions: Update to windows-2019

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -185,7 +185,6 @@ jobs:
       shell: cmd
 
     - name: Build dependencies / LCMS2
-      if: false
       run: |
         set INCLUDE=C:\Program Files (x86)\Microsoft SDKs\Windows\V7.1A\Include
         set INCLIB=%GITHUB_WORKSPACE%\winbuild\depends\msvcr10-x32
@@ -197,7 +196,7 @@ jobs:
         rmdir /S /Q Projects\VC2015\Release
         set VCTargetsPath=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\
         set MSBUILD="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe"
-        powershell -Command "(gc Projects\VC2015\lcms2_static\lcms2_static.vcxproj) -replace 'MultiThreaded<', 'MultiThreadedDLL<' | Out-File -encoding ASCII Projects\VC2015\lcms2_static\lcms2_static.vcxproj"
+        powershell %GITHUB_WORKSPACE%\winbuild\lcms2_patch.ps1
         %MSBUILD% Projects\VC2015\lcms2.sln /t:Clean;lcms2_static /p:Configuration="Release" /p:Platform=${{ matrix.platform-msbuild }} /m
         xcopy /Y /E /Q include %INCLIB%
         copy /Y /B Lib\MS\*.lib %INCLIB%

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -43,6 +43,7 @@ jobs:
         Write-Host "::set-env name=pythonLocation::$env:PYTHON" # new syntax https://github.com/actions/toolkit/blob/5bb77ec03fea98332e41f9347c8fbb1ce1e48f4a/docs/commands.md
         New-Item -ItemType SymbolicLink -Path "$env:PYTHON\python.exe" -Target "$env:PYTHON\pypy3.exe"
         curl -fsSL -o get-pip.py https://bootstrap.pypa.io/get-pip.py
+        $env:PATH = "$env:PYTHON\bin;$env:PATH"
         & $env:PYTHON\python.exe get-pip.py
       shell: pwsh
 

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "pypy3.6"]
+        python-version: ["3.5", "3.6", "3.7"]
         architecture: ["x86", "x64"]
         include:
           - architecture: "x86"

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -68,6 +68,12 @@ jobs:
         Write-Host "`#`#[add-path]$env:RUNNER_WORKSPACE\nasm-2.14.02"
         Write-Host "::add-path::$env:RUNNER_WORKSPACE\nasm-2.14.02"
 
+        # 32-bit should work on both platforms
+        curl -fsSL -o gs950.exe https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs950/gs950w32.exe
+        ./gs950.exe /S
+        Write-Host "`#`#[add-path]C:\Program Files (x86)\gs\gs9.50\bin"
+        Write-Host "::add-path::C:\Program Files (x86)\gs\gs9.50\bin"
+
         $env:PYTHON=$env:pythonLocation
         curl -fsSL -o pillow-depends.zip https://github.com/python-pillow/pillow-depends/archive/master.zip
         7z x pillow-depends.zip -oc:\
@@ -308,23 +314,6 @@ jobs:
         copy /Y /B libraqm.dll %INCLIB%
       shell: cmd
 
-    - name: Build dependencies / ghostscript
-      if: false
-      run: |
-        set INCLUDE=C:\Program Files (x86)\Microsoft SDKs\Windows\V7.1A\Include
-        set INCLIB=%GITHUB_WORKSPACE%\winbuild\depends\msvcr10-x32
-        set BUILD=%GITHUB_WORKSPACE%\winbuild\build
-        cd /D %BUILD%\ghostscript-9.27
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
-        echo on
-        set MSVC_VERSION=14
-        set RCOMP="C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\Bin\RC.Exe"
-        if "${{ matrix.architecture }}"=="x64" set WIN64=""
-        nmake -nologo -f psi\msvc.mak
-        rem Add bin to PATH variable: Copy to INCLIB, then add INCLIB to PATH in Test step.
-        copy /Y /B bin\* %INCLIB%
-      shell: cmd
-
     - name: Build Pillow
       run: |
         set PYTHON=%pythonLocation%
@@ -338,7 +327,7 @@ jobs:
         set DISTUTILS_USE_SDK=1
         set py_vcruntime_redist=true
         %PYTHON%\python.exe setup.py build_ext install
-        rem Add GhostScript and Raqm binaries (copied to INCLIB) to PATH.
+        rem Add libraqm.dll (copied to INCLIB) to PATH.
         path %INCLIB%;%PATH%
         %PYTHON%\python.exe selftest.py --installed
       shell: cmd
@@ -354,7 +343,7 @@ jobs:
       run: |
         set PYTHON=%pythonLocation%
         set INCLIB=%GITHUB_WORKSPACE%\winbuild\depends\msvcr10-x32
-        rem Add GhostScript and Raqm binaries (copied to INCLIB) to PATH.
+        rem Add libraqm.dll (copied to INCLIB) to PATH.
         path %INCLIB%;%PATH%
         cd /D %GITHUB_WORKSPACE%
         %PYTHON%\python.exe -m pytest -vx --cov PIL --cov-report term --cov-report xml Tests

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: windows-2016
+    runs-on: windows-2019
     strategy:
       fail-fast: false
       matrix:
@@ -89,7 +89,7 @@ jobs:
         set INCLIB=%GITHUB_WORKSPACE%\winbuild\depends\msvcr10-x32
         set BUILD=%GITHUB_WORKSPACE%\winbuild\build
         cd /D %BUILD%\jpeg-9c
-        call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" ${{ matrix.platform-vcvars }} 8.1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
         echo on
         nmake -nologo -f makefile.vc setup-vc6
         nmake -nologo -f makefile.vc clean
@@ -105,7 +105,7 @@ jobs:
         set INCLIB=%GITHUB_WORKSPACE%\winbuild\depends\msvcr10-x32
         set BUILD=%GITHUB_WORKSPACE%\winbuild\build
         cd /D %BUILD%\libjpeg-turbo-2.0.3
-        call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" ${{ matrix.platform-vcvars }} 8.1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
         echo on
         set CMAKE=cmake.exe -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES:BOOL=OFF
         set CMAKE=%CMAKE% -DENABLE_SHARED:BOOL=OFF -DWITH_JPEG8:BOOL=TRUE -DWITH_CRT_DLL:BOOL=TRUE -DCMAKE_BUILD_TYPE=Release
@@ -124,7 +124,7 @@ jobs:
         set INCLIB=%GITHUB_WORKSPACE%\winbuild\depends\msvcr10-x32
         set BUILD=%GITHUB_WORKSPACE%\winbuild\build
         cd /D %BUILD%\zlib-1.2.11
-        call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" ${{ matrix.platform-vcvars }} 8.1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
         echo on
         nmake -nologo -f win32\Makefile.msc clean
         nmake -nologo -f win32\Makefile.msc zlib.lib
@@ -139,7 +139,7 @@ jobs:
         set INCLIB=%GITHUB_WORKSPACE%\winbuild\depends\msvcr10-x32
         set BUILD=%GITHUB_WORKSPACE%\winbuild\build
         cd /D %BUILD%\tiff-4.1.0
-        call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" ${{ matrix.platform-vcvars }} 8.1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
         echo on
         copy %GITHUB_WORKSPACE%\winbuild\tiff.opt nmake.opt
         nmake -nologo -f makefile.vc clean
@@ -155,7 +155,7 @@ jobs:
         set INCLIB=%GITHUB_WORKSPACE%\winbuild\depends\msvcr10-x32
         set BUILD=%GITHUB_WORKSPACE%\winbuild\build
         cd /D %BUILD%\libwebp-1.0.3
-        call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" ${{ matrix.platform-vcvars }} 8.1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
         echo on
         rmdir /S /Q output\release-static
         nmake -nologo -f Makefile.vc CFG=release-static OBJDIR=output ARCH=${{ matrix.architecture }} all
@@ -172,12 +172,12 @@ jobs:
         set INCLIB=%GITHUB_WORKSPACE%\winbuild\depends\msvcr10-x32
         set BUILD=%GITHUB_WORKSPACE%\winbuild\build
         cd /D %BUILD%\freetype-2.10.1
-        call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" ${{ matrix.platform-vcvars }} 8.1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
         echo on
         rmdir /S /Q objs
-        set DefaultPlatformToolset=v140
-        set VCTargetsPath=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\VC\VCTargets
-        set MSBUILD="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"
+        set DefaultPlatformToolset=v142
+        set VCTargetsPath=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\
+        set MSBUILD="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe"
         powershell -Command "(gc builds\windows\vc2010\freetype.vcxproj) -replace 'MultiThreaded<', 'MultiThreadedDLL<' | Out-File -encoding ASCII builds\windows\vc2010\freetype.vcxproj"
         %MSBUILD% builds\windows\vc2010\freetype.sln /t:Build /p:Configuration="Release Static" /p:Platform=${{ matrix.platform-msbuild }} /m
         xcopy /Y /E /Q include %INCLIB%
@@ -185,17 +185,18 @@ jobs:
       shell: cmd
 
     - name: Build dependencies / LCMS2
+      if: false
       run: |
         set INCLUDE=C:\Program Files (x86)\Microsoft SDKs\Windows\V7.1A\Include
         set INCLIB=%GITHUB_WORKSPACE%\winbuild\depends\msvcr10-x32
         set BUILD=%GITHUB_WORKSPACE%\winbuild\build
         cd /D %BUILD%\lcms2-2.8
-        call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" ${{ matrix.platform-vcvars }} 8.1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
         echo on
         rmdir /S /Q Lib
         rmdir /S /Q Projects\VC2015\Release
-        set VCTargetsPath=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\VC\VCTargets
-        set MSBUILD="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"
+        set VCTargetsPath=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\
+        set MSBUILD="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe"
         powershell -Command "(gc Projects\VC2015\lcms2_static\lcms2_static.vcxproj) -replace 'MultiThreaded<', 'MultiThreadedDLL<' | Out-File -encoding ASCII Projects\VC2015\lcms2_static\lcms2_static.vcxproj"
         %MSBUILD% Projects\VC2015\lcms2.sln /t:Clean;lcms2_static /p:Configuration="Release" /p:Platform=${{ matrix.platform-msbuild }} /m
         xcopy /Y /E /Q include %INCLIB%
@@ -208,7 +209,7 @@ jobs:
         set INCLIB=%GITHUB_WORKSPACE%\winbuild\depends\msvcr10-x32
         set BUILD=%GITHUB_WORKSPACE%\winbuild\build
         cd /D %BUILD%\openjpeg-2.3.1msvcr10-x32
-        call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" ${{ matrix.platform-vcvars }} 8.1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
         echo on
         set CMAKE=cmake.exe -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES:BOOL=OFF
         set CMAKE=%CMAKE% -DBUILD_THIRDPARTY:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=OFF
@@ -230,7 +231,7 @@ jobs:
         set BUILD=%GITHUB_WORKSPACE%\winbuild\build
         rem ba653c8: Merge tag '2.12.5' into msvc
         cd /D %BUILD%\libimagequant-ba653c8ccb34dde4e21c6076d85a72d21ed9d971
-        call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" ${{ matrix.platform-vcvars }} 8.1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
         echo on
         echo (gc CMakeLists.txt) -replace 'add_library', "add_compile_options(-openmp-)`r`nadd_library" ^| Out-File -encoding ASCII CMakeLists.txt > patch.ps1
         echo (gc CMakeLists.txt) -replace ' SHARED', ' STATIC' ^| Out-File -encoding ASCII CMakeLists.txt >> patch.ps1
@@ -254,7 +255,7 @@ jobs:
         set INCLUDE=%INCLUDE%;%INCLIB%
         set LIB=%LIB%;%INCLIB%
         cd /D %BUILD%\harfbuzz-2.6.1
-        call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" ${{ matrix.platform-vcvars }} 8.1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
         echo on
         set CMAKE=cmake.exe -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES:BOOL=OFF
         set CMAKE=%CMAKE% -DHB_HAVE_FREETYPE:BOOL=ON -DCMAKE_BUILD_TYPE=Release
@@ -273,7 +274,7 @@ jobs:
         set INCLIB=%GITHUB_WORKSPACE%\winbuild\depends\msvcr10-x32
         set BUILD=%GITHUB_WORKSPACE%\winbuild\build
         cd /D %BUILD%\fribidi-1.0.7
-        call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" ${{ matrix.platform-vcvars }} 8.1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
         echo on
         copy /Y /B %GITHUB_WORKSPACE%\winbuild\fribidi.cmake CMakeLists.txt
         set CMAKE=cmake.exe -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES:BOOL=OFF
@@ -295,7 +296,7 @@ jobs:
         set INCLUDE=%INCLUDE%;%INCLIB%
         set LIB=%LIB%;%INCLIB%
         cd /D %BUILD%\libraqm-0.7.0
-        call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" ${{ matrix.platform-vcvars }} 8.1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
         echo on
         copy /Y /B %GITHUB_WORKSPACE%\winbuild\raqm.cmake CMakeLists.txt
         set CMAKE=cmake.exe -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_RULE_MESSAGES:BOOL=OFF
@@ -308,12 +309,13 @@ jobs:
       shell: cmd
 
     - name: Build dependencies / ghostscript
+      if: false
       run: |
         set INCLUDE=C:\Program Files (x86)\Microsoft SDKs\Windows\V7.1A\Include
         set INCLIB=%GITHUB_WORKSPACE%\winbuild\depends\msvcr10-x32
         set BUILD=%GITHUB_WORKSPACE%\winbuild\build
         cd /D %BUILD%\ghostscript-9.27
-        call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" ${{ matrix.platform-vcvars }} 8.1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
         echo on
         set MSVC_VERSION=14
         set RCOMP="C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\Bin\RC.Exe"
@@ -332,7 +334,7 @@ jobs:
         cd /D %GITHUB_WORKSPACE%
         set LIB=%INCLIB%;%PYTHON%\tcl
         set INCLUDE=%INCLIB%;%GITHUB_WORKSPACE%\depends\tcl86\include;%INCLUDE%
-        call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" ${{ matrix.platform-vcvars }} 8.1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
         %PYTHON%\python.exe setup.py build_ext install
         rem Add GhostScript and Raqm binaries (copied to INCLIB) to PATH.
         path %INCLIB%;%PATH%
@@ -373,7 +375,7 @@ jobs:
         cd /D %GITHUB_WORKSPACE%
         set LIB=%INCLIB%;%PYTHON%\tcl
         set INCLUDE=%INCLIB%;%GITHUB_WORKSPACE%\depends\tcl86\include;%INCLUDE%
-        call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" ${{ matrix.platform-vcvars }} 8.1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
         %PYTHON%\python.exe setup.py bdist_wheel
       shell: cmd
 

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -335,6 +335,8 @@ jobs:
         set LIB=%INCLIB%;%PYTHON%\tcl
         set INCLUDE=%INCLIB%;%GITHUB_WORKSPACE%\depends\tcl86\include;%INCLUDE%
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
+        set DISTUTILS_USE_SDK=1
+        set py_vcruntime_redist=true
         %PYTHON%\python.exe setup.py build_ext install
         rem Add GhostScript and Raqm binaries (copied to INCLIB) to PATH.
         path %INCLIB%;%PATH%

--- a/winbuild/lcms2_patch.ps1
+++ b/winbuild/lcms2_patch.ps1
@@ -1,0 +1,9 @@
+
+Get-ChildItem .\Projects\VC2015\ *.vcxproj -recurse |
+    Foreach-Object {
+        $c = ($_ | Get-Content)
+        $c = $c -replace 'MultiThreaded<','MultiThreadedDLL<'
+        $c = $c -replace '<WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>','<WindowsTargetPlatformVersion>10</WindowsTargetPlatformVersion>'
+        $c = $c -replace '<PlatformToolset>v140</PlatformToolset>','<PlatformToolset>v142</PlatformToolset>'
+        [IO.File]::WriteAllText($_.FullName, ($c -join "`r`n"))
+    }


### PR DESCRIPTION
Fixes #4188

Changes proposed in this pull request:

 * Run Windows tests on `windows-2019`
 * Use official prebuilt Ghostscript binary
 * Patch LCMS2 build scripts to work with VS2019 (1)
 * Use `DISTUTILS_USE_SDK=1` to help Python 3.5 and 3.6 find the compiler (1)
 * Fix PyPy3.6 pip warning causing early failures; FIXME PyPy can't find the compiler

(1) These two changes should probably be reverted once VS2017 is added to `windows-2019` as promised in https://github.com/actions/virtual-environments/issues/68#issuecomment-548534537
