### PR TITLE
Add testpaths to tell pytest where to search for tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,4 @@ multi_line_output = 3
 
 [tool:pytest]
 addopts = -rs
+testpaths = Tests


### PR DESCRIPTION
A small optimisation for when running bare `pytest` locally.

> **testpaths**
> 
> Sets list of directories that should be searched for tests when no specific directories, files or test ids are given in the command line when executing pytest from the rootdir directory. Useful when all project tests are in a known location to speed up test collection and to avoid picking up undesired tests by accident.

https://docs.pytest.org/en/stable/reference.html?highlight=testpaths#confval-testpaths

Like running `pytest Tests`, but saves a bit of typing.

Demo using `--collect-only` as this affects the test collection phase:

```console
$ # master
$ pytest --collect-only | grep " in "
============================ no tests ran in 3.18s =============================
$ pytest --collect-only | grep " in "
============================ no tests ran in 2.89s =============================
```
```console
$ # PR
$ pytest --collect-only | grep " in "
============================ no tests ran in 2.44s =============================
$ pytest --collect-only | grep " in "
============================ no tests ran in 2.40s =============================
```

And useful when using `-k` to select a single test:

```console
$ # master
$ pytest -k test_quantize_no_dither --collect-only | grep " in "
=========================== 1467 deselected in 3.19s ===========================
$ pytest -k test_quantize_no_dither --collect-only | grep " in "
=========================== 1467 deselected in 2.69s ===========================
```
```console
$ # PR
$ pytest -k test_quantize_no_dither --collect-only | grep " in "
=========================== 1467 deselected in 2.33s ===========================
$ pytest -k test_quantize_no_dither --collect-only | grep " in "
=========================== 1467 deselected in 2.70s ===========================
```

