### PR TITLE
Write JFIF header when saving JPEG

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -91,15 +91,17 @@ class TestFileJpeg:
             assert k > 0.9
 
     def test_dpi(self):
-        def test(xdpi, ydpi=None):
-            with Image.open(TEST_FILE) as im:
-                im = self.roundtrip(im, dpi=(xdpi, ydpi or xdpi))
-            return im.info.get("dpi")
+        for test_image_path in [TEST_FILE, "Tests/images/pil_sample_cmyk.jpg"]:
 
-        assert test(72) == (72, 72)
-        assert test(300) == (300, 300)
-        assert test(100, 200) == (100, 200)
-        assert test(0) is None  # square pixels
+            def test(xdpi, ydpi=None):
+                with Image.open(test_image_path) as im:
+                    im = self.roundtrip(im, dpi=(xdpi, ydpi or xdpi))
+                return im.info.get("dpi")
+
+            assert test(72) == (72, 72)
+            assert test(300) == (300, 300)
+            assert test(100, 200) == (100, 200)
+            assert test(0) is None  # square pixels
 
     def test_icc(self, tmp_path):
         # Test ICC support

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -90,18 +90,19 @@ class TestFileJpeg:
             ]
             assert k > 0.9
 
-    def test_dpi(self):
-        for test_image_path in [TEST_FILE, "Tests/images/pil_sample_cmyk.jpg"]:
+    @pytest.mark.parametrize(
+        "test_image_path", [TEST_FILE, "Tests/images/pil_sample_cmyk.jpg"],
+    )
+    def test_dpi(self, test_image_path):
+        def test(xdpi, ydpi=None):
+            with Image.open(test_image_path) as im:
+                im = self.roundtrip(im, dpi=(xdpi, ydpi or xdpi))
+            return im.info.get("dpi")
 
-            def test(xdpi, ydpi=None):
-                with Image.open(test_image_path) as im:
-                    im = self.roundtrip(im, dpi=(xdpi, ydpi or xdpi))
-                return im.info.get("dpi")
-
-            assert test(72) == (72, 72)
-            assert test(300) == (300, 300)
-            assert test(100, 200) == (100, 200)
-            assert test(0) is None  # square pixels
+        assert test(72) == (72, 72)
+        assert test(300) == (300, 300)
+        assert test(100, 200) == (100, 200)
+        assert test(0) is None  # square pixels
 
     def test_icc(self, tmp_path):
         # Test ICC support

--- a/src/libImaging/JpegEncode.c
+++ b/src/libImaging/JpegEncode.c
@@ -222,6 +222,7 @@ ImagingJpegEncode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
                 context->cinfo.smoothing_factor = context->smooth;
                 context->cinfo.optimize_coding = (boolean) context->optimize;
                 if (context->xdpi > 0 && context->ydpi > 0) {
+                    context->cinfo.write_JFIF_header = TRUE;
                     context->cinfo.density_unit = 1; /* dots per inch */
                     context->cinfo.X_density = context->xdpi;
                     context->cinfo.Y_density = context->ydpi;


### PR DESCRIPTION
Resolves #3328

Pillow has some C code that sets `density_unit`, `X_density` and `Y_density`. However, [libjpeg](https://github.com/LuaDist/libjpeg/blob/master/libjpeg.txt) states that

> UINT8 density_unit
> UINT16 X_density
> UINT16 Y_density
> 	The resolution information to be written into the JFIF marker;
> 	not used otherwise.

So this code should tell libjpeg to [write the JFIF marker](https://github.com/LuaDist/libjpeg/blob/6c0fcb8ddee365e7abc4d332662b06900612e923/jcmarker.c#L528).