### PR TITLE
Added is_animated and n_frames to all images

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -65,6 +65,8 @@ class TestImage:
         assert repr(im)[:45] == "<PIL.Image.Image image mode=L size=100x100 at"
         assert im.mode == "L"
         assert im.size == (100, 100)
+        assert not im.is_animated
+        assert im.n_frames == 1
 
         im = Image.new("RGB", (100, 100))
         assert repr(im)[:45] == "<PIL.Image.Image image mode=RGB size=100x100 "

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -538,6 +538,10 @@ class Image:
         self.readonly = 0
         self.pyaccess = None
         self._exif = None
+        if "is_animated" not in dir(self):
+            self.is_animated = False
+        if "n_frames" not in dir(self):
+            self.n_frames = 1
 
     @property
     def width(self):


### PR DESCRIPTION
Resolves #4609 

Sets `is_animated` and `n_frames` for the base `Image` class so that they are present for all images.