### PR TITLE
Removed coveralls

### DIFF
--- a/.ci/after_success.sh
+++ b/.ci/after_success.sh
@@ -10,15 +10,10 @@ fi
 lcov --capture --directory . -b . --output-file coverage.info
 #  filter to remove system headers
 lcov --remove coverage.info '/usr/*' -o coverage.filtered.info
-#  convert to json
-sudo gem install coveralls-lcov
-coveralls-lcov -v -n coverage.filtered.info > coverage.c.json
 
 pip install codecov
 coverage report
 
-pip install coveralls-merge
-coveralls-merge coverage.c.json
 if [[ $TRAVIS ]]; then
     codecov
 fi

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -47,8 +47,6 @@ jobs:
     - name: After success
       if: success()
       run: |
-        pip install wheel
-        sudo apt-get install -qq ruby-dev
         PATH="$PATH:~/.local/bin"
         .ci/after_success.sh
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,6 @@ jobs:
         .ci/after_success.sh
       env:
         MATRIX_OS: ${{ matrix.os }}
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
     - name: Prepare coverage token
       if: success() && github.repository == 'python-pillow/Pillow'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 black; python_version >= '3.6'
 check-manifest
 coverage
-coveralls
 jarn.viewdoc
 olefile
 pycodestyle


### PR DESCRIPTION
Removes coveralls, since codecov is now used for assessing coverage.

As evidence that codecov is not affected by this, compare [before](https://codecov.io/gh/python-pillow/Pillow/commit/a520a435d6b6534a3db2c9457328b6a90733a793) with [after](https://codecov.io/gh/python-pillow/Pillow/tree/8dee4c2ceed04dace04ad0930eee4996d078fd81).