### PR TITLE
install using Python 3

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -250,7 +250,7 @@ Build Options
 
 Sample usage::
 
-    MAX_CONCURRENCY=1 python setup.py build_ext --enable-[feature] install
+    MAX_CONCURRENCY=1 python3 setup.py build_ext --enable-[feature] install
 
 or using pip::
 
@@ -285,7 +285,7 @@ Now install Pillow with::
 
 or from within the uncompressed source directory::
 
-    python setup.py install
+    python3 setup.py install
 
 Building on Windows
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
At https://pillow.readthedocs.io/en/latest/installation.html#building-on-macos, I find the lack of symmetry between the `python` invocations odd.

![image](https://user-images.githubusercontent.com/3112309/76900665-e662e480-68ed-11ea-8d9a-d0e7eef12c42.png)

So this PR switches it and another situation to use `python3`, like the `pip` commands.