### PR TITLE
get_display_profile is only supported on Windows

### DIFF
--- a/src/PIL/ImageCms.py
+++ b/src/PIL/ImageCms.py
@@ -254,20 +254,15 @@ def get_display_profile(handle=None):
     :returns: None if the profile is not known.
     """
 
-    if sys.platform == "win32":
-        from PIL import ImageWin
+    if sys.platform != "win32":
+        return
 
-        if isinstance(handle, ImageWin.HDC):
-            profile = core.get_display_profile_win32(handle, 1)
-        else:
-            profile = core.get_display_profile_win32(handle or 0)
+    from PIL import ImageWin
+
+    if isinstance(handle, ImageWin.HDC):
+        profile = core.get_display_profile_win32(handle, 1)
     else:
-        try:
-            get = _imagingcms.get_display_profile
-        except AttributeError:
-            return None
-        else:
-            profile = get()
+        profile = core.get_display_profile_win32(handle or 0)
     return ImageCmsProfile(profile)
 
 

--- a/src/PIL/ImageCms.py
+++ b/src/PIL/ImageCms.py
@@ -255,7 +255,7 @@ def get_display_profile(handle=None):
     """
 
     if sys.platform != "win32":
-        return
+        return None
 
     from PIL import ImageWin
 


### PR DESCRIPTION
If not on Windows, the ImageCms `get_display_profile` function checks for `_imagingcms.get_display_profile`. That method does not exist. It wasn't in PIL 1.1.17, and hasn't existed since the fork. So this PR cleans up the code, returning quickly on non-Windows platforms, rather than performing a failing check.