### PR TITLE
Remove redundant str() call

### DIFF
--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -8,4 +8,4 @@ def pytest_report_header(config):
             features.pilinfo(out=out, supported_formats=False)
             return out.getvalue()
     except Exception as e:
-        return "pytest_report_header failed: %s" % str(e)
+        return "pytest_report_header failed: %s" % e


### PR DESCRIPTION
The `%s` placeholder already coerces arguments to a string.