### PR TITLE
Update install docs and release notes for #4260

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,9 +55,9 @@ Windows Installation
 ^^^^^^^^^^^^^^^^^^^^
 
 We provide Pillow binaries for Windows compiled for the matrix of
-supported Pythons in both 32 and 64-bit versions in wheel, egg, and
-executable installers. These binaries have all of the optional
-libraries included except for raqm and libimagequant::
+supported Pythons in both 32 and 64-bit versions in the wheel format.
+These binaries have all of the optional libraries included except
+for raqm, libimagequant, and libxcb::
 
     python3 -m pip install --upgrade pip
     python3 -m pip install --upgrade Pillow
@@ -68,8 +68,8 @@ macOS Installation
 
 We provide binaries for macOS for each of the supported Python
 versions in the wheel format. These include support for all optional
-libraries except libimagequant.  Raqm support requires libraqm,
-fribidi, and harfbuzz to be installed separately::
+libraries except libimagequant and libxcb. Raqm support requires
+libraqm, fribidi, and harfbuzz to be installed separately::
 
     python3 -m pip install --upgrade pip
     python3 -m pip install --upgrade Pillow
@@ -193,6 +193,8 @@ Many of Pillow's features require external libraries:
     is available if all the libraries are installed.
   * Windows support: Raqm is not included in prebuilt wheels
 
+* **libxcb** provides X11 screengrab support.
+
 Once you have installed the prerequisites, run::
 
     python3 -m pip install --upgrade pip
@@ -226,14 +228,14 @@ Build Options
 * Build flags: ``--disable-zlib``, ``--disable-jpeg``,
   ``--disable-tiff``, ``--disable-freetype``, ``--disable-lcms``,
   ``--disable-webp``, ``--disable-webpmux``, ``--disable-jpeg2000``,
-  ``--disable-imagequant``.
+  ``--disable-imagequant``, ``--disable-xcb``.
   Disable building the corresponding feature even if the development
   libraries are present on the building machine.
 
 * Build flags: ``--enable-zlib``, ``--enable-jpeg``,
   ``--enable-tiff``, ``--enable-freetype``, ``--enable-lcms``,
   ``--enable-webp``, ``--enable-webpmux``, ``--enable-jpeg2000``,
-  ``--enable-imagequant``.
+  ``--enable-imagequant``, ``--enable-xcb``.
   Require that the corresponding feature is built. The build will raise
   an exception if the libraries are not found. Webpmux (WebP metadata)
   relies on WebP support. Tcl and Tk also must be used together.
@@ -305,7 +307,7 @@ Make sure you have Python's development libraries installed::
 
 Prerequisites are installed on **FreeBSD 10 or 11** with::
 
-    sudo pkg install jpeg-turbo tiff webp lcms2 freetype2 openjpeg harfbuzz fribidi
+    sudo pkg install jpeg-turbo tiff webp lcms2 freetype2 openjpeg harfbuzz fribidi libxcb
 
 Then see ``depends/install_raqm_cmake.sh`` to install libraqm.
 
@@ -330,7 +332,7 @@ Prerequisites are installed on **Ubuntu 16.04 LTS** with::
 
     sudo apt-get install libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev \
         libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \
-        libharfbuzz-dev libfribidi-dev
+        libharfbuzz-dev libfribidi-dev libxcb1-dev
 
 Then see ``depends/install_raqm.sh`` to install libraqm.
 
@@ -338,7 +340,7 @@ Prerequisites are installed on recent **RedHat** **Centos** or **Fedora** with::
 
     sudo dnf install libtiff-devel libjpeg-devel openjpeg2-devel zlib-devel \
         freetype-devel lcms2-devel libwebp-devel tcl-devel tk-devel \
-        harfbuzz-devel fribidi-devel libraqm-devel libimagequant-devel
+        harfbuzz-devel fribidi-devel libraqm-devel libimagequant-devel libxcb-devel
 
 Note that the package manager may be yum or dnf, depending on the
 exact distribution.

--- a/docs/releasenotes/7.1.0.rst
+++ b/docs/releasenotes/7.1.0.rst
@@ -42,6 +42,18 @@ Reading JPEG comments
 When opening a JPEG image, the comment may now be read into
 :py:attr:`~PIL.Image.Image.info`.
 
+X11 ImageGrab.grab()
+^^^^^^^^^^^^^^^^^^^^
+Support has been added for ``ImageGrab.grab()`` on Linux using the X server
+with the XCB library.
+
+An optional ``xdisplay`` parameter has been added to select the X server,
+with the default value of ``None`` using the default X server.
+
+Passing a different value on Windows or macOS will force taking a snapshot
+using the selected X server; pass an empty string to use the default X server.
+XCB support is not included in pre-compiled wheels for Windows and macOS.
+
 
 Other Changes
 =============


### PR DESCRIPTION
Release notes for #4260 
Update installation docs for #4260 and #4029 

I'm assuming Windows and macOS don't need (and will not have) XCB support in distributed wheels, as this is quite an unusual (although valid) scenario; please correct this if necessary. (I don't think XCB even supports Windows outside MinGW.)