### PR TITLE
Change STRIPBYTECOUNTS to LONG if necessary when saving

### DIFF
--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -156,6 +156,23 @@ def test_write_metadata(tmp_path):
             assert value == reloaded[tag], "%s didn't roundtrip" % tag
 
 
+def test_change_stripbytecounts_tag_type(tmp_path):
+    out = str(tmp_path / "temp.tiff")
+    with Image.open("Tests/images/hopper.tif") as im:
+        info = im.tag_v2
+
+        # Resize the image so that STRIPBYTECOUNTS will be larger than a SHORT
+        im = im.resize((500, 500))
+
+        # STRIPBYTECOUNTS can be a SHORT or a LONG
+        info.tagtype[TiffImagePlugin.STRIPBYTECOUNTS] = TiffTags.SHORT
+
+        im.save(out, tiffinfo=info)
+
+    with Image.open(out) as reloaded:
+        assert reloaded.tag_v2.tagtype[TiffImagePlugin.STRIPBYTECOUNTS] == TiffTags.LONG
+
+
 def test_no_duplicate_50741_tag():
     assert TAG_IDS["MakerNoteSafety"] == 50741
     assert TAG_IDS["BestQualityScale"] == 50780

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1508,10 +1508,10 @@ def _save(im, fp, filename):
     # data orientation
     stride = len(bits) * ((im.size[0] * bits[0] + 7) // 8)
     ifd[ROWSPERSTRIP] = im.size[1]
-    stripByteCounts = stride * im.size[1]
-    if stripByteCounts >= 2 ** 16:
+    strip_byte_counts = stride * im.size[1]
+    if strip_byte_counts >= 2 ** 16:
         ifd.tagtype[STRIPBYTECOUNTS] = TiffTags.LONG
-    ifd[STRIPBYTECOUNTS] = stripByteCounts
+    ifd[STRIPBYTECOUNTS] = strip_byte_counts
     ifd[STRIPOFFSETS] = 0  # this is adjusted by IFD writer
     # no compression by default:
     ifd[COMPRESSION] = COMPRESSION_INFO_REV.get(compression, 1)

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1508,7 +1508,10 @@ def _save(im, fp, filename):
     # data orientation
     stride = len(bits) * ((im.size[0] * bits[0] + 7) // 8)
     ifd[ROWSPERSTRIP] = im.size[1]
-    ifd[STRIPBYTECOUNTS] = stride * im.size[1]
+    stripByteCounts = stride * im.size[1]
+    if stripByteCounts >= 2 ** 16:
+        ifd.tagtype[STRIPBYTECOUNTS] = TiffTags.LONG
+    ifd[STRIPBYTECOUNTS] = stripByteCounts
     ifd[STRIPOFFSETS] = 0  # this is adjusted by IFD writer
     # no compression by default:
     ifd[COMPRESSION] = COMPRESSION_INFO_REV.get(compression, 1)


### PR DESCRIPTION
Resolves #4360

If STRIPBYTECOUNTS is specified to be SHORT, a valid type for the tag [according to documentation](https://www.awaresystems.be/imaging/tiff/tifftags/stripbytecounts.html), but Pillow calculates a STRIPBYTECOUNTS value too large for SHORT when saving, then an error is thrown.

This PR fixes the situation by changing STRIPBYTECOUNTS to LONG if necessary when saving.