### PR TITLE
Avoid undefined signed overflow

### DIFF
--- a/src/libImaging/ImagingUtils.h
+++ b/src/libImaging/ImagingUtils.h
@@ -1,11 +1,11 @@
 #ifdef WORDS_BIGENDIAN
-    #define MAKE_UINT32(u0, u1, u2, u3) (u3 | (u2<<8) | (u1<<16) | (u0<<24))
+    #define MAKE_UINT32(u0, u1, u2, u3) ((UINT32)(u3) | ((UINT32)(u2)<<8) | ((UINT32)(u1)<<16) | ((UINT32)(u0)<<24))
     #define MASK_UINT32_CHANNEL_0 0xff000000
     #define MASK_UINT32_CHANNEL_1 0x00ff0000
     #define MASK_UINT32_CHANNEL_2 0x0000ff00
     #define MASK_UINT32_CHANNEL_3 0x000000ff
 #else
-    #define MAKE_UINT32(u0, u1, u2, u3) (u0 | (u1<<8) | (u2<<16) | (u3<<24))
+    #define MAKE_UINT32(u0, u1, u2, u3) ((UINT32)(u0) | ((UINT32)(u1)<<8) | ((UINT32)(u2)<<16) | ((UINT32)(u3)<<24))
     #define MASK_UINT32_CHANNEL_0 0x000000ff
     #define MASK_UINT32_CHANNEL_1 0x0000ff00
     #define MASK_UINT32_CHANNEL_2 0x00ff0000


### PR DESCRIPTION
The clangs UndefinedBehaviorSanitizer complains about signed overflow in the `(255 << 24)` expression:
```
Pillow/libImaging/Unpack.c:491:21: runtime error: left shift of 255 by 24 places cannot be represented in type 'int'
```
But the unsigned left shift is completely defined.