### PR TITLE
GHA: Install lcov on macOS to report coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,5 +71,6 @@ jobs:
       run: |
         .travis/after_success.sh
       env:
+        MATRIX_OS: ${{ matrix.os }}
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 # gather the coverage data
-sudo apt-get -qq install lcov
+if [[ "$MATRIX_OS" == "macOS-latest" ]]; then
+    brew install lcov
+else
+    sudo apt-get -qq install lcov
+fi
+
 lcov --capture --directory . -b . --output-file coverage.info
 #  filter to remove system headers
 lcov --remove coverage.info '/usr/*' -o coverage.filtered.info


### PR DESCRIPTION
Fix split out from https://github.com/python-pillow/Pillow/pull/4216.