### PR TITLE
Release buffer if function returns prematurely

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -355,17 +355,21 @@ PyImaging_MapBuffer(PyObject* self, PyObject* args)
 
     if (view.len < 0) {
         PyErr_SetString(PyExc_ValueError, "buffer has negative size");
+        PyBuffer_Release(&view);
         return NULL;
     }
     if (offset + size > view.len) {
         PyErr_SetString(PyExc_ValueError, "buffer is not large enough");
+        PyBuffer_Release(&view);
         return NULL;
     }
 
     im = ImagingNewPrologueSubtype(
         mode, xsize, ysize, sizeof(ImagingBufferInstance));
-    if (!im)
+    if (!im) {
+        PyBuffer_Release(&view);
         return NULL;
+    }
 
     /* setup file pointers */
     if (ystep > 0)


### PR DESCRIPTION
Resolves #4329 

In `PyImaging_MapBuffer`, [`Py_Buffer view`](https://github.com/python-pillow/Pillow/blob/d33d467169250d1277b32167eb184623c61c34c7/src/map.c#L313) is [set up](https://github.com/python-pillow/Pillow/blob/d33d467169250d1277b32167eb184623c61c34c7/src/map.c#L353), and [when the image is destroyed](https://github.com/python-pillow/Pillow/blob/d33d467169250d1277b32167eb184623c61c34c7/src/map.c#L378), it is [released](https://github.com/python-pillow/Pillow/blob/d33d467169250d1277b32167eb184623c61c34c7/src/map.c#L298-L302). However, if the function returns before that, then `view` is not released.

The setup [calls `PyObject_GetBuffer`](https://github.com/python-pillow/Pillow/blob/d33d467169250d1277b32167eb184623c61c34c7/src/_imaging.c#L247-L250), which is documented to require `PyBuffer_Release` - https://python.readthedocs.io/en/stable/c-api/buffer.html#c.PyObject_GetBuffer

> Successful calls to PyObject_GetBuffer() must be paired with calls to PyBuffer_Release(), similar to malloc() and free(). Thus, after the consumer is done with the buffer, PyBuffer_Release() must be called exactly once.

So this PR fixes a memory leak that is reported in the issue.