### PR TITLE
GHA: Print some basic system information for the logs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Build system information
+      run: python .github/workflows/system-info.py
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/system-info.py
+++ b/.github/workflows/system-info.py
@@ -21,4 +21,5 @@ print("platform.machine()\t", platform.machine())
 print("platform.platform()\t", platform.platform())
 print("platform.version()\t", platform.version())
 print("platform.uname()\t", platform.uname())
-print("platform.mac_ver()\t", platform.mac_ver())
+if sys.platform == "darwin":
+    print("platform.mac_ver()\t", platform.mac_ver())

--- a/.github/workflows/system-info.py
+++ b/.github/workflows/system-info.py
@@ -1,0 +1,24 @@
+"""
+Print out some handy system info like Travis CI does.
+
+This sort of info is missing from GitHub Actions.
+
+Requested here:
+https://github.com/actions/virtual-environments/issues/79
+"""
+import os
+import platform
+import sys
+
+print("Build system information")
+print()
+
+print("sys.version\t\t", sys.version.split("\n"))
+print("os.name\t\t\t", os.name)
+print("sys.platform\t\t", sys.platform)
+print("platform.system()\t", platform.system())
+print("platform.machine()\t", platform.machine())
+print("platform.platform()\t", platform.platform())
+print("platform.version()\t", platform.version())
+print("platform.uname()\t", platform.uname())
+print("platform.mac_ver()\t", platform.mac_ver())

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -29,6 +29,9 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - name: Build system information
+      run: python .github/workflows/system-info.py
+
     - name: Docker pull
       run: |
         docker pull pythonpillow/${{ matrix.docker }}:${{ matrix.dockerTag }}

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -70,6 +70,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}
 
+    - name: Build system information
+      run: python .github/workflows/system-info.py
+
     - name: pip install wheel pytest pytest-cov
       run: |
         "%pythonLocation%\python.exe" -m pip install wheel pytest pytest-cov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Build system information
+      run: python .github/workflows/system-info.py
+
     - name: Install Linux dependencies
       if: startsWith(matrix.os, 'ubuntu')
       run: |


### PR DESCRIPTION
Changes proposed in this pull request:

 * Unlike Travis CI, GitHub Actions doesn't print out build system information at the top of the logs
 * That means it's not clear what `macos-latest` or `windows-latest` really are, especially during rollout of new versions (eg. https://github.com/actions/virtual-environments/issues/53#issuecomment-550405295) or the docs saying one thing and the build another (eg. https://github.com/python-pillow/Pillow/pull/4228#discussion_r355053699, https://github.com/actions/virtual-environments/issues/81#issuecomment-562761489)
 * See https://github.com/actions/virtual-environments/issues/79 for a request for this to be added to GitHub Actions
 * In the meantime, let's add some basics ourselves

