### PR TITLE
Mention Ubuntu versions younger than 16.04

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -328,7 +328,7 @@ In Fedora, the command is::
 
 .. Note:: ``redhat-rpm-config`` is required on Fedora 23, but not earlier versions.
 
-Prerequisites for **Ubuntu 16.04 LTS or later** are installed with::
+Prerequisites for **Ubuntu 16.04 LTS - 20.04 LTS** are installed with::
 
     sudo apt-get install libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev \
         libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -328,7 +328,7 @@ In Fedora, the command is::
 
 .. Note:: ``redhat-rpm-config`` is required on Fedora 23, but not earlier versions.
 
-Prerequisites are installed on **Ubuntu 16.04 LTS** with::
+Prerequisites for **Ubuntu 16.04 LTS or later** are installed with::
 
     sudo apt-get install libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev \
         libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \


### PR DESCRIPTION
I suppose people will just try it either way but it's good to know that it still works with the same libs all the way through to 20.04

 * Update the docs to mention Ubuntu versions younger than 16.04