### PR TITLE
Added reading and writing of private PNG chunks

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -564,6 +564,28 @@ class TestFilePng:
         chunks = PngImagePlugin.getchunks(im)
         assert len(chunks) == 3
 
+    def test_read_private_chunks(self):
+        im = Image.open("Tests/images/exif.png")
+        assert im.private_chunks == [(b"orNT", b"\x01")]
+
+    def test_roundtrip_private_chunk(self):
+        # Check private chunk roundtripping
+
+        with Image.open(TEST_PNG_FILE) as im:
+            info = PngImagePlugin.PngInfo()
+            info.add(b"prIV", b"VALUE")
+            info.add(b"atEC", b"VALUE2")
+            info.add(b"prIV", b"VALUE3", True)
+
+            im = roundtrip(im, pnginfo=info)
+        assert im.private_chunks == [(b"prIV", b"VALUE"), (b"atEC", b"VALUE2")]
+        im.load()
+        assert im.private_chunks == [
+            (b"prIV", b"VALUE"),
+            (b"atEC", b"VALUE2"),
+            (b"prIV", b"VALUE3", True),
+        ]
+
     def test_textual_chunks_after_idat(self):
         with Image.open("Tests/images/hopper.png") as im:
             assert "comment" in im.text.keys()

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -527,7 +527,7 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
     A tuple of two numbers corresponding to the desired dpi in each direction.
 
 **pnginfo**
-    A :py:class:`PIL.PngImagePlugin.PngInfo` instance containing text tags.
+    A :py:class:`PIL.PngImagePlugin.PngInfo` instance containing chunks.
 
 **compress_level**
     ZLIB compression level, a number between 0 and 9: 1 gives best speed,


### PR DESCRIPTION
Resolves #4265

Private PNG chunks can now be read as
```python
from PIL import Image
im = Image.open("Tests/images/exif.png")
im.private_chunks #  [(b'orNT', b'\x01')]
```

The issue states that the spec doesn't exclude writing unknown chunks - but I find it actually describes how private chunks are to be used.

From https://www.w3.org/TR/PNG/#5Chunk-naming-conventions, if the second letter is lowercase, the chunk is private.

From https://www.w3.org/TR/PNG/#14Ordering
> When copying an unknown safe-to-copy ancillary chunk, a PNG editor shall not move the chunk from before IDAT to after IDAT or vice versa.

Pillow doesn't automatically save private chunks, but it should give users the ability to keep the ordering. So I have set it so that `private_chunks` may have a third value to specify if a chunk is after IDAT when reading, and I have added an `after_idat` argument to `PngInfo.add` to specify when writing.