### PR TITLE
Use dedicated docker tag for 6.2.x

### DIFF
--- a/.azure-pipelines/jobs/test-docker.yml
+++ b/.azure-pipelines/jobs/test-docker.yml
@@ -1,6 +1,6 @@
 parameters:
   docker: ''  # defaults for any parameters that aren't specified
-  dockerTag: 'master'
+  dockerTag: '6.2.x'
   name: ''
   vmImage: 'Ubuntu-16.04'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ matrix:
     - env: DOCKER="centos-7-amd64" DOCKER_TAG="6.2.x"
     - env: DOCKER="amazon-1-amd64" DOCKER_TAG="6.2.x"
     - env: DOCKER="amazon-2-amd64" DOCKER_TAG="6.2.x"
-    - env: DOCKER="fedora-29-amd64" DOCKER_TAG="6.2.x"
     - env: DOCKER="fedora-30-amd64" DOCKER_TAG="6.2.x"
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,18 +36,18 @@ matrix:
     - python: '3.5'
       name: "3.5 Xenial PYTHONOPTIMIZE=2"
       env: PYTHONOPTIMIZE=2
-    - env: DOCKER="alpine" DOCKER_TAG="master"
-    - env: DOCKER="arch" DOCKER_TAG="master" # contains PyQt5
-    - env: DOCKER="ubuntu-16.04-xenial-amd64" DOCKER_TAG="master"
-    - env: DOCKER="ubuntu-18.04-bionic-amd64" DOCKER_TAG="master"
-    - env: DOCKER="debian-9-stretch-x86" DOCKER_TAG="master"
-    - env: DOCKER="debian-10-buster-x86" DOCKER_TAG="master"
-    - env: DOCKER="centos-6-amd64" DOCKER_TAG="master"
-    - env: DOCKER="centos-7-amd64" DOCKER_TAG="master"
-    - env: DOCKER="amazon-1-amd64" DOCKER_TAG="master"
-    - env: DOCKER="amazon-2-amd64" DOCKER_TAG="master"
-    - env: DOCKER="fedora-29-amd64" DOCKER_TAG="master"
-    - env: DOCKER="fedora-30-amd64" DOCKER_TAG="master"
+    - env: DOCKER="alpine" DOCKER_TAG="6.2.x"
+    - env: DOCKER="arch" DOCKER_TAG="6.2.x" # contains PyQt5
+    - env: DOCKER="ubuntu-16.04-xenial-amd64" DOCKER_TAG="6.2.x"
+    - env: DOCKER="ubuntu-18.04-bionic-amd64" DOCKER_TAG="6.2.x"
+    - env: DOCKER="debian-9-stretch-x86" DOCKER_TAG="6.2.x"
+    - env: DOCKER="debian-10-buster-x86" DOCKER_TAG="6.2.x"
+    - env: DOCKER="centos-6-amd64" DOCKER_TAG="6.2.x"
+    - env: DOCKER="centos-7-amd64" DOCKER_TAG="6.2.x"
+    - env: DOCKER="amazon-1-amd64" DOCKER_TAG="6.2.x"
+    - env: DOCKER="amazon-2-amd64" DOCKER_TAG="6.2.x"
+    - env: DOCKER="fedora-29-amd64" DOCKER_TAG="6.2.x"
+    - env: DOCKER="fedora-30-amd64" DOCKER_TAG="6.2.x"
 
 services:
   - docker

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,10 +63,5 @@ jobs:
 
 - template: .azure-pipelines/jobs/test-docker.yml
   parameters:
-    docker: 'fedora-29-amd64'
-    name:   'fedora_29_amd64'
-
-- template: .azure-pipelines/jobs/test-docker.yml
-  parameters:
     docker: 'fedora-30-amd64'
     name:   'fedora_30_amd64'


### PR DESCRIPTION
I've created a [6.2.x branch for docker-images](https://github.com/python-pillow/docker-images/tree/6.2.x), which has [pushed to docker hub](https://hub.docker.com/repository/docker/pythonpillow/debian-10-buster-x86).

This PR allows the Pillow 6.2.x branch to use that, so that it does not miss out on Python 2 Docker testing (which has been removed from the master branch of docker-images)