### PR TITLE
Remove leftover Python 2 compatibility shim

### DIFF
--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -241,14 +241,10 @@ class PdfName:
                 result.extend(make_bytes("#%02X" % b))
         return bytes(result)
 
-    __str__ = __bytes__
-
 
 class PdfArray(list):
     def __bytes__(self):
         return b"[ " + b" ".join(pdf_repr(x) for x in self) + b" ]"
-
-    __str__ = __bytes__
 
 
 class PdfDict(collections.UserDict):


### PR DESCRIPTION
In Python 3, `__str__` should not return bytes.