### PR TITLE
Throw image loading error faster

### DIFF
--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -150,10 +150,10 @@ class ImageFile(Image.Image):
     def load(self):
         """Load image data based on tile list"""
 
-        pixel = Image.Image.load(self)
-
         if self.tile is None:
             raise OSError("cannot load this image")
+
+        pixel = Image.Image.load(self)
         if not self.tile:
             return pixel
 

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1094,10 +1094,10 @@ class TiffImageFile(ImageFile.ImageFile):
         """ Overload method triggered when we detect a compressed tiff
             Calls out to libtiff """
 
-        pixel = Image.Image.load(self)
-
         if self.tile is None:
             raise OSError("cannot load this image")
+
+        pixel = Image.Image.load(self)
         if not self.tile:
             return pixel
 


### PR DESCRIPTION
Minor rearrangement of code, so that `OSError("cannot load this image")` can be thrown before calling `Image.load`.

`Image.load` doesn't affect the `self.tile` check that leads to the error, so this is just faster.