### PR TITLE
Use Codecov bash because the Action times out on macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,8 +106,7 @@ jobs:
 
     - name: Upload coverage
       if: success()
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        flags: ${{ matrix.codecov-flag }}
-        name: ${{ matrix.os }} Python ${{ matrix.python-version }}
+      run: bash <(curl -s https://codecov.io/bash) -F ${{ matrix.codecov-flag }}
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        CODECOV_NAME: ${{ matrix.os }} Python ${{ matrix.python-version }}


### PR DESCRIPTION
Changes proposed in this pull request:

 * Use the Codecov bash uploader for macOS and Linux, because the Action was times out on macOS after 12 minutes
 * Fixes macOS coverage

---

Recently, the Codecov Action for uploading coverage has been timing out after about 12 minutes on macOS. Most recent master build:

```
2020-02-21T22:12:07.4228970Z [0;90m==>[0m Uploading reports
2020-02-21T22:12:07.4230580Z     [0;90murl:[0m https://codecov.io
2020-02-21T22:12:07.4231890Z     [0;90mquery:[0m branch=master&commit=20d6b6271ce329870e1fab7f6b750838eb56510e&build=&build_url=http%3A%2F%2Fgithub.com%2Fpython-pillow%2FPillow%2Factions%2Fruns%2F&name=macOS-latest%20Python%20pypy3&tag=&slug=python-pillow%2FPillow&service=github-actions&flags=GHA_macOS&pr=&job=
2020-02-21T22:12:07.4336250Z     [0;90m->[0m Pinging Codecov
2020-02-21T22:12:07.4337830Z https://codecov.io/upload/v4?package=bash-20200214-585fef0&token=secret&branch=master&commit=20d6b6271ce329870e1fab7f6b750838eb56510e&build=&build_url=http%3A%2F%2Fgithub.com%2Fpython-pillow%2FPillow%2Factions%2Fruns%2F&name=macOS-latest%20Python%20pypy3&tag=&slug=python-pillow%2FPillow&service=github-actions&flags=GHA_macOS&pr=&job=
2020-02-21T22:12:07.8370190Z     [0;90m->[0m Uploading
2020-02-21T22:13:07.9564500Z     [0;31mX>[0m Failed to upload
2020-02-21T22:13:07.9565190Z     [0;90m->[0m Sleeping for 30s and trying again...
2020-02-21T22:13:38.0845530Z     [0;90m->[0m Pinging Codecov
2020-02-21T22:13:38.0846580Z https://codecov.io/upload/v4?package=bash-20200214-585fef0&token=secret&branch=master&commit=20d6b6271ce329870e1fab7f6b750838eb56510e&build=&build_url=http%3A%2F%2Fgithub.com%2Fpython-pillow%2FPillow%2Factions%2Fruns%2F&name=macOS-latest%20Python%20pypy3&tag=&slug=python-pillow%2FPillow&service=github-actions&flags=GHA_macOS&pr=&job=
2020-02-21T22:13:38.3309090Z     [0;90m->[0m Uploading
2020-02-21T22:14:38.4381230Z     [0;31mX>[0m Failed to upload
2020-02-21T22:14:38.4382970Z     [0;90m->[0m Sleeping for 30s and trying again...
2020-02-21T22:15:08.5549940Z     [0;90m->[0m Pinging Codecov
2020-02-21T22:15:08.5550950Z https://codecov.io/upload/v4?package=bash-20200214-585fef0&token=secret&branch=master&commit=20d6b6271ce329870e1fab7f6b750838eb56510e&build=&build_url=http%3A%2F%2Fgithub.com%2Fpython-pillow%2FPillow%2Factions%2Fruns%2F&name=macOS-latest%20Python%20pypy3&tag=&slug=python-pillow%2FPillow&service=github-actions&flags=GHA_macOS&pr=&job=
2020-02-21T22:15:08.8578280Z     [0;90m->[0m Uploading
2020-02-21T22:16:08.9588660Z     [0;31mX>[0m Failed to upload
2020-02-21T22:16:08.9589900Z     [0;90m->[0m Sleeping for 30s and trying again...
2020-02-21T22:16:39.0990190Z     [0;90m->[0m Pinging Codecov
2020-02-21T22:16:39.0991150Z https://codecov.io/upload/v4?package=bash-20200214-585fef0&token=secret&branch=master&commit=20d6b6271ce329870e1fab7f6b750838eb56510e&build=&build_url=http%3A%2F%2Fgithub.com%2Fpython-pillow%2FPillow%2Factions%2Fruns%2F&name=macOS-latest%20Python%20pypy3&tag=&slug=python-pillow%2FPillow&service=github-actions&flags=GHA_macOS&pr=&job=
2020-02-21T22:16:39.3449530Z     [0;90m->[0m Uploading
2020-02-21T22:17:39.4338130Z     [0;31mX>[0m Failed to upload
2020-02-21T22:17:39.4339250Z     [0;90m->[0m Sleeping for 30s and trying again...
2020-02-21T22:18:09.5599610Z     [0;90m->[0m Uploading to Codecov
2020-02-21T22:19:09.6541500Z     [0;90m->[0m Sleeping for 30s and trying again...
2020-02-21T22:20:39.8930390Z     [0;90m->[0m Sleeping for 30s and trying again...
2020-02-21T22:22:10.0224740Z     [0;90m->[0m Sleeping for 30s and trying again...
2020-02-21T22:23:40.2020460Z     [0;90m->[0m Sleeping for 30s and trying again...
2020-02-21T22:24:10.3447750Z     [0;31mX> Failed to upload coverage reports[0m
```

https://github.com/python-pillow/Pillow/runs/461238759?check_suite_focus=true

This may account for the "failing" +- check on PRs (eg. https://github.com/python-pillow/Pillow/pull/4404):

![image](https://user-images.githubusercontent.com/1324225/75092223-5f388000-557e-11ea-9bf3-ec2143d61659.png)

Plus the lack of `GHA_macOS` flag on files:

![image](https://user-images.githubusercontent.com/1324225/75092274-b0e10a80-557e-11ea-89f5-3a99c9239fac.png)

https://codecov.io/gh/python-pillow/Pillow/src/a8c07941074a16ee06879071f42ea5b624210f5f/src/PIL/BdfFontFile.py

---

Switching to the Codecov bash uploader fixes it, uploads coverage in 7s:

![image](https://user-images.githubusercontent.com/1324225/75092316-fef60e00-557e-11ea-9088-da00631f68e3.png)

And shows the flag:

![image](https://user-images.githubusercontent.com/1324225/75092290-d53ce700-557e-11ea-87d4-8df1ca6bd52e.png)

https://codecov.io/gh/hugovk/Pillow/src/3218cf8afe4e7d102a62dcfd82d4562807cad274/src/PIL/BdfFontFile.py

---

I've not reported this to Codecov, and didn't find it in their issue tracker or on the forum, but they often suggest to people to try the bash uploader if they have problems with the Action or Python client, as the bash client is their main cross-platform tool with the most maintenance.
