### PR TITLE
Raise ValueError for io.StringIO in Image.open

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1,3 +1,4 @@
+import io
 import os
 import shutil
 import tempfile
@@ -90,6 +91,9 @@ class TestImage(PillowTestCase):
 
     def test_bad_mode(self):
         self.assertRaises(ValueError, Image.open, "filename", "bad mode")
+
+    def test_stringio(self):
+        self.assertRaises(ValueError, Image.open, io.StringIO())
 
     def test_pathlib(self):
         from PIL.Image import Path

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2690,7 +2690,7 @@ def open(fp, mode="r"):
     :exception FileNotFoundError: If the file cannot be found.
     :exception PIL.UnidentifiedImageError: If the image cannot be opened and
        identified.
-    :exception ValueError: If the ``mode`` is not "r", or if a StringIO
+    :exception ValueError: If the ``mode`` is not "r", or if a ``StringIO``
        instance is used for ``fp``.
     """
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2690,10 +2690,16 @@ def open(fp, mode="r"):
     :exception FileNotFoundError: If the file cannot be found.
     :exception PIL.UnidentifiedImageError: If the image cannot be opened and
        identified.
+    :exception ValueError: If the ``mode`` is not "r", or if a StringIO
+       instance is used for ``fp``.
     """
 
     if mode != "r":
         raise ValueError("bad mode %r" % mode)
+    elif isinstance(fp, io.StringIO):
+        raise ValueError(
+            "StringIO cannot be used to open an image. Binary data must be used instead"
+        )
 
     exclusive_fp = False
     filename = ""

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2698,7 +2698,8 @@ def open(fp, mode="r"):
         raise ValueError("bad mode %r" % mode)
     elif isinstance(fp, io.StringIO):
         raise ValueError(
-            "StringIO cannot be used to open an image. Binary data must be used instead."
+            "StringIO cannot be used to open an image. "
+            "Binary data must be used instead."
         )
 
     exclusive_fp = False

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2698,7 +2698,7 @@ def open(fp, mode="r"):
         raise ValueError("bad mode %r" % mode)
     elif isinstance(fp, io.StringIO):
         raise ValueError(
-            "StringIO cannot be used to open an image. Binary data must be used instead"
+            "StringIO cannot be used to open an image. Binary data must be used instead."
         )
 
     exclusive_fp = False


### PR DESCRIPTION
Resolves #4097 

The conclusion of discussion in the issue is that StringIO can't be used to pass bytes into Image.open.

```python
import io
from PIL import Image
im = Image.open(io.StringIO("'\x89\x50\x4E\x47\x0D"))
```
```
OSError: cannot identify image file <_io.StringIO object at 0x104ecdd70>
```

A ValueError with a clearer message with now be raised in this situation, explaining that byte data is required instead of StringIO.