### PR TITLE
Retry on apt-get update problems

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -1,8 +1,22 @@
 #!/bin/bash
 
+aptget_update()
+{
+    if [ ! -z $1 ]; then
+        echo ""
+        echo "Retrying apt-get update..."
+        echo ""
+    fi
+    output=`sudo apt-get update 2>&1`
+    echo "$output"
+    if [[ $output == *[WE]:\ * ]]; then
+        return 1
+    fi
+}
+aptget_update || aptget_update retry || aptget_update retry
+
 set -e
 
-sudo apt-get update
 sudo apt-get -qq install libfreetype6-dev liblcms2-dev python3-tk\
                          ghostscript libffi-dev libjpeg-turbo-progs libopenjp2-7-dev\
                          cmake imagemagick libharfbuzz-dev libfribidi-dev


### PR DESCRIPTION
Helps #4508 

The issue reports that `apt-get update` is failing sometimes. This PR attempts to help by running the command up to two more times if there is a warning or error.

However, when I did manage to see `apt-get update` fail on this branch, the command ran again, but it also failed on the subsequent attempts. So be aware of that.