### PR TITLE
Fix ImageChops documentation

### DIFF
--- a/src/PIL/ImageChops.py
+++ b/src/PIL/ImageChops.py
@@ -240,8 +240,10 @@ def subtract_modulo(image1, image2):
 def logical_and(image1, image2):
     """Logical AND between two images.
 
-    Both of the images must have mode "1". For an AND in RGB mode, use a
-    multiply() by a black-and-white mask.
+    Both of the images must have mode "1". If you would like to perform a
+    logical AND on an image with a mode other than "1", try
+    :py:meth:`~PIL.ImageChops.multiply` instead, using a black-and-white mask
+    as the second image.
 
     .. code-block:: python
 

--- a/src/PIL/ImageChops.py
+++ b/src/PIL/ImageChops.py
@@ -54,7 +54,7 @@ def invert(image):
 def lighter(image1, image2):
     """
     Compares the two images, pixel by pixel, and returns a new image containing
-    the lighter values. At least one of the images must have mode "1".
+    the lighter values.
 
     .. code-block:: python
 
@@ -71,7 +71,7 @@ def lighter(image1, image2):
 def darker(image1, image2):
     """
     Compares the two images, pixel by pixel, and returns a new image containing
-    the darker values. At least one of the images must have mode "1".
+    the darker values.
 
     .. code-block:: python
 
@@ -88,7 +88,7 @@ def darker(image1, image2):
 def difference(image1, image2):
     """
     Returns the absolute value of the pixel-by-pixel difference between the two
-    images. At least one of the images must have mode "1".
+    images.
 
     .. code-block:: python
 
@@ -107,8 +107,7 @@ def multiply(image1, image2):
     Superimposes two images on top of each other.
 
     If you multiply an image with a solid black image, the result is black. If
-    you multiply with a solid white image, the image is unaffected. At least
-    one of the images must have mode "1".
+    you multiply with a solid white image, the image is unaffected.
 
     .. code-block:: python
 
@@ -124,8 +123,7 @@ def multiply(image1, image2):
 
 def screen(image1, image2):
     """
-    Superimposes two inverted images on top of each other. At least one of the
-    images must have mode "1".
+    Superimposes two inverted images on top of each other.
 
     .. code-block:: python
 
@@ -179,7 +177,6 @@ def add(image1, image2, scale=1.0, offset=0):
     """
     Adds two images, dividing the result by scale and adding the
     offset. If omitted, scale defaults to 1.0, and offset to 0.0.
-    At least one of the images must have mode "1".
 
     .. code-block:: python
 
@@ -196,8 +193,7 @@ def add(image1, image2, scale=1.0, offset=0):
 def subtract(image1, image2, scale=1.0, offset=0):
     """
     Subtracts two images, dividing the result by scale and adding the offset.
-    If omitted, scale defaults to 1.0, and offset to 0.0. At least one of the
-    images must have mode "1".
+    If omitted, scale defaults to 1.0, and offset to 0.0.
 
     .. code-block:: python
 
@@ -212,8 +208,7 @@ def subtract(image1, image2, scale=1.0, offset=0):
 
 
 def add_modulo(image1, image2):
-    """Add two images, without clipping the result. At least one of the images
-    must have mode "1".
+    """Add two images, without clipping the result.
 
     .. code-block:: python
 
@@ -228,8 +223,7 @@ def add_modulo(image1, image2):
 
 
 def subtract_modulo(image1, image2):
-    """Subtract two images, without clipping the result. At least one of the
-    images must have mode "1".
+    """Subtract two images, without clipping the result.
 
     .. code-block:: python
 
@@ -244,8 +238,10 @@ def subtract_modulo(image1, image2):
 
 
 def logical_and(image1, image2):
-    """Logical AND between two images. At least one of the images must have
-    mode "1".
+    """Logical AND between two images.
+
+    Both of the images must have mode "1". For an AND in RGB mode, use a
+    multiply() by a black-and-white mask.
 
     .. code-block:: python
 
@@ -260,8 +256,9 @@ def logical_and(image1, image2):
 
 
 def logical_or(image1, image2):
-    """Logical OR between two images. At least one of the images must have
-    mode "1".
+    """Logical OR between two images.
+
+    Both of the images must have mode "1".
 
     .. code-block:: python
 
@@ -276,8 +273,9 @@ def logical_or(image1, image2):
 
 
 def logical_xor(image1, image2):
-    """Logical XOR between two images. At least one of the images must have
-    mode "1".
+    """Logical XOR between two images.
+
+    Both of the images must have mode "1".
 
     .. code-block:: python
 


### PR DESCRIPTION
Many methods were incorrectly documented as requiring mode "1". The remaining
ones require *both* images to be mode "1".

Documentation only, [ci skip]

Fixes #2571