### PR TITLE
Updated test

### DIFF
--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -244,7 +244,7 @@ class TestImageDraw(PillowTestCase):
 
         # Assert
         expected = Image.open("Tests/images/imagedraw_ellipse_translucent.png")
-        self.assert_image_similar(im, expected, 1)
+        assert_image_similar(im, expected, 1)
 
     def test_ellipse_edge(self):
         # Arrange


### PR DESCRIPTION
master has started failing tests after the merging of #4333, as it was not updated for the pytest changes.