### PR TITLE
Docs: Speed up linkcheck by checking in parallel

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -142,7 +142,7 @@ changes:
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
 linkcheck:
-	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
+	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck -j auto
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."


### PR DESCRIPTION
Link checking is is run as part of `make doc`, and calls `make -C docs linkcheck` which calls `sphinx-build`.

```
$ console
sphinx-build --help
...
general options:
...
  -j N              build in parallel with N processes where possible (special value "auto" will set N to cpu-count)
```

Before, three runs of `make -C docs linkcheck` took:

* 1m35s
* 1m38s
* 1m29s

After:

* 19s
* 23s
* 15s
