### PR TITLE
make doccheck: turn warnings into errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,12 +83,6 @@ jobs:
         name: errors
         path: Tests/errors
 
-    - name: Docs
-      if: matrix.python-version == 3.8
-      run: |
-        pip install sphinx-rtd-theme
-        make doccheck
-
     - name: After success
       if: success()
       run: |

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -3,7 +3,7 @@
 set -e
 
 sudo apt-get update
-sudo apt-get -qq install libfreetype6-dev liblcms2-dev python-tk\
+sudo apt-get -qq install libfreetype6-dev liblcms2-dev python3-tk\
                          ghostscript libffi-dev libjpeg-turbo-progs libopenjp2-7-dev\
                          cmake imagemagick libharfbuzz-dev libfribidi-dev
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -42,7 +42,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 html:
-	$(SPHINXBUILD) -b html -W $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html -W --keep-going $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -42,7 +42,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html -W $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -335,7 +335,7 @@ Or for Python 3::
 Prerequisites are installed on **Ubuntu 16.04 LTS** with::
 
     $ sudo apt-get install libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev \
-        libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python-tk \
+        libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \
         libharfbuzz-dev libfribidi-dev
 
 Then see ``depends/install_raqm.sh`` to install libraqm.

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2181,12 +2181,14 @@ class Image:
 
           It may also be an :py:class:`~PIL.Image.ImageTransformHandler`
           object::
+
             class Example(Image.ImageTransformHandler):
                 def transform(size, method, data, resample, fill=1):
                     # Return result
 
           It may also be an object with a :py:meth:`~method.getdata` method
           that returns a tuple supplying new **method** and **data** values::
+
             class Example(object):
                 def getdata(self):
                     method = Image.EXTENT

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -234,6 +234,7 @@ def pad(image, size, method=Image.BICUBIC, color=None, centering=(0.5, 0.5)):
     :param color: The background color of the padded image.
     :param centering: Control the position of the original image within the
                       padded version.
+
                           (0.5, 0.5) will keep the image centered
                           (0, 0) will keep the image aligned to the top left
                           (1, 1) will keep the image aligned to the bottom


### PR DESCRIPTION
Changes proposed in this pull request:

 * Catch issues like https://github.com/python-pillow/Pillow/pull/4271 and https://github.com/python-pillow/Pillow/pull/4282 on the CI, by turning the warnings from sphinx-build into errors

# Warnings as warnings

For example, a build of an commit before those two fixes, with normal warnings, has exit code 0 so the CI passes:

```
⌂90% [hugo:~/github/Pillow] 52113a82+* ± make doccheck
/Library/Developer/CommandLineTools/usr/bin/make -C docs html
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v2.1.2
making output directory... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 72 source files that are out of date
updating environment: 72 added, 0 changed, 0 removed
reading sources... [100%] releasenotes/index
/Users/hugo/github/Pillow/docs/handbook/concepts.rst:168: WARNING: Malformed table.

+------------+-------------+-----------+-------------+
| Filter     | Downscaling | Upscaling | Performance |
|            | quality     | quality   |             |
+============+=============+===========+=============+
|``NEAREST`` |             |           | ⭐⭐⭐⭐⭐       |
+------------+-------------+-----------+-------------+
|``BOX``     | ⭐           |           | ⭐⭐⭐⭐        |
+------------+-------------+-----------+-------------+
|``BILINEAR``| ⭐           | ⭐         | ⭐⭐⭐         |
+------------+-------------+-----------+-------------+
|``HAMMING`` | ⭐⭐          |           | ⭐⭐⭐         |
+------------+-------------+-----------+-------------+
|``BICUBIC`` | ⭐⭐⭐         | ⭐⭐⭐       | ⭐⭐          |
+------------+-------------+-----------+-------------+
|``LANCZOS`` | ⭐⭐⭐⭐        | ⭐⭐⭐⭐      | ⭐           |
+------------+-------------+-----------+-------------+
/Users/hugo/github/pillow-security/src/PIL/Image.py:docstring of PIL.Image.Image.transform:16: WARNING: Unexpected indentation.
/Users/hugo/github/pillow-security/src/PIL/Image.py:docstring of PIL.Image.Image.transform:22: WARNING: Unexpected indentation.
/Users/hugo/github/pillow-security/src/PIL/ImageOps.py:docstring of PIL.ImageOps.pad:12: WARNING: Unexpected indentation.
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] releasenotes/index
generating indices... genindex py-modindex
highlighting module code... [100%] PIL._binary
writing additional pages... search/usr/local/lib/python3.7/site-packages/sphinx_rtd_theme/search.html:20: RemovedInSphinx30Warning: To modify script_files in the theme is deprecated. Please insert a <script> tag directly in your theme instead.
  {{ super() }}

copying images... [100%] releasenotes/../../Tests/images/imagedraw_stroke_different.png
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 4 warnings.

The HTML pages are in _build/html.

Build finished. The HTML pages are in _build/html.
/Library/Developer/CommandLineTools/usr/bin/make -C docs linkcheck || true
sphinx-build -b linkcheck -d _build/doctrees   . _build/linkcheck
Running Sphinx v2.1.2
making output directory... done
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [linkcheck]: targets for 72 source files that are out of date
updating environment: 0 added, 0 changed, 0 removed
looking for now-outdated files... none found
preparing documents... done
writing output... [  1%] PIL
(line   41) ok        https://en.wikipedia.org/wiki/Quantization_matrix#Quantization_matrices
(line   27) ok        https://en.wikipedia.org/wiki/Chroma_subsampling
(line   41) ok        https://en.wikipedia.org/wiki/JPEG#Quantization
(line   64) ok        https://web.archive.org/web/20120328125543/http://www.jpegcameras.com/libjpeg/libjpeg-3.html
writing output... [  2%] about
(line   11) ok        https://pypi.org/project/Pillow/
(line   22) ok        https://raw.githubusercontent.com/python-pillow/Pillow/master/LICENSE
(line    9) ok        https://travis-ci.org/python-pillow/Pillow
(line   10) ok        https://github.com/python-pillow/Pillow
(line   27) ok        https://mail.python.org/pipermail/image-sig/2010-August/006480.html
(line    9) ok        https://ci.appveyor.com/project/Python-pillow/pillow
(line    9) broken    https://github.com/python-pillow/Pillow/actions - 404 Client Error: Not Found for url: https://github.com/python-pillow/Pillow/actions
(line   39) ok        https://bitbucket.org/effbot/pil-2009-raclette/issues
(line   39) ok        https://github.com/python-pillow/Pillow/issues
writing output... [  4%] deprecations
writing output... [  5%] handbook/appendices
writing output... [  6%] handbook/concepts
writing output... [  8%] handbook/image-file-formats
(line  550) -local-   ../installation.html
(line  600) ok        https://spider.wadsworth.org/spider_doc/spider/docs/spider.html
(line  600) ok        https://www.wadsworth.org/
writing output... [  9%] handbook/index
writing output... [ 11%] handbook/overview
writing output... [ 12%] handbook/tutorial
writing output... [ 13%] handbook/writing-your-own-file-decoder
writing output... [ 15%] index
(line    6) ok        https://tidelift.com/subscription/pkg/pypi-pillow?utm_source=pillow&utm_medium=referral&utm_campaign=docs
(line    4) ok        https://github.com/python-pillow/Pillow/graphs/contributors
(line    2) ok        https://travis-ci.org/python-pillow/pillow-wheels
(line    2) redirect  https://pillow.readthedocs.io/?badge=latest - with Found to https://pillow.readthedocs.io/en/stable/?badge=latest
(line    2) redirect  https://zenodo.org/badge/17549/python-pillow/Pillow.svg - with Found to https://zenodo.org/badge/doi/10.5281/zenodo.44297.svg
(line    2) ok        https://readthedocs.org/projects/pillow/badge/?version=latest
(line    2) ok        https://ci.appveyor.com/project/python-pillow/Pillow
(line    2) ok        https://img.shields.io/travis/python-pillow/Pillow/master.svg?label=Linux%20build
(line    2) ok        https://codecov.io/gh/python-pillow/Pillow
(line    2) ok        https://img.shields.io/travis/python-pillow/pillow-wheels/master.svg?label=macOS%20build
(line    2) redirect  https://zenodo.org/badge/latestdoi/17549/python-pillow/Pillow - with Found to https://zenodo.org/record/44297
(line    2) ok        https://img.shields.io/pypi/v/pillow.svg
(line    2) ok        https://img.shields.io/appveyor/ci/python-pillow/Pillow/master.svg?label=Windows%20build
(line    2) ok        https://codecov.io/gh/python-pillow/Pillow/branch/master/graph/badge.svg
(line    2) ok        https://img.shields.io/pypi/dm/pillow.svg
writing output... [ 16%] installation
(line  491) ok        https://pypi.org/project/Pillow/#history
(line  491) ok        https://pypi.org/project/Pillow/1.0/
(line  265) ok        https://brew.sh/
(line  128) ok        https://github.com/python-pillow/docker-images
(line  352) ok        https://github.com/python-pillow/docker-images
(line  103) ok        https://www.freshports.org/graphics/py-pillow/
writing output... [ 18%] porting
writing output... [ 19%] reference/ExifTags
writing output... [ 20%] reference/Image
(line   53) ok        https://en.wikipedia.org/wiki/Zip_bomb
(line   53) ok        https://docs.python.org/3/library/logging.html#integration-with-the-warnings-module
writing output... [ 22%] reference/ImageChops
writing output... [ 23%] reference/ImageCms
writing output... [ 25%] reference/ImageColor
writing output... [ 26%] reference/ImageDraw
(line  401) ok        https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist
(line  325) ok        https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist
(line  277) ok        https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist
(line  362) ok        https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist
(line   12) ok        https://github.com/pytroll/aggdraw
writing output... [ 27%] reference/ImageEnhance
writing output... [ 29%] reference/ImageFile
writing output... [ 30%] reference/ImageFilter
(line    3) ok        https://en.wikipedia.org/wiki/Unsharp_masking#Digital_unsharp_masking
writing output... [ 31%] reference/ImageFont
writing output... [ 33%] reference/ImageGrab
writing output... [ 34%] reference/ImageMath
writing output... [ 36%] reference/ImageMorph
writing output... [ 37%] reference/ImageOps
writing output... [ 38%] reference/ImagePalette
writing output... [ 40%] reference/ImagePath
(line   36) ok        https://en.wikipedia.org/wiki/Manhattan_distance
writing output... [ 41%] reference/ImageQt
writing output... [ 43%] reference/ImageSequence
writing output... [ 44%] reference/ImageStat
writing output... [ 45%] reference/ImageTk
writing output... [ 47%] reference/ImageWin
writing output... [ 48%] reference/PSDraw
writing output... [ 50%] reference/PixelAccess
writing output... [ 51%] reference/PyAccess
writing output... [ 52%] reference/TiffTags
writing output... [ 54%] reference/block_allocator
writing output... [ 55%] reference/index
writing output... [ 56%] reference/internal_design
writing output... [ 58%] reference/limits
(line   40) ok        https://developers.google.com/speed/webp/docs/api
writing output... [ 59%] reference/open_files
writing output... [ 61%] reference/plugins
(line   14) ok        https://code.google.com/archive/p/casadebender/wikis/Win32IconImagePlugin.wiki
writing output... [ 62%] releasenotes/2.7.0
(line    7) ok        https://github.com/python-pillow/Sane
writing output... [ 63%] releasenotes/2.8.0
writing output... [ 65%] releasenotes/3.0.0
writing output... [ 66%] releasenotes/3.1.0
writing output... [ 68%] releasenotes/3.1.1
writing output... [ 69%] releasenotes/3.1.2
writing output... [ 70%] releasenotes/3.2.0
writing output... [ 72%] releasenotes/3.3.0
writing output... [ 73%] releasenotes/3.3.2
writing output... [ 75%] releasenotes/3.4.0
writing output... [ 76%] releasenotes/4.0.0
writing output... [ 77%] releasenotes/4.1.0
writing output... [ 79%] releasenotes/4.1.1
(line   17) ok        https://bugs.python.org/issue29943
writing output... [ 80%] releasenotes/4.2.0
(line    7) -local-   ../installation.html
writing output... [ 81%] releasenotes/4.2.1
writing output... [ 83%] releasenotes/4.3.0
writing output... [ 84%] releasenotes/5.0.0
(line   29) ok        https://github.com/python-pillow/pillow-scripts
writing output... [ 86%] releasenotes/5.1.0
writing output... [ 87%] releasenotes/5.2.0
(line   28) ok        https://en.wikipedia.org/wiki/3D_lookup_table
(line  108) ok        https://pillow.readthedocs.io/en/5.1.x/about.html#why-a-fork
writing output... [ 88%] releasenotes/5.3.0
writing output... [ 90%] releasenotes/5.4.0
writing output... [ 91%] releasenotes/5.4.1
writing output... [ 93%] releasenotes/6.0.0
writing output... [ 94%] releasenotes/6.1.0
writing output... [ 95%] releasenotes/6.2.0
writing output... [ 97%] releasenotes/6.2.1
writing output... [ 98%] releasenotes/7.0.0
writing output... [100%] releasenotes/index

build finished with problems.
make[1]: *** [linkcheck] Error 1
⌂71% [hugo:~/github/Pillow] 52113a82+* 44s ±
```

# Warnings as errors

This has a non-zero return code, will fail the build:

```
⌂63% [hugo:~/github/Pillow] 52113a82(+1/-1)+* 25s ± rm -rf docs/_build
[hugo:~/github/Pillow] 52113a82(+1/-1)+* ± make doccheck
/Library/Developer/CommandLineTools/usr/bin/make -C docs html
sphinx-build -b html -W -d _build/doctrees   . _build/html
Running Sphinx v2.1.2
making output directory... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 72 source files that are out of date
updating environment: 72 added, 0 changed, 0 removed
reading sources... [100%] releasenotes/index

Warning, treated as error:
/Users/hugo/github/Pillow/docs/handbook/concepts.rst:168:Malformed table.

+------------+-------------+-----------+-------------+
| Filter     | Downscaling | Upscaling | Performance |
|            | quality     | quality   |             |
+============+=============+===========+=============+
|``NEAREST`` |             |           | \u2b50\u2b50\u2b50\u2b50\u2b50       |
+------------+-------------+-----------+-------------+
|``BOX``     | \u2b50           |           | \u2b50\u2b50\u2b50\u2b50        |
+------------+-------------+-----------+-------------+
|``BILINEAR``| \u2b50           | \u2b50         | \u2b50\u2b50\u2b50         |
+------------+-------------+-----------+-------------+
|``HAMMING`` | \u2b50\u2b50          |           | \u2b50\u2b50\u2b50         |
+------------+-------------+-----------+-------------+
|``BICUBIC`` | \u2b50\u2b50\u2b50         | \u2b50\u2b50\u2b50       | \u2b50\u2b50          |
+------------+-------------+-----------+-------------+
|``LANCZOS`` | \u2b50\u2b50\u2b50\u2b50        | \u2b50\u2b50\u2b50\u2b50      | \u2b50           |
+------------+-------------+-----------+-------------+
make[1]: *** [html] Error 2
make: *** [doccheck] Error 2
[hugo:~/github/Pillow] 52113a82(+1/-1)+* 11s 2 ±
```
