### PR TITLE
Updated exception documentation

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2687,8 +2687,9 @@ def open(fp, mode="r"):
        and be opened in binary mode.
     :param mode: The mode.  If given, this argument must be "r".
     :returns: An :py:class:`~PIL.Image.Image` object.
-    :exception IOError: If the file cannot be found, or the image cannot be
-       opened and identified.
+    :exception FileNotFoundError: If the file cannot be found.
+    :exception PIL.UnidentifiedImageError: If the image cannot be opened and
+       identified.
     """
 
     if mode != "r":


### PR DESCRIPTION
Follow up to #4182

Rather than saying that an `IOError` is raised by `Image.open`, I think it is more helpful to say that an `UnidentifiedImageError` is raised.

Also an `IOError` is not raised by `Image.open("blah")`, `FileNotFoundError` is.