### PR TITLE
Updated documentation

### DIFF
--- a/depends/README.rst
+++ b/depends/README.rst
@@ -7,24 +7,3 @@ build & install non-packaged dependencies; useful for testing with Travis CI.
 
 ``install_extra_test_images.sh`` can be used to install additional test images
 that are used for Travis CI and AppVeyor.
-
-The other scripts can be used to install all of the dependencies for
-the listed operating systems/distros. The ``ubuntu_14.04.sh`` and
-``debian_8.2.sh`` scripts have been tested on bare AWS images and will
-install all required dependencies for the system Python 2.7 and 3.4
-for all of the optional dependencies.  Git may also be required prior
-to running the script to actually download Pillow.
-
-e.g.::
-
-  $ sudo apt-get install git
-  $ git clone https://github.com/python-pillow/Pillow.git
-  $ cd Pillow/depends
-  $ ./debian_8.2.sh
-  $ cd ..
-  $ git checkout [branch or tag]
-  $ virtualenv -p /usr/bin/python2.7 ~/vpy27
-  $ source ~/vpy27/bin/activate
-  $ make install
-  $ make test
-

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -95,14 +95,13 @@ Pillow can be installed on FreeBSD via the official Ports or Packages systems:
 
 **Packages**::
 
-  $ pkg install py27-pillow
+  $ pkg install py36-pillow
 
 .. note::
 
     The `Pillow FreeBSD port
     <https://www.freshports.org/graphics/py-pillow/>`_ and packages
-    are tested by the ports team with all supported FreeBSD versions
-    and against Python 2.7 and 3.x.
+    are tested by the ports team with all supported FreeBSD versions.
 
 
 Building From Source
@@ -174,8 +173,6 @@ Many of Pillow's features require external libraries:
   * Libimagequant is licensed GPLv3, which is more restrictive than
     the Pillow license, therefore we will not be distributing binaries
     with libimagequant support enabled.
-  * Windows support: Libimagequant requires VS2015/MSVC 19 to compile,
-    so it is unlikely to work with Python 2.7 on Windows.
 
 * **libraqm** provides complex text layout support.
 


### PR DESCRIPTION
Helps #3642

- Removes two notes about Python 2.7
- Updates a package install note to direct users to install a Python 3.6 version instead of Python 2.7 - see https://www.freshports.org/graphics/py-pillow/ for reference that there is a Python 3.6 version of the package
- Removes a section of the depends README describing files that were removed in #4109