### PR TITLE
Raise an error if BMP file size is too large when saving

### DIFF
--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -41,6 +41,13 @@ class TestFileBmp(PillowTestCase):
             self.assertEqual(im.size, reloaded.size)
             self.assertEqual(reloaded.format, "BMP")
 
+    def test_save_too_large(self):
+        outfile = self.tempfile("temp.bmp")
+        with Image.new("RGB", (1, 1)) as im:
+            im._size = (37838, 37838)
+            with self.assertRaises(ValueError):
+                im.save(outfile)
+
     def test_dpi(self):
         dpi = (72, 72)
 

--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -321,9 +321,12 @@ def _save(im, fp, filename, bitmap_header=True):
     # bitmap header
     if bitmap_header:
         offset = 14 + header + colors * 4
+        file_size = offset + image
+        if file_size > 2 ** 32 - 1:
+            raise ValueError("File size is too large for the BMP format")
         fp.write(
             b"BM"  # file type (magic)
-            + o32(offset + image)  # file size
+            + o32(file_size)  # file size
             + o32(0)  # reserved
             + o32(offset)  # image data offset
         )

--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -322,11 +322,11 @@ def _save(im, fp, filename, bitmap_header=True):
     if bitmap_header:
         offset = 14 + header + colors * 4
         fp.write(
-            b"BM"
-            + o32(offset + image)  # file type (magic)
-            + o32(0)  # file size
-            + o32(offset)  # reserved
-        )  # image data offset
+            b"BM"  # file type (magic)
+            + o32(offset + image)  # file size
+            + o32(0)  # reserved
+            + o32(offset)  # image data offset
+        )
 
     # bitmap info header
     fp.write(


### PR DESCRIPTION
Resolves #4274, by throwing an error if the file size is too large to fit into 4 bytes.

I set the size artificially in the test to avoid using a large amount of memory.

Also fixes up the comments, which were out of sync. Reference http://www.ece.ualberta.ca/~elliott/ee552/studentAppNotes/2003_w/misc/bmp_file_format/bmp_file_format.htm