### PR TITLE
CI: Python 3.5 and 3.6 are tested by GHA, remove from AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,10 +15,6 @@ environment:
   matrix:
   - PYTHON: C:/Python38
   - PYTHON: C:/Python38-x64
-  - PYTHON: C:/Python37
-  - PYTHON: C:/Python37-x64
-  - PYTHON: C:/Python36
-  - PYTHON: C:/Python36-x64
   - PYTHON: C:/Python35
   - PYTHON: C:/Python35-x64
   - PYTHON: C:/msys64/mingw32


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/3606.

Since 13th November, GitHub Actions is now out of beta and hopefully more stable.

Let's make a first step in reducing AppVeyor testing. The **10 jobs** currently take around **40 minutes in serial**.

| Python  | AppVeyor | GitHub Actions |
| --------| :-------:|:--------------:|
| 3.5 x86 | ✅       | ✅             |
| 3.5 x64 | ✅       | ✅             |
| 3.6 x86 | ✅       | ✅             |
| 3.6 x64 | ✅       | ✅             |
| 3.7 x86 | ✅       | ✅             |
| 3.7 x64 | ✅       | ✅             |
| 3.8 x86 | ✅       | ✅             |
| 3.8 x64 | ✅       | ✅             |
| MinGW   | ✅       | ❌             |
| PyPy3   | ✅       | ✅             |

To begin, how about removing 3.6 and 3.7 from AppVeyor? We'll then still be testing the oldest and newest supported CPythons on AppVeyor:

| Python  | AppVeyor | GitHub Actions |
| --------| :-------:|:--------------:|
| 3.5 x86 | ✅       | ✅             |
| 3.5 x64 | ✅       | ✅             |
| 3.6 x86 | ❌       | ✅             |
| 3.6 x64 | ❌       | ✅             |
| 3.7 x86 | ❌       | ✅             |
| 3.7 x64 | ❌       | ✅             |
| 3.8 x86 | ✅       | ✅             |
| 3.8 x64 | ✅       | ✅             |
| MinGW   | ✅       | ❌             |
| PyPy3   | ✅       | ✅             |

Those **6 jobs** take around **23 minutes in serial**.

In the end it would be good to reduce AppVeyor down to only the unique ones (or unique plus one or two) so it's no longer the PR build bottleneck.
