### PR TITLE
Add JPEG comment to info dictionary

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -60,6 +60,8 @@ class TestFileJpeg:
             )
             assert len(im.applist) == 2
 
+            assert im.info["comment"] == b"File written by Adobe Photoshop\xa8 4.0\x00"
+
     def test_cmyk(self):
         # Test CMYK handling.  Thanks to Tim and Charlie for test data,
         # Michael for getting me to look one more time.

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -298,6 +298,11 @@ The :py:meth:`~PIL.Image.Image.open` method may set the following
 **exif**
     Raw EXIF data from the image.
 
+**comment**
+    A comment about the image.
+
+    .. versionadded:: 7.1.0
+
 
 The :py:meth:`~PIL.Image.Image.save` method supports the following options:
 

--- a/docs/releasenotes/7.1.0.rst
+++ b/docs/releasenotes/7.1.0.rst
@@ -18,6 +18,15 @@ been resolved.
     im = Image.open("hopper.jpg")
     im.save("out.jpg", quality=0)
 
+API Additions
+=============
+
+Reading JPEG comments
+^^^^^^^^^^^^^^^^^^^^^
+
+When opening a JPEG image, the comment may now be read into
+:py:attr:`~PIL.Image.Image.info`.
+
 Other Changes
 =============
 

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -176,6 +176,7 @@ def COM(self, marker):
     n = i16(self.fp.read(2)) - 2
     s = ImageFile._safe_read(self.fp, n)
 
+    self.info["comment"] = s
     self.app["COM"] = s  # compatibility
     self.applist.append(("COM", s))
 


### PR DESCRIPTION
Resolves #4450 

Adds JPEG comment to the `info` dictionary, in the same way that [GIF](https://github.com/python-pillow/Pillow/blob/1c1ad65a9646f73d80ce8f77894a447b03f203a6/src/PIL/GifImagePlugin.py#L213) and [GBR](https://github.com/python-pillow/Pillow/blob/1c1ad65a9646f73d80ce8f77894a447b03f203a6/src/PIL/GbrImagePlugin.py#L78) do.