### PR TITLE
Various test changes

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -368,14 +368,6 @@ else:
     IMCONVERT = "convert"
 
 
-def distro():
-    if os.path.exists("/etc/os-release"):
-        with open("/etc/os-release", "r") as f:
-            for line in f:
-                if "ID=" in line:
-                    return line.strip().split("=")[1]
-
-
 class cached_property:
     def __init__(self, func):
         self.func = func

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -205,11 +205,8 @@ class PillowTestCase(unittest.TestCase):
 
     def skipKnownBadTest(self, msg=None):
         # Skip if PILLOW_RUN_KNOWN_BAD is not true in the environment.
-        if os.environ.get("PILLOW_RUN_KNOWN_BAD", False):
-            print(os.environ.get("PILLOW_RUN_KNOWN_BAD", False))
-            return
-
-        self.skipTest(msg or "Known Bad Test")
+        if not os.environ.get("PILLOW_RUN_KNOWN_BAD", False):
+            self.skipTest(msg or "Known Bad Test")
 
     def tempfile(self, template):
         assert template[:5] in ("temp.", "temp_")

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -132,8 +132,7 @@ class TestImageSpider(PillowTestCase):
     def test_nonstack_dos(self):
         with Image.open(TEST_FILE) as im:
             for i, frame in enumerate(ImageSequence.Iterator(im)):
-                if i > 1:
-                    self.fail("Non-stack DOS file test failed")
+                self.assertLessEqual(i, 1, "Non-stack DOS file test failed")
 
     # for issue #4093
     def test_odd_size(self):

--- a/Tests/test_file_tga.py
+++ b/Tests/test_file_tga.py
@@ -4,7 +4,7 @@ from itertools import product
 
 from PIL import Image
 
-from .helper import PillowTestCase
+from .helper import PillowTestCase, hopper
 
 _TGA_DIR = os.path.join("Tests", "images", "tga")
 _TGA_DIR_COMMON = os.path.join(_TGA_DIR, "common")
@@ -111,6 +111,13 @@ class TestFileTga(PillowTestCase):
             im.convert("RGBA").save(out)
         with Image.open(out) as test_im:
             self.assertEqual(test_im.size, (100, 100))
+
+    def test_save_wrong_mode(self):
+        im = hopper("PA")
+        out = self.tempfile("temp.tga")
+
+        with self.assertRaises(OSError):
+            im.save(out)
 
     def test_save_id_section(self):
         test_file = "Tests/images/rgb32rle.tga"

--- a/Tests/test_file_webp_animated.py
+++ b/Tests/test_file_webp_animated.py
@@ -164,3 +164,11 @@ class TestFileWebpAnimation(PillowTestCase):
                 self.assertEqual(im.info["duration"], dur)
                 self.assertEqual(im.info["timestamp"], ts)
                 ts -= dur
+
+    def test_seek_errors(self):
+        with Image.open("Tests/images/iss634.webp") as im:
+            with self.assertRaises(EOFError):
+                im.seek(-1)
+
+            with self.assertRaises(EOFError):
+                im.seek(42)

--- a/Tests/test_file_xbm.py
+++ b/Tests/test_file_xbm.py
@@ -2,7 +2,7 @@ from io import BytesIO
 
 from PIL import Image
 
-from .helper import PillowTestCase
+from .helper import PillowTestCase, hopper
 
 PIL151 = b"""
 #define basic_width 32
@@ -58,3 +58,10 @@ class TestFileXbm(PillowTestCase):
             # Assert
             self.assertEqual(im.mode, "1")
             self.assertEqual(im.size, (128, 128))
+
+    def test_save_wrong_mode(self):
+        im = hopper()
+        out = self.tempfile("temp.xbm")
+
+        with self.assertRaises(OSError):
+            im.save(out)

--- a/Tests/test_file_xbm.py
+++ b/Tests/test_file_xbm.py
@@ -65,3 +65,13 @@ class TestFileXbm(PillowTestCase):
 
         with self.assertRaises(OSError):
             im.save(out)
+
+    def test_hotspot(self):
+        im = hopper("1")
+        out = self.tempfile("temp.xbm")
+
+        hotspot = (0, 7)
+        im.save(out, hotspot=hotspot)
+
+        with Image.open(out) as reloaded:
+            self.assertEqual(reloaded.info["hotspot"], hotspot)

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -502,13 +502,9 @@ class CoreResampleBoxTest(PillowTestCase):
             ((40, 50), (10, 0, 50, 50)),
             ((40, 50), (10, 20, 50, 70)),
         ]:
-            try:
-                res = im.resize(size, Image.LANCZOS, box)
-                self.assertEqual(res.size, size)
-                self.assert_image_equal(res, im.crop(box))
-            except AssertionError:
-                print(">>>", size, box)
-                raise
+            res = im.resize(size, Image.LANCZOS, box)
+            self.assertEqual(res.size, size)
+            self.assert_image_equal(res, im.crop(box), ">>> {} {}".format(size, box))
 
     def test_no_passthrough(self):
         # When resize is required
@@ -520,15 +516,13 @@ class CoreResampleBoxTest(PillowTestCase):
             ((40, 50), (10.4, 0.4, 50.4, 50.4)),
             ((40, 50), (10.4, 20.4, 50.4, 70.4)),
         ]:
-            try:
-                res = im.resize(size, Image.LANCZOS, box)
-                self.assertEqual(res.size, size)
-                with self.assertRaisesRegex(AssertionError, r"difference \d"):
-                    # check that the difference at least that much
-                    self.assert_image_similar(res, im.crop(box), 20)
-            except AssertionError:
-                print(">>>", size, box)
-                raise
+            res = im.resize(size, Image.LANCZOS, box)
+            self.assertEqual(res.size, size)
+            with self.assertRaisesRegex(AssertionError, r"difference \d"):
+                # check that the difference at least that much
+                self.assert_image_similar(
+                    res, im.crop(box), 20, ">>> {} {}".format(size, box)
+                )
 
     def test_skip_horizontal(self):
         # Can skip resize for one dimension
@@ -541,14 +535,15 @@ class CoreResampleBoxTest(PillowTestCase):
                 ((40, 50), (10, 0, 50, 90)),
                 ((40, 50), (10, 20, 50, 90)),
             ]:
-                try:
-                    res = im.resize(size, flt, box)
-                    self.assertEqual(res.size, size)
-                    # Borders should be slightly different
-                    self.assert_image_similar(res, im.crop(box).resize(size, flt), 0.4)
-                except AssertionError:
-                    print(">>>", size, box, flt)
-                    raise
+                res = im.resize(size, flt, box)
+                self.assertEqual(res.size, size)
+                # Borders should be slightly different
+                self.assert_image_similar(
+                    res,
+                    im.crop(box).resize(size, flt),
+                    0.4,
+                    ">>> {} {} {}".format(size, box, flt),
+                )
 
     def test_skip_vertical(self):
         # Can skip resize for one dimension
@@ -561,11 +556,12 @@ class CoreResampleBoxTest(PillowTestCase):
                 ((40, 50), (0, 10, 90, 60)),
                 ((40, 50), (20, 10, 90, 60)),
             ]:
-                try:
-                    res = im.resize(size, flt, box)
-                    self.assertEqual(res.size, size)
-                    # Borders should be slightly different
-                    self.assert_image_similar(res, im.crop(box).resize(size, flt), 0.4)
-                except AssertionError:
-                    print(">>>", size, box, flt)
-                    raise
+                res = im.resize(size, flt, box)
+                self.assertEqual(res.size, size)
+                # Borders should be slightly different
+                self.assert_image_similar(
+                    res,
+                    im.crop(box).resize(size, flt),
+                    0.4,
+                    ">>> {} {} {}".format(size, box, flt),
+                )

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -15,6 +15,9 @@ try:
             ]:
                 self.assert_image(im, im.mode, im.size)
 
+            im = ImageGrab.grab(bbox=(10, 20, 50, 80))
+            self.assert_image(im, im.mode, (40, 60))
+
         def test_grabclipboard(self):
             if sys.platform == "darwin":
                 subprocess.call(["screencapture", "-cx"])


### PR DESCRIPTION
Some commits simplifying test code, some commits adding new tests.

I think the only commits that need commentary are -
- Removed print: Removes a `print` statement that doesn't look necessary or helpful
- Removed unnecessary code: Removes code if `__version__` contains 'rc'. Pillow doesn't use 'rc' versions.