### PR TITLE
Release Python GIL during WEBP encode

### DIFF
--- a/src/_webp.c
+++ b/src/_webp.c
@@ -21,13 +21,11 @@
 
 #endif
 
-void ImagingSectionEnter(ImagingSectionCookie* cookie)
-{
+void ImagingSectionEnter(ImagingSectionCookie* cookie) {
     *cookie = (PyThreadState *) PyEval_SaveThread();
 }
 
-void ImagingSectionLeave(ImagingSectionCookie* cookie)
-{
+void ImagingSectionLeave(ImagingSectionCookie* cookie) {
     PyEval_RestoreThread((PyThreadState*) *cookie);
 }
 


### PR DESCRIPTION
Changes proposed in this pull request: release GIL in WEBP encoding.

I don't know if the patch is the right way to do it, but it works for me and it makes webp encoding in threads scale, so even if the patch is bad, please do the feature.