### PR TITLE
Document getexif

### DIFF
--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -179,6 +179,7 @@ This helps to get the bounding box coordinates of the input image:
 .. automethod:: PIL.Image.Image.getcolors
 .. automethod:: PIL.Image.Image.getdata
 .. automethod:: PIL.Image.Image.getextrema
+.. automethod:: PIL.Image.Image.getexif
 .. automethod:: PIL.Image.Image.getpalette
 .. automethod:: PIL.Image.Image.getpixel
 .. automethod:: PIL.Image.Image.histogram


### PR DESCRIPTION
Adds `getexif` method to Image documentation.

Inspired by https://github.com/python-pillow/Pillow/issues/4537#issuecomment-612008156