### PR TITLE
Update the out-dated termux.sh

### DIFF
--- a/depends/termux.sh
+++ b/depends/termux.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-pkg -y install python python-dev ndk-sysroot clang make \
-    libjpeg-turbo-dev 
+pkg install -y python ndk-sysroot clang make \
+    libjpeg-turbo
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -362,8 +362,8 @@ Building on Android
 Basic Android support has been added for compilation within the Termux
 environment. The dependencies can be installed by::
 
-    $ pkg -y install python python-dev ndk-sysroot clang make \
-        libjpeg-turbo-dev
+    $ pkg install -y python ndk-sysroot clang make \
+        libjpeg-turbo
 
 This has been tested within the Termux app on ChromeOS, on x86.
 


### PR DESCRIPTION
Termux does not have -dev packages any more(https://wiki.termux.com/wiki/No_more_-dev_packages) and pkg install -y instead of pkg -y install should be used

Changes proposed in this pull request:

 * Use the right package name
 * Change pkg -y install (which doesn't work) to pkg install -y
