### PR TITLE
Accept io.StringIO as a path for Image.open

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1,3 +1,4 @@
+import io
 import os
 import shutil
 import tempfile
@@ -90,6 +91,11 @@ class TestImage(PillowTestCase):
 
     def test_bad_mode(self):
         self.assertRaises(ValueError, Image.open, "filename", "bad mode")
+
+    def test_stringio(self):
+        with Image.open(io.StringIO("Tests/images/hopper.jpg")) as im:
+            self.assertEqual(im.mode, "RGB")
+            self.assertEqual(im.size, (128, 128))
 
     def test_pathlib(self):
         from PIL.Image import Path

--- a/docs/reference/open_files.rst
+++ b/docs/reference/open_files.rst
@@ -3,10 +3,10 @@
 File Handling in Pillow
 =======================
 
-When opening a file as an image, Pillow requires a filename, ``pathlib.Path``
-object, or a file-like object. Pillow uses the filename or ``Path`` to open a
-file, so for the rest of this article, they will all be treated as a file-like
-object.
+When opening a file as an image, Pillow requires a filename, ``io.StringIO``
+object, ``pathlib.Path`` object, or a file-like object. Pillow uses the
+filename, ``StringIO`` or ``Path`` to open a file, so for the rest of this
+article, they will all be treated as a file-like object.
 
 The following are all equivalent::
 
@@ -15,6 +15,9 @@ The following are all equivalent::
     import pathlib
 
     with Image.open('test.jpg') as im:
+        ...
+
+    with Image.open(io.StringIO('test.jpg')) as im2:
         ...
 
     with Image.open(pathlib.Path('test.jpg')) as im2:

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2674,8 +2674,8 @@ def open(fp, mode="r"):
     :py:meth:`~PIL.Image.Image.load` method).  See
     :py:func:`~PIL.Image.new`. See :ref:`file-handling`.
 
-    :param fp: A filename (string), pathlib.Path object or a file object.
-       The file object must implement :py:meth:`~file.read`,
+    :param fp: A filename (string), io.StringIO object, pathlib.Path object
+       or a file object. The file object must implement :py:meth:`~file.read`,
        :py:meth:`~file.seek`, and :py:meth:`~file.tell` methods,
        and be opened in binary mode.
     :param mode: The mode.  If given, this argument must be "r".
@@ -2691,6 +2691,8 @@ def open(fp, mode="r"):
     filename = ""
     if isinstance(fp, Path):
         filename = str(fp.resolve())
+    elif isinstance(fp, io.StringIO):
+        filename = fp.getvalue()
     elif isPath(fp):
         filename = fp
 


### PR DESCRIPTION
Resolves #4097 

The conclusion of discussion in the issue is that StringIO can't be used to pass bytes into Image.open.

```python
import io
from PIL import Image
im = Image.open(io.StringIO("'\x89\x50\x4E\x47\x0D"))
```
```
OSError: cannot identify image file <_io.StringIO object at 0x104ecdd70>
```

A user suggests that we raise an explicit error if someone passes StringIO in.

However, I like the idea of being able to use StringIO for something, rather than just rejecting it - so this PR adds functionality to use StringIO as a path instead.

```python
import io
from PIL import Image
im = Image.open(io.StringIO("Tests/images/hopper.jpg"))
```