### PR TITLE
Do not install PyQt5 5.14.1

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -17,7 +17,7 @@ pip install test-image-results
 pip install numpy
 if [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then
     sudo apt-get -qq install pyqt5-dev-tools
-    pip install pyqt5
+    pip install pyqt5!=5.14.1
 fi
 
 # docs only on Python 3.8


### PR DESCRIPTION
PyQt5 5.14.1 was released 9 hours ago - https://pypi.org/project/PyQt5/5.14.1/#history

Since then, tests have been failing in master. This is presumably a temporary measure until PyQt5 5.14.2 is released.