### PR TITLE
Allow string comment when saving GIF

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -565,13 +565,17 @@ class TestFileGif(PillowTestCase):
                 im.info["comment"], b"File written by Adobe Photoshop\xa8 4.0"
             )
 
-            out = self.tempfile("temp.gif")
-            im = Image.new("L", (100, 100), "#000")
-            im.info["comment"] = b"Test comment text"
-            im.save(out)
+        out = self.tempfile("temp.gif")
+        im = Image.new("L", (100, 100), "#000")
+        im.info["comment"] = b"Test comment text"
+        im.save(out)
         with Image.open(out) as reread:
-
             self.assertEqual(reread.info["comment"], im.info["comment"])
+
+        im.info["comment"] = "Test comment text"
+        im.save(out)
+        with Image.open(out) as reread:
+            self.assertEqual(reread.info["comment"], im.info["comment"].encode())
 
     def test_comment_over_255(self):
         out = self.tempfile("temp.gif")

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -569,8 +569,11 @@ def _write_local_header(fp, im, offset, flags):
 
     if "comment" in im.encoderinfo and 1 <= len(im.encoderinfo["comment"]):
         fp.write(b"!" + o8(254))  # extension intro
-        for i in range(0, len(im.encoderinfo["comment"]), 255):
-            subblock = im.encoderinfo["comment"][i : i + 255]
+        comment = im.encoderinfo["comment"]
+        if isinstance(comment, str):
+            comment = comment.encode()
+        for i in range(0, len(comment), 255):
+            subblock = comment[i : i + 255]
             fp.write(o8(len(subblock)) + subblock)
         fp.write(o8(0))
     if "loop" in im.encoderinfo:


### PR DESCRIPTION
Resolves #4325 

The issue reports that saving a GIF with a string comment results in an error. A simple reproduction would be -
```python
from PIL import Image
im = Image.new("L", (100, 100))
im.save("test.gif", comment="comment")
```

This PR fixes it by encoding the comment into bytes, if it is a string.