### PR TITLE
Fix pickling WebP

### DIFF
--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -1,11 +1,14 @@
 import pickle
 
+import pytest
 from PIL import Image
 
 
-def helper_pickle_file(tmp_path, pickle, protocol=0, mode=None):
+def helper_pickle_file(
+    tmp_path, pickle, protocol=0, test_file="Tests/images/hopper.jpg", mode=None
+):
     # Arrange
-    with Image.open("Tests/images/hopper.jpg") as im:
+    with Image.open(test_file) as im:
         filename = str(tmp_path / "temp.pkl")
         if mode:
             im = im.convert(mode)
@@ -35,11 +38,14 @@ def helper_pickle_string(
         assert im == loaded_im
 
 
-def test_pickle_image(tmp_path):
+@pytest.mark.parametrize(
+    "test_file", ["Tests/images/hopper.jpg"],
+)
+def test_pickle_image(test_file, tmp_path):
     # Act / Assert
     for protocol in range(0, pickle.HIGHEST_PROTOCOL + 1):
-        helper_pickle_string(pickle, protocol)
-        helper_pickle_file(tmp_path, pickle, protocol)
+        helper_pickle_string(pickle, protocol, test_file)
+        helper_pickle_file(tmp_path, pickle, protocol, test_file)
 
 
 def test_pickle_p_mode():

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -82,3 +82,14 @@ def test_pickle_la_mode_with_palette(tmp_path):
 
         im.mode = "PA"
         assert im == loaded_im
+
+
+def test_pickle_tell():
+    # Arrange
+    image = Image.open("Tests/images/hopper.webp")
+
+    # Act: roundtrip
+    unpickled_image = pickle.loads(pickle.dumps(image))
+
+    # Assert
+    assert unpickled_image.tell() == 0

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -3,6 +3,8 @@ import pickle
 import pytest
 from PIL import Image
 
+from .helper import skip_unless_feature
+
 
 def helper_pickle_file(
     tmp_path, pickle, protocol=0, test_file="Tests/images/hopper.jpg", mode=None
@@ -44,7 +46,9 @@ def helper_pickle_string(
         ("Tests/images/hopper.jpg", None),
         ("Tests/images/hopper.jpg", "L"),
         ("Tests/images/hopper.jpg", "PA"),
-        ("Tests/images/hopper.webp", None),
+        pytest.param(
+            "Tests/images/hopper.webp", None, marks=skip_unless_feature("webp")
+        ),
         ("Tests/images/test-card.png", None),
         ("Tests/images/zero_bb.png", None),
         ("Tests/images/zero_bb_scale2.png", None),

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -62,8 +62,8 @@ def helper_pickle_string(
 def test_pickle_image(tmp_path, test_file, test_mode):
     # Act / Assert
     for protocol in range(0, pickle.HIGHEST_PROTOCOL + 1):
-        helper_pickle_string(pickle, protocol, test_file)
-        helper_pickle_file(tmp_path, pickle, protocol, test_file)
+        helper_pickle_string(pickle, protocol, test_file, test_mode)
+        helper_pickle_file(tmp_path, pickle, protocol, test_file, test_mode)
 
 
 def test_pickle_la_mode_with_palette(tmp_path):

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -39,43 +39,26 @@ def helper_pickle_string(
 
 
 @pytest.mark.parametrize(
-    "test_file", ["Tests/images/hopper.jpg"],
+    ("test_file", "test_mode"),
+    [
+        ("Tests/images/hopper.jpg", None),
+        ("Tests/images/hopper.jpg", "L"),
+        ("Tests/images/hopper.jpg", "PA"),
+        ("Tests/images/test-card.png", None),
+        ("Tests/images/zero_bb.png", None),
+        ("Tests/images/zero_bb_scale2.png", None),
+        ("Tests/images/non_zero_bb.png", None),
+        ("Tests/images/non_zero_bb_scale2.png", None),
+        ("Tests/images/p_trns_single.png", None),
+        ("Tests/images/pil123p.png", None),
+        ("Tests/images/itxt_chunks.png", None),
+    ],
 )
-def test_pickle_image(test_file, tmp_path):
+def test_pickle_image(tmp_path, test_file, test_mode):
     # Act / Assert
     for protocol in range(0, pickle.HIGHEST_PROTOCOL + 1):
         helper_pickle_string(pickle, protocol, test_file)
         helper_pickle_file(tmp_path, pickle, protocol, test_file)
-
-
-def test_pickle_p_mode():
-    # Act / Assert
-    for test_file in [
-        "Tests/images/test-card.png",
-        "Tests/images/zero_bb.png",
-        "Tests/images/zero_bb_scale2.png",
-        "Tests/images/non_zero_bb.png",
-        "Tests/images/non_zero_bb_scale2.png",
-        "Tests/images/p_trns_single.png",
-        "Tests/images/pil123p.png",
-        "Tests/images/itxt_chunks.png",
-    ]:
-        for protocol in range(0, pickle.HIGHEST_PROTOCOL + 1):
-            helper_pickle_string(pickle, protocol=protocol, test_file=test_file)
-
-
-def test_pickle_pa_mode(tmp_path):
-    # Act / Assert
-    for protocol in range(0, pickle.HIGHEST_PROTOCOL + 1):
-        helper_pickle_string(pickle, protocol, mode="PA")
-        helper_pickle_file(tmp_path, pickle, protocol, mode="PA")
-
-
-def test_pickle_l_mode(tmp_path):
-    # Act / Assert
-    for protocol in range(0, pickle.HIGHEST_PROTOCOL + 1):
-        helper_pickle_string(pickle, protocol, mode="L")
-        helper_pickle_file(tmp_path, pickle, protocol, mode="L")
 
 
 def test_pickle_la_mode_with_palette(tmp_path):

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -44,6 +44,7 @@ def helper_pickle_string(
         ("Tests/images/hopper.jpg", None),
         ("Tests/images/hopper.jpg", "L"),
         ("Tests/images/hopper.jpg", "PA"),
+        ("Tests/images/hopper.webp", None),
         ("Tests/images/test-card.png", None),
         ("Tests/images/zero_bb.png", None),
         ("Tests/images/zero_bb_scale2.png", None),

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -38,6 +38,8 @@ class WebPImageFile(ImageFile.ImageFile):
 
     format = "WEBP"
     format_description = "WebP image"
+    __loaded = -1
+    __logical_frame = -1
 
     def _open(self):
         if not _webp.HAVE_WEBPANIM:

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -39,7 +39,7 @@ class WebPImageFile(ImageFile.ImageFile):
     format = "WEBP"
     format_description = "WebP image"
     __loaded = -1
-    __logical_frame = -1
+    __logical_frame = 0
 
     def _open(self):
         if not _webp.HAVE_WEBPANIM:

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -40,6 +40,7 @@ class WebPImageFile(ImageFile.ImageFile):
     format_description = "WebP image"
     __loaded = -1
     __logical_frame = 0
+    __physical_frame = 0
 
     def _open(self):
         if not _webp.HAVE_WEBPANIM:


### PR DESCRIPTION
Fixes #4559. 

Changes proposed in this pull request:

 * Fix pickling and unpickling WebP
 * Refactor some similar tests to use `pytest.mark.parametrize` to reduce duplication and make tests independent
