### PR TITLE
Define box filter equal 1.0 on (-0.5, 0.5] range instead of [-0.5, 0.5)

### DIFF
--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -212,6 +212,11 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
             for channel in case.split():
                 self.check_case(channel, self.make_sample(data, (12, 12)))
 
+    def test_box_filter_correct_range(self):
+        im = Image.new("RGB", (8, 8), "#1688ff").resize((100, 100), Image.BOX)
+        ref = Image.new("RGB", (100, 100), "#1688ff")
+        self.assert_image_equal(im, ref)
+
 
 class CoreResampleConsistencyTest(PillowTestCase):
     def make_case(self, mode, fill):

--- a/src/libImaging/Resample.c
+++ b/src/libImaging/Resample.c
@@ -13,7 +13,7 @@ struct filter {
 
 static inline double box_filter(double x)
 {
-    if (x >= -0.5 && x < 0.5)
+    if (x > -0.5 && x <= 0.5)
         return 1.0;
     return 0.0;
 }


### PR DESCRIPTION
Fixes #4258. Explanations in [the comment](https://github.com/python-pillow/Pillow/issues/4258#issuecomment-567263707).