### PR TITLE
extents are not used by map_buffer

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2634,7 +2634,7 @@ def frombuffer(mode, size, data, decoder_name="raw", *args):
             args = mode, 0, 1
         if args[0] in _MAPMODES:
             im = new(mode, (1, 1))
-            im = im._new(core.map_buffer(data, size, decoder_name, None, 0, args))
+            im = im._new(core.map_buffer(data, size, decoder_name, 0, args))
             im.readonly = 1
             return im
 

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -194,7 +194,7 @@ class ImageFile(Image.Image):
                                 fp.fileno(), 0, access=mmap.ACCESS_READ
                             )
                         self.im = Image.core.map_buffer(
-                            self.map, self.size, decoder_name, extents, offset, args
+                            self.map, self.size, decoder_name, offset, args
                         )
                     readonly = 1
                     # After trashing self.im,

--- a/src/map.c
+++ b/src/map.c
@@ -313,14 +313,13 @@ PyImaging_MapBuffer(PyObject* self, PyObject* args)
     Py_buffer view;
     char* mode;
     char* codec;
-    PyObject* bbox;
     Py_ssize_t offset;
     int xsize, ysize;
     int stride;
     int ystep;
 
-    if (!PyArg_ParseTuple(args, "O(ii)sOn(sii)", &target, &xsize, &ysize,
-                          &codec, &bbox, &offset, &mode, &stride, &ystep))
+    if (!PyArg_ParseTuple(args, "O(ii)sn(sii)", &target, &xsize, &ysize,
+                          &codec, &offset, &mode, &stride, &ystep))
         return NULL;
 
     if (!PyImaging_CheckBuffer(target)) {


### PR DESCRIPTION
`extents` does not need to be passed into `Image.core.map_buffer`, as the corresponding variable. `bbox` is not used in `PyImaging_MapBuffer`.