### PR TITLE
Fix saving bug in IcnsImagePlugin __main__

### DIFF
--- a/src/PIL/IcnsImagePlugin.py
+++ b/src/PIL/IcnsImagePlugin.py
@@ -368,9 +368,7 @@ if __name__ == "__main__":
     imf = IcnsImageFile(open(sys.argv[1], "rb"))
     for size in imf.info["sizes"]:
         imf.size = size
-        imf.load()
-        im = imf.im
-        im.save("out-%s-%s-%s.png" % size)
+        imf.save("out-%s-%s-%s.png" % size)
     im = Image.open(sys.argv[1])
     im.save("out.png")
     if sys.platform == "windows":

--- a/src/PIL/IcnsImagePlugin.py
+++ b/src/PIL/IcnsImagePlugin.py
@@ -365,11 +365,12 @@ if __name__ == "__main__":
         print("Syntax: python IcnsImagePlugin.py [file]")
         sys.exit()
 
-    imf = IcnsImageFile(open(sys.argv[1], "rb"))
-    for size in imf.info["sizes"]:
-        imf.size = size
-        imf.save("out-%s-%s-%s.png" % size)
-    im = Image.open(sys.argv[1])
-    im.save("out.png")
-    if sys.platform == "windows":
-        os.startfile("out.png")
+    with open(sys.argv[1], "rb") as fp:
+        imf = IcnsImageFile(fp)
+        for size in imf.info["sizes"]:
+            imf.size = size
+            imf.save("out-%s-%s-%s.png" % size)
+        im = Image.open(sys.argv[1])
+        im.save("out.png")
+        if sys.platform == "windows":
+            os.startfile("out.png")


### PR DESCRIPTION
When using the `__main__` functionality of IcnsImagePlugin, I found a bug.

> $ python IcnsImagePlugin.py in.icns
> Traceback (most recent call last):
>   File "IcnsImagePlugin.py", line 373, in <module>
>     im.save("out-%s-%s-%s.png" % size)
> AttributeError: 'ImagingCore' object has no attribute 'save'

https://github.com/python-pillow/Pillow/blob/29fee8fc43d59dd65b7c533def44548aa5b9bc12/src/PIL/IcnsImagePlugin.py#L372-L373

This PR fixes that bug, and also ensures that the file pointer that is opened is closed again.