### PR TITLE
Fix size calculation of Image.thumbnail()

### DIFF
--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -58,6 +58,10 @@ def test_aspect():
     im.thumbnail((50, 50))
     assert im.size == (34, 50)  # ratio is 0.68
 
+    im = Image.new("L", (100, 30))  # ratio is 3.333333333333
+    im.thumbnail((75, 75))
+    assert im.size == (75, 23)  # ratio is 3.260869565217
+
 
 def test_float():
     im = Image.new("L", (128, 128))

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -50,6 +50,14 @@ def test_aspect():
     im.thumbnail((33, 33))
     assert im.size == (21, 33)  # ratio is 0.6363636364
 
+    im = Image.new("L", (145, 100))  # ratio is 1.45
+    im.thumbnail((50, 50))
+    assert im.size ==(50, 34)  # ratio is 1.47058823529
+
+    im = Image.new("L", (100, 145))  # ratio is 0.689655172414
+    im.thumbnail((50, 50))
+    assert im.size == (34, 50)  # ratio is 0.68
+
 
 def test_float():
     im = Image.new("L", (128, 128))

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -34,9 +34,9 @@ def test_aspect():
     im.thumbnail((100, 100))
     assert im.size == (100, 50)
 
-    im = Image.new("L", (256, 128))
-    im.thumbnail((100, 50))
-    assert im.size == (100, 50)
+    im = Image.new("L", (64, 64))
+    im.thumbnail((100, 100))
+    assert im.size == (64, 64)
 
     im = Image.new("L", (128, 128))
     im.thumbnail((100, 100))

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -34,13 +34,13 @@ def test_aspect():
     im.thumbnail((100, 100))
     assert im.size == (100, 50)
 
+    im = Image.new("L", (256, 128))
+    im.thumbnail((100, 50))
+    assert im.size == (100, 50)
+
     im = Image.new("L", (64, 64))
     im.thumbnail((100, 100))
     assert im.size == (64, 64)
-
-    im = Image.new("L", (128, 128))
-    im.thumbnail((100, 100))
-    assert im.size == (100, 100)
 
     im = Image.new("L", (256, 162))  # ratio is 1.5802469136
     im.thumbnail((33, 33))
@@ -52,7 +52,7 @@ def test_aspect():
 
     im = Image.new("L", (145, 100))  # ratio is 1.45
     im.thumbnail((50, 50))
-    assert im.size ==(50, 34)  # ratio is 1.47058823529
+    assert im.size == (50, 34)  # ratio is 1.47058823529
 
     im = Image.new("L", (100, 145))  # ratio is 0.689655172414
     im.thumbnail((50, 50))
@@ -62,7 +62,7 @@ def test_aspect():
 def test_float():
     im = Image.new("L", (128, 128))
     im.thumbnail((99.9, 99.9))
-    assert im.size == (100, 100)
+    assert im.size == (99, 99)
 
 
 def test_no_resize():

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2240,13 +2240,20 @@ class Image:
         if x >= self.width and y >= self.height:
             return
 
+        def round_aspect(number):
+            if x / y >= aspect:
+                key = lambda n: abs(aspect - n / y)  # noqa: E731
+            else:
+                key = lambda n: abs(aspect - x / n)  # noqa: E731
+            return max(min(math.floor(number), math.ceil(number), key=key), 1)
+
         # preserve aspect ratio
         aspect = self.width / self.height
         if x / y >= aspect:
-            x = max(y * aspect, 1)
+            x = round_aspect(y * aspect)
         else:
-            y = max(x / aspect, 1)
-        size = (round(x), round(y))
+            y = round_aspect(x / aspect)
+        size = (x, y)
 
         box = None
         if reducing_gap is not None:

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2236,7 +2236,7 @@ class Image:
         :returns: None
         """
 
-        x, y = size
+        x, y = map(math.floor, size)
         if x >= self.width and y >= self.height:
             return
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2237,19 +2237,18 @@ class Image:
         """
 
         # preserve aspect ratio
-        x, y = self.size
-        if x > size[0]:
-            y = max(round(y * size[0] / x), 1)
-            x = round(size[0])
-        if y > size[1]:
-            x = max(round(x * size[1] / y), 1)
-            y = round(size[1])
-        size = x, y
-        box = None
+        x, y = size
+        aspect = self.width / self.height
+        if x / y >= aspect:
+            x = max(y * aspect, 1)
+        else:
+            y = max(x / aspect, 1)
+        size = (round(x), round(y))
 
         if size == self.size:
             return
 
+        box = None
         if reducing_gap is not None:
             res = self.draft(None, (size[0] * reducing_gap, size[1] * reducing_gap))
             if res is not None:

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2236,17 +2236,17 @@ class Image:
         :returns: None
         """
 
-        # preserve aspect ratio
         x, y = size
+        if x >= self.width and y >= self.height:
+            return
+
+        # preserve aspect ratio
         aspect = self.width / self.height
         if x / y >= aspect:
             x = max(y * aspect, 1)
         else:
             y = max(x / aspect, 1)
         size = (round(x), round(y))
-
-        if size == self.size:
-            return
 
         box = None
         if reducing_gap is not None:

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2240,19 +2240,15 @@ class Image:
         if x >= self.width and y >= self.height:
             return
 
-        def round_aspect(number):
-            if x / y >= aspect:
-                key = lambda n: abs(aspect - n / y)  # noqa: E731
-            else:
-                key = lambda n: abs(aspect - x / n)  # noqa: E731
+        def round_aspect(number, key):
             return max(min(math.floor(number), math.ceil(number), key=key), 1)
 
         # preserve aspect ratio
         aspect = self.width / self.height
         if x / y >= aspect:
-            x = round_aspect(y * aspect)
+            x = round_aspect(y * aspect, key=lambda n: abs(aspect - n / y))
         else:
-            y = round_aspect(x / aspect)
+            y = round_aspect(x / aspect, key=lambda n: abs(aspect - x / n))
         size = (x, y)
 
         box = None


### PR DESCRIPTION
The current size calculation is fine if only one axis is smaller or if the image is wide, but it trips up when both axes are smaller and the image is tall. Here's an example:
```py
from PIL import Image

im = Image.new("L", (145, 100))
im.thumbnail((50, 50))
assert im.size == (50, 34)  # This is fine, the image is wide.

im = Image.new("L", (100, 145))
im.thumbnail((100, 50))
assert im.size == (34, 50)  # Also fine, only one axis is smaller.

im = Image.new("L", (100, 145))
im.thumbnail((50, 50))
assert im.size == (34, 50)  # Oh no! It returned (35, 50)!
```
Someone made a [pull request](https://github.com/python-pillow/Pillow/pull/2089) that fixed this in 2016, but it looks like he closed it shortly after due to a CI failure.