### PR TITLE
Prevent masking Image reduce method in Jpeg2K

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -135,10 +135,8 @@ def test_reduce():
         im.load()
         assert im.size == (160, 120)
 
-        try:
-            im.thumbnail((40, 40))
-        except ValueError as e:
-            assert str(e) == "box can't exceed original image size"
+        im.thumbnail((40, 40))
+        assert im.size == (40, 30)
 
 
 def test_layers_type(tmp_path):

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -127,9 +127,18 @@ def test_prog_res_rt():
 
 def test_reduce():
     with Image.open("Tests/images/test-card-lossless.jp2") as im:
+        assert callable(im.reduce)
+
         im.reduce = 2
+        assert im.reduce == 2
+
         im.load()
         assert im.size == (160, 120)
+
+        try:
+            im.thumbnail((40, 40))
+        except ValueError as e:
+            assert str(e) == "box can't exceed original image size"
 
 
 def test_layers_type(tmp_path):

--- a/Tests/test_image_reduce.py
+++ b/Tests/test_image_reduce.py
@@ -3,6 +3,9 @@ from PIL import Image, ImageMath, ImageMode
 
 from .helper import convert_to_comparable
 
+codecs = dir(Image.core)
+
+
 # There are several internal implementations
 remarkable_factors = [
     # special implementations
@@ -247,3 +250,11 @@ def test_mode_F():
     for factor in remarkable_factors:
         compare_reduce_with_reference(im, factor, 0, 0)
         compare_reduce_with_box(im, factor)
+
+
+@pytest.mark.skipif(
+    "jpeg2k_decoder" not in codecs, reason="JPEG 2000 support not available"
+)
+def test_jpeg2k():
+    with Image.open("Tests/images/test-card-lossless.jp2") as im:
+        assert im.reduce(2).size == (320, 240)

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1866,7 +1866,11 @@ class Image:
             factor_y = int((box[3] - box[1]) / size[1] / reducing_gap) or 1
             if factor_x > 1 or factor_y > 1:
                 reduce_box = self._get_safe_box(size, resample, box)
-                self = self.reduce((factor_x, factor_y), box=reduce_box)
+                factor = (factor_x, factor_y)
+                if callable(self.reduce):
+                    self = self.reduce(factor, box=reduce_box)
+                else:
+                    self = Image.reduce(self, factor, box=reduce_box)
                 box = (
                     (box[0] - reduce_box[0]) / factor_x,
                     (box[1] - reduce_box[1]) / factor_y,

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -176,7 +176,7 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
         if self.size is None or self.mode is None:
             raise SyntaxError("unable to determine size/mode")
 
-        self.reduce = 0
+        self._reduce = 0
         self.layers = 0
 
         fd = -1
@@ -200,13 +200,21 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
                 "jpeg2k",
                 (0, 0) + self.size,
                 0,
-                (self.codec, self.reduce, self.layers, fd, length),
+                (self.codec, self._reduce, self.layers, fd, length),
             )
         ]
 
+    @property
+    def reduce(self):
+        return self._reduce or super().reduce
+
+    @reduce.setter
+    def reduce(self, value):
+        self._reduce = value
+
     def load(self):
-        if self.reduce:
-            power = 1 << self.reduce
+        if self._reduce:
+            power = 1 << self._reduce
             adjust = power >> 1
             self._size = (
                 int((self.size[0] + adjust) / power),
@@ -216,7 +224,7 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
         if self.tile:
             # Update the reduce and layers settings
             t = self.tile[0]
-            t3 = (t[3][0], self.reduce, self.layers, t[3][3], t[3][4])
+            t3 = (t[3][0], self._reduce, self.layers, t[3][3], t[3][4])
             self.tile = [(t[0], (0, 0) + self.size, t[2], t3)]
 
         return ImageFile.ImageFile.load(self)

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -216,7 +216,7 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
         self._reduce = value
 
     def load(self):
-        if self._reduce:
+        if self.tile and self._reduce:
             power = 1 << self._reduce
             adjust = power >> 1
             self._size = (
@@ -224,7 +224,6 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
                 int((self.size[1] + adjust) / power),
             )
 
-        if self.tile:
             # Update the reduce and layers settings
             t = self.tile[0]
             t3 = (t[3][0], self._reduce, self.layers, t[3][3], t[3][4])

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -206,6 +206,9 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
 
     @property
     def reduce(self):
+        # https://github.com/python-pillow/Pillow/issues/4343 found that the
+        # new Image 'reduce' method was shadowed by this plugin's 'reduce'
+        # property. This attempts to allow for both scenarios
         return self._reduce or super().reduce
 
     @reduce.setter


### PR DESCRIPTION
Resolves #4343. Alternative to #4344

The new Image `reduce` method does not work for Jpeg2K images, as [Jpeg2KImagePlugin has a `reduce` variable that masks it](https://github.com/python-pillow/Pillow/blob/ef4a0b2f4c9346db37140f102e80068abc280167/src/PIL/Jpeg2KImagePlugin.py#L179). The variable is not purely internal, but is actually tested behaviour -

https://github.com/python-pillow/Pillow/blob/ef4a0b2f4c9346db37140f102e80068abc280167/Tests/test_file_jpeg2k.py#L112-L116

PR #4344 tried to address this by treating the setting of `reduce` as an integer, and the use of `reduce` as a method, as two different scenarios that were not to interact.

So instead, this PR changes Pillow so that if you set `reduce` as an integer, the user will then see `reduce` as an integer.

```python
with Image.open("Tests/images/test-card-lossless.jp2") as im:
        assert callable(im.reduce)

        im.reduce = 2
        assert im.reduce == 2
```

At that point, you can't call the `reduce` method externally. If Pillow tries to call the `reduce` method internally though, it will ignore this new use of `reduce`, and still call the Pillow method.