### PR TITLE
Convert most PillowTestCase methods to pytest

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -178,31 +178,6 @@ class PillowTestCase(unittest.TestCase):
         except OSError:
             pass  # report?
 
-    def assert_warning(self, warn_class, func, *args, **kwargs):
-        import warnings
-
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-
-            # Hopefully trigger a warning.
-            result = func(*args, **kwargs)
-
-            # Verify some things.
-            if warn_class is None:
-                self.assertEqual(
-                    len(w), 0, "Expected no warnings, got %s" % [v.category for v in w]
-                )
-            else:
-                self.assertGreaterEqual(len(w), 1)
-                found = False
-                for v in w:
-                    if issubclass(v.category, warn_class):
-                        found = True
-                        break
-                self.assertTrue(found)
-        return result
-
     def tempfile(self, template):
         assert template[:5] in ("temp.", "temp_")
         fd, path = tempfile.mkstemp(template[4:], template[:4])

--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -2,7 +2,7 @@ import os
 
 from PIL import Image
 
-from .helper import PillowTestCase
+from .helper import PillowTestCase, assert_image_similar
 
 base = os.path.join("Tests", "images", "bmp")
 
@@ -97,7 +97,7 @@ class TestBmpReference(PillowTestCase):
                             # be differently ordered for an equivalent image.
                             im = im.convert("RGBA")
                             compare = im.convert("RGBA")
-                        self.assert_image_similar(im, compare, 5)
+                        assert_image_similar(im, compare, 5)
 
             except Exception as msg:
                 # there are three here that are unsupported:

--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -1,5 +1,6 @@
 import os
 
+import pytest
 from PIL import Image
 
 from .helper import PillowTestCase, assert_image_similar
@@ -28,7 +29,7 @@ class TestBmpReference(PillowTestCase):
                     pass
 
             # Assert that there is no unclosed file warning
-            self.assert_warning(None, open, f)
+            pytest.warns(None, open, f)
 
     def test_questionable(self):
         """ These shouldn't crash/dos, but it's not well defined that these

--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -3,7 +3,7 @@ from array import array
 
 from PIL import Image, ImageFilter
 
-from .helper import PillowTestCase
+from .helper import PillowTestCase, assert_image_equal
 
 try:
     import numpy
@@ -147,7 +147,7 @@ class TestColorLut3DCoreAPI(PillowTestCase):
 
         # Fast test with small cubes
         for size in [2, 3, 5, 7, 11, 16, 17]:
-            self.assert_image_equal(
+            assert_image_equal(
                 im,
                 im._new(
                     im.im.color_lut_3d(
@@ -157,7 +157,7 @@ class TestColorLut3DCoreAPI(PillowTestCase):
             )
 
         # Not so fast
-        self.assert_image_equal(
+        assert_image_equal(
             im,
             im._new(
                 im.im.color_lut_3d(
@@ -173,7 +173,7 @@ class TestColorLut3DCoreAPI(PillowTestCase):
         )
 
         # Red channel copied to alpha
-        self.assert_image_equal(
+        assert_image_equal(
             Image.merge("RGBA", (im.split() * 2)[:4]),
             im._new(
                 im.im.color_lut_3d(
@@ -194,7 +194,7 @@ class TestColorLut3DCoreAPI(PillowTestCase):
             ],
         )
 
-        self.assert_image_equal(
+        assert_image_equal(
             im,
             im._new(
                 im.im.color_lut_3d(
@@ -211,7 +211,7 @@ class TestColorLut3DCoreAPI(PillowTestCase):
 
         # Reverse channels by splitting and using table
         # fmt: off
-        self.assert_image_equal(
+        assert_image_equal(
             Image.merge('RGB', im.split()[::-1]),
             im._new(im.im.color_lut_3d('RGB', Image.LINEAR,
                     3, 2, 2, 2, [
@@ -368,15 +368,15 @@ class TestColorLut3DFilter(PillowTestCase):
 
         lut = ImageFilter.Color3DLUT.generate((7, 9, 11), lambda r, g, b: (r, g, b))
         lut.table = numpy.array(lut.table, dtype=numpy.float16)
-        self.assert_image_equal(im, im.filter(lut))
+        assert_image_equal(im, im.filter(lut))
 
         lut = ImageFilter.Color3DLUT.generate((7, 9, 11), lambda r, g, b: (r, g, b))
         lut.table = numpy.array(lut.table, dtype=numpy.float32)
-        self.assert_image_equal(im, im.filter(lut))
+        assert_image_equal(im, im.filter(lut))
 
         lut = ImageFilter.Color3DLUT.generate((7, 9, 11), lambda r, g, b: (r, g, b))
         lut.table = numpy.array(lut.table, dtype=numpy.float64)
-        self.assert_image_equal(im, im.filter(lut))
+        assert_image_equal(im, im.filter(lut))
 
         lut = ImageFilter.Color3DLUT.generate((7, 9, 11), lambda r, g, b: (r, g, b))
         lut.table = numpy.array(lut.table, dtype=numpy.int32)

--- a/Tests/test_core_resources.py
+++ b/Tests/test_core_resources.py
@@ -1,6 +1,7 @@
 import sys
 import unittest
 
+import pytest
 from PIL import Image
 
 from .helper import PillowTestCase, is_pypy
@@ -169,12 +170,12 @@ class TestEnvVars(PillowTestCase):
         self.assertEqual(Image.core.get_block_size(), 2 * 1024 * 1024)
 
     def test_warnings(self):
-        self.assert_warning(
+        pytest.warns(
             UserWarning, Image._apply_env_variables, {"PILLOW_ALIGNMENT": "15"}
         )
-        self.assert_warning(
+        pytest.warns(
             UserWarning, Image._apply_env_variables, {"PILLOW_BLOCK_SIZE": "1024"}
         )
-        self.assert_warning(
+        pytest.warns(
             UserWarning, Image._apply_env_variables, {"PILLOW_BLOCKS_MAX": "wat"}
         )

--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -1,3 +1,4 @@
+import pytest
 from PIL import Image
 
 from .helper import PillowTestCase, hopper
@@ -38,7 +39,7 @@ class TestDecompressionBomb(PillowTestCase):
             with Image.open(TEST_FILE):
                 pass
 
-        self.assert_warning(Image.DecompressionBombWarning, open)
+        pytest.warns(Image.DecompressionBombWarning, open)
 
     def test_exception(self):
         # Set limit to trigger exception on the test file
@@ -71,7 +72,7 @@ class TestDecompressionCrop(PillowTestCase):
         # Crops can extend the extents, therefore we should have the
         # same decompression bomb warnings on them.
         box = (0, 0, self.src.width * 2, self.src.height * 2)
-        self.assert_warning(Image.DecompressionBombWarning, self.src.crop, box)
+        pytest.warns(Image.DecompressionBombWarning, self.src.crop, box)
 
     def test_crop_decompression_checks(self):
 
@@ -87,7 +88,7 @@ class TestDecompressionCrop(PillowTestCase):
             self.assertEqual(im.crop(value).size, (9, 9))
 
         for value in warning_values:
-            self.assert_warning(Image.DecompressionBombWarning, im.crop, value)
+            pytest.warns(Image.DecompressionBombWarning, im.crop, value)
 
         for value in error_values:
             with self.assertRaises(Image.DecompressionBombError):

--- a/Tests/test_file_blp.py
+++ b/Tests/test_file_blp.py
@@ -1,20 +1,20 @@
 from PIL import Image
 
-from .helper import PillowTestCase
+from .helper import PillowTestCase, assert_image_equal
 
 
 class TestFileBlp(PillowTestCase):
     def test_load_blp2_raw(self):
         with Image.open("Tests/images/blp/blp2_raw.blp") as im:
             with Image.open("Tests/images/blp/blp2_raw.png") as target:
-                self.assert_image_equal(im, target)
+                assert_image_equal(im, target)
 
     def test_load_blp2_dxt1(self):
         with Image.open("Tests/images/blp/blp2_dxt1.blp") as im:
             with Image.open("Tests/images/blp/blp2_dxt1.png") as target:
-                self.assert_image_equal(im, target)
+                assert_image_equal(im, target)
 
     def test_load_blp2_dxt1a(self):
         with Image.open("Tests/images/blp/blp2_dxt1a.blp") as im:
             with Image.open("Tests/images/blp/blp2_dxt1a.png") as target:
-                self.assert_image_equal(im, target)
+                assert_image_equal(im, target)

--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -2,7 +2,7 @@ import io
 
 from PIL import BmpImagePlugin, Image
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 
 
 class TestFileBmp(PillowTestCase):
@@ -102,7 +102,7 @@ class TestFileBmp(PillowTestCase):
             self.assertEqual(im.get_format_mimetype(), "image/bmp")
 
             with Image.open("Tests/images/clipboard_target.png") as target:
-                self.assert_image_equal(im, target)
+                assert_image_equal(im, target)
 
     def test_save_dib(self):
         outfile = self.tempfile("temp.dib")
@@ -113,7 +113,7 @@ class TestFileBmp(PillowTestCase):
             with Image.open(outfile) as reloaded:
                 self.assertEqual(reloaded.format, "DIB")
                 self.assertEqual(reloaded.get_format_mimetype(), "image/bmp")
-                self.assert_image_equal(im, reloaded)
+                assert_image_equal(im, reloaded)
 
     def test_rgba_bitfields(self):
         # This test image has been manually hexedited
@@ -125,4 +125,4 @@ class TestFileBmp(PillowTestCase):
             im = Image.merge("RGB", (r, g, b))
 
         with Image.open("Tests/images/bmp/q/rgb32bf-xbgr.bmp") as target:
-            self.assert_image_equal(im, target)
+            assert_image_equal(im, target)

--- a/Tests/test_file_dcx.py
+++ b/Tests/test_file_dcx.py
@@ -2,7 +2,7 @@ import unittest
 
 from PIL import DcxImagePlugin, Image
 
-from .helper import PillowTestCase, hopper, is_pypy
+from .helper import PillowTestCase, assert_image_equal, hopper, is_pypy
 
 # Created with ImageMagick: convert hopper.ppm hopper.dcx
 TEST_FILE = "Tests/images/hopper.dcx"
@@ -19,7 +19,7 @@ class TestFileDcx(PillowTestCase):
             self.assertEqual(im.size, (128, 128))
             self.assertIsInstance(im, DcxImagePlugin.DcxImageFile)
             orig = hopper()
-            self.assert_image_equal(im, orig)
+            assert_image_equal(im, orig)
 
     @unittest.skipIf(is_pypy(), "Requires CPython")
     def test_unclosed_file(self):

--- a/Tests/test_file_dcx.py
+++ b/Tests/test_file_dcx.py
@@ -1,5 +1,6 @@
 import unittest
 
+import pytest
 from PIL import DcxImagePlugin, Image
 
 from .helper import PillowTestCase, assert_image_equal, hopper, is_pypy
@@ -27,7 +28,7 @@ class TestFileDcx(PillowTestCase):
             im = Image.open(TEST_FILE)
             im.load()
 
-        self.assert_warning(ResourceWarning, open)
+        pytest.warns(ResourceWarning, open)
 
     def test_closed_file(self):
         def open():
@@ -35,14 +36,14 @@ class TestFileDcx(PillowTestCase):
             im.load()
             im.close()
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)
 
     def test_context_manager(self):
         def open():
             with Image.open(TEST_FILE) as im:
                 im.load()
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)
 
     def test_invalid_file(self):
         with open("Tests/images/flower.jpg", "rb") as fp:

--- a/Tests/test_file_dds.py
+++ b/Tests/test_file_dds.py
@@ -2,7 +2,7 @@ from io import BytesIO
 
 from PIL import DdsImagePlugin, Image
 
-from .helper import PillowTestCase
+from .helper import PillowTestCase, assert_image_equal
 
 TEST_FILE_DXT1 = "Tests/images/dxt1-rgb-4bbp-noalpha_MipMaps-1.dds"
 TEST_FILE_DXT3 = "Tests/images/dxt3-argb-8bbp-explicitalpha_MipMaps-1.dds"
@@ -26,7 +26,7 @@ class TestFileDds(PillowTestCase):
             self.assertEqual(im.mode, "RGBA")
             self.assertEqual(im.size, (256, 256))
 
-            self.assert_image_equal(im, target)
+            assert_image_equal(im, target)
 
     def test_sanity_dxt5(self):
         """Check DXT5 images can be opened"""
@@ -39,7 +39,7 @@ class TestFileDds(PillowTestCase):
         self.assertEqual(im.size, (256, 256))
 
         with Image.open(TEST_FILE_DXT5.replace(".dds", ".png")) as target:
-            self.assert_image_equal(target, im)
+            assert_image_equal(target, im)
 
     def test_sanity_dxt3(self):
         """Check DXT3 images can be opened"""
@@ -52,7 +52,7 @@ class TestFileDds(PillowTestCase):
                 self.assertEqual(im.mode, "RGBA")
                 self.assertEqual(im.size, (256, 256))
 
-                self.assert_image_equal(target, im)
+                assert_image_equal(target, im)
 
     def test_dx10_bc7(self):
         """Check DX10 images can be opened"""
@@ -65,7 +65,7 @@ class TestFileDds(PillowTestCase):
             self.assertEqual(im.size, (256, 256))
 
             with Image.open(TEST_FILE_DX10_BC7.replace(".dds", ".png")) as target:
-                self.assert_image_equal(target, im)
+                assert_image_equal(target, im)
 
     def test_dx10_bc7_unorm_srgb(self):
         """Check DX10 unsigned normalized integer images can be opened"""
@@ -81,7 +81,7 @@ class TestFileDds(PillowTestCase):
             with Image.open(
                 TEST_FILE_DX10_BC7_UNORM_SRGB.replace(".dds", ".png")
             ) as target:
-                self.assert_image_equal(target, im)
+                assert_image_equal(target, im)
 
     def test_unimplemented_dxgi_format(self):
         self.assertRaises(
@@ -103,7 +103,7 @@ class TestFileDds(PillowTestCase):
             with Image.open(
                 TEST_FILE_UNCOMPRESSED_RGB.replace(".dds", ".png")
             ) as target:
-                self.assert_image_equal(target, im)
+                assert_image_equal(target, im)
 
     def test__validate_true(self):
         """Check valid prefix"""

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -3,7 +3,7 @@ import unittest
 
 from PIL import EpsImagePlugin, Image
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_similar, hopper
 
 HAS_GHOSTSCRIPT = EpsImagePlugin.has_ghostscript()
 
@@ -69,7 +69,7 @@ class TestFileEps(PillowTestCase):
 
             if "jpeg_decoder" in dir(Image.core):
                 with Image.open("Tests/images/pil_sample_rgb.jpg") as target:
-                    self.assert_image_similar(cmyk_image, target, 10)
+                    assert_image_similar(cmyk_image, target, 10)
 
     @unittest.skipUnless(HAS_GHOSTSCRIPT, "Ghostscript not available")
     def test_showpage(self):
@@ -79,7 +79,7 @@ class TestFileEps(PillowTestCase):
                 # should not crash/hang
                 plot_image.load()
                 #  fonts could be slightly different
-                self.assert_image_similar(plot_image, target, 6)
+                assert_image_similar(plot_image, target, 6)
 
     @unittest.skipUnless(HAS_GHOSTSCRIPT, "Ghostscript not available")
     def test_file_object(self):
@@ -106,7 +106,7 @@ class TestFileEps(PillowTestCase):
             with Image.open(file1_compare) as image1_scale1_compare:
                 image1_scale1_compare = image1_scale1_compare.convert("RGB")
             image1_scale1_compare.load()
-            self.assert_image_similar(img, image1_scale1_compare, 5)
+            assert_image_similar(img, image1_scale1_compare, 5)
 
     def test_image_mode_not_supported(self):
         im = hopper("RGBA")
@@ -126,7 +126,7 @@ class TestFileEps(PillowTestCase):
             with Image.open(file1_compare) as image1_scale1_compare:
                 image1_scale1_compare = image1_scale1_compare.convert("RGB")
             image1_scale1_compare.load()
-            self.assert_image_similar(image1_scale1, image1_scale1_compare, 5)
+            assert_image_similar(image1_scale1, image1_scale1_compare, 5)
 
         # Non-Zero bounding box
         with Image.open(file2) as image2_scale1:
@@ -134,7 +134,7 @@ class TestFileEps(PillowTestCase):
             with Image.open(file2_compare) as image2_scale1_compare:
                 image2_scale1_compare = image2_scale1_compare.convert("RGB")
             image2_scale1_compare.load()
-            self.assert_image_similar(image2_scale1, image2_scale1_compare, 10)
+            assert_image_similar(image2_scale1, image2_scale1_compare, 10)
 
     @unittest.skipUnless(HAS_GHOSTSCRIPT, "Ghostscript not available")
     def test_render_scale2(self):
@@ -149,7 +149,7 @@ class TestFileEps(PillowTestCase):
             with Image.open(file1_compare_scale2) as image1_scale2_compare:
                 image1_scale2_compare = image1_scale2_compare.convert("RGB")
             image1_scale2_compare.load()
-            self.assert_image_similar(image1_scale2, image1_scale2_compare, 5)
+            assert_image_similar(image1_scale2, image1_scale2_compare, 5)
 
         # Non-Zero bounding box
         with Image.open(file2) as image2_scale2:
@@ -157,7 +157,7 @@ class TestFileEps(PillowTestCase):
             with Image.open(file2_compare_scale2) as image2_scale2_compare:
                 image2_scale2_compare = image2_scale2_compare.convert("RGB")
             image2_scale2_compare.load()
-            self.assert_image_similar(image2_scale2, image2_scale2_compare, 10)
+            assert_image_similar(image2_scale2, image2_scale2_compare, 10)
 
     @unittest.skipUnless(HAS_GHOSTSCRIPT, "Ghostscript not available")
     def test_resize(self):

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -1,5 +1,6 @@
 import unittest
 
+import pytest
 from PIL import FliImagePlugin, Image
 
 from .helper import PillowTestCase, assert_image_equal, is_pypy
@@ -34,7 +35,7 @@ class TestFileFli(PillowTestCase):
             im = Image.open(static_test_file)
             im.load()
 
-        self.assert_warning(ResourceWarning, open)
+        pytest.warns(ResourceWarning, open)
 
     def test_closed_file(self):
         def open():
@@ -42,14 +43,14 @@ class TestFileFli(PillowTestCase):
             im.load()
             im.close()
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)
 
     def test_context_manager(self):
         def open():
             with Image.open(static_test_file) as im:
                 im.load()
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)
 
     def test_tell(self):
         # Arrange

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -2,7 +2,7 @@ import unittest
 
 from PIL import FliImagePlugin, Image
 
-from .helper import PillowTestCase, is_pypy
+from .helper import PillowTestCase, assert_image_equal, is_pypy
 
 # created as an export of a palette image from Gimp2.6
 # save as...-> hopper.fli, default options.
@@ -113,4 +113,4 @@ class TestFileFli(PillowTestCase):
             im.seek(50)
 
             with Image.open("Tests/images/a_fli.png") as expected:
-                self.assert_image_equal(im, expected)
+                assert_image_equal(im, expected)

--- a/Tests/test_file_ftex.py
+++ b/Tests/test_file_ftex.py
@@ -1,15 +1,15 @@
 from PIL import Image
 
-from .helper import PillowTestCase
+from .helper import PillowTestCase, assert_image_equal, assert_image_similar
 
 
 class TestFileFtex(PillowTestCase):
     def test_load_raw(self):
         with Image.open("Tests/images/ftex_uncompressed.ftu") as im:
             with Image.open("Tests/images/ftex_uncompressed.png") as target:
-                self.assert_image_equal(im, target)
+                assert_image_equal(im, target)
 
     def test_load_dxt1(self):
         with Image.open("Tests/images/ftex_dxt1.ftc") as im:
             with Image.open("Tests/images/ftex_dxt1.png") as target:
-                self.assert_image_similar(im, target.convert("RGBA"), 15)
+                assert_image_similar(im, target.convert("RGBA"), 15)

--- a/Tests/test_file_gbr.py
+++ b/Tests/test_file_gbr.py
@@ -1,6 +1,6 @@
 from PIL import GbrImagePlugin, Image
 
-from .helper import PillowTestCase
+from .helper import PillowTestCase, assert_image_equal
 
 
 class TestFileGbr(PillowTestCase):
@@ -12,4 +12,4 @@ class TestFileGbr(PillowTestCase):
     def test_gbr_file(self):
         with Image.open("Tests/images/gbr.gbr") as im:
             with Image.open("Tests/images/gbr.png") as target:
-                self.assert_image_equal(target, im)
+                assert_image_equal(target, im)

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -3,7 +3,14 @@ from io import BytesIO
 
 from PIL import GifImagePlugin, Image, ImageDraw, ImagePalette
 
-from .helper import PillowTestCase, hopper, is_pypy, netpbm_available
+from .helper import (
+    PillowTestCase,
+    assert_image_equal,
+    assert_image_similar,
+    hopper,
+    is_pypy,
+    netpbm_available,
+)
 
 try:
     from PIL import _webp
@@ -101,7 +108,7 @@ class TestFileGif(PillowTestCase):
                 )
                 self.assertEqual(expected_palette_length, palette_length)
 
-                self.assert_image_equal(im.convert("RGB"), reloaded.convert("RGB"))
+                assert_image_equal(im.convert("RGB"), reloaded.convert("RGB"))
 
         # These do optimize the palette
         check(128, 511, 128)
@@ -130,7 +137,7 @@ class TestFileGif(PillowTestCase):
         im.save(out)
         with Image.open(out) as reread:
 
-            self.assert_image_similar(reread.convert("RGB"), im, 50)
+            assert_image_similar(reread.convert("RGB"), im, 50)
 
     def test_roundtrip2(self):
         # see https://github.com/python-pillow/Pillow/issues/403
@@ -140,7 +147,7 @@ class TestFileGif(PillowTestCase):
             im2.save(out)
         with Image.open(out) as reread:
 
-            self.assert_image_similar(reread.convert("RGB"), hopper(), 50)
+            assert_image_similar(reread.convert("RGB"), hopper(), 50)
 
     def test_roundtrip_save_all(self):
         # Single frame image
@@ -149,7 +156,7 @@ class TestFileGif(PillowTestCase):
         im.save(out, save_all=True)
         with Image.open(out) as reread:
 
-            self.assert_image_similar(reread.convert("RGB"), im, 50)
+            assert_image_similar(reread.convert("RGB"), im, 50)
 
         # Multiframe image
         with Image.open("Tests/images/dispose_bgnd.gif") as im:
@@ -188,7 +195,7 @@ class TestFileGif(PillowTestCase):
 
         with Image.open(f) as reloaded:
 
-            self.assert_image_similar(im, reloaded.convert("RGB"), 10)
+            assert_image_similar(im, reloaded.convert("RGB"), 10)
 
     def test_palette_434(self):
         # see https://github.com/python-pillow/Pillow/issues/434
@@ -204,15 +211,15 @@ class TestFileGif(PillowTestCase):
         with Image.open(orig) as im:
 
             with roundtrip(im) as reloaded:
-                self.assert_image_similar(im, reloaded, 1)
+                assert_image_similar(im, reloaded, 1)
             with roundtrip(im, optimize=True) as reloaded:
-                self.assert_image_similar(im, reloaded, 1)
+                assert_image_similar(im, reloaded, 1)
 
             im = im.convert("RGB")
             # check automatic P conversion
             with roundtrip(im) as reloaded:
                 reloaded = reloaded.convert("RGB")
-                self.assert_image_equal(im, reloaded)
+                assert_image_equal(im, reloaded)
 
     @unittest.skipUnless(netpbm_available(), "netpbm not available")
     def test_save_netpbm_bmp_mode(self):
@@ -222,7 +229,7 @@ class TestFileGif(PillowTestCase):
             tempfile = self.tempfile("temp.gif")
             GifImagePlugin._save_netpbm(img, 0, tempfile)
             with Image.open(tempfile) as reloaded:
-                self.assert_image_similar(img, reloaded.convert("RGB"), 0)
+                assert_image_similar(img, reloaded.convert("RGB"), 0)
 
     @unittest.skipUnless(netpbm_available(), "netpbm not available")
     def test_save_netpbm_l_mode(self):
@@ -232,7 +239,7 @@ class TestFileGif(PillowTestCase):
             tempfile = self.tempfile("temp.gif")
             GifImagePlugin._save_netpbm(img, 0, tempfile)
             with Image.open(tempfile) as reloaded:
-                self.assert_image_similar(img, reloaded.convert("L"), 0)
+                assert_image_similar(img, reloaded.convert("L"), 0)
 
     def test_seek(self):
         with Image.open("Tests/images/dispose_none.gif") as img:
@@ -260,7 +267,7 @@ class TestFileGif(PillowTestCase):
 
             with Image.open("Tests/images/iss634.gif") as expected:
                 expected.seek(1)
-                self.assert_image_equal(im, expected)
+                assert_image_equal(im, expected)
 
     def test_n_frames(self):
         for path, n_frames in [[TEST_GIF, 1], ["Tests/images/iss634.gif", 42]]:
@@ -592,7 +599,7 @@ class TestFileGif(PillowTestCase):
     def test_zero_comment_subblocks(self):
         with Image.open("Tests/images/hopper_zero_comment_subblocks.gif") as im:
             with Image.open(TEST_GIF) as expected:
-                self.assert_image_equal(im, expected)
+                assert_image_equal(im, expected)
 
     def test_version(self):
         out = self.tempfile("temp.gif")
@@ -713,7 +720,7 @@ class TestFileGif(PillowTestCase):
 
         with Image.open(out) as reloaded:
 
-            self.assert_image_equal(reloaded.convert("RGB"), im.convert("RGB"))
+            assert_image_equal(reloaded.convert("RGB"), im.convert("RGB"))
 
     def test_palette_save_P(self):
         # pass in a different palette, then construct what the image
@@ -728,7 +735,7 @@ class TestFileGif(PillowTestCase):
 
         with Image.open(out) as reloaded:
             im.putpalette(palette)
-            self.assert_image_equal(reloaded, im)
+            assert_image_equal(reloaded, im)
 
     def test_palette_save_ImagePalette(self):
         # pass in a different palette, as an ImagePalette.ImagePalette
@@ -742,7 +749,7 @@ class TestFileGif(PillowTestCase):
 
         with Image.open(out) as reloaded:
             im.putpalette(palette)
-            self.assert_image_equal(reloaded, im)
+            assert_image_equal(reloaded, im)
 
     def test_save_I(self):
         # Test saving something that would trigger the auto-convert to 'L'
@@ -753,7 +760,7 @@ class TestFileGif(PillowTestCase):
         im.save(out)
 
         with Image.open(out) as reloaded:
-            self.assert_image_equal(reloaded.convert("L"), im.convert("L"))
+            assert_image_equal(reloaded.convert("L"), im.convert("L"))
 
     def test_getdata(self):
         # test getheader/getdata against legacy values

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1,6 +1,7 @@
 import unittest
 from io import BytesIO
 
+import pytest
 from PIL import GifImagePlugin, Image, ImageDraw, ImagePalette
 
 from .helper import (
@@ -47,7 +48,7 @@ class TestFileGif(PillowTestCase):
             im = Image.open(TEST_GIF)
             im.load()
 
-        self.assert_warning(ResourceWarning, open)
+        pytest.warns(ResourceWarning, open)
 
     def test_closed_file(self):
         def open():
@@ -55,14 +56,14 @@ class TestFileGif(PillowTestCase):
             im.load()
             im.close()
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)
 
     def test_context_manager(self):
         def open():
             with Image.open(TEST_GIF) as im:
                 im.load()
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)
 
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
@@ -684,7 +685,7 @@ class TestFileGif(PillowTestCase):
         # Single frame
         im = Image.new("RGB", (1, 1))
         im.info["transparency"] = (255, 0, 0)
-        self.assert_warning(UserWarning, im.save, out)
+        pytest.warns(UserWarning, im.save, out)
 
         with Image.open(out) as reloaded:
             self.assertNotIn("transparency", reloaded.info)
@@ -693,7 +694,7 @@ class TestFileGif(PillowTestCase):
         im = Image.new("RGB", (1, 1))
         im.info["transparency"] = b""
         ims = [Image.new("RGB", (1, 1))]
-        self.assert_warning(UserWarning, im.save, out, save_all=True, append_images=ims)
+        pytest.warns(UserWarning, im.save, out, save_all=True, append_images=ims)
 
         with Image.open(out) as reloaded:
             self.assertNotIn("transparency", reloaded.info)

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -2,6 +2,7 @@ import io
 import sys
 import unittest
 
+import pytest
 from PIL import IcnsImagePlugin, Image
 
 from .helper import PillowTestCase, assert_image_equal, assert_image_similar
@@ -19,7 +20,7 @@ class TestFileIcns(PillowTestCase):
         with Image.open(TEST_FILE) as im:
 
             # Assert that there is no unclosed file warning
-            self.assert_warning(None, im.load)
+            pytest.warns(None, im.load)
 
             self.assertEqual(im.mode, "RGBA")
             self.assertEqual(im.size, (1024, 1024))

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -4,7 +4,7 @@ import unittest
 
 from PIL import IcnsImagePlugin, Image
 
-from .helper import PillowTestCase
+from .helper import PillowTestCase, assert_image_equal, assert_image_similar
 
 # sample icon file
 TEST_FILE = "Tests/images/pillow.icns"
@@ -46,12 +46,12 @@ class TestFileIcns(PillowTestCase):
             im.save(temp_file, append_images=[provided_im])
 
             with Image.open(temp_file) as reread:
-                self.assert_image_similar(reread, im, 1)
+                assert_image_similar(reread, im, 1)
 
             with Image.open(temp_file) as reread:
                 reread.size = (16, 16, 2)
                 reread.load()
-                self.assert_image_equal(reread, provided_im)
+                assert_image_equal(reread, provided_im)
 
     def test_sizes(self):
         # Check that we can load all of the sizes, and that the final pixel

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -2,7 +2,7 @@ import io
 
 from PIL import IcoImagePlugin, Image, ImageDraw
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 
 TEST_ICO_FILE = "Tests/images/hopper.ico"
 
@@ -33,7 +33,7 @@ class TestFileIco(PillowTestCase):
             self.assertEqual(im.mode, reloaded.mode)
             self.assertEqual((64, 64), reloaded.size)
             self.assertEqual(reloaded.format, "ICO")
-            self.assert_image_equal(reloaded, hopper().resize((64, 64), Image.LANCZOS))
+            assert_image_equal(reloaded, hopper().resize((64, 64), Image.LANCZOS))
 
         # the other one
         output.seek(0)
@@ -43,7 +43,7 @@ class TestFileIco(PillowTestCase):
             self.assertEqual(im.mode, reloaded.mode)
             self.assertEqual((32, 32), reloaded.size)
             self.assertEqual(reloaded.format, "ICO")
-            self.assert_image_equal(reloaded, hopper().resize((32, 32), Image.LANCZOS))
+            assert_image_equal(reloaded, hopper().resize((32, 32), Image.LANCZOS))
 
     def test_incorrect_size(self):
         with Image.open(TEST_ICO_FILE) as im:
@@ -100,4 +100,4 @@ class TestFileIco(PillowTestCase):
         with Image.open(outfile) as im:
             im.save("Tests/images/hopper_draw.ico")
             with Image.open("Tests/images/hopper_draw.ico") as reloaded:
-                self.assert_image_equal(im, reloaded)
+                assert_image_equal(im, reloaded)

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -1,5 +1,6 @@
 import io
 
+import pytest
 from PIL import IcoImagePlugin, Image, ImageDraw
 
 from .helper import PillowTestCase, assert_image_equal, hopper
@@ -87,7 +88,7 @@ class TestFileIco(PillowTestCase):
             with Image.open("Tests/images/hopper_unexpected.ico") as im:
                 self.assertEqual(im.size, (16, 16))
 
-        self.assert_warning(UserWarning, open)
+        pytest.warns(UserWarning, open)
 
     def test_draw_reloaded(self):
         with Image.open(TEST_ICO_FILE) as im:

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -1,5 +1,6 @@
 import unittest
 
+import pytest
 from PIL import Image, ImImagePlugin
 
 from .helper import PillowTestCase, assert_image_equal, hopper, is_pypy
@@ -22,7 +23,7 @@ class TestFileIm(PillowTestCase):
             im = Image.open(TEST_IM)
             im.load()
 
-        self.assert_warning(ResourceWarning, open)
+        pytest.warns(ResourceWarning, open)
 
     def test_closed_file(self):
         def open():
@@ -30,14 +31,14 @@ class TestFileIm(PillowTestCase):
             im.load()
             im.close()
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)
 
     def test_context_manager(self):
         def open():
             with Image.open(TEST_IM) as im:
                 im.load()
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)
 
     def test_tell(self):
         # Arrange

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -2,7 +2,7 @@ import unittest
 
 from PIL import Image, ImImagePlugin
 
-from .helper import PillowTestCase, hopper, is_pypy
+from .helper import PillowTestCase, assert_image_equal, hopper, is_pypy
 
 # sample im
 TEST_IM = "Tests/images/hopper.im"
@@ -72,7 +72,7 @@ class TestFileIm(PillowTestCase):
             im.save(out)
             with Image.open(out) as reread:
 
-                self.assert_image_equal(reread, im)
+                assert_image_equal(reread, im)
 
     def test_save_unsupported_mode(self):
         out = self.tempfile("temp.im")

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -1,6 +1,7 @@
 import os
 from io import BytesIO
 
+import pytest
 from PIL import Image, ImageFile, JpegImagePlugin
 
 from .helper import (
@@ -531,7 +532,7 @@ class TestFileJpeg(PillowTestCase):
         # Act
         # Shouldn't raise error
         fn = "Tests/images/sugarshack_bad_mpo_header.jpg"
-        with self.assert_warning(UserWarning, Image.open, fn) as im:
+        with pytest.warns(UserWarning, Image.open, fn) as im:
 
             # Assert
             self.assertEqual(im.format, "JPEG")

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -5,6 +5,9 @@ from PIL import Image, ImageFile, JpegImagePlugin
 
 from .helper import (
     PillowTestCase,
+    assert_image,
+    assert_image_equal,
+    assert_image_similar,
     cjpeg_available,
     djpeg_available,
     hopper,
@@ -114,7 +117,7 @@ class TestFileJpeg(PillowTestCase):
             # Roundtrip via memory buffer.
             im1 = self.roundtrip(hopper())
             im2 = self.roundtrip(hopper(), icc_profile=icc_profile)
-            self.assert_image_equal(im1, im2)
+            assert_image_equal(im1, im2)
             self.assertFalse(im1.info.get("icc_profile"))
             self.assertTrue(im2.info.get("icc_profile"))
 
@@ -161,8 +164,8 @@ class TestFileJpeg(PillowTestCase):
         im1 = self.roundtrip(hopper())
         im2 = self.roundtrip(hopper(), optimize=0)
         im3 = self.roundtrip(hopper(), optimize=1)
-        self.assert_image_equal(im1, im2)
-        self.assert_image_equal(im1, im3)
+        assert_image_equal(im1, im2)
+        assert_image_equal(im1, im3)
         self.assertGreaterEqual(im1.bytes, im2.bytes)
         self.assertGreaterEqual(im1.bytes, im3.bytes)
 
@@ -181,7 +184,7 @@ class TestFileJpeg(PillowTestCase):
         self.assertFalse(im2.info.get("progressive"))
         self.assertTrue(im3.info.get("progressive"))
 
-        self.assert_image_equal(im1, im3)
+        assert_image_equal(im1, im3)
         self.assertGreaterEqual(im1.bytes, im3.bytes)
 
     def test_progressive_large_buffer(self):
@@ -286,8 +289,8 @@ class TestFileJpeg(PillowTestCase):
 
         im2 = self.roundtrip(hopper(), progressive=1)
         im3 = self.roundtrip(hopper(), progression=1)  # compatibility
-        self.assert_image_equal(im1, im2)
-        self.assert_image_equal(im1, im3)
+        assert_image_equal(im1, im2)
+        assert_image_equal(im1, im3)
         self.assertTrue(im2.info.get("progressive"))
         self.assertTrue(im2.info.get("progression"))
         self.assertTrue(im3.info.get("progressive"))
@@ -296,13 +299,13 @@ class TestFileJpeg(PillowTestCase):
     def test_quality(self):
         im1 = self.roundtrip(hopper())
         im2 = self.roundtrip(hopper(), quality=50)
-        self.assert_image(im1, im2.mode, im2.size)
+        assert_image(im1, im2.mode, im2.size)
         self.assertGreaterEqual(im1.bytes, im2.bytes)
 
     def test_smooth(self):
         im1 = self.roundtrip(hopper())
         im2 = self.roundtrip(hopper(), smooth=100)
-        self.assert_image(im1, im2.mode, im2.size)
+        assert_image(im1, im2.mode, im2.size)
 
     def test_subsampling(self):
         def getsampling(im):
@@ -398,9 +401,9 @@ class TestFileJpeg(PillowTestCase):
             qtables = im.quantization
             reloaded = self.roundtrip(im, qtables=qtables, subsampling=0)
             self.assertEqual(im.quantization, reloaded.quantization)
-            self.assert_image_similar(im, self.roundtrip(im, qtables="web_low"), 30)
-            self.assert_image_similar(im, self.roundtrip(im, qtables="web_high"), 30)
-            self.assert_image_similar(im, self.roundtrip(im, qtables="keep"), 30)
+            assert_image_similar(im, self.roundtrip(im, qtables="web_low"), 30)
+            assert_image_similar(im, self.roundtrip(im, qtables="web_high"), 30)
+            assert_image_similar(im, self.roundtrip(im, qtables="keep"), 30)
 
             # valid bounds for baseline qtable
             bounds_qtable = [int(s) for s in ("255 1 " * 32).split(None)]
@@ -439,7 +442,7 @@ class TestFileJpeg(PillowTestCase):
                 )
             ]
             # list of qtable lists
-            self.assert_image_similar(
+            assert_image_similar(
                 im,
                 self.roundtrip(
                     im, qtables=[standard_l_qtable, standard_chrominance_qtable]
@@ -448,7 +451,7 @@ class TestFileJpeg(PillowTestCase):
             )
 
             # tuple of qtable lists
-            self.assert_image_similar(
+            assert_image_similar(
                 im,
                 self.roundtrip(
                     im, qtables=(standard_l_qtable, standard_chrominance_qtable)
@@ -457,7 +460,7 @@ class TestFileJpeg(PillowTestCase):
             )
 
             # dict of qtable lists
-            self.assert_image_similar(
+            assert_image_similar(
                 im,
                 self.roundtrip(
                     im, qtables={0: standard_l_qtable, 1: standard_chrominance_qtable}
@@ -490,7 +493,7 @@ class TestFileJpeg(PillowTestCase):
     def test_load_djpeg(self):
         with Image.open(TEST_FILE) as img:
             img.load_djpeg()
-            self.assert_image_similar(img, Image.open(TEST_FILE), 0)
+            assert_image_similar(img, Image.open(TEST_FILE), 0)
 
     @unittest.skipUnless(cjpeg_available(), "cjpeg not available")
     def test_save_cjpeg(self):
@@ -498,7 +501,7 @@ class TestFileJpeg(PillowTestCase):
             tempfile = self.tempfile("temp.jpg")
             JpegImagePlugin._save_cjpeg(img, 0, tempfile)
             # Default save quality is 75%, so a tiny bit of difference is alright
-            self.assert_image_similar(img, Image.open(tempfile), 17)
+            assert_image_similar(img, Image.open(tempfile), 17)
 
     def test_no_duplicate_0x1001_tag(self):
         # Arrange
@@ -670,7 +673,7 @@ class TestFileJpeg(PillowTestCase):
             # Test that the image can still load, even with broken Photoshop data
             # This image had the APP13 length hexedited to be smaller
             with Image.open("Tests/images/photoshop-200dpi-broken.jpg") as im_broken:
-                self.assert_image_equal(im_broken, im)
+                assert_image_equal(im_broken, im)
 
         # This image does not contain a Photoshop header string
         with Image.open("Tests/images/app13.jpg") as im:

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -3,7 +3,13 @@ from io import BytesIO
 import pytest
 from PIL import Image, Jpeg2KImagePlugin
 
-from .helper import PillowTestCase, is_big_endian, on_ci
+from .helper import (
+    PillowTestCase,
+    assert_image_equal,
+    assert_image_similar,
+    is_big_endian,
+    on_ci,
+)
 
 codecs = dir(Image.core)
 
@@ -57,7 +63,7 @@ class TestFileJpeg2k(PillowTestCase):
             data = BytesIO(f.read())
         with Image.open(data) as im:
             im.load()
-            self.assert_image_similar(im, test_card, 1.0e-3)
+            assert_image_similar(im, test_card, 1.0e-3)
 
     # These two test pre-written JPEG 2000 files that were not written with
     # PIL (they were made using Adobe Photoshop)
@@ -67,30 +73,30 @@ class TestFileJpeg2k(PillowTestCase):
             im.load()
             outfile = self.tempfile("temp_test-card.png")
             im.save(outfile)
-        self.assert_image_similar(im, test_card, 1.0e-3)
+        assert_image_similar(im, test_card, 1.0e-3)
 
     def test_lossy_tiled(self):
         with Image.open("Tests/images/test-card-lossy-tiled.jp2") as im:
             im.load()
-            self.assert_image_similar(im, test_card, 2.0)
+            assert_image_similar(im, test_card, 2.0)
 
     def test_lossless_rt(self):
         im = self.roundtrip(test_card)
-        self.assert_image_equal(im, test_card)
+        assert_image_equal(im, test_card)
 
     def test_lossy_rt(self):
         im = self.roundtrip(test_card, quality_layers=[20])
-        self.assert_image_similar(im, test_card, 2.0)
+        assert_image_similar(im, test_card, 2.0)
 
     def test_tiled_rt(self):
         im = self.roundtrip(test_card, tile_size=(128, 128))
-        self.assert_image_equal(im, test_card)
+        assert_image_equal(im, test_card)
 
     def test_tiled_offset_rt(self):
         im = self.roundtrip(
             test_card, tile_size=(128, 128), tile_offset=(0, 0), offset=(32, 32)
         )
-        self.assert_image_equal(im, test_card)
+        assert_image_equal(im, test_card)
 
     def test_tiled_offset_too_small(self):
         with self.assertRaises(ValueError):
@@ -100,15 +106,15 @@ class TestFileJpeg2k(PillowTestCase):
 
     def test_irreversible_rt(self):
         im = self.roundtrip(test_card, irreversible=True, quality_layers=[20])
-        self.assert_image_similar(im, test_card, 2.0)
+        assert_image_similar(im, test_card, 2.0)
 
     def test_prog_qual_rt(self):
         im = self.roundtrip(test_card, quality_layers=[60, 40, 20], progression="LRCP")
-        self.assert_image_similar(im, test_card, 2.0)
+        assert_image_similar(im, test_card, 2.0)
 
     def test_prog_res_rt(self):
         im = self.roundtrip(test_card, num_resolutions=8, progression="RLCP")
-        self.assert_image_equal(im, test_card)
+        assert_image_equal(im, test_card)
 
     def test_reduce(self):
         with Image.open("Tests/images/test-card-lossless.jp2") as im:
@@ -136,13 +142,13 @@ class TestFileJpeg2k(PillowTestCase):
         with Image.open(out) as im:
             im.layers = 1
             im.load()
-            self.assert_image_similar(im, test_card, 13)
+            assert_image_similar(im, test_card, 13)
 
         out.seek(0)
         with Image.open(out) as im:
             im.layers = 3
             im.load()
-            self.assert_image_similar(im, test_card, 0.4)
+            assert_image_similar(im, test_card, 0.4)
 
     def test_rgba(self):
         # Arrange
@@ -170,23 +176,23 @@ class TestFileJpeg2k(PillowTestCase):
     def test_16bit_monochrome_jp2_like_tiff(self):
         with Image.open("Tests/images/16bit.cropped.tif") as tiff_16bit:
             with Image.open("Tests/images/16bit.cropped.jp2") as jp2:
-                self.assert_image_similar(jp2, tiff_16bit, 1e-3)
+                assert_image_similar(jp2, tiff_16bit, 1e-3)
 
     @pytest.mark.xfail(is_big_endian() and on_ci(), reason="Fails on big-endian")
     def test_16bit_monochrome_j2k_like_tiff(self):
         with Image.open("Tests/images/16bit.cropped.tif") as tiff_16bit:
             with Image.open("Tests/images/16bit.cropped.j2k") as j2k:
-                self.assert_image_similar(j2k, tiff_16bit, 1e-3)
+                assert_image_similar(j2k, tiff_16bit, 1e-3)
 
     def test_16bit_j2k_roundtrips(self):
         with Image.open("Tests/images/16bit.cropped.j2k") as j2k:
             im = self.roundtrip(j2k)
-            self.assert_image_equal(im, j2k)
+            assert_image_equal(im, j2k)
 
     def test_16bit_jp2_roundtrips(self):
         with Image.open("Tests/images/16bit.cropped.jp2") as jp2:
             im = self.roundtrip(jp2)
-            self.assert_image_equal(im, jp2)
+            assert_image_equal(im, jp2)
 
     def test_unbound_local(self):
         # prepatch, a malformed jp2 file could cause an UnboundLocalError

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -8,7 +8,14 @@ from ctypes import c_float
 
 from PIL import Image, TiffImagePlugin, TiffTags, features
 
-from .helper import PillowTestCase, hopper
+from .helper import (
+    PillowTestCase,
+    assert_image_equal,
+    assert_image_equal_tofile,
+    assert_image_similar,
+    assert_image_similar_tofile,
+    hopper,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -91,14 +98,14 @@ class TestFileLibTiff(LibTiffTestCase):
         """ Checking that we're actually getting the data that we expect"""
         with Image.open("Tests/images/hopper_bw_500.png") as png:
             with Image.open("Tests/images/hopper_g4_500.tif") as g4:
-                self.assert_image_equal(g4, png)
+                assert_image_equal(g4, png)
 
     # see https://github.com/python-pillow/Pillow/issues/279
     def test_g4_fillorder_eq_png(self):
         """ Checking that we're actually getting the data that we expect"""
         with Image.open("Tests/images/g4-fillorder-test.png") as png:
             with Image.open("Tests/images/g4-fillorder-test.tif") as g4:
-                self.assert_image_equal(g4, png)
+                assert_image_equal(g4, png)
 
     def test_g4_write(self):
         """Checking to see that the saved image is the same as what we wrote"""
@@ -112,7 +119,7 @@ class TestFileLibTiff(LibTiffTestCase):
             with Image.open(out) as reread:
                 self.assertEqual(reread.size, (500, 500))
                 self._assert_noerr(reread)
-                self.assert_image_equal(reread, rot)
+                assert_image_equal(reread, rot)
                 self.assertEqual(reread.info["compression"], "group4")
 
                 self.assertEqual(reread.info["compression"], orig.info["compression"])
@@ -127,7 +134,7 @@ class TestFileLibTiff(LibTiffTestCase):
             self.assertEqual(im.tile[0][:3], ("libtiff", (0, 0, 278, 374), 0))
             im.load()
 
-            self.assert_image_equal_tofile(im, "Tests/images/tiff_adobe_deflate.png")
+            assert_image_equal_tofile(im, "Tests/images/tiff_adobe_deflate.png")
 
     def test_write_metadata(self):
         """ Test metadata writing through libtiff """
@@ -335,7 +342,7 @@ class TestFileLibTiff(LibTiffTestCase):
 
             with Image.open(out) as reread:
                 self.assertEqual(reread.info["compression"], "group3")
-                self.assert_image_equal(reread, i)
+                assert_image_equal(reread, i)
 
     def test_little_endian(self):
         with Image.open("Tests/images/16bit.deflate.tif") as im:
@@ -399,7 +406,7 @@ class TestFileLibTiff(LibTiffTestCase):
             # imagemagick will auto scale so that a 12bit FFF is 16bit FFF0,
             # so we need to unshift so that the integer values are the same.
 
-            self.assert_image_equal_tofile(im, "Tests/images/12in16bit.tif")
+            assert_image_equal_tofile(im, "Tests/images/12in16bit.tif")
 
     def test_blur(self):
         # test case from irc, how to do blur on b/w image
@@ -416,7 +423,7 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open(out) as im2:
             im2.load()
 
-            self.assert_image_equal(im, im2)
+            assert_image_equal(im, im2)
 
     def test_compressions(self):
         # Test various tiff compressions and assert similar image content but reduced
@@ -430,17 +437,17 @@ class TestFileLibTiff(LibTiffTestCase):
             im.save(out, compression=compression)
             size_compressed = os.path.getsize(out)
             with Image.open(out) as im2:
-                self.assert_image_equal(im, im2)
+                assert_image_equal(im, im2)
 
         im.save(out, compression="jpeg")
         size_jpeg = os.path.getsize(out)
         with Image.open(out) as im2:
-            self.assert_image_similar(im, im2, 30)
+            assert_image_similar(im, im2, 30)
 
         im.save(out, compression="jpeg", quality=30)
         size_jpeg_30 = os.path.getsize(out)
         with Image.open(out) as im3:
-            self.assert_image_similar(im2, im3, 30)
+            assert_image_similar(im2, im3, 30)
 
         self.assertGreater(size_raw, size_compressed)
         self.assertGreater(size_compressed, size_jpeg)
@@ -463,7 +470,7 @@ class TestFileLibTiff(LibTiffTestCase):
 
         im.save(out, compression="tiff_adobe_deflate")
         with Image.open(out) as im2:
-            self.assert_image_equal(im, im2)
+            assert_image_equal(im, im2)
 
     def xtest_bw_compression_w_rgb(self):
         """ This test passes, but when running all tests causes a failure due
@@ -544,7 +551,7 @@ class TestFileLibTiff(LibTiffTestCase):
             # Assert
             self.assertEqual(im.size, (128, 128))
             self.assertEqual(im.mode, "L")
-            self.assert_image_similar(im, original, 7.3)
+            assert_image_similar(im, original, 7.3)
 
     def test_gray_semibyte_per_pixel(self):
         test_files = (
@@ -572,12 +579,12 @@ class TestFileLibTiff(LibTiffTestCase):
             with Image.open(group[0]) as im:
                 self.assertEqual(im.size, (128, 128))
                 self.assertEqual(im.mode, "L")
-                self.assert_image_similar(im, original, epsilon)
+                assert_image_similar(im, original, epsilon)
             for file in group[1:]:
                 with Image.open(file) as im2:
                     self.assertEqual(im2.size, (128, 128))
                     self.assertEqual(im2.mode, "L")
-                    self.assert_image_equal(im, im2)
+                    assert_image_equal(im, im2)
 
     def test_save_bytesio(self):
         # PR 1011
@@ -596,7 +603,7 @@ class TestFileLibTiff(LibTiffTestCase):
             buffer_io.seek(0)
 
             with Image.open(buffer_io) as pilim_load:
-                self.assert_image_similar(pilim, pilim_load, 0)
+                assert_image_similar(pilim, pilim_load, 0)
 
         save_bytesio()
         save_bytesio("raw")
@@ -701,7 +708,7 @@ class TestFileLibTiff(LibTiffTestCase):
             )
             im.load()
 
-            self.assert_image_equal_tofile(im, "Tests/images/tiff_16bit_RGB_target.png")
+            assert_image_equal_tofile(im, "Tests/images/tiff_16bit_RGB_target.png")
 
     def test_16bit_RGBa_tiff(self):
         with Image.open("Tests/images/tiff_16bit_RGBa.tiff") as im:
@@ -720,9 +727,7 @@ class TestFileLibTiff(LibTiffTestCase):
             )
             im.load()
 
-            self.assert_image_equal_tofile(
-                im, "Tests/images/tiff_16bit_RGBa_target.png"
-            )
+            assert_image_equal_tofile(im, "Tests/images/tiff_16bit_RGBa_target.png")
 
     def test_gimp_tiff(self):
         # Read TIFF JPEG images from GIMP [@PIL168]
@@ -741,14 +746,14 @@ class TestFileLibTiff(LibTiffTestCase):
             )
             im.load()
 
-            self.assert_image_equal_tofile(im, "Tests/images/pil168.png")
+            assert_image_equal_tofile(im, "Tests/images/pil168.png")
 
     def test_sampleformat(self):
         # https://github.com/python-pillow/Pillow/issues/1466
         with Image.open("Tests/images/copyleft.tiff") as im:
             self.assertEqual(im.mode, "RGB")
 
-            self.assert_image_equal_tofile(im, "Tests/images/copyleft.png", mode="RGB")
+            assert_image_equal_tofile(im, "Tests/images/copyleft.png", mode="RGB")
 
     def test_lzw(self):
         with Image.open("Tests/images/hopper_lzw.tif") as im:
@@ -756,55 +761,47 @@ class TestFileLibTiff(LibTiffTestCase):
             self.assertEqual(im.size, (128, 128))
             self.assertEqual(im.format, "TIFF")
             im2 = hopper()
-            self.assert_image_similar(im, im2, 5)
+            assert_image_similar(im, im2, 5)
 
     def test_strip_cmyk_jpeg(self):
         infile = "Tests/images/tiff_strip_cmyk_jpeg.tif"
         with Image.open(infile) as im:
-            self.assert_image_similar_tofile(
-                im, "Tests/images/pil_sample_cmyk.jpg", 0.5
-            )
+            assert_image_similar_tofile(im, "Tests/images/pil_sample_cmyk.jpg", 0.5)
 
     def test_strip_cmyk_16l_jpeg(self):
         infile = "Tests/images/tiff_strip_cmyk_16l_jpeg.tif"
         with Image.open(infile) as im:
-            self.assert_image_similar_tofile(
-                im, "Tests/images/pil_sample_cmyk.jpg", 0.5
-            )
+            assert_image_similar_tofile(im, "Tests/images/pil_sample_cmyk.jpg", 0.5)
 
     def test_strip_ycbcr_jpeg_2x2_sampling(self):
         infile = "Tests/images/tiff_strip_ycbcr_jpeg_2x2_sampling.tif"
         with Image.open(infile) as im:
-            self.assert_image_similar_tofile(im, "Tests/images/flower.jpg", 0.5)
+            assert_image_similar_tofile(im, "Tests/images/flower.jpg", 0.5)
 
     def test_strip_ycbcr_jpeg_1x1_sampling(self):
         infile = "Tests/images/tiff_strip_ycbcr_jpeg_1x1_sampling.tif"
         with Image.open(infile) as im:
-            self.assert_image_equal_tofile(im, "Tests/images/flower2.jpg")
+            assert_image_equal_tofile(im, "Tests/images/flower2.jpg")
 
     def test_tiled_cmyk_jpeg(self):
         infile = "Tests/images/tiff_tiled_cmyk_jpeg.tif"
         with Image.open(infile) as im:
-            self.assert_image_similar_tofile(
-                im, "Tests/images/pil_sample_cmyk.jpg", 0.5
-            )
+            assert_image_similar_tofile(im, "Tests/images/pil_sample_cmyk.jpg", 0.5)
 
     def test_tiled_ycbcr_jpeg_1x1_sampling(self):
         infile = "Tests/images/tiff_tiled_ycbcr_jpeg_1x1_sampling.tif"
         with Image.open(infile) as im:
-            self.assert_image_equal_tofile(im, "Tests/images/flower2.jpg")
+            assert_image_equal_tofile(im, "Tests/images/flower2.jpg")
 
     def test_tiled_ycbcr_jpeg_2x2_sampling(self):
         infile = "Tests/images/tiff_tiled_ycbcr_jpeg_2x2_sampling.tif"
         with Image.open(infile) as im:
-            self.assert_image_similar_tofile(im, "Tests/images/flower.jpg", 0.5)
+            assert_image_similar_tofile(im, "Tests/images/flower.jpg", 0.5)
 
     def test_old_style_jpeg(self):
         infile = "Tests/images/old-style-jpeg-compression.tif"
         with Image.open(infile) as im:
-            self.assert_image_equal_tofile(
-                im, "Tests/images/old-style-jpeg-compression.png"
-            )
+            assert_image_equal_tofile(im, "Tests/images/old-style-jpeg-compression.png")
 
     def test_no_rows_per_strip(self):
         # This image does not have a RowsPerStrip TIFF tag
@@ -819,7 +816,7 @@ class TestFileLibTiff(LibTiffTestCase):
                 with Image.open("Tests/images/g4_orientation_" + str(i) + ".tif") as im:
                     im.load()
 
-                    self.assert_image_similar(base_im, im, 0.7)
+                    assert_image_similar(base_im, im, 0.7)
 
     def test_sampleformat_not_corrupted(self):
         # Assert that a TIFF image with SampleFormat=UINT tag is not corrupted

--- a/Tests/test_file_mcidas.py
+++ b/Tests/test_file_mcidas.py
@@ -1,6 +1,6 @@
 from PIL import Image, McIdasImagePlugin
 
-from .helper import PillowTestCase
+from .helper import PillowTestCase, assert_image_equal
 
 
 class TestFileMcIdas(PillowTestCase):
@@ -25,4 +25,4 @@ class TestFileMcIdas(PillowTestCase):
             self.assertEqual(im.mode, "I")
             self.assertEqual(im.size, (1800, 400))
             with Image.open(saved_file) as im2:
-                self.assert_image_equal(im, im2)
+                assert_image_equal(im, im2)

--- a/Tests/test_file_mic.py
+++ b/Tests/test_file_mic.py
@@ -2,7 +2,7 @@ import unittest
 
 from PIL import Image, ImagePalette, features
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_similar, hopper
 
 try:
     from PIL import MicImagePlugin
@@ -29,7 +29,7 @@ class TestFileMic(PillowTestCase):
             im = Image.merge("RGBA", [chan.point(lut) for chan in im.split()])
 
             im2 = hopper("RGBA")
-            self.assert_image_similar(im, im2, 10)
+            assert_image_similar(im, im2, 10)
 
     def test_n_frames(self):
         with Image.open(TEST_FILE) as im:

--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -1,6 +1,7 @@
 import unittest
 from io import BytesIO
 
+import pytest
 from PIL import Image
 
 from .helper import PillowTestCase, assert_image_similar, is_pypy
@@ -38,7 +39,7 @@ class TestFileMpo(PillowTestCase):
             im = Image.open(test_files[0])
             im.load()
 
-        self.assert_warning(ResourceWarning, open)
+        pytest.warns(ResourceWarning, open)
 
     def test_closed_file(self):
         def open():
@@ -46,14 +47,14 @@ class TestFileMpo(PillowTestCase):
             im.load()
             im.close()
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)
 
     def test_context_manager(self):
         def open():
             with Image.open(test_files[0]) as im:
                 im.load()
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)
 
     def test_app(self):
         for test_file in test_files:

--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -3,7 +3,7 @@ from io import BytesIO
 
 from PIL import Image
 
-from .helper import PillowTestCase, is_pypy
+from .helper import PillowTestCase, assert_image_similar, is_pypy
 
 test_files = ["Tests/images/sugarshack.mpo", "Tests/images/frozenpond.mpo"]
 
@@ -194,8 +194,8 @@ class TestFileMpo(PillowTestCase):
             with Image.open(test_file) as im:
                 self.assertEqual(im.tell(), 0)
                 jpg0 = self.frame_roundtrip(im)
-                self.assert_image_similar(im, jpg0, 30)
+                assert_image_similar(im, jpg0, 30)
                 im.seek(1)
                 self.assertEqual(im.tell(), 1)
                 jpg1 = self.frame_roundtrip(im)
-                self.assert_image_similar(im, jpg1, 30)
+                assert_image_similar(im, jpg1, 30)

--- a/Tests/test_file_msp.py
+++ b/Tests/test_file_msp.py
@@ -3,7 +3,7 @@ import unittest
 
 from PIL import Image, MspImagePlugin
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 
 TEST_FILE = "Tests/images/hopper.msp"
 EXTRA_DIR = "Tests/images/picins"
@@ -41,13 +41,13 @@ class TestFileMsp(PillowTestCase):
         with Image.open(TEST_FILE) as im:
 
             # Assert
-            self.assert_image_equal(im, hopper("1"))
+            assert_image_equal(im, hopper("1"))
             self.assertIsInstance(im, MspImagePlugin.MspImageFile)
 
     def _assert_file_image_equal(self, source_path, target_path):
         with Image.open(source_path) as im:
             with Image.open(target_path) as target:
-                self.assert_image_equal(im, target)
+                assert_image_equal(im, target)
 
     @unittest.skipUnless(os.path.exists(EXTRA_DIR), "Extra image files not installed")
     def test_open_windows_v2(self):

--- a/Tests/test_file_palm.py
+++ b/Tests/test_file_palm.py
@@ -1,6 +1,12 @@
 import os.path
 
-from .helper import PillowTestCase, hopper, imagemagick_available
+from .helper import (
+    PillowTestCase,
+    assert_image_equal,
+    hopper,
+    imagemagick_available,
+    skip_known_bad_test,
+)
 
 
 class TestFilePalm(PillowTestCase):
@@ -27,7 +33,7 @@ class TestFilePalm(PillowTestCase):
 
         im.save(outfile)
         converted = self.open_withImagemagick(outfile)
-        self.assert_image_equal(converted, im)
+        assert_image_equal(converted, im)
 
     def test_monochrome(self):
         # Arrange
@@ -43,7 +49,7 @@ class TestFilePalm(PillowTestCase):
 
         # Act / Assert
         self.helper_save_as_palm(mode)
-        self.skipKnownBadTest("Palm P image is wrong")
+        skip_known_bad_test("Palm P image is wrong")
         self.roundtrip(mode)
 
     def test_l_ioerror(self):

--- a/Tests/test_file_pcd.py
+++ b/Tests/test_file_pcd.py
@@ -15,4 +15,4 @@ class TestFilePcd(PillowTestCase):
         # from convert look find on pillow and not imagemagick.
 
         # target = hopper().resize((768,512))
-        # self.assert_image_similar(im, target, 10)
+        # assert_image_similar(im, target, 10)

--- a/Tests/test_file_pcx.py
+++ b/Tests/test_file_pcx.py
@@ -1,6 +1,6 @@
 from PIL import Image, ImageFile, PcxImagePlugin
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 
 
 class TestFilePcx(PillowTestCase):
@@ -12,7 +12,7 @@ class TestFilePcx(PillowTestCase):
             self.assertEqual(im2.size, im.size)
             self.assertEqual(im2.format, "PCX")
             self.assertEqual(im2.get_format_mimetype(), "image/x-pcx")
-            self.assert_image_equal(im2, im)
+            assert_image_equal(im2, im)
 
     def test_sanity(self):
         for mode in ("1", "L", "P", "RGB"):

--- a/Tests/test_file_pixar.py
+++ b/Tests/test_file_pixar.py
@@ -1,6 +1,6 @@
 from PIL import Image, PixarImagePlugin
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_similar, hopper
 
 TEST_FILE = "Tests/images/hopper.pxr"
 
@@ -15,7 +15,7 @@ class TestFilePixar(PillowTestCase):
             self.assertIsNone(im.get_format_mimetype())
 
             im2 = hopper()
-            self.assert_image_similar(im, im2, 4.8)
+            assert_image_similar(im, im2, 4.8)
 
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -8,6 +8,9 @@ from PIL import Image, ImageFile, PngImagePlugin
 from .helper import (
     PillowLeakTestCase,
     PillowTestCase,
+    assert_image,
+    assert_image_equal,
+    assert_image_similar,
     hopper,
     is_big_endian,
     is_win32,
@@ -103,7 +106,7 @@ class TestFilePng(PillowTestCase):
             with Image.open(test_file) as reloaded:
                 if mode == "I;16":
                     reloaded = reloaded.convert(mode)
-                self.assert_image_equal(reloaded, im)
+                assert_image_equal(reloaded, im)
 
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
@@ -205,14 +208,14 @@ class TestFilePng(PillowTestCase):
 
         test_file = "Tests/images/pil123p.png"
         with Image.open(test_file) as im:
-            self.assert_image(im, "P", (162, 150))
+            assert_image(im, "P", (162, 150))
             self.assertTrue(im.info.get("interlace"))
 
             im.load()
 
         test_file = "Tests/images/pil123rgba.png"
         with Image.open(test_file) as im:
-            self.assert_image(im, "RGBA", (162, 150))
+            assert_image(im, "RGBA", (162, 150))
             self.assertTrue(im.info.get("interlace"))
 
             im.load()
@@ -220,9 +223,9 @@ class TestFilePng(PillowTestCase):
     def test_load_transparent_p(self):
         test_file = "Tests/images/pil123p.png"
         with Image.open(test_file) as im:
-            self.assert_image(im, "P", (162, 150))
+            assert_image(im, "P", (162, 150))
             im = im.convert("RGBA")
-        self.assert_image(im, "RGBA", (162, 150))
+        assert_image(im, "RGBA", (162, 150))
 
         # image has 124 unique alpha values
         self.assertEqual(len(im.getchannel("A").getcolors()), 124)
@@ -232,9 +235,9 @@ class TestFilePng(PillowTestCase):
         with Image.open(test_file) as im:
             self.assertEqual(im.info["transparency"], (0, 255, 52))
 
-            self.assert_image(im, "RGB", (64, 64))
+            assert_image(im, "RGB", (64, 64))
             im = im.convert("RGBA")
-        self.assert_image(im, "RGBA", (64, 64))
+        assert_image(im, "RGBA", (64, 64))
 
         # image has 876 transparent pixels
         self.assertEqual(im.getchannel("A").getcolors()[0][0], 876)
@@ -253,9 +256,9 @@ class TestFilePng(PillowTestCase):
         with Image.open(test_file) as im:
             self.assertEqual(len(im.info["transparency"]), 256)
 
-            self.assert_image(im, "P", (162, 150))
+            assert_image(im, "P", (162, 150))
             im = im.convert("RGBA")
-        self.assert_image(im, "RGBA", (162, 150))
+        assert_image(im, "RGBA", (162, 150))
 
         # image has 124 unique alpha values
         self.assertEqual(len(im.getchannel("A").getcolors()), 124)
@@ -274,9 +277,9 @@ class TestFilePng(PillowTestCase):
         with Image.open(test_file) as im:
             self.assertEqual(im.info["transparency"], 164)
             self.assertEqual(im.getpixel((31, 31)), 164)
-            self.assert_image(im, "P", (64, 64))
+            assert_image(im, "P", (64, 64))
             im = im.convert("RGBA")
-        self.assert_image(im, "RGBA", (64, 64))
+        assert_image(im, "RGBA", (64, 64))
 
         self.assertEqual(im.getpixel((31, 31)), (0, 255, 52, 0))
 
@@ -296,9 +299,9 @@ class TestFilePng(PillowTestCase):
         # check if saved image contains same transparency
         with Image.open(test_file) as im:
             self.assertEqual(len(im.info["transparency"]), 256)
-            self.assert_image(im, "P", (10, 10))
+            assert_image(im, "P", (10, 10))
             im = im.convert("RGBA")
-        self.assert_image(im, "RGBA", (10, 10))
+        assert_image(im, "RGBA", (10, 10))
         self.assertEqual(im.getcolors(), [(100, (0, 0, 0, 0))])
 
     def test_save_greyscale_transparency(self):
@@ -317,7 +320,7 @@ class TestFilePng(PillowTestCase):
             with Image.open(test_file) as test_im:
                 self.assertEqual(test_im.mode, mode)
                 self.assertEqual(test_im.info["transparency"], 255)
-                self.assert_image_equal(im, test_im)
+                assert_image_equal(im, test_im)
 
             test_im_rgba = test_im.convert("RGBA")
             self.assertEqual(
@@ -500,7 +503,7 @@ class TestFilePng(PillowTestCase):
         with Image.open(f) as im2:
             self.assertIn("transparency", im2.info)
 
-            self.assert_image_equal(im2.convert("RGBA"), im.convert("RGBA"))
+            assert_image_equal(im2.convert("RGBA"), im.convert("RGBA"))
 
     def test_trns_null(self):
         # Check reading images with null tRNS value, issue #1239
@@ -543,7 +546,7 @@ class TestFilePng(PillowTestCase):
 
         with Image.open(BytesIO(im._repr_png_())) as repr_png:
             self.assertEqual(repr_png.format, "PNG")
-            self.assert_image_equal(im, repr_png)
+            assert_image_equal(im, repr_png)
 
     def test_chunk_order(self):
         with Image.open("Tests/images/icc_profile.png") as im:
@@ -638,7 +641,7 @@ class TestFilePng(PillowTestCase):
 
             # This also tests reading unknown PNG chunks (fcTL and fdAT) in load_end
             with Image.open("Tests/images/iss634.webp") as expected:
-                self.assert_image_similar(im, expected, 0.23)
+                assert_image_similar(im, expected, 0.23)
 
 
 @unittest.skipIf(is_win32(), "requires Unix or macOS")

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -338,7 +338,7 @@ class TestFilePng(PillowTestCase):
 
         with Image.open(TEST_PNG_FILE) as im:
             # Assert that there is no unclosed file warning
-            self.assert_warning(None, im.verify)
+            pytest.warns(None, im.verify)
 
         with Image.open(TEST_PNG_FILE) as im:
             im.load()

--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -1,6 +1,6 @@
 from PIL import Image
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, assert_image_similar, hopper
 
 # sample ppm stream
 test_file = "Tests/images/hopper.ppm"
@@ -23,7 +23,7 @@ class TestFilePpm(PillowTestCase):
             self.assertEqual(im.get_format_mimetype(), "image/x-portable-graymap")
 
             with Image.open("Tests/images/16_bit_binary_pgm.png") as tgt:
-                self.assert_image_equal(im, tgt)
+                assert_image_equal(im, tgt)
 
     def test_16bit_pgm_write(self):
         with Image.open("Tests/images/16_bit_binary.pgm") as im:
@@ -33,17 +33,17 @@ class TestFilePpm(PillowTestCase):
             im.save(f, "PPM")
 
             with Image.open(f) as reloaded:
-                self.assert_image_equal(im, reloaded)
+                assert_image_equal(im, reloaded)
 
     def test_pnm(self):
         with Image.open("Tests/images/hopper.pnm") as im:
-            self.assert_image_similar(im, hopper(), 0.0001)
+            assert_image_similar(im, hopper(), 0.0001)
 
             f = self.tempfile("temp.pnm")
             im.save(f)
 
             with Image.open(f) as reloaded:
-                self.assert_image_equal(im, reloaded)
+                assert_image_equal(im, reloaded)
 
     def test_truncated_file(self):
         path = self.tempfile("temp.pgm")

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -1,5 +1,6 @@
 import unittest
 
+import pytest
 from PIL import Image, PsdImagePlugin
 
 from .helper import PillowTestCase, assert_image_similar, hopper, is_pypy
@@ -24,7 +25,7 @@ class TestImagePsd(PillowTestCase):
             im = Image.open(test_file)
             im.load()
 
-        self.assert_warning(ResourceWarning, open)
+        pytest.warns(ResourceWarning, open)
 
     def test_closed_file(self):
         def open():
@@ -32,14 +33,14 @@ class TestImagePsd(PillowTestCase):
             im.load()
             im.close()
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)
 
     def test_context_manager(self):
         def open():
             with Image.open(test_file) as im:
                 im.load()
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)
 
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -2,7 +2,7 @@ import unittest
 
 from PIL import Image, PsdImagePlugin
 
-from .helper import PillowTestCase, hopper, is_pypy
+from .helper import PillowTestCase, assert_image_similar, hopper, is_pypy
 
 test_file = "Tests/images/hopper.psd"
 
@@ -16,7 +16,7 @@ class TestImagePsd(PillowTestCase):
             self.assertEqual(im.format, "PSD")
 
             im2 = hopper()
-            self.assert_image_similar(im, im2, 4.8)
+            assert_image_similar(im, im2, 4.8)
 
     @unittest.skipIf(is_pypy(), "Requires CPython")
     def test_unclosed_file(self):

--- a/Tests/test_file_sgi.py
+++ b/Tests/test_file_sgi.py
@@ -1,6 +1,6 @@
 from PIL import Image, SgiImagePlugin
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, assert_image_similar, hopper
 
 
 class TestFileSgi(PillowTestCase):
@@ -10,14 +10,14 @@ class TestFileSgi(PillowTestCase):
         test_file = "Tests/images/hopper.rgb"
 
         with Image.open(test_file) as im:
-            self.assert_image_equal(im, hopper())
+            assert_image_equal(im, hopper())
             self.assertEqual(im.get_format_mimetype(), "image/rgb")
 
     def test_rgb16(self):
         test_file = "Tests/images/hopper16.rgb"
 
         with Image.open(test_file) as im:
-            self.assert_image_equal(im, hopper())
+            assert_image_equal(im, hopper())
 
     def test_l(self):
         # Created with ImageMagick
@@ -25,7 +25,7 @@ class TestFileSgi(PillowTestCase):
         test_file = "Tests/images/hopper.bw"
 
         with Image.open(test_file) as im:
-            self.assert_image_similar(im, hopper("L"), 2)
+            assert_image_similar(im, hopper("L"), 2)
             self.assertEqual(im.get_format_mimetype(), "image/sgi")
 
     def test_rgba(self):
@@ -35,7 +35,7 @@ class TestFileSgi(PillowTestCase):
 
         with Image.open(test_file) as im:
             with Image.open("Tests/images/transparent.png") as target:
-                self.assert_image_equal(im, target)
+                assert_image_equal(im, target)
             self.assertEqual(im.get_format_mimetype(), "image/sgi")
 
     def test_rle(self):
@@ -45,14 +45,14 @@ class TestFileSgi(PillowTestCase):
 
         with Image.open(test_file) as im:
             with Image.open("Tests/images/hopper.rgb") as target:
-                self.assert_image_equal(im, target)
+                assert_image_equal(im, target)
 
     def test_rle16(self):
         test_file = "Tests/images/tv16.sgi"
 
         with Image.open(test_file) as im:
             with Image.open("Tests/images/tv.rgb") as target:
-                self.assert_image_equal(im, target)
+                assert_image_equal(im, target)
 
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"
@@ -64,7 +64,7 @@ class TestFileSgi(PillowTestCase):
             out = self.tempfile("temp.sgi")
             img.save(out, format="sgi")
             with Image.open(out) as reloaded:
-                self.assert_image_equal(img, reloaded)
+                assert_image_equal(img, reloaded)
 
         for mode in ("L", "RGB", "RGBA"):
             roundtrip(hopper(mode))
@@ -80,7 +80,7 @@ class TestFileSgi(PillowTestCase):
             im.save(out, format="sgi", bpc=2)
 
             with Image.open(out) as reloaded:
-                self.assert_image_equal(im, reloaded)
+                assert_image_equal(im, reloaded)
 
     def test_unsupported_mode(self):
         im = hopper("LA")

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -2,6 +2,7 @@ import tempfile
 import unittest
 from io import BytesIO
 
+import pytest
 from PIL import Image, ImageSequence, SpiderImagePlugin
 
 from .helper import PillowTestCase, assert_image_equal, hopper, is_pypy
@@ -23,7 +24,7 @@ class TestImageSpider(PillowTestCase):
             im = Image.open(TEST_FILE)
             im.load()
 
-        self.assert_warning(ResourceWarning, open)
+        pytest.warns(ResourceWarning, open)
 
     def test_closed_file(self):
         def open():
@@ -31,14 +32,14 @@ class TestImageSpider(PillowTestCase):
             im.load()
             im.close()
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)
 
     def test_context_manager(self):
         def open():
             with Image.open(TEST_FILE) as im:
                 im.load()
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)
 
     def test_save(self):
         # Arrange

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -4,7 +4,7 @@ from io import BytesIO
 
 from PIL import Image, ImageSequence, SpiderImagePlugin
 
-from .helper import PillowTestCase, hopper, is_pypy
+from .helper import PillowTestCase, assert_image_equal, hopper, is_pypy
 
 TEST_FILE = "Tests/images/hopper.spider"
 
@@ -143,4 +143,4 @@ class TestImageSpider(PillowTestCase):
 
         data.seek(0)
         with Image.open(data) as im2:
-            self.assert_image_equal(im, im2)
+            assert_image_equal(im, im2)

--- a/Tests/test_file_sun.py
+++ b/Tests/test_file_sun.py
@@ -3,7 +3,7 @@ import unittest
 
 from PIL import Image, SunImagePlugin
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, assert_image_similar, hopper
 
 EXTRA_DIR = "Tests/images/sunraster"
 
@@ -20,7 +20,7 @@ class TestFileSun(PillowTestCase):
             # Assert
             self.assertEqual(im.size, (128, 128))
 
-            self.assert_image_similar(im, hopper(), 5)  # visually verified
+            assert_image_similar(im, hopper(), 5)  # visually verified
 
         invalid_file = "Tests/images/flower.jpg"
         self.assertRaises(SyntaxError, SunImagePlugin.SunImageFile, invalid_file)
@@ -28,7 +28,7 @@ class TestFileSun(PillowTestCase):
     def test_im1(self):
         with Image.open("Tests/images/sunraster.im1") as im:
             with Image.open("Tests/images/sunraster.im1.png") as target:
-                self.assert_image_equal(im, target)
+                assert_image_equal(im, target)
 
     @unittest.skipUnless(os.path.exists(EXTRA_DIR), "Extra image files not installed")
     def test_others(self):
@@ -44,4 +44,4 @@ class TestFileSun(PillowTestCase):
                 target_path = "%s.png" % os.path.splitext(path)[0]
                 # im.save(target_file)
                 with Image.open(target_path) as target:
-                    self.assert_image_equal(im, target)
+                    assert_image_equal(im, target)

--- a/Tests/test_file_tar.py
+++ b/Tests/test_file_tar.py
@@ -1,5 +1,6 @@
 import unittest
 
+import pytest
 from PIL import Image, TarIO
 
 from .helper import PillowTestCase, is_pypy
@@ -33,18 +34,18 @@ class TestFileTar(PillowTestCase):
         def open():
             TarIO.TarIO(TEST_TAR_FILE, "hopper.jpg")
 
-        self.assert_warning(ResourceWarning, open)
+        pytest.warns(ResourceWarning, open)
 
     def test_close(self):
         def open():
             tar = TarIO.TarIO(TEST_TAR_FILE, "hopper.jpg")
             tar.close()
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)
 
     def test_contextmanager(self):
         def open():
             with TarIO.TarIO(TEST_TAR_FILE, "hopper.jpg"):
                 pass
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)

--- a/Tests/test_file_tga.py
+++ b/Tests/test_file_tga.py
@@ -2,6 +2,7 @@ import os
 from glob import glob
 from itertools import product
 
+import pytest
 from PIL import Image
 
 from .helper import PillowTestCase, assert_image_equal, hopper
@@ -136,7 +137,7 @@ class TestFileTga(PillowTestCase):
 
         # Save with custom id section greater than 255 characters
         id_section = b"Test content" * 25
-        self.assert_warning(UserWarning, lambda: im.save(out, id_section=id_section))
+        pytest.warns(UserWarning, lambda: im.save(out, id_section=id_section))
         with Image.open(out) as test_im:
             self.assertEqual(test_im.info["id_section"], id_section[:255])
 

--- a/Tests/test_file_tga.py
+++ b/Tests/test_file_tga.py
@@ -4,7 +4,7 @@ from itertools import product
 
 from PIL import Image
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 
 _TGA_DIR = os.path.join("Tests", "images", "tga")
 _TGA_DIR_COMMON = os.path.join(_TGA_DIR, "common")
@@ -51,7 +51,7 @@ class TestFileTga(PillowTestCase):
                                     original_im.getpalette(), reference_im.getpalette()
                                 )
 
-                            self.assert_image_equal(original_im, reference_im)
+                            assert_image_equal(original_im, reference_im)
 
                             # Generate a new test name every time so the
                             # test will not fail with permission error
@@ -74,7 +74,7 @@ class TestFileTga(PillowTestCase):
                                         saved_im.getpalette(), original_im.getpalette()
                                     )
 
-                                self.assert_image_equal(saved_im, original_im)
+                                assert_image_equal(saved_im, original_im)
 
     def test_id_field(self):
         # tga file with id field
@@ -206,4 +206,4 @@ class TestFileTga(PillowTestCase):
             self.assertEqual(test_im.mode, "LA")
             self.assertEqual(test_im.getchannel("A").getcolors()[0][0], num_transparent)
 
-            self.assert_image_equal(im, test_im)
+            assert_image_equal(im, test_im)

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -60,7 +60,7 @@ class TestFileTiff(PillowTestCase):
             im = Image.open("Tests/images/multipage.tiff")
             im.load()
 
-        self.assert_warning(ResourceWarning, open)
+        pytest.warns(ResourceWarning, open)
 
     def test_closed_file(self):
         def open():
@@ -68,14 +68,14 @@ class TestFileTiff(PillowTestCase):
             im.load()
             im.close()
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)
 
     def test_context_manager(self):
         def open():
             with Image.open("Tests/images/multipage.tiff") as im:
                 im.load()
 
-        self.assert_warning(None, open)
+        pytest.warns(None, open)
 
     def test_mac_tiff(self):
         # Read RGBa images from macOS [@PIL136]
@@ -185,7 +185,7 @@ class TestFileTiff(PillowTestCase):
     def test_bad_exif(self):
         with Image.open("Tests/images/hopper_bad_exif.jpg") as i:
             # Should not raise struct.error.
-            self.assert_warning(UserWarning, i._getexif)
+            pytest.warns(UserWarning, i._getexif)
 
     def test_save_rgba(self):
         im = hopper("RGBA")

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -7,7 +7,16 @@ import pytest
 from PIL import Image, TiffImagePlugin
 from PIL.TiffImagePlugin import RESOLUTION_UNIT, X_RESOLUTION, Y_RESOLUTION
 
-from .helper import PillowTestCase, hopper, is_pypy, is_win32
+from .helper import (
+    PillowTestCase,
+    assert_image_equal,
+    assert_image_equal_tofile,
+    assert_image_similar,
+    assert_image_similar_tofile,
+    hopper,
+    is_pypy,
+    is_win32,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +87,7 @@ class TestFileTiff(PillowTestCase):
             self.assertEqual(im.tile, [("raw", (0, 0, 55, 43), 8, ("RGBa", 0, 1))])
             im.load()
 
-            self.assert_image_similar_tofile(im, "Tests/images/pil136.png", 1)
+            assert_image_similar_tofile(im, "Tests/images/pil136.png", 1)
 
     def test_wrong_bits_per_sample(self):
         with Image.open("Tests/images/tiff_wrong_bits_per_sample.tiff") as im:
@@ -226,7 +235,7 @@ class TestFileTiff(PillowTestCase):
             # imagemagick will auto scale so that a 12bit FFF is 16bit FFF0,
             # so we need to unshift so that the integer values are the same.
 
-            self.assert_image_equal_tofile(im, "Tests/images/12in16bit.tif")
+            assert_image_equal_tofile(im, "Tests/images/12in16bit.tif")
 
     def test_32bit_float(self):
         # Issue 614, specific 32-bit float format
@@ -409,7 +418,7 @@ class TestFileTiff(PillowTestCase):
         with Image.open(test_file) as im:
             self.assertEqual(im.size, (128, 128))
             self.assertEqual(im.mode, "L")
-            self.assert_image_similar(im, original, 7.3)
+            assert_image_similar(im, original, 7.3)
 
     def test_gray_semibyte_per_pixel(self):
         test_files = (
@@ -437,12 +446,12 @@ class TestFileTiff(PillowTestCase):
             with Image.open(group[0]) as im:
                 self.assertEqual(im.size, (128, 128))
                 self.assertEqual(im.mode, "L")
-                self.assert_image_similar(im, original, epsilon)
+                assert_image_similar(im, original, epsilon)
                 for file in group[1:]:
                     with Image.open(file) as im2:
                         self.assertEqual(im2.size, (128, 128))
                         self.assertEqual(im2.mode, "L")
-                        self.assert_image_equal(im, im2)
+                        assert_image_equal(im, im2)
 
     def test_with_underscores(self):
         kwargs = {"resolution_unit": "inch", "x_resolution": 72, "y_resolution": 36}
@@ -469,25 +478,25 @@ class TestFileTiff(PillowTestCase):
             im.save(tmpfile)
 
             with Image.open(tmpfile) as reloaded:
-                self.assert_image_equal(im, reloaded)
+                assert_image_equal(im, reloaded)
 
     def test_strip_raw(self):
         infile = "Tests/images/tiff_strip_raw.tif"
         with Image.open(infile) as im:
-            self.assert_image_equal_tofile(im, "Tests/images/tiff_adobe_deflate.png")
+            assert_image_equal_tofile(im, "Tests/images/tiff_adobe_deflate.png")
 
     def test_strip_planar_raw(self):
         # gdal_translate -of GTiff -co INTERLEAVE=BAND \
         # tiff_strip_raw.tif tiff_strip_planar_raw.tiff
         infile = "Tests/images/tiff_strip_planar_raw.tif"
         with Image.open(infile) as im:
-            self.assert_image_equal_tofile(im, "Tests/images/tiff_adobe_deflate.png")
+            assert_image_equal_tofile(im, "Tests/images/tiff_adobe_deflate.png")
 
     def test_strip_planar_raw_with_overviews(self):
         # gdaladdo tiff_strip_planar_raw2.tif 2 4 8 16
         infile = "Tests/images/tiff_strip_planar_raw_with_overviews.tif"
         with Image.open(infile) as im:
-            self.assert_image_equal_tofile(im, "Tests/images/tiff_adobe_deflate.png")
+            assert_image_equal_tofile(im, "Tests/images/tiff_adobe_deflate.png")
 
     def test_tiled_planar_raw(self):
         # gdal_translate -of GTiff -co TILED=YES -co BLOCKXSIZE=32 \
@@ -495,7 +504,7 @@ class TestFileTiff(PillowTestCase):
         # tiff_tiled_raw.tif tiff_tiled_planar_raw.tiff
         infile = "Tests/images/tiff_tiled_planar_raw.tif"
         with Image.open(infile) as im:
-            self.assert_image_equal_tofile(im, "Tests/images/tiff_adobe_deflate.png")
+            assert_image_equal_tofile(im, "Tests/images/tiff_adobe_deflate.png")
 
     def test_palette(self):
         for mode in ["P", "PA"]:
@@ -505,7 +514,7 @@ class TestFileTiff(PillowTestCase):
             im.save(outfile)
 
             with Image.open(outfile) as reloaded:
-                self.assert_image_equal(im.convert("RGB"), reloaded.convert("RGB"))
+                assert_image_equal(im.convert("RGB"), reloaded.convert("RGB"))
 
     def test_tiff_save_all(self):
         mp = BytesIO()

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -4,7 +4,7 @@ import struct
 from PIL import Image, TiffImagePlugin, TiffTags
 from PIL.TiffImagePlugin import IFDRational
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_deep_equal, hopper
 
 tag_ids = {info.name: info.value for info in TiffTags.TAGS_V2.values()}
 
@@ -149,7 +149,7 @@ class TestFileTiffMetadata(PillowTestCase):
             ):
                 # Need to compare element by element in the tuple,
                 # not comparing tuples of object references
-                self.assert_deep_equal(
+                assert_deep_equal(
                     original[tag],
                     value,
                     "{} didn't roundtrip, {}, {}".format(tag, original[tag], value),

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -1,6 +1,7 @@
 import io
 import struct
 
+import pytest
 from PIL import Image, TiffImagePlugin, TiffTags
 from PIL.TiffImagePlugin import IFDRational
 
@@ -174,7 +175,7 @@ class TestFileTiffMetadata(PillowTestCase):
         head = f.read(8)
         info = TiffImagePlugin.ImageFileDirectory(head)
         # Should not raise struct.error.
-        self.assert_warning(UserWarning, info.load, f)
+        pytest.warns(UserWarning, info.load, f)
 
     def test_iccprofile(self):
         # https://github.com/python-pillow/Pillow/issues/1462
@@ -333,4 +334,4 @@ class TestFileTiffMetadata(PillowTestCase):
         ifd.tagtype[277] = TiffTags.SHORT
 
         # Should not raise ValueError.
-        self.assert_warning(UserWarning, lambda: ifd[277])
+        pytest.warns(UserWarning, lambda: ifd[277])

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -2,7 +2,12 @@ import unittest
 
 from PIL import Image, WebPImagePlugin
 
-from .helper import PillowTestCase, hopper
+from .helper import (
+    PillowTestCase,
+    assert_image_similar,
+    assert_image_similar_tofile,
+    hopper,
+)
 
 try:
     from PIL import _webp
@@ -50,9 +55,7 @@ class TestFileWebp(PillowTestCase):
 
             # generated with:
             # dwebp -ppm ../../Tests/images/hopper.webp -o hopper_webp_bits.ppm
-            self.assert_image_similar_tofile(
-                image, "Tests/images/hopper_webp_bits.ppm", 1.0
-            )
+            assert_image_similar_tofile(image, "Tests/images/hopper_webp_bits.ppm", 1.0)
 
     def test_write_rgb(self):
         """
@@ -71,7 +74,7 @@ class TestFileWebp(PillowTestCase):
             image.getdata()
 
             # generated with: dwebp -ppm temp.webp -o hopper_webp_write.ppm
-            self.assert_image_similar_tofile(
+            assert_image_similar_tofile(
                 image, "Tests/images/hopper_webp_write.ppm", 12.0
             )
 
@@ -81,7 +84,7 @@ class TestFileWebp(PillowTestCase):
             # the image. The old lena images for WebP are showing ~16 on
             # Ubuntu, the jpegs are showing ~18.
             target = hopper(self.rgb_mode)
-            self.assert_image_similar(image, target, 12.0)
+            assert_image_similar(image, target, 12.0)
 
     def test_write_unsupported_mode_L(self):
         """
@@ -100,7 +103,7 @@ class TestFileWebp(PillowTestCase):
             image.getdata()
             target = hopper("L").convert(self.rgb_mode)
 
-            self.assert_image_similar(image, target, 10.0)
+            assert_image_similar(image, target, 10.0)
 
     def test_write_unsupported_mode_P(self):
         """
@@ -119,7 +122,7 @@ class TestFileWebp(PillowTestCase):
             image.getdata()
             target = hopper("P").convert(self.rgb_mode)
 
-            self.assert_image_similar(image, target, 50.0)
+            assert_image_similar(image, target, 50.0)
 
     def test_WebPEncode_with_invalid_args(self):
         """

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -1,5 +1,6 @@
 import unittest
 
+import pytest
 from PIL import Image, WebPImagePlugin
 
 from .helper import (
@@ -23,7 +24,7 @@ class TestUnsupportedWebp(PillowTestCase):
             WebPImagePlugin.SUPPORTED = False
 
         file_path = "Tests/images/hopper.webp"
-        self.assert_warning(
+        pytest.warns(
             UserWarning, lambda: self.assertRaises(IOError, Image.open, file_path)
         )
 
@@ -146,7 +147,7 @@ class TestFileWebp(PillowTestCase):
         file_path = "Tests/images/hopper.webp"
         with Image.open(file_path) as image:
             temp_file = self.tempfile("temp.webp")
-            self.assert_warning(None, image.save, temp_file)
+            pytest.warns(None, image.save, temp_file)
 
     def test_file_pointer_could_be_reused(self):
         file_path = "Tests/images/hopper.webp"

--- a/Tests/test_file_webp_alpha.py
+++ b/Tests/test_file_webp_alpha.py
@@ -2,7 +2,7 @@ import unittest
 
 from PIL import Image
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, assert_image_similar, hopper
 
 try:
     from PIL import _webp
@@ -36,7 +36,7 @@ class TestFileWebpAlpha(PillowTestCase):
             image.tobytes()
 
             with Image.open("Tests/images/transparent.png") as target:
-                self.assert_image_similar(image, target, 20.0)
+                assert_image_similar(image, target, 20.0)
 
     def test_write_lossless_rgb(self):
         """
@@ -64,7 +64,7 @@ class TestFileWebpAlpha(PillowTestCase):
             image.load()
             image.getdata()
 
-            self.assert_image_equal(image, pil_image)
+            assert_image_equal(image, pil_image)
 
     def test_write_rgba(self):
         """
@@ -92,9 +92,9 @@ class TestFileWebpAlpha(PillowTestCase):
             # early versions of webp are known to produce higher deviations:
             # deal with it
             if _webp.WebPDecoderVersion(self) <= 0x201:
-                self.assert_image_similar(image, pil_image, 3.0)
+                assert_image_similar(image, pil_image, 3.0)
             else:
-                self.assert_image_similar(image, pil_image, 1.0)
+                assert_image_similar(image, pil_image, 1.0)
 
     def test_write_unsupported_mode_PA(self):
         """
@@ -116,4 +116,4 @@ class TestFileWebpAlpha(PillowTestCase):
             with Image.open(file_path) as im:
                 target = im.convert("RGBA")
 
-            self.assert_image_similar(image, target, 25.0)
+            assert_image_similar(image, target, 25.0)

--- a/Tests/test_file_webp_animated.py
+++ b/Tests/test_file_webp_animated.py
@@ -1,7 +1,13 @@
 import pytest
 from PIL import Image
 
-from .helper import PillowTestCase, is_big_endian, on_ci
+from .helper import (
+    PillowTestCase,
+    assert_image_equal,
+    assert_image_similar,
+    is_big_endian,
+    on_ci,
+)
 
 try:
     from PIL import _webp
@@ -56,12 +62,12 @@ class TestFileWebpAnimation(PillowTestCase):
                 # Compare first and last frames to the original animated GIF
                 orig.load()
                 im.load()
-                self.assert_image_similar(im, orig.convert("RGBA"), 25.0)
+                assert_image_similar(im, orig.convert("RGBA"), 25.0)
                 orig.seek(orig.n_frames - 1)
                 im.seek(im.n_frames - 1)
                 orig.load()
                 im.load()
-                self.assert_image_similar(im, orig.convert("RGBA"), 25.0)
+                assert_image_similar(im, orig.convert("RGBA"), 25.0)
 
     @pytest.mark.xfail(is_big_endian() and on_ci(), reason="Fails on big-endian")
     def test_write_animation_RGB(self):
@@ -76,12 +82,12 @@ class TestFileWebpAnimation(PillowTestCase):
 
                 # Compare first frame to original
                 im.load()
-                self.assert_image_equal(im, frame1.convert("RGBA"))
+                assert_image_equal(im, frame1.convert("RGBA"))
 
                 # Compare second frame to original
                 im.seek(1)
                 im.load()
-                self.assert_image_equal(im, frame2.convert("RGBA"))
+                assert_image_equal(im, frame2.convert("RGBA"))
 
         with Image.open("Tests/images/anim_frame1.webp") as frame1:
             with Image.open("Tests/images/anim_frame2.webp") as frame2:

--- a/Tests/test_file_webp_lossless.py
+++ b/Tests/test_file_webp_lossless.py
@@ -1,6 +1,6 @@
 from PIL import Image
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 
 try:
     from PIL import _webp
@@ -35,4 +35,4 @@ class TestFileWebpLossless(PillowTestCase):
             image.load()
             image.getdata()
 
-            self.assert_image_equal(image, hopper(self.rgb_mode))
+            assert_image_equal(image, hopper(self.rgb_mode))

--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -1,6 +1,6 @@
 from PIL import Image, WmfImagePlugin
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_similar, hopper
 
 
 class TestFileWmf(PillowTestCase):
@@ -14,7 +14,7 @@ class TestFileWmf(PillowTestCase):
                 # Compare to reference rendering
                 with Image.open("Tests/images/drawing_emf_ref.png") as imref:
                     imref.load()
-                    self.assert_image_similar(im, imref, 0)
+                    assert_image_similar(im, imref, 0)
 
         # Test basic WMF open and rendering
         with Image.open("Tests/images/drawing.wmf") as im:
@@ -24,7 +24,7 @@ class TestFileWmf(PillowTestCase):
                 # Compare to reference rendering
                 with Image.open("Tests/images/drawing_wmf_ref.png") as imref:
                     imref.load()
-                    self.assert_image_similar(im, imref, 2.0)
+                    assert_image_similar(im, imref, 2.0)
 
     def test_register_handler(self):
         class TestHandler:
@@ -62,7 +62,7 @@ class TestFileWmf(PillowTestCase):
                 self.assertEqual(im.size, (164, 164))
 
                 with Image.open("Tests/images/drawing_wmf_ref_144.png") as expected:
-                    self.assert_image_similar(im, expected, 2.0)
+                    assert_image_similar(im, expected, 2.0)
 
     def test_save(self):
         im = hopper()

--- a/Tests/test_file_xpm.py
+++ b/Tests/test_file_xpm.py
@@ -1,6 +1,6 @@
 from PIL import Image, XpmImagePlugin
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_similar, hopper
 
 TEST_FILE = "Tests/images/hopper.xpm"
 
@@ -14,7 +14,7 @@ class TestFileXpm(PillowTestCase):
             self.assertEqual(im.format, "XPM")
 
             # large error due to quantization->44 colors.
-            self.assert_image_similar(im.convert("RGB"), hopper("RGB"), 60)
+            assert_image_similar(im.convert("RGB"), hopper("RGB"), 60)
 
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"

--- a/Tests/test_file_xvthumb.py
+++ b/Tests/test_file_xvthumb.py
@@ -1,6 +1,6 @@
 from PIL import Image, XVThumbImagePlugin
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_similar, hopper
 
 TEST_FILE = "Tests/images/hopper.p7"
 
@@ -15,7 +15,7 @@ class TestFileXVThumb(PillowTestCase):
 
             # Create a Hopper image with a similar XV palette
             im_hopper = hopper().quantize(palette=im)
-            self.assert_image_similar(im, im_hopper, 9)
+            assert_image_similar(im, im_hopper, 9)
 
     def test_unexpected_eof(self):
         # Test unexpected EOF reading XV thumbnail file

--- a/Tests/test_font_pcf.py
+++ b/Tests/test_font_pcf.py
@@ -1,6 +1,6 @@
 from PIL import FontFile, Image, ImageDraw, ImageFont, PcfFontFile
 
-from .helper import PillowTestCase
+from .helper import PillowTestCase, assert_image_equal, assert_image_similar
 
 codecs = dir(Image.core)
 
@@ -27,7 +27,7 @@ class TestFontPcf(PillowTestCase):
 
         with Image.open(tempname.replace(".pil", ".pbm")) as loaded:
             with Image.open("Tests/fonts/10x20.pbm") as target:
-                self.assert_image_equal(loaded, target)
+                assert_image_equal(loaded, target)
 
         with open(tempname, "rb") as f_loaded:
             with open("Tests/fonts/10x20.pil", "rb") as f_target:
@@ -48,7 +48,7 @@ class TestFontPcf(PillowTestCase):
         draw = ImageDraw.Draw(im)
         draw.text((0, 0), message, "black", font=font)
         with Image.open("Tests/images/test_draw_pbm_target.png") as target:
-            self.assert_image_similar(im, target, 0)
+            assert_image_similar(im, target, 0)
 
     def test_textsize(self):
         tempname = self.save_font()
@@ -68,7 +68,7 @@ class TestFontPcf(PillowTestCase):
         draw = ImageDraw.Draw(im)
         draw.text((0, 0), message, "black", font=font)
         with Image.open("Tests/images/high_ascii_chars.png") as target:
-            self.assert_image_similar(im, target, 0)
+            assert_image_similar(im, target, 0)
 
     def test_high_characters(self):
         message = "".join(chr(i + 1) for i in range(140, 232))

--- a/Tests/test_format_hsv.py
+++ b/Tests/test_format_hsv.py
@@ -3,7 +3,7 @@ import itertools
 
 from PIL import Image
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_similar, hopper
 
 
 class TestFormatHSV(PillowTestCase):
@@ -76,29 +76,29 @@ class TestFormatHSV(PillowTestCase):
         im = src.convert("HSV")
         comparable = self.to_hsv_colorsys(src)
 
-        self.assert_image_similar(
+        assert_image_similar(
             im.getchannel(0), comparable.getchannel(0), 1, "Hue conversion is wrong"
         )
-        self.assert_image_similar(
+        assert_image_similar(
             im.getchannel(1),
             comparable.getchannel(1),
             1,
             "Saturation conversion is wrong",
         )
-        self.assert_image_similar(
+        assert_image_similar(
             im.getchannel(2), comparable.getchannel(2), 1, "Value conversion is wrong"
         )
 
         comparable = src
         im = im.convert("RGB")
 
-        self.assert_image_similar(
+        assert_image_similar(
             im.getchannel(0), comparable.getchannel(0), 3, "R conversion is wrong"
         )
-        self.assert_image_similar(
+        assert_image_similar(
             im.getchannel(1), comparable.getchannel(1), 3, "G conversion is wrong"
         )
-        self.assert_image_similar(
+        assert_image_similar(
             im.getchannel(2), comparable.getchannel(2), 3, "B conversion is wrong"
         )
 
@@ -106,16 +106,16 @@ class TestFormatHSV(PillowTestCase):
         im = hopper("RGB").convert("HSV")
         comparable = self.to_hsv_colorsys(hopper("RGB"))
 
-        self.assert_image_similar(
+        assert_image_similar(
             im.getchannel(0), comparable.getchannel(0), 1, "Hue conversion is wrong"
         )
-        self.assert_image_similar(
+        assert_image_similar(
             im.getchannel(1),
             comparable.getchannel(1),
             1,
             "Saturation conversion is wrong",
         )
-        self.assert_image_similar(
+        assert_image_similar(
             im.getchannel(2), comparable.getchannel(2), 1, "Value conversion is wrong"
         )
 
@@ -124,19 +124,19 @@ class TestFormatHSV(PillowTestCase):
         converted = comparable.convert("RGB")
         comparable = self.to_rgb_colorsys(comparable)
 
-        self.assert_image_similar(
+        assert_image_similar(
             converted.getchannel(0),
             comparable.getchannel(0),
             3,
             "R conversion is wrong",
         )
-        self.assert_image_similar(
+        assert_image_similar(
             converted.getchannel(1),
             comparable.getchannel(1),
             3,
             "G conversion is wrong",
         )
-        self.assert_image_similar(
+        assert_image_similar(
             converted.getchannel(2),
             comparable.getchannel(2),
             3,

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 
+import pytest
 from PIL import Image, UnidentifiedImageError
 
 from .helper import (
@@ -576,7 +577,7 @@ class TestImage(PillowTestCase):
 
         # Act/Assert
         with Image.open(test_file) as im:
-            self.assert_warning(None, im.save, temp_file)
+            pytest.warns(None, im.save, temp_file)
 
     def test_load_on_nonexclusive_multiframe(self):
         with open("Tests/images/frozenpond.mpo", "rb") as fp:

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -6,7 +6,14 @@ import unittest
 
 from PIL import Image, UnidentifiedImageError
 
-from .helper import PillowTestCase, hopper, is_win32
+from .helper import (
+    PillowTestCase,
+    assert_image_equal,
+    assert_image_similar,
+    assert_not_all_same,
+    hopper,
+    is_win32,
+)
 
 
 class TestImage(PillowTestCase):
@@ -132,7 +139,7 @@ class TestImage(PillowTestCase):
             im.save(fp, "JPEG")
             fp.seek(0)
             with Image.open(fp) as reloaded:
-                self.assert_image_similar(im, reloaded, 20)
+                assert_image_similar(im, reloaded, 20)
 
     def test_unknown_extension(self):
         im = hopper()
@@ -222,12 +229,12 @@ class TestImage(PillowTestCase):
         im = hopper("YCbCr")
         Y, Cb, Cr = im.split()
 
-        self.assert_image_equal(Y, im.getchannel(0))
-        self.assert_image_equal(Y, im.getchannel("Y"))
-        self.assert_image_equal(Cb, im.getchannel(1))
-        self.assert_image_equal(Cb, im.getchannel("Cb"))
-        self.assert_image_equal(Cr, im.getchannel(2))
-        self.assert_image_equal(Cr, im.getchannel("Cr"))
+        assert_image_equal(Y, im.getchannel(0))
+        assert_image_equal(Y, im.getchannel("Y"))
+        assert_image_equal(Cb, im.getchannel(1))
+        assert_image_equal(Cb, im.getchannel("Cb"))
+        assert_image_equal(Cr, im.getchannel(2))
+        assert_image_equal(Cr, im.getchannel("Cr"))
 
     def test_getbbox(self):
         # Arrange
@@ -292,30 +299,26 @@ class TestImage(PillowTestCase):
         # basic
         full = src.copy()
         full.alpha_composite(over)
-        self.assert_image_equal(full, target)
+        assert_image_equal(full, target)
 
         # with offset down to right
         offset = src.copy()
         offset.alpha_composite(over, (64, 64))
-        self.assert_image_equal(
-            offset.crop((64, 64, 127, 127)), target.crop((0, 0, 63, 63))
-        )
+        assert_image_equal(offset.crop((64, 64, 127, 127)), target.crop((0, 0, 63, 63)))
         self.assertEqual(offset.size, (128, 128))
 
         # offset and crop
         box = src.copy()
         box.alpha_composite(over, (64, 64), (0, 0, 32, 32))
-        self.assert_image_equal(box.crop((64, 64, 96, 96)), target.crop((0, 0, 32, 32)))
-        self.assert_image_equal(box.crop((96, 96, 128, 128)), src.crop((0, 0, 32, 32)))
+        assert_image_equal(box.crop((64, 64, 96, 96)), target.crop((0, 0, 32, 32)))
+        assert_image_equal(box.crop((96, 96, 128, 128)), src.crop((0, 0, 32, 32)))
         self.assertEqual(box.size, (128, 128))
 
         # source point
         source = src.copy()
         source.alpha_composite(over, (32, 32), (32, 32, 96, 96))
 
-        self.assert_image_equal(
-            source.crop((32, 32, 96, 96)), target.crop((32, 32, 96, 96))
-        )
+        assert_image_equal(source.crop((32, 32, 96, 96)), target.crop((32, 32, 96, 96)))
         self.assertEqual(source.size, (128, 128))
 
         # errors
@@ -370,7 +373,7 @@ class TestImage(PillowTestCase):
         # Assert
         self.assertEqual(im.size, (512, 512))
         with Image.open("Tests/images/effect_mandelbrot.png") as im2:
-            self.assert_image_equal(im, im2)
+            assert_image_equal(im, im2)
 
     def test_effect_mandelbrot_bad_arguments(self):
         # Arrange
@@ -399,7 +402,7 @@ class TestImage(PillowTestCase):
         p2 = im.getpixel((0, 2))
         p3 = im.getpixel((0, 3))
         p4 = im.getpixel((0, 4))
-        self.assert_not_all_same([p0, p1, p2, p3, p4])
+        assert_not_all_same([p0, p1, p2, p3, p4])
 
     def test_effect_spread(self):
         # Arrange
@@ -412,7 +415,7 @@ class TestImage(PillowTestCase):
         # Assert
         self.assertEqual(im.size, (128, 128))
         with Image.open("Tests/images/effect_spread.png") as im3:
-            self.assert_image_similar(im2, im3, 110)
+            assert_image_similar(im2, im3, 110)
 
     def test_check_size(self):
         # Checking that the _check_size function throws value errors
@@ -481,7 +484,7 @@ class TestImage(PillowTestCase):
             self.assertEqual(im.getpixel((255, 255)), 255)
             with Image.open(target_file) as target:
                 target = target.convert(mode)
-            self.assert_image_equal(im, target)
+            assert_image_equal(im, target)
 
     def test_radial_gradient_wrong_mode(self):
         # Arrange
@@ -506,7 +509,7 @@ class TestImage(PillowTestCase):
             self.assertEqual(im.getpixel((128, 128)), 0)
             with Image.open(target_file) as target:
                 target = target.convert(mode)
-            self.assert_image_equal(im, target)
+            assert_image_equal(im, target)
 
     def test_register_extensions(self):
         test_format = "a"
@@ -563,7 +566,7 @@ class TestImage(PillowTestCase):
         ]:
             im = Image.new("P", (100, 100), color)
             expected = Image.new(mode, (100, 100), color)
-            self.assert_image_equal(im.convert(mode), expected)
+            assert_image_equal(im.convert(mode), expected)
 
     def test_no_resource_warning_on_save(self):
         # https://github.com/python-pillow/Pillow/issues/835

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -7,7 +7,7 @@ from distutils import ccompiler, sysconfig
 
 from PIL import Image
 
-from .helper import PillowTestCase, hopper, is_win32, on_ci
+from .helper import PillowTestCase, assert_image_equal, hopper, is_win32, on_ci
 
 # CFFI imports pycparser which doesn't support PYTHONOPTIMIZE=2
 # https://github.com/eliben/pycparser/pull/198#issuecomment-317001670
@@ -45,7 +45,7 @@ class TestImagePutPixel(AccessTest):
                 pos = x, y
                 im2.putpixel(pos, im1.getpixel(pos))
 
-        self.assert_image_equal(im1, im2)
+        assert_image_equal(im1, im2)
 
         im2 = Image.new(im1.mode, im1.size, 0)
         im2.readonly = 1
@@ -56,7 +56,7 @@ class TestImagePutPixel(AccessTest):
                 im2.putpixel(pos, im1.getpixel(pos))
 
         self.assertFalse(im2.readonly)
-        self.assert_image_equal(im1, im2)
+        assert_image_equal(im1, im2)
 
         im2 = Image.new(im1.mode, im1.size, 0)
 
@@ -67,7 +67,7 @@ class TestImagePutPixel(AccessTest):
             for x in range(im1.size[0]):
                 pix2[x, y] = pix1[x, y]
 
-        self.assert_image_equal(im1, im2)
+        assert_image_equal(im1, im2)
 
     def test_sanity_negative_index(self):
         im1 = hopper()
@@ -82,7 +82,7 @@ class TestImagePutPixel(AccessTest):
                 pos = x, y
                 im2.putpixel(pos, im1.getpixel(pos))
 
-        self.assert_image_equal(im1, im2)
+        assert_image_equal(im1, im2)
 
         im2 = Image.new(im1.mode, im1.size, 0)
         im2.readonly = 1
@@ -93,7 +93,7 @@ class TestImagePutPixel(AccessTest):
                 im2.putpixel(pos, im1.getpixel(pos))
 
         self.assertFalse(im2.readonly)
-        self.assert_image_equal(im1, im2)
+        assert_image_equal(im1, im2)
 
         im2 = Image.new(im1.mode, im1.size, 0)
 
@@ -104,7 +104,7 @@ class TestImagePutPixel(AccessTest):
             for x in range(-1, -im1.size[0] - 1, -1):
                 pix2[x, y] = pix1[x, y]
 
-        self.assert_image_equal(im1, im2)
+        assert_image_equal(im1, im2)
 
 
 class TestImageGetPixel(AccessTest):

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -1,6 +1,12 @@
 from PIL import Image
 
-from .helper import PillowTestCase, hopper
+from .helper import (
+    PillowTestCase,
+    assert_image,
+    assert_image_equal,
+    assert_image_similar,
+    hopper,
+)
 
 
 class TestImageConvert(PillowTestCase):
@@ -39,11 +45,11 @@ class TestImageConvert(PillowTestCase):
     def test_default(self):
 
         im = hopper("P")
-        self.assert_image(im, "P", im.size)
+        assert_image(im, "P", im.size)
         im = im.convert()
-        self.assert_image(im, "RGB", im.size)
+        assert_image(im, "RGB", im.size)
         im = im.convert()
-        self.assert_image(im, "RGB", im.size)
+        assert_image(im, "RGB", im.size)
 
     # ref https://github.com/python-pillow/Pillow/issues/274
 
@@ -71,7 +77,7 @@ class TestImageConvert(PillowTestCase):
         converted = im.convert("P")
         comparable = converted.convert("RGBA")
 
-        self.assert_image_similar(im, comparable, 20)
+        assert_image_similar(im, comparable, 20)
 
     def test_trns_p(self):
         im = hopper("P")
@@ -160,7 +166,7 @@ class TestImageConvert(PillowTestCase):
 
         comparable = im.convert("P").convert("LA").getchannel("A")
 
-        self.assert_image_similar(alpha, comparable, 5)
+        assert_image_similar(alpha, comparable, 5)
 
     def test_matrix_illegal_conversion(self):
         # Arrange
@@ -212,10 +218,10 @@ class TestImageConvert(PillowTestCase):
             self.assertEqual(converted_im.size, im.size)
             with Image.open("Tests/images/hopper-XYZ.png") as target:
                 if converted_im.mode == "RGB":
-                    self.assert_image_similar(converted_im, target, 3)
+                    assert_image_similar(converted_im, target, 3)
                     self.assertEqual(converted_im.info["transparency"], (105, 54, 4))
                 else:
-                    self.assert_image_similar(converted_im, target.getchannel(0), 1)
+                    assert_image_similar(converted_im, target.getchannel(0), 1)
                     self.assertEqual(converted_im.info["transparency"], 105)
 
         matrix_convert("RGB")
@@ -238,4 +244,4 @@ class TestImageConvert(PillowTestCase):
 
         # Assert
         # No change
-        self.assert_image_equal(converted_im, im)
+        assert_image_equal(converted_im, im)

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -1,3 +1,4 @@
+import pytest
 from PIL import Image
 
 from .helper import (
@@ -122,7 +123,7 @@ class TestImageConvert(PillowTestCase):
         self.assertIn("transparency", im_p.info)
         im_p.save(f)
 
-        im_p = self.assert_warning(UserWarning, im.convert, "P", palette=Image.ADAPTIVE)
+        im_p = pytest.warns(UserWarning, im.convert, "P", palette=Image.ADAPTIVE)
         self.assertNotIn("transparency", im_p.info)
         im_p.save(f)
 
@@ -144,7 +145,7 @@ class TestImageConvert(PillowTestCase):
         self.assertNotIn("transparency", im_rgba.info)
         im_rgba.save(f)
 
-        im_p = self.assert_warning(UserWarning, im.convert, "P", palette=Image.ADAPTIVE)
+        im_p = pytest.warns(UserWarning, im.convert, "P", palette=Image.ADAPTIVE)
         self.assertNotIn("transparency", im_p.info)
         im_p.save(f)
 

--- a/Tests/test_image_crop.py
+++ b/Tests/test_image_crop.py
@@ -1,13 +1,13 @@
 from PIL import Image
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 
 
 class TestImageCrop(PillowTestCase):
     def test_crop(self):
         def crop(mode):
             im = hopper(mode)
-            self.assert_image_equal(im.crop(), im)
+            assert_image_equal(im.crop(), im)
 
             cropped = im.crop((50, 50, 100, 100))
             self.assertEqual(cropped.mode, mode)

--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -1,6 +1,6 @@
 from PIL import Image, ImageFilter
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 
 
 class TestImageFilter(PillowTestCase):
@@ -114,7 +114,7 @@ class TestImageFilter(PillowTestCase):
                 reference = reference.split() * 2
 
                 for mode in ["L", "LA", "RGB", "CMYK"]:
-                    self.assert_image_equal(
+                    assert_image_equal(
                         Image.merge(mode, source[: len(mode)]).filter(kernel),
                         Image.merge(mode, reference[: len(mode)]),
                     )
@@ -137,7 +137,7 @@ class TestImageFilter(PillowTestCase):
                 reference = reference.split() * 2
 
                 for mode in ["L", "LA", "RGB", "CMYK"]:
-                    self.assert_image_equal(
+                    assert_image_equal(
                         Image.merge(mode, source[: len(mode)]).filter(kernel),
                         Image.merge(mode, reference[: len(mode)]),
                     )

--- a/Tests/test_image_frombytes.py
+++ b/Tests/test_image_frombytes.py
@@ -1,6 +1,6 @@
 from PIL import Image
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 
 
 class TestImageFromBytes(PillowTestCase):
@@ -8,7 +8,7 @@ class TestImageFromBytes(PillowTestCase):
         im1 = hopper()
         im2 = Image.frombytes(im1.mode, im1.size, im1.tobytes())
 
-        self.assert_image_equal(im1, im2)
+        assert_image_equal(im1, im2)
 
     def test_not_implemented(self):
         self.assertRaises(NotImplementedError, Image.fromstring)

--- a/Tests/test_image_fromqimage.py
+++ b/Tests/test_image_fromqimage.py
@@ -1,6 +1,6 @@
 from PIL import Image, ImageQt
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 from .test_imageqt import PillowQtTestCase
 
 
@@ -22,9 +22,9 @@ class TestFromQImage(PillowQtTestCase, PillowTestCase):
         result = ImageQt.fromqimage(intermediate)
 
         if intermediate.hasAlphaChannel():
-            self.assert_image_equal(result, expected.convert("RGBA"))
+            assert_image_equal(result, expected.convert("RGBA"))
         else:
-            self.assert_image_equal(result, expected.convert("RGB"))
+            assert_image_equal(result, expected.convert("RGB"))
 
     def test_sanity_1(self):
         for im in self.files_to_test:

--- a/Tests/test_image_paste.py
+++ b/Tests/test_image_paste.py
@@ -1,6 +1,6 @@
 from PIL import Image
 
-from .helper import PillowTestCase, cached_property
+from .helper import PillowTestCase, assert_image_equal, cached_property
 
 
 class TestImagingPaste(PillowTestCase):
@@ -99,7 +99,7 @@ class TestImagingPaste(PillowTestCase):
             im.paste(im2, (12, 23))
 
             im = im.crop((12, 23, im2.width + 12, im2.height + 23))
-            self.assert_image_equal(im, im2)
+            assert_image_equal(im, im2)
 
     def test_image_mask_1(self):
         for mode in ("RGBA", "RGB", "L"):

--- a/Tests/test_image_point.py
+++ b/Tests/test_image_point.py
@@ -1,4 +1,4 @@
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 
 
 class TestImagePoint(PillowTestCase):
@@ -32,7 +32,7 @@ class TestImagePoint(PillowTestCase):
         out = im.point(lut, "F")
 
         int_lut = [x // 2 for x in range(256)]
-        self.assert_image_equal(out.convert("L"), im.point(int_lut, "L"))
+        assert_image_equal(out.convert("L"), im.point(int_lut, "L"))
 
     def test_f_mode(self):
         im = hopper("F")

--- a/Tests/test_image_putdata.py
+++ b/Tests/test_image_putdata.py
@@ -3,7 +3,7 @@ from array import array
 
 from PIL import Image
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 
 
 class TestImagePutData(PillowTestCase):
@@ -16,7 +16,7 @@ class TestImagePutData(PillowTestCase):
         im2 = Image.new(im1.mode, im1.size, 0)
         im2.putdata(data)
 
-        self.assert_image_equal(im1, im2)
+        assert_image_equal(im1, im2)
 
         # readonly
         im2 = Image.new(im1.mode, im2.size, 0)
@@ -24,7 +24,7 @@ class TestImagePutData(PillowTestCase):
         im2.putdata(data)
 
         self.assertFalse(im2.readonly)
-        self.assert_image_equal(im1, im2)
+        assert_image_equal(im1, im2)
 
     def test_long_integers(self):
         # see bug-200802-systemerror

--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -1,19 +1,19 @@
 from PIL import Image
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image, assert_image_similar, hopper
 
 
 class TestImageQuantize(PillowTestCase):
     def test_sanity(self):
         image = hopper()
         converted = image.quantize()
-        self.assert_image(converted, "P", converted.size)
-        self.assert_image_similar(converted.convert("RGB"), image, 10)
+        assert_image(converted, "P", converted.size)
+        assert_image_similar(converted.convert("RGB"), image, 10)
 
         image = hopper()
         converted = image.quantize(palette=hopper("P"))
-        self.assert_image(converted, "P", converted.size)
-        self.assert_image_similar(converted.convert("RGB"), image, 60)
+        assert_image(converted, "P", converted.size)
+        assert_image_similar(converted.convert("RGB"), image, 60)
 
     def test_libimagequant_quantize(self):
         image = hopper()
@@ -24,15 +24,15 @@ class TestImageQuantize(PillowTestCase):
                 self.skipTest("libimagequant support not available")
             else:
                 raise
-        self.assert_image(converted, "P", converted.size)
-        self.assert_image_similar(converted.convert("RGB"), image, 15)
+        assert_image(converted, "P", converted.size)
+        assert_image_similar(converted.convert("RGB"), image, 15)
         self.assertEqual(len(converted.getcolors()), 100)
 
     def test_octree_quantize(self):
         image = hopper()
         converted = image.quantize(100, Image.FASTOCTREE)
-        self.assert_image(converted, "P", converted.size)
-        self.assert_image_similar(converted.convert("RGB"), image, 20)
+        assert_image(converted, "P", converted.size)
+        assert_image_similar(converted.convert("RGB"), image, 20)
         self.assertEqual(len(converted.getcolors()), 100)
 
     def test_rgba_quantize(self):
@@ -45,8 +45,8 @@ class TestImageQuantize(PillowTestCase):
         with Image.open("Tests/images/caption_6_33_22.png") as image:
             image = image.convert("RGB")
         converted = image.quantize()
-        self.assert_image(converted, "P", converted.size)
-        self.assert_image_similar(converted.convert("RGB"), image, 1)
+        assert_image(converted, "P", converted.size)
+        assert_image_similar(converted.convert("RGB"), image, 1)
 
     def test_quantize_no_dither(self):
         image = hopper()
@@ -54,7 +54,7 @@ class TestImageQuantize(PillowTestCase):
             palette = palette.convert("P")
 
         converted = image.quantize(dither=0, palette=palette)
-        self.assert_image(converted, "P", converted.size)
+        assert_image(converted, "P", converted.size)
 
     def test_quantize_dither_diff(self):
         image = hopper()

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 
 from PIL import Image, ImageDraw
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, assert_image_similar, hopper
 
 
 class TestImagingResampleVulnerability(PillowTestCase):
@@ -215,7 +215,7 @@ class TestImagingCoreResampleAccuracy(PillowTestCase):
     def test_box_filter_correct_range(self):
         im = Image.new("RGB", (8, 8), "#1688ff").resize((100, 100), Image.BOX)
         ref = Image.new("RGB", (100, 100), "#1688ff")
-        self.assert_image_equal(im, ref)
+        assert_image_equal(im, ref)
 
 
 class CoreResampleConsistencyTest(PillowTestCase):
@@ -360,7 +360,7 @@ class CoreResamplePassesTest(PillowTestCase):
             with_box = im.resize(im.size, Image.BILINEAR, box)
         with self.count(2):
             cropped = im.crop(box).resize(im.size, Image.BILINEAR)
-        self.assert_image_similar(with_box, cropped, 0.1)
+        assert_image_similar(with_box, cropped, 0.1)
 
     def test_box_vertical(self):
         im = hopper("L")
@@ -370,7 +370,7 @@ class CoreResamplePassesTest(PillowTestCase):
             with_box = im.resize(im.size, Image.BILINEAR, box)
         with self.count(2):
             cropped = im.crop(box).resize(im.size, Image.BILINEAR)
-        self.assert_image_similar(with_box, cropped, 0.1)
+        assert_image_similar(with_box, cropped, 0.1)
 
 
 class CoreResampleCoefficientsTest(PillowTestCase):
@@ -462,7 +462,7 @@ class CoreResampleBoxTest(PillowTestCase):
 
             for tiles in [(1, 1), (3, 3), (9, 7), (100, 100)]:
                 tiled = self.resize_tiled(im, dst_size, *tiles)
-                self.assert_image_similar(reference, tiled, 0.01)
+                assert_image_similar(reference, tiled, 0.01)
 
     def test_subsample(self):
         # This test shows advantages of the subpixel resizing
@@ -479,9 +479,9 @@ class CoreResampleBoxTest(PillowTestCase):
         without_box = supersampled.resize(dst_size, Image.BICUBIC)
 
         # error with box should be much smaller than without
-        self.assert_image_similar(reference, with_box, 6)
+        assert_image_similar(reference, with_box, 6)
         with self.assertRaisesRegex(AssertionError, r"difference 29\."):
-            self.assert_image_similar(reference, without_box, 5)
+            assert_image_similar(reference, without_box, 5)
 
     def test_formats(self):
         for resample in [Image.NEAREST, Image.BILINEAR]:
@@ -490,7 +490,7 @@ class CoreResampleBoxTest(PillowTestCase):
                 box = (20, 20, im.size[0] - 20, im.size[1] - 20)
                 with_box = im.resize((32, 32), resample, box)
                 cropped = im.crop(box).resize((32, 32), resample)
-                self.assert_image_similar(cropped, with_box, 0.4)
+                assert_image_similar(cropped, with_box, 0.4)
 
     def test_passthrough(self):
         # When no resize is required
@@ -504,7 +504,7 @@ class CoreResampleBoxTest(PillowTestCase):
         ]:
             res = im.resize(size, Image.LANCZOS, box)
             self.assertEqual(res.size, size)
-            self.assert_image_equal(res, im.crop(box), ">>> {} {}".format(size, box))
+            assert_image_equal(res, im.crop(box), ">>> {} {}".format(size, box))
 
     def test_no_passthrough(self):
         # When resize is required
@@ -520,7 +520,7 @@ class CoreResampleBoxTest(PillowTestCase):
             self.assertEqual(res.size, size)
             with self.assertRaisesRegex(AssertionError, r"difference \d"):
                 # check that the difference at least that much
-                self.assert_image_similar(
+                assert_image_similar(
                     res, im.crop(box), 20, ">>> {} {}".format(size, box)
                 )
 
@@ -538,7 +538,7 @@ class CoreResampleBoxTest(PillowTestCase):
                 res = im.resize(size, flt, box)
                 self.assertEqual(res.size, size)
                 # Borders should be slightly different
-                self.assert_image_similar(
+                assert_image_similar(
                     res,
                     im.crop(box).resize(size, flt),
                     0.4,
@@ -559,7 +559,7 @@ class CoreResampleBoxTest(PillowTestCase):
                 res = im.resize(size, flt, box)
                 self.assertEqual(res.size, size)
                 # Borders should be slightly different
-                self.assert_image_similar(
+                assert_image_similar(
                     res,
                     im.crop(box).resize(size, flt),
                     0.4,

--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -5,7 +5,7 @@ from itertools import permutations
 
 from PIL import Image
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, assert_image_similar, hopper
 
 
 class TestImagingCoreResize(PillowTestCase):
@@ -116,7 +116,7 @@ class TestImagingCoreResize(PillowTestCase):
                     for i, ch in enumerate(resized.split()):
                         # check what resized channel in image is the same
                         # as separately resized channel
-                        self.assert_image_equal(ch, references[channels[i]])
+                        assert_image_equal(ch, references[channels[i]])
 
     def test_enlarge_zero(self):
         for f in [
@@ -145,7 +145,7 @@ class TestReducingGapResize(PillowTestCase):
     def test_reducing_gap_values(self):
         ref = self.gradients_image.resize((52, 34), Image.BICUBIC, reducing_gap=None)
         im = self.gradients_image.resize((52, 34), Image.BICUBIC)
-        self.assert_image_equal(ref, im)
+        assert_image_equal(ref, im)
 
         with self.assertRaises(ValueError):
             self.gradients_image.resize((52, 34), Image.BICUBIC, reducing_gap=0)
@@ -165,9 +165,9 @@ class TestReducingGapResize(PillowTestCase):
             )
 
             with self.assertRaises(AssertionError):
-                self.assert_image_equal(ref, im)
+                assert_image_equal(ref, im)
 
-            self.assert_image_similar(ref, im, epsilon)
+            assert_image_similar(ref, im, epsilon)
 
     def test_reducing_gap_2(self):
         for box, epsilon in [
@@ -181,9 +181,9 @@ class TestReducingGapResize(PillowTestCase):
             )
 
             with self.assertRaises(AssertionError):
-                self.assert_image_equal(ref, im)
+                assert_image_equal(ref, im)
 
-            self.assert_image_similar(ref, im, epsilon)
+            assert_image_similar(ref, im, epsilon)
 
     def test_reducing_gap_3(self):
         for box, epsilon in [
@@ -197,9 +197,9 @@ class TestReducingGapResize(PillowTestCase):
             )
 
             with self.assertRaises(AssertionError):
-                self.assert_image_equal(ref, im)
+                assert_image_equal(ref, im)
 
-            self.assert_image_similar(ref, im, epsilon)
+            assert_image_similar(ref, im, epsilon)
 
     def test_reducing_gap_8(self):
         for box in [None, (1.1, 2.2, 510.8, 510.9), (3, 10, 410, 256)]:
@@ -208,7 +208,7 @@ class TestReducingGapResize(PillowTestCase):
                 (52, 34), Image.BICUBIC, box=box, reducing_gap=8.0
             )
 
-            self.assert_image_equal(ref, im)
+            assert_image_equal(ref, im)
 
     def test_box_filter(self):
         for box, epsilon in [
@@ -220,7 +220,7 @@ class TestReducingGapResize(PillowTestCase):
                 (52, 34), Image.BOX, box=box, reducing_gap=1.0
             )
 
-            self.assert_image_similar(ref, im, epsilon)
+            assert_image_similar(ref, im, epsilon)
 
 
 class TestImageResize(PillowTestCase):

--- a/Tests/test_image_rotate.py
+++ b/Tests/test_image_rotate.py
@@ -1,6 +1,6 @@
 from PIL import Image
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, assert_image_similar, hopper
 
 
 class TestImageRotate(PillowTestCase):
@@ -46,7 +46,7 @@ class TestImageRotate(PillowTestCase):
             ):
                 im = hopper()
                 im = im.rotate(45, resample=resample, expand=True)
-                self.assert_image_similar(im, target, epsilon)
+                assert_image_similar(im, target, epsilon)
 
     def test_center_0(self):
         im = hopper()
@@ -56,7 +56,7 @@ class TestImageRotate(PillowTestCase):
             target_origin = target.size[1] / 2
             target = target.crop((0, target_origin, 128, target_origin + 128))
 
-        self.assert_image_similar(im, target, 15)
+        assert_image_similar(im, target, 15)
 
     def test_center_14(self):
         im = hopper()
@@ -66,7 +66,7 @@ class TestImageRotate(PillowTestCase):
             target_origin = target.size[1] / 2 - 14
             target = target.crop((6, target_origin, 128 + 6, target_origin + 128))
 
-            self.assert_image_similar(im, target, 10)
+            assert_image_similar(im, target, 10)
 
     def test_translate(self):
         im = hopper()
@@ -78,21 +78,21 @@ class TestImageRotate(PillowTestCase):
 
         im = im.rotate(45, translate=(5, 5), resample=Image.BICUBIC)
 
-        self.assert_image_similar(im, target, 1)
+        assert_image_similar(im, target, 1)
 
     def test_fastpath_center(self):
         # if the center is -1,-1 and we rotate by 90<=x<=270 the
         # resulting image should be black
         for angle in (90, 180, 270):
             im = hopper().rotate(angle, center=(-1, -1))
-            self.assert_image_equal(im, Image.new("RGB", im.size, "black"))
+            assert_image_equal(im, Image.new("RGB", im.size, "black"))
 
     def test_fastpath_translate(self):
         # if we post-translate by -128
         # resulting image should be black
         for angle in (0, 90, 180, 270):
             im = hopper().rotate(angle, translate=(-128, -128))
-            self.assert_image_equal(im, Image.new("RGB", im.size, "black"))
+            assert_image_equal(im, Image.new("RGB", im.size, "black"))
 
     def test_center(self):
         im = hopper()
@@ -104,13 +104,13 @@ class TestImageRotate(PillowTestCase):
         im = Image.new("RGB", (100, 100), "green")
         im = im.rotate(45)
         with Image.open("Tests/images/rotate_45_no_fill.png") as target:
-            self.assert_image_equal(im, target)
+            assert_image_equal(im, target)
 
     def test_rotate_with_fill(self):
         im = Image.new("RGB", (100, 100), "green")
         im = im.rotate(45, fillcolor="white")
         with Image.open("Tests/images/rotate_45_with_fill.png") as target:
-            self.assert_image_equal(im, target)
+            assert_image_equal(im, target)
 
     def test_alpha_rotate_no_fill(self):
         # Alpha images are handled differently internally

--- a/Tests/test_image_split.py
+++ b/Tests/test_image_split.py
@@ -1,6 +1,6 @@
 from PIL import Image
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 
 
 class TestImageSplit(PillowTestCase):
@@ -33,15 +33,15 @@ class TestImageSplit(PillowTestCase):
         def split_merge(mode):
             return Image.merge(mode, hopper(mode).split())
 
-        self.assert_image_equal(hopper("1"), split_merge("1"))
-        self.assert_image_equal(hopper("L"), split_merge("L"))
-        self.assert_image_equal(hopper("I"), split_merge("I"))
-        self.assert_image_equal(hopper("F"), split_merge("F"))
-        self.assert_image_equal(hopper("P"), split_merge("P"))
-        self.assert_image_equal(hopper("RGB"), split_merge("RGB"))
-        self.assert_image_equal(hopper("RGBA"), split_merge("RGBA"))
-        self.assert_image_equal(hopper("CMYK"), split_merge("CMYK"))
-        self.assert_image_equal(hopper("YCbCr"), split_merge("YCbCr"))
+        assert_image_equal(hopper("1"), split_merge("1"))
+        assert_image_equal(hopper("L"), split_merge("L"))
+        assert_image_equal(hopper("I"), split_merge("I"))
+        assert_image_equal(hopper("F"), split_merge("F"))
+        assert_image_equal(hopper("P"), split_merge("P"))
+        assert_image_equal(hopper("RGB"), split_merge("RGB"))
+        assert_image_equal(hopper("RGBA"), split_merge("RGBA"))
+        assert_image_equal(hopper("CMYK"), split_merge("CMYK"))
+        assert_image_equal(hopper("YCbCr"), split_merge("YCbCr"))
 
     def test_split_open(self):
         codecs = dir(Image.core)

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -1,6 +1,13 @@
 from PIL import Image
 
-from .helper import PillowTestCase, fromstring, hopper, tostring
+from .helper import (
+    PillowTestCase,
+    assert_image_equal,
+    assert_image_similar,
+    fromstring,
+    hopper,
+    tostring,
+)
 
 
 class TestImageThumbnail(PillowTestCase):
@@ -70,7 +77,7 @@ class TestImageThumbnail(PillowTestCase):
 
         ref = im.resize((32, 32), Image.BICUBIC)
         # This is still JPEG, some error is present. Without the fix it is 11.5
-        self.assert_image_similar(thumb, ref, 1.5)
+        assert_image_similar(thumb, ref, 1.5)
 
     def test_reducing_gap_values(self):
         im = hopper()
@@ -79,14 +86,14 @@ class TestImageThumbnail(PillowTestCase):
         ref = hopper()
         ref.thumbnail((18, 18), Image.BICUBIC, reducing_gap=2.0)
         # reducing_gap=2.0 should be the default
-        self.assert_image_equal(ref, im)
+        assert_image_equal(ref, im)
 
         ref = hopper()
         ref.thumbnail((18, 18), Image.BICUBIC, reducing_gap=None)
         with self.assertRaises(AssertionError):
-            self.assert_image_equal(ref, im)
+            assert_image_equal(ref, im)
 
-        self.assert_image_similar(ref, im, 3.5)
+        assert_image_similar(ref, im, 3.5)
 
     def test_reducing_gap_for_DCT_scaling(self):
         with Image.open("Tests/images/hopper.jpg") as ref:
@@ -97,4 +104,4 @@ class TestImageThumbnail(PillowTestCase):
             with Image.open("Tests/images/hopper.jpg") as im:
                 im.thumbnail((18, 18), Image.BICUBIC, reducing_gap=3.0)
 
-                self.assert_image_equal(ref, im)
+                assert_image_equal(ref, im)

--- a/Tests/test_image_tobitmap.py
+++ b/Tests/test_image_tobitmap.py
@@ -1,4 +1,4 @@
-from .helper import PillowTestCase, fromstring, hopper
+from .helper import PillowTestCase, assert_image_equal, fromstring, hopper
 
 
 class TestImageToBitmap(PillowTestCase):
@@ -11,4 +11,4 @@ class TestImageToBitmap(PillowTestCase):
         bitmap = im1.tobitmap()
 
         self.assertIsInstance(bitmap, bytes)
-        self.assert_image_equal(im1, fromstring(bitmap))
+        assert_image_equal(im1, fromstring(bitmap))

--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -2,7 +2,7 @@ import math
 
 from PIL import Image, ImageTransform
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, assert_image_similar, hopper
 
 
 class TestImageTransform(PillowTestCase):
@@ -43,7 +43,7 @@ class TestImageTransform(PillowTestCase):
         scaled = im.resize((w * 2, h * 2), Image.BILINEAR).crop((0, 0, w, h))
 
         # undone -- precision?
-        self.assert_image_similar(transformed, scaled, 23)
+        assert_image_similar(transformed, scaled, 23)
 
     def test_quad(self):
         # one simple quad transform, equivalent to scale & crop upper left quad
@@ -61,7 +61,7 @@ class TestImageTransform(PillowTestCase):
             (w, h), Image.AFFINE, (0.5, 0, 0, 0, 0.5, 0), Image.BILINEAR
         )
 
-        self.assert_image_equal(transformed, scaled)
+        assert_image_equal(transformed, scaled)
 
     def test_fill(self):
         for mode, pixel in [
@@ -104,13 +104,13 @@ class TestImageTransform(PillowTestCase):
         checker.paste(scaled, (0, 0))
         checker.paste(scaled, (w // 2, h // 2))
 
-        self.assert_image_equal(transformed, checker)
+        assert_image_equal(transformed, checker)
 
         # now, check to see that the extra area is (0, 0, 0, 0)
         blank = Image.new("RGBA", (w // 2, h // 2), (0, 0, 0, 0))
 
-        self.assert_image_equal(blank, transformed.crop((w // 2, 0, w, h // 2)))
-        self.assert_image_equal(blank, transformed.crop((0, h // 2, w // 2, h)))
+        assert_image_equal(blank, transformed.crop((w // 2, 0, w, h // 2)))
+        assert_image_equal(blank, transformed.crop((0, h // 2, w // 2, h)))
 
     def _test_alpha_premult(self, op):
         # create image with half white, half black,
@@ -214,7 +214,7 @@ class TestImageTransformAffine(PillowTestCase):
             transformed = im.transform(
                 transposed.size, self.transform, matrix, resample
             )
-            self.assert_image_equal(transposed, transformed)
+            assert_image_equal(transposed, transformed)
 
     def test_rotate_0_deg(self):
         self._test_rotate(0, None)
@@ -244,7 +244,7 @@ class TestImageTransformAffine(PillowTestCase):
             transformed = transformed.transform(
                 im.size, self.transform, matrix_down, resample
             )
-            self.assert_image_similar(transformed, im, epsilon * epsilonscale)
+            assert_image_similar(transformed, im, epsilon * epsilonscale)
 
     def test_resize_1_1x(self):
         self._test_resize(1.1, 6.9)
@@ -277,7 +277,7 @@ class TestImageTransformAffine(PillowTestCase):
             transformed = transformed.transform(
                 im.size, self.transform, matrix_down, resample
             )
-            self.assert_image_similar(transformed, im, epsilon * epsilonscale)
+            assert_image_similar(transformed, im, epsilon * epsilonscale)
 
     def test_translate_0_1(self):
         self._test_translate(0.1, 0, 3.7)

--- a/Tests/test_image_transpose.py
+++ b/Tests/test_image_transpose.py
@@ -9,7 +9,7 @@ from PIL.Image import (
 )
 
 from . import helper
-from .helper import PillowTestCase
+from .helper import PillowTestCase, assert_image_equal
 
 
 class TestImageTranspose(PillowTestCase):
@@ -138,22 +138,22 @@ class TestImageTranspose(PillowTestCase):
             def transpose(first, second):
                 return im.transpose(first).transpose(second)
 
-            self.assert_image_equal(im, transpose(FLIP_LEFT_RIGHT, FLIP_LEFT_RIGHT))
-            self.assert_image_equal(im, transpose(FLIP_TOP_BOTTOM, FLIP_TOP_BOTTOM))
-            self.assert_image_equal(im, transpose(ROTATE_90, ROTATE_270))
-            self.assert_image_equal(im, transpose(ROTATE_180, ROTATE_180))
-            self.assert_image_equal(
+            assert_image_equal(im, transpose(FLIP_LEFT_RIGHT, FLIP_LEFT_RIGHT))
+            assert_image_equal(im, transpose(FLIP_TOP_BOTTOM, FLIP_TOP_BOTTOM))
+            assert_image_equal(im, transpose(ROTATE_90, ROTATE_270))
+            assert_image_equal(im, transpose(ROTATE_180, ROTATE_180))
+            assert_image_equal(
                 im.transpose(TRANSPOSE), transpose(ROTATE_90, FLIP_TOP_BOTTOM)
             )
-            self.assert_image_equal(
+            assert_image_equal(
                 im.transpose(TRANSPOSE), transpose(ROTATE_270, FLIP_LEFT_RIGHT)
             )
-            self.assert_image_equal(
+            assert_image_equal(
                 im.transpose(TRANSVERSE), transpose(ROTATE_90, FLIP_LEFT_RIGHT)
             )
-            self.assert_image_equal(
+            assert_image_equal(
                 im.transpose(TRANSVERSE), transpose(ROTATE_270, FLIP_TOP_BOTTOM)
             )
-            self.assert_image_equal(
+            assert_image_equal(
                 im.transpose(TRANSVERSE), transpose(ROTATE_180, TRANSPOSE)
             )

--- a/Tests/test_imagechops.py
+++ b/Tests/test_imagechops.py
@@ -1,6 +1,6 @@
 from PIL import Image, ImageChops
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 
 BLACK = (0, 0, 0)
 BROWN = (127, 64, 0)
@@ -132,7 +132,7 @@ class TestImageChops(PillowTestCase):
                 new = ImageChops.darker(im1, im2)
 
                 # Assert
-                self.assert_image_equal(new, im2)
+                assert_image_equal(new, im2)
 
     def test_darker_pixel(self):
         # Arrange
@@ -175,7 +175,7 @@ class TestImageChops(PillowTestCase):
         new = ImageChops.duplicate(im)
 
         # Assert
-        self.assert_image_equal(new, im)
+        assert_image_equal(new, im)
 
     def test_invert(self):
         # Arrange
@@ -198,7 +198,7 @@ class TestImageChops(PillowTestCase):
                 new = ImageChops.lighter(im1, im2)
 
         # Assert
-        self.assert_image_equal(new, im1)
+        assert_image_equal(new, im1)
 
     def test_lighter_pixel(self):
         # Arrange
@@ -222,7 +222,7 @@ class TestImageChops(PillowTestCase):
         new = ImageChops.multiply(im1, black)
 
         # Assert
-        self.assert_image_equal(new, black)
+        assert_image_equal(new, black)
 
     def test_multiply_green(self):
         # Arrange
@@ -248,7 +248,7 @@ class TestImageChops(PillowTestCase):
         new = ImageChops.multiply(im1, white)
 
         # Assert
-        self.assert_image_equal(new, im1)
+        assert_image_equal(new, im1)
 
     def test_offset(self):
         # Arrange

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -2,6 +2,7 @@ import datetime
 import os
 from io import BytesIO
 
+import pytest
 from PIL import Image, ImageMode
 
 from .helper import (
@@ -447,7 +448,7 @@ class TestImageCms(PillowTestCase):
         p = o.profile
 
         def helper_deprecated(attr, expected):
-            result = self.assert_warning(DeprecationWarning, getattr, p, attr)
+            result = pytest.warns(DeprecationWarning, getattr, p, attr)
             self.assertEqual(result, expected)
 
         # p.color_space

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -4,7 +4,13 @@ from io import BytesIO
 
 from PIL import Image, ImageMode
 
-from .helper import PillowTestCase, hopper
+from .helper import (
+    PillowTestCase,
+    assert_image,
+    assert_image_equal,
+    assert_image_similar,
+    hopper,
+)
 
 try:
     from PIL import ImageCms
@@ -48,32 +54,32 @@ class TestImageCms(PillowTestCase):
 
         self.skip_missing()
         i = ImageCms.profileToProfile(hopper(), SRGB, SRGB)
-        self.assert_image(i, "RGB", (128, 128))
+        assert_image(i, "RGB", (128, 128))
 
         i = hopper()
         ImageCms.profileToProfile(i, SRGB, SRGB, inPlace=True)
-        self.assert_image(i, "RGB", (128, 128))
+        assert_image(i, "RGB", (128, 128))
 
         t = ImageCms.buildTransform(SRGB, SRGB, "RGB", "RGB")
         i = ImageCms.applyTransform(hopper(), t)
-        self.assert_image(i, "RGB", (128, 128))
+        assert_image(i, "RGB", (128, 128))
 
         with hopper() as i:
             t = ImageCms.buildTransform(SRGB, SRGB, "RGB", "RGB")
             ImageCms.applyTransform(hopper(), t, inPlace=True)
-            self.assert_image(i, "RGB", (128, 128))
+            assert_image(i, "RGB", (128, 128))
 
         p = ImageCms.createProfile("sRGB")
         o = ImageCms.getOpenProfile(SRGB)
         t = ImageCms.buildTransformFromOpenProfiles(p, o, "RGB", "RGB")
         i = ImageCms.applyTransform(hopper(), t)
-        self.assert_image(i, "RGB", (128, 128))
+        assert_image(i, "RGB", (128, 128))
 
         t = ImageCms.buildProofTransform(SRGB, SRGB, SRGB, "RGB", "RGB")
         self.assertEqual(t.inputMode, "RGB")
         self.assertEqual(t.outputMode, "RGB")
         i = ImageCms.applyTransform(hopper(), t)
-        self.assert_image(i, "RGB", (128, 128))
+        assert_image(i, "RGB", (128, 128))
 
         # test PointTransform convenience API
         hopper().point(t)
@@ -225,12 +231,12 @@ class TestImageCms(PillowTestCase):
         # findLCMSType, and have that mapping work back to a PIL mode
         # (likely RGB).
         i = ImageCms.applyTransform(hopper(), t)
-        self.assert_image(i, "LAB", (128, 128))
+        assert_image(i, "LAB", (128, 128))
 
         # i.save('temp.lab.tif')  # visually verified vs PS.
 
         with Image.open("Tests/images/hopper.Lab.tif") as target:
-            self.assert_image_similar(i, target, 3.5)
+            assert_image_similar(i, target, 3.5)
 
     def test_lab_srgb(self):
         psRGB = ImageCms.createProfile("sRGB")
@@ -242,7 +248,7 @@ class TestImageCms(PillowTestCase):
 
         # img_srgb.save('temp.srgb.tif') # visually verified vs ps.
 
-        self.assert_image_similar(hopper(), img_srgb, 30)
+        assert_image_similar(hopper(), img_srgb, 30)
         self.assertTrue(img_srgb.info["icc_profile"])
 
         profile = ImageCmsProfile(BytesIO(img_srgb.info["icc_profile"]))
@@ -262,7 +268,7 @@ class TestImageCms(PillowTestCase):
 
         out = ImageCms.applyTransform(i, t2)
 
-        self.assert_image_similar(hopper(), out, 2)
+        assert_image_similar(hopper(), out, 2)
 
     def test_profile_tobytes(self):
         with Image.open("Tests/images/rgb.jpg") as i:
@@ -532,7 +538,7 @@ class TestImageCms(PillowTestCase):
             result_image = ImageCms.applyTransform(source_image, t, inPlace=False)
         result_image_aux = result_image.getchannel(preserved_channel)
 
-        self.assert_image_equal(source_image_aux, result_image_aux)
+        assert_image_equal(source_image_aux, result_image_aux)
 
     def test_preserve_auxiliary_channels_rgba(self):
         self.assert_aux_channel_preserved(
@@ -602,6 +608,6 @@ class TestImageCms(PillowTestCase):
                         source_image.convert(src_format[2]), reference_transform
                     )
 
-                    self.assert_image_equal(
+                    assert_image_equal(
                         test_image.convert(dst_format[2]), reference_image
                     )

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -3,7 +3,7 @@ import unittest
 
 from PIL import Image, ImageColor, ImageDraw, ImageFont, features
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, assert_image_similar, hopper
 
 BLACK = (0, 0, 0)
 WHITE = (255, 255, 255)
@@ -65,7 +65,7 @@ class TestImageDraw(PillowTestCase):
         draw.arc(bbox, start, end)
 
         # Assert
-        self.assert_image_similar(im, Image.open("Tests/images/imagedraw_arc.png"), 1)
+        assert_image_similar(im, Image.open("Tests/images/imagedraw_arc.png"), 1)
 
     def test_arc1(self):
         self.helper_arc(BBOX1, 0, 180)
@@ -86,7 +86,7 @@ class TestImageDraw(PillowTestCase):
         draw.arc(BBOX1, start=start, end=end)
 
         # Assert
-        self.assert_image_equal(
+        assert_image_equal(
             im, Image.open("Tests/images/imagedraw_arc_end_le_start.png")
         )
 
@@ -102,7 +102,7 @@ class TestImageDraw(PillowTestCase):
         draw.arc(BBOX1, start=start, end=end)
 
         # Assert
-        self.assert_image_similar(
+        assert_image_similar(
             im, Image.open("Tests/images/imagedraw_arc_no_loops.png"), 1
         )
 
@@ -116,7 +116,7 @@ class TestImageDraw(PillowTestCase):
         draw.arc(BBOX1, 10, 260, width=5)
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 1)
+        assert_image_similar(im, Image.open(expected), 1)
 
     def test_arc_width_pieslice_large(self):
         # Tests an arc with a large enough width that it is a pieslice
@@ -129,7 +129,7 @@ class TestImageDraw(PillowTestCase):
         draw.arc(BBOX1, 10, 260, fill="yellow", width=100)
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 1)
+        assert_image_similar(im, Image.open(expected), 1)
 
     def test_arc_width_fill(self):
         # Arrange
@@ -141,7 +141,7 @@ class TestImageDraw(PillowTestCase):
         draw.arc(BBOX1, 10, 260, fill="yellow", width=5)
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 1)
+        assert_image_similar(im, Image.open(expected), 1)
 
     def test_arc_width_non_whole_angle(self):
         # Arrange
@@ -153,7 +153,7 @@ class TestImageDraw(PillowTestCase):
         draw.arc(BBOX1, 10, 259.5, width=5)
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 1)
+        assert_image_similar(im, Image.open(expected), 1)
 
     def test_bitmap(self):
         # Arrange
@@ -166,7 +166,7 @@ class TestImageDraw(PillowTestCase):
             draw.bitmap((10, 10), small)
 
         # Assert
-        self.assert_image_equal(im, Image.open("Tests/images/imagedraw_bitmap.png"))
+        assert_image_equal(im, Image.open("Tests/images/imagedraw_bitmap.png"))
 
     def helper_chord(self, mode, bbox, start, end):
         # Arrange
@@ -178,7 +178,7 @@ class TestImageDraw(PillowTestCase):
         draw.chord(bbox, start, end, fill="red", outline="yellow")
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 1)
+        assert_image_similar(im, Image.open(expected), 1)
 
     def test_chord1(self):
         for mode in ["RGB", "L"]:
@@ -200,7 +200,7 @@ class TestImageDraw(PillowTestCase):
         draw.chord(BBOX1, 10, 260, outline="yellow", width=5)
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 1)
+        assert_image_similar(im, Image.open(expected), 1)
 
     def test_chord_width_fill(self):
         # Arrange
@@ -212,7 +212,7 @@ class TestImageDraw(PillowTestCase):
         draw.chord(BBOX1, 10, 260, fill="red", outline="yellow", width=5)
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 1)
+        assert_image_similar(im, Image.open(expected), 1)
 
     def helper_ellipse(self, mode, bbox):
         # Arrange
@@ -224,7 +224,7 @@ class TestImageDraw(PillowTestCase):
         draw.ellipse(bbox, fill="green", outline="blue")
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 1)
+        assert_image_similar(im, Image.open(expected), 1)
 
     def test_ellipse1(self):
         for mode in ["RGB", "L"]:
@@ -243,7 +243,7 @@ class TestImageDraw(PillowTestCase):
         draw.ellipse(((0, 0), (W - 1, H)), fill="white")
 
         # Assert
-        self.assert_image_similar(
+        assert_image_similar(
             im, Image.open("Tests/images/imagedraw_ellipse_edge.png"), 1
         )
 
@@ -252,7 +252,7 @@ class TestImageDraw(PillowTestCase):
             im = Image.new("RGB", (101, 101))
             draw = ImageDraw.Draw(im)
             draw.ellipse(bbox, fill="green", outline="blue")
-            self.assert_image_equal(im, im.transpose(Image.FLIP_LEFT_RIGHT))
+            assert_image_equal(im, im.transpose(Image.FLIP_LEFT_RIGHT))
 
     def test_ellipse_width(self):
         # Arrange
@@ -264,7 +264,7 @@ class TestImageDraw(PillowTestCase):
         draw.ellipse(BBOX1, outline="blue", width=5)
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 1)
+        assert_image_similar(im, Image.open(expected), 1)
 
     def test_ellipse_width_large(self):
         # Arrange
@@ -276,7 +276,7 @@ class TestImageDraw(PillowTestCase):
         draw.ellipse((25, 25, 475, 475), outline="blue", width=75)
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 1)
+        assert_image_similar(im, Image.open(expected), 1)
 
     def test_ellipse_width_fill(self):
         # Arrange
@@ -288,7 +288,7 @@ class TestImageDraw(PillowTestCase):
         draw.ellipse(BBOX1, fill="green", outline="blue", width=5)
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 1)
+        assert_image_similar(im, Image.open(expected), 1)
 
     def helper_line(self, points):
         # Arrange
@@ -299,7 +299,7 @@ class TestImageDraw(PillowTestCase):
         draw.line(points, fill="yellow", width=2)
 
         # Assert
-        self.assert_image_equal(im, Image.open("Tests/images/imagedraw_line.png"))
+        assert_image_equal(im, Image.open("Tests/images/imagedraw_line.png"))
 
     def test_line1(self):
         self.helper_line(POINTS1)
@@ -325,7 +325,7 @@ class TestImageDraw(PillowTestCase):
         draw.shape(s, fill=1)
 
         # Assert
-        self.assert_image_equal(im, Image.open("Tests/images/imagedraw_shape1.png"))
+        assert_image_equal(im, Image.open("Tests/images/imagedraw_shape1.png"))
 
     def test_shape2(self):
         # Arrange
@@ -345,7 +345,7 @@ class TestImageDraw(PillowTestCase):
         draw.shape(s, outline="blue")
 
         # Assert
-        self.assert_image_equal(im, Image.open("Tests/images/imagedraw_shape2.png"))
+        assert_image_equal(im, Image.open("Tests/images/imagedraw_shape2.png"))
 
     def helper_pieslice(self, bbox, start, end):
         # Arrange
@@ -356,9 +356,7 @@ class TestImageDraw(PillowTestCase):
         draw.pieslice(bbox, start, end, fill="white", outline="blue")
 
         # Assert
-        self.assert_image_similar(
-            im, Image.open("Tests/images/imagedraw_pieslice.png"), 1
-        )
+        assert_image_similar(im, Image.open("Tests/images/imagedraw_pieslice.png"), 1)
 
     def test_pieslice1(self):
         self.helper_pieslice(BBOX1, -90, 45)
@@ -378,7 +376,7 @@ class TestImageDraw(PillowTestCase):
         draw.pieslice(BBOX1, 10, 260, outline="blue", width=5)
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 1)
+        assert_image_similar(im, Image.open(expected), 1)
 
     def test_pieslice_width_fill(self):
         # Arrange
@@ -390,7 +388,7 @@ class TestImageDraw(PillowTestCase):
         draw.pieslice(BBOX1, 10, 260, fill="white", outline="blue", width=5)
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 1)
+        assert_image_similar(im, Image.open(expected), 1)
 
     def helper_point(self, points):
         # Arrange
@@ -401,7 +399,7 @@ class TestImageDraw(PillowTestCase):
         draw.point(points, fill="yellow")
 
         # Assert
-        self.assert_image_equal(im, Image.open("Tests/images/imagedraw_point.png"))
+        assert_image_equal(im, Image.open("Tests/images/imagedraw_point.png"))
 
     def test_point1(self):
         self.helper_point(POINTS1)
@@ -418,7 +416,7 @@ class TestImageDraw(PillowTestCase):
         draw.polygon(points, fill="red", outline="blue")
 
         # Assert
-        self.assert_image_equal(im, Image.open("Tests/images/imagedraw_polygon.png"))
+        assert_image_equal(im, Image.open("Tests/images/imagedraw_polygon.png"))
 
     def test_polygon1(self):
         self.helper_polygon(POINTS1)
@@ -439,7 +437,7 @@ class TestImageDraw(PillowTestCase):
             draw.polygon(KITE_POINTS, fill="blue", outline="yellow")
 
             # Assert
-            self.assert_image_equal(im, Image.open(expected))
+            assert_image_equal(im, Image.open(expected))
 
     def helper_rectangle(self, bbox):
         # Arrange
@@ -450,7 +448,7 @@ class TestImageDraw(PillowTestCase):
         draw.rectangle(bbox, fill="black", outline="green")
 
         # Assert
-        self.assert_image_equal(im, Image.open("Tests/images/imagedraw_rectangle.png"))
+        assert_image_equal(im, Image.open("Tests/images/imagedraw_rectangle.png"))
 
     def test_rectangle1(self):
         self.helper_rectangle(BBOX1)
@@ -470,7 +468,7 @@ class TestImageDraw(PillowTestCase):
         draw.rectangle(bbox, fill="orange")
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 1)
+        assert_image_similar(im, Image.open(expected), 1)
 
     def test_rectangle_width(self):
         # Arrange
@@ -482,7 +480,7 @@ class TestImageDraw(PillowTestCase):
         draw.rectangle(BBOX1, outline="green", width=5)
 
         # Assert
-        self.assert_image_equal(im, Image.open(expected))
+        assert_image_equal(im, Image.open(expected))
 
     def test_rectangle_width_fill(self):
         # Arrange
@@ -494,7 +492,7 @@ class TestImageDraw(PillowTestCase):
         draw.rectangle(BBOX1, fill="blue", outline="green", width=5)
 
         # Assert
-        self.assert_image_equal(im, Image.open(expected))
+        assert_image_equal(im, Image.open(expected))
 
     def test_rectangle_I16(self):
         # Arrange
@@ -505,7 +503,7 @@ class TestImageDraw(PillowTestCase):
         draw.rectangle(BBOX1, fill="black", outline="green")
 
         # Assert
-        self.assert_image_equal(
+        assert_image_equal(
             im.convert("I"), Image.open("Tests/images/imagedraw_rectangle_I.png")
         )
 
@@ -525,20 +523,20 @@ class TestImageDraw(PillowTestCase):
             # Assert
             expected = "Tests/images/imagedraw_floodfill_" + mode + ".png"
             with Image.open(expected) as im_floodfill:
-                self.assert_image_equal(im, im_floodfill)
+                assert_image_equal(im, im_floodfill)
 
         # Test that using the same colour does not change the image
         ImageDraw.floodfill(im, centre_point, red)
-        self.assert_image_equal(im, im_floodfill)
+        assert_image_equal(im, im_floodfill)
 
         # Test that filling outside the image does not change the image
         ImageDraw.floodfill(im, (W, H), red)
-        self.assert_image_equal(im, im_floodfill)
+        assert_image_equal(im, im_floodfill)
 
         # Test filling at the edge of an image
         im = Image.new("RGB", (1, 1))
         ImageDraw.floodfill(im, (0, 0), red)
-        self.assert_image_equal(im, Image.new("RGB", (1, 1), red))
+        assert_image_equal(im, Image.new("RGB", (1, 1), red))
 
     def test_floodfill_border(self):
         # floodfill() is experimental
@@ -558,7 +556,7 @@ class TestImageDraw(PillowTestCase):
         )
 
         # Assert
-        self.assert_image_equal(im, Image.open("Tests/images/imagedraw_floodfill2.png"))
+        assert_image_equal(im, Image.open("Tests/images/imagedraw_floodfill2.png"))
 
     def test_floodfill_thresh(self):
         # floodfill() is experimental
@@ -573,7 +571,7 @@ class TestImageDraw(PillowTestCase):
         ImageDraw.floodfill(im, centre_point, ImageColor.getrgb("red"), thresh=30)
 
         # Assert
-        self.assert_image_equal(im, Image.open("Tests/images/imagedraw_floodfill2.png"))
+        assert_image_equal(im, Image.open("Tests/images/imagedraw_floodfill2.png"))
 
     def test_floodfill_not_negative(self):
         # floodfill() is experimental
@@ -589,7 +587,7 @@ class TestImageDraw(PillowTestCase):
         ImageDraw.floodfill(im, (int(W / 4), int(H / 4)), ImageColor.getrgb("red"))
 
         # Assert
-        self.assert_image_equal(
+        assert_image_equal(
             im, Image.open("Tests/images/imagedraw_floodfill_not_negative.png")
         )
 
@@ -608,25 +606,23 @@ class TestImageDraw(PillowTestCase):
             expected.load()
             img, draw = self.create_base_image_draw((10, 10))
             draw.polygon([(2, 2), (2, 7), (7, 7), (7, 2)], BLACK)
-            self.assert_image_equal(img, expected, "square as normal polygon failed")
+            assert_image_equal(img, expected, "square as normal polygon failed")
             img, draw = self.create_base_image_draw((10, 10))
             draw.polygon([(7, 7), (7, 2), (2, 2), (2, 7)], BLACK)
-            self.assert_image_equal(img, expected, "square as inverted polygon failed")
+            assert_image_equal(img, expected, "square as inverted polygon failed")
             img, draw = self.create_base_image_draw((10, 10))
             draw.rectangle((2, 2, 7, 7), BLACK)
-            self.assert_image_equal(img, expected, "square as normal rectangle failed")
+            assert_image_equal(img, expected, "square as normal rectangle failed")
             img, draw = self.create_base_image_draw((10, 10))
             draw.rectangle((7, 7, 2, 2), BLACK)
-            self.assert_image_equal(
-                img, expected, "square as inverted rectangle failed"
-            )
+            assert_image_equal(img, expected, "square as inverted rectangle failed")
 
     def test_triangle_right(self):
         with Image.open(os.path.join(IMAGES_PATH, "triangle_right.png")) as expected:
             expected.load()
             img, draw = self.create_base_image_draw((20, 20))
             draw.polygon([(3, 5), (17, 5), (10, 12)], BLACK)
-            self.assert_image_equal(img, expected, "triangle right failed")
+            assert_image_equal(img, expected, "triangle right failed")
 
     def test_line_horizontal(self):
         with Image.open(
@@ -635,7 +631,7 @@ class TestImageDraw(PillowTestCase):
             expected.load()
             img, draw = self.create_base_image_draw((20, 20))
             draw.line((5, 5, 14, 5), BLACK, 2)
-            self.assert_image_equal(
+            assert_image_equal(
                 img, expected, "line straight horizontal normal 2px wide failed"
             )
         with Image.open(
@@ -644,7 +640,7 @@ class TestImageDraw(PillowTestCase):
             expected.load()
             img, draw = self.create_base_image_draw((20, 20))
             draw.line((14, 5, 5, 5), BLACK, 2)
-            self.assert_image_equal(
+            assert_image_equal(
                 img, expected, "line straight horizontal inverted 2px wide failed"
             )
         with Image.open(
@@ -653,12 +649,12 @@ class TestImageDraw(PillowTestCase):
             expected.load()
             img, draw = self.create_base_image_draw((20, 20))
             draw.line((5, 5, 14, 5), BLACK, 3)
-            self.assert_image_equal(
+            assert_image_equal(
                 img, expected, "line straight horizontal normal 3px wide failed"
             )
             img, draw = self.create_base_image_draw((20, 20))
             draw.line((14, 5, 5, 5), BLACK, 3)
-            self.assert_image_equal(
+            assert_image_equal(
                 img, expected, "line straight horizontal inverted 3px wide failed"
             )
         with Image.open(
@@ -667,7 +663,7 @@ class TestImageDraw(PillowTestCase):
             expected.load()
             img, draw = self.create_base_image_draw((200, 110))
             draw.line((5, 55, 195, 55), BLACK, 101)
-            self.assert_image_equal(
+            assert_image_equal(
                 img, expected, "line straight horizontal 101px wide failed"
             )
 
@@ -679,7 +675,7 @@ class TestImageDraw(PillowTestCase):
             expected.load()
             img, draw = self.create_base_image_draw((20, 20))
             draw.line((5, 5, 14, 6), BLACK, 2)
-            self.assert_image_equal(
+            assert_image_equal(
                 img, expected, "line horizontal 1px slope 2px wide failed"
             )
 
@@ -690,7 +686,7 @@ class TestImageDraw(PillowTestCase):
             expected.load()
             img, draw = self.create_base_image_draw((20, 20))
             draw.line((5, 5, 5, 14), BLACK, 2)
-            self.assert_image_equal(
+            assert_image_equal(
                 img, expected, "line straight vertical normal 2px wide failed"
             )
         with Image.open(
@@ -699,7 +695,7 @@ class TestImageDraw(PillowTestCase):
             expected.load()
             img, draw = self.create_base_image_draw((20, 20))
             draw.line((5, 14, 5, 5), BLACK, 2)
-            self.assert_image_equal(
+            assert_image_equal(
                 img, expected, "line straight vertical inverted 2px wide failed"
             )
         with Image.open(
@@ -708,12 +704,12 @@ class TestImageDraw(PillowTestCase):
             expected.load()
             img, draw = self.create_base_image_draw((20, 20))
             draw.line((5, 5, 5, 14), BLACK, 3)
-            self.assert_image_equal(
+            assert_image_equal(
                 img, expected, "line straight vertical normal 3px wide failed"
             )
             img, draw = self.create_base_image_draw((20, 20))
             draw.line((5, 14, 5, 5), BLACK, 3)
-            self.assert_image_equal(
+            assert_image_equal(
                 img, expected, "line straight vertical inverted 3px wide failed"
             )
         with Image.open(
@@ -722,7 +718,7 @@ class TestImageDraw(PillowTestCase):
             expected.load()
             img, draw = self.create_base_image_draw((110, 200))
             draw.line((55, 5, 55, 195), BLACK, 101)
-            self.assert_image_equal(
+            assert_image_equal(
                 img, expected, "line straight vertical 101px wide failed"
             )
         with Image.open(
@@ -731,9 +727,7 @@ class TestImageDraw(PillowTestCase):
             expected.load()
             img, draw = self.create_base_image_draw((20, 20))
             draw.line((5, 5, 6, 14), BLACK, 2)
-            self.assert_image_equal(
-                img, expected, "line vertical 1px slope 2px wide failed"
-            )
+            assert_image_equal(img, expected, "line vertical 1px slope 2px wide failed")
 
     def test_line_oblique_45(self):
         with Image.open(
@@ -742,12 +736,12 @@ class TestImageDraw(PillowTestCase):
             expected.load()
             img, draw = self.create_base_image_draw((20, 20))
             draw.line((5, 5, 14, 14), BLACK, 3)
-            self.assert_image_equal(
+            assert_image_equal(
                 img, expected, "line oblique 45 normal 3px wide A failed"
             )
             img, draw = self.create_base_image_draw((20, 20))
             draw.line((14, 14, 5, 5), BLACK, 3)
-            self.assert_image_equal(
+            assert_image_equal(
                 img, expected, "line oblique 45 inverted 3px wide A failed"
             )
         with Image.open(
@@ -756,12 +750,12 @@ class TestImageDraw(PillowTestCase):
             expected.load()
             img, draw = self.create_base_image_draw((20, 20))
             draw.line((14, 5, 5, 14), BLACK, 3)
-            self.assert_image_equal(
+            assert_image_equal(
                 img, expected, "line oblique 45 normal 3px wide B failed"
             )
             img, draw = self.create_base_image_draw((20, 20))
             draw.line((5, 14, 14, 5), BLACK, 3)
-            self.assert_image_equal(
+            assert_image_equal(
                 img, expected, "line oblique 45 inverted 3px wide B failed"
             )
 
@@ -777,7 +771,7 @@ class TestImageDraw(PillowTestCase):
         draw.line([(50, 50), (50, 50)], width=3)
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 1)
+        assert_image_similar(im, Image.open(expected), 1)
 
     def test_line_joint(self):
         im = Image.new("RGB", (500, 325))
@@ -804,7 +798,7 @@ class TestImageDraw(PillowTestCase):
         draw.line(xy, GRAY, 50, "curve")
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 3)
+        assert_image_similar(im, Image.open(expected), 3)
 
     def test_textsize_empty_string(self):
         # https://github.com/python-pillow/Pillow/issues/2783
@@ -846,7 +840,7 @@ class TestImageDraw(PillowTestCase):
             )
 
             # Assert
-            self.assert_image_similar(
+            assert_image_similar(
                 im, Image.open("Tests/images/imagedraw_stroke_" + suffix + ".png"), 3.1
             )
 
@@ -863,7 +857,7 @@ class TestImageDraw(PillowTestCase):
         )
 
         # Assert
-        self.assert_image_similar(
+        assert_image_similar(
             im, Image.open("Tests/images/imagedraw_stroke_multiline.png"), 3.3
         )
 
@@ -903,4 +897,4 @@ class TestImageDraw(PillowTestCase):
                     expected = "Tests/images/imagedraw_outline_{}_{}.png".format(
                         operation, mode
                     )
-                    self.assert_image_similar(im, Image.open(expected), 1)
+                    assert_image_similar(im, Image.open(expected), 1)

--- a/Tests/test_imagedraw2.py
+++ b/Tests/test_imagedraw2.py
@@ -3,7 +3,7 @@ import unittest
 
 from PIL import Image, ImageDraw2, features
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, assert_image_similar, hopper
 
 BLACK = (0, 0, 0)
 WHITE = (255, 255, 255)
@@ -60,7 +60,7 @@ class TestImageDraw(PillowTestCase):
         draw.ellipse(bbox, pen, brush)
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 1)
+        assert_image_similar(im, Image.open(expected), 1)
 
     def test_ellipse1(self):
         self.helper_ellipse("RGB", BBOX1)
@@ -78,7 +78,7 @@ class TestImageDraw(PillowTestCase):
         draw.ellipse(((0, 0), (W - 1, H)), brush)
 
         # Assert
-        self.assert_image_similar(
+        assert_image_similar(
             im, Image.open("Tests/images/imagedraw_ellipse_edge.png"), 1
         )
 
@@ -92,7 +92,7 @@ class TestImageDraw(PillowTestCase):
         draw.line(points, pen)
 
         # Assert
-        self.assert_image_equal(im, Image.open("Tests/images/imagedraw_line.png"))
+        assert_image_equal(im, Image.open("Tests/images/imagedraw_line.png"))
 
     def test_line1_pen(self):
         self.helper_line(POINTS1)
@@ -112,7 +112,7 @@ class TestImageDraw(PillowTestCase):
         draw.line(POINTS1, pen, brush)
 
         # Assert
-        self.assert_image_equal(im, Image.open("Tests/images/imagedraw_line.png"))
+        assert_image_equal(im, Image.open("Tests/images/imagedraw_line.png"))
 
     def helper_polygon(self, points):
         # Arrange
@@ -125,7 +125,7 @@ class TestImageDraw(PillowTestCase):
         draw.polygon(points, pen, brush)
 
         # Assert
-        self.assert_image_equal(im, Image.open("Tests/images/imagedraw_polygon.png"))
+        assert_image_equal(im, Image.open("Tests/images/imagedraw_polygon.png"))
 
     def test_polygon1(self):
         self.helper_polygon(POINTS1)
@@ -144,7 +144,7 @@ class TestImageDraw(PillowTestCase):
         draw.rectangle(bbox, pen, brush)
 
         # Assert
-        self.assert_image_equal(im, Image.open("Tests/images/imagedraw_rectangle.png"))
+        assert_image_equal(im, Image.open("Tests/images/imagedraw_rectangle.png"))
 
     def test_rectangle1(self):
         self.helper_rectangle(BBOX1)
@@ -165,7 +165,7 @@ class TestImageDraw(PillowTestCase):
         draw.rectangle(bbox, brush)
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 1)
+        assert_image_similar(im, Image.open(expected), 1)
 
     @unittest.skipUnless(HAS_FREETYPE, "ImageFont not available")
     def test_text(self):
@@ -179,7 +179,7 @@ class TestImageDraw(PillowTestCase):
         draw.text((5, 5), "ImageDraw2", font)
 
         # Assert
-        self.assert_image_similar(im, Image.open(expected), 13)
+        assert_image_similar(im, Image.open(expected), 13)
 
     @unittest.skipUnless(HAS_FREETYPE, "ImageFont not available")
     def test_textsize(self):
@@ -220,4 +220,4 @@ class TestImageDraw(PillowTestCase):
         im2 = draw.flush()
 
         # Assert
-        self.assert_image_equal(im, im2)
+        assert_image_equal(im, im2)

--- a/Tests/test_imageenhance.py
+++ b/Tests/test_imageenhance.py
@@ -1,6 +1,6 @@
 from PIL import Image, ImageEnhance
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 
 
 class TestImageEnhance(PillowTestCase):
@@ -32,7 +32,7 @@ class TestImageEnhance(PillowTestCase):
 
     def _check_alpha(self, im, original, op, amount):
         self.assertEqual(im.getbands(), original.getbands())
-        self.assert_image_equal(
+        assert_image_equal(
             im.getchannel("A"),
             original.getchannel("A"),
             "Diff on {}: {}".format(op, amount),

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -3,7 +3,15 @@ from io import BytesIO
 
 from PIL import EpsImagePlugin, Image, ImageFile
 
-from .helper import PillowTestCase, fromstring, hopper, tostring
+from .helper import (
+    PillowTestCase,
+    assert_image,
+    assert_image_equal,
+    assert_image_similar,
+    fromstring,
+    hopper,
+    tostring,
+)
 
 try:
     from PIL import _webp
@@ -40,23 +48,23 @@ class TestImageFile(PillowTestCase):
 
             return im, imOut
 
-        self.assert_image_equal(*roundtrip("BMP"))
+        assert_image_equal(*roundtrip("BMP"))
         im1, im2 = roundtrip("GIF")
-        self.assert_image_similar(im1.convert("P"), im2, 1)
-        self.assert_image_equal(*roundtrip("IM"))
-        self.assert_image_equal(*roundtrip("MSP"))
+        assert_image_similar(im1.convert("P"), im2, 1)
+        assert_image_equal(*roundtrip("IM"))
+        assert_image_equal(*roundtrip("MSP"))
         if "zip_encoder" in codecs:
             try:
                 # force multiple blocks in PNG driver
                 ImageFile.MAXBLOCK = 8192
-                self.assert_image_equal(*roundtrip("PNG"))
+                assert_image_equal(*roundtrip("PNG"))
             finally:
                 ImageFile.MAXBLOCK = MAXBLOCK
-        self.assert_image_equal(*roundtrip("PPM"))
-        self.assert_image_equal(*roundtrip("TIFF"))
-        self.assert_image_equal(*roundtrip("XBM"))
-        self.assert_image_equal(*roundtrip("TGA"))
-        self.assert_image_equal(*roundtrip("PCX"))
+        assert_image_equal(*roundtrip("PPM"))
+        assert_image_equal(*roundtrip("TIFF"))
+        assert_image_equal(*roundtrip("XBM"))
+        assert_image_equal(*roundtrip("TGA"))
+        assert_image_equal(*roundtrip("PCX"))
 
         if EpsImagePlugin.has_ghostscript():
             im1, im2 = roundtrip("EPS")
@@ -67,11 +75,11 @@ class TestImageFile(PillowTestCase):
             # md5sum: ba974835ff2d6f3f2fd0053a23521d4a
 
             # EPS comes back in RGB:
-            self.assert_image_similar(im1, im2.convert("L"), 20)
+            assert_image_similar(im1, im2.convert("L"), 20)
 
         if "jpeg_encoder" in codecs:
             im1, im2 = roundtrip("JPEG")  # lossy compression
-            self.assert_image(im1, im2.mode, im2.size)
+            assert_image(im1, im2.mode, im2.size)
 
         self.assertRaises(IOError, roundtrip, "PDF")
 
@@ -94,7 +102,7 @@ class TestImageFile(PillowTestCase):
         finally:
             ImageFile.SAFEBLOCK = SAFEBLOCK
 
-        self.assert_image_equal(im1, im2)
+        assert_image_equal(im1, im2)
 
     def test_raise_ioerror(self):
         self.assertRaises(IOError, ImageFile.raise_ioerror, 1)

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -9,7 +9,14 @@ from io import BytesIO
 
 from PIL import Image, ImageDraw, ImageFont, features
 
-from .helper import PillowTestCase, is_pypy, is_win32
+from .helper import (
+    PillowTestCase,
+    assert_image_equal,
+    assert_image_similar,
+    assert_image_similar_tofile,
+    is_pypy,
+    is_win32,
+)
 
 FONT_PATH = "Tests/fonts/FreeMono.ttf"
 FONT_SIZE = 20
@@ -166,7 +173,7 @@ class TestImageFont(PillowTestCase):
             font_filelike = BytesIO(f.read())
         img_filelike = self._render(font_filelike)
 
-        self.assert_image_equal(img_path, img_filelike)
+        assert_image_equal(img_path, img_filelike)
 
     def test_textsize_equal(self):
         im = Image.new(mode="RGB", size=(300, 100))
@@ -182,7 +189,7 @@ class TestImageFont(PillowTestCase):
         with Image.open(target) as target_img:
 
             # Epsilon ~.5 fails with FreeType 2.7
-            self.assert_image_similar(im, target_img, self.metrics["textsize"])
+            assert_image_similar(im, target_img, self.metrics["textsize"])
 
     def test_render_multiline(self):
         im = Image.new(mode="RGB", size=(300, 100))
@@ -201,7 +208,7 @@ class TestImageFont(PillowTestCase):
             # some versions of freetype have different horizontal spacing.
             # setting a tight epsilon, I'm showing the original test failure
             # at epsilon = ~38.
-            self.assert_image_similar(im, target_img, self.metrics["multiline"])
+            assert_image_similar(im, target_img, self.metrics["multiline"])
 
     def test_render_multiline_text(self):
         ttf = self.get_font()
@@ -216,7 +223,7 @@ class TestImageFont(PillowTestCase):
         with Image.open(target) as target_img:
 
             # Epsilon ~.5 fails with FreeType 2.7
-            self.assert_image_similar(im, target_img, self.metrics["multiline"])
+            assert_image_similar(im, target_img, self.metrics["multiline"])
 
         # Test that text() can pass on additional arguments
         # to multiline_text()
@@ -235,7 +242,7 @@ class TestImageFont(PillowTestCase):
             with Image.open(target) as target_img:
 
                 # Epsilon ~.5 fails with FreeType 2.7
-                self.assert_image_similar(im, target_img, self.metrics["multiline"])
+                assert_image_similar(im, target_img, self.metrics["multiline"])
 
     def test_unknown_align(self):
         im = Image.new(mode="RGB", size=(300, 100))
@@ -300,7 +307,7 @@ class TestImageFont(PillowTestCase):
         with Image.open(target) as target_img:
 
             # Epsilon ~.5 fails with FreeType 2.7
-            self.assert_image_similar(im, target_img, self.metrics["multiline"])
+            assert_image_similar(im, target_img, self.metrics["multiline"])
 
     def test_rotated_transposed_font(self):
         img_grey = Image.new("L", (100, 100))
@@ -439,7 +446,7 @@ class TestImageFont(PillowTestCase):
             draw.text((10, 10), txt, font=default_font)
 
             # Assert
-            self.assert_image_equal(im, target_img)
+            assert_image_equal(im, target_img)
 
     def test_getsize_empty(self):
         # issue #2614
@@ -455,7 +462,7 @@ class TestImageFont(PillowTestCase):
         draw = ImageDraw.Draw(im)
         # should not crash here.
         draw.text((10, 10), "", font=font)
-        self.assert_image_equal(im, target)
+        assert_image_equal(im, target)
 
     def test_unicode_pilfont(self):
         # should not segfault, should return UnicodeDecodeError
@@ -479,7 +486,7 @@ class TestImageFont(PillowTestCase):
         d = ImageDraw.Draw(img)
         d.text((10, 10), text, font=ttf)
 
-        self.assert_image_similar_tofile(img, target, self.metrics["multiline"])
+        assert_image_similar_tofile(img, target, self.metrics["multiline"])
 
     def _test_fake_loading_font(self, path_to_fake, fontname):
         # Make a copy of FreeTypeFont so we can patch the original
@@ -704,7 +711,7 @@ class TestImageFont(PillowTestCase):
             d.text((10, 10), "Text", font=font, fill="black")
 
             with Image.open(path) as expected:
-                self.assert_image_similar(im, expected, epsilon)
+                assert_image_similar(im, expected, epsilon)
 
         font = ImageFont.truetype("Tests/fonts/AdobeVFPrototype.ttf", 36)
         _check_text(font, "Tests/images/variation_adobe.png", 11)
@@ -734,7 +741,7 @@ class TestImageFont(PillowTestCase):
             d.text((10, 10), "Text", font=font, fill="black")
 
             with Image.open(path) as expected:
-                self.assert_image_similar(im, expected, epsilon)
+                assert_image_similar(im, expected, epsilon)
 
         font = ImageFont.truetype("Tests/fonts/AdobeVFPrototype.ttf", 36)
         font.set_variation_by_axes([500, 50])

--- a/Tests/test_imagefont_bitmap.py
+++ b/Tests/test_imagefont_bitmap.py
@@ -2,7 +2,7 @@ import unittest
 
 from PIL import Image, ImageDraw, ImageFont
 
-from .helper import PillowTestCase
+from .helper import PillowTestCase, assert_image_similar
 
 image_font_installed = True
 try:
@@ -42,4 +42,4 @@ class TestImageFontBitmap(PillowTestCase):
             fill=(0, 0, 0),
             font=font_outline,
         )
-        self.assert_image_similar(im_bitmap, im_outline, 20)
+        assert_image_similar(im_bitmap, im_outline, 20)

--- a/Tests/test_imagefontctl.py
+++ b/Tests/test_imagefontctl.py
@@ -2,7 +2,7 @@ import unittest
 
 from PIL import Image, ImageDraw, ImageFont, features
 
-from .helper import PillowTestCase
+from .helper import PillowTestCase, assert_image_similar
 
 FONT_SIZE = 20
 FONT_PATH = "Tests/fonts/DejaVuSans.ttf"
@@ -26,7 +26,7 @@ class TestImagecomplextext(PillowTestCase):
 
         target = "Tests/images/test_text.png"
         with Image.open(target) as target_img:
-            self.assert_image_similar(im, target_img, 0.5)
+            assert_image_similar(im, target_img, 0.5)
 
     def test_y_offset(self):
         ttf = ImageFont.truetype("Tests/fonts/NotoNastaliqUrdu-Regular.ttf", FONT_SIZE)
@@ -37,7 +37,7 @@ class TestImagecomplextext(PillowTestCase):
 
         target = "Tests/images/test_y_offset.png"
         with Image.open(target) as target_img:
-            self.assert_image_similar(im, target_img, 1.7)
+            assert_image_similar(im, target_img, 1.7)
 
     def test_complex_unicode_text(self):
         ttf = ImageFont.truetype(FONT_PATH, FONT_SIZE)
@@ -48,7 +48,7 @@ class TestImagecomplextext(PillowTestCase):
 
         target = "Tests/images/test_complex_unicode_text.png"
         with Image.open(target) as target_img:
-            self.assert_image_similar(im, target_img, 0.5)
+            assert_image_similar(im, target_img, 0.5)
 
         ttf = ImageFont.truetype("Tests/fonts/KhmerOSBattambang-Regular.ttf", FONT_SIZE)
 
@@ -58,7 +58,7 @@ class TestImagecomplextext(PillowTestCase):
 
         target = "Tests/images/test_complex_unicode_text2.png"
         with Image.open(target) as target_img:
-            self.assert_image_similar(im, target_img, 2.3)
+            assert_image_similar(im, target_img, 2.3)
 
     def test_text_direction_rtl(self):
         ttf = ImageFont.truetype(FONT_PATH, FONT_SIZE)
@@ -69,7 +69,7 @@ class TestImagecomplextext(PillowTestCase):
 
         target = "Tests/images/test_direction_rtl.png"
         with Image.open(target) as target_img:
-            self.assert_image_similar(im, target_img, 0.5)
+            assert_image_similar(im, target_img, 0.5)
 
     def test_text_direction_ltr(self):
         ttf = ImageFont.truetype(FONT_PATH, FONT_SIZE)
@@ -80,7 +80,7 @@ class TestImagecomplextext(PillowTestCase):
 
         target = "Tests/images/test_direction_ltr.png"
         with Image.open(target) as target_img:
-            self.assert_image_similar(im, target_img, 0.5)
+            assert_image_similar(im, target_img, 0.5)
 
     def test_text_direction_rtl2(self):
         ttf = ImageFont.truetype(FONT_PATH, FONT_SIZE)
@@ -91,7 +91,7 @@ class TestImagecomplextext(PillowTestCase):
 
         target = "Tests/images/test_direction_ltr.png"
         with Image.open(target) as target_img:
-            self.assert_image_similar(im, target_img, 0.5)
+            assert_image_similar(im, target_img, 0.5)
 
     def test_text_direction_ttb(self):
         ttf = ImageFont.truetype("Tests/fonts/NotoSansJP-Regular.otf", FONT_SIZE)
@@ -106,7 +106,7 @@ class TestImagecomplextext(PillowTestCase):
 
         target = "Tests/images/test_direction_ttb.png"
         with Image.open(target) as target_img:
-            self.assert_image_similar(im, target_img, 1.15)
+            assert_image_similar(im, target_img, 1.15)
 
     def test_text_direction_ttb_stroke(self):
         ttf = ImageFont.truetype("Tests/fonts/NotoSansJP-Regular.otf", 50)
@@ -129,7 +129,7 @@ class TestImagecomplextext(PillowTestCase):
 
         target = "Tests/images/test_direction_ttb_stroke.png"
         with Image.open(target) as target_img:
-            self.assert_image_similar(im, target_img, 12.4)
+            assert_image_similar(im, target_img, 12.4)
 
     def test_ligature_features(self):
         ttf = ImageFont.truetype(FONT_PATH, FONT_SIZE)
@@ -139,7 +139,7 @@ class TestImagecomplextext(PillowTestCase):
         draw.text((0, 0), "filling", font=ttf, fill=500, features=["-liga"])
         target = "Tests/images/test_ligature_features.png"
         with Image.open(target) as target_img:
-            self.assert_image_similar(im, target_img, 0.5)
+            assert_image_similar(im, target_img, 0.5)
 
         liga_size = ttf.getsize("fi", features=["-liga"])
         self.assertEqual(liga_size, (13, 19))
@@ -153,7 +153,7 @@ class TestImagecomplextext(PillowTestCase):
 
         target = "Tests/images/test_kerning_features.png"
         with Image.open(target) as target_img:
-            self.assert_image_similar(im, target_img, 0.5)
+            assert_image_similar(im, target_img, 0.5)
 
     def test_arabictext_features(self):
         ttf = ImageFont.truetype(FONT_PATH, FONT_SIZE)
@@ -170,7 +170,7 @@ class TestImagecomplextext(PillowTestCase):
 
         target = "Tests/images/test_arabictext_features.png"
         with Image.open(target) as target_img:
-            self.assert_image_similar(im, target_img, 0.5)
+            assert_image_similar(im, target_img, 0.5)
 
     def test_x_max_and_y_offset(self):
         ttf = ImageFont.truetype("Tests/fonts/ArefRuqaa-Regular.ttf", 40)
@@ -181,7 +181,7 @@ class TestImagecomplextext(PillowTestCase):
 
         target = "Tests/images/test_x_max_and_y_offset.png"
         with Image.open(target) as target_img:
-            self.assert_image_similar(im, target_img, 0.5)
+            assert_image_similar(im, target_img, 0.5)
 
     def test_language(self):
         ttf = ImageFont.truetype(FONT_PATH, FONT_SIZE)
@@ -192,4 +192,4 @@ class TestImagecomplextext(PillowTestCase):
 
         target = "Tests/images/test_language.png"
         with Image.open(target) as target_img:
-            self.assert_image_similar(im, target_img, 0.5)
+            assert_image_similar(im, target_img, 0.5)

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -1,7 +1,7 @@
 import subprocess
 import sys
 
-from .helper import PillowTestCase
+from .helper import PillowTestCase, assert_image
 
 try:
     from PIL import ImageGrab
@@ -13,10 +13,10 @@ try:
                 ImageGrab.grab(include_layered_windows=True),
                 ImageGrab.grab(all_screens=True),
             ]:
-                self.assert_image(im, im.mode, im.size)
+                assert_image(im, im.mode, im.size)
 
             im = ImageGrab.grab(bbox=(10, 20, 50, 80))
-            self.assert_image(im, im.mode, (40, 60))
+            assert_image(im, im.mode, (40, 60))
 
         def test_grabclipboard(self):
             if sys.platform == "darwin":
@@ -34,7 +34,7 @@ $bmp = New-Object Drawing.Bitmap 200, 200
                 p.communicate()
 
             im = ImageGrab.grabclipboard()
-            self.assert_image(im, im.mode, im.size)
+            assert_image(im, im.mode, im.size)
 
 
 except ImportError:

--- a/Tests/test_imagemorph.py
+++ b/Tests/test_imagemorph.py
@@ -1,7 +1,7 @@
 # Test the ImageMorphology functionality
 from PIL import Image, ImageMorph, _imagingmorph
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 
 
 class MorphTests(PillowTestCase):
@@ -52,7 +52,7 @@ class MorphTests(PillowTestCase):
 
     def test_str_to_img(self):
         with Image.open("Tests/images/morph_a.png") as im:
-            self.assert_image_equal(self.A, im)
+            assert_image_equal(self.A, im)
 
     def create_lut(self):
         for op in ("corner", "dilation4", "dilation8", "erosion4", "erosion8", "edge"):

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -1,6 +1,12 @@
 from PIL import Image, ImageOps
 
-from .helper import PillowTestCase, hopper
+from .helper import (
+    PillowTestCase,
+    assert_image_equal,
+    assert_image_similar,
+    assert_tuple_approx_equal,
+    hopper,
+)
 
 try:
     from PIL import _webp
@@ -109,7 +115,7 @@ class TestImageOps(PillowTestCase):
                 with Image.open(
                     "Tests/images/imageops_pad_" + label + "_" + str(i) + ".jpg"
                 ) as target:
-                    self.assert_image_similar(new_im, target, 6)
+                    assert_image_similar(new_im, target, 6)
 
     def test_pil163(self):
         # Division by zero in equalize if < 255 pixels in image (@PIL163)
@@ -150,19 +156,19 @@ class TestImageOps(PillowTestCase):
         left = (0, 1)
         middle = (127, 1)
         right = (255, 1)
-        self.assert_tuple_approx_equal(
+        assert_tuple_approx_equal(
             im_test.getpixel(left),
             (255, 0, 0),
             threshold=1,
             msg="black test pixel incorrect",
         )
-        self.assert_tuple_approx_equal(
+        assert_tuple_approx_equal(
             im_test.getpixel(middle),
             (127, 63, 0),
             threshold=1,
             msg="mid test pixel incorrect",
         )
-        self.assert_tuple_approx_equal(
+        assert_tuple_approx_equal(
             im_test.getpixel(right),
             (0, 127, 0),
             threshold=1,
@@ -185,19 +191,19 @@ class TestImageOps(PillowTestCase):
         left = (25, 1)
         middle = (75, 1)
         right = (125, 1)
-        self.assert_tuple_approx_equal(
+        assert_tuple_approx_equal(
             im_test.getpixel(left),
             (255, 0, 0),
             threshold=1,
             msg="black test pixel incorrect",
         )
-        self.assert_tuple_approx_equal(
+        assert_tuple_approx_equal(
             im_test.getpixel(middle),
             (127, 63, 0),
             threshold=1,
             msg="mid test pixel incorrect",
         )
-        self.assert_tuple_approx_equal(
+        assert_tuple_approx_equal(
             im_test.getpixel(right),
             (0, 127, 0),
             threshold=1,
@@ -228,28 +234,28 @@ class TestImageOps(PillowTestCase):
         middle = (100, 1)
         right_middle = (150, 1)
         right = (225, 1)
-        self.assert_tuple_approx_equal(
+        assert_tuple_approx_equal(
             im_test.getpixel(left),
             (255, 0, 0),
             threshold=1,
             msg="black test pixel incorrect",
         )
-        self.assert_tuple_approx_equal(
+        assert_tuple_approx_equal(
             im_test.getpixel(left_middle),
             (127, 0, 127),
             threshold=1,
             msg="low-mid test pixel incorrect",
         )
-        self.assert_tuple_approx_equal(
+        assert_tuple_approx_equal(
             im_test.getpixel(middle), (0, 0, 255), threshold=1, msg="mid incorrect"
         )
-        self.assert_tuple_approx_equal(
+        assert_tuple_approx_equal(
             im_test.getpixel(right_middle),
             (0, 63, 127),
             threshold=1,
             msg="high-mid test pixel incorrect",
         )
-        self.assert_tuple_approx_equal(
+        assert_tuple_approx_equal(
             im_test.getpixel(right),
             (0, 127, 0),
             threshold=1,
@@ -273,7 +279,7 @@ class TestImageOps(PillowTestCase):
                         else:
                             original_exif = im.info["exif"]
                         transposed_im = ImageOps.exif_transpose(im)
-                        self.assert_image_similar(base_im, transposed_im, 17)
+                        assert_image_similar(base_im, transposed_im, 17)
                         if orientation_im is base_im:
                             self.assertNotIn("exif", im.info)
                         else:
@@ -286,7 +292,7 @@ class TestImageOps(PillowTestCase):
                         # Repeat the operation
                         # to test that it does not keep transposing
                         transposed_im2 = ImageOps.exif_transpose(transposed_im)
-                        self.assert_image_equal(transposed_im2, transposed_im)
+                        assert_image_equal(transposed_im2, transposed_im)
 
                 check(base_im)
                 for i in range(2, 9):

--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -1,6 +1,6 @@
 from PIL import Image, ImagePalette
 
-from .helper import PillowTestCase
+from .helper import PillowTestCase, assert_image_equal
 
 
 class TestImagePalette(PillowTestCase):
@@ -129,7 +129,7 @@ class TestImagePalette(PillowTestCase):
         img.save(outfile, format="PNG")
 
         with Image.open(outfile) as reloaded:
-            self.assert_image_equal(img, reloaded)
+            assert_image_equal(img, reloaded)
 
     def test_invalid_palette(self):
         self.assertRaises(IOError, ImagePalette.load, "Tests/images/hopper.jpg")

--- a/Tests/test_imagesequence.py
+++ b/Tests/test_imagesequence.py
@@ -1,6 +1,6 @@
 from PIL import Image, ImageSequence, TiffImagePlugin
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 
 
 class TestImageSequence(PillowTestCase):
@@ -15,7 +15,7 @@ class TestImageSequence(PillowTestCase):
 
         index = 0
         for frame in seq:
-            self.assert_image_equal(im, frame)
+            assert_image_equal(im, frame)
             self.assertEqual(im.tell(), index)
             index += 1
 
@@ -64,7 +64,7 @@ class TestImageSequence(PillowTestCase):
                 if firstFrame is None:
                     firstFrame = frame.copy()
             for frame in ImageSequence.Iterator(im):
-                self.assert_image_equal(frame, firstFrame)
+                assert_image_equal(frame, firstFrame)
                 break
 
     def test_palette_mmap(self):
@@ -85,7 +85,7 @@ class TestImageSequence(PillowTestCase):
                 self.assertFalse(im_frame is im)
 
                 im.seek(i)
-                self.assert_image_equal(im, im_frame)
+                assert_image_equal(im, im_frame)
 
             # Test a series of images
             ims = ImageSequence.all_frames([im, hopper(), im])
@@ -95,4 +95,4 @@ class TestImageSequence(PillowTestCase):
             ims = ImageSequence.all_frames(im, lambda im_frame: im_frame.rotate(90))
             for i, im_frame in enumerate(ims):
                 im.seek(i)
-                self.assert_image_equal(im.rotate(90), im_frame)
+                assert_image_equal(im.rotate(90), im_frame)

--- a/Tests/test_imagetk.py
+++ b/Tests/test_imagetk.py
@@ -2,7 +2,7 @@ import unittest
 
 from PIL import Image
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 
 try:
     from PIL import ImageTk
@@ -39,11 +39,11 @@ class TestImageTk(PillowTestCase):
 
                 # Test "file"
                 im = ImageTk._get_image_from_kw(kw)
-                self.assert_image_equal(im, im1)
+                assert_image_equal(im, im1)
 
                 # Test "data"
                 im = ImageTk._get_image_from_kw(kw)
-                self.assert_image_equal(im, im2)
+                assert_image_equal(im, im2)
 
         # Test no relevant entry
         im = ImageTk._get_image_from_kw(kw)
@@ -61,7 +61,7 @@ class TestImageTk(PillowTestCase):
             self.assertEqual(im_tk.height(), im.height)
 
             reloaded = ImageTk.getimage(im_tk)
-            self.assert_image_equal(reloaded, im.convert("RGBA"))
+            assert_image_equal(reloaded, im.convert("RGBA"))
 
     def test_photoimage_blank(self):
         # test a image using mode/size:
@@ -72,7 +72,7 @@ class TestImageTk(PillowTestCase):
             self.assertEqual(im_tk.height(), 100)
 
             # reloaded = ImageTk.getimage(im_tk)
-            # self.assert_image_equal(reloaded, im)
+            # assert_image_equal(reloaded, im)
 
     def test_bitmapimage(self):
         im = hopper("1")
@@ -84,4 +84,4 @@ class TestImageTk(PillowTestCase):
         self.assertEqual(im_tk.height(), im.height)
 
         # reloaded = ImageTk.getimage(im_tk)
-        # self.assert_image_equal(reloaded, im)
+        # assert_image_equal(reloaded, im)

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -2,7 +2,7 @@ import unittest
 
 from PIL import Image
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_deep_equal, assert_image, hopper
 
 try:
     import numpy
@@ -37,59 +37,59 @@ class TestNumpy(PillowTestCase):
             return i
 
         # Check supported 1-bit integer formats
-        self.assert_image(to_image(numpy.bool, 1, 1), "1", TEST_IMAGE_SIZE)
-        self.assert_image(to_image(numpy.bool8, 1, 1), "1", TEST_IMAGE_SIZE)
+        assert_image(to_image(numpy.bool, 1, 1), "1", TEST_IMAGE_SIZE)
+        assert_image(to_image(numpy.bool8, 1, 1), "1", TEST_IMAGE_SIZE)
 
         # Check supported 8-bit integer formats
-        self.assert_image(to_image(numpy.uint8), "L", TEST_IMAGE_SIZE)
-        self.assert_image(to_image(numpy.uint8, 3), "RGB", TEST_IMAGE_SIZE)
-        self.assert_image(to_image(numpy.uint8, 4), "RGBA", TEST_IMAGE_SIZE)
-        self.assert_image(to_image(numpy.int8), "I", TEST_IMAGE_SIZE)
+        assert_image(to_image(numpy.uint8), "L", TEST_IMAGE_SIZE)
+        assert_image(to_image(numpy.uint8, 3), "RGB", TEST_IMAGE_SIZE)
+        assert_image(to_image(numpy.uint8, 4), "RGBA", TEST_IMAGE_SIZE)
+        assert_image(to_image(numpy.int8), "I", TEST_IMAGE_SIZE)
 
         # Check non-fixed-size integer types
         # These may fail, depending on the platform, since we have no native
         # 64 bit int image types.
-        # self.assert_image(to_image(numpy.uint), "I", TEST_IMAGE_SIZE)
-        # self.assert_image(to_image(numpy.int), "I", TEST_IMAGE_SIZE)
+        # assert_image(to_image(numpy.uint), "I", TEST_IMAGE_SIZE)
+        # assert_image(to_image(numpy.int), "I", TEST_IMAGE_SIZE)
 
         # Check 16-bit integer formats
         if Image._ENDIAN == "<":
-            self.assert_image(to_image(numpy.uint16), "I;16", TEST_IMAGE_SIZE)
+            assert_image(to_image(numpy.uint16), "I;16", TEST_IMAGE_SIZE)
         else:
-            self.assert_image(to_image(numpy.uint16), "I;16B", TEST_IMAGE_SIZE)
+            assert_image(to_image(numpy.uint16), "I;16B", TEST_IMAGE_SIZE)
 
-        self.assert_image(to_image(numpy.int16), "I", TEST_IMAGE_SIZE)
+        assert_image(to_image(numpy.int16), "I", TEST_IMAGE_SIZE)
 
         # Check 32-bit integer formats
-        self.assert_image(to_image(numpy.uint32), "I", TEST_IMAGE_SIZE)
-        self.assert_image(to_image(numpy.int32), "I", TEST_IMAGE_SIZE)
+        assert_image(to_image(numpy.uint32), "I", TEST_IMAGE_SIZE)
+        assert_image(to_image(numpy.int32), "I", TEST_IMAGE_SIZE)
 
         # Check 64-bit integer formats
         self.assertRaises(TypeError, to_image, numpy.uint64)
         self.assertRaises(TypeError, to_image, numpy.int64)
 
         # Check floating-point formats
-        self.assert_image(to_image(numpy.float), "F", TEST_IMAGE_SIZE)
+        assert_image(to_image(numpy.float), "F", TEST_IMAGE_SIZE)
         self.assertRaises(TypeError, to_image, numpy.float16)
-        self.assert_image(to_image(numpy.float32), "F", TEST_IMAGE_SIZE)
-        self.assert_image(to_image(numpy.float64), "F", TEST_IMAGE_SIZE)
+        assert_image(to_image(numpy.float32), "F", TEST_IMAGE_SIZE)
+        assert_image(to_image(numpy.float64), "F", TEST_IMAGE_SIZE)
 
-        self.assert_image(to_image(numpy.uint8, 2), "LA", (10, 10))
-        self.assert_image(to_image(numpy.uint8, 3), "RGB", (10, 10))
-        self.assert_image(to_image(numpy.uint8, 4), "RGBA", (10, 10))
+        assert_image(to_image(numpy.uint8, 2), "LA", (10, 10))
+        assert_image(to_image(numpy.uint8, 3), "RGB", (10, 10))
+        assert_image(to_image(numpy.uint8, 4), "RGBA", (10, 10))
 
     # based on an erring example at
     # https://stackoverflow.com/questions/10854903/what-is-causing-dimension-dependent-attributeerror-in-pil-fromarray-function
     def test_3d_array(self):
         size = (5, TEST_IMAGE_SIZE[0], TEST_IMAGE_SIZE[1])
         a = numpy.ones(size, dtype=numpy.uint8)
-        self.assert_image(Image.fromarray(a[1, :, :]), "L", TEST_IMAGE_SIZE)
+        assert_image(Image.fromarray(a[1, :, :]), "L", TEST_IMAGE_SIZE)
         size = (TEST_IMAGE_SIZE[0], 5, TEST_IMAGE_SIZE[1])
         a = numpy.ones(size, dtype=numpy.uint8)
-        self.assert_image(Image.fromarray(a[:, 1, :]), "L", TEST_IMAGE_SIZE)
+        assert_image(Image.fromarray(a[:, 1, :]), "L", TEST_IMAGE_SIZE)
         size = (TEST_IMAGE_SIZE[0], TEST_IMAGE_SIZE[1], 5)
         a = numpy.ones(size, dtype=numpy.uint8)
-        self.assert_image(Image.fromarray(a[:, :, 1]), "L", TEST_IMAGE_SIZE)
+        assert_image(Image.fromarray(a[:, :, 1]), "L", TEST_IMAGE_SIZE)
 
     def _test_img_equals_nparray(self, img, np):
         self.assertGreaterEqual(len(np.shape), 2)
@@ -98,7 +98,7 @@ class TestNumpy(PillowTestCase):
         px = img.load()
         for x in range(0, img.size[0], int(img.size[0] / 10)):
             for y in range(0, img.size[1], int(img.size[1] / 10)):
-                self.assert_deep_equal(px[x, y], np[y, x])
+                assert_deep_equal(px[x, y], np[y, x])
 
     def test_16bit(self):
         with Image.open("Tests/images/16bit.cropped.tif") as img:

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -1,5 +1,6 @@
 import unittest
 
+import pytest
 from PIL import Image
 
 from .helper import PillowTestCase, assert_deep_equal, assert_image, hopper
@@ -220,4 +221,4 @@ class TestNumpy(PillowTestCase):
         with Image.open(test_file) as im:
 
             # Act/Assert
-            self.assert_warning(None, lambda: array(im))
+            pytest.warns(None, lambda: array(im))

--- a/Tests/test_qt_image_fromqpixmap.py
+++ b/Tests/test_qt_image_fromqpixmap.py
@@ -1,6 +1,6 @@
 from PIL import ImageQt
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 from .test_imageqt import PillowQPixmapTestCase
 
 
@@ -8,7 +8,7 @@ class TestFromQPixmap(PillowQPixmapTestCase, PillowTestCase):
     def roundtrip(self, expected):
         result = ImageQt.fromqpixmap(ImageQt.toqpixmap(expected))
         # Qt saves all pixmaps as rgb
-        self.assert_image_equal(result, expected.convert("RGB"))
+        assert_image_equal(result, expected.convert("RGB"))
 
     def test_sanity(self):
         for mode in ("1", "RGB", "RGBA", "L", "P"):

--- a/Tests/test_qt_image_toqimage.py
+++ b/Tests/test_qt_image_toqimage.py
@@ -1,6 +1,6 @@
 from PIL import Image, ImageQt
 
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, hopper
 from .test_imageqt import PillowQtTestCase
 
 if ImageQt.qt_is_installed:
@@ -26,9 +26,9 @@ class TestToQImage(PillowQtTestCase, PillowTestCase):
             # reload directly from the qimage
             rt = ImageQt.fromqimage(data)
             if mode in ("L", "P", "1"):
-                self.assert_image_equal(rt, src.convert("RGB"))
+                assert_image_equal(rt, src.convert("RGB"))
             else:
-                self.assert_image_equal(rt, src)
+                assert_image_equal(rt, src)
 
             if mode == "1":
                 # BW appears to not save correctly on QT4 and QT5
@@ -44,7 +44,7 @@ class TestToQImage(PillowQtTestCase, PillowTestCase):
 
             # Check that it actually worked.
             with Image.open(tempfile) as reloaded:
-                self.assert_image_equal(reloaded, src)
+                assert_image_equal(reloaded, src)
 
     def test_segfault(self):
         app = QApplication([])

--- a/Tests/test_uploader.py
+++ b/Tests/test_uploader.py
@@ -1,13 +1,13 @@
-from .helper import PillowTestCase, hopper
+from .helper import PillowTestCase, assert_image_equal, assert_image_similar, hopper
 
 
 class TestUploader(PillowTestCase):
     def check_upload_equal(self):
         result = hopper("P").convert("RGB")
         target = hopper("RGB")
-        self.assert_image_equal(result, target)
+        assert_image_equal(result, target)
 
     def check_upload_similar(self):
         result = hopper("P").convert("RGB")
         target = hopper("RGB")
-        self.assert_image_similar(result, target, 0)
+        assert_image_similar(result, target, 0)

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["Tests.helper"]


### PR DESCRIPTION
For #4193.

The tempfile and warning asserts can probably be replaced with pytest functionality.

Edit: Also replace `PillowTestCase.assert_warning` with `pytest.warns`.