### PR TITLE
Simplified animation code

### DIFF
--- a/src/PIL/DcxImagePlugin.py
+++ b/src/PIL/DcxImagePlugin.py
@@ -59,15 +59,9 @@ class DcxImageFile(PcxImageFile):
 
         self.__fp = self.fp
         self.frame = None
+        self.n_frames = len(self._offset)
+        self.is_animated = self.n_frames > 1
         self.seek(0)
-
-    @property
-    def n_frames(self):
-        return len(self._offset)
-
-    @property
-    def is_animated(self):
-        return len(self._offset) > 1
 
     def seek(self, frame):
         if not self._seek_check(frame):

--- a/src/PIL/FliImagePlugin.py
+++ b/src/PIL/FliImagePlugin.py
@@ -51,7 +51,8 @@ class FliImageFile(ImageFile.ImageFile):
             raise SyntaxError("not an FLI/FLC file")
 
         # frames
-        self.__framecount = i16(s[6:8])
+        self.n_frames = i16(s[6:8])
+        self.is_animated = self.n_frames > 1
 
         # image characteristics
         self.mode = "P"
@@ -109,14 +110,6 @@ class FliImageFile(ImageFile.ImageFile):
                 b = i8(s[n + 2]) << shift
                 palette[i] = (r, g, b)
                 i += 1
-
-    @property
-    def n_frames(self):
-        return self.__framecount
-
-    @property
-    def is_animated(self):
-        return self.__framecount > 1
 
     def seek(self, frame):
         if not self._seek_check(frame):

--- a/src/PIL/MicImagePlugin.py
+++ b/src/PIL/MicImagePlugin.py
@@ -64,19 +64,13 @@ class MicImageFile(TiffImagePlugin.TiffImageFile):
 
         self.__fp = self.fp
         self.frame = None
+        self._n_frames = len(self.images)
+        self.is_animated = self._n_frames > 1
 
         if len(self.images) > 1:
             self.category = Image.CONTAINER
 
         self.seek(0)
-
-    @property
-    def n_frames(self):
-        return len(self.images)
-
-    @property
-    def is_animated(self):
-        return len(self.images) > 1
 
     def seek(self, frame):
         if not self._seek_check(frame):

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -119,6 +119,8 @@ class PsdImageFile(ImageFile.ImageFile):
             if size:
                 self.layers = _layerinfo(self.fp)
             self.fp.seek(end)
+        self.n_frames = len(self.layers)
+        self.is_animated = self.n_frames > 1
 
         #
         # image descriptor
@@ -129,14 +131,6 @@ class PsdImageFile(ImageFile.ImageFile):
         self.__fp = self.fp
         self.frame = 1
         self._min_frame = 1
-
-    @property
-    def n_frames(self):
-        return len(self.layers)
-
-    @property
-    def is_animated(self):
-        return len(self.layers) > 1
 
     def seek(self, layer):
         if not self._seek_check(layer):

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1015,10 +1015,6 @@ class TiffImageFile(ImageFile.ImageFile):
             self.seek(current)
         return self._n_frames
 
-    @property
-    def is_animated(self):
-        return self._is_animated
-
     def seek(self, frame):
         """Select a given frame as current image"""
         if not self._seek_check(frame):
@@ -1052,7 +1048,7 @@ class TiffImageFile(ImageFile.ImageFile):
             if self.__next == 0:
                 self._n_frames = frame + 1
             if len(self._frame_pos) == 1:
-                self._is_animated = self.__next != 0
+                self.is_animated = self.__next != 0
             self.__frame += 1
         self.fp.seek(self._frame_pos[frame])
         self.tag_v2.load(self.fp)
@@ -1087,7 +1083,7 @@ class TiffImageFile(ImageFile.ImageFile):
 
         # allow closing if we're on the first frame, there's no next
         # This is the ImageFile.load path only, libtiff specific below.
-        if not self._is_animated:
+        if not self.is_animated:
             self._close_exclusive_fp_after_loading = True
 
     def _load_libtiff(self):
@@ -1138,7 +1134,7 @@ class TiffImageFile(ImageFile.ImageFile):
         except ValueError:
             raise OSError("Couldn't set the image")
 
-        close_self_fp = self._exclusive_fp and not self._is_animated
+        close_self_fp = self._exclusive_fp and not self.is_animated
         if hasattr(self.fp, "getvalue"):
             # We've got a stringio like thing passed in. Yay for all in memory.
             # The decoder needs the entire file in one shot, so there's not

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -92,7 +92,6 @@ class WebPImageFile(ImageFile.ImageFile):
 
         # Initialize seek state
         self._reset(reset=False)
-        self.seek(0)
 
     def _getexif(self):
         if "exif" not in self.info:

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -54,7 +54,8 @@ class WebPImageFile(ImageFile.ImageFile):
             self._size = width, height
             self.fp = BytesIO(data)
             self.tile = [("raw", (0, 0) + self.size, 0, self.mode)]
-            self._n_frames = 1
+            self.n_frames = 1
+            self.is_animated = False
             return
 
         # Use the newer AnimDecoder API to parse the (possibly) animated file,
@@ -72,7 +73,8 @@ class WebPImageFile(ImageFile.ImageFile):
             bgcolor & 0xFF,
         )
         self.info["background"] = (bg_r, bg_g, bg_b, bg_a)
-        self._n_frames = frame_count
+        self.n_frames = frame_count
+        self.is_animated = self.n_frames > 1
         self.mode = "RGB" if mode == "RGBX" else mode
         self.rawmode = mode
         self.tile = []
@@ -96,14 +98,6 @@ class WebPImageFile(ImageFile.ImageFile):
         if "exif" not in self.info:
             return None
         return dict(self.getexif())
-
-    @property
-    def n_frames(self):
-        return self._n_frames
-
-    @property
-    def is_animated(self):
-        return self._n_frames > 1
 
     def seek(self, frame):
         if not _webp.HAVE_WEBPANIM:

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -100,14 +100,8 @@ class WebPImageFile(ImageFile.ImageFile):
         return dict(self.getexif())
 
     def seek(self, frame):
-        if not _webp.HAVE_WEBPANIM:
-            return super().seek(frame)
-
-        # Perform some simple checks first
-        if frame >= self._n_frames:
-            raise EOFError("attempted to seek beyond end of sequence")
-        if frame < 0:
-            raise EOFError("negative frame index is not valid")
+        if not self._seek_check(frame):
+            return
 
         # Set logical frame to requested position
         self.__logical_frame = frame


### PR DESCRIPTION
* Replaced property methods for n_frames and/or is_animated with normal properties
* Use the common `_seek_check` method in WebP
* Since WebP has `__logical_frame` set to zero on initialisation now, thanks to #4561, the initial seek to zero has no effect, and can be removed