### PR TITLE
Add assigned CVE numbers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -97,16 +97,16 @@ Changelog (Pillow)
 
 - This is the last Pillow release to support Python 2.7 #3642
 
-- Overflow checks for realloc for tiff decoding. CVE TBD
+- Overflow checks for realloc for tiff decoding. CVE-2020-5310
   [wiredfool, radarhere]
 
-- Catch SGI buffer overrun. CVE TBD
+- Catch SGI buffer overrun. CVE-2020-5311
   [radarhere]
 
-- Catch PCX P mode buffer overrun. CVE TBD
+- Catch PCX P mode buffer overrun. CVE-2020-5312
   [radarhere]
 
-- Catch FLI buffer overrun. CVE TBD
+- Catch FLI buffer overrun. CVE-2020-5313
   [radarhere]
 
 - Raise an error for an invalid number of bands in FPX image. CVE-2019-19911

--- a/docs/releasenotes/6.2.2.rst
+++ b/docs/releasenotes/6.2.2.rst
@@ -4,15 +4,14 @@
 Security
 ========
 
-This release addresses several security problems (CVEs TBD), as well as addressing
-CVE-2019-19911.
+This release addresses several security problems.
 
 CVE-2019-19911 is regarding FPX images. If an image reports that it has a large number
 of bands, a large amount of resources will be used when trying to process the
 image. This is fixed by limiting the number of bands to those usable by Pillow.
 
-Buffer overruns were found when processing an SGI, PCX or FLI image. Checks
-have been added to prevent this.
+Buffer overruns were found when processing an SGI (CVE-2020-5311), PCX (CVE-2020-5312)
+or FLI image (CVE-2020-5313). Checks have been added to prevent this.
 
-Overflow checks have been added when calculating the size of a memory block to
-be reallocated in the processing of a TIFF image.
+CVE-2020-5310: Overflow checks have been added when calculating the size of a memory
+block to be reallocated in the processing of a TIFF image.


### PR DESCRIPTION
For the fixes already released in Pillow 6.2.2 and 7.0.0.