### PR TITLE
Added method argument to single frame WebP saving

### DIFF
--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -1,3 +1,5 @@
+import io
+
 import pytest
 from PIL import Image, WebPImagePlugin
 
@@ -54,15 +56,10 @@ class TestFileWebp:
             # dwebp -ppm ../../Tests/images/hopper.webp -o hopper_webp_bits.ppm
             assert_image_similar_tofile(image, "Tests/images/hopper_webp_bits.ppm", 1.0)
 
-    def test_write_rgb(self, tmp_path):
-        """
-        Can we write a RGB mode file to webp without error.
-        Does it have the bits we expect?
-        """
-
+    def _roundtrip(self, tmp_path, mode, epsilon, args={}):
         temp_file = str(tmp_path / "temp.webp")
 
-        hopper(self.rgb_mode).save(temp_file)
+        hopper(mode).save(temp_file, **args)
         with Image.open(temp_file) as image:
             assert image.mode == self.rgb_mode
             assert image.size == (128, 128)
@@ -70,18 +67,38 @@ class TestFileWebp:
             image.load()
             image.getdata()
 
-            # generated with: dwebp -ppm temp.webp -o hopper_webp_write.ppm
-            assert_image_similar_tofile(
-                image, "Tests/images/hopper_webp_write.ppm", 12.0
-            )
+            if mode == self.rgb_mode:
+                # generated with: dwebp -ppm temp.webp -o hopper_webp_write.ppm
+                assert_image_similar_tofile(
+                    image, "Tests/images/hopper_webp_write.ppm", 12.0
+                )
 
             # This test asserts that the images are similar. If the average pixel
             # difference between the two images is less than the epsilon value,
             # then we're going to accept that it's a reasonable lossy version of
-            # the image. The old lena images for WebP are showing ~16 on
-            # Ubuntu, the jpegs are showing ~18.
-            target = hopper(self.rgb_mode)
-            assert_image_similar(image, target, 12.0)
+            # the image.
+            target = hopper(mode)
+            if mode != self.rgb_mode:
+                target = target.convert(self.rgb_mode)
+            assert_image_similar(image, target, epsilon)
+
+    def test_write_rgb(self, tmp_path):
+        """
+        Can we write a RGB mode file to webp without error?
+        Does it have the bits we expect?
+        """
+
+        self._roundtrip(tmp_path, self.rgb_mode, 12.5)
+
+    def test_write_method(self, tmp_path):
+        self._roundtrip(tmp_path, self.rgb_mode, 12.0, {"method": 6})
+
+        buffer_no_args = io.BytesIO()
+        hopper().save(buffer_no_args, format="WEBP")
+
+        buffer_method = io.BytesIO()
+        hopper().save(buffer_method, format="WEBP", method=6)
+        assert buffer_no_args.getbuffer() != buffer_method.getbuffer()
 
     def test_write_unsupported_mode_L(self, tmp_path):
         """
@@ -89,18 +106,7 @@ class TestFileWebp:
         similar to the original file.
         """
 
-        temp_file = str(tmp_path / "temp.webp")
-        hopper("L").save(temp_file)
-        with Image.open(temp_file) as image:
-            assert image.mode == self.rgb_mode
-            assert image.size == (128, 128)
-            assert image.format == "WEBP"
-
-            image.load()
-            image.getdata()
-            target = hopper("L").convert(self.rgb_mode)
-
-            assert_image_similar(image, target, 10.0)
+        self._roundtrip(tmp_path, "L", 10.0)
 
     def test_write_unsupported_mode_P(self, tmp_path):
         """
@@ -108,18 +114,7 @@ class TestFileWebp:
         similar to the original file.
         """
 
-        temp_file = str(tmp_path / "temp.webp")
-        hopper("P").save(temp_file)
-        with Image.open(temp_file) as image:
-            assert image.mode == self.rgb_mode
-            assert image.size == (128, 128)
-            assert image.format == "WEBP"
-
-            image.load()
-            image.getdata()
-            target = hopper("P").convert(self.rgb_mode)
-
-            assert_image_similar(image, target, 50.0)
+        self._roundtrip(tmp_path, "P", 50.0)
 
     def test_WebPEncode_with_invalid_args(self):
         """

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -325,6 +325,7 @@ def _save(im, fp, filename):
     if isinstance(exif, Image.Exif):
         exif = exif.tobytes()
     xmp = im.encoderinfo.get("xmp", "")
+    method = im.encoderinfo.get("method", 0)
 
     if im.mode not in _VALID_WEBP_LEGACY_MODES:
         alpha = (
@@ -342,6 +343,7 @@ def _save(im, fp, filename):
         float(quality),
         im.mode,
         icc_profile,
+        method,
         exif,
         xmp,
     )


### PR DESCRIPTION
Resolves #4042

The issue reports that a `method` argument is documented for saving in WebP, but it has no effect for single frame images. This PR adds that feature.

Uses #1263 as a starting point, but really uses more of the [existing Pillow Webp code](https://github.com/python-pillow/Pillow/blob/0ee089be8f495dce1f1fd682d279419595364206/src/_webp.c#L203).

See https://developers.google.com/speed/webp/docs/api#advanced_encoding_api for documentation outlining most of this.