### PR TITLE
Fix repeatedly loading .gbr

### DIFF
--- a/Tests/test_file_gbr.py
+++ b/Tests/test_file_gbr.py
@@ -15,3 +15,10 @@ def test_gbr_file():
     with Image.open("Tests/images/gbr.gbr") as im:
         with Image.open("Tests/images/gbr.png") as target:
             assert_image_equal(target, im)
+
+
+def test_multiples_operation():
+    with Image.open("Tests/images/gbr.gbr") as im:
+        rect = (0, 0, 10, 10)
+        im.crop(rect)
+        im.crop(rect)

--- a/Tests/test_file_gbr.py
+++ b/Tests/test_file_gbr.py
@@ -17,8 +17,9 @@ def test_gbr_file():
             assert_image_equal(target, im)
 
 
-def test_multiples_operation():
+def test_multiple_load_operations():
     with Image.open("Tests/images/gbr.gbr") as im:
-        rect = (0, 0, 10, 10)
-        im.crop(rect)
-        im.crop(rect)
+        im.load()
+        im.load()
+        with Image.open("Tests/images/gbr.png") as target:
+            assert_image_equal(target, im)

--- a/src/PIL/GbrImagePlugin.py
+++ b/src/PIL/GbrImagePlugin.py
@@ -84,8 +84,9 @@ class GbrImageFile(ImageFile.ImageFile):
         self._data_size = width * height * color_depth
 
     def load(self):
-        self.im = Image.core.new(self.mode, self.size)
-        self.frombytes(self.fp.read(self._data_size))
+        if not self.im:
+            self.im = Image.core.new(self.mode, self.size)
+            self.frombytes(self.fp.read(self._data_size))
 
 
 #

--- a/src/PIL/GbrImagePlugin.py
+++ b/src/PIL/GbrImagePlugin.py
@@ -84,9 +84,12 @@ class GbrImageFile(ImageFile.ImageFile):
         self._data_size = width * height * color_depth
 
     def load(self):
-        if not self.im:
-            self.im = Image.core.new(self.mode, self.size)
-            self.frombytes(self.fp.read(self._data_size))
+        if self.im:
+            # Already loaded
+            return
+
+        self.im = Image.core.new(self.mode, self.size)
+        self.frombytes(self.fp.read(self._data_size))
 
 
 #


### PR DESCRIPTION
.gbr files are not usable since on each `load()` we try to load the image from the file buffer.
This lead to an error on the second `load()` since the buffer is empty (we reached the end of the file).

Changes proposed in this pull request:
 * read from the file only if `self.im is None`
 * a basic test doing 2 `crop` in a row that would crash without the fix