### PR TITLE
Remove Docker from Travis CI, they're run on GHA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ notifications:
 # Run fast lint first to get fast feedback.
 # Run slow PyPy next, to give it a headstart and reduce waiting time.
 # Run latest 3.x next, to get quick compatibility results.
-# Then run the remainder, with fastest Docker jobs last.
+# Then run the remainder.
 
 matrix:
   fast_finish: true
@@ -32,31 +32,12 @@ matrix:
       name: "3.5 Xenial PYTHONOPTIMIZE=2"
       env: PYTHONOPTIMIZE=2
       services: xvfb
-    - env: DOCKER="alpine" DOCKER_TAG="master"
-    - env: DOCKER="arch" DOCKER_TAG="master" # contains PyQt5
-    - env: DOCKER="ubuntu-16.04-xenial-amd64" DOCKER_TAG="master"
-    - env: DOCKER="ubuntu-18.04-bionic-amd64" DOCKER_TAG="master"
-    - env: DOCKER="debian-9-stretch-x86" DOCKER_TAG="master"
-    - env: DOCKER="debian-10-buster-x86" DOCKER_TAG="master"
-    - env: DOCKER="centos-6-amd64" DOCKER_TAG="master"
-    - env: DOCKER="centos-7-amd64" DOCKER_TAG="master"
-    - env: DOCKER="centos-8-amd64" DOCKER_TAG="master"
-    - env: DOCKER="amazon-1-amd64" DOCKER_TAG="master"
-    - env: DOCKER="amazon-2-amd64" DOCKER_TAG="master"
-    - env: DOCKER="fedora-30-amd64" DOCKER_TAG="master"
-    - env: DOCKER="fedora-31-amd64" DOCKER_TAG="master"
-
-services:
-  - docker
-
-before_install:
-  - if [ "$DOCKER" ]; then travis_retry docker pull pythonpillow/$DOCKER:$DOCKER_TAG; fi
 
 install:
   - |
     if [ "$LINT" == "true" ]; then
       pip install tox
-    elif [ "$DOCKER" == "" ]; then
+    else
       .travis/install.sh;
     fi
 
@@ -64,13 +45,9 @@ script:
 - |
   if [ "$LINT" == "true" ]; then
     tox -e lint
-  elif [ "$DOCKER" == "" ]; then
+  else
     .travis/build.sh
     .travis/test.sh
-  elif [ "$DOCKER" ]; then
-    # the Pillow user in the docker container is UID 1000
-    sudo chown -R 1000 $TRAVIS_BUILD_DIR
-    docker run -v $TRAVIS_BUILD_DIR:/Pillow pythonpillow/$DOCKER:$DOCKER_TAG
   fi
 
 after_success:

--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -23,7 +23,7 @@ if [[ $TRAVIS ]]; then
     codecov
 fi
 
-if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ] && [ "$DOCKER" == "" ]; then
+if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
     # Coverage and quality reports on just the latest diff.
     depends/diffcover-install.sh
     depends/diffcover-run.sh


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/3606.

Changes proposed in this pull request:

 * PR https://github.com/python-pillow/Pillow/pull/4316 added coverage to Docker on the faster GitHub Actions
 * We can now remove Docker builds from Travis CI


# Before

* Ran for 13 min 5 sec
* Total time 50 min 59 sec

![image](https://user-images.githubusercontent.com/1324225/71777873-e457dd80-2fae-11ea-8f2f-1a806327bf48.png)


# After

* Ran for 9 min 9 sec
* Total time 19 min 45 sec

![image](https://user-images.githubusercontent.com/1324225/71777852-a955aa00-2fae-11ea-8270-8f6d4a66771f.png)

