### PR TITLE
Add flags to Codecov for easier coverage checking/debugging

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -81,7 +81,7 @@ test_script:
 
 after_test:
 - pip install codecov
-- codecov --file coverage.xml --name %PYTHON%
+- codecov --file coverage.xml --name %PYTHON% --flags AppVeyor
 
 matrix:
   fast_finish: true

--- a/.ci/after_success.sh
+++ b/.ci/after_success.sh
@@ -9,7 +9,7 @@ else
 fi
 
 if [[ $TRAVIS ]]; then
-    codecov
+    codecov --flags TravisCI
 fi
 
 if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ]; then

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -66,5 +66,5 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        flags: GHADocker
+        flags: GHA_Docker
         name: ${{ matrix.docker }}

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -66,4 +66,5 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: GHADocker
         name: ${{ matrix.docker }}

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -361,6 +361,7 @@ jobs:
       with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
+          flags: GHAWindows
           name: ${{ runner.os }} Python ${{ matrix.python-version }}
 
     - name: Build wheel

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -361,7 +361,7 @@ jobs:
       with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-          flags: GHAWindows
+          flags: GHA_Windows
           name: ${{ runner.os }} Python ${{ matrix.python-version }}
 
     - name: Build wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,12 @@ jobs:
           env: PYTHONOPTIMIZE=2
         - python-version: "3.6"
           env: PYTHONOPTIMIZE=1
+        # Include new variables for Codecov
+        - os: ubuntu-latest
+          codecov-flag: GHA_Ubuntu
+        - os: macOS-latest
+          codecov-flag: GHA_macOS
+
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} Python ${{ matrix.python-version }}
 
@@ -97,5 +103,5 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        flags: GHA
+        flags: ${{ matrix.codecov-flag }}
         name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,4 +97,5 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: GHA
         name: ${{ matrix.os }} Python ${{ matrix.python-version }}


### PR DESCRIPTION
Changes proposed in this pull request:

 * Add flags for each upload of coverage to Codecov
   * flags must match pattern `^[\w\,]+$`
 * This allows us to easily filter by group (see top-right corner), to see which groups cover different bits of code, or if one is missing
 * For example, we can see there's no GHA Windows coverage, and that only Travis CI has Qt coverage
   * https://codecov.io/gh/hugovk/Pillow/src/b55e5b6d5f8c3bdf0c24f7cf06140ef3104ff569/Tests/test_imageqt.py

![image](https://user-images.githubusercontent.com/1324225/73059143-bd9a1200-3e9d-11ea-882f-1fda30037ea9.png)

cc @nulano @radarhere
