### PR TITLE
Fixed bug when unpickling TIFF images

### DIFF
--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -49,6 +49,7 @@ def helper_pickle_string(
         pytest.param(
             "Tests/images/hopper.webp", None, marks=skip_unless_feature("webp")
         ),
+        ("Tests/images/hopper.tif", None),
         ("Tests/images/test-card.png", None),
         ("Tests/images/zero_bb.png", None),
         ("Tests/images/zero_bb_scale2.png", None),

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1066,7 +1066,7 @@ class TiffImageFile(ImageFile.ImageFile):
         return self.__frame
 
     def load(self):
-        if self.use_load_libtiff:
+        if self.tile and self.use_load_libtiff:
             return self._load_libtiff()
         return super().load()
 
@@ -1094,12 +1094,7 @@ class TiffImageFile(ImageFile.ImageFile):
         """ Overload method triggered when we detect a compressed tiff
             Calls out to libtiff """
 
-        if self.tile is None:
-            raise OSError("cannot load this image")
-
-        pixel = Image.Image.load(self)
-        if not self.tile:
-            return pixel
+        Image.Image.load(self)
 
         self.load_prepare()
 


### PR DESCRIPTION
Resolves #3690

When trying to load an unpickled TIFF, an error is currently thrown because `self.use_load_libtiff` is not defined.

https://github.com/python-pillow/Pillow/blob/529e1135059f76d3ba3733d18fe7f8ea82e3c679/src/PIL/TiffImagePlugin.py#L1068-L1071

Now, one solution could be to set that variable on initialisation, but there is another way that I think is simpler (in the end. It might require some explanation first)

The only place that `self.use_load_libtiff` is set is in `_setup`.

https://github.com/python-pillow/Pillow/blob/529e1135059f76d3ba3733d18fe7f8ea82e3c679/src/PIL/TiffImagePlugin.py#L1289

`_setup` is called when seeking, and there is an initial seek upon opening. So we don't need to worry about this variable for any seeking of an unpickled image, just the load operation immediately after unpickling.

Except, immediately after unpickling, there is nothing left to load. Pickling loads an image (via [`tobytes()`](https://github.com/python-pillow/Pillow/blob/e4fa234340f5b4c583bd17db7037ef560aa92e5f/src/PIL/Image.py#L690-L691) it calls [load()](https://github.com/python-pillow/Pillow/blob/e4fa234340f5b4c583bd17db7037ef560aa92e5f/src/PIL/Image.py#L705-L729)).

And when there is nothing to load, `_load_libtiff` and the parent `load()` both behave the same - https://github.com/python-pillow/Pillow/blob/529e1135059f76d3ba3733d18fe7f8ea82e3c679/src/PIL/TiffImagePlugin.py#L1093-L1102 vs https://github.com/python-pillow/Pillow/blob/529e1135059f76d3ba3733d18fe7f8ea82e3c679/src/PIL/ImageFile.py#L150-L158.

So instead of worrying about the value of `self.use_load_libtiff` to [decide whether to call `_load_libtiff` or the parent `load()`](https://github.com/python-pillow/Pillow/blob/529e1135059f76d3ba3733d18fe7f8ea82e3c679/src/PIL/TiffImagePlugin.py#L1068-L1071
), if there is nothing to load, this PR just calls the parent `load()`.

There are also some other lines removed from `_load_libtiff` in this PR, now that it is no longer called if there is nothing to load.