### PR TITLE
GitHub Actions now sets CI=true

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,10 +21,8 @@ exclude .appveyor.yml
 exclude .coveragerc
 exclude .editorconfig
 exclude .readthedocs.yml
-exclude azure-pipelines.yml
 exclude codecov.yml
 global-exclude .git*
 global-exclude *.pyc
 global-exclude *.so
-prune .azure-pipelines
 prune .ci

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -272,12 +272,8 @@ def on_github_actions():
 
 
 def on_ci():
-    # Travis and AppVeyor have "CI"
-    # Azure Pipelines has "TF_BUILD"
-    # GitHub Actions has "GITHUB_ACTIONS"
-    return (
-        "CI" in os.environ or "TF_BUILD" in os.environ or "GITHUB_ACTIONS" in os.environ
-    )
+    # GitHub Actions, Travis and AppVeyor have "CI"
+    return "CI" in os.environ
 
 
 def is_big_endian():


### PR DESCRIPTION
Changes proposed in this pull request:

 * "The GitHub Actions runner now sets the CI=true environment variable by default"
 * https://github.blog/changelog/2020-04-15-github-actions-sets-the-ci-environment-variable-to-true/
 * We also removed Azure Pipelines in https://github.com/python-pillow/Pillow/pull/4387
