### PR TITLE
Fix ImportError on Python 3.9.0b1 for Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -731,9 +731,9 @@ class pil_build_ext(build_ext):
             defs.append(("WORDS_BIGENDIAN", None))
 
         if (
-            sys.platform == "win32" and
-            sys.version_info < (3, 9) and
-            not (PLATFORM_PYPY or PLATFORM_MINGW)
+            sys.platform == "win32"
+            and sys.version_info < (3, 9)
+            and not (PLATFORM_PYPY or PLATFORM_MINGW)
         ):
             defs.append(("PILLOW_VERSION", '"\\"%s\\""' % PILLOW_VERSION))
         else:

--- a/setup.py
+++ b/setup.py
@@ -730,7 +730,11 @@ class pil_build_ext(build_ext):
         if struct.unpack("h", b"\0\1")[0] == 1:
             defs.append(("WORDS_BIGENDIAN", None))
 
-        if sys.platform == "win32" and not (PLATFORM_PYPY or PLATFORM_MINGW):
+        if (
+            sys.platform == "win32" and
+            sys.version_info < (3, 9) and
+            not (PLATFORM_PYPY or PLATFORM_MINGW)
+        ):
             defs.append(("PILLOW_VERSION", '"\\"%s\\""' % PILLOW_VERSION))
         else:
             defs.append(("PILLOW_VERSION", '"%s"' % PILLOW_VERSION))


### PR DESCRIPTION
```
Python 3.9.0b1 (tags/v3.9.0b1:97fe9cf, May 19 2020, 09:02:07) [MSC v.1924 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from PIL import Image
X:\Python39\lib\site-packages\PIL\Image.py:114: RuntimeWarning: The _imaging extension was built for another version of Pillow or PIL:
Core version: "7.1.2"
Pillow version: 7.1.2
  warnings.warn(str(v), RuntimeWarning)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "X:\Python39\lib\site-packages\PIL\Image.py", line 96, in <module>
    raise ImportError(
ImportError: The _imaging extension was built for another version of Pillow or PIL:
Core version: "7.1.2"
Pillow version: 7.1.2
```
