### PR TITLE
Remove redundant noqa

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,16 +8,27 @@ repos:
         files: \.py$
         types: []
 
+  - repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/asottile/yesqa
+    rev: v1.1.1
+    hooks:
+      - id: yesqa
+
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.1.7
+    hooks:
+      - id: remove-tabs
+        exclude: (Makefile$|\.bat$|\.cmake$|\.eps$|\.fits$|\.opt$)
+
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.2
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
-
-  - repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21
-    hooks:
-      - id: isort
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.5.1
@@ -26,13 +37,7 @@ repos:
       - id: rst-backticks
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.1.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
-
-  - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.7
-    hooks:
-      - id: remove-tabs
-        exclude: (Makefile$|\.bat$|\.cmake$|\.eps$|\.fits$|\.opt$)

--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -112,7 +112,7 @@ def test_kernel_not_enough_coefficients():
 def test_consistency_3x3():
     with Image.open("Tests/images/hopper.bmp") as source:
         with Image.open("Tests/images/hopper_emboss.bmp") as reference:
-            kernel = ImageFilter.Kernel(  # noqa: E127
+            kernel = ImageFilter.Kernel(
                 (3, 3),
                 # fmt: off
                 (-1, -1,  0,
@@ -134,7 +134,7 @@ def test_consistency_3x3():
 def test_consistency_5x5():
     with Image.open("Tests/images/hopper.bmp") as source:
         with Image.open("Tests/images/hopper_emboss_more.bmp") as reference:
-            kernel = ImageFilter.Kernel(  # noqa: E127
+            kernel = ImageFilter.Kernel(
                 (5, 5),
                 # fmt: off
                 (-1, -1, -1, -1,  0,

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -484,7 +484,7 @@ def assert_aux_channel_preserved(mode, transform_in_place, preserved_channel):
     def create_test_image():
         # set up test image with something interesting in the tested aux channel.
         # fmt: off
-        nine_grid_deltas = [  # noqa: E131
+        nine_grid_deltas = [
             (-1, -1), (-1, 0), (-1, 1),
             (0,  -1),  (0, 0),  (0, 1),
             (1,  -1),  (1, 0),  (1, 1),

--- a/src/PIL/JpegPresets.py
+++ b/src/PIL/JpegPresets.py
@@ -71,7 +71,7 @@ https://web.archive.org/web/20120328125543/http://www.jpegcameras.com/libjpeg/li
 """
 
 # fmt: off
-presets = {  # noqa: E128
+presets = {
             'web_low':      {'subsampling':  2,  # "4:2:0"
                              'quantization': [
                                [20, 16, 25, 39, 50, 46, 62, 68,

--- a/src/PIL/PalmImagePlugin.py
+++ b/src/PIL/PalmImagePlugin.py
@@ -11,7 +11,7 @@ from . import Image, ImageFile
 from ._binary import o8, o16be as o16b
 
 # fmt: off
-_Palm8BitColormapValues = (  # noqa: E131
+_Palm8BitColormapValues = (
     (255, 255, 255), (255, 204, 255), (255, 153, 255), (255, 102, 255),
     (255,  51, 255), (255,   0, 255), (255, 255, 204), (255, 204, 204),
     (255, 153, 204), (255, 102, 204), (255,  51, 204), (255,   0, 204),

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -154,7 +154,7 @@ deps = {
         # "bins": [r"libtiff\*.dll"],
     },
     "libwebp": {
-        "url": "http://downloads.webmproject.org/releases/webp/libwebp-1.1.0.tar.gz",  # noqa: E501
+        "url": "http://downloads.webmproject.org/releases/webp/libwebp-1.1.0.tar.gz",
         "filename": "libwebp-1.1.0.tar.gz",
         "dir": "libwebp-1.1.0",
         "build": [


### PR DESCRIPTION
Changes proposed in this pull request:

 * Add https://github.com/asottile/yesqa to pre-commit to remove redundant `noqa` markers
 * Run pre-commit hooks which can edit code first, they may fix things later hooks would fail on
 * `pre-commit autoupdate`: only updated `pre-commit/pre-commit-hooks`
