### PR TITLE
Fix broken string in test error message

### DIFF
--- a/Tests/test_image_reduce.py
+++ b/Tests/test_image_reduce.py
@@ -174,8 +174,10 @@ def assert_compare_images(a, b, max_average_diff, max_diff=255):
         average_diff = sum(i * num for i, num in enumerate(ch_hist)) / (
             a.size[0] * a.size[1]
         )
-        msg = "average pixel value difference {:.4f} > expected {:.4f} "
-        "for '{}' band".format(average_diff, max_average_diff, band)
+        msg = (
+            "average pixel value difference {:.4f} > expected {:.4f} "
+            "for '{}' band".format(average_diff, max_average_diff, band)
+        )
         assert max_average_diff >= average_diff, msg
 
         last_diff = [i for i, num in enumerate(ch_hist) if num > 0][-1]


### PR DESCRIPTION
Hasn't cropped up because the test is passing :)

# Demo

```python
average_diff = 2
max_average_diff = 1
band = "R"

# broken
msg = "average pixel value difference {:.4f} > expected {:.4f} "
"for '{}' band".format(average_diff, max_average_diff, band)

print(msg)

# fixed
msg = (
    "average pixel value difference {:.4f} > expected {:.4f} "
    "for '{}' band".format(average_diff, max_average_diff, band)
)

print(msg)
```
```
average pixel value difference {:.4f} > expected {:.4f}
average pixel value difference 2.0000 > expected 1.0000 for 'R' band
```