### PR TITLE
Renamed Jpeg2K variable to prevent masking Image reduce method

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -142,6 +142,13 @@ def test_layers_type(tmp_path):
             test_card.save(outfile, quality_layers=quality_layers)
 
 
+def test_load_reduce():
+    with Image.open("Tests/images/test-card-lossless.jp2") as im:
+        im.load_reduce = 2
+        im.load()
+        assert im.size == (160, 120)
+
+
 def test_layers():
     out = BytesIO()
     test_card.save(out, "JPEG2000", quality_layers=[100, 50, 10], progression="LRCP")

--- a/Tests/test_image_reduce.py
+++ b/Tests/test_image_reduce.py
@@ -3,6 +3,8 @@ from PIL import Image, ImageMath, ImageMode
 
 from .helper import PillowTestCase, convert_to_comparable
 
+codecs = dir(Image.core)
+
 
 class TestImageReduce(PillowTestCase):
     # There are several internal implementations
@@ -236,3 +238,10 @@ class TestImageReduce(PillowTestCase):
         for factor in self.remarkable_factors:
             self.compare_reduce_with_reference(im, factor, 0, 0)
             self.compare_reduce_with_box(im, factor)
+
+    @pytest.mark.skipif(
+        "jpeg2k_decoder" not in codecs, reason="JPEG 2000 support not available"
+    )
+    def test_jpeg2k(self):
+        with Image.open("Tests/images/test-card-lossless.jp2") as im:
+            assert im.reduce(2).size == (320, 240)

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -176,7 +176,7 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
         if self.size is None or self.mode is None:
             raise SyntaxError("unable to determine size/mode")
 
-        self.reduce = 0
+        self.load_reduce = 0
         self.layers = 0
 
         fd = -1
@@ -200,13 +200,14 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
                 "jpeg2k",
                 (0, 0) + self.size,
                 0,
-                (self.codec, self.reduce, self.layers, fd, length),
+                (self.codec, self.load_reduce, self.layers, fd, length),
             )
         ]
 
     def load(self):
-        if self.reduce:
-            power = 1 << self.reduce
+        reduce = self.reduce if not callable(self.reduce) else self.load_reduce
+        if reduce:
+            power = 1 << reduce
             adjust = power >> 1
             self._size = (
                 int((self.size[0] + adjust) / power),
@@ -216,7 +217,7 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
         if self.tile:
             # Update the reduce and layers settings
             t = self.tile[0]
-            t3 = (t[3][0], self.reduce, self.layers, t[3][3], t[3][4])
+            t3 = (t[3][0], reduce, self.layers, t[3][3], t[3][4])
             self.tile = [(t[0], (0, 0) + self.size, t[2], t3)]
 
         return ImageFile.ImageFile.load(self)


### PR DESCRIPTION
Resolves #4343

The new Image `reduce` method does not work for Jpeg2K images, as [Jpeg2KImagePlugin has a `reduce` variable that masks it](https://github.com/python-pillow/Pillow/blob/ef4a0b2f4c9346db37140f102e80068abc280167/src/PIL/Jpeg2KImagePlugin.py#L179). The variable is not purely internal, but is actually tested behaviour -

https://github.com/python-pillow/Pillow/blob/ef4a0b2f4c9346db37140f102e80068abc280167/Tests/test_file_jpeg2k.py#L112-L116

This PR renames the `reduce` variable to `load_reduce` for the sake of moving forward, while also keeping the tested behaviour by checking if `reduce` is callable.