### PR TITLE
ImageGrab.grab() for Linux with XCB

### DIFF
--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -66,9 +66,7 @@ $bmp = New-Object Drawing.Bitmap 200, 200
         else:
             with pytest.raises(NotImplementedError) as e:
                 ImageGrab.grabclipboard()
-            self.assertEqual(
-                str(e.value), "ImageGrab.grabclipboard() is macOS and Windows only"
-            )
+            assert str(e.value) == "ImageGrab.grabclipboard() is macOS and Windows only"
             return
 
         im = ImageGrab.grabclipboard()

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -36,15 +36,9 @@ class TestImageGrab:
 
     @pytest.mark.skipif(not Image.core.HAVE_XCB, reason="requires XCB")
     def test_grab_invalid_xdisplay(self):
-        exception = None
-
-        try:
+        with pytest.raises(IOError) as e:
             ImageGrab.grab(xdisplay="error.test:0.0")
-        except Exception as e:
-            exception = e
-
-        assert isinstance(exception, IOError)
-        assert str(exception).startswith("X connection failed")
+        assert str(e.value).startswith("X connection failed")
 
     def test_grabclipboard(self):
         if sys.platform == "darwin":
@@ -59,15 +53,11 @@ $bmp = New-Object Drawing.Bitmap 200, 200
             )
             p.communicate()
         else:
-            exception = None
-
-            try:
+            with pytest.raises(NotImplementedError) as e:
                 ImageGrab.grabclipboard()
-            except IOError as e:
-                exception = e
-
-            assert isinstance(exception, IOError)
-            assert str(exception) == "ImageGrab.grabclipboard() is macOS and Windows only"
+            self.assertEqual(
+                str(e.value), "ImageGrab.grabclipboard() is macOS and Windows only"
+            )
             return
 
         im = ImageGrab.grabclipboard()

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -46,9 +46,6 @@ class TestImageGrab:
         assert isinstance(exception, IOError)
         assert str(exception).startswith("X connection failed")
 
-    @pytest.mark.skipif(
-        sys.platform not in ("win32", "darwin"), reason="requires Windows or macOS"
-    )
     def test_grabclipboard(self):
         if sys.platform == "darwin":
             subprocess.call(["screencapture", "-cx"])
@@ -62,7 +59,15 @@ $bmp = New-Object Drawing.Bitmap 200, 200
             )
             p.communicate()
         else:
-            pytest.skip("ImageGrab.grabclipboard() is macOS and Windows only")
+            exception = None
+
+            try:
+                ImageGrab.grabclipboard()
+            except IOError as e:
+                exception = e
+
+            assert isinstance(exception, IOError)
+            assert str(exception) == "ImageGrab.grabclipboard() is macOS and Windows only"
             return
 
         im = ImageGrab.grabclipboard()

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -34,6 +34,17 @@ class TestImageGrab:
         except IOError as e:
             pytest.skip(str(e))
 
+    @pytest.mark.skipif(Image.core.HAVE_XCB, reason="tests missing XCB")
+    def test_grab_no_xcb(self):
+        if sys.platform not in ("win32", "darwin"):
+            with pytest.raises(IOError) as e:
+                ImageGrab.grab()
+            assert str(e.value).startswith("Pillow was built without XCB support")
+
+        with pytest.raises(IOError) as e:
+            ImageGrab.grab(xdisplay="")
+        assert str(e.value).startswith("Pillow was built without XCB support")
+
     @pytest.mark.skipif(not Image.core.HAVE_XCB, reason="requires XCB")
     def test_grab_invalid_xdisplay(self):
         with pytest.raises(IOError) as e:

--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -17,7 +17,7 @@ or the clipboard to a PIL image memory.
     returned as an "RGB" image on Windows or "RGBA" on macOS.
     If the bounding box is omitted, the entire screen is copied.
 
-    .. versionadded:: 1.1.3 (Windows), 3.0.0 (macOS), 7.0.0 (Linux (X11))
+    .. versionadded:: 1.1.3 (Windows), 3.0.0 (macOS), 7.1.0 (Linux (X11))
 
     :param bbox: What region to copy. Default is the entire screen.
                  Note that on Windows OS, the top-left point may be negative if ``all_screens=True`` is used.
@@ -31,7 +31,7 @@ or the clipboard to a PIL image memory.
     :param xdisplay: X11 Display address. Pass ``None`` to grab the default system screen.
                      Pass ``""`` to grab the default X11 screen on Windows or macOS.
 
-        .. versionadded:: 7.0.0
+        .. versionadded:: 7.1.0
     :return: An image
 
 .. py:function:: PIL.ImageGrab.grabclipboard()

--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -11,13 +11,13 @@ or the clipboard to a PIL image memory.
 
 .. versionadded:: 1.1.3
 
-.. py:function:: PIL.ImageGrab.grab(bbox=None, include_layered_windows=False, all_screens=False)
+.. py:function:: PIL.ImageGrab.grab(bbox=None, include_layered_windows=False, all_screens=False, xdisplay=None)
 
     Take a snapshot of the screen. The pixels inside the bounding box are
     returned as an "RGB" image on Windows or "RGBA" on macOS.
     If the bounding box is omitted, the entire screen is copied.
 
-    .. versionadded:: 1.1.3 (Windows), 3.0.0 (macOS)
+    .. versionadded:: 1.1.3 (Windows), 3.0.0 (macOS), 7.0.0 (Linux (X11))
 
     :param bbox: What region to copy. Default is the entire screen.
                  Note that on Windows OS, the top-left point may be negative if ``all_screens=True`` is used.
@@ -27,6 +27,11 @@ or the clipboard to a PIL image memory.
     :param all_screens: Capture all monitors. Windows OS only.
 
         .. versionadded:: 6.2.0
+
+    :param xdisplay: X11 Display address. Pass ``None`` to grab the default system screen.
+                     Pass ``""`` to grab the default X11 screen on Windows or macOS.
+
+        .. versionadded:: 7.0.0
     :return: An image
 
 .. py:function:: PIL.ImageGrab.grabclipboard()

--- a/setup.py
+++ b/setup.py
@@ -286,6 +286,7 @@ class pil_build_ext(build_ext):
             "webpmux",
             "jpeg2000",
             "imagequant",
+            "xcb",
         ]
 
         required = {"jpeg", "zlib"}
@@ -681,6 +682,12 @@ class pil_build_ext(build_ext):
                 ):
                     feature.webpmux = "libwebpmux"
 
+        if feature.want("xcb"):
+            _dbg("Looking for xcb")
+            if _find_include_file(self, "xcb/xcb.h"):
+                if _find_library_file(self, "xcb"):
+                    feature.xcb = "xcb"
+
         for f in feature:
             if not getattr(feature, f) and feature.require(f):
                 if f in ("jpeg", "zlib"):
@@ -715,6 +722,9 @@ class pil_build_ext(build_ext):
         if feature.tiff:
             libs.append(feature.tiff)
             defs.append(("HAVE_LIBTIFF", None))
+        if feature.xcb:
+            libs.append(feature.xcb)
+            defs.append(("HAVE_XCB", None))
         if sys.platform == "win32":
             libs.extend(["kernel32", "user32", "gdi32"])
         if struct.unpack("h", b"\0\1")[0] == 1:

--- a/setup.py
+++ b/setup.py
@@ -823,6 +823,7 @@ class pil_build_ext(build_ext):
             (feature.lcms, "LITTLECMS2"),
             (feature.webp, "WEBP"),
             (feature.webpmux, "WEBPMUX"),
+            (feature.xcb, "XCB (X protocol)"),
         ]
 
         all = 1

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -22,38 +22,62 @@ import tempfile
 
 from . import Image
 
-if sys.platform not in ["win32", "darwin"]:
-    raise ImportError("ImageGrab is macOS and Windows only")
+if sys.platform == "win32":
+    pass
+elif sys.platform == "darwin":
+    import os
+    import tempfile
+    import subprocess
+elif not Image.core.HAVE_XCB:
+    raise ImportError("ImageGrab requires Windows, macOS, or the XCB library")
 
 
-def grab(bbox=None, include_layered_windows=False, all_screens=False):
-    if sys.platform == "darwin":
-        fh, filepath = tempfile.mkstemp(".png")
-        os.close(fh)
-        subprocess.call(["screencapture", "-x", filepath])
-        im = Image.open(filepath)
-        im.load()
-        os.unlink(filepath)
-        if bbox:
-            im_cropped = im.crop(bbox)
-            im.close()
-            return im_cropped
-    else:
-        offset, size, data = Image.core.grabscreen(include_layered_windows, all_screens)
-        im = Image.frombytes(
-            "RGB",
-            size,
-            data,
-            # RGB, 32-bit line padding, origin lower left corner
-            "raw",
-            "BGR",
-            (size[0] * 3 + 3) & -4,
-            -1,
-        )
-        if bbox:
-            x0, y0 = offset
-            left, top, right, bottom = bbox
-            im = im.crop((left - x0, top - y0, right - x0, bottom - y0))
+def grab(bbox=None, include_layered_windows=False, all_screens=False, xdisplay=None):
+    if xdisplay is None:
+        if sys.platform == "darwin":
+            fh, filepath = tempfile.mkstemp(".png")
+            os.close(fh)
+            subprocess.call(["screencapture", "-x", filepath])
+            im = Image.open(filepath)
+            im.load()
+            os.unlink(filepath)
+            if bbox:
+                im_cropped = im.crop(bbox)
+                im.close()
+                return im_cropped
+            return im
+        elif sys.platform == "win32":
+            offset, size, data = Image.core.grabscreen(include_layered_windows, all_screens)
+            im = Image.frombytes(
+                "RGB",
+                size,
+                data,
+                # RGB, 32-bit line padding, origin lower left corner
+                "raw",
+                "BGR",
+                (size[0] * 3 + 3) & -4,
+                -1,
+            )
+            if bbox:
+                x0, y0 = offset
+                left, top, right, bottom = bbox
+                im = im.crop((left - x0, top - y0, right - x0, bottom - y0))
+            return im
+    # use xdisplay=None for default display on non-win32/macOS systems
+    if not Image.core.HAVE_XCB:
+        raise OSError("XCB support not included")
+    size, data = Image.core.grabscreen_x11(xdisplay)
+    im = Image.frombytes(
+        "RGB",
+        size,
+        data,
+        "raw",
+        "BGRX",
+        size[0] * 4,
+        1,
+    )
+    if bbox:
+        im = im.crop(bbox)
     return im
 
 
@@ -81,8 +105,8 @@ def grabclipboard():
             im.load()
         os.unlink(filepath)
         return im
-    else:
-        data = Image.core.grabclipboard()
+    elif sys.platform == "win32":
+        data = Image.core.grabclipboard_win32()
         if isinstance(data, bytes):
             from . import BmpImagePlugin
             import io

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -101,4 +101,4 @@ def grabclipboard():
             return BmpImagePlugin.DibImageFile(io.BytesIO(data))
         return data
     else:
-        raise IOError("ImageGrab.grabclipboard() is macOS and Windows only")
+        raise NotImplementedError("ImageGrab.grabclipboard() is macOS and Windows only")

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -22,12 +22,12 @@ import tempfile
 
 from . import Image
 
-if sys.platform == "win32":
-    pass
-elif sys.platform == "darwin":
+if sys.platform == "darwin":
     import os
     import tempfile
     import subprocess
+elif sys.platform == "win32":
+    pass
 elif not Image.core.HAVE_XCB:
     raise ImportError("ImageGrab requires Windows, macOS, or the XCB library")
 
@@ -65,17 +65,9 @@ def grab(bbox=None, include_layered_windows=False, all_screens=False, xdisplay=N
             return im
     # use xdisplay=None for default display on non-win32/macOS systems
     if not Image.core.HAVE_XCB:
-        raise OSError("XCB support not included")
+        raise AttributeError("XCB support not present")
     size, data = Image.core.grabscreen_x11(xdisplay)
-    im = Image.frombytes(
-        "RGB",
-        size,
-        data,
-        "raw",
-        "BGRX",
-        size[0] * 4,
-        1,
-    )
+    im = Image.frombytes("RGB", size, data, "raw", "BGRX", size[0] * 4, 1)
     if bbox:
         im = im.crop(bbox)
     return im

--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -56,6 +56,7 @@ features = {
     "raqm": ("PIL._imagingft", "HAVE_RAQM"),
     "libjpeg_turbo": ("PIL._imaging", "HAVE_LIBJPEGTURBO"),
     "libimagequant": ("PIL._imaging", "HAVE_LIBIMAGEQUANT"),
+    "xcb": ("PIL._imaging", "HAVE_XCB"),
 }
 
 
@@ -132,6 +133,7 @@ def pilinfo(out=None, supported_formats=True):
         ("libtiff", "LIBTIFF"),
         ("raqm", "RAQM (Bidirectional Text)"),
         ("libimagequant", "LIBIMAGEQUANT (Quantization method)"),
+        ("xcb", "XCB (X protocol)"),
     ]:
         if check(name):
             print("---", feature, "support ok", file=out)

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -3781,6 +3781,9 @@ extern PyObject* PyImaging_ListWindowsWin32(PyObject* self, PyObject* args);
 extern PyObject* PyImaging_EventLoopWin32(PyObject* self, PyObject* args);
 extern PyObject* PyImaging_DrawWmf(PyObject* self, PyObject* args);
 #endif
+#ifdef HAVE_XCB
+extern PyObject* PyImaging_GrabScreenX11(PyObject* self, PyObject* args);
+#endif
 
 /* Experimental path stuff (in path.c) */
 extern PyObject* PyPath_Create(ImagingObject* self, PyObject* args);
@@ -3853,12 +3856,15 @@ static PyMethodDef functions[] = {
 #ifdef _WIN32
     {"display", (PyCFunction)PyImaging_DisplayWin32, 1},
     {"display_mode", (PyCFunction)PyImaging_DisplayModeWin32, 1},
-    {"grabscreen", (PyCFunction)PyImaging_GrabScreenWin32, 1},
-    {"grabclipboard", (PyCFunction)PyImaging_GrabClipboardWin32, 1},
+    {"grabscreen_win32", (PyCFunction)PyImaging_GrabScreenWin32, 1},
+    {"grabclipboard_win32", (PyCFunction)PyImaging_GrabClipboardWin32, 1},
     {"createwindow", (PyCFunction)PyImaging_CreateWindowWin32, 1},
     {"eventloop", (PyCFunction)PyImaging_EventLoopWin32, 1},
     {"listwindows", (PyCFunction)PyImaging_ListWindowsWin32, 1},
     {"drawwmf", (PyCFunction)PyImaging_DrawWmf, 1},
+#endif
+#ifdef HAVE_XCB
+    {"grabscreen_x11", (PyCFunction)PyImaging_GrabScreenX11, 1},
 #endif
 
     /* Utilities */
@@ -3977,6 +3983,12 @@ setup_module(PyObject* m) {
 #endif
     PyDict_SetItemString(d, "libtiff_support_custom_tags", support_custom_tags);
   }
+#endif
+
+#ifdef HAVE_XCB
+    PyModule_AddObject(m, "HAVE_XCB", Py_True);
+#else
+    PyModule_AddObject(m, "HAVE_XCB", Py_False);
 #endif
 
     PyDict_SetItemString(d, "PILLOW_VERSION", PyUnicode_FromString(version));

--- a/src/display.c
+++ b/src/display.c
@@ -887,7 +887,7 @@ PyImaging_GrabScreenX11(PyObject* self, PyObject* args)
         buffer = PyBytes_FromStringAndSize((char*)xcb_get_image_data(reply),
                                            xcb_get_image_data_length(reply));
     } else {
-        PyErr_Format(PyExc_IOError, "usupported bit depth: %i", reply->depth);
+        PyErr_Format(PyExc_IOError, "unsupported bit depth: %i", reply->depth);
     }
 
     free(reply);

--- a/src/display.c
+++ b/src/display.c
@@ -815,3 +815,82 @@ error:
 }
 
 #endif /* _WIN32 */
+
+/* -------------------------------------------------------------------- */
+/* X11 support	*/
+
+#ifdef HAVE_XCB
+#include <xcb/xcb.h>
+
+/* -------------------------------------------------------------------- */
+/* X11 screen grabber */
+
+PyObject*
+PyImaging_GrabScreenX11(PyObject* self, PyObject* args)
+{
+    int width, height;
+    char* display_name;
+    xcb_connection_t* connection;
+    int screen_number;
+    xcb_screen_iterator_t iter;
+    xcb_screen_t* screen = NULL;
+    xcb_get_image_reply_t* reply;
+    xcb_generic_error_t* error;
+    PyObject* buffer = NULL;
+
+    if (!PyArg_ParseTuple(args, "|z", &display_name))
+        return NULL;
+
+    /* connect to X and get screen data */
+
+    connection = xcb_connect(display_name, &screen_number);
+    if (xcb_connection_has_error(connection)) {
+        xcb_disconnect(connection);
+        PyErr_SetString(PyExc_IOError, "X connection failed");
+        return NULL;
+    }
+
+    iter = xcb_setup_roots_iterator(xcb_get_setup(connection));
+    for (; iter.rem; --screen_number, xcb_screen_next(&iter)) {
+        if (screen_number == 0) {
+            screen = iter.data;
+            break;
+        }
+    }
+    if (screen == NULL) {
+        xcb_disconnect(connection);
+        PyErr_SetString(PyExc_IOError, "X screen not found");
+        return NULL;
+    }
+
+    width = screen->width_in_pixels;
+    height = screen->height_in_pixels;
+
+    /* get image data */
+
+    reply = xcb_get_image_reply(connection,
+                                xcb_get_image(connection, XCB_IMAGE_FORMAT_Z_PIXMAP, screen->root,
+                                              0, 0, width, height, 0x00ffffff),
+                                &error);
+    if (reply == NULL) {
+        free(error);
+        xcb_disconnect(connection);
+        PyErr_SetString(PyExc_IOError, "X get_image failed");
+        return NULL;
+    }
+
+    /* store data in Python buffer */
+
+    buffer = PyBytes_FromStringAndSize((char*)xcb_get_image_data(reply),
+                                       xcb_get_image_data_length(reply));
+
+    free(reply);
+    xcb_disconnect(connection);
+
+    if (!buffer)
+        return NULL;
+
+    return Py_BuildValue("(ii)N", width, height, buffer);
+}
+
+#endif /* HAVE_XCB */


### PR DESCRIPTION
Partially resolves #2028

Alternative to #4198

Changes proposed in this pull request:

 * Add `ImageGrab.grab()` support for X11 (Linux) using the XCB library (only screenshots for now, clipboard can be added in the future)

There is also support for taking X11 screenshots on Windows and macOS (where X11 can be installed as a separate window manager). This proposed implementation uses the old methods if `xdisplay=None` is passed, but if `xdisplay=""` is passed (or on Linux), it will grab the default X11 screen (likely from the DISPLAY envvar). A different value can be passed in the `xdisplay` parameter to override the default X11 screen address.

Unlike [mss](https://github.com/BoboTiG/python-mss) which uses Xlib, this uses XCB. This provides more resilient error handling at the cost of potentially slightly lower OS compatibility (Xlib is older).