### PR TITLE
Corrected undefined behaviour

### DIFF
--- a/src/libImaging/QuantOctree.c
+++ b/src/libImaging/QuantOctree.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <limits.h>
 
+#include "ImagingUtils.h"
 #include "QuantOctree.h"
 
 typedef struct _ColorBucket{
@@ -152,10 +153,10 @@ static void
 avg_color_from_color_bucket(const ColorBucket bucket, Pixel *dst) {
    float count = bucket->count;
    if (count != 0) {
-       dst->c.r = (int)(bucket->r / count);
-       dst->c.g = (int)(bucket->g / count);
-       dst->c.b = (int)(bucket->b / count);
-       dst->c.a = (int)(bucket->a / count);
+       dst->c.r = CLIP8((int)(bucket->r / count));
+       dst->c.g = CLIP8((int)(bucket->g / count));
+       dst->c.b = CLIP8((int)(bucket->b / count));
+       dst->c.a = CLIP8((int)(bucket->a / count));
    } else {
        dst->c.r = 0;
        dst->c.g = 0;


### PR DESCRIPTION
Resolves #3031 

Mentioned in that issue is the undefined behaviour of dividing by zero - this has already been fixed by #3388.

Left is the undefined behaviour of assigning an int to an unsigned char. So this PR uses `CLIP8` to resolve that, in much the same way that #3107 resolved #3030.