### PR TITLE
Changed to publicly visible GHA link

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -12,7 +12,7 @@ The fork author's goal is to foster and support active development of PIL throug
 
 .. _Travis CI: https://travis-ci.org/python-pillow/Pillow
 .. _AppVeyor: https://ci.appveyor.com/project/Python-pillow/pillow
-.. _GitHub Actions: https://github.com/python-pillow/Pillow/actions
+.. _GitHub Actions: https://github.com/python-pillow/Pillow/commit/6e0f07bbe38def22d36ee176b2efd9ea74b453a6/checks
 .. _GitHub: https://github.com/python-pillow/Pillow
 .. _Python Package Index: https://pypi.org/project/Pillow/
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions isn't actually publicly visible - if you open the link without being logged in to GitHub, you get a 404. So rather than linking to all of the action jobs, this PR does the next best thing, linking to just set of one action jobs - https://github.com/python-pillow/Pillow/commit/6e0f07bbe38def22d36ee176b2efd9ea74b453a6/checks