### PR TITLE
Added Fedora 31 to 6.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ matrix:
     - env: DOCKER="amazon-1-amd64" DOCKER_TAG="6.2.x"
     - env: DOCKER="amazon-2-amd64" DOCKER_TAG="6.2.x"
     - env: DOCKER="fedora-30-amd64" DOCKER_TAG="6.2.x"
+    - env: DOCKER="fedora-31-amd64" DOCKER_TAG="6.2.x"
 
 services:
   - docker

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,3 +65,8 @@ jobs:
   parameters:
     docker: 'fedora-30-amd64'
     name:   'fedora_30_amd64'
+
+- template: .azure-pipelines/jobs/test-docker.yml
+  parameters:
+    docker: 'fedora-31-amd64'
+    name:   'fedora_31_amd64'


### PR DESCRIPTION
I have added Python 2.7 to Fedora 31 on the docker-images 6.2.x branch - https://github.com/python-pillow/docker-images/commit/0b97670b452e23216f3d00f626c8d317f739b7d3