### PR TITLE
Fix EXIF rational serialization issue due to mismatch between legacy and new mode

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -307,3 +307,10 @@ def test_exif_transpose():
                     "Tests/images/hopper_orientation_" + str(i) + ext
                 ) as orientation_im:
                     check(orientation_im)
+
+
+def test_exif_transpose_metadata_error():
+    with Image.open("Tests/images/exif_transpose_rational_mismatch.jpg") as img:
+        transposed = ImageOps.exif_transpose(img)
+        parsed_exif = transposed.getexif()
+        assert parsed_exif[318] == [(313, 1000), (329, 1000)]

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -258,8 +258,9 @@ def _accept(prefix):
 
 
 def _limit_rational(val, max_val):
-    inv = abs(val) > 1
-    n_d = IFDRational(1 / val if inv else val).limit_rational(max_val)
+    ifd_val = IFDRational(val[0], val[1]) if isinstance(val, tuple) else val
+    inv = abs(ifd_val) > 1
+    n_d = IFDRational(1 / ifd_val if inv else ifd_val).limit_rational(max_val)
     return n_d[::-1] if inv else n_d
 
 


### PR DESCRIPTION
Note that I do not have any prior experience with the Pillow codebase nor EXIF parsing. Please be thorough when reviewing.

The test image is a copy of the image with id `17e017d9f38ada01 ` from the [Open Images Dataset](https://storage.googleapis.com/openimages/web/index.html).

**Current behavior:**
The added `test_exif_transpose_metadata_error` test fails with a type error trying to call `abs` on a tuple.

**New behavior:**
Test does not crash, but gives incorrect result:
```python
    def test_exif_transpose_metadata_error(self):
        with Image.open("Tests/images/exif_transpose_rational_mismatch.jpg") as img:
            transposed = ImageOps.exif_transpose(img)
            parsed_exif = transposed.getexif()
>           self.assertEqual(parsed_exif[318], [(313, 1000), (329, 1000)])
E           AssertionError: ((538976288, 8224), (313, 1000)) != [(313, 1000), (329, 1000)]
```

**Expected behavior:**
Test should succeed with the expected result.
Looking at the de-serialized EXIF data, I see the following:
```[...] 318: ((538976288, 8224), (313, 1000)), 319: ((329, 1000), [...]```
Hence, it looks like the bytes have been pushed somehow.

I do not believe that the offset EXIF information has been caused by my change. Any input on how and where to look to fix this is appreciated.