### PR TITLE
Add Documentation and Github URLs for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -859,7 +859,11 @@ try:
         license="HPND",
         author="Alex Clark (PIL Fork Author)",
         author_email="aclark@python-pillow.org",
-        url="http://python-pillow.org",
+        url="https://python-pillow.org/",
+        project_urls={
+            "Documentation": "https://pillow.readthedocs.io/en/stable/",
+            "Source Code": "https://github.com/python-pillow/Pillow",
+        },
         classifiers=[
             "Development Status :: 6 - Mature",
             "License :: OSI Approved :: Historical Permission Notice and Disclaimer (HPND)",  # noqa: E501

--- a/setup.py
+++ b/setup.py
@@ -859,10 +859,11 @@ try:
         license="HPND",
         author="Alex Clark (PIL Fork Author)",
         author_email="aclark@python-pillow.org",
-        url="https://python-pillow.org/",
+        url="https://python-pillow.org",
         project_urls={
             "Documentation": "https://pillow.readthedocs.io",
             "Source": "https://github.com/python-pillow/Pillow",
+            "Funding": "https://tidelift.com/subscription/pkg/pypi-pillow",
         },
         classifiers=[
             "Development Status :: 6 - Mature",

--- a/setup.py
+++ b/setup.py
@@ -861,8 +861,8 @@ try:
         author_email="aclark@python-pillow.org",
         url="https://python-pillow.org/",
         project_urls={
-            "Documentation": "https://pillow.readthedocs.io/en/stable/",
-            "Source Code": "https://github.com/python-pillow/Pillow",
+            "Documentation": "https://pillow.readthedocs.io",
+            "Source": "https://github.com/python-pillow/Pillow",
         },
         classifiers=[
             "Development Status :: 6 - Mature",


### PR DESCRIPTION
Warehouse now uses the `project_urls` provided to display links in the sidebar, as well as including them in API responses to help automation tool find the source code for Pillow. For example, see Django's [setup.cfg](https://github.com/django/django/blob/master/setup.cfg) and [PyPI listing](https://pypi.org/project/Django/).