### PR TITLE
Replaced distutils with C version check

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -1,5 +1,4 @@
 import base64
-import distutils.version
 import io
 import itertools
 import logging
@@ -272,12 +271,8 @@ class TestFileLibTiff(LibTiffTestCase):
             )
         }
 
-        libtiff_version = TiffImagePlugin._libtiff_version()
-
         libtiffs = [False]
-        if distutils.version.StrictVersion(
-            libtiff_version
-        ) >= distutils.version.StrictVersion("4.0"):
+        if Image.core.libtiff_v4_or_greater:
             libtiffs.append(True)
 
         for libtiff in libtiffs:

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -272,7 +272,7 @@ class TestFileLibTiff(LibTiffTestCase):
         }
 
         libtiffs = [False]
-        if Image.core.libtiff_v4_or_greater:
+        if Image.core.libtiff_support_custom_tags:
             libtiffs.append(True)
 
         for libtiff in libtiffs:

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -38,7 +38,6 @@
 #
 # See the README file for information on usage and redistribution.
 #
-import distutils.version
 import io
 import itertools
 import os
@@ -1559,11 +1558,10 @@ def _save(im, fp, filename):
             # Custom items are supported for int, float, unicode, string and byte
             # values. Other types and tuples require a tagtype.
             if tag not in TiffTags.LIBTIFF_CORE:
-                if TiffTags.lookup(tag).type == TiffTags.UNDEFINED:
-                    continue
-                if distutils.version.StrictVersion(
-                    _libtiff_version()
-                ) < distutils.version.StrictVersion("4.0"):
+                if (
+                    TiffTags.lookup(tag).type == TiffTags.UNDEFINED
+                    or not Image.core.libtiff_v4_or_greater
+                ):
                     continue
 
                 if tag in ifd.tagtype:

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -263,10 +263,6 @@ def _limit_rational(val, max_val):
     return n_d[::-1] if inv else n_d
 
 
-def _libtiff_version():
-    return Image.core.libtiff_version.split("\n")[0].split("Version ")[1]
-
-
 ##
 # Wrapper for TIFF IFDs.
 

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1556,7 +1556,7 @@ def _save(im, fp, filename):
             if tag not in TiffTags.LIBTIFF_CORE:
                 if (
                     TiffTags.lookup(tag).type == TiffTags.UNDEFINED
-                    or not Image.core.libtiff_v4_or_greater
+                    or not Image.core.libtiff_support_custom_tags
                 ):
                     continue
 

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -3969,13 +3969,13 @@ setup_module(PyObject* m) {
     PyDict_SetItemString(d, "libtiff_version", PyUnicode_FromString(ImagingTiffVersion()));
 
     // Test for libtiff 4.0 or later, excluding libtiff 3.9.6 and 3.9.7
-    PyObject* v4_or_greater;
+    PyObject* support_custom_tags;
 #if TIFFLIB_VERSION >= 20111221 && TIFFLIB_VERSION != 20120218 && TIFFLIB_VERSION != 20120922
-    v4_or_greater = Py_True;
+    support_custom_tags = Py_True;
 #else
-    v4_or_greater = Py_False;
+    support_custom_tags = Py_False;
 #endif
-    PyDict_SetItemString(d, "libtiff_v4_or_greater", v4_or_greater);
+    PyDict_SetItemString(d, "libtiff_support_custom_tags", support_custom_tags);
   }
 #endif
 

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -82,6 +82,12 @@
 #include "zlib.h"
 #endif
 
+#ifdef HAVE_LIBTIFF
+#ifndef _TIFFIO_
+#include <tiffio.h>
+#endif
+#endif
+
 #include "Imaging.h"
 
 #define _USE_MATH_DEFINES
@@ -3961,6 +3967,15 @@ setup_module(PyObject* m) {
   {
     extern const char * ImagingTiffVersion(void);
     PyDict_SetItemString(d, "libtiff_version", PyUnicode_FromString(ImagingTiffVersion()));
+
+    // Test for libtiff 4.0 or later, excluding libtiff 3.9.6 and 3.9.7
+    PyObject* v4_or_greater;
+#if TIFFLIB_VERSION >= 20111221 && TIFFLIB_VERSION != 20120218 && TIFFLIB_VERSION != 20120922
+    v4_or_greater = Py_True;
+#else
+    v4_or_greater = Py_False;
+#endif
+    PyDict_SetItemString(d, "libtiff_v4_or_greater", v4_or_greater);
   }
 #endif
 


### PR DESCRIPTION
Resolves #4211

This PR is another version of #3552, again the goal of removing distutils in order to resolve problems external to Pillow. That PR was not accepted, so I understand if this one is not either.

This time, I'm suggesting moving the Python-level version check into C.

It then duplicates the version check performed in TiffDecode.c -
https://github.com/python-pillow/Pillow/blob/661ceac71739023b55c2849bb80dd46b7ef586bd/src/libImaging/TiffDecode.c#L556-L561

However, the two checks are not for exact the same purpose. The check in TiffDecode.c is for ease of compilation because of the different return types between libtiff versions, whereas this one is about functionality.