### PR TITLE
Updated draft documentation

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1127,15 +1127,14 @@ class Image:
         Configures the image file loader so it returns a version of the
         image that as closely as possible matches the given mode and
         size.  For example, you can use this method to convert a color
-        JPEG to greyscale while loading it, or to extract a 128x192
-        version from a PCD file.
+        JPEG to greyscale while loading it.
 
         Note that this method modifies the :py:class:`~PIL.Image.Image` object
         in place.  If the image has already been loaded, this method has no
         effect.
 
         Note: This method is not implemented for most images. It is
-        currently implemented only for JPEG and PCD images.
+        currently implemented only for JPEG and MPO images.
 
         :param mode: The requested mode.
         :param size: The requested size.


### PR DESCRIPTION
The PCD `draft` method was removed in #1169.

Meanwhile, MpoImageFile has a `draft` method because it inherits from JpegImageFile - https://github.com/python-pillow/Pillow/blob/fafeeefccda1d24f8ee33d2f2fd4e339ea2d64a3/src/PIL/MpoImagePlugin.py#L38