### PR TITLE
Import unittest from stdlib rather than helper.py

### DIFF
--- a/Tests/bench_cffi_access.py
+++ b/Tests/bench_cffi_access.py
@@ -1,8 +1,9 @@
 import time
+import unittest
 
 from PIL import PyAccess
 
-from .helper import PillowTestCase, hopper, unittest
+from .helper import PillowTestCase, hopper
 
 # Not running this test by default. No DOS against Travis CI.
 

--- a/Tests/check_fli_overflow.py
+++ b/Tests/check_fli_overflow.py
@@ -1,6 +1,8 @@
+import unittest
+
 from PIL import Image
 
-from .helper import PillowTestCase, unittest
+from .helper import PillowTestCase
 
 TEST_FILE = "Tests/images/fli_overflow.fli"
 

--- a/Tests/check_imaging_leaks.py
+++ b/Tests/check_imaging_leaks.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
+import unittest
+
 from PIL import Image
 
-from .helper import PillowTestCase, is_win32, unittest
+from .helper import PillowTestCase, is_win32
 
 min_iterations = 100
 max_iterations = 10000

--- a/Tests/check_j2k_leaks.py
+++ b/Tests/check_j2k_leaks.py
@@ -1,8 +1,9 @@
+import unittest
 from io import BytesIO
 
 from PIL import Image
 
-from .helper import PillowTestCase, is_win32, unittest
+from .helper import PillowTestCase, is_win32
 
 # Limits for testing the leak
 mem_limit = 1024 * 1048576

--- a/Tests/check_j2k_overflow.py
+++ b/Tests/check_j2k_overflow.py
@@ -1,6 +1,8 @@
+import unittest
+
 from PIL import Image
 
-from .helper import PillowTestCase, unittest
+from .helper import PillowTestCase
 
 
 class TestJ2kEncodeOverflow(PillowTestCase):

--- a/Tests/check_jpeg_leaks.py
+++ b/Tests/check_jpeg_leaks.py
@@ -1,6 +1,7 @@
+import unittest
 from io import BytesIO
 
-from .helper import PillowTestCase, hopper, is_win32, unittest
+from .helper import PillowTestCase, hopper, is_win32
 
 iterations = 5000
 

--- a/Tests/check_large_memory.py
+++ b/Tests/check_large_memory.py
@@ -1,8 +1,9 @@
 import sys
+import unittest
 
 from PIL import Image
 
-from .helper import PillowTestCase, unittest
+from .helper import PillowTestCase
 
 # This test is not run automatically.
 #

--- a/Tests/check_large_memory_numpy.py
+++ b/Tests/check_large_memory_numpy.py
@@ -1,8 +1,9 @@
 import sys
+import unittest
 
 from PIL import Image
 
-from .helper import PillowTestCase, unittest
+from .helper import PillowTestCase
 
 # This test is not run automatically.
 #

--- a/Tests/check_libtiff_segfault.py
+++ b/Tests/check_libtiff_segfault.py
@@ -1,6 +1,8 @@
+import unittest
+
 from PIL import Image
 
-from .helper import PillowTestCase, unittest
+from .helper import PillowTestCase
 
 TEST_FILE = "Tests/images/libtiff_segfault.tif"
 

--- a/Tests/check_png_dos.py
+++ b/Tests/check_png_dos.py
@@ -1,9 +1,10 @@
+import unittest
 import zlib
 from io import BytesIO
 
 from PIL import Image, ImageFile, PngImagePlugin
 
-from .helper import PillowTestCase, unittest
+from .helper import PillowTestCase
 
 TEST_FILE = "Tests/images/png_decompression_dos.png"
 

--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -1,8 +1,9 @@
+import unittest
 from array import array
 
 from PIL import Image, ImageFilter
 
-from .helper import PillowTestCase, unittest
+from .helper import PillowTestCase
 
 try:
     import numpy

--- a/Tests/test_core_resources.py
+++ b/Tests/test_core_resources.py
@@ -1,8 +1,9 @@
 import sys
+import unittest
 
 from PIL import Image
 
-from .helper import PillowTestCase, is_pypy, unittest
+from .helper import PillowTestCase, is_pypy
 
 
 class TestCoreStats(PillowTestCase):

--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -1,8 +1,9 @@
 import io
+import unittest
 
 from PIL import features
 
-from .helper import PillowTestCase, unittest
+from .helper import PillowTestCase
 
 try:
     from PIL import _webp

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -1,8 +1,9 @@
 import io
+import unittest
 
 from PIL import EpsImagePlugin, Image
 
-from .helper import PillowTestCase, hopper, unittest
+from .helper import PillowTestCase, hopper
 
 HAS_GHOSTSCRIPT = EpsImagePlugin.has_ghostscript()
 

--- a/Tests/test_file_fpx.py
+++ b/Tests/test_file_fpx.py
@@ -1,4 +1,6 @@
-from .helper import PillowTestCase, unittest
+import unittest
+
+from .helper import PillowTestCase
 
 try:
     from PIL import FpxImagePlugin

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1,8 +1,9 @@
+import unittest
 from io import BytesIO
 
 from PIL import GifImagePlugin, Image, ImageDraw, ImagePalette
 
-from .helper import PillowTestCase, hopper, is_pypy, netpbm_available, unittest
+from .helper import PillowTestCase, hopper, is_pypy, netpbm_available
 
 try:
     from PIL import _webp

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -1,9 +1,10 @@
 import io
 import sys
+import unittest
 
 from PIL import IcnsImagePlugin, Image
 
-from .helper import PillowTestCase, unittest
+from .helper import PillowTestCase
 
 # sample icon file
 TEST_FILE = "Tests/images/pillow.icns"

--- a/Tests/test_file_mic.py
+++ b/Tests/test_file_mic.py
@@ -1,6 +1,8 @@
+import unittest
+
 from PIL import Image, ImagePalette, features
 
-from .helper import PillowTestCase, hopper, unittest
+from .helper import PillowTestCase, hopper
 
 try:
     from PIL import MicImagePlugin

--- a/Tests/test_file_msp.py
+++ b/Tests/test_file_msp.py
@@ -1,8 +1,9 @@
 import os
+import unittest
 
 from PIL import Image, MspImagePlugin
 
-from .helper import PillowTestCase, hopper, unittest
+from .helper import PillowTestCase, hopper
 
 TEST_FILE = "Tests/images/hopper.msp"
 EXTRA_DIR = "Tests/images/picins"

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -1,9 +1,10 @@
+import unittest
 import zlib
 from io import BytesIO
 
 from PIL import Image, ImageFile, PngImagePlugin
 
-from .helper import PillowLeakTestCase, PillowTestCase, hopper, is_win32, unittest
+from .helper import PillowLeakTestCase, PillowTestCase, hopper, is_win32
 
 try:
     from PIL import _webp

--- a/Tests/test_file_sun.py
+++ b/Tests/test_file_sun.py
@@ -1,8 +1,9 @@
 import os
+import unittest
 
 from PIL import Image, SunImagePlugin
 
-from .helper import PillowTestCase, hopper, unittest
+from .helper import PillowTestCase, hopper
 
 EXTRA_DIR = "Tests/images/sunraster"
 

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -1,12 +1,13 @@
 import logging
 import os
+import unittest
 from io import BytesIO
 
 import pytest
 from PIL import Image, TiffImagePlugin
 from PIL.TiffImagePlugin import RESOLUTION_UNIT, X_RESOLUTION, Y_RESOLUTION
 
-from .helper import PillowTestCase, hopper, is_pypy, is_win32, unittest
+from .helper import PillowTestCase, hopper, is_pypy, is_win32
 
 logger = logging.getLogger(__name__)
 

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -1,6 +1,8 @@
+import unittest
+
 from PIL import Image, WebPImagePlugin
 
-from .helper import PillowTestCase, hopper, unittest
+from .helper import PillowTestCase, hopper
 
 try:
     from PIL import _webp

--- a/Tests/test_file_webp_alpha.py
+++ b/Tests/test_file_webp_alpha.py
@@ -1,6 +1,8 @@
+import unittest
+
 from PIL import Image
 
-from .helper import PillowTestCase, hopper, unittest
+from .helper import PillowTestCase, hopper
 
 try:
     from PIL import _webp

--- a/Tests/test_font_leaks.py
+++ b/Tests/test_font_leaks.py
@@ -1,6 +1,8 @@
+import unittest
+
 from PIL import Image, ImageDraw, ImageFont, features
 
-from .helper import PillowLeakTestCase, is_win32, unittest
+from .helper import PillowLeakTestCase, is_win32
 
 
 @unittest.skipIf(is_win32(), "requires Unix or macOS")

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1,10 +1,11 @@
 import os
 import shutil
 import tempfile
+import unittest
 
 from PIL import Image, UnidentifiedImageError
 
-from .helper import PillowTestCase, hopper, is_win32, unittest
+from .helper import PillowTestCase, hopper, is_win32
 
 
 class TestImage(PillowTestCase):

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -2,11 +2,12 @@ import ctypes
 import os
 import subprocess
 import sys
+import unittest
 from distutils import ccompiler, sysconfig
 
 from PIL import Image
 
-from .helper import PillowTestCase, hopper, is_win32, on_ci, unittest
+from .helper import PillowTestCase, hopper, is_win32, on_ci
 
 # CFFI imports pycparser which doesn't support PYTHONOPTIMIZE=2
 # https://github.com/eliben/pycparser/pull/198#issuecomment-317001670

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -1,8 +1,9 @@
+import unittest
 from contextlib import contextmanager
 
 from PIL import Image, ImageDraw
 
-from .helper import PillowTestCase, hopper, unittest
+from .helper import PillowTestCase, hopper
 
 
 class TestImagingResampleVulnerability(PillowTestCase):

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -1,8 +1,9 @@
 import os.path
+import unittest
 
 from PIL import Image, ImageColor, ImageDraw, ImageFont, features
 
-from .helper import PillowTestCase, hopper, unittest
+from .helper import PillowTestCase, hopper
 
 BLACK = (0, 0, 0)
 WHITE = (255, 255, 255)

--- a/Tests/test_imagedraw2.py
+++ b/Tests/test_imagedraw2.py
@@ -1,8 +1,9 @@
 import os.path
+import unittest
 
 from PIL import Image, ImageDraw2, features
 
-from .helper import PillowTestCase, hopper, unittest
+from .helper import PillowTestCase, hopper
 
 BLACK = (0, 0, 0)
 WHITE = (255, 255, 255)

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -1,8 +1,9 @@
+import unittest
 from io import BytesIO
 
 from PIL import EpsImagePlugin, Image, ImageFile
 
-from .helper import PillowTestCase, fromstring, hopper, tostring, unittest
+from .helper import PillowTestCase, fromstring, hopper, tostring
 
 try:
     from PIL import _webp

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -4,11 +4,12 @@ import os
 import re
 import shutil
 import sys
+import unittest
 from io import BytesIO
 
 from PIL import Image, ImageDraw, ImageFont, features
 
-from .helper import PillowTestCase, is_pypy, is_win32, unittest
+from .helper import PillowTestCase, is_pypy, is_win32
 
 FONT_PATH = "Tests/fonts/FreeMono.ttf"
 FONT_SIZE = 20

--- a/Tests/test_imagefont_bitmap.py
+++ b/Tests/test_imagefont_bitmap.py
@@ -1,6 +1,8 @@
+import unittest
+
 from PIL import Image, ImageDraw, ImageFont
 
-from .helper import PillowTestCase, unittest
+from .helper import PillowTestCase
 
 image_font_installed = True
 try:

--- a/Tests/test_imagefontctl.py
+++ b/Tests/test_imagefontctl.py
@@ -1,6 +1,8 @@
+import unittest
+
 from PIL import Image, ImageDraw, ImageFont, features
 
-from .helper import PillowTestCase, unittest
+from .helper import PillowTestCase
 
 FONT_SIZE = 20
 FONT_PATH = "Tests/fonts/DejaVuSans.ttf"

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -1,6 +1,8 @@
+import unittest
+
 from PIL import Image, ImageShow
 
-from .helper import PillowTestCase, hopper, is_win32, on_ci, on_github_actions, unittest
+from .helper import PillowTestCase, hopper, is_win32, on_ci, on_github_actions
 
 
 class TestImageShow(PillowTestCase):

--- a/Tests/test_imagetk.py
+++ b/Tests/test_imagetk.py
@@ -1,6 +1,8 @@
+import unittest
+
 from PIL import Image
 
-from .helper import PillowTestCase, hopper, unittest
+from .helper import PillowTestCase, hopper
 
 try:
     from PIL import ImageTk

--- a/Tests/test_imagewin.py
+++ b/Tests/test_imagewin.py
@@ -1,6 +1,8 @@
+import unittest
+
 from PIL import ImageWin
 
-from .helper import PillowTestCase, hopper, is_win32, unittest
+from .helper import PillowTestCase, hopper, is_win32
 
 
 class TestImageWin(PillowTestCase):

--- a/Tests/test_lib_image.py
+++ b/Tests/test_lib_image.py
@@ -1,6 +1,8 @@
+import unittest
+
 from PIL import Image
 
-from .helper import PillowTestCase, unittest
+from .helper import PillowTestCase
 
 
 class TestLibImage(PillowTestCase):

--- a/Tests/test_locale.py
+++ b/Tests/test_locale.py
@@ -1,8 +1,9 @@
 import locale
+import unittest
 
 from PIL import Image
 
-from .helper import PillowTestCase, unittest
+from .helper import PillowTestCase
 
 # ref https://github.com/python-pillow/Pillow/issues/272
 # on windows, in polish locale:

--- a/Tests/test_main.py
+++ b/Tests/test_main.py
@@ -1,9 +1,10 @@
 import os
 import subprocess
 import sys
+import unittest
 from unittest import TestCase
 
-from .helper import is_pypy, is_win32, on_github_actions, unittest
+from .helper import is_pypy, is_win32, on_github_actions
 
 
 class TestMain(TestCase):

--- a/Tests/test_map.py
+++ b/Tests/test_map.py
@@ -1,8 +1,9 @@
 import sys
+import unittest
 
 from PIL import Image
 
-from .helper import PillowTestCase, is_win32, unittest
+from .helper import PillowTestCase, is_win32
 
 try:
     import numpy

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -1,6 +1,8 @@
+import unittest
+
 from PIL import Image
 
-from .helper import PillowTestCase, hopper, unittest
+from .helper import PillowTestCase, hopper
 
 try:
     import numpy

--- a/Tests/test_pyroma.py
+++ b/Tests/test_pyroma.py
@@ -1,6 +1,8 @@
+import unittest
+
 from PIL import __version__
 
-from .helper import PillowTestCase, unittest
+from .helper import PillowTestCase
 
 try:
     import pyroma

--- a/Tests/test_util.py
+++ b/Tests/test_util.py
@@ -1,6 +1,8 @@
+import unittest
+
 from PIL import _util
 
-from .helper import PillowTestCase, unittest
+from .helper import PillowTestCase
 
 
 class TestUtil(PillowTestCase):

--- a/Tests/test_webp_leaks.py
+++ b/Tests/test_webp_leaks.py
@@ -1,8 +1,9 @@
+import unittest
 from io import BytesIO
 
 from PIL import Image, features
 
-from .helper import PillowLeakTestCase, unittest
+from .helper import PillowLeakTestCase
 
 test_file = "Tests/images/hopper.webp"
 


### PR DESCRIPTION
The unittest in helper.py has not offered an interesting abstraction
since dbe9f85c7d8f760756ebf8129195470700e63e3d so import from the more
typical stdlib location.
