### PR TITLE
Remove deprecated pytest-runner support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@ co:
     done
 
 coverage:
-	python3 selftest.py
-	python3 setup.py test
+	pytest -qq
 	rm -r htmlcov || true
 	coverage report
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[aliases]
-test=pytest
-
 [flake8]
 extend-ignore = E203, W503
 max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -845,9 +845,6 @@ def debug_build():
     return hasattr(sys, "gettotalrefcount")
 
 
-needs_pytest = {"pytest", "test", "ptr"}.intersection(sys.argv)
-pytest_runner = ["pytest-runner"] if needs_pytest else []
-
 try:
     setup(
         name=NAME,
@@ -884,8 +881,6 @@ try:
         cmdclass={"build_ext": pil_build_ext},
         ext_modules=[Extension("PIL._imaging", ["_imaging.c"])],
         include_package_data=True,
-        setup_requires=pytest_runner,
-        tests_require=["pytest"],
         packages=["PIL"],
         package_dir={"": "src"},
         keywords=["Imaging"],


### PR DESCRIPTION
The pytest-runner package is deprecated and its use is discouraged. See:

https://github.com/pytest-dev/pytest-runner/

> pytest-runner depends on deprecated features of setuptools and relies
> on features that break security mechanisms in pip. For example
> 'setup_requires' and 'tests_require' bypass pip --require-hashes. See
> also https://github.com/pypa/setuptools/issues/1684.
>
> It is recommended that you:
>
> - Remove 'pytest-runner' from your 'setup_requires', preferably
>   removing the setup_requires option.
> - Remove 'pytest' and any other testing requirements from
>   'tests_require', preferably removing the setup_requires option.
> - Select a tool to bootstrap and then run tests such as tox

Running tests should go through the tox entrypoint.