### PR TITLE
Invoke pip using python3

### DIFF
--- a/Tests/README.rst
+++ b/Tests/README.rst
@@ -8,7 +8,7 @@ Dependencies
 
 Install::
 
-    pip install pytest pytest-cov
+    python3 -m pip install pytest pytest-cov
 
 Execution
 ---------

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -154,4 +154,4 @@ PIL.OleFileIO
 PIL.OleFileIO was removed as a vendored file and in Pillow 4.0.0 (2017-01) in favour of
 the upstream olefile Python package, and replaced with an ``ImportError`` in 5.0.0
 (2018-01). The deprecated file has now been removed from Pillow. If needed, install from
-PyPI (eg. ``pip install olefile``).
+PyPI (eg. ``python3 -m pip install olefile``).


### PR DESCRIPTION
As in the likes of #4214 and #4459, invoke pip from Python to avoid possible confusion.