### PR TITLE
Use ImageFileDirectory_v2 in Image.Exif

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -219,7 +219,7 @@ class TestFileJpeg:
             gps_index = 34853
             expected_exif_gps = {
                 0: b"\x00\x00\x00\x01",
-                2: (4294967295, 1),
+                2: 4294967295,
                 5: b"\x01",
                 30: 65535,
                 29: "1999:99:99 99:99:99",
@@ -241,7 +241,7 @@ class TestFileJpeg:
             36867: "2099:09:29 10:10:10",
             34853: {
                 0: b"\x00\x00\x00\x01",
-                2: (4294967295, 1),
+                2: 4294967295,
                 5: b"\x01",
                 30: 65535,
                 29: "1999:99:99 99:99:99",
@@ -253,11 +253,11 @@ class TestFileJpeg:
             271: "Make",
             272: "XXX-XXX",
             305: "PIL",
-            42034: ((1, 1), (1, 1), (1, 1), (1, 1)),
+            42034: (1, 1, 1, 1),
             42035: "LensMake",
             34856: b"\xaa\xaa\xaa\xaa\xaa\xaa",
-            282: (4294967295, 1),
-            33434: (4294967295, 1),
+            282: 4294967295,
+            33434: 4294967295,
         }
 
         with Image.open("Tests/images/exif_gps.jpg") as im:
@@ -646,6 +646,19 @@ class TestFileJpeg:
             # This should return the default, and not a SyntaxError or
             # OSError for unidentified image.
             assert im.info.get("dpi") == (72, 72)
+
+    def test_exif_x_resolution(self, tmp_path):
+        with Image.open("Tests/images/flower.jpg") as im:
+            exif = im.getexif()
+            assert exif[282] == 180
+
+            out = str(tmp_path / "out.jpg")
+            with pytest.warns(None) as record:
+                im.save(out, exif=exif)
+            assert len(record) == 0
+
+        with Image.open(out) as reloaded:
+            assert reloaded.getexif()[282] == 180
 
     def test_invalid_exif_x_resolution(self):
         # When no x or y resolution is defined in EXIF

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3248,7 +3248,7 @@ class Exif(MutableMapping):
 
     def _fixup(self, value):
         try:
-            if len(value) == 1 and not isinstance(value, dict):
+            if len(value) == 1 and isinstance(value, tuple):
                 return value[0]
         except Exception:
             pass
@@ -3269,7 +3269,7 @@ class Exif(MutableMapping):
         else:
             from . import TiffImagePlugin
 
-            info = TiffImagePlugin.ImageFileDirectory_v1(self.head)
+            info = TiffImagePlugin.ImageFileDirectory_v2(self.head)
             info.load(self.fp)
             return self._fixup_dict(info)
 
@@ -3294,7 +3294,7 @@ class Exif(MutableMapping):
         # process dictionary
         from . import TiffImagePlugin
 
-        self._info = TiffImagePlugin.ImageFileDirectory_v1(self.head)
+        self._info = TiffImagePlugin.ImageFileDirectory_v2(self.head)
         self.endian = self._info._endian
         self.fp.seek(self._info.next)
         self._info.load(self.fp)


### PR DESCRIPTION
The `Image.Exif` class currently uses the legacy `ImageFileDirectory_v1`. This PR changes it to use `ImageFileDirectory_v2`.

Aside from the good practice of moving away from a legacy class, it also changes RATIONALs to be [read as IFDRationals, instead of a tuple with (numerator, denominator)](https://github.com/python-pillow/Pillow/blob/75716a310a1ebc965d793492a2d65a918c412180/src/PIL/TiffImagePlugin.py#L686).

A warning when saving tags [282](https://www.awaresystems.be/imaging/tiff/tifftags/xresolution.html) and [283](https://www.awaresystems.be/imaging/tiff/tifftags/yresolution.html) has been reported [here](https://github.com/python-pillow/Pillow/issues/4537#issuecomment-612008156) and [here](https://github.com/python-pillow/Pillow/issues/4238#issuecomment-624300805), that the tags `had too many entries: 2, expected 1`. This PR means that only one value, the IFDRational, will be attempted to be saved, instead of two values, a tuple of the numerator and the denominator.