### PR TITLE
Improve ImageGrab.grabclipboard() on Windows

### DIFF
--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 
@@ -79,7 +80,8 @@ $bmp = New-Object Drawing.Bitmap 200, 200
         p.communicate()
 
         im = ImageGrab.grabclipboard()
-        assert_image_equal_tofile(im, "Tests/images/hopper.gif")
+        assert len(im) == 1
+        assert os.path.samefile(im[0], "Tests/images/hopper.gif")
 
     @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
     def test_grabclipboard_png(self):

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 from PIL import Image, ImageGrab
 
-from .helper import assert_image
+from .helper import assert_image, assert_image_equal_tofile
 
 
 class TestImageGrab:
@@ -71,3 +71,26 @@ $bmp = New-Object Drawing.Bitmap 200, 200
 
         im = ImageGrab.grabclipboard()
         assert_image(im, im.mode, im.size)
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
+    def test_grabclipboard_file(self):
+        p = subprocess.Popen(["powershell", "-command", "-"], stdin=subprocess.PIPE)
+        p.stdin.write(rb'Set-Clipboard -Path "Tests\images\hopper.gif"')
+        p.communicate()
+
+        im = ImageGrab.grabclipboard()
+        assert_image_equal_tofile(im, "Tests/images/hopper.gif")
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
+    def test_grabclipboard_png(self):
+        p = subprocess.Popen(["powershell", "-command", "-"], stdin=subprocess.PIPE)
+        p.stdin.write(
+            rb"""$bytes = [System.IO.File]::ReadAllBytes("Tests\images\hopper.png")
+$ms = new-object System.IO.MemoryStream(, $bytes)
+[Reflection.Assembly]::LoadWithPartialName("System.Windows.Forms")
+[Windows.Forms.Clipboard]::SetData("PNG", $ms)"""
+        )
+        p.communicate()
+
+        im = ImageGrab.grabclipboard()
+        assert_image_equal_tofile(im, "Tests/images/hopper.png")

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -100,10 +100,9 @@ def grabclipboard():
             o = struct.unpack_from("I", data)[0]
             if data[16] != 0:
                 files = data[o:].decode("utf-16le").split("\0")
-                return files[: files.index("")]
             else:
                 files = data[o:].decode("mbcs").split("\0")
-                return files[: files.index("")]
+            return files[: files.index("")]
         if isinstance(data, bytes):
             import io
 

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -93,12 +93,24 @@ def grabclipboard():
         os.unlink(filepath)
         return im
     elif sys.platform == "win32":
-        data = Image.core.grabclipboard_win32()
-        if isinstance(data, bytes):
-            from . import BmpImagePlugin
-            import io
+        import io
 
-            return BmpImagePlugin.DibImageFile(io.BytesIO(data))
-        return data
+        fmt, data = Image.core.grabclipboard_win32()
+        if isinstance(data, str):
+            if fmt == "file":
+                with open(data, "rb") as f:
+                    im = Image.open(io.BytesIO(f.read()))
+                return im
+        if isinstance(data, bytes):
+            data = io.BytesIO(data)
+            if fmt == "png":
+                from . import PngImagePlugin
+
+                return PngImagePlugin.PngImageFile(data)
+            elif fmt == "DIB":
+                from . import BmpImagePlugin
+
+                return BmpImagePlugin.DibImageFile(data)
+        return None
     else:
         raise NotImplementedError("ImageGrab.grabclipboard() is macOS and Windows only")

--- a/src/display.c
+++ b/src/display.c
@@ -32,6 +32,7 @@
 
 #ifdef _WIN32
 
+#include <Shlobj.h>
 #include "ImDib.h"
 
 #if SIZEOF_VOID_P == 8
@@ -473,33 +474,66 @@ PyObject*
 PyImaging_GrabClipboardWin32(PyObject* self, PyObject* args)
 {
     int clip;
-    HANDLE handle;
+    HANDLE handle = NULL;
     int size;
     void* data;
     PyObject* result;
+    UINT format;
+    UINT formats[] = { CF_DIB, CF_DIBV5, CF_HDROP, RegisterClipboardFormatA("PNG"), 0 };
+    LPCSTR format_names[] = { "DIB", "DIB", "file", "png", NULL };
 
-    clip = OpenClipboard(NULL);
-    /* FIXME: check error status */
-
-    handle = GetClipboardData(CF_DIB);
-    if (!handle) {
-        /* FIXME: add CF_HDROP support to allow cut-and-paste from
-           the explorer */
-        CloseClipboard();
-        Py_INCREF(Py_None);
-        return Py_None;
+    if (!OpenClipboard(NULL)) {
+        PyErr_SetString(PyExc_OSError, "failed to open clipboard");
+        return NULL;
     }
 
-    size = GlobalSize(handle);
+    // find best format as set by clipboard owner
+    format = 0;
+    while (!handle && (format = EnumClipboardFormats(format))) {
+        for (UINT i = 0; formats[i] != 0; i++) {
+            if (format == formats[i]) {
+                handle = GetClipboardData(format);
+                format = i;
+                break;
+            }
+        }
+    }
+
+    if (!handle) {
+        CloseClipboard();
+        return Py_BuildValue("zO", NULL, Py_None);
+    }
+
+    if (formats[format] == CF_HDROP) {
+        LPDROPFILES files = (LPDROPFILES)GlobalLock(handle);
+        size = GlobalSize(handle);
+
+        if (files->fWide) {
+            LPCWSTR filename = (LPCWSTR)(((char*)files) + files->pFiles);
+            size = wcsnlen(filename, (size - files->pFiles) / 2);
+            result = Py_BuildValue("zu#", "file", filename, size);
+        }
+        else {
+            LPCSTR filename = (LPCSTR)(((char*)files) + files->pFiles);
+            size = strnlen(filename, size - files->pFiles);
+            result = Py_BuildValue("zs#", "file", filename, size);
+        }
+
+        GlobalUnlock(handle);
+        CloseClipboard();
+
+        return result;
+    }
+
     data = GlobalLock(handle);
+    size = GlobalSize(handle);
 
     result = PyBytes_FromStringAndSize(data, size);
 
     GlobalUnlock(handle);
-
     CloseClipboard();
 
-    return result;
+    return Py_BuildValue("zN", format_names[format], result);
 }
 
 /* -------------------------------------------------------------------- */

--- a/src/display.c
+++ b/src/display.c
@@ -32,7 +32,6 @@
 
 #ifdef _WIN32
 
-#include <Shlobj.h>
 #include "ImDib.h"
 
 #if SIZEOF_VOID_P == 8
@@ -502,27 +501,6 @@ PyImaging_GrabClipboardWin32(PyObject* self, PyObject* args)
     if (!handle) {
         CloseClipboard();
         return Py_BuildValue("zO", NULL, Py_None);
-    }
-
-    if (formats[format] == CF_HDROP) {
-        LPDROPFILES files = (LPDROPFILES)GlobalLock(handle);
-        size = GlobalSize(handle);
-
-        if (files->fWide) {
-            LPCWSTR filename = (LPCWSTR)(((char*)files) + files->pFiles);
-            size = wcsnlen(filename, (size - files->pFiles) / 2);
-            result = Py_BuildValue("zu#", "file", filename, size);
-        }
-        else {
-            LPCSTR filename = (LPCSTR)(((char*)files) + files->pFiles);
-            size = strnlen(filename, size - files->pFiles);
-            result = Py_BuildValue("zs#", "file", filename, size);
-        }
-
-        GlobalUnlock(handle);
-        CloseClipboard();
-
-        return result;
     }
 
     data = GlobalLock(handle);


### PR DESCRIPTION
Helps #4611

Adds support for the following clipboard formats on Windows in addition to the already supported `CF_DIB`:

 * `CF_DIBV5`
 * `'PNG'` used by e.g. MS Word 2016 and Paint.NET,
 * `CF_HDROP` used by most browsers (except Chrome), file explorers, etc.

*Support for `CF_HDROP` was already hinted at in the documentation, but there was merely a FIXME in place of the code.*

Used format is selected out of available formats based on the priority specified by the clipboard owner.

While I could see the argument that CF_HDROP is more complicated and should therefore only be a fallback, based on my testing, it is almost always the preferred format, and preserves the original image data (e.g. transparency, tags, ...), unlike bitmaps.
