### PR TITLE
Allow libtiff to write COLORMAP tag

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -203,6 +203,7 @@ class TestFileLibTiff(LibTiffTestCase):
                     del core_items[tag]
                 except KeyError:
                     pass
+            del core_items[320]  # colormap is special, tested below
 
             # Type codes:
             #     2: "ascii",
@@ -478,6 +479,18 @@ class TestFileLibTiff(LibTiffTestCase):
         im.save(out, compression="tiff_adobe_deflate")
         with Image.open(out) as im2:
             assert_image_equal(im, im2)
+
+    def test_palette_save(self, tmp_path):
+        im = hopper("P")
+        out = str(tmp_path / "temp.tif")
+
+        TiffImagePlugin.WRITE_LIBTIFF = True
+        im.save(out)
+        TiffImagePlugin.WRITE_LIBTIFF = False
+
+        with Image.open(out) as reloaded:
+            # colormap/palette tag
+            assert len(reloaded.tag_v2[320]) == 768
 
     def xtest_bw_compression_w_rgb(self, tmp_path):
         """ This test passes, but when running all tests causes a failure due

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1524,7 +1524,6 @@ def _save(im, fp, filename):
         # BITSPERSAMPLE, etc), passing arrays with a different length will result in
         # segfaults. Block these tags until we add extra validation.
         blocklist = [
-            COLORMAP,
             REFERENCEBLACKWHITE,
             SAMPLEFORMAT,
             STRIPBYTECOUNTS,

--- a/src/PIL/TiffTags.py
+++ b/src/PIL/TiffTags.py
@@ -483,7 +483,6 @@ LIBTIFF_CORE = {
     65537,
 }
 
-LIBTIFF_CORE.remove(320)  # Array of short, crashes
 LIBTIFF_CORE.remove(301)  # Array of short, crashes
 LIBTIFF_CORE.remove(532)  # Array of long, crashes
 


### PR DESCRIPTION
Taking a part of #2288

At the moment, `COLORMAP` is the TiffImagePlugin `blocklist`, tags that are blocked when saving.

https://github.com/python-pillow/Pillow/blob/a78de17346da722bc015cf35af0189adcdc0e2b9/src/PIL/TiffImagePlugin.py#L1520-L1524

This PR adds that validation, throwing an error if it does not have length 768.

The tag is treated as special when writing because libtiff handles it specially - https://gitlab.com/libtiff/libtiff/-/blob/master/libtiff/tif_dir.c#L374-379