### PR TITLE
Removed unnecessary coverage line

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,7 +10,6 @@ exclude_lines =
     if 0:
     if __name__ == .__main__.:
     # Don't complain about debug code
-    if Image.DEBUG:
     if DEBUG:
 
 [run]


### PR DESCRIPTION
`Image.DEBUG` was removed in #1207, so it can be removed from .coveragerc