### PR TITLE
Test Python 3.8 and PyPy3.6 on Windows with GitHub Actions

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8"]
+        python-version: ["3.5", "3.6", "3.7", "3.8", "pypy3.6"]
         architecture: ["x86", "x64"]
         include:
           - architecture: "x86"
@@ -324,6 +324,7 @@ jobs:
         set LIB=%INCLIB%;%PYTHON%\tcl
         set INCLUDE=%INCLIB%;%GITHUB_WORKSPACE%\depends\tcl86\include;%INCLUDE%
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.platform-vcvars }}
+        set MSSdk=1
         set DISTUTILS_USE_SDK=1
         set py_vcruntime_redist=true
         %PYTHON%\python.exe setup.py build_ext install

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5", "3.6", "3.7"]
+        python-version: ["3.5", "3.6", "3.7", "3.8"]
         architecture: ["x86", "x64"]
         include:
           - architecture: "x86"

--- a/winbuild/config.py
+++ b/winbuild/config.py
@@ -3,10 +3,10 @@ import os
 SF_MIRROR = "https://iweb.dl.sourceforge.net"
 
 pythons = {
+    "pypy3": {"compiler": 7.1, "vc": 2015},
     # for AppVeyor
     "35": {"compiler": 7.1, "vc": 2015},
     "36": {"compiler": 7.1, "vc": 2015},
-    "pypy3": {"compiler": 7.1, "vc": 2015},
     "37": {"compiler": 7.1, "vc": 2015},
     "38": {"compiler": 7.1, "vc": 2015},
     # for GitHub Actions

--- a/winbuild/config.py
+++ b/winbuild/config.py
@@ -13,6 +13,7 @@ pythons = {
     "3.5": {"compiler": 7.1, "vc": 2015},
     "3.6": {"compiler": 7.1, "vc": 2015},
     "3.7": {"compiler": 7.1, "vc": 2015},
+    "3.8": {"compiler": 7.1, "vc": 2015},
 }
 
 VIRT_BASE = "c:/vp/"


### PR DESCRIPTION
Adds Python 3.8 to Windows build matrix on GitHub Actions.
Edit: Also adds PyPy3.6-7.2.0 to Windows build matrix on GitHub Actions.