### PR TITLE
Replaced tiff_jpeg with jpeg compression when saving TIFF images

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -448,6 +448,14 @@ class TestFileLibTiff(LibTiffTestCase):
         assert size_compressed > size_jpeg
         assert size_jpeg > size_jpeg_30
 
+    def test_tiff_jpeg_compression(self, tmp_path):
+        im = hopper("RGB")
+        out = str(tmp_path / "temp.tif")
+        im.save(out, compression="tiff_jpeg")
+
+        with Image.open(out) as reloaded:
+            assert reloaded.info["compression"] == "jpeg"
+
     def test_quality(self, tmp_path):
         im = hopper("RGB")
         out = str(tmp_path / "temp.tif")

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1427,6 +1427,9 @@ def _save(im, fp, filename):
     compression = im.encoderinfo.get("compression", im.info.get("compression"))
     if compression is None:
         compression = "raw"
+    elif compression == "tiff_jpeg":
+        # OJPEG is obsolete, so use new-style JPEG compression instead
+        compression = "jpeg"
 
     libtiff = WRITE_LIBTIFF or compression != "raw"
 


### PR DESCRIPTION
Resolves #3786

In this issue, the user opens an image with 'tiff_jpeg' compression, and then tries to save it. libtiff throws an error though - 'OJPEGSetupEncode: OJPEG encoding not supported; use new-style JPEG compression instead.'

For a longer explanation of this error message, see the text at the beginning of the libtiff file that contains the error - https://gitlab.com/libtiff/libtiff/-/blob/master/libtiff/tif_ojpeg.c

According to https://www.awaresystems.be/imaging/tiff/tifftags/compression.html - 6 is old-style JPEG (Pillow [tiff_jpeg](https://github.com/python-pillow/Pillow/blob/4634eafe3c695a014267eefdce830b4a825beed7/src/PIL/TiffImagePlugin.py#L114) compression), 7 is new-style JPEG (Pillow [jpeg](https://github.com/python-pillow/Pillow/blob/4634eafe3c695a014267eefdce830b4a825beed7/src/PIL/TiffImagePlugin.py#L115) compression).

So this PR takes the advice from libtiff, and changes from 'tiff_jpeg' to 'jpeg' when saving.