### PR TITLE
Fixed drawing a jointed line with a sequence of numeric values

### DIFF
--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -873,8 +873,9 @@ def test_wide_line_dot():
     assert_image_similar(im, Image.open(expected), 1)
 
 
-def test_line_joint():
-    for xy in [
+@pytest.mark.parametrize(
+    "xy",
+    [
         [
             (400, 280),
             (380, 280),
@@ -951,16 +952,18 @@ def test_line_joint():
             250,
             100,
         ],
-    ]:
-        im = Image.new("RGB", (500, 325))
-        draw = ImageDraw.Draw(im)
-        expected = "Tests/images/imagedraw_line_joint_curve.png"
+    ],
+)
+def test_line_joint(xy):
+    im = Image.new("RGB", (500, 325))
+    draw = ImageDraw.Draw(im)
+    expected = "Tests/images/imagedraw_line_joint_curve.png"
 
-        # Act
-        draw.line(xy, GRAY, 50, "curve")
+    # Act
+    draw.line(xy, GRAY, 50, "curve")
 
-        # Assert
-        assert_image_similar(im, Image.open(expected), 3)
+    # Assert
+    assert_image_similar(im, Image.open(expected), 3)
 
 
 def test_textsize_empty_string():

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -874,31 +874,93 @@ def test_wide_line_dot():
 
 
 def test_line_joint():
-    im = Image.new("RGB", (500, 325))
-    draw = ImageDraw.Draw(im)
-    expected = "Tests/images/imagedraw_line_joint_curve.png"
+    for xy in [
+        [
+            (400, 280),
+            (380, 280),
+            (450, 280),
+            (440, 120),
+            (350, 200),
+            (310, 280),
+            (300, 280),
+            (250, 280),
+            (250, 200),
+            (150, 200),
+            (150, 260),
+            (50, 200),
+            (150, 50),
+            (250, 100),
+        ],
+        (
+            400,
+            280,
+            380,
+            280,
+            450,
+            280,
+            440,
+            120,
+            350,
+            200,
+            310,
+            280,
+            300,
+            280,
+            250,
+            280,
+            250,
+            200,
+            150,
+            200,
+            150,
+            260,
+            50,
+            200,
+            150,
+            50,
+            250,
+            100,
+        ),
+        [
+            400,
+            280,
+            380,
+            280,
+            450,
+            280,
+            440,
+            120,
+            350,
+            200,
+            310,
+            280,
+            300,
+            280,
+            250,
+            280,
+            250,
+            200,
+            150,
+            200,
+            150,
+            260,
+            50,
+            200,
+            150,
+            50,
+            250,
+            100,
+        ],
+    ]:
+        im = Image.new("RGB", (500, 325))
+        draw = ImageDraw.Draw(im)
+        expected = "Tests/images/imagedraw_line_joint_curve.png"
 
-    # Act
-    xy = [
-        (400, 280),
-        (380, 280),
-        (450, 280),
-        (440, 120),
-        (350, 200),
-        (310, 280),
-        (300, 280),
-        (250, 280),
-        (250, 200),
-        (150, 200),
-        (150, 260),
-        (50, 200),
-        (150, 50),
-        (250, 100),
-    ]
-    draw.line(xy, GRAY, 50, "curve")
+        # Act
+        draw.line(xy, GRAY, 50, "curve")
 
-    # Assert
-    assert_image_similar(im, Image.open(expected), 3)
+        # Assert
+        assert_image_similar(im, Image.open(expected), 3)
 
 
 def test_textsize_empty_string():

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -156,6 +156,8 @@ class ImageDraw:
         if ink is not None:
             self.draw.draw_lines(xy, ink, width)
             if joint == "curve" and width > 4:
+                if not isinstance(xy[0], (list, tuple)):
+                    xy = [tuple(xy[i : i + 2]) for i in range(0, len(xy), 2)]
                 for i in range(1, len(xy) - 1):
                     point = xy[i]
                     angles = [


### PR DESCRIPTION
Resolves #4579

The issue reports that
```python
draw.line(((400, 200), (300, 280), (100, 280)), 0, 50, joint='curve')
```
works, but
```python
draw.line((400, 200, 300, 280, 100, 280), 0, 50, joint='curve')
```
does not.