### PR TITLE
Don't show own deprecation warning in test logs

### DIFF
--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -95,7 +95,7 @@ class TestImageFile:
 
     def test_raise_ioerror(self):
         with pytest.raises(IOError):
-            with pytest.raises(DeprecationWarning):
+            with pytest.warns(DeprecationWarning):
                 ImageFile.raise_ioerror(1)
 
     def test_raise_oserror(self):


### PR DESCRIPTION
Should be `pytest.warns(DeprecationWarning)` not `pytest.raises(DeprecationWarning)`

# Before

```console
$ pytest Tests/test_imagefile.py -k raise_ioerror
========================================================= test session starts =========================================================

<snip>

Tests/test_imagefile.py .                                                                                                       [100%]

========================================================== warnings summary ===========================================================
Tests/test_imagefile.py::TestImageFile::test_raise_ioerror
  /Users/hugo/github/Pillow/src/PIL/ImageFile.py:69: DeprecationWarning: raise_ioerror is deprecated and will be removed in a future release. Use raise_oserror instead.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================= 1 passed, 19 deselected, 1 warning in 0.23s =============================================
```

# After

```console
$ pytest Tests/test_imagefile.py -k raise_ioerror
========================================================= test session starts =========================================================

<snip>

Tests/test_imagefile.py .                                                                                                       [100%]

================================================== 1 passed, 19 deselected in 0.18s ===================================================
```