### PR TITLE
Re-disable Codecov PR comment

### DIFF
--- a/.github/codecov-upstream.yml
+++ b/.github/codecov-upstream.yml
@@ -8,7 +8,7 @@ codecov:
 
   token: 6dafc396-e7f5-4221-a38a-8b07a49fbdae
 
-comment: off
+comment: false
 
 # Matches 'omit:' in .coveragerc
 ignore:

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ codecov:
   # https://docs.codecov.io/docs/comparing-commits
   allow_coverage_offsets: true
 
-comment: off
+comment: false
 
 # Matches 'omit:' in .coveragerc
 ignore:


### PR DESCRIPTION
Codecov comments have started showing up again, for example: https://github.com/python-pillow/Pillow/pull/4384#issuecomment-578510771.

In their [22 Sept 2019 docs](https://web.archive.org/web/20190922233407/https://docs.codecov.io/docs/pull-request-comments):

```yml
comment: off
```

But in the next one, on [17 Jan 2020 docs](https://web.archive.org/web/20200117175353/https://docs.codecov.io/docs/pull-request-comments) and [today](https://docs.codecov.io/docs/pull-request-comments), it's changed:

```yml
comment: false
```
