### PR TITLE
Move safe imports to the top of test files

### DIFF
--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -1,6 +1,7 @@
-def pytest_report_header(config):
-    import io
+import io
 
+
+def pytest_report_header(config):
     try:
         from PIL import features
 

--- a/Tests/test_file_gimpgradient.py
+++ b/Tests/test_file_gimpgradient.py
@@ -1,4 +1,4 @@
-from PIL import GimpGradientFile
+from PIL import GimpGradientFile, ImagePalette
 
 
 def test_linear_pos_le_middle():
@@ -99,8 +99,6 @@ def test_sphere_decreasing():
 
 def test_load_via_imagepalette():
     # Arrange
-    from PIL import ImagePalette
-
     test_file = "Tests/images/gimp_gradient.ggr"
 
     # Act
@@ -114,8 +112,6 @@ def test_load_via_imagepalette():
 
 def test_load_1_3_via_imagepalette():
     # Arrange
-    from PIL import ImagePalette
-
     # GIMP 1.3 gradient files contain a name field
     test_file = "Tests/images/gimp_gradient_with_name.ggr"
 

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -2,7 +2,7 @@ import os
 from io import BytesIO
 
 import pytest
-from PIL import Image, ImageFile, JpegImagePlugin
+from PIL import ExifTags, Image, ImageFile, JpegImagePlugin
 
 from .helper import (
     PillowTestCase,
@@ -506,8 +506,6 @@ class TestFileJpeg(PillowTestCase):
 
     def test_no_duplicate_0x1001_tag(self):
         # Arrange
-        from PIL import ExifTags
-
         tag_ids = {v: k for k, v in ExifTags.TAGS.items()}
 
         # Assert

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 
 import pytest
-from PIL import Image, Jpeg2KImagePlugin
+from PIL import Image, ImageFile, Jpeg2KImagePlugin
 
 from .helper import (
     PillowTestCase,
@@ -202,8 +202,6 @@ class TestFileJpeg2k(PillowTestCase):
 
     def test_parser_feed(self):
         # Arrange
-        from PIL import ImageFile
-
         with open("Tests/images/test-card-lossless.jp2", "rb") as f:
             data = f.read()
 

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -6,7 +6,7 @@ import os
 from collections import namedtuple
 from ctypes import c_float
 
-from PIL import Image, TiffImagePlugin, TiffTags, features
+from PIL import Image, ImageFilter, TiffImagePlugin, TiffTags, features
 
 from .helper import (
     PillowTestCase,
@@ -411,8 +411,6 @@ class TestFileLibTiff(LibTiffTestCase):
     def test_blur(self):
         # test case from irc, how to do blur on b/w image
         # and save to compressed tif.
-        from PIL import ImageFilter
-
         out = self.tempfile("temp.tif")
         with Image.open("Tests/images/pport_g4.tif") as im:
             im = im.convert("L")

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 
 import pytest
-from PIL import Image, UnidentifiedImageError
+from PIL import Image, ImageDraw, ImagePalette, UnidentifiedImageError
 
 from .helper import (
     PillowTestCase,
@@ -258,8 +258,6 @@ class TestImage(PillowTestCase):
     def test_alpha_composite(self):
         # https://stackoverflow.com/questions/3374878
         # Arrange
-        from PIL import ImageDraw
-
         expected_colors = sorted(
             [
                 (1122, (128, 127, 0, 255)),
@@ -534,8 +532,6 @@ class TestImage(PillowTestCase):
             self.assertRaises(ValueError, im.remap_palette, None)
 
     def test__new(self):
-        from PIL import ImagePalette
-
         im = hopper("RGB")
         im_p = hopper("P")
 

--- a/Tests/test_image_mode.py
+++ b/Tests/test_image_mode.py
@@ -1,4 +1,4 @@
-from PIL import Image
+from PIL import Image, ImageMode
 
 from .helper import hopper
 
@@ -7,8 +7,6 @@ def test_sanity():
 
     with hopper() as im:
         im.mode
-
-    from PIL import ImageMode
 
     ImageMode.getmode("1")
     ImageMode.getmode("L")

--- a/Tests/test_imagedraw2.py
+++ b/Tests/test_imagedraw2.py
@@ -1,7 +1,7 @@
 import os.path
 
 import pytest
-from PIL import Image, ImageDraw2, features
+from PIL import Image, ImageDraw, ImageDraw2, features
 
 from .helper import assert_image_equal, assert_image_similar, hopper
 
@@ -40,8 +40,6 @@ def test_sanity():
     draw = ImageDraw2.Draw(im)
     pen = ImageDraw2.Pen("blue", width=7)
     draw.line(list(range(10)), pen)
-
-    from PIL import ImageDraw
 
     draw, handler = ImageDraw.getdraw(im)
     pen = ImageDraw2.Pen("blue", width=7)


### PR DESCRIPTION
These modules are safe to import and this better follows PEP 8.

From https://www.python.org/dev/peps/pep-0008/#imports

> Imports are always put at the top of the file, just after any module
> comments and docstrings, and before module globals and constants.
