### PR TITLE
Fixed comparison warnings

### DIFF
--- a/src/libImaging/Jpeg.h
+++ b/src/libImaging/Jpeg.h
@@ -110,7 +110,7 @@ typedef struct {
 
     int extra_offset;
 
-    int rawExifLen;   /* EXIF data length */
+    size_t rawExifLen;   /* EXIF data length */
     char* rawExif;  /* EXIF buffer pointer */
 
 } JPEGENCODERSTATE;

--- a/src/libImaging/Jpeg2KEncode.c
+++ b/src/libImaging/Jpeg2KEncode.c
@@ -50,7 +50,7 @@ static OPJ_SIZE_T
 j2k_write(void *p_buffer, OPJ_SIZE_T p_nb_bytes, void *p_user_data)
 {
     ImagingCodecState state = (ImagingCodecState)p_user_data;
-    int result;
+    unsigned int result;
 
     result = _imaging_write_pyFd(state->fd, p_buffer, p_nb_bytes);
 
@@ -399,8 +399,8 @@ j2k_encode_entry(Imaging im, ImagingCodecState state)
         Py_ssize_t n;
         float *pq;
 
-        if (len) {
-            if (len > sizeof(params.tcp_rates) / sizeof(params.tcp_rates[0])) {
+        if (len > 0) {
+            if ((unsigned)len > sizeof(params.tcp_rates) / sizeof(params.tcp_rates[0])) {
                 len = sizeof(params.tcp_rates)/sizeof(params.tcp_rates[0]);
             }
 

--- a/src/libImaging/QuantPngQuant.c
+++ b/src/libImaging/QuantPngQuant.c
@@ -20,8 +20,8 @@
 int
 quantize_pngquant(
     Pixel *pixelData,
-    int width,
-    int height,
+    unsigned int width,
+    unsigned int height,
     uint32_t quantPixels,
     Pixel **palette,
     uint32_t *paletteLength,

--- a/src/libImaging/QuantPngQuant.h
+++ b/src/libImaging/QuantPngQuant.h
@@ -4,8 +4,8 @@
 #include "QuantTypes.h"
 
 int quantize_pngquant(Pixel *,
-    int,
-    int,
+    unsigned int,
+    unsigned int,
     uint32_t,
     Pixel **,
     uint32_t *,


### PR DESCRIPTION
* JpegEncode.c [before](https://travis-ci.org/github/python-pillow/Pillow/jobs/673981863#L2357-L2361) and [after](https://travis-ci.org/github/python-pillow/Pillow/jobs/674229403#L2275)
* Jpeg2KEncode.c [before](https://travis-ci.org/github/python-pillow/Pillow/jobs/673981863#L2432-L2440) and [after](https://travis-ci.org/github/python-pillow/Pillow/jobs/674229403#L2346)
* QuantPngQuant.c [before](https://travis-ci.org/github/python-pillow/Pillow/jobs/673981863#L2442-L2449) and [after](https://travis-ci.org/github/python-pillow/Pillow/jobs/674229403#L2348)