### PR TITLE
Remove unnecessary make_bytes() function

### DIFF
--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -214,9 +214,9 @@ def _save(im, fp, filename, save_all=False):
             #
             # page contents
 
-            page_contents = PdfParser.make_bytes(
-                "q %d 0 0 %d 0 0 cm /image Do Q\n"
-                % (int(width * 72.0 / resolution), int(height * 72.0 / resolution))
+            page_contents = b"q %d 0 0 %d 0 0 cm /image Do Q\n" % (
+                int(width * 72.0 / resolution),
+                int(height * 72.0 / resolution),
             )
 
             existing_pdf.write_obj(contents_refs[pageNumber], stream=page_contents)

--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -8,10 +8,6 @@ import time
 import zlib
 
 
-def make_bytes(s):
-    return s.encode("us-ascii")
-
-
 # see 7.9.2.2 Text String Type on page 86 and D.3 PDFDocEncoding Character Set
 # on page 656
 def encode_text(s):
@@ -179,10 +175,10 @@ class XrefTable:
             else:
                 contiguous_keys = keys
                 keys = None
-            f.write(make_bytes("%d %d\n" % (contiguous_keys[0], len(contiguous_keys))))
+            f.write(b"%d %d\n" % (contiguous_keys[0], len(contiguous_keys)))
             for object_id in contiguous_keys:
                 if object_id in self.new_entries:
-                    f.write(make_bytes("%010d %05d n \n" % self.new_entries[object_id]))
+                    f.write(b"%010d %05d n \n" % self.new_entries[object_id])
                 else:
                     this_deleted_object_id = deleted_keys.pop(0)
                     check_format_condition(
@@ -195,10 +191,8 @@ class XrefTable:
                     except IndexError:
                         next_in_linked_list = 0
                     f.write(
-                        make_bytes(
-                            "%010d %05d f \n"
-                            % (next_in_linked_list, self.deleted_entries[object_id])
-                        )
+                        b"%010d %05d f \n"
+                        % (next_in_linked_list, self.deleted_entries[object_id])
                     )
         return startxref
 
@@ -238,7 +232,7 @@ class PdfName:
             if b in self.allowed_chars:
                 result.append(b)
             else:
-                result.extend(make_bytes("#%02X" % b))
+                result.extend(b"#%02X" % b)
         return bytes(result)
 
     __str__ = __bytes__
@@ -304,7 +298,7 @@ class PdfBinary:
         self.data = data
 
     def __bytes__(self):
-        return make_bytes("<%s>" % "".join("%02X" % b for b in self.data))
+        return b"<%s>" % b"".join(b"%02X" % b for b in self.data)
 
 
 class PdfStream:
@@ -495,7 +489,7 @@ class PdfParser:
         self.f.write(
             b"trailer\n"
             + bytes(PdfDict(trailer_dict))
-            + make_bytes("\nstartxref\n%d\n%%%%EOF" % start_xref)
+            + b"\nstartxref\n%d\n%%%%EOF" % start_xref
         )
 
     def write_page(self, ref, *objs, **dict_obj):


### PR DESCRIPTION
The function was introduced in 65112bad7e4a692ea01980a642e540ec4c0a2fcb
to handle the differences between Python 2 & 3 byte handling. Now that
Python 3 supports byte formatting, can drop the unnecessary
compatibility shim in favor of native features.