### PR TITLE
Fixes default offset for Exif

### DIFF
--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -261,9 +261,9 @@ class TestPyDecoder:
         with Image.open(out) as reloaded:
             reloaded_exif = reloaded.getexif()
             assert reloaded_exif[258] == 8
-            assert 40960 not in exif
+            assert 40960 not in reloaded_exif
             assert reloaded_exif[40963] == 455
-            assert exif[11] == "Pillow test"
+            assert reloaded_exif[11] == "Pillow test"
 
         with Image.open("Tests/images/no-dpi-in-exif.jpg") as im:  # Big endian
             exif = im.getexif()
@@ -281,9 +281,9 @@ class TestPyDecoder:
         with Image.open(out) as reloaded:
             reloaded_exif = reloaded.getexif()
             assert reloaded_exif[258] == 8
-            assert 40960 not in exif
+            assert 34665 not in reloaded_exif
             assert reloaded_exif[40963] == 455
-            assert exif[305] == "Pillow test"
+            assert reloaded_exif[305] == "Pillow test"
 
     @skip_unless_feature("webp")
     @skip_unless_feature("webp_anim")
@@ -302,7 +302,7 @@ class TestPyDecoder:
                     reloaded_exif = reloaded.getexif()
                     assert reloaded_exif[258] == 8
                     assert reloaded_exif[40963] == 455
-                    assert exif[305] == "Pillow test"
+                    assert reloaded_exif[305] == "Pillow test"
 
             im.save(out, exif=exif)
             check_exif()

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3281,7 +3281,7 @@ class Exif(MutableMapping):
             self._data.update(ifd)
             self._ifds[0x8769] = ifd
 
-    def tobytes(self, offset=0):
+    def tobytes(self, offset=8):
         from . import TiffImagePlugin
 
         if self.endian == "<":


### PR DESCRIPTION
test_imagefile.py checks exif instead of reloaded_exif; making the tests pass when they should not.

