### PR TITLE
Fixes djpeg load test

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -494,7 +494,7 @@ class TestFileJpeg(PillowTestCase):
     def test_load_djpeg(self):
         with Image.open(TEST_FILE) as img:
             img.load_djpeg()
-            assert_image_similar(img, Image.open(TEST_FILE), 0)
+            assert_image_similar(img, Image.open(TEST_FILE), 5)
 
     @unittest.skipUnless(cjpeg_available(), "cjpeg not available")
     def test_save_cjpeg(self):


### PR DESCRIPTION
* Test fails with `libjpeg-turbo` and `libjpeg-progs` on Ubuntu 16.04
* Epsilon reported is 4.18... - This PR sets it to 5.0

The test test_load_djpeg fails if the djpeg decoder is different from the one Pillow is compiled against.