### PR TITLE
Fix deprecation warnings in test_file_wmf

### DIFF
--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -55,11 +55,11 @@ class TestFileWmf(PillowTestCase):
 
     def test_load_set_dpi(self):
         with Image.open("Tests/images/drawing.wmf") as im:
-            self.assertEquals(im.size, (82, 82))
+            self.assertEqual(im.size, (82, 82))
 
             if hasattr(Image.core, "drawwmf"):
                 im.load(144)
-                self.assertEquals(im.size, (164, 164))
+                self.assertEqual(im.size, (164, 164))
 
                 with Image.open("Tests/images/drawing_wmf_ref_144.png") as expected:
                     self.assert_image_similar(im, expected, 2.0)


### PR DESCRIPTION
Fix two deprecation warnings in `test_file_wmf` introduced in #4311.

From https://github.com/python-pillow/Pillow/runs/369013311#step:24:1469:
```
============================== warnings summary ===============================
Tests/test_file_wmf.py::TestFileWmf::test_load_set_dpi
  d:\a\Pillow\Pillow\Tests\test_file_wmf.py:58: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(im.size, (82, 82))

Tests/test_file_wmf.py::TestFileWmf::test_load_set_dpi
  d:\a\Pillow\Pillow\Tests\test_file_wmf.py:62: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(im.size, (164, 164))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```