### PR TITLE
Fixed endian handling for I;16 getextrema

### DIFF
--- a/Tests/test_image_getextrema.py
+++ b/Tests/test_image_getextrema.py
@@ -1,10 +1,8 @@
-import pytest
 from PIL import Image
 
-from .helper import hopper, is_big_endian, on_ci
+from .helper import hopper
 
 
-@pytest.mark.xfail(is_big_endian() and on_ci(), reason="Fails on big-endian")
 def test_extrema():
     def extrema(mode):
         return hopper(mode).getextrema()
@@ -20,7 +18,6 @@ def test_extrema():
     assert extrema("I;16") == (1, 255)
 
 
-@pytest.mark.xfail(is_big_endian() and on_ci(), reason="Fails on big-endian")
 def test_true_16():
     with Image.open("Tests/images/16_bit_noise.tif") as im:
         assert im.mode == "I;16"

--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -166,11 +166,21 @@ ImagingGetExtrema(Imaging im, void *extrema)
     case IMAGING_TYPE_SPECIAL:
       if (strcmp(im->mode, "I;16") == 0) {
           UINT16 v;
-          memcpy(&v, *im->image8, sizeof(v));
+          UINT8* pixel = *im->image8;
+#ifdef WORDS_BIGENDIAN
+          v = pixel[0] + (pixel[1] << 8);
+#else
+          memcpy(&v, pixel, sizeof(v));
+#endif
           imin = imax = v;
           for (y = 0; y < im->ysize; y++) {
               for (x = 0; x < im->xsize; x++) {
-                  memcpy(&v, im->image[y] + x * sizeof(v), sizeof(v));
+                  pixel = im->image[y] + x * sizeof(v);
+#ifdef WORDS_BIGENDIAN
+                  v = pixel[0] + (pixel[1] << 8);
+#else
+                  memcpy(&v, pixel, sizeof(v));
+#endif
                   if (imin > v)
                       imin = v;
                   else if (imax < v)


### PR DESCRIPTION
Helps #4213

Using the endian handling in https://github.com/python-pillow/Pillow/blob/b73e3dddcc9e6b3039db366b202254f693ccd13d/src/libImaging/Unpack.c#L1042-L1046 as inspiration, fixes `getextrema` I;16 operations for big-endian.