### PR TITLE
Use prebuilt GhostScript on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -56,6 +56,9 @@ install:
         c:\pillow\winbuild\build_deps.cmd
         $host.SetShouldExit(0)
       }
+- curl -fsSL -o gs950.exe https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs950/gs950w32.exe
+- gs950.exe /S
+- path %path%;C:\Program Files (x86)\gs\gs9.50\bin
 
 build_script:
 - ps: |

--- a/winbuild/build_dep.py
+++ b/winbuild/build_dep.py
@@ -300,33 +300,6 @@ endlocal
     )
 
 
-def build_ghostscript(compiler, bit):
-    script = (
-        r"""
-rem Build gs
-setlocal
-"""
-        + vc_setup(compiler, bit)
-        + r"""
-set MSVC_VERSION="""
-        + {"2010": "90", "2015": "14"}[compiler["vc_version"]]
-        + r"""
-set RCOMP="C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\Bin\RC.Exe"
-cd /D %%GHOSTSCRIPT%%
-"""
-    )
-    if bit == 64:
-        script += r"""
-set WIN64=""
-"""
-    script += r"""
-nmake -nologo -f psi/msvc.mak
-copy /Y /B bin\ C:\Python27\
-endlocal
-"""
-    return script % compiler
-
-
 def add_compiler(compiler, bit):
     script.append(setup_compiler(compiler))
     script.append(nmake_libs(compiler, bit))
@@ -336,7 +309,6 @@ def add_compiler(compiler, bit):
     script.append(msbuild_freetype(compiler, bit))
     script.append(build_lcms2(compiler))
     script.append(nmake_openjpeg(compiler, bit))
-    script.append(build_ghostscript(compiler, bit))
     script.append(end_compiler())
 
 

--- a/winbuild/config.py
+++ b/winbuild/config.py
@@ -53,11 +53,6 @@ libs = {
         "filename": "lcms2-2.8.zip",
         "dir": "lcms2-2.8",
     },
-    "ghostscript": {
-        "url": "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs927/ghostscript-9.27.tar.gz",  # noqa: E501
-        "filename": "ghostscript-9.27.tar.gz",
-        "dir": "ghostscript-9.27",
-    },
     "tcl-8.5": {
         "url": SF_MIRROR + "/project/tcl/Tcl/8.5.19/tcl8519-src.zip",
         "filename": "tcl8519-src.zip",


### PR DESCRIPTION
#4201 changed to using official prebuilt GhostScript binaries on GitHub Actions (instead of compiling it), as it is hard to compile on `windows-2019`.

This PR does the same for AppVeyor to speed it up significantly.

Also see https://github.com/python-pillow/Pillow/issues/4188#issuecomment-551155313 for a (brief) discussion.