### PR TITLE
Added support for 1-D NumPy arrays

### DIFF
--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -89,6 +89,11 @@ def test_3d_array():
     assert_image(Image.fromarray(a[:, :, 1]), "L", TEST_IMAGE_SIZE)
 
 
+def test_1d_array():
+    a = numpy.ones(5, dtype=numpy.uint8)
+    assert_image(Image.fromarray(a), "L", (1, 5))
+
+
 def _test_img_equals_nparray(img, np):
     assert len(np.shape) >= 2
     np_size = np.shape[1], np.shape[0]

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2727,7 +2727,7 @@ def fromarray(obj, mode=None):
     if ndim > ndmax:
         raise ValueError("Too many dimensions: %d > %d." % (ndim, ndmax))
 
-    size = shape[1], shape[0]
+    size = 1 if ndim == 1 else shape[1], shape[0]
     if strides is not None:
         if hasattr(obj, "tobytes"):
             obj = obj.tobytes()


### PR DESCRIPTION
Resolves #4606

`fromarray` presumes that a NumPy array has a shape of at least 2 dimensions. This PR changes it so that if there is only 1 dimension, the other size dimension is 1, using the code suggestion from the issue.