### PR TITLE
Updated spacing defaults documentation

### DIFF
--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -255,7 +255,7 @@ Methods
 
     Draw a shape.
 
-.. py:method:: PIL.ImageDraw.ImageDraw.text(xy, text, fill=None, font=None, anchor=None, spacing=0, align="left", direction=None, features=None, language=None, stroke_width=0, stroke_fill=None)
+.. py:method:: PIL.ImageDraw.ImageDraw.text(xy, text, fill=None, font=None, anchor=None, spacing=4, align="left", direction=None, features=None, language=None, stroke_width=0, stroke_fill=None)
 
     Draws the string at the given position.
 
@@ -306,7 +306,7 @@ Methods
 
                      .. versionadded:: 6.2.0
 
-.. py:method:: PIL.ImageDraw.ImageDraw.multiline_text(xy, text, fill=None, font=None, anchor=None, spacing=0, align="left", direction=None, features=None, language=None)
+.. py:method:: PIL.ImageDraw.ImageDraw.multiline_text(xy, text, fill=None, font=None, anchor=None, spacing=4, align="left", direction=None, features=None, language=None)
 
     Draws the string at the given position.
 


### PR DESCRIPTION
Resolves #4367 

Updates the defaults for `spacing` in the documentation, so that [`text`](https://github.com/python-pillow/Pillow/blame/master/docs/reference/ImageDraw.rst#L258) and [`multiline_text`](https://github.com/python-pillow/Pillow/blame/master/docs/reference/ImageDraw.rst#L309)
matches https://github.com/python-pillow/Pillow/blob/a520a435d6b6534a3db2c9457328b6a90733a793/src/PIL/ImageDraw.py#L263-L270 and https://github.com/python-pillow/Pillow/blob/a520a435d6b6534a3db2c9457328b6a90733a793/src/PIL/ImageDraw.py#L353-L360

For reference, itooks like #1574 just forgot to update the documentation.