### PR TITLE
Return None if display profile not found in ImageCms.get_display_profile

### DIFF
--- a/src/PIL/ImageCms.py
+++ b/src/PIL/ImageCms.py
@@ -263,6 +263,8 @@ def get_display_profile(handle=None):
         profile = core.get_display_profile_win32(handle, 1)
     else:
         profile = core.get_display_profile_win32(handle or 0)
+    if profile is None:
+        return None
     return ImageCmsProfile(profile)
 
 


### PR DESCRIPTION
Building and running Pillow tests in a Windows Server Docker instance fails for two tests `test_imagecms.test_display_profile` and `test_imagegrab.test_grab` because it is run headless.

While I think the `test_grab` failure is reasonable, the other test fails with a TypeError raised from `ImageCms.get_display_profile`, which is confusing at best. This is caused by [`ImageCms.core.get_display_profile_win32` returning None](https://github.com/python-pillow/Pillow/blob/3aa5d56bae3b9cee79fa88ed6e5be7bb28fc96e4/src/_imagingcms.c#L622), which is obviously not accepted by the `ImageCmsProfile` constructor. This PR proposes returning None instead (in accordance with the functions docs).

![image](https://user-images.githubusercontent.com/3819630/72690239-43baff00-3b12-11ea-867d-7aaaf6043ed3.png)