### PR TITLE
Docs: Avoid ambiguity by explicitly invoking python3

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -47,8 +47,8 @@ Basic Installation
 
 Install Pillow with :command:`pip`::
 
-    python -m pip install --upgrade pip
-    python -m pip install --upgrade Pillow
+    python3 -m pip install --upgrade pip
+    python3 -m pip install --upgrade Pillow
 
 
 Windows Installation
@@ -59,8 +59,8 @@ supported Pythons in both 32 and 64-bit versions in wheel, egg, and
 executable installers. These binaries have all of the optional
 libraries included except for raqm and libimagequant::
 
-    python -m pip install --upgrade pip
-    python -m pip install --upgrade Pillow
+    python3 -m pip install --upgrade pip
+    python3 -m pip install --upgrade Pillow
 
 
 macOS Installation
@@ -71,8 +71,8 @@ versions in the wheel format. These include support for all optional
 libraries except libimagequant.  Raqm support requires libraqm,
 fribidi, and harfbuzz to be installed separately::
 
-    python -m pip install --upgrade pip
-    python -m pip install --upgrade Pillow
+    python3 -m pip install --upgrade pip
+    python3 -m pip install --upgrade Pillow
 
 Linux Installation
 ^^^^^^^^^^^^^^^^^^
@@ -82,8 +82,8 @@ versions in the manylinux wheel format. These include support for all
 optional libraries except libimagequant. Raqm support requires
 libraqm, fribidi, and harfbuzz to be installed separately::
 
-    python -m pip install --upgrade pip
-    python -m pip install --upgrade Pillow
+    python3 -m pip install --upgrade pip
+    python3 -m pip install --upgrade Pillow
 
 Most major Linux distributions, including Fedora, Debian/Ubuntu and
 ArchLinux also include Pillow in packages that previously contained
@@ -195,8 +195,8 @@ Many of Pillow's features require external libraries:
 
 Once you have installed the prerequisites, run::
 
-    python -m pip install --upgrade pip
-    python -m pip install --upgrade Pillow
+    python3 -m pip install --upgrade pip
+    python3 -m pip install --upgrade Pillow
 
 If the prerequisites are installed in the standard library locations
 for your machine (e.g. :file:`/usr` or :file:`/usr/local`), no
@@ -206,7 +206,7 @@ those locations by editing :file:`setup.py` or
 :file:`setup.cfg`, or by adding environment variables on the command
 line::
 
-    CFLAGS="-I/usr/pkg/include" python -m pip install --upgrade Pillow
+    CFLAGS="-I/usr/pkg/include" python3 -m pip install --upgrade Pillow
 
 If Pillow has been previously built without the required
 prerequisites, it may be necessary to manually clear the pip cache or
@@ -254,7 +254,7 @@ Sample usage::
 
 or using pip::
 
-    python -m pip install --upgrade Pillow --global-option="build_ext" --global-option="--enable-[feature]"
+    python3 -m pip install --upgrade Pillow --global-option="build_ext" --global-option="--enable-[feature]"
 
 
 Building on macOS
@@ -280,8 +280,8 @@ Then see ``depends/install_raqm_cmake.sh`` to install libraqm.
 
 Now install Pillow with::
 
-    python -m pip install --upgrade pip
-    python -m pip install --upgrade Pillow
+    python3 -m pip install --upgrade pip
+    python3 -m pip install --upgrade Pillow
 
 or from within the uncompressed source directory::
 


### PR DESCRIPTION
https://github.com/python/pythondotorg/issues/1549 details someone's difficulty pip installing Pillow.

Whilst it's more a general Python issue than a Pillow issue, one reply is (https://github.com/python/pythondotorg/issues/1549#issuecomment-583545173):


> Thanks for the report. I think the main issue here is the continuing confusion between Python 2 and Python 3 command names and scripts, something not unique to macOS installations of Python. The confusion here could have been avoided by better documentation of the differences between using the command nanes`python`, `python2`, and `python3` and similarly `pip`, `pip2`, and `pip3`. Yes, use of virtual environments is one way to avoid the differences, in that an active Python 3 virtual environment provides a `python` and `pip` _alias_ to the Python 3 versions. But use of a virtual environment isn't necessary in situations like this; all that is required is ensuring that you are using the instance of pip that is associated with the instance of Python in use. If one is invoking python with `python3` then _usually_ there will be a corresponding `pip3` (likewise, for example, `python3.8` and `pip3.8`):
> 
> `pip3 install pillow `
> 
> But, even better, you can avoid any ambiguity by invoking pip via the python command line:
> 
> `python3 -m pip install pillow `
> 
> Unfortunately, our documentation in this area lags somewhat. With the retirement of Python 2, there are some on-going efforts to improve the docs but there is still much to be done.

---

We recently updated the docs to recommend using `python -m pip` over `pip` (https://github.com/python-pillow/Pillow/pull/4214).

Let's also recommend using `python3 -m pip` over `python -m pip`.

