### PR TITLE
Add append_images support for ICO

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,18 @@
 Changelog (Pillow)
 ==================
 
+7.2.0 (unreleased)
+------------------
+
+- Fixed bug when unpickling TIFF images #4565
+  [radarhere]
+
+- Fix pickling WebP #4561
+  [hugovk, radarhere]
+
+- Raise an EOFError when seeking too far in PNG #4528
+  [radarhere]
+
 7.1.1 (2020-04-02)
 ------------------
 

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -90,7 +90,7 @@ def test_only_save_append_images(tmp_path):
     im = hopper()
     provided_im = Image.new("RGBA", (32, 32), (255, 0, 0, 255))
     outfile = str(tmp_path / "temp_saved_multi_icon.ico")
-    im.save(outfile, sizes = [(32, 32), (64, 64)], append_images = [provided_im])
+    im.save(outfile, sizes=[(32, 32), (64, 64)], append_images=[provided_im])
 
     with Image.open(outfile) as reread:
         reread.size = (64, 64)

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -85,6 +85,24 @@ def test_only_save_relevant_sizes(tmp_path):
         assert im_saved.info["sizes"] == {(16, 16), (24, 24), (32, 32), (48, 48)}
 
 
+def test_only_save_append_images(tmp_path):
+    """append_images should work to provide alternative sizes"""
+    im = hopper()
+    provided_im = Image.new("RGBA", (32, 32), (255, 0, 0, 255))
+    outfile = str(tmp_path / "temp_saved_multi_icon.ico")
+    im.save(outfile, sizes = [(32, 32), (64, 64)], append_images = [provided_im])
+
+    with Image.open(outfile) as reread:
+        reread.size = (64, 64)
+        reread.load()
+        assert_image_equal(reread, hopper().resize((64, 64), Image.LANCZOS))
+
+    with Image.open(outfile) as reread:
+        reread.size = (32, 32)
+        reread.load()
+        assert_image_equal(reread, provided_im)
+
+
 def test_unexpected_size():
     # This image has been manually hexedited to state that it is 16x32
     # while the image within is still 16x16

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -85,8 +85,8 @@ def test_only_save_relevant_sizes(tmp_path):
         assert im_saved.info["sizes"] == {(16, 16), (24, 24), (32, 32), (48, 48)}
 
 
-def test_only_save_append_images(tmp_path):
-    """append_images should work to provide alternative sizes"""
+def test_save_append_images(tmp_path):
+    # append_images should be used for scaled down versions of the image
     im = hopper("RGBA")
     provided_im = Image.new("RGBA", (32, 32), (255, 0, 0))
     outfile = str(tmp_path / "temp_saved_multi_icon.ico")

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -52,9 +52,7 @@ def _save(im, fp, filename):
     sizes = list(sizes)
     fp.write(struct.pack("<H", len(sizes)))  # idCount(2)
     offset = fp.tell() + len(sizes) * 16
-    alt_images = {
-        im.size: im for im in im.encoderinfo.get("append_images", [])
-    }
+    alt_images = {im.size: im for im in im.encoderinfo.get("append_images", [])}
     for size in sizes:
         width, height = size
         # 0 means 256

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -52,6 +52,9 @@ def _save(im, fp, filename):
     sizes = list(sizes)
     fp.write(struct.pack("<H", len(sizes)))  # idCount(2)
     offset = fp.tell() + len(sizes) * 16
+    alt_images = {
+        im.size: im for im in im.encoderinfo.get("append_images", [])
+    }
     for size in sizes:
         width, height = size
         # 0 means 256
@@ -63,9 +66,12 @@ def _save(im, fp, filename):
         fp.write(struct.pack("<H", 32))  # wBitCount(2)
 
         image_io = BytesIO()
-        # TODO: invent a more convenient method for proportional scalings
-        tmp = im.copy()
-        tmp.thumbnail(size, Image.LANCZOS, reducing_gap=None)
+        if size in alt_images:
+            tmp = alt_images[size]
+        else:
+            # TODO: invent a more convenient method for proportional scalings
+            tmp = im.copy()
+            tmp.thumbnail(size, Image.LANCZOS, reducing_gap=None)
         tmp.save(image_io, "png")
         image_io.seek(0)
         image_bytes = image_io.read()

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -64,9 +64,8 @@ def _save(im, fp, filename):
         fp.write(struct.pack("<H", 32))  # wBitCount(2)
 
         image_io = BytesIO()
-        if size in alt_images:
-            tmp = alt_images[size]
-        else:
+        tmp = alt_images.get(size)
+        if not tmp:
             # TODO: invent a more convenient method for proportional scalings
             tmp = im.copy()
             tmp.thumbnail(size, Image.LANCZOS, reducing_gap=None)


### PR DESCRIPTION
This adds support for the append_images parameter when saving .ICO files. Its behavior is much the same as for .ICNS files, and can be used to provide alternative sprites for particular icon sizes instead of simply resizing the main image to fit that size.
