### PR TITLE
Updated URL

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@
 codecov:
   # Avoid "Missing base report" due to committing CHANGES.rst with "[CI skip]"
   # https://github.com/codecov/support/issues/363
-  # https://docs.codecov.io/v4.3.6/docs/comparing-commits
+  # https://docs.codecov.io/docs/comparing-commits
   allow_coverage_offsets: true
 
   token: 6dafc396-e7f5-4221-a38a-8b07a49fbdae


### PR DESCRIPTION
https://docs.codecov.io/v4.3.6/docs/comparing-commits returns a 404 page.