### PR TITLE
Merge pull request #4384 from jdufresne/float

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -124,7 +124,6 @@ class PillowTestCase(unittest.TestCase):
             self.assert_image_equal(a, img, msg)
 
     def assert_image_similar(self, a, b, epsilon, msg=None):
-        epsilon = float(epsilon)
         self.assertEqual(
             a.mode, b.mode, msg or "got mode {!r}, expected {!r}".format(a.mode, b.mode)
         )
@@ -139,7 +138,7 @@ class PillowTestCase(unittest.TestCase):
             chdiff = ImageMath.eval("abs(a - b)", a=ach, b=bch).convert("L")
             diff += sum(i * num for i, num in enumerate(chdiff.histogram()))
 
-        ave_diff = float(diff) / (a.size[0] * a.size[1])
+        ave_diff = diff / (a.size[0] * a.size[1])
         try:
             self.assertGreaterEqual(
                 epsilon,

--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -20,11 +20,11 @@ class TestColorLut3DCoreAPI(PillowTestCase):
 
         table = [
             [
-                r / float(size1D - 1) if size1D != 1 else 0,
-                g / float(size2D - 1) if size2D != 1 else 0,
-                b / float(size3D - 1) if size3D != 1 else 0,
-                r / float(size1D - 1) if size1D != 1 else 0,
-                g / float(size2D - 1) if size2D != 1 else 0,
+                r / (size1D - 1) if size1D != 1 else 0,
+                g / (size2D - 1) if size2D != 1 else 0,
+                b / (size3D - 1) if size3D != 1 else 0,
+                r / (size1D - 1) if size1D != 1 else 0,
+                g / (size2D - 1) if size2D != 1 else 0,
             ][:channels]
             for b in range(size3D)
             for g in range(size2D)

--- a/Tests/test_format_hsv.py
+++ b/Tests/test_format_hsv.py
@@ -8,10 +8,10 @@ from .helper import PillowTestCase, hopper
 
 class TestFormatHSV(PillowTestCase):
     def int_to_float(self, i):
-        return float(i) / 255.0
+        return i / 255
 
     def str_to_float(self, i):
-        return float(ord(i)) / 255.0
+        return ord(i) / 255
 
     def tuple_to_ints(self, tp):
         x, y, z = tp

--- a/Tests/test_image_reduce.py
+++ b/Tests/test_image_reduce.py
@@ -164,7 +164,7 @@ class TestImageReduce(PillowTestCase):
             ch_diff = ImageMath.eval("convert(abs(a - b), 'L')", a=ach, b=bch)
             ch_hist = ch_diff.histogram()
 
-            average_diff = sum(i * num for i, num in enumerate(ch_hist)) / float(
+            average_diff = sum(i * num for i, num in enumerate(ch_hist)) / (
                 a.size[0] * a.size[1]
             )
             self.assertGreaterEqual(

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -499,8 +499,8 @@ class TestImageCms(PillowTestCase):
                 # paste pattern with varying offsets to avoid correlation
                 # potentially hiding some bugs (like channels getting mixed).
                 paste_offset = (
-                    int(band_ndx / float(len(bands)) * channel_pattern.size[0]),
-                    int(band_ndx / float(len(bands) * 2) * channel_pattern.size[1]),
+                    int(band_ndx / len(bands) * channel_pattern.size[0]),
+                    int(band_ndx / (len(bands) * 2) * channel_pattern.size[1]),
                 )
                 channel_data = Image.new(channel_type, channel_pattern.size)
                 for delta in nine_grid_deltas:

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -75,8 +75,8 @@ def Ghostscript(tile, size, fp, scale=1):
     size = (size[0] * scale, size[1] * scale)
     # resolution is dependent on bbox and size
     res = (
-        float((72.0 * size[0]) / (bbox[2] - bbox[0])),
-        float((72.0 * size[1]) / (bbox[3] - bbox[1])),
+        72.0 * size[0] / (bbox[2] - bbox[0]),
+        72.0 * size[1] / (bbox[3] - bbox[1]),
     )
 
     out_fd, outfile = tempfile.mkstemp()

--- a/src/PIL/GimpGradientFile.py
+++ b/src/PIL/GimpGradientFile.py
@@ -73,7 +73,7 @@ class GradientFile:
 
         for i in range(entries):
 
-            x = i / float(entries - 1)
+            x = i / (entries - 1)
 
             while x1 < x:
                 ix += 1

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2357,8 +2357,8 @@ class Image:
         elif method == EXTENT:
             # convert extent to an affine transform
             x0, y0, x1, y1 = data
-            xs = float(x1 - x0) / w
-            ys = float(y1 - y0) / h
+            xs = (x1 - x0) / w
+            ys = (y1 - y0) / h
             method = AFFINE
             data = (xs, 0, x0, 0, ys, y0)
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -243,7 +243,7 @@ def pad(image, size, method=Image.BICUBIC, color=None, centering=(0.5, 0.5)):
     """
 
     im_ratio = image.width / image.height
-    dest_ratio = float(size[0]) / size[1]
+    dest_ratio = size[0] / size[1]
 
     if im_ratio == dest_ratio:
         out = image.resize(size, resample=method)
@@ -420,10 +420,10 @@ def fit(image, size, method=Image.BICUBIC, bleed=0.0, centering=(0.5, 0.5)):
     )
 
     # calculate the aspect ratio of the live_size
-    live_size_ratio = float(live_size[0]) / live_size[1]
+    live_size_ratio = live_size[0] / live_size[1]
 
     # calculate the aspect ratio of the output image
-    output_ratio = float(size[0]) / size[1]
+    output_ratio = size[0] / size[1]
 
     # figure out if the sides or top/bottom will be cropped off
     if live_size_ratio == output_ratio:

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -437,7 +437,7 @@ class JpegImageFile(ImageFile.ImageFile):
         self.tile = [(d, e, o, a)]
         self.decoderconfig = (scale, 0)
 
-        box = (0, 0, original_size[0] / float(scale), original_size[1] / float(scale))
+        box = (0, 0, original_size[0] / scale, original_size[1] / scale)
         return (self.mode, box)
 
     def load_djpeg(self):

--- a/src/PIL/PSDraw.py
+++ b/src/PIL/PSDraw.py
@@ -119,8 +119,8 @@ class PSDraw:
             else:
                 dpi = 100  # greyscale
         # image size (on paper)
-        x = float(im.size[0] * 72) / dpi
-        y = float(im.size[1] * 72) / dpi
+        x = im.size[0] * 72 / dpi
+        y = im.size[1] * 72 / dpi
         # max allowed size
         xmax = float(box[2] - box[0])
         ymax = float(box[3] - box[1])


### PR DESCRIPTION
In Python 3, the division operator is floating point division. No longer
need to coerce integers to floating point numbers before division.