### PR TITLE
GHA Docker: Don't cancel all jobs if any another fails

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -7,6 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         docker: [
           alpine,


### PR DESCRIPTION
If one job fails, keep running the others.

This will allow us to see if the others pass, and whether the failure was unique to a given job.

We have this set for the other two, test.yml and test-windows.yml, and we have the build capacity.

Docs: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
