### PR TITLE
Deprecate Image.show(command="...")

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -664,6 +664,18 @@ class TestImage:
             except OSError as e:
                 assert str(e) == "buffer overrun when reading image file"
 
+    def test_show_deprecation(self, monkeypatch):
+        monkeypatch.setattr(Image, "_show", lambda *args, **kwargs: None)
+
+        im = Image.new("RGB", (50, 50), "white")
+
+        with pytest.warns(None) as raised:
+            im.show()
+        assert not raised
+
+        with pytest.warns(DeprecationWarning):
+            im.show(command="mock")
+
 
 class MockEncoder:
     pass

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -12,6 +12,14 @@ Deprecated features
 Below are features which are considered deprecated. Where appropriate,
 a ``DeprecationWarning`` is issued.
 
+Image.show
+~~~~~~~~~~
+
+.. deprecated:: 7.2.0
+
+The ``command`` parameter was deprecated and will be removed in a future release.
+Use a subclass of ``ImageShow.Viewer`` instead.
+
 ImageFile.raise_ioerror
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -12,8 +12,8 @@ Deprecated features
 Below are features which are considered deprecated. Where appropriate,
 a ``DeprecationWarning`` is issued.
 
-Image.show
-~~~~~~~~~~
+Image.show command parameter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. deprecated:: 7.2.0
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2177,7 +2177,7 @@ class Image:
 
         if command is not None:
             warnings.warn(
-                "The command parameter was deprecated and will be removed in a future"
+                "The command parameter is deprecated and will be removed in a future"
                 "release. Use a subclass of ImageShow.Viewer instead.",
                 DeprecationWarning,
             )

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2172,8 +2172,14 @@ class Image:
 
         :param title: Optional title to use for the image window,
            where possible.
-        :param command: command used to show the image
         """
+
+        if command is not None:
+            warnings.warn(
+                "The command parameter was deprecated and will be removed in a future"
+                "release. Use a subclass of ImageShow.Viewer instead.",
+                DeprecationWarning,
+            )
 
         _show(self, title=title, command=command)
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2177,7 +2177,7 @@ class Image:
 
         if command is not None:
             warnings.warn(
-                "The command parameter is deprecated and will be removed in a future"
+                "The command parameter is deprecated and will be removed in a future "
                 "release. Use a subclass of ImageShow.Viewer instead.",
                 DeprecationWarning,
             )

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2157,8 +2157,10 @@ class Image:
 
     def show(self, title=None, command=None):
         """
-        Displays this image. This method is mainly intended for
-        debugging purposes.
+        Displays this image. This method is mainly intended for debugging purposes.
+
+        This method calls :py:func:`PIL.ImageShow.show` internally. You can use
+        :py:func:`PIL.ImageShow.register` to override its default behaviour.
 
         The image is first saved to a temporary file. By default, it will be in
         PNG format.
@@ -2170,8 +2172,7 @@ class Image:
 
         On Windows, the image is opened with the standard PNG display utility.
 
-        :param title: Optional title to use for the image window,
-           where possible.
+        :param title: Optional title to use for the image window, where possible.
         """
 
         if command is not None:


### PR DESCRIPTION
For #4643 

Changes proposed in this pull request:

 * Deprecate the `Image.show(command="...")` parameter and remove its documentation, because it hasn't been implemented since the PIL fork, and implementing it is non-trivial.
