### PR TITLE
Remove soon-EOL Fedora 30

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -22,7 +22,6 @@ jobs:
           centos-8-amd64,
           amazon-1-amd64,
           amazon-2-amd64,
-          fedora-30-amd64,
           fedora-31-amd64,
         ]
         dockerTag: [master]


### PR DESCRIPTION
Fedora 30 will be EOL on 2020-06-03, before the next scheduled Pillow 7.2.0 on 2020-07-01.

* https://fedorapeople.org/groups/schedule/f-30/f-30-all-tasks.html

See also https://github.com/python-pillow/docker-images/pull/78.