### PR TITLE
GHA: Check docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,12 @@ jobs:
         name: errors
         path: Tests/errors
 
+    - name: Docs
+      if: matrix.python-version == 3.8
+      run: |
+        pip install sphinx-rtd-theme
+        make doccheck
+
     - name: After success
       if: success()
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
         path: Tests/errors
 
     - name: Docs
-      if: matrix.python-version == 3.8
+      if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == 3.8
       run: |
         pip install sphinx-rtd-theme
         make doccheck


### PR DESCRIPTION
Changes proposed in this pull request:

 * Revert https://github.com/python-pillow/Pillow/commit/fbb14f67a30b612454bc7cf9a5f73d6b35e7eb14 from https://github.com/python-pillow/Pillow/pull/4284 as `make doccheck` is now possible on GitHub Actions
 * Do it only for Python 3.8 on Ubuntu

