### PR TITLE
Warn on typos passed to features.check()

### DIFF
--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -44,6 +44,13 @@ def test_check_modules():
         assert features.check_codec(feature) in [True, False]
 
 
+def test_check_warns_on_nonexistent():
+    with pytest.warns(UserWarning) as cm:
+        has_feature = features.check("typo")
+    assert has_feature is False
+    assert str(cm[-1].message) == "Unknown feature 'typo'."
+
+
 def test_supported_modules():
     assert isinstance(features.get_supported_modules(), list)
     assert isinstance(features.get_supported_codecs(), list)

--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -1,6 +1,7 @@
 import collections
 import os
 import sys
+import warnings
 
 import PIL
 
@@ -76,14 +77,14 @@ def get_supported_features():
 
 
 def check(feature):
-    return (
-        feature in modules
-        and check_module(feature)
-        or feature in codecs
-        and check_codec(feature)
-        or feature in features
-        and check_feature(feature)
-    )
+    if feature in modules:
+        return check_module(feature)
+    if feature in codecs:
+        return check_codec(feature)
+    if feature in features:
+        return check_feature(feature)
+    warnings.warn("Unknown feature '%s'." % feature, stacklevel=2)
+    return False
 
 
 def get_supported():


### PR DESCRIPTION
If the feature isn't one of the recognized types, a UserWarning is emitted.