### PR TITLE
Raise an EOFError when seeking too far in PNG

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -637,6 +637,9 @@ class TestFilePng:
         with Image.open(TEST_PNG_FILE) as im:
             im.seek(0)
 
+            with pytest.raises(EOFError):
+                im.seek(1)
+
 
 @pytest.mark.skipif(is_win32(), reason="Requires Unix or macOS")
 @skip_unless_feature("zlib")

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -229,7 +229,7 @@ Plugin reference
 ----------------------------
 
 .. automodule:: PIL.PngImagePlugin
-    :members: ChunkStream, PngImageFile, PngStream, getchunks, is_cid, putchunk
+    :members: ChunkStream, PngStream, getchunks, is_cid, putchunk
     :show-inheritance:
 .. autoclass:: PIL.PngImagePlugin.ChunkStream
     :members:

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -673,7 +673,7 @@ class PngImageFile(ImageFile.ImageFile):
         self._text = None
         self.tile = self.png.im_tile
         self.custom_mimetype = self.png.im_custom_mimetype
-        self._n_frames = self.png.im_n_frames
+        self.n_frames = self.png.im_n_frames or 1
         self.default_image = self.info.get("default_image", False)
 
         if self.png.im_palette:
@@ -685,15 +685,16 @@ class PngImageFile(ImageFile.ImageFile):
         else:
             self.__prepare_idat = length  # used by load_prepare()
 
-        if self._n_frames is not None:
+        if self.png.im_n_frames is not None:
             self._close_exclusive_fp_after_loading = False
             self.png.save_rewind()
             self.__rewind_idat = self.__prepare_idat
             self.__rewind = self.__fp.tell()
             if self.default_image:
                 # IDAT chunk contains default image and not first animation frame
-                self._n_frames += 1
+                self.n_frames += 1
             self._seek(0)
+        self.is_animated = self.n_frames > 1
 
     @property
     def text(self):
@@ -709,16 +710,6 @@ class PngImageFile(ImageFile.ImageFile):
             if self.is_animated:
                 self.seek(frame)
         return self._text
-
-    @property
-    def n_frames(self):
-        if self._n_frames is None:
-            return 1
-        return self._n_frames
-
-    @property
-    def is_animated(self):
-        return self._n_frames is not None and self._n_frames > 1
 
     def verify(self):
         """Verify PNG file"""


### PR DESCRIPTION
Resolves #4518

Looking at PngImagePlugin, there's no need for `n_frames` or `is_animated` to use property decorators - they can just be regular properties.

You might think this is just a simplification of the code, and that it would have no effect on behaviour. This is not the case - the common [`_seek_check` method](https://github.com/python-pillow/Pillow/blob/8c9100e267f40a63081b344220abaa57325a3d6d/src/PIL/ImageFile.py#L294-L306) changes behaviour. If `_n_frames` is present, and `None`, then it doesn't check the upper limit on the frame number, because that would potentially require seeking all the way to the end of the file. Now that there is no `_n_frames`, it checks the upper limit, and throws an `EOFError`.

I've added a test to ensure that an EOFError is thrown moving forward.

Testing, I find that this resolves the issue. This is also noted in https://github.com/python-pillow/Pillow/issues/4518#issuecomment-608360106.