### PR TITLE
png: initialize _n_frames

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -635,7 +635,10 @@ class TestFilePng:
 
     def test_seek(self):
         with Image.open(TEST_PNG_FILE) as im:
+            assert im.n_frames == 1
             im.seek(0)
+            with pytest.raises(EOFError):
+                im.seek(1)
 
 
 @pytest.mark.skipif(is_win32(), reason="Requires Unix or macOS")

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -85,6 +85,8 @@ class TestFilePng:
             assert im.size == (128, 128)
             assert im.format == "PNG"
             assert im.get_format_mimetype() == "image/png"
+            assert im.n_frames == 1
+            assert not im.is_animated
 
         for mode in ["1", "L", "P", "RGB", "I", "I;16"]:
             im = hopper(mode)
@@ -635,7 +637,6 @@ class TestFilePng:
 
     def test_seek(self):
         with Image.open(TEST_PNG_FILE) as im:
-            assert im.n_frames == 1
             im.seek(0)
             with pytest.raises(EOFError):
                 im.seek(1)

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -636,7 +636,6 @@ class PngImageFile(ImageFile.ImageFile):
         if self.fp.read(8) != _MAGIC:
             raise SyntaxError("not a PNG file")
         self.__fp = self.fp
-        self.__frame = 0
 
         #
         # Parse headers up to the first IDAT or fDAT chunk
@@ -685,7 +684,12 @@ class PngImageFile(ImageFile.ImageFile):
         else:
             self.__prepare_idat = length  # used by load_prepare()
 
-        if self._n_frames is not None:
+        if self._n_frames is None:
+            # standard PNG image, frame-related attributes still need to be
+            # initialized for seek()/_seek_check() to behave as expected
+            self.__frame = 0
+            self._n_frames = 1
+        else:
             self._close_exclusive_fp_after_loading = False
             self.png.save_rewind()
             self.__rewind_idat = self.__prepare_idat


### PR DESCRIPTION
Fixes #4518 

Changes proposed in this pull request:

 * after the original APNG changes, `ImageFile._seek_check()` won't raise EOF for out of bounds seek unless `_n_frames` is properly set for standard (non-animated) PNG images