### PR TITLE
Link to Filters concept from methods' parameters

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2247,6 +2247,7 @@ class Image:
            :py:attr:`PIL.Image.BICUBIC`, or :py:attr:`PIL.Image.LANCZOS`.
            If omitted, it defaults to :py:attr:`PIL.Image.BICUBIC`.
            (was :py:attr:`PIL.Image.NEAREST` prior to version 2.5.0).
+           See: :ref:`concept-filters`.
         :param reducing_gap: Apply optimization by resizing the image
            in two steps. First, reducing the image by integer times
            using :py:meth:`~PIL.Image.Image.reduce` or
@@ -2336,6 +2337,7 @@ class Image:
            environment), or :py:attr:`PIL.Image.BICUBIC` (cubic spline
            interpolation in a 4x4 environment). If omitted, or if the image
            has mode "1" or "P", it is set to :py:attr:`PIL.Image.NEAREST`.
+           See: :ref:`concept-filters`.
         :param fill: If **method** is an
           :py:class:`~PIL.Image.ImageTransformHandler` object, this is one of
           the arguments passed to it. Otherwise, it is unused.


### PR DESCRIPTION
We link to the [Filters concept](https://pillow.readthedocs.io/en/stable/handbook/concepts.html#concept-filters) when mentioning filters in the parameters for `Image.resize` and `Image.rotate`:
 
* https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.resize
* https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.rotate

But not for `Image.thumbnail` or `Image.transform`:

https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.thumbnail
https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.transform

Let's add it to those two too.