### PR TITLE
Better _binary module use

### DIFF
--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -47,7 +47,7 @@ def _accept(prefix):
 
 
 def _dib_accept(prefix):
-    return i32(prefix[:4]) in [12, 40, 64, 108, 124]
+    return i32(prefix) in [12, 40, 64, 108, 124]
 
 
 # =============================================================================
@@ -82,10 +82,10 @@ class BmpImageFile(ImageFile.ImageFile):
         # -------------------------------------------------- IBM OS/2 Bitmap v1
         # ----- This format has different offsets because of width/height types
         if file_info["header_size"] == 12:
-            file_info["width"] = i16(header_data[0:2])
-            file_info["height"] = i16(header_data[2:4])
-            file_info["planes"] = i16(header_data[4:6])
-            file_info["bits"] = i16(header_data[6:8])
+            file_info["width"] = i16(header_data, 0)
+            file_info["height"] = i16(header_data, 2)
+            file_info["planes"] = i16(header_data, 4)
+            file_info["bits"] = i16(header_data, 6)
             file_info["compression"] = self.RAW
             file_info["palette_padding"] = 3
 
@@ -94,22 +94,22 @@ class BmpImageFile(ImageFile.ImageFile):
         elif file_info["header_size"] in (40, 64, 108, 124):
             file_info["y_flip"] = header_data[7] == 0xFF
             file_info["direction"] = 1 if file_info["y_flip"] else -1
-            file_info["width"] = i32(header_data[0:4])
+            file_info["width"] = i32(header_data, 0)
             file_info["height"] = (
-                i32(header_data[4:8])
+                i32(header_data, 4)
                 if not file_info["y_flip"]
-                else 2 ** 32 - i32(header_data[4:8])
+                else 2 ** 32 - i32(header_data, 4)
             )
-            file_info["planes"] = i16(header_data[8:10])
-            file_info["bits"] = i16(header_data[10:12])
-            file_info["compression"] = i32(header_data[12:16])
+            file_info["planes"] = i16(header_data, 8)
+            file_info["bits"] = i16(header_data, 10)
+            file_info["compression"] = i32(header_data, 12)
             # byte size of pixel data
-            file_info["data_size"] = i32(header_data[16:20])
+            file_info["data_size"] = i32(header_data, 16)
             file_info["pixels_per_meter"] = (
-                i32(header_data[20:24]),
-                i32(header_data[24:28]),
+                i32(header_data, 20),
+                i32(header_data, 24),
             )
-            file_info["colors"] = i32(header_data[28:32])
+            file_info["colors"] = i32(header_data, 28)
             file_info["palette_padding"] = 4
             self.info["dpi"] = tuple(
                 int(x / 39.3701 + 0.5) for x in file_info["pixels_per_meter"]
@@ -119,7 +119,7 @@ class BmpImageFile(ImageFile.ImageFile):
                     for idx, mask in enumerate(
                         ["r_mask", "g_mask", "b_mask", "a_mask"]
                     ):
-                        file_info[mask] = i32(header_data[36 + idx * 4 : 40 + idx * 4])
+                        file_info[mask] = i32(header_data, 36 + idx * 4)
                 else:
                     # 40 byte headers only have the three components in the
                     # bitfields masks, ref:
@@ -266,7 +266,7 @@ class BmpImageFile(ImageFile.ImageFile):
         if head_data[0:2] != b"BM":
             raise SyntaxError("Not a BMP file")
         # read the start position of the BMP image data (u32)
-        offset = i32(head_data[10:14])
+        offset = i32(head_data, 10)
         # load bitmap information (offset=raster info)
         self._bitmap(offset=offset)
 

--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -25,7 +25,7 @@
 
 
 from . import Image, ImageFile, ImagePalette
-from ._binary import i8, i16le as i16, i32le as i32, o8, o16le as o16, o32le as o32
+from ._binary import i16le as i16, i32le as i32, o8, o16le as o16, o32le as o32
 
 #
 # --------------------------------------------------------------------
@@ -92,7 +92,7 @@ class BmpImageFile(ImageFile.ImageFile):
         # --------------------------------------------- Windows Bitmap v2 to v5
         # v3, OS/2 v2, v4, v5
         elif file_info["header_size"] in (40, 64, 108, 124):
-            file_info["y_flip"] = i8(header_data[7]) == 0xFF
+            file_info["y_flip"] = header_data[7] == 0xFF
             file_info["direction"] = 1 if file_info["y_flip"] else -1
             file_info["width"] = i32(header_data[0:4])
             file_info["height"] = (

--- a/src/PIL/CurImagePlugin.py
+++ b/src/PIL/CurImagePlugin.py
@@ -16,7 +16,7 @@
 # See the README file for information on usage and redistribution.
 #
 from . import BmpImagePlugin, Image
-from ._binary import i8, i16le as i16, i32le as i32
+from ._binary import i16le as i16, i32le as i32
 
 #
 # --------------------------------------------------------------------
@@ -50,7 +50,7 @@ class CurImageFile(BmpImagePlugin.BmpImageFile):
             s = self.fp.read(16)
             if not m:
                 m = s
-            elif i8(s[0]) > i8(m[0]) and i8(s[1]) > i8(m[1]):
+            elif s[0] > m[0] and s[1] > m[1]:
                 m = s
         if not m:
             raise TypeError("No cursors were found")

--- a/src/PIL/CurImagePlugin.py
+++ b/src/PIL/CurImagePlugin.py
@@ -46,7 +46,7 @@ class CurImageFile(BmpImagePlugin.BmpImageFile):
 
         # pick the largest cursor in the file
         m = b""
-        for i in range(i16(s[4:])):
+        for i in range(i16(s, 4)):
             s = self.fp.read(16)
             if not m:
                 m = s
@@ -56,7 +56,7 @@ class CurImageFile(BmpImagePlugin.BmpImageFile):
             raise TypeError("No cursors were found")
 
         # load as bitmap
-        self._bitmap(i32(m[12:]) + offset)
+        self._bitmap(i32(m, 12) + offset)
 
         # patch up the bitmap height
         self._size = self.size[0], self.size[1] // 2

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -312,14 +312,14 @@ class EpsImageFile(ImageFile.ImageFile):
             fp.seek(0, io.SEEK_END)
             length = fp.tell()
             offset = 0
-        elif i32(s[0:4]) == 0xC6D3D0C5:
+        elif i32(s, 0) == 0xC6D3D0C5:
             # FIX for: Some EPS file not handled correctly / issue #302
             # EPS can contain binary data
             # or start directly with latin coding
             # more info see:
             # https://web.archive.org/web/20160528181353/http://partners.adobe.com/public/developer/en/ps/5002.EPSF_Spec.pdf
-            offset = i32(s[4:8])
-            length = i32(s[8:12])
+            offset = i32(s, 4)
+            length = i32(s, 8)
         else:
             raise SyntaxError("not an EPS file")
 

--- a/src/PIL/FliImagePlugin.py
+++ b/src/PIL/FliImagePlugin.py
@@ -24,7 +24,7 @@ from ._binary import i16le as i16, i32le as i32, o8
 
 
 def _accept(prefix):
-    return len(prefix) >= 6 and i16(prefix[4:6]) in [0xAF11, 0xAF12]
+    return len(prefix) >= 6 and i16(prefix, 4) in [0xAF11, 0xAF12]
 
 
 ##
@@ -42,24 +42,24 @@ class FliImageFile(ImageFile.ImageFile):
 
         # HEAD
         s = self.fp.read(128)
-        magic = i16(s[4:6])
+        magic = i16(s, 4)
         if not (
             magic in [0xAF11, 0xAF12]
-            and i16(s[14:16]) in [0, 3]  # flags
+            and i16(s, 14) in [0, 3]  # flags
             and s[20:22] == b"\x00\x00"  # reserved
         ):
             raise SyntaxError("not an FLI/FLC file")
 
         # frames
-        self.n_frames = i16(s[6:8])
+        self.n_frames = i16(s, 6)
         self.is_animated = self.n_frames > 1
 
         # image characteristics
         self.mode = "P"
-        self._size = i16(s[8:10]), i16(s[10:12])
+        self._size = i16(s, 8), i16(s, 10)
 
         # animation speed
-        duration = i32(s[16:20])
+        duration = i32(s, 16)
         if magic == 0xAF11:
             duration = (duration * 1000) // 70
         self.info["duration"] = duration
@@ -71,17 +71,17 @@ class FliImageFile(ImageFile.ImageFile):
 
         self.__offset = 128
 
-        if i16(s[4:6]) == 0xF100:
+        if i16(s, 4) == 0xF100:
             # prefix chunk; ignore it
             self.__offset = self.__offset + i32(s)
             s = self.fp.read(16)
 
-        if i16(s[4:6]) == 0xF1FA:
+        if i16(s, 4) == 0xF1FA:
             # look for palette chunk
             s = self.fp.read(6)
-            if i16(s[4:6]) == 11:
+            if i16(s, 4) == 11:
                 self._palette(palette, 2)
-            elif i16(s[4:6]) == 4:
+            elif i16(s, 4) == 4:
                 self._palette(palette, 0)
 
         palette = [o8(r) + o8(g) + o8(b) for (r, g, b) in palette]

--- a/src/PIL/FliImagePlugin.py
+++ b/src/PIL/FliImagePlugin.py
@@ -17,7 +17,7 @@
 
 
 from . import Image, ImageFile, ImagePalette
-from ._binary import i8, i16le as i16, i32le as i32, o8
+from ._binary import i16le as i16, i32le as i32, o8
 
 #
 # decoder
@@ -99,15 +99,15 @@ class FliImageFile(ImageFile.ImageFile):
         i = 0
         for e in range(i16(self.fp.read(2))):
             s = self.fp.read(2)
-            i = i + i8(s[0])
-            n = i8(s[1])
+            i = i + s[0]
+            n = s[1]
             if n == 0:
                 n = 256
             s = self.fp.read(n * 3)
             for n in range(0, len(s), 3):
-                r = i8(s[n]) << shift
-                g = i8(s[n + 1]) << shift
-                b = i8(s[n + 2]) << shift
+                r = s[n] << shift
+                g = s[n + 1] << shift
+                b = s[n + 2] << shift
                 palette[i] = (r, g, b)
                 i += 1
 

--- a/src/PIL/FpxImagePlugin.py
+++ b/src/PIL/FpxImagePlugin.py
@@ -17,7 +17,7 @@
 import olefile
 
 from . import Image, ImageFile
-from ._binary import i8, i32le as i32
+from ._binary import i32le as i32
 
 # we map from colour field tuples to (mode, rawmode) descriptors
 MODES = {
@@ -180,8 +180,8 @@ class FpxImageFile(ImageFile.ImageFile):
 
             elif compression == 2:
 
-                internal_color_conversion = i8(s[14])
-                jpeg_tables = i8(s[15])
+                internal_color_conversion = s[14]
+                jpeg_tables = s[15]
                 rawmode = self.rawmode
 
                 if internal_color_conversion:

--- a/src/PIL/GbrImagePlugin.py
+++ b/src/PIL/GbrImagePlugin.py
@@ -29,7 +29,7 @@ from ._binary import i32be as i32
 
 
 def _accept(prefix):
-    return len(prefix) >= 8 and i32(prefix[:4]) >= 20 and i32(prefix[4:8]) in (1, 2)
+    return len(prefix) >= 8 and i32(prefix, 0) >= 20 and i32(prefix, 4) in (1, 2)
 
 
 ##

--- a/src/PIL/GdImageFile.py
+++ b/src/PIL/GdImageFile.py
@@ -43,17 +43,17 @@ class GdImageFile(ImageFile.ImageFile):
         # Header
         s = self.fp.read(1037)
 
-        if not i16(s[:2]) in [65534, 65535]:
+        if not i16(s) in [65534, 65535]:
             raise SyntaxError("Not a valid GD 2.x .gd file")
 
         self.mode = "L"  # FIXME: "P"
-        self._size = i16(s[2:4]), i16(s[4:6])
+        self._size = i16(s, 2), i16(s, 4)
 
         trueColor = s[6]
         trueColorOffset = 2 if trueColor else 0
 
         # transparency index
-        tindex = i32(s[7 + trueColorOffset : 7 + trueColorOffset + 4])
+        tindex = i32(s, 7 + trueColorOffset)
         if tindex < 256:
             self.info["transparency"] = tindex
 

--- a/src/PIL/GdImageFile.py
+++ b/src/PIL/GdImageFile.py
@@ -24,7 +24,7 @@
 
 
 from . import ImageFile, ImagePalette, UnidentifiedImageError
-from ._binary import i8, i16be as i16, i32be as i32
+from ._binary import i16be as i16, i32be as i32
 
 ##
 # Image plugin for the GD uncompressed format.  Note that this format
@@ -49,7 +49,7 @@ class GdImageFile(ImageFile.ImageFile):
         self.mode = "L"  # FIXME: "P"
         self._size = i16(s[2:4]), i16(s[4:6])
 
-        trueColor = i8(s[6])
+        trueColor = s[6]
         trueColorOffset = 2 if trueColor else 0
 
         # transparency index

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -67,7 +67,7 @@ class GifImageFile(ImageFile.ImageFile):
             raise SyntaxError("not a GIF file")
 
         self.info["version"] = s[:6]
-        self._size = i16(s[6:]), i16(s[8:])
+        self._size = i16(s, 6), i16(s, 8)
         self.tile = []
         flags = s[10]
         bits = (flags & 7) + 1
@@ -191,7 +191,7 @@ class GifImageFile(ImageFile.ImageFile):
                     flags = block[0]
                     if flags & 1:
                         info["transparency"] = block[3]
-                    info["duration"] = i16(block[1:3]) * 10
+                    info["duration"] = i16(block, 1) * 10
 
                     # disposal method - find the value of bits 4 - 6
                     dispose_bits = 0b00011100 & flags
@@ -221,7 +221,7 @@ class GifImageFile(ImageFile.ImageFile):
                     if block[:11] == b"NETSCAPE2.0":
                         block = self.data()
                         if len(block) >= 3 and block[0] == 1:
-                            info["loop"] = i16(block[1:3])
+                            info["loop"] = i16(block, 1)
                 while self.data():
                     pass
 
@@ -232,8 +232,8 @@ class GifImageFile(ImageFile.ImageFile):
                 s = self.fp.read(9)
 
                 # extent
-                x0, y0 = i16(s[0:]), i16(s[2:])
-                x1, y1 = x0 + i16(s[4:]), y0 + i16(s[6:])
+                x0, y0 = i16(s, 0), i16(s, 2)
+                x1, y1 = x0 + i16(s, 4), y0 + i16(s, 6)
                 if x1 > self.size[0] or y1 > self.size[1]:
                     self._size = max(x1, self.size[0]), max(y1, self.size[1])
                 self.dispose_extent = x0, y0, x1, y1

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -30,7 +30,7 @@ import os
 import subprocess
 
 from . import Image, ImageChops, ImageFile, ImagePalette, ImageSequence
-from ._binary import i8, i16le as i16, o8, o16le as o16
+from ._binary import i16le as i16, o8, o16le as o16
 
 # --------------------------------------------------------------------
 # Identify/read GIF files
@@ -55,8 +55,8 @@ class GifImageFile(ImageFile.ImageFile):
 
     def data(self):
         s = self.fp.read(1)
-        if s and i8(s):
-            return self.fp.read(i8(s))
+        if s and s[0]:
+            return self.fp.read(s[0])
         return None
 
     def _open(self):
@@ -69,16 +69,16 @@ class GifImageFile(ImageFile.ImageFile):
         self.info["version"] = s[:6]
         self._size = i16(s[6:]), i16(s[8:])
         self.tile = []
-        flags = i8(s[10])
+        flags = s[10]
         bits = (flags & 7) + 1
 
         if flags & 128:
             # get global palette
-            self.info["background"] = i8(s[11])
+            self.info["background"] = s[11]
             # check if palette contains colour indices
             p = self.fp.read(3 << bits)
             for i in range(0, len(p), 3):
-                if not (i // 3 == i8(p[i]) == i8(p[i + 1]) == i8(p[i + 2])):
+                if not (i // 3 == p[i] == p[i + 1] == p[i + 2]):
                     p = ImagePalette.raw("RGB", p)
                     self.global_palette = self.palette = p
                     break
@@ -184,13 +184,13 @@ class GifImageFile(ImageFile.ImageFile):
                 #
                 s = self.fp.read(1)
                 block = self.data()
-                if i8(s) == 249:
+                if s[0] == 249:
                     #
                     # graphic control extension
                     #
-                    flags = i8(block[0])
+                    flags = block[0]
                     if flags & 1:
-                        info["transparency"] = i8(block[3])
+                        info["transparency"] = block[3]
                     info["duration"] = i16(block[1:3]) * 10
 
                     # disposal method - find the value of bits 4 - 6
@@ -202,7 +202,7 @@ class GifImageFile(ImageFile.ImageFile):
                         # correct, but it seems to prevent the last
                         # frame from looking odd for some animations
                         self.disposal_method = dispose_bits
-                elif i8(s) == 254:
+                elif s[0] == 254:
                     #
                     # comment extension
                     #
@@ -213,14 +213,14 @@ class GifImageFile(ImageFile.ImageFile):
                             info["comment"] = block
                         block = self.data()
                     continue
-                elif i8(s) == 255:
+                elif s[0] == 255:
                     #
                     # application extension
                     #
                     info["extension"] = block, self.fp.tell()
                     if block[:11] == b"NETSCAPE2.0":
                         block = self.data()
-                        if len(block) >= 3 and i8(block[0]) == 1:
+                        if len(block) >= 3 and block[0] == 1:
                             info["loop"] = i16(block[1:3])
                 while self.data():
                     pass
@@ -237,7 +237,7 @@ class GifImageFile(ImageFile.ImageFile):
                 if x1 > self.size[0] or y1 > self.size[1]:
                     self._size = max(x1, self.size[0]), max(y1, self.size[1])
                 self.dispose_extent = x0, y0, x1, y1
-                flags = i8(s[8])
+                flags = s[8]
 
                 interlace = (flags & 64) != 0
 
@@ -246,7 +246,7 @@ class GifImageFile(ImageFile.ImageFile):
                     self.palette = ImagePalette.raw("RGB", self.fp.read(3 << bits))
 
                 # image data
-                bits = i8(self.fp.read(1))
+                bits = self.fp.read(1)[0]
                 self.__offset = self.fp.tell()
                 self.tile = [
                     ("gif", (x0, y0, x1, y1), self.__offset, (bits, interlace))
@@ -255,7 +255,7 @@ class GifImageFile(ImageFile.ImageFile):
 
             else:
                 pass
-                # raise OSError, "illegal GIF tag `%x`" % i8(s)
+                # raise OSError, "illegal GIF tag `%x`" % s[0]
 
         try:
             if self.disposal_method < 2:

--- a/src/PIL/GribStubImagePlugin.py
+++ b/src/PIL/GribStubImagePlugin.py
@@ -10,7 +10,6 @@
 #
 
 from . import Image, ImageFile
-from ._binary import i8
 
 _handler = None
 
@@ -30,7 +29,7 @@ def register_handler(handler):
 
 
 def _accept(prefix):
-    return prefix[0:4] == b"GRIB" and i8(prefix[7]) == 1
+    return prefix[0:4] == b"GRIB" and prefix[7] == 1
 
 
 class GribStubImageFile(ImageFile.StubImageFile):

--- a/src/PIL/IcnsImagePlugin.py
+++ b/src/PIL/IcnsImagePlugin.py
@@ -24,7 +24,6 @@ import sys
 import tempfile
 
 from PIL import Image, ImageFile, PngImagePlugin
-from PIL._binary import i8
 
 enable_jpeg2k = hasattr(Image.core, "jp2klib_version")
 if enable_jpeg2k:
@@ -70,7 +69,7 @@ def read_32(fobj, start_length, size):
                 byte = fobj.read(1)
                 if not byte:
                     break
-                byte = i8(byte)
+                byte = byte[0]
                 if byte & 0x80:
                     blocksize = byte - 125
                     byte = fobj.read(1)

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -28,7 +28,7 @@ from io import BytesIO
 from math import ceil, log
 
 from . import BmpImagePlugin, Image, ImageFile, PngImagePlugin
-from ._binary import i8, i16le as i16, i32le as i32
+from ._binary import i16le as i16, i32le as i32
 
 #
 # --------------------------------------------------------------------
@@ -105,10 +105,10 @@ class IcoFile:
             s = buf.read(16)
 
             icon_header = {
-                "width": i8(s[0]),
-                "height": i8(s[1]),
-                "nb_color": i8(s[2]),  # No. of colors in image (0 if >=8bpp)
-                "reserved": i8(s[3]),
+                "width": s[0],
+                "height": s[1],
+                "nb_color": s[2],  # No. of colors in image (0 if >=8bpp)
+                "reserved": s[3],
                 "planes": i16(s[4:]),
                 "bpp": i16(s[6:]),
                 "size": i32(s[8:]),

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -98,7 +98,7 @@ class IcoFile:
         self.entry = []
 
         # Number of items in file
-        self.nb_items = i16(s[4:])
+        self.nb_items = i16(s, 4)
 
         # Get headers for each item
         for i in range(self.nb_items):
@@ -109,10 +109,10 @@ class IcoFile:
                 "height": s[1],
                 "nb_color": s[2],  # No. of colors in image (0 if >=8bpp)
                 "reserved": s[3],
-                "planes": i16(s[4:]),
-                "bpp": i16(s[6:]),
-                "size": i32(s[8:]),
-                "offset": i32(s[12:]),
+                "planes": i16(s, 4),
+                "bpp": i16(s, 6),
+                "size": i32(s, 8),
+                "offset": i32(s, 12),
             }
 
             # See Wikipedia

--- a/src/PIL/ImImagePlugin.py
+++ b/src/PIL/ImImagePlugin.py
@@ -30,7 +30,6 @@ import os
 import re
 
 from . import Image, ImageFile, ImagePalette
-from ._binary import i8
 
 # --------------------------------------------------------------------
 # Standard tags
@@ -223,14 +222,14 @@ class ImImageFile(ImageFile.ImageFile):
             linear = 1  # linear greyscale palette
             for i in range(256):
                 if palette[i] == palette[i + 256] == palette[i + 512]:
-                    if i8(palette[i]) != i:
+                    if palette[i] != i:
                         linear = 0
                 else:
                     greyscale = 0
             if self.mode in ["L", "LA", "P", "PA"]:
                 if greyscale:
                     if not linear:
-                        self.lut = [i8(c) for c in palette[:256]]
+                        self.lut = list(palette[:256])
                 else:
                     if self.mode in ["L", "P"]:
                         self.mode = self.rawmode = "P"
@@ -240,7 +239,7 @@ class ImImageFile(ImageFile.ImageFile):
                     self.palette = ImagePalette.raw("RGB;L", palette)
             elif self.mode == "RGB":
                 if not greyscale or not linear:
-                    self.lut = [i8(c) for c in palette]
+                    self.lut = list(palette)
 
         self.frame = 0
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -49,7 +49,7 @@ from . import (
     _plugins,
     _raise_version_warning,
 )
-from ._binary import i8, i32le
+from ._binary import i32le
 from ._util import deferred_error, isPath
 
 if sys.version_info >= (3, 7):
@@ -1352,7 +1352,7 @@ class Image:
 
         self.load()
         x, y = self.im.getprojection()
-        return [i8(c) for c in x], [i8(c) for c in y]
+        return list(x), list(y)
 
     def histogram(self, mask=None, extrema=None):
         """

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3303,7 +3303,7 @@ class Exif(MutableMapping):
 
                 if self[0x927C][:8] == b"FUJIFILM":
                     exif_data = self[0x927C]
-                    ifd_offset = i32le(exif_data[8:12])
+                    ifd_offset = i32le(exif_data, 8)
                     ifd_data = exif_data[ifd_offset:]
 
                     makernote = {}

--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -59,14 +59,14 @@ class IptcImageFile(ImageFile.ImageFile):
         if not len(s):
             return None, 0
 
-        tag = i8(s[1]), i8(s[2])
+        tag = s[1], s[2]
 
         # syntax
-        if i8(s[0]) != 0x1C or tag[0] < 1 or tag[0] > 9:
+        if s[0] != 0x1C or tag[0] < 1 or tag[0] > 9:
             raise SyntaxError("invalid IPTC/NAA file")
 
         # field size
-        size = i8(s[3])
+        size = s[3]
         if size > 132:
             raise OSError("illegal field length in IPTC/NAA file")
         elif size == 128:

--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -74,7 +74,7 @@ class IptcImageFile(ImageFile.ImageFile):
         elif size > 128:
             size = i(self.fp.read(size - 128))
         else:
-            size = i16(s[3:])
+            size = i16(s, 3)
 
         return tag, size
 

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -40,7 +40,7 @@ import tempfile
 import warnings
 
 from . import Image, ImageFile, TiffImagePlugin
-from ._binary import i8, i16be as i16, i32be as i32, o8
+from ._binary import i16be as i16, i32be as i32, o8
 from .JpegPresets import presets
 
 #
@@ -71,7 +71,7 @@ def APP(self, marker):
         self.info["jfif_version"] = divmod(version, 256)
         # extract JFIF properties
         try:
-            jfif_unit = i8(s[7])
+            jfif_unit = s[7]
             jfif_density = i16(s, 8), i16(s, 10)
         except Exception:
             pass
@@ -111,7 +111,7 @@ def APP(self, marker):
                 code = i16(s, offset)
                 offset += 2
                 # resource name (usually empty)
-                name_len = i8(s[offset])
+                name_len = s[offset]
                 # name = s[offset+1:offset+1+name_len]
                 offset += 1 + name_len
                 offset += offset & 1  # align
@@ -136,7 +136,7 @@ def APP(self, marker):
         self.info["adobe"] = i16(s, 5)
         # extract Adobe custom properties
         try:
-            adobe_transform = i8(s[1])
+            adobe_transform = s[1]
         except Exception:
             pass
         else:
@@ -193,11 +193,11 @@ def SOF(self, marker):
     s = ImageFile._safe_read(self.fp, n)
     self._size = i16(s[3:]), i16(s[1:])
 
-    self.bits = i8(s[0])
+    self.bits = s[0]
     if self.bits != 8:
         raise SyntaxError("cannot handle %d-bit layers" % self.bits)
 
-    self.layers = i8(s[5])
+    self.layers = s[5]
     if self.layers == 1:
         self.mode = "L"
     elif self.layers == 3:
@@ -213,7 +213,7 @@ def SOF(self, marker):
     if self.icclist:
         # fixup icc profile
         self.icclist.sort()  # sort by sequence number
-        if i8(self.icclist[0][13]) == len(self.icclist):
+        if self.icclist[0][13] == len(self.icclist):
             profile = []
             for p in self.icclist:
                 profile.append(p[14:])
@@ -226,7 +226,7 @@ def SOF(self, marker):
     for i in range(6, len(s), 3):
         t = s[i : i + 3]
         # 4-tuples: id, vsamp, hsamp, qtable
-        self.layer.append((t[0], i8(t[1]) // 16, i8(t[1]) & 15, i8(t[2])))
+        self.layer.append((t[0], t[1] // 16, t[1] & 15, t[2]))
 
 
 def DQT(self, marker):
@@ -243,7 +243,7 @@ def DQT(self, marker):
     while len(s):
         if len(s) < 65:
             raise SyntaxError("bad quantization table marker")
-        v = i8(s[0])
+        v = s[0]
         if v // 16 == 0:
             self.quantization[v & 15] = array.array("B", s[1:65])
             s = s[65:]
@@ -339,7 +339,7 @@ class JpegImageFile(ImageFile.ImageFile):
 
         s = self.fp.read(1)
 
-        if i8(s) != 255:
+        if s[0] != 255:
             raise SyntaxError("not a JPEG file")
 
         # Create attributes
@@ -356,7 +356,7 @@ class JpegImageFile(ImageFile.ImageFile):
 
         while True:
 
-            i = i8(s)
+            i = s[0]
             if i == 0xFF:
                 s = s + self.fp.read(1)
                 i = i16(s)

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -121,10 +121,10 @@ def APP(self, marker):
                 data = s[offset : offset + size]
                 if code == 0x03ED:  # ResolutionInfo
                     data = {
-                        "XResolution": i32(data[:4]) / 65536,
-                        "DisplayedUnitsX": i16(data[4:8]),
-                        "YResolution": i32(data[8:12]) / 65536,
-                        "DisplayedUnitsY": i16(data[12:]),
+                        "XResolution": i32(data, 0) / 65536,
+                        "DisplayedUnitsX": i16(data, 4),
+                        "YResolution": i32(data, 8) / 65536,
+                        "DisplayedUnitsY": i16(data, 12),
                     }
                 photoshop[code] = data
                 offset += size
@@ -191,7 +191,7 @@ def SOF(self, marker):
 
     n = i16(self.fp.read(2)) - 2
     s = ImageFile._safe_read(self.fp, n)
-    self._size = i16(s[3:]), i16(s[1:])
+    self._size = i16(s, 3), i16(s, 1)
 
     self.bits = s[0]
     if self.bits != 8:

--- a/src/PIL/MspImagePlugin.py
+++ b/src/PIL/MspImagePlugin.py
@@ -57,12 +57,12 @@ class MspImageFile(ImageFile.ImageFile):
         # Header checksum
         checksum = 0
         for i in range(0, 32, 2):
-            checksum = checksum ^ i16(s[i : i + 2])
+            checksum = checksum ^ i16(s, i)
         if checksum != 0:
             raise SyntaxError("bad MSP checksum")
 
         self.mode = "1"
-        self._size = i16(s[4:]), i16(s[6:])
+        self._size = i16(s, 4), i16(s, 6)
 
         if s[:4] == b"DanM":
             self.tile = [("raw", (0, 0) + self.size, 32, ("1", 0, 1))]

--- a/src/PIL/MspImagePlugin.py
+++ b/src/PIL/MspImagePlugin.py
@@ -27,7 +27,7 @@ import io
 import struct
 
 from . import Image, ImageFile
-from ._binary import i8, i16le as i16, o16le as o16
+from ._binary import i16le as i16, o16le as o16
 
 #
 # read MSP files
@@ -131,7 +131,7 @@ class MspDecoder(ImageFile.PyDecoder):
                     )
                 idx = 0
                 while idx < rowlen:
-                    runtype = i8(row[idx])
+                    runtype = row[idx]
                     idx += 1
                     if runtype == 0:
                         (runcount, runval) = struct.unpack_from("Bc", row, idx)

--- a/src/PIL/PcdImagePlugin.py
+++ b/src/PIL/PcdImagePlugin.py
@@ -16,7 +16,6 @@
 
 
 from . import Image, ImageFile
-from ._binary import i8
 
 ##
 # Image plugin for PhotoCD images.  This plugin only reads the 768x512
@@ -38,7 +37,7 @@ class PcdImageFile(ImageFile.ImageFile):
         if s[:4] != b"PCD_":
             raise SyntaxError("not a PCD file")
 
-        orientation = i8(s[1538]) & 3
+        orientation = s[1538] & 3
         self.tile_post_rotate = None
         if orientation == 1:
             self.tile_post_rotate = 90

--- a/src/PIL/PcxImagePlugin.py
+++ b/src/PIL/PcxImagePlugin.py
@@ -29,13 +29,13 @@ import io
 import logging
 
 from . import Image, ImageFile, ImagePalette
-from ._binary import i8, i16le as i16, o8, o16le as o16
+from ._binary import i16le as i16, o8, o16le as o16
 
 logger = logging.getLogger(__name__)
 
 
 def _accept(prefix):
-    return i8(prefix[0]) == 10 and i8(prefix[1]) in [0, 2, 3, 5]
+    return prefix[0] == 10 and prefix[1] in [0, 2, 3, 5]
 
 
 ##
@@ -61,9 +61,9 @@ class PcxImageFile(ImageFile.ImageFile):
         logger.debug("BBox: %s %s %s %s", *bbox)
 
         # format
-        version = i8(s[1])
-        bits = i8(s[3])
-        planes = i8(s[65])
+        version = s[1]
+        bits = s[3]
+        planes = s[65]
         stride = i16(s, 66)
         logger.debug(
             "PCX version %s, bits %s, planes %s, stride %s",
@@ -88,7 +88,7 @@ class PcxImageFile(ImageFile.ImageFile):
             # FIXME: hey, this doesn't work with the incremental loader !!!
             self.fp.seek(-769, io.SEEK_END)
             s = self.fp.read(769)
-            if len(s) == 769 and i8(s[0]) == 12:
+            if len(s) == 769 and s[0] == 12:
                 # check if the palette is linear greyscale
                 for i in range(256):
                     if s[i * 3 + 1 : i * 3 + 4] != o8(i) * 3:

--- a/src/PIL/PixarImagePlugin.py
+++ b/src/PIL/PixarImagePlugin.py
@@ -49,10 +49,10 @@ class PixarImageFile(ImageFile.ImageFile):
         # read rest of header
         s = s + self.fp.read(508)
 
-        self._size = i16(s[418:420]), i16(s[416:418])
+        self._size = i16(s, 418), i16(s, 416)
 
         # get channel/depth descriptions
-        mode = i16(s[424:426]), i16(s[426:428])
+        mode = i16(s, 424), i16(s, 426)
 
         if mode == (14, 2):
             self.mode = "RGB"

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -369,7 +369,7 @@ class PngStream(ChunkStream):
 
         # image header
         s = ImageFile._safe_read(self.fp, length)
-        self.im_size = i32(s), i32(s[4:])
+        self.im_size = i32(s, 0), i32(s, 4)
         try:
             self.im_mode, self.im_rawmode = _MODES[(s[8], s[9])]
         except Exception:
@@ -424,7 +424,7 @@ class PngStream(ChunkStream):
         elif self.im_mode in ("1", "L", "I"):
             self.im_info["transparency"] = i16(s)
         elif self.im_mode == "RGB":
-            self.im_info["transparency"] = i16(s), i16(s[2:]), i16(s[4:])
+            self.im_info["transparency"] = i16(s), i16(s, 2), i16(s, 4)
         return s
 
     def chunk_gAMA(self, pos, length):
@@ -457,7 +457,7 @@ class PngStream(ChunkStream):
 
         # pixels per unit
         s = ImageFile._safe_read(self.fp, length)
-        px, py = i32(s), i32(s[4:])
+        px, py = i32(s, 0), i32(s, 4)
         unit = s[8]
         if unit == 1:  # meter
             dpi = int(px * 0.0254 + 0.5), int(py * 0.0254 + 0.5)
@@ -579,7 +579,7 @@ class PngStream(ChunkStream):
             warnings.warn("Invalid APNG, will use default PNG image if possible")
             return s
         self.im_n_frames = n_frames
-        self.im_info["loop"] = i32(s[4:])
+        self.im_info["loop"] = i32(s, 4)
         self.im_custom_mimetype = "image/apng"
         return s
 
@@ -591,13 +591,13 @@ class PngStream(ChunkStream):
         ):
             raise SyntaxError("APNG contains frame sequence errors")
         self._seq_num = seq
-        width, height = i32(s[4:]), i32(s[8:])
-        px, py = i32(s[12:]), i32(s[16:])
+        width, height = i32(s, 4), i32(s, 8)
+        px, py = i32(s, 12), i32(s, 16)
         im_w, im_h = self.im_size
         if px + width > im_w or py + height > im_h:
             raise SyntaxError("APNG contains invalid frames")
         self.im_info["bbox"] = (px, py, px + width, py + height)
-        delay_num, delay_den = i16(s[20:]), i16(s[22:])
+        delay_num, delay_den = i16(s, 20), i16(s, 22)
         if delay_den == 0:
             delay_den = 100
         self.im_info["duration"] = float(delay_num) / float(delay_den) * 1000

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -61,12 +61,12 @@ class PsdImageFile(ImageFile.ImageFile):
         # header
 
         s = read(26)
-        if s[:4] != b"8BPS" or i16(s[4:]) != 1:
+        if s[:4] != b"8BPS" or i16(s, 4) != 1:
             raise SyntaxError("not a PSD file")
 
-        psd_bits = i16(s[22:])
-        psd_channels = i16(s[12:])
-        psd_mode = i16(s[24:])
+        psd_bits = i16(s, 22)
+        psd_channels = i16(s, 12)
+        psd_mode = i16(s, 24)
 
         mode, channels = MODES[(psd_mode, psd_bits)]
 
@@ -74,7 +74,7 @@ class PsdImageFile(ImageFile.ImageFile):
             raise OSError("not enough channels")
 
         self.mode = mode
-        self._size = i32(s[18:]), i32(s[14:])
+        self._size = i32(s, 18), i32(s, 14)
 
         #
         # color mode data
@@ -289,7 +289,7 @@ def _maketile(file, mode, bbox, channels):
                 layer += ";I"
             tile.append(("packbits", bbox, offset, layer))
             for y in range(ysize):
-                offset = offset + i16(bytecount[i : i + 2])
+                offset = offset + i16(bytecount, i)
                 i += 2
 
     file.seek(offset)

--- a/src/PIL/SgiImagePlugin.py
+++ b/src/PIL/SgiImagePlugin.py
@@ -69,16 +69,16 @@ class SgiImageFile(ImageFile.ImageFile):
         bpc = s[3]
 
         # dimension : 1, 2 or 3 (depending on xsize, ysize and zsize)
-        dimension = i16(s[4:])
+        dimension = i16(s, 4)
 
         # xsize : width
-        xsize = i16(s[6:])
+        xsize = i16(s, 6)
 
         # ysize : height
-        ysize = i16(s[8:])
+        ysize = i16(s, 8)
 
         # zsize : channels count
-        zsize = i16(s[10:])
+        zsize = i16(s, 10)
 
         # layout
         layout = bpc, dimension, zsize

--- a/src/PIL/SgiImagePlugin.py
+++ b/src/PIL/SgiImagePlugin.py
@@ -26,7 +26,7 @@ import os
 import struct
 
 from . import Image, ImageFile
-from ._binary import i8, i16be as i16, o8
+from ._binary import i16be as i16, o8
 
 
 def _accept(prefix):
@@ -63,10 +63,10 @@ class SgiImageFile(ImageFile.ImageFile):
             raise ValueError("Not an SGI image file")
 
         # compression : verbatim or RLE
-        compression = i8(s[2])
+        compression = s[2]
 
         # bpc : 1 or 2 bytes (8bits or 16bits)
-        bpc = i8(s[3])
+        bpc = s[3]
 
         # dimension : 1, 2 or 3 (depending on xsize, ysize and zsize)
         dimension = i16(s[4:])

--- a/src/PIL/SunImagePlugin.py
+++ b/src/PIL/SunImagePlugin.py
@@ -58,13 +58,13 @@ class SunImageFile(ImageFile.ImageFile):
 
         offset = 32
 
-        self._size = i32(s[4:8]), i32(s[8:12])
+        self._size = i32(s, 4), i32(s, 8)
 
-        depth = i32(s[12:16])
-        # data_length = i32(s[16:20])   # unreliable, ignore.
-        file_type = i32(s[20:24])
-        palette_type = i32(s[24:28])  # 0: None, 1: RGB, 2: Raw/arbitrary
-        palette_length = i32(s[28:32])
+        depth = i32(s, 12)
+        # data_length = i32(s, 16)   # unreliable, ignore.
+        file_type = i32(s, 20)
+        palette_type = i32(s, 24)  # 0: None, 1: RGB, 2: Raw/arbitrary
+        palette_length = i32(s, 28)
 
         if depth == 1:
             self.mode, rawmode = "1", "1;I"

--- a/src/PIL/TgaImagePlugin.py
+++ b/src/PIL/TgaImagePlugin.py
@@ -62,7 +62,7 @@ class TgaImageFile(ImageFile.ImageFile):
 
         flags = s[17]
 
-        self._size = i16(s[12:]), i16(s[14:])
+        self._size = i16(s, 12), i16(s, 14)
 
         # validate header fields
         if (
@@ -108,7 +108,7 @@ class TgaImageFile(ImageFile.ImageFile):
 
         if colormaptype:
             # read palette
-            start, size, mapdepth = i16(s[3:]), i16(s[5:]), i16(s[7:])
+            start, size, mapdepth = i16(s, 3), i16(s, 5), i16(s, 7)
             if mapdepth == 16:
                 self.palette = ImagePalette.raw(
                     "BGR;16", b"\0" * 2 * start + self.fp.read(2 * size)

--- a/src/PIL/TgaImagePlugin.py
+++ b/src/PIL/TgaImagePlugin.py
@@ -20,7 +20,7 @@
 import warnings
 
 from . import Image, ImageFile, ImagePalette
-from ._binary import i8, i16le as i16, o8, o16le as o16
+from ._binary import i16le as i16, o8, o16le as o16
 
 #
 # --------------------------------------------------------------------
@@ -53,14 +53,14 @@ class TgaImageFile(ImageFile.ImageFile):
         # process header
         s = self.fp.read(18)
 
-        id_len = i8(s[0])
+        id_len = s[0]
 
-        colormaptype = i8(s[1])
-        imagetype = i8(s[2])
+        colormaptype = s[1]
+        imagetype = s[2]
 
-        depth = i8(s[16])
+        depth = s[16]
 
-        flags = i8(s[17])
+        flags = s[17]
 
         self._size = i16(s[12:]), i16(s[14:])
 

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -48,7 +48,7 @@ from fractions import Fraction
 from numbers import Number, Rational
 
 from . import Image, ImageFile, ImagePalette, TiffTags
-from ._binary import i8, o8
+from ._binary import o8
 from .TiffTags import TYPES
 
 DEBUG = False  # Needs to be merged with the new logging approach.
@@ -1504,7 +1504,7 @@ def _save(im, fp, filename):
 
     if im.mode in ["P", "PA"]:
         lut = im.im.getpalette("RGB", "RGB;L")
-        ifd[COLORMAP] = tuple(i8(v) * 256 for v in lut)
+        ifd[COLORMAP] = tuple(v * 256 for v in lut)
     # data orientation
     stride = len(bits) * ((im.size[0] * bits[0] + 7) // 8)
     ifd[ROWSPERSTRIP] = im.size[1]

--- a/src/PIL/XVThumbImagePlugin.py
+++ b/src/PIL/XVThumbImagePlugin.py
@@ -18,7 +18,7 @@
 #
 
 from . import Image, ImageFile, ImagePalette
-from ._binary import i8, o8
+from ._binary import o8
 
 _MAGIC = b"P7 332"
 
@@ -59,7 +59,7 @@ class XVThumbImageFile(ImageFile.ImageFile):
             s = self.fp.readline()
             if not s:
                 raise SyntaxError("Unexpected EOF reading XV thumbnail file")
-            if i8(s[0]) != 35:  # ie. when not a comment: '#'
+            if s[0] != 35:  # ie. when not a comment: '#'
                 break
 
         # parse header line (already read)

--- a/src/PIL/XpmImagePlugin.py
+++ b/src/PIL/XpmImagePlugin.py
@@ -18,7 +18,7 @@
 import re
 
 from . import Image, ImageFile, ImagePalette
-from ._binary import i8, o8
+from ._binary import o8
 
 # XPM header
 xpm_head = re.compile(b'"([0-9]*) ([0-9]*) ([0-9]*) ([0-9]*)')
@@ -72,7 +72,7 @@ class XpmImageFile(ImageFile.ImageFile):
             elif s[-1:] in b"\r\n":
                 s = s[:-1]
 
-            c = i8(s[1])
+            c = s[1]
             s = s[2:-2].split()
 
             for i in range(0, len(s), 2):


### PR DESCRIPTION
* remove extra i8 calls where input is proved bytes[] or int. Most of i8 calls are not required in py3.
* use offset for all binary input functions instead of slicing which should be slightly faster especially when slicing "until the end" is used (`s[4:]`).