### PR TITLE
Replace spaces with tabs and add to pre-commit linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,9 @@ repos:
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
+
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.1.7
+    hooks:
+      - id: remove-tabs
+        exclude: (Makefile$|\.bat$|\.cmake$|\.eps$|\.fits$|\.opt$)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5310,23 +5310,23 @@ Pre-fork
     + Added keyword options to the "save" method.  The following options
       are currently supported:
 
-          format	option		description
+          Format    Option          Description
           --------------------------------------------------------
-          JPEG	optimize	minimize output file at the
-                    expense of compression speed.
+          JPEG      optimize        Minimize output file at the
+                                    expense of compression speed.
 
-          JPEG	progressive	enable progressive output. the
-                    option value is ignored.
+          JPEG      progressive     Enable progressive output.
+                                    The option value is ignored.
 
-          JPEG	quality		set compression quality (1-100).
-                    the default value is 75.
+          JPEG      quality         Set compression quality (1-100).
+                                    The default value is 75.
 
-          JPEG	smooth		smooth dithered images.  value
-                    is strength (1-100).  default is
-                    off (0).
+          JPEG      smooth          Smooth dithered images.
+                                    Value is strength (1-100).
+                                    Default is off (0).
 
-          PNG	optimize	minimize output file at the
-                    expense of compression speed.
+          PNG       optimize        Minimize output file at the
+                                    expense of compression speed.
 
       Expect more options in future releases.  Also note that
       file writers silently ignore unknown options.
@@ -5347,31 +5347,31 @@ Pre-fork
     + Various improvements to the sample scripts:
 
       "pilconvert"  Carries out some extra tricks in order to make
-            the resulting file as small as possible.
+                    the resulting file as small as possible.
 
-      "explode"	(NEW) Split an image sequence into individual frames.
+      "explode"     (NEW) Split an image sequence into individual frames.
 
-      "gifmaker"	(NEW) Convert a sequence file into a GIF animation.
-            Note that the GIF encoder create "uncompressed" GIF
-            files, so animations created by this script are
-            rather large (typically 2-5 times the compressed
-            sizes).
+      "gifmaker"    (NEW) Convert a sequence file into a GIF animation.
+                    Note that the GIF encoder create "uncompressed" GIF
+                    files, so animations created by this script are
+                    rather large (typically 2-5 times the compressed
+                    sizes).
 
-      "image2py"	(NEW) Convert a single image to a python module.  See
-            comments in this script for details.
+      "image2py"    (NEW) Convert a single image to a python module.  See
+                    comments in this script for details.
 
-      "player"	If multiple images are given on the command line,
-            they are interpreted as frames in a sequence.  The
-            script assumes that they all have the same size.
-            Also note that this script now can play FLI/FLC
-            and GIF animations.
+      "player"      If multiple images are given on the command line,
+                    they are interpreted as frames in a sequence.  The
+                    script assumes that they all have the same size.
+                    Also note that this script now can play FLI/FLC
+                    and GIF animations.
 
             This player can also execute embedded Python
             animation applets (ARG format only).
 
-      "viewer"	Transparent images ("P" with transparency property,
-            and "RGBA") are superimposed on the standard Tk back-
-            ground.
+      "viewer"  Transparent images ("P" with transparency property,
+                and "RGBA") are superimposed on the standard Tk back-
+                ground.
 
     + Fixed colour argument to "new".  For multilayer images, pass a
       tuple: (Red, Green, Blue), (Red, Green, Blue, Alpha), or (Cyan,

--- a/depends/install_extra_test_images.sh
+++ b/depends/install_extra_test_images.sh
@@ -4,12 +4,12 @@
 # Use SVN to just fetch a single Git subdirectory
 svn_export()
 {
-	if [ ! -z $1 ]; then
-		echo ""
-		echo "Retrying svn export..."
-		echo ""
-	fi
+    if [ ! -z $1 ]; then
+        echo ""
+        echo "Retrying svn export..."
+        echo ""
+    fi
 
-	svn export --force https://github.com/python-pillow/pillow-depends/trunk/test_images ../Tests/images
+    svn export --force https://github.com/python-pillow/pillow-depends/trunk/test_images ../Tests/images
 }
 svn_export || svn_export retry || svn_export retry || svn_export retry

--- a/docs/handbook/writing-your-own-file-decoder.rst
+++ b/docs/handbook/writing-your-own-file-decoder.rst
@@ -179,7 +179,7 @@ complete list, see the table in the :py:mod:`Unpack.c` module. The following
 table describes some commonly used **raw modes**:
 
 +-----------+-----------------------------------------------------------------+
-| mode	    | description                                                     |
+| mode      | description                                                     |
 +===========+=================================================================+
 | ``1``     | 1-bit bilevel, stored with the leftmost pixel in the most       |
 |           | significant bit. 0 means black, 1 means white.                  |
@@ -223,7 +223,7 @@ You can use the ``raw`` decoder to read images where data is packed in any
 standard machine data type, using one of the following raw modes:
 
 ============ =======================================
-mode	     description
+mode         description
 ============ =======================================
 ``F``        32-bit native floating point.
 ``F;8``      8-bit unsigned integer.

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -58,8 +58,8 @@ Functions
         ``warnings.simplefilter('ignore', Image.DecompressionBombWarning)``. See also `the logging
         documentation`_ to have warnings output to the logging facility instead of stderr.
 
-	.. _decompression bombs: https://en.wikipedia.org/wiki/Zip_bomb
-	.. _the logging documentation: https://docs.python.org/3/library/logging.html#integration-with-the-warnings-module
+    .. _decompression bombs: https://en.wikipedia.org/wiki/Zip_bomb
+    .. _the logging documentation: https://docs.python.org/3/library/logging.html#integration-with-the-warnings-module
 
 Image processing
 ^^^^^^^^^^^^^^^^

--- a/docs/reference/ImageCms.rst
+++ b/docs/reference/ImageCms.rst
@@ -413,10 +413,10 @@ can be easily displayed in a chromaticity diagram, for example).
         with :py:attr:`.intent_supported`.
 
         :param intent: One of ``ImageCms.INTENT_ABSOLUTE_COLORIMETRIC``,
-    		   ``ImageCms.INTENT_PERCEPTUAL``,
-    		   ``ImageCms.INTENT_RELATIVE_COLORIMETRIC``
-    		   and ``ImageCms.INTENT_SATURATION``.
+               ``ImageCms.INTENT_PERCEPTUAL``,
+               ``ImageCms.INTENT_RELATIVE_COLORIMETRIC``
+               and ``ImageCms.INTENT_SATURATION``.
         :param direction: One of ``ImageCms.DIRECTION_INPUT``,
-    		      ``ImageCms.DIRECTION_OUTPUT``
-    		      and ``ImageCms.DIRECTION_PROOF``
+                  ``ImageCms.DIRECTION_OUTPUT``
+                  and ``ImageCms.DIRECTION_PROOF``
         :return: Boolean if the intent and direction is supported.


### PR DESCRIPTION
Changes proposed in this pull request:

 * Replace spaces with tabs in non-C files
 * Check for tabs in linting

PR https://github.com/python-pillow/Pillow/pull/4600 replaced the tabs with spaces in the .c and .h files. :tada: Let's keep them out with a lint checker.

Now, there are some test images (like .eps) that contain valid tabs and also makefiles must use tabs.

We've a couple of options:

* Only check certain file types (for example: .c .h .py .md .rst .txt ...?)
* Check all but exclude certain file types (Makefile .bat .cmake .eps .fits .opt)

This PR does the latter to keep the net wider. It's possible it could find a valid tab in another file in the future, and we could adjust the exclusion list then. Or, as the `exclude:` is a regex, we could also exclude directories now.

But the former could be okay too, most invalid tabs would probably show up in a smaller set of file types that account for the most files. I don't have a strong preference.