### PR TITLE
Replace IOError and WindowsError aliases with OSError

### DIFF
--- a/Tests/check_j2k_overflow.py
+++ b/Tests/check_j2k_overflow.py
@@ -5,5 +5,5 @@ from PIL import Image
 def test_j2k_overflow(tmp_path):
     im = Image.new("RGBA", (1024, 131584))
     target = str(tmp_path / "temp.jpc")
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         im.save(target)

--- a/Tests/check_libtiff_segfault.py
+++ b/Tests/check_libtiff_segfault.py
@@ -9,6 +9,6 @@ def test_libtiff_segfault():
         libtiff >= 4.0.0
         """
 
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         with Image.open(TEST_FILE) as im:
             im.load()

--- a/Tests/test_file_bufrstub.py
+++ b/Tests/test_file_bufrstub.py
@@ -32,7 +32,7 @@ def test_load():
     with Image.open(TEST_FILE) as im:
 
         # Act / Assert: stub cannot load without an implemented handler
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             im.load()
 
 
@@ -42,5 +42,5 @@ def test_save(tmp_path):
     tmpfile = str(tmp_path / "temp.bufr")
 
     # Act / Assert: stub cannot save without an implemented handler
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         im.save(tmpfile)

--- a/Tests/test_file_dds.py
+++ b/Tests/test_file_dds.py
@@ -138,7 +138,7 @@ def test_short_header():
     def short_header():
         Image.open(BytesIO(img_file[:119]))
 
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         short_header()
 
 
@@ -152,7 +152,7 @@ def test_short_file():
         with Image.open(BytesIO(img_file[:-100])) as im:
             im.load()
 
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         short_file()
 
 

--- a/Tests/test_file_fitsstub.py
+++ b/Tests/test_file_fitsstub.py
@@ -30,7 +30,7 @@ def test_load():
     with Image.open(TEST_FILE) as im:
 
         # Act / Assert: stub cannot load without an implemented handler
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             im.load()
 
 
@@ -41,7 +41,7 @@ def test_save():
         dummy_filename = "dummy.filename"
 
         # Act / Assert: stub cannot save without an implemented handler
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             im.save(dummy_filename)
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             FitsStubImagePlugin._save(im, dummy_fp, dummy_filename)

--- a/Tests/test_file_fpx.py
+++ b/Tests/test_file_fpx.py
@@ -19,5 +19,5 @@ def test_invalid_file():
 
 
 def test_fpx_invalid_number_of_bands():
-    with pytest.raises(IOError, match="Invalid number of bands"):
+    with pytest.raises(OSError, match="Invalid number of bands"):
         Image.open("Tests/images/input_bw_five_bands.fpx")

--- a/Tests/test_file_gribstub.py
+++ b/Tests/test_file_gribstub.py
@@ -32,7 +32,7 @@ def test_load():
     with Image.open(TEST_FILE) as im:
 
         # Act / Assert: stub cannot load without an implemented handler
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             im.load()
 
 
@@ -42,5 +42,5 @@ def test_save(tmp_path):
     tmpfile = str(tmp_path / "temp.grib")
 
     # Act / Assert: stub cannot save without an implemented handler
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         im.save(tmpfile)

--- a/Tests/test_file_hdf5stub.py
+++ b/Tests/test_file_hdf5stub.py
@@ -30,7 +30,7 @@ def test_load():
     with Image.open(TEST_FILE) as im:
 
         # Act / Assert: stub cannot load without an implemented handler
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             im.load()
 
 
@@ -41,7 +41,7 @@ def test_save():
         dummy_filename = "dummy.filename"
 
         # Act / Assert: stub cannot save without an implemented handler
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             im.save(dummy_filename)
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             Hdf5StubImagePlugin._save(im, dummy_fp, dummy_filename)

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -147,7 +147,7 @@ class TestFileJpeg:
         with Image.open("Tests/images/icc_profile_big.jpg") as im:
             f = str(tmp_path / "temp.jpg")
             icc_profile = im.info["icc_profile"]
-            # Should not raise IOError for image with icc larger than image size.
+            # Should not raise OSError for image with icc larger than image size.
             im.save(
                 f,
                 format="JPEG",
@@ -379,14 +379,14 @@ class TestFileJpeg:
             ImageFile.LOAD_TRUNCATED_IMAGES = False
             assert im.getbbox() is not None
 
-    def test_truncated_jpeg_throws_IOError(self):
+    def test_truncated_jpeg_throws_oserror(self):
         filename = "Tests/images/truncated_jpeg.jpg"
         with Image.open(filename) as im:
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 im.load()
 
             # Test that the error is raised if loaded a second time
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 im.load()
 
     def test_qtables(self, tmp_path):
@@ -552,7 +552,7 @@ class TestFileJpeg:
         out = BytesIO()
         for mode in ["LA", "La", "RGBA", "RGBa", "P"]:
             img = Image.new(mode, (20, 20))
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 img.save(out, "JPEG")
 
     def test_save_tiff_with_dpi(self, tmp_path):
@@ -702,7 +702,7 @@ class TestFileCloseW32:
         im = Image.open(tmpfile)
         fp = im.fp
         assert not fp.closed
-        with pytest.raises(WindowsError):
+        with pytest.raises(OSError):
             os.remove(tmpfile)
         im.load()
         assert fp.closed

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -218,7 +218,7 @@ def test_16bit_jp2_roundtrips():
 
 def test_unbound_local():
     # prepatch, a malformed jp2 file could cause an UnboundLocalError exception.
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         Image.open("Tests/images/unbound_variable.jp2")
 
 

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -479,11 +479,11 @@ class TestFileLibTiff(LibTiffTestCase):
         im = hopper("RGB")
         out = str(tmp_path / "temp.tif")
 
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             im.save(out, compression="tiff_ccitt")
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             im.save(out, compression="group3")
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             im.save(out, compression="group4")
 
     def test_fp_leak(self):
@@ -831,7 +831,7 @@ class TestFileLibTiff(LibTiffTestCase):
     def test_realloc_overflow(self):
         TiffImagePlugin.READ_LIBTIFF = True
         with Image.open("Tests/images/tiff_overflow_rows_per_strip.tif") as im:
-            with pytest.raises(IOError) as e:
+            with pytest.raises(OSError) as e:
                 im.load()
 
             # Assert that the error code is IMAGING_CODEC_MEMORY

--- a/Tests/test_file_msp.py
+++ b/Tests/test_file_msp.py
@@ -86,5 +86,5 @@ def test_cannot_save_wrong_mode(tmp_path):
     filename = str(tmp_path / "temp.msp")
 
     # Act/Assert
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         im.save(filename)

--- a/Tests/test_file_palm.py
+++ b/Tests/test_file_palm.py
@@ -72,19 +72,19 @@ def test_p_mode(tmp_path):
     roundtrip(tmp_path, mode)
 
 
-def test_l_ioerror(tmp_path):
+def test_l_oserror(tmp_path):
     # Arrange
     mode = "L"
 
     # Act / Assert
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         helper_save_as_palm(tmp_path, mode)
 
 
-def test_rgb_ioerror(tmp_path):
+def test_rgb_oserror(tmp_path):
     # Arrange
     mode = "RGB"
 
     # Act / Assert
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         helper_save_as_palm(tmp_path, mode)

--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -172,7 +172,7 @@ def test_pdf_open(tmp_path):
 def test_pdf_append_fails_on_nonexistent_file():
     im = hopper("RGB")
     with tempfile.TemporaryDirectory() as temp_dir:
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             im.save(os.path.join(temp_dir, "nonexistent.pdf"), append=True)
 
 

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -105,7 +105,7 @@ class TestFilePng:
         # file was checked into Subversion as a text file.
 
         test_file = "Tests/images/broken.png"
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             Image.open(test_file)
 
     def test_bad_text(self):
@@ -334,7 +334,7 @@ class TestFilePng:
     def test_verify_struct_error(self):
         # Check open/load/verify exception (#1755)
 
-        # offsets to test, -10: breaks in i32() in read. (IOError)
+        # offsets to test, -10: breaks in i32() in read. (OSError)
         #                  -13: breaks in crc, txt chunk.
         #                  -14: malformed chunk
 
@@ -344,7 +344,7 @@ class TestFilePng:
 
             with Image.open(BytesIO(test_file)) as im:
                 assert im.fp is not None
-                with pytest.raises((IOError, SyntaxError)):
+                with pytest.raises((OSError, SyntaxError)):
                     im.verify()
 
     def test_verify_ignores_crc_error(self):
@@ -463,7 +463,7 @@ class TestFilePng:
             data = b"\x89" + fd.read()
 
         pngfile = BytesIO(data)
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             Image.open(pngfile)
 
     def test_trns_rgb(self):
@@ -575,13 +575,13 @@ class TestFilePng:
 
         # Raises a SyntaxError in load_end
         with Image.open("Tests/images/broken_data_stream.png") as im:
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 assert isinstance(im.text, dict)
 
         # Raises a UnicodeDecodeError in load_end
         with Image.open("Tests/images/truncated_image.png") as im:
             # The file is truncated
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 im.text()
             ImageFile.LOAD_TRUNCATED_IMAGES = True
             assert isinstance(im.text, dict)

--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -64,7 +64,7 @@ def test_neg_ppm():
     # has been removed. The default opener doesn't accept negative
     # sizes.
 
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         Image.open("Tests/images/negative_size.ppm")
 
 

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -125,5 +125,5 @@ def test_combined_larger_than_size():
 
     # If we instead take the 'size' of the extra data field as the source of truth,
     # then the seek can't be negative
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         Image.open("Tests/images/combined_larger_than_size.psd")

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -134,7 +134,7 @@ def test_is_int_not_a_number():
 def test_invalid_file():
     invalid_file = "Tests/images/invalid.spider"
 
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         Image.open(invalid_file)
 
 

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -196,7 +196,7 @@ class TestFileTiff:
     def test_save_unsupported_mode(self, tmp_path):
         im = hopper("HSV")
         outfile = str(tmp_path / "temp.tif")
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             im.save(outfile)
 
     def test_little_endian(self):
@@ -249,7 +249,7 @@ class TestFileTiff:
             assert im.getextrema() == (-3.140936851501465, 3.140684127807617)
 
     def test_unknown_pixel_mode(self):
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             Image.open("Tests/images/hopper_unknown_pixel_mode.tif")
 
     def test_n_frames(self):
@@ -614,7 +614,7 @@ class TestFileTiffW32:
         im = Image.open(tmpfile)
         fp = im.fp
         assert not fp.closed
-        with pytest.raises(WindowsError):
+        with pytest.raises(OSError):
             os.remove(tmpfile)
         im.load()
         assert fp.closed

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -22,7 +22,7 @@ class TestUnsupportedWebp:
             WebPImagePlugin.SUPPORTED = False
 
         file_path = "Tests/images/hopper.webp"
-        pytest.warns(UserWarning, lambda: pytest.raises(IOError, Image.open, file_path))
+        pytest.warns(UserWarning, lambda: pytest.raises(OSError, Image.open, file_path))
 
         if HAVE_WEBP:
             WebPImagePlugin.SUPPORTED = True

--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -74,5 +74,5 @@ def test_save(tmp_path):
 
     for ext in [".wmf", ".emf"]:
         tmpfile = str(tmp_path / ("temp" + ext))
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             im.save(tmpfile)

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -57,7 +57,7 @@ class TestImage:
             assert str(e.value) == "unrecognized image mode"
 
     def test_exception_inheritance(self):
-        assert issubclass(UnidentifiedImageError, IOError)
+        assert issubclass(UnidentifiedImageError, OSError)
 
     def test_sanity(self):
 
@@ -687,5 +687,5 @@ class TestRegistry:
         assert enc.args == ("RGB", "args", "extra")
 
     def test_encode_registry_fail(self):
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             Image._getencoder("RGB", "DoesNotExist", ("args",), extra=("extra",))

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -93,6 +93,11 @@ class TestImageFile:
 
         assert_image_equal(im1, im2)
 
+    def test_raise_ioerror(self):
+        with pytest.raises(IOError):
+            with pytest.raises(DeprecationWarning):
+                ImageFile.raise_ioerror(1)
+
     def test_raise_oserror(self):
         with pytest.raises(OSError):
             ImageFile.raise_oserror(1)

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -71,7 +71,7 @@ class TestImageFile:
             im1, im2 = roundtrip("JPEG")  # lossy compression
             assert_image(im1, im2.mode, im2.size)
 
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             roundtrip("PDF")
 
     def test_ico(self):
@@ -93,9 +93,9 @@ class TestImageFile:
 
         assert_image_equal(im1, im2)
 
-    def test_raise_ioerror(self):
-        with pytest.raises(IOError):
-            ImageFile.raise_ioerror(1)
+    def test_raise_oserror(self):
+        with pytest.raises(OSError):
+            ImageFile.raise_oserror(1)
 
     def test_raise_typeerror(self):
         with pytest.raises(TypeError):
@@ -107,17 +107,17 @@ class TestImageFile:
             input = f.read()
         p = ImageFile.Parser()
         p.feed(input)
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             p.close()
 
     @skip_unless_feature("zlib")
     def test_truncated_with_errors(self):
         with Image.open("Tests/images/truncated_image.png") as im:
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 im.load()
 
             # Test that the error is raised if loaded a second time
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 im.load()
 
     @skip_unless_feature("zlib")
@@ -132,7 +132,7 @@ class TestImageFile:
     @skip_unless_feature("zlib")
     def test_broken_datastream_with_errors(self):
         with Image.open("Tests/images/broken_data_stream.png") as im:
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 im.load()
 
     @skip_unless_feature("zlib")

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -393,14 +393,14 @@ class TestImageFont:
         filename = "somefilenamethatdoesntexist.ttf"
 
         # Act/Assert
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             ImageFont.load_path(filename)
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             ImageFont.truetype(filename)
 
     def test_load_non_font_bytes(self):
         with open("Tests/images/hopper.jpg", "rb") as f:
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 ImageFont.truetype(f)
 
     def test_default_font(self):
@@ -615,9 +615,9 @@ class TestImageFont:
                 font.get_variation_axes()
             return
 
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             font.get_variation_names()
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             font.get_variation_axes()
 
         font = ImageFont.truetype("Tests/fonts/AdobeVFPrototype.ttf")
@@ -669,7 +669,7 @@ class TestImageFont:
                 font.set_variation_by_name("Bold")
             return
 
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             font.set_variation_by_name("Bold")
 
         def _check_text(font, path, epsilon):
@@ -701,7 +701,7 @@ class TestImageFont:
                 font.set_variation_by_axes([100])
             return
 
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             font.set_variation_by_axes([500, 50])
 
         def _check_text(font, path, epsilon):

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -31,23 +31,23 @@ class TestImageGrab:
 
             im2 = ImageGrab.grab(xdisplay="")
             assert_image(im2, im2.mode, im2.size)
-        except IOError as e:
+        except OSError as e:
             pytest.skip(str(e))
 
     @pytest.mark.skipif(Image.core.HAVE_XCB, reason="tests missing XCB")
     def test_grab_no_xcb(self):
         if sys.platform not in ("win32", "darwin"):
-            with pytest.raises(IOError) as e:
+            with pytest.raises(OSError) as e:
                 ImageGrab.grab()
             assert str(e.value).startswith("Pillow was built without XCB support")
 
-        with pytest.raises(IOError) as e:
+        with pytest.raises(OSError) as e:
             ImageGrab.grab(xdisplay="")
         assert str(e.value).startswith("Pillow was built without XCB support")
 
     @pytest.mark.skipif(not Image.core.HAVE_XCB, reason="requires XCB")
     def test_grab_invalid_xdisplay(self):
-        with pytest.raises(IOError) as e:
+        with pytest.raises(OSError) as e:
             ImageGrab.grab(xdisplay="error.test:0.0")
         assert str(e.value).startswith("X connection failed")
 

--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -145,5 +145,5 @@ def test_2bit_palette(tmp_path):
 
 
 def test_invalid_palette():
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         ImagePalette.load("Tests/images/hopper.jpg")

--- a/Tests/test_map.py
+++ b/Tests/test_map.py
@@ -20,7 +20,7 @@ def test_overflow():
 
     # This image hits the offset test.
     with Image.open("Tests/images/l2rgb_read.bmp") as im:
-        with pytest.raises((ValueError, MemoryError, IOError)):
+        with pytest.raises((ValueError, MemoryError, OSError)):
             im.load()
 
     Image.MAX_IMAGE_PIXELS = max_pixels

--- a/Tests/test_sgi_crash.py
+++ b/Tests/test_sgi_crash.py
@@ -10,5 +10,5 @@ from PIL import Image
 def test_crashes(test_file):
     with open(test_file, "rb") as f:
         im = Image.open(f)
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             im.load()

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -12,6 +12,15 @@ Deprecated features
 Below are features which are considered deprecated. Where appropriate,
 a ``DeprecationWarning`` is issued.
 
+ImageFile.raise_ioerror
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 7.2.0
+
+IOError was merged into OSError in Python 3.3. So, ``ImageFile.raise_ioerror``
+is now deprecated and will be removed in a future released. Use
+``ImageFile.raise_oserror`` instead.
+
 PILLOW_VERSION constant
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -17,7 +17,7 @@ ImageFile.raise_ioerror
 
 .. deprecated:: 7.2.0
 
-IOError was merged into OSError in Python 3.3. So, ``ImageFile.raise_ioerror``
+``IOError`` was merged into ``OSError`` in Python 3.3. So, ``ImageFile.raise_ioerror``
 is now deprecated and will be removed in a future released. Use
 ``ImageFile.raise_oserror`` instead.
 

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1226,7 +1226,7 @@ The :py:meth:`~PIL.Image.Image.save` method can take the following keyword argum
 
 **append**
     Set to True to append pages to an existing PDF file. If the file doesn't
-    exist, an :py:exc:`IOError` will be raised.
+    exist, an :py:exc:`OSError` will be raised.
 
     .. versionadded:: 5.1.0
 

--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -29,7 +29,7 @@ bands in the image, and also the pixel type and depth. Common modes are “L”
 (luminance) for greyscale images, “RGB” for true color images, and “CMYK” for
 pre-press images.
 
-If the file cannot be opened, an :py:exc:`IOError` exception is raised.
+If the file cannot be opened, an :py:exc:`OSError` exception is raised.
 
 Once you have an instance of the :py:class:`~PIL.Image.Image` class, you can use
 the methods defined by this class to process and manipulate the image. For
@@ -76,7 +76,7 @@ Convert files to JPEG
             try:
                 with Image.open(infile) as im:
                     im.save(outfile)
-            except IOError:
+            except OSError:
                 print("cannot convert", infile)
 
 A second argument can be supplied to the :py:meth:`~PIL.Image.Image.save`
@@ -100,7 +100,7 @@ Create JPEG thumbnails
                 with Image.open(infile) as im:
                     im.thumbnail(size)
                     im.save(outfile, "JPEG")
-            except IOError:
+            except OSError:
                 print("cannot create thumbnail for", infile)
 
 It is important to note that the library doesn’t decode or load the raster data
@@ -125,7 +125,7 @@ Identify Image Files
         try:
             with Image.open(infile) as im:
                 print(infile, im.format, "%dx%d" % im.size, im.mode)
-        except IOError:
+        except OSError:
             pass
 
 Cutting, pasting, and merging images
@@ -450,7 +450,7 @@ context manager::
         ...
 
 If everything goes well, the result is an :py:class:`PIL.Image.Image` object.
-Otherwise, an :exc:`IOError` exception is raised.
+Otherwise, an :exc:`OSError` exception is raised.
 
 You can use a file-like object instead of the filename. The object must
 implement :py:meth:`~file.read`, :py:meth:`~file.seek` and

--- a/docs/releasenotes/7.0.0.rst
+++ b/docs/releasenotes/7.0.0.rst
@@ -85,7 +85,7 @@ Custom unidentified image error
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Pillow will now throw a custom ``UnidentifiedImageError`` when an image cannot be
-identified. For backwards compatibility, this will inherit from ``IOError``.
+identified. For backwards compatibility, this will inherit from ``OSError``.
 
 New argument ``reducing_gap`` for Image.resize() and Image.thumbnail() methods
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/selftest.py
+++ b/selftest.py
@@ -47,7 +47,7 @@ def testimage():
     ('PPM', 'RGB', (128, 128))
     >>> try:
     ...  _info(Image.open("Tests/images/hopper.jpg"))
-    ... except IOError as v:
+    ... except OSError as v:
     ...  print(v)
     ('JPEG', 'RGB', (128, 128))
 

--- a/setup.py
+++ b/setup.py
@@ -579,7 +579,7 @@ class pil_build_ext(build_ext):
                 try:
                     listdir = os.listdir(directory)
                 except Exception:
-                    # WindowsError, FileNotFoundError
+                    # OSError, FileNotFoundError
                     continue
                 for name in listdir:
                     if name.startswith("openjpeg-") and os.path.isfile(

--- a/src/PIL/FpxImagePlugin.py
+++ b/src/PIL/FpxImagePlugin.py
@@ -99,7 +99,7 @@ class FpxImageFile(ImageFile.ImageFile):
         colors = []
         bands = i32(s, 4)
         if bands > 4:
-            raise IOError("Invalid number of bands")
+            raise OSError("Invalid number of bands")
         for i in range(bands):
             # note: for now, we ignore the "uncalibrated" flag
             colors.append(i32(s, 8 + i * 4) & 0x7FFFFFFF)

--- a/src/PIL/GdImageFile.py
+++ b/src/PIL/GdImageFile.py
@@ -74,7 +74,7 @@ def open(fp, mode="r"):
     :param mode: Optional mode.  In this version, if the mode argument
         is given, it must be "r".
     :returns: An image instance.
-    :raises IOError: If the image could not be read.
+    :raises OSError: If the image could not be read.
     """
     if mode != "r":
         raise ValueError("bad mode")

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -255,7 +255,7 @@ class GifImageFile(ImageFile.ImageFile):
 
             else:
                 pass
-                # raise IOError, "illegal GIF tag `%x`" % i8(s)
+                # raise OSError, "illegal GIF tag `%x`" % i8(s)
 
         try:
             if self.disposal_method < 2:

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2080,7 +2080,7 @@ class Image:
         :returns: None
         :exception ValueError: If the output format could not be determined
            from the file name.  Use the format option to solve this.
-        :exception IOError: If the file could not be written.  The file
+        :exception OSError: If the file could not be written.  The file
            may have been created, and may contain partial data.
         """
 

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -49,7 +49,12 @@ ERRORS = {
 }
 
 
-def raise_ioerror(error):
+#
+# --------------------------------------------------------------------
+# Helpers
+
+
+def raise_oserror(error):
     try:
         message = Image.core.getcodecstatus(error)
     except AttributeError:
@@ -57,11 +62,6 @@ def raise_ioerror(error):
     if not message:
         message = "decoder error %d" % error
     raise OSError(message + " when reading image file")
-
-
-#
-# --------------------------------------------------------------------
-# Helpers
 
 
 def _tilesort(t):
@@ -267,7 +267,7 @@ class ImageFile(Image.Image):
 
         if not self.map and not LOAD_TRUNCATED_IMAGES and err_code < 0:
             # still raised if decoder fails to return anything
-            raise_ioerror(err_code)
+            raise_oserror(err_code)
 
         return Image.Image.load(self)
 
@@ -358,7 +358,7 @@ class Parser:
         (Consumer) Feed data to the parser.
 
         :param data: A string buffer.
-        :exception IOError: If the parser failed to parse the image file.
+        :exception OSError: If the parser failed to parse the image file.
         """
         # collect data
 
@@ -390,7 +390,7 @@ class Parser:
                 if e < 0:
                     # decoding error
                     self.image = None
-                    raise_ioerror(e)
+                    raise_oserror(e)
                 else:
                     # end of image
                     return
@@ -444,7 +444,7 @@ class Parser:
         (Consumer) Close the stream.
 
         :returns: An image object.
-        :exception IOError: If the parser failed to parse the image file either
+        :exception OSError: If the parser failed to parse the image file either
                             because it cannot be identified or cannot be
                             decoded.
         """

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -30,6 +30,7 @@
 import io
 import struct
 import sys
+import warnings
 
 from . import Image
 from ._util import isPath
@@ -62,6 +63,15 @@ def raise_oserror(error):
     if not message:
         message = "decoder error %d" % error
     raise OSError(message + " when reading image file")
+
+
+def raise_ioerror(error):
+    warnings.warn(
+        "raise_ioerror is deprecated and will be removed in a future release. "
+        "Use raise_oserror instead.",
+        DeprecationWarning,
+    )
+    return raise_oserror(error)
 
 
 def _tilesort(t):

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -499,7 +499,7 @@ class FreeTypeFont:
     def get_variation_names(self):
         """
         :returns: A list of the named styles in a variation font.
-        :exception IOError: If the font is not a variation font.
+        :exception OSError: If the font is not a variation font.
         """
         try:
             names = self.font.getvarnames()
@@ -510,7 +510,7 @@ class FreeTypeFont:
     def set_variation_by_name(self, name):
         """
         :param name: The name of the style.
-        :exception IOError: If the font is not a variation font.
+        :exception OSError: If the font is not a variation font.
         """
         names = self.get_variation_names()
         if not isinstance(name, bytes):
@@ -529,7 +529,7 @@ class FreeTypeFont:
     def get_variation_axes(self):
         """
         :returns: A list of the axes in a variation font.
-        :exception IOError: If the font is not a variation font.
+        :exception OSError: If the font is not a variation font.
         """
         try:
             axes = self.font.getvaraxes()
@@ -542,7 +542,7 @@ class FreeTypeFont:
     def set_variation_by_axes(self, axes):
         """
         :param axes: A list of values for each axis.
-        :exception IOError: If the font is not a variation font.
+        :exception OSError: If the font is not a variation font.
         """
         try:
             self.font.setvaraxes(axes)
@@ -586,7 +586,7 @@ def load(filename):
 
     :param filename: Name of font file.
     :return: A font object.
-    :exception IOError: If the file could not be read.
+    :exception OSError: If the file could not be read.
     """
     f = ImageFont()
     f._load_pilfont(filename)
@@ -638,7 +638,7 @@ def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):
     :param layout_engine: Which layout engine to use, if available:
                      `ImageFont.LAYOUT_BASIC` or `ImageFont.LAYOUT_RAQM`.
     :return: A font object.
-    :exception IOError: If the file could not be read.
+    :exception OSError: If the file could not be read.
     """
 
     def freetype(font):
@@ -698,7 +698,7 @@ def load_path(filename):
 
     :param filename: Name of font file.
     :return: A font object.
-    :exception IOError: If the file could not be read.
+    :exception OSError: If the file could not be read.
     """
     for directory in sys.path:
         if isDirectory(directory):

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -60,7 +60,7 @@ def grab(bbox=None, include_layered_windows=False, all_screens=False, xdisplay=N
             return im
     # use xdisplay=None for default display on non-win32/macOS systems
     if not Image.core.HAVE_XCB:
-        raise IOError("Pillow was built without XCB support")
+        raise OSError("Pillow was built without XCB support")
     size, data = Image.core.grabscreen_x11(xdisplay)
     im = Image.frombytes("RGB", size, data, "raw", "BGRX", size[0] * 4, 1)
     if bbox:

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1123,7 +1123,7 @@ class TiffImageFile(ImageFile.ImageFile):
             if hasattr(self.fp, "flush"):
                 self.fp.flush()
         except OSError:
-            # io.BytesIO have a fileno, but returns an IOError if
+            # io.BytesIO have a fileno, but returns an OSError if
             # it doesn't use a file descriptor.
             fp = False
 
@@ -1147,7 +1147,7 @@ class TiffImageFile(ImageFile.ImageFile):
             # underlying string for stringio.
             #
             # Rearranging for supporting byteio items, since they have a fileno
-            # that returns an IOError if there's no underlying fp. Easier to
+            # that returns an OSError if there's no underlying fp. Easier to
             # deal with here by reordering.
             if DEBUG:
                 print("have getvalue. just sending in a string from getvalue")

--- a/src/PIL/__init__.py
+++ b/src/PIL/__init__.py
@@ -131,5 +131,5 @@ _plugins = [
 ]
 
 
-class UnidentifiedImageError(IOError):
+class UnidentifiedImageError(OSError):
     pass

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -268,9 +268,9 @@ static const char* readonly = "image is readonly";
 /* static const char* no_content = "image has no content"; */
 
 void *
-ImagingError_IOError(void)
+ImagingError_OSError(void)
 {
-    PyErr_SetString(PyExc_IOError, "error when accessing file");
+    PyErr_SetString(PyExc_OSError, "error when accessing file");
     return NULL;
 }
 

--- a/src/_imagingcms.c
+++ b/src/_imagingcms.c
@@ -107,7 +107,7 @@ cms_profile_open(PyObject* self, PyObject* args)
 
     hProfile = cmsOpenProfileFromFile(sProfile, "r");
     if (!hProfile) {
-        PyErr_SetString(PyExc_IOError, "cannot open profile file");
+        PyErr_SetString(PyExc_OSError, "cannot open profile file");
         return NULL;
     }
 
@@ -126,7 +126,7 @@ cms_profile_fromstring(PyObject* self, PyObject* args)
 
     hProfile = cmsOpenProfileFromMem(pProfile, nProfile);
     if (!hProfile) {
-        PyErr_SetString(PyExc_IOError, "cannot open profile from string");
+        PyErr_SetString(PyExc_OSError, "cannot open profile from string");
         return NULL;
     }
 
@@ -150,18 +150,18 @@ cms_profile_tobytes(PyObject* self, PyObject* args)
     profile = ((CmsProfileObject*)CmsProfile)->profile;
 
     if (!cmsSaveProfileToMem(profile, pProfile, &nProfile)) {
-        PyErr_SetString(PyExc_IOError, "Could not determine profile size");
+        PyErr_SetString(PyExc_OSError, "Could not determine profile size");
         return NULL;
     }
 
     pProfile = (char*)malloc(nProfile);
     if (!pProfile) {
-        PyErr_SetString(PyExc_IOError, "Out of Memory");
+        PyErr_SetString(PyExc_OSError, "Out of Memory");
         return NULL;
     }
 
     if (!cmsSaveProfileToMem(profile, pProfile, &nProfile)) {
-        PyErr_SetString(PyExc_IOError, "Could not get profile");
+        PyErr_SetString(PyExc_OSError, "Could not get profile");
         free(pProfile);
         return NULL;
     }
@@ -655,7 +655,7 @@ _profile_read_mlu(CmsProfileObject* self, cmsTagSignature info)
 
     buf = malloc(len);
     if (!buf) {
-        PyErr_SetString(PyExc_IOError, "Out of Memory");
+        PyErr_SetString(PyExc_OSError, "Out of Memory");
         return NULL;
     }
     /* Just in case the next call fails.  */

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -139,11 +139,11 @@ geterror(int code)
 
     for (i = 0; ft_errors[i].message; i++)
         if (ft_errors[i].code == code) {
-            PyErr_SetString(PyExc_IOError, ft_errors[i].message);
+            PyErr_SetString(PyExc_OSError, ft_errors[i].message);
             return NULL;
         }
 
-    PyErr_SetString(PyExc_IOError, "unknown freetype error");
+    PyErr_SetString(PyExc_OSError, "unknown freetype error");
     return NULL;
 }
 
@@ -259,7 +259,7 @@ getfont(PyObject* self_, PyObject* args, PyObject* kw)
 
     if (!library) {
         PyErr_SetString(
-            PyExc_IOError,
+            PyExc_OSError,
             "failed to initialize FreeType library"
             );
         return NULL;

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -70,7 +70,7 @@ PyObject* HandleMuxError(WebPMuxError err, char* chunk) {
 
         case WEBP_MUX_BAD_DATA:
         case WEBP_MUX_NOT_ENOUGH_DATA:
-            PyErr_SetString(PyExc_IOError, message);
+            PyErr_SetString(PyExc_OSError, message);
             break;
 
         default:
@@ -423,7 +423,7 @@ PyObject* _anim_decoder_get_next(PyObject* self)
     WebPAnimDecoderObject* decp = (WebPAnimDecoderObject*)self;
 
     if (!WebPAnimDecoderGetNext(decp->dec, &buf, &timestamp)) {
-        PyErr_SetString(PyExc_IOError, "failed to read next frame");
+        PyErr_SetString(PyExc_OSError, "failed to read next frame");
         return NULL;
     }
 

--- a/src/display.c
+++ b/src/display.c
@@ -158,7 +158,7 @@ _getdc(ImagingDisplayObject* display, PyObject* args)
 
     dc = GetDC(window);
     if (!dc) {
-        PyErr_SetString(PyExc_IOError, "cannot create dc");
+        PyErr_SetString(PyExc_OSError, "cannot create dc");
         return NULL;
     }
 
@@ -397,7 +397,7 @@ PyImaging_GrabScreenWin32(PyObject* self, PyObject* args)
     return Py_BuildValue("(ii)(ii)N", x, y, width, height, buffer);
 
 error:
-    PyErr_SetString(PyExc_IOError, "screen grab failed");
+    PyErr_SetString(PyExc_OSError, "screen grab failed");
 
     DeleteDC(screen_copy);
     DeleteDC(screen);
@@ -677,7 +677,7 @@ PyImaging_CreateWindowWin32(PyObject* self, PyObject* args)
         );
 
     if (!wnd) {
-        PyErr_SetString(PyExc_IOError, "failed to create window");
+        PyErr_SetString(PyExc_OSError, "failed to create window");
         return NULL;
     }
 
@@ -755,7 +755,7 @@ PyImaging_DrawWmf(PyObject* self, PyObject* args)
     }
 
     if (!meta) {
-        PyErr_SetString(PyExc_IOError, "cannot load metafile");
+        PyErr_SetString(PyExc_OSError, "cannot load metafile");
         return NULL;
     }
 
@@ -774,12 +774,12 @@ PyImaging_DrawWmf(PyObject* self, PyObject* args)
         );
 
     if (!bitmap) {
-        PyErr_SetString(PyExc_IOError, "cannot create bitmap");
+        PyErr_SetString(PyExc_OSError, "cannot create bitmap");
         goto error;
     }
 
     if (!SelectObject(dc, bitmap)) {
-        PyErr_SetString(PyExc_IOError, "cannot select bitmap");
+        PyErr_SetString(PyExc_OSError, "cannot select bitmap");
         goto error;
     }
 
@@ -793,7 +793,7 @@ PyImaging_DrawWmf(PyObject* self, PyObject* args)
     FillRect(dc, &rect, GetStockObject(WHITE_BRUSH));
 
     if (!PlayEnhMetaFile(dc, meta, &rect)) {
-        PyErr_SetString(PyExc_IOError, "cannot render metafile");
+        PyErr_SetString(PyExc_OSError, "cannot render metafile");
         goto error;
     }
 
@@ -845,7 +845,7 @@ PyImaging_GrabScreenX11(PyObject* self, PyObject* args)
 
     connection = xcb_connect(display_name, &screen_number);
     if (xcb_connection_has_error(connection)) {
-        PyErr_Format(PyExc_IOError, "X connection failed: error %i", xcb_connection_has_error(connection));
+        PyErr_Format(PyExc_OSError, "X connection failed: error %i", xcb_connection_has_error(connection));
         xcb_disconnect(connection);
         return NULL;
     }
@@ -860,7 +860,7 @@ PyImaging_GrabScreenX11(PyObject* self, PyObject* args)
     if (screen == NULL || screen->root == 0) {
         // this case is usually caught with "X connection failed: error 6" above
         xcb_disconnect(connection);
-        PyErr_SetString(PyExc_IOError, "X screen not found");
+        PyErr_SetString(PyExc_OSError, "X screen not found");
         return NULL;
     }
 
@@ -874,7 +874,7 @@ PyImaging_GrabScreenX11(PyObject* self, PyObject* args)
                                               0, 0, width, height, 0x00ffffff),
                                 &error);
     if (reply == NULL) {
-        PyErr_Format(PyExc_IOError, "X get_image failed: error %i (%i, %i, %i)",
+        PyErr_Format(PyExc_OSError, "X get_image failed: error %i (%i, %i, %i)",
                      error->error_code, error->major_code, error->minor_code, error->resource_id);
         free(error);
         xcb_disconnect(connection);
@@ -887,7 +887,7 @@ PyImaging_GrabScreenX11(PyObject* self, PyObject* args)
         buffer = PyBytes_FromStringAndSize((char*)xcb_get_image_data(reply),
                                            xcb_get_image_data_length(reply));
     } else {
-        PyErr_Format(PyExc_IOError, "unsupported bit depth: %i", reply->depth);
+        PyErr_Format(PyExc_OSError, "unsupported bit depth: %i", reply->depth);
     }
 
     free(reply);

--- a/src/encode.c
+++ b/src/encode.c
@@ -201,7 +201,7 @@ _encode_to_file(ImagingEncoderObject* encoder, PyObject* args)
             if (write(fh, buf, status) < 0) {
                 ImagingSectionLeave(&cookie);
                 free(buf);
-                return PyErr_SetFromErrno(PyExc_IOError);
+                return PyErr_SetFromErrno(PyExc_OSError);
             }
 
     } while (encoder->state.errcode == 0);

--- a/src/libImaging/Except.c
+++ b/src/libImaging/Except.c
@@ -26,7 +26,7 @@
 /* exception state */
 
 void *
-ImagingError_IOError(void)
+ImagingError_OSError(void)
 {
     fprintf(stderr, "*** exception: file access error\n");
     return NULL;

--- a/src/libImaging/File.c
+++ b/src/libImaging/File.c
@@ -59,7 +59,7 @@ ImagingSavePPM(Imaging im, const char* outfile)
 
     fp = fopen(outfile, "wb");
     if (!fp) {
-        (void) ImagingError_IOError();
+        (void) ImagingError_OSError();
         return 0;
     }
 

--- a/src/libImaging/Imaging.h
+++ b/src/libImaging/Imaging.h
@@ -229,7 +229,7 @@ extern void ImagingSectionLeave(ImagingSectionCookie* cookie);
 /* Exceptions */
 /* ---------- */
 
-extern void* ImagingError_IOError(void);
+extern void* ImagingError_OSError(void);
 extern void* ImagingError_MemoryError(void);
 extern void* ImagingError_ModeError(void); /* maps to ValueError by default */
 extern void* ImagingError_Mismatch(void); /* maps to ValueError by default */

--- a/src/map.c
+++ b/src/map.c
@@ -70,7 +70,7 @@ PyImaging_MapperNew(const char* filename, int readonly)
         FILE_ATTRIBUTE_NORMAL,
         NULL);
     if (mapper->hFile == (HANDLE)-1) {
-        PyErr_SetString(PyExc_IOError, "cannot open file");
+        PyErr_SetString(PyExc_OSError, "cannot open file");
         Py_DECREF(mapper);
         return NULL;
     }
@@ -81,7 +81,7 @@ PyImaging_MapperNew(const char* filename, int readonly)
         0, 0, NULL);
     if (mapper->hMap == (HANDLE)-1) {
         CloseHandle(mapper->hFile);
-        PyErr_SetString(PyExc_IOError, "cannot map file");
+        PyErr_SetString(PyExc_OSError, "cannot map file");
         Py_DECREF(mapper);
         return NULL;
     }
@@ -209,7 +209,7 @@ mapping_readimage(ImagingMapperObject* mapper, PyObject* args)
     size = ysize * stride;
 
     if (mapper->offset + size > mapper->size) {
-        PyErr_SetString(PyExc_IOError, "image file truncated");
+        PyErr_SetString(PyExc_OSError, "image file truncated");
         return NULL;
     }
 


### PR DESCRIPTION
Fixes https://github.com/python-pillow/Pillow/issues/4535.

Changes proposed in this pull request:

 * > _Changed in [Python] version 3.3:_ `EnvironmentError`, `IOError`, `WindowsError`, `socket.error`, `select.error` and `mmap.error` have been merged into `OSError`, and the constructor may return a subclass.
 * https://docs.python.org/3/library/exceptions.html#OSError
 * [pyupgrade](https://github.com/asottile/pyupgrade/#oserror-aliases) replaced some in https://github.com/python-pillow/Pillow/pull/4109
 * This PR replaces the rest
 
Two questions:

In `src/PIL/ImageFile.py`, this PR renames the `raise_ioerror` helper function to `raise_oserror`. Technically this could be considered a breaking change.

1. Should we keep the old `raise_ioerror` with a deprecation warning?
2. Should we name the new one `_raise_oserror` to indicate it is internal? 
