### PR TITLE
Use Codecov's GitHub Action

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,4 +6,6 @@ codecov:
   # https://docs.codecov.io/v4.3.6/docs/comparing-commits
   allow_coverage_offsets: true
 
+  token: 6dafc396-e7f5-4221-a38a-8b07a49fbdae
+
 comment: off

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,6 +6,4 @@ codecov:
   # https://docs.codecov.io/v4.3.6/docs/comparing-commits
   allow_coverage_offsets: true
 
-  token: 6dafc396-e7f5-4221-a38a-8b07a49fbdae
-
 comment: off

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -55,10 +55,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}
 
-    - name: pip install wheel pytest pytest-cov codecov
+    - name: pip install wheel pytest pytest-cov
       run: |
         "%pythonLocation%\python.exe" -m pip install wheel pytest pytest-cov
-        pip install codecov
       shell: cmd
 
     - name: Fetch dependencies
@@ -357,8 +356,11 @@ jobs:
         path: Tests/errors
 
     - name: Upload coverage
-      run: 'codecov --file "%GITHUB_WORKSPACE%\coverage.xml" --name "%pythonLocation%"'
-      shell: cmd
+      if: success()
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        name: ${{ runner.os }} Python ${{ matrix.python-version }}
 
     - name: Build wheel
       id: wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,5 +71,13 @@ jobs:
       run: |
         .travis/after_success.sh
       env:
+        MATRIX_OS: ${{ matrix.os }}
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+
+    - name: Upload coverage
+      if: success()
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 # gather the coverage data
-sudo apt-get -qq install lcov
+if [[ "$MATRIX_OS" == "macOS-latest" ]]; then
+    brew install lcov
+else
+    sudo apt-get -qq install lcov
+fi
+
 lcov --capture --directory . -b . --output-file coverage.info
 #  filter to remove system headers
 lcov --remove coverage.info '/usr/*' -o coverage.filtered.info
@@ -13,7 +18,9 @@ coverage report
 pip install codecov
 pip install coveralls-merge
 coveralls-merge coverage.c.json
-codecov
+if [[ $TRAVIS ]]; then
+    codecov
+fi
 
 if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ] && [ "$DOCKER" == "" ]; then
     # Coverage and quality reports on just the latest diff.


### PR DESCRIPTION
Changes proposed in this pull request:

 * Codecov GitHub Action is now available for all three operating systems
 * https://github.com/codecov/codecov-action
 * There was a problem including the Pillow token in `.codecov.yml`: some of the build jobs in my fork were sent to Pillow's Codecov, not mine
 * ~Plus fix so GHA macOS coverage is collected: needed to install lcov properly~ Done in https://github.com/python-pillow/Pillow/pull/4217
