### PR TITLE
Ensure that errors directory exists before trying to upload from it

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -357,6 +357,12 @@ jobs:
         %PYTHON%\python.exe -m pytest -vx --cov PIL --cov Tests --cov-report term --cov-report xml Tests
       shell: cmd
 
+    - name: Prepare to upload errors
+      if: failure()
+      run: |
+        mkdir -p Tests/errors
+      shell: pwsh
+
     - name: Upload errors
       uses: actions/upload-artifact@v1
       if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,12 @@ jobs:
       run: |
         .ci/test.sh
 
+    - name: Prepare to upload errors
+      if: failure()
+      run: |
+        mkdir -p Tests/errors
+      shell: pwsh
+
     - name: Upload errors
       uses: actions/upload-artifact@v1
       if: failure()


### PR DESCRIPTION
Saw this in a failed test in #4378 

```
2020-01-25T02:08:26.0031734Z ##[error]Process completed with exit code 1.
2020-01-25T02:08:26.0213052Z ##[group]Run actions/upload-artifact@v1
2020-01-25T02:08:26.0213188Z with:
2020-01-25T02:08:26.0213274Z   name: errors
2020-01-25T02:08:26.0213352Z   path: Tests/errors
2020-01-25T02:08:26.0213415Z env:
2020-01-25T02:08:26.0213494Z   pythonLocation: d:\a\Pillow\pypy3.6
2020-01-25T02:08:26.0213574Z ##[endgroup]
2020-01-25T02:08:26.2089374Z ##[error]Path does not exist d:\a\Pillow\Pillow\Tests\errors
2020-01-25T02:08:26.2448668Z ##[error]Exit code 1 returned from process: file name 'c:\runners\2.164.0\bin\Runner.PluginHost.exe', arguments 'action "GitHub.Runner.Plugins.Artifact.PublishArtifact, Runner.Plugins"'.
2020-01-25T02:08:26.2467880Z Cleaning up orphan processes
```

This PR fixes the error that the path does not exist, using `mkdir -p`.