### PR TITLE
Removed duplicate line

### DIFF
--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -882,7 +882,6 @@ def _save(im, fp, filename, chunk=putchunk):
             b"\x01",
         )
 
-    info = im.encoderinfo.get("pnginfo")
     if info:
         chunks = [b"bKGD", b"hIST"]
         for cid, data in info.chunks:


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/fafeeefccda1d24f8ee33d2f2fd4e339ea2d64a3/src/PIL/PngImagePlugin.py#L885 is a duplicate of https://github.com/python-pillow/Pillow/blob/fafeeefccda1d24f8ee33d2f2fd4e339ea2d64a3/src/PIL/PngImagePlugin.py#L829

`info` isn't modified in the middle, so the second line can be removed.