### PR TITLE
Re-add deprecated PILLOW_VERSION to give projects more time to upgrade

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog (Pillow)
 7.1.0 (unreleased)
 ------------------
 
+- Added reading of earlier ImageMagick PNG EXIF data #4471
+  [radarhere]
+
 - Fixed endian handling for I;16 getextrema #4457
   [radarhere]
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -12,6 +12,17 @@ Deprecated features
 Below are features which are considered deprecated. Where appropriate,
 a ``DeprecationWarning`` is issued.
 
+PILLOW_VERSION constant
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 5.2.0
+
+``PILLOW_VERSION`` has been deprecated and will be removed in a future release. Use
+``__version__`` instead.
+
+It was initially removed in Pillow 7.0.0, but brought back in 7.1.0 to give projects
+more time to upgrade.
+
 ImageCms.CmsProfile attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -68,13 +79,6 @@ Use instead:
 
     with Image.open("hopper.png") as im:
         im.save("out.jpg")
-
-PILLOW_VERSION constant
-~~~~~~~~~~~~~~~~~~~~~~~
-
-*Removed in version 7.0.0.*
-
-``PILLOW_VERSION`` has been removed. Use ``__version__`` instead.
 
 PIL.*ImagePlugin.__version__ attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releasenotes/7.1.0.rst
+++ b/docs/releasenotes/7.1.0.rst
@@ -27,6 +27,15 @@ Reading JPEG comments
 When opening a JPEG image, the comment may now be read into
 :py:attr:`~PIL.Image.Image.info`.
 
+PILLOW_VERSION constant
+^^^^^^^^^^^^^^^^^^^^^^^
+
+``PILLOW_VERSION`` has been re-added but is deprecated and will be removed in a future
+release. Use ``__version__`` instead.
+
+It was initially removed in Pillow 7.0.0, but brought back in 7.1.0 to give projects
+more time to upgrade.
+
 Other Changes
 =============
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -39,11 +39,21 @@ from collections.abc import Callable, MutableMapping
 from pathlib import Path
 
 # VERSION was removed in Pillow 6.0.0.
-# PILLOW_VERSION was removed in Pillow 7.0.0.
+# PILLOW_VERSION is deprecated and will be removed in a future release.
 # Use __version__ instead.
-from . import ImageMode, TiffTags, UnidentifiedImageError, __version__, _plugins
+from . import (
+    PILLOW_VERSION,
+    ImageMode,
+    TiffTags,
+    UnidentifiedImageError,
+    __version__,
+    _plugins,
+)
 from ._binary import i8, i32le
 from ._util import deferred_error, isPath
+
+# Silence warning
+assert PILLOW_VERSION
 
 logger = logging.getLogger(__name__)
 

--- a/src/PIL/__init__.py
+++ b/src/PIL/__init__.py
@@ -16,9 +16,9 @@ Use PIL.__version__ for this Pillow version.
 from . import _version
 
 # VERSION was removed in Pillow 6.0.0.
-# PILLOW_VERSION was removed in Pillow 7.0.0.
+# PILLOW_VERSION is deprecated and will be removed in a future release.
 # Use __version__ instead.
-__version__ = _version.__version__
+PILLOW_VERSION = __version__ = _version.__version__
 
 del _version
 


### PR DESCRIPTION
`PILLOW_VERSION` was deprecated in Pillow 5.2.0 in July 2018 (https://github.com/python-pillow/Pillow/pull/3090, https://github.com/python-pillow/Pillow/pull/3782) and removed in 7.0.0 in January 2020 (https://github.com/python-pillow/Pillow/pull/4107).

However, it didn't raise a deprecation warning. The removal has caused problems for users of torchvision.

torchvision had already updated to use `__version__ ` in October 2019 (https://github.com/pytorch/vision/pull/1501) but when Pillow 7.0.0 came out on 2020-01-02, had not yet released it (https://github.com/pytorch/vision/issues/1712).

The fixed [torchvision 0.5.0](https://github.com/pytorch/vision/releases/tag/v0.5.0) was released on 2020-01-16.

However, some people are still having difficulties using torchvision 0.5.0 and Pillow 7.0.0 (https://github.com/pytorch/vision/issues/1712) and are pinning to old Pillow versions or editing the source. As it's not much code for us, I suggest re-adding `PILLOW_VERSION` until some unspecified future release.

---

As before, this still doesn't raise a deprecation warning. I don't know if it's possible to raise one when calling a constant (or calling something that looks like calling a constant), but that would be welcome for 7.1.0 or a later release.
