### PR TITLE
Ensure tempfile is unlinked

### DIFF
--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -616,38 +616,42 @@ def _save_netpbm(im, fp, filename):
     # below for information on how to enable this.
     tempfile = im._dump()
 
-    with open(filename, "wb") as f:
-        if im.mode != "RGB":
-            subprocess.check_call(
-                ["ppmtogif", tempfile], stdout=f, stderr=subprocess.DEVNULL
-            )
-        else:
-            # Pipe ppmquant output into ppmtogif
-            # "ppmquant 256 %s | ppmtogif > %s" % (tempfile, filename)
-            quant_cmd = ["ppmquant", "256", tempfile]
-            togif_cmd = ["ppmtogif"]
-            quant_proc = subprocess.Popen(
-                quant_cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
-            )
-            togif_proc = subprocess.Popen(
-                togif_cmd, stdin=quant_proc.stdout, stdout=f, stderr=subprocess.DEVNULL
-            )
-
-            # Allow ppmquant to receive SIGPIPE if ppmtogif exits
-            quant_proc.stdout.close()
-
-            retcode = quant_proc.wait()
-            if retcode:
-                raise subprocess.CalledProcessError(retcode, quant_cmd)
-
-            retcode = togif_proc.wait()
-            if retcode:
-                raise subprocess.CalledProcessError(retcode, togif_cmd)
-
     try:
-        os.unlink(tempfile)
-    except OSError:
-        pass
+        with open(filename, "wb") as f:
+            if im.mode != "RGB":
+                subprocess.check_call(
+                    ["ppmtogif", tempfile], stdout=f, stderr=subprocess.DEVNULL
+                )
+            else:
+                # Pipe ppmquant output into ppmtogif
+                # "ppmquant 256 %s | ppmtogif > %s" % (tempfile, filename)
+                quant_cmd = ["ppmquant", "256", tempfile]
+                togif_cmd = ["ppmtogif"]
+                quant_proc = subprocess.Popen(
+                    quant_cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
+                )
+                togif_proc = subprocess.Popen(
+                    togif_cmd,
+                    stdin=quant_proc.stdout,
+                    stdout=f,
+                    stderr=subprocess.DEVNULL,
+                )
+
+                # Allow ppmquant to receive SIGPIPE if ppmtogif exits
+                quant_proc.stdout.close()
+
+                retcode = quant_proc.wait()
+                if retcode:
+                    raise subprocess.CalledProcessError(retcode, quant_cmd)
+
+                retcode = togif_proc.wait()
+                if retcode:
+                    raise subprocess.CalledProcessError(retcode, togif_cmd)
+    finally:
+        try:
+            os.unlink(tempfile)
+        except OSError:
+            pass
 
 
 # Force optimization so that we can test performance against


### PR DESCRIPTION
If a `subprocess.CalledProcessError` is thrown, then the tempfile would not be unlinked. this PR ensures that whatever error is thrown, the tempfile will be unlinked.