### PR TITLE
Writing TIFF tags: improved BYTE, added UNDEFINED

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -299,7 +299,11 @@ class TestFileLibTiff(LibTiffTestCase):
                             )
                             continue
 
-                        if libtiff and isinstance(value, bytes):
+                        if (
+                            libtiff
+                            and isinstance(value, bytes)
+                            and isinstance(tiffinfo, dict)
+                        ):
                             value = value.decode()
 
                         assert reloaded_value == value
@@ -321,6 +325,17 @@ class TestFileLibTiff(LibTiffTestCase):
                 }
             )
         TiffImagePlugin.WRITE_LIBTIFF = False
+
+    def test_xmlpacket_tag(self, tmp_path):
+        TiffImagePlugin.WRITE_LIBTIFF = True
+
+        out = str(tmp_path / "temp.tif")
+        hopper().save(out, tiffinfo={700: b"xmlpacket tag"})
+        TiffImagePlugin.WRITE_LIBTIFF = False
+
+        with Image.open(out) as reloaded:
+            if 700 in reloaded.tag_v2:
+                assert reloaded.tag_v2[700] == b"xmlpacket tag"
 
     def test_int_dpi(self, tmp_path):
         # issue #1765

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -319,13 +319,13 @@ def test_empty_values():
 
 def test_PhotoshopInfo(tmp_path):
     with Image.open("Tests/images/issue_2278.tif") as im:
-        assert len(im.tag_v2[34377]) == 1
-        assert isinstance(im.tag_v2[34377][0], bytes)
+        assert len(im.tag_v2[34377]) == 70
+        assert isinstance(im.tag_v2[34377], bytes)
         out = str(tmp_path / "temp.tiff")
         im.save(out)
     with Image.open(out) as reloaded:
-        assert len(reloaded.tag_v2[34377]) == 1
-        assert isinstance(reloaded.tag_v2[34377][0], bytes)
+        assert len(reloaded.tag_v2[34377]) == 70
+        assert isinstance(reloaded.tag_v2[34377], bytes)
 
 
 def test_too_many_entries():

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -573,8 +573,10 @@ class ImageFileDirectory_v2(MutableMapping):
         # Spec'd length == 1, Actual > 1, Warn and truncate. Formerly barfed.
         # No Spec, Actual length 1, Formerly (<4.2) returned a 1 element tuple.
         # Don't mess with the legacy api, since it's frozen.
-        if (info.length == 1) or (
-            info.length is None and len(values) == 1 and not legacy_api
+        if (
+            (info.length == 1)
+            or self.tagtype[tag] == TiffTags.BYTE
+            or (info.length is None and len(values) == 1 and not legacy_api)
         ):
             # Don't mess with the legacy api, since it's frozen.
             if legacy_api and self.tagtype[tag] in [

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -553,9 +553,10 @@ class ImageFileDirectory_v2(MutableMapping):
                         )
                 elif all(isinstance(v, float) for v in values):
                     self.tagtype[tag] = TiffTags.DOUBLE
-                else:
-                    if all(isinstance(v, str) for v in values):
-                        self.tagtype[tag] = TiffTags.ASCII
+                elif all(isinstance(v, str) for v in values):
+                    self.tagtype[tag] = TiffTags.ASCII
+                elif all(isinstance(v, bytes) for v in values):
+                    self.tagtype[tag] = TiffTags.BYTE
 
         if self.tagtype[tag] == TiffTags.UNDEFINED:
             values = [
@@ -1548,16 +1549,17 @@ def _save(im, fp, filename):
             # Custom items are supported for int, float, unicode, string and byte
             # values. Other types and tuples require a tagtype.
             if tag not in TiffTags.LIBTIFF_CORE:
-                if (
-                    TiffTags.lookup(tag).type == TiffTags.UNDEFINED
-                    or not Image.core.libtiff_support_custom_tags
-                ):
+                if not Image.core.libtiff_support_custom_tags:
                     continue
 
                 if tag in ifd.tagtype:
                     types[tag] = ifd.tagtype[tag]
                 elif not (isinstance(value, (int, float, str, bytes))):
                     continue
+                else:
+                    type = TiffTags.lookup(tag).type
+                    if type:
+                        types[tag] = type
             if tag not in atts and tag not in blocklist:
                 if isinstance(value, str):
                     atts[tag] = value.encode("ascii", "replace") + b"\0"

--- a/src/encode.c
+++ b/src/encode.c
@@ -761,11 +761,6 @@ PyImaging_LibTiffEncoderNew(PyObject* self, PyObject* args)
             }
         }
 
-        if (PyBytes_Check(value) && type == TIFF_UNDEFINED) {
-            // For backwards compatibility
-            type = TIFF_ASCII;
-        }
-
         if (PyTuple_Check(value)) {
             Py_ssize_t len;
             len = PyTuple_Size(value);
@@ -797,7 +792,7 @@ PyImaging_LibTiffEncoderNew(PyObject* self, PyObject* args)
             }
         }
 
-        if (type == TIFF_BYTE) {
+        if (type == TIFF_BYTE || type == TIFF_UNDEFINED) {
             status = ImagingLibTiffSetField(&encoder->state,
                     (ttag_t) key_int,
                     PyBytes_Size(value), PyBytes_AsString(value));

--- a/src/encode.c
+++ b/src/encode.c
@@ -761,8 +761,7 @@ PyImaging_LibTiffEncoderNew(PyObject* self, PyObject* args)
             }
         }
 
-        if (PyBytes_Check(value) &&
-                (type == TIFF_BYTE || type == TIFF_UNDEFINED)) {
+        if (PyBytes_Check(value) && type == TIFF_UNDEFINED) {
             // For backwards compatibility
             type = TIFF_ASCII;
         }

--- a/src/encode.c
+++ b/src/encode.c
@@ -790,28 +790,24 @@ PyImaging_LibTiffEncoderNew(PyObject* self, PyObject* args)
 
         if (!is_core_tag) {
             // Register field for non core tags.
+            if (type == TIFF_BYTE) {
+                is_var_length = 1;
+            }
             if (ImagingLibTiffMergeFieldInfo(&encoder->state, type, key_int, is_var_length)) {
                 continue;
             }
         }
 
-        if (is_var_length) {
+        if (type == TIFF_BYTE) {
+            status = ImagingLibTiffSetField(&encoder->state,
+                    (ttag_t) key_int,
+                    PyBytes_Size(value), PyBytes_AsString(value));
+        } else if (is_var_length) {
             Py_ssize_t len,i;
             TRACE(("Setting from Tuple: %d \n", key_int));
             len = PyTuple_Size(value);
 
-            if (type == TIFF_BYTE) {
-                UINT8 *av;
-                /* malloc check ok, calloc checks for overflow */
-                av = calloc(len, sizeof(UINT8));
-                if (av) {
-                    for (i=0;i<len;i++) {
-                        av[i] = (UINT8)PyLong_AsLong(PyTuple_GetItem(value,i));
-                    }
-                    status = ImagingLibTiffSetField(&encoder->state, (ttag_t) key_int, len, av);
-                    free(av);
-                }
-            } else if (type == TIFF_SHORT) {
+            if (type == TIFF_SHORT) {
                 UINT16 *av;
                 /* malloc check ok, calloc checks for overflow */
                 av = calloc(len, sizeof(UINT16));
@@ -914,10 +910,6 @@ PyImaging_LibTiffEncoderNew(PyObject* self, PyObject* args)
                 status = ImagingLibTiffSetField(&encoder->state,
                         (ttag_t) key_int,
                         (FLOAT64)PyFloat_AsDouble(value));
-            } else if (type == TIFF_BYTE) {
-                status = ImagingLibTiffSetField(&encoder->state,
-                        (ttag_t) key_int,
-                        (UINT8)PyLong_AsLong(value));
             } else if (type == TIFF_SBYTE) {
                 status = ImagingLibTiffSetField(&encoder->state,
                         (ttag_t) key_int,


### PR DESCRIPTION
Resolves #3677

This PR has two changes.

Firstly, Pillow currently treats BYTE tags of count N as if they might have N strings. I do not believe this should be the case. To look at count values for character-related tags, [the BYTE tag GPSAltitudeRef](https://www.awaresystems.be/imaging/tiff/tifftags/privateifd/gps/gpsaltituderef.html) has count 1 for 1 character, [the ASCII tag GPSDateStamp](https://www.awaresystems.be/imaging/tiff/tifftags/privateifd/gps/gpsdatestamp.html) has count 11 for 11 characters, and [the UNDEFINED tag Flashpix Version](https://www.awaresystems.be/imaging/tiff/tifftags/privateifd/exif/flashpixversion.html) has count 4 for 4 characters. So, I think BYTE tags of count N have N characters, and are only single strings.

Secondly, this PR changes the following current code, to no longer force BYTE tags into ASCII tags.
https://github.com/python-pillow/Pillow/blob/d23df7227c419a010c4a82599856f83abd2633b5/src/encode.c#L732-L736

This second change was made because in trying to resolve the issue, I found that libtiff was throwing an error for the [XMLPACKET tag](https://www.awaresystems.be/imaging/tiff/tifftags/xmp.html). It seems reasonable that it would - it is a BYTE tag, and we are instead passing ASCII.

Together, these changes resolve the issue.