### PR TITLE
Do not install PyQt5 5.14.2

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -20,7 +20,7 @@ if [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then
   # "ERROR: Could not find a version that satisfies the requirement pyqt5"
   if [[ $TRAVIS_CPU_ARCH == "amd64" ]]; then
     sudo apt-get -qq install pyqt5-dev-tools
-    pip install pyqt5!=5.14.1
+    pip install pyqt5!=5.14.1,!=5.14.2
   fi
 fi
 


### PR DESCRIPTION
Like https://github.com/python-pillow/Pillow/pull/4339 but for the new PyQt 5.14.2 which was released today (https://pypi.org/project/PyQt5/5.14.2/) and builds have started failing:

https://travis-ci.org/github/python-pillow/Pillow/jobs/670532178#L606
