### PR TITLE
Updated URL

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@
 # Create and test a Python package on multiple Python versions.
 # Add steps that analyze code, save the dist with the build record,
 # publish to a PyPI-compatible index, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+# https://docs.microsoft.com/azure/devops/pipelines/ecosystems/python
 
 jobs:
 


### PR DESCRIPTION
https://docs.microsoft.com/azure/devops/pipelines/languages/python redirects to
https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/python?view=azure-devops

If we want to allow 'en-us' to be region specific, fair enough, but this PR changes 'languages' to 'ecosystems'.