### PR TITLE
Ignore PyTest 5.4.2

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -25,7 +25,7 @@ pip install --upgrade pip
 PYTHONOPTIMIZE=0 pip install cffi
 pip install coverage
 pip install olefile
-pip install -U pytest
+pip install -U pytest!=5.4.2
 pip install -U pytest-cov
 pip install pyroma
 pip install test-image-results


### PR DESCRIPTION
Python 3.9-pre tests have started failing recently, with a segmentation fault in PyTest rewrite during collection: https://travis-ci.org/github/python-pillow/Pillow/jobs/686090749#L2777

Pinning `pytest!=5.4.2` to force PyTest 5.4.1 seems to fix this.