### PR TITLE
Updated Python version

### DIFF
--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -23,7 +23,7 @@ if [[ $TRAVIS ]]; then
     codecov
 fi
 
-if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
+if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ]; then
     # Coverage and quality reports on just the latest diff.
     depends/diffcover-install.sh
     depends/diffcover-run.sh


### PR DESCRIPTION
> Coverage and quality reports on just the latest diff.

If 'latest' refers to the latest Python version, then this should be updated from 3.7 to 3.8.