### PR TITLE
Use the same Python version to build docs in Travis and  GHA

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -20,8 +20,8 @@ if [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then
     pip install pyqt5
 fi
 
-# docs only on Python 3.7
-if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then pip install -r requirements.txt ; fi
+# docs only on Python 3.8
+if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ]; then pip install -r requirements.txt ; fi
 
 # webp
 pushd depends && ./install_webp.sh && popd

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -5,4 +5,4 @@ set -e
 python -m pytest -v -x --cov PIL --cov Tests --cov-report term Tests
 
 # Docs
-if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then make doccheck; fi
+if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ]; then make doccheck; fi


### PR DESCRIPTION
We're currently using [3.7 for Travis](https://github.com/python-pillow/Pillow/blob/master/.travis/test.sh#L8) and [3.8 for GHA](https://github.com/python-pillow/Pillow/blob/master/.github/workflows/test.yml#L87)