### PR TITLE
Run lint with pre-commit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,22 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - name: pip cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: lint-pip-${{ hashFiles('**/setup.py') }}
+        restore-keys: |
+          lint-pip-
+
+    - name: pre-commit cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pre-commit
+        key: lint-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
+        restore-keys: |
+          lint-pre-commit-
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -30,3 +46,4 @@ jobs:
 
     - name: Lint
       run: tox -e lint
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+      - id: black
+        args: ["--target-version", "py35"]
+        # Only .py files, until https://github.com/psf/black/issues/402 resolved
+        files: \.py$
+        types: []
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
+
+  - repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.5.1
+    hooks:
+      - id: python-check-blanket-noqa
+      - id: rst-backticks
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 dist: xenial
 language: python
-cache: pip
+cache:
+  pip: true
+  directories:
+    - $HOME/.cache/pre-commit
 
 notifications:
   irc: "chat.freenode.net#pil"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include *.py
 include *.rst
 include *.sh
 include *.txt
+include *.yaml
 include LICENSE
 include Makefile
 include tox.ini

--- a/tox.ini
+++ b/tox.ini
@@ -24,13 +24,9 @@ deps =
 
 [testenv:lint]
 commands =
-    black --target-version py35 --check --diff .
-    flake8 --statistics --count
-    isort --check-only --diff
+    pre-commit run --all-files
     check-manifest
 deps =
-    black
+    pre-commit
     check-manifest
-    flake8
-    isort
 skip_install = true


### PR DESCRIPTION
[pre-commit](https://pre-commit.com)  can be used locally to check files when committing. If problems are found, it stops the commit with an error message. Some tools (like Black and isort) also fix the problems they find.

Fail fast, fail early.

pre-commit is not for everyone, and it's not mandatory to run it locally. I didn't used to be keen, but now I find it really helpful. It's important it doesn't take too long to run.

Even if you don't run it locally, and there's absolutely no requirement to do so, it's handy for grouping together and pinning many linters, and running on the CI.

Here are the main commands for local use:

```bash
# Do this just once to install the tool:
pip install pre-commit

# Do this just once to init a repo:
pre-commit install

# The first run can take a bit longer to set up, after that it's quick

# Then commit like normal, it’ll run the checks on only the staged files:
git commit -m "something"

# If you want to skip the pre-commit checks:
git commit -m "something" -n

# If you want to run on all files (do this on CI):
pre-commit run all-files

# Once in a while, check for new versions of your lint tools:
pre-commit autoupdate  # and then commit the updated config file

# Stop using it locally:
pre-commit uninstall
```

Our CI linting runs four tools: `black`, `check-manifest`, `flake8` and `isort`.

`check-manifest` is a bit slow, so I added the other three to pre-commit.

I also added some extra handy linters, such as:

* `check-yaml`, which is really handy to find syntax errors in, say, `.travis.yml` before pushing and trying to find out why nothing was built
* `rst-backticks` looks for single backticks in RST files
* `python-check-blanket-noqa` makes sure  `noqa` always comes with a specific code

