### PR TITLE
Fix ResourceWarning emitted during tests

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-python -m pytest -v -x --cov PIL --cov Tests --cov-report term Tests
+python -m pytest -v -x -W always --cov PIL --cov Tests --cov-report term Tests
 
 # Docs
 if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ] && [ "$TRAVIS_CPU_ARCH" == "amd64" ]; then

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -335,7 +335,7 @@ jobs:
         rem Add libraqm.dll (copied to INCLIB) to PATH.
         path %INCLIB%;%PATH%
         cd /D %GITHUB_WORKSPACE%
-        %PYTHON%\python.exe -m pytest -vx --cov PIL --cov Tests --cov-report term --cov-report xml Tests
+        %PYTHON%\python.exe -m pytest -vx -W always --cov PIL --cov Tests --cov-report term --cov-report xml Tests
       shell: cmd
 
     - name: Prepare to upload errors

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -640,11 +640,11 @@ class TestFileJpeg(PillowTestCase):
 
     def test_invalid_exif_x_resolution(self):
         # When no x or y resolution is defined in EXIF
-        im = Image.open("Tests/images/invalid-exif-without-x-resolution.jpg")
+        with Image.open("Tests/images/invalid-exif-without-x-resolution.jpg") as im:
 
-        # This should return the default, and not a ValueError or
-        # OSError for an unidentified image.
-        self.assertEqual(im.info.get("dpi"), (72, 72))
+            # This should return the default, and not a ValueError or
+            # OSError for an unidentified image.
+            self.assertEqual(im.info.get("dpi"), (72, 72))
 
     def test_ifd_offset_exif(self):
         # Arrange

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -231,9 +231,9 @@ class TestFileTiffMetadata(PillowTestCase):
         out = self.tempfile("temp.tiff")
         im.save(out, tiffinfo=info, compression="raw")
 
-        reloaded = Image.open(out)
-        self.assertEqual(max_long, reloaded.tag_v2[41493].numerator)
-        self.assertEqual(1, reloaded.tag_v2[41493].denominator)
+        with Image.open(out) as reloaded:
+            self.assertEqual(max_long, reloaded.tag_v2[41493].numerator)
+            self.assertEqual(1, reloaded.tag_v2[41493].denominator)
 
         # out of bounds of 4 byte unsigned long
         numerator = max_long + 1
@@ -243,9 +243,9 @@ class TestFileTiffMetadata(PillowTestCase):
         out = self.tempfile("temp.tiff")
         im.save(out, tiffinfo=info, compression="raw")
 
-        reloaded = Image.open(out)
-        self.assertEqual(max_long, reloaded.tag_v2[41493].numerator)
-        self.assertEqual(1, reloaded.tag_v2[41493].denominator)
+        with Image.open(out) as reloaded:
+            self.assertEqual(max_long, reloaded.tag_v2[41493].numerator)
+            self.assertEqual(1, reloaded.tag_v2[41493].denominator)
 
     def test_ifd_signed_rational(self):
         im = hopper()
@@ -260,9 +260,9 @@ class TestFileTiffMetadata(PillowTestCase):
         out = self.tempfile("temp.tiff")
         im.save(out, tiffinfo=info, compression="raw")
 
-        reloaded = Image.open(out)
-        self.assertEqual(numerator, reloaded.tag_v2[37380].numerator)
-        self.assertEqual(denominator, reloaded.tag_v2[37380].denominator)
+        with Image.open(out) as reloaded:
+            self.assertEqual(numerator, reloaded.tag_v2[37380].numerator)
+            self.assertEqual(denominator, reloaded.tag_v2[37380].denominator)
 
         numerator = -(2 ** 31)
         denominator = 2 ** 31 - 1
@@ -272,9 +272,9 @@ class TestFileTiffMetadata(PillowTestCase):
         out = self.tempfile("temp.tiff")
         im.save(out, tiffinfo=info, compression="raw")
 
-        reloaded = Image.open(out)
-        self.assertEqual(numerator, reloaded.tag_v2[37380].numerator)
-        self.assertEqual(denominator, reloaded.tag_v2[37380].denominator)
+        with Image.open(out) as reloaded:
+            self.assertEqual(numerator, reloaded.tag_v2[37380].numerator)
+            self.assertEqual(denominator, reloaded.tag_v2[37380].denominator)
 
         # out of bounds of 4 byte signed long
         numerator = -(2 ** 31) - 1
@@ -285,9 +285,9 @@ class TestFileTiffMetadata(PillowTestCase):
         out = self.tempfile("temp.tiff")
         im.save(out, tiffinfo=info, compression="raw")
 
-        reloaded = Image.open(out)
-        self.assertEqual(2 ** 31 - 1, reloaded.tag_v2[37380].numerator)
-        self.assertEqual(-1, reloaded.tag_v2[37380].denominator)
+        with Image.open(out) as reloaded:
+            self.assertEqual(2 ** 31 - 1, reloaded.tag_v2[37380].numerator)
+            self.assertEqual(-1, reloaded.tag_v2[37380].denominator)
 
     def test_ifd_signed_long(self):
         im = hopper()
@@ -298,8 +298,8 @@ class TestFileTiffMetadata(PillowTestCase):
         out = self.tempfile("temp.tiff")
         im.save(out, tiffinfo=info, compression="raw")
 
-        reloaded = Image.open(out)
-        self.assertEqual(reloaded.tag_v2[37000], -60000)
+        with Image.open(out) as reloaded:
+            self.assertEqual(reloaded.tag_v2[37000], -60000)
 
     def test_empty_values(self):
         data = io.BytesIO(

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
     {envpython} setup.py clean
     {envpython} setup.py build_ext --inplace
     {envpython} selftest.py
-    {envpython} -m pytest {posargs}
+    {envpython} -W always -m pytest {posargs}
 deps =
     cffi
     numpy

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
     {envpython} setup.py clean
     {envpython} setup.py build_ext --inplace
     {envpython} selftest.py
-    {envpython} -W always -m pytest {posargs}
+    {envpython} -m pytest -W always {posargs}
 deps =
     cffi
     numpy


### PR DESCRIPTION
Appeared in the form:

    ResourceWarning: unclosed file <_io.BufferedReader name='Tests/images/invalid-exif-without-x-resolution.jpg'>

Enable all warnings to always display during tests to help catch these
warnings earlier.