### PR TITLE
Do not render glyphs during text layout

### DIFF
--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -553,7 +553,7 @@ text_layout_fallback(PyObject* string, FontObject* self, const char* dir, PyObje
         return 0;
     }
 
-    load_flags = FT_LOAD_RENDER|FT_LOAD_NO_BITMAP;
+    load_flags = FT_LOAD_NO_BITMAP;
     if (mask) {
         load_flags |= FT_LOAD_TARGET_MONO;
     }


### PR DESCRIPTION
For #4651 

> I would assume the advance value only depends on hinting, which should probably run without the FT_LOAD_RENDER flag. In fact, the FreeType docs mention the flag FT_LOAD_BITMAP_METRICS_ONLY which seems appropriate here and conflicts with FT_LOAD_RENDER. https://www.freetype.org/freetype2/docs/reference/ft2-base_interface.html#ft_load_xxx

~~While the `FT_LOAD_BITMAP_METRICS_ONLY` will likely be ignored due to `FT_LOAD_NO_BITMAP`, it should serve as a reminder for when #891 is resolved properly. *(I know the solution, I intend to submit a PR later. Essentially, Pillow should check the bitdepth of the returned bitmap instead of guessing.)*~~ Edit: Removed for now as it is not supported on all FreeType versions.

Testing I get the following results (in s) on my Windows 10 laptop with the code below.
| 7.1.2 (PyPI) | master (local compile) | PR (local compile) |
| --- | --- | --- |
| 0.088 | 0.0895 | 0.079 |
```python
    from timeit import repeat

    print(
        'getsize(L) (x100): ',
        min(repeat(
            'font.getsize("Hello world")',
            'from PIL import ImageFont; font = ImageFont.truetype("Tests/fonts/FreeMono.ttf", 20, layout_engine=ImageFont.LAYOUT_BASIC)',
            number=100, repeat=30
        )),
    )
```