### PR TITLE
Updated deprecated method

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -289,4 +289,4 @@ texinfo_documents = [
 
 
 def setup(app):
-    app.add_javascript("js/script.js")
+    app.add_js_file("js/script.js")


### PR DESCRIPTION
https://travis-ci.org/github/python-pillow/Pillow/jobs/671584849#L4879-L4880

> /home/travis/build/python-pillow/Pillow/docs/conf.py:292: RemovedInSphinx40Warning: The app.add_javascript() is deprecated. Please use app.add_js_file() instead.
>   app.add_javascript("js/script.js")

This change is documented at https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_js_file