### PR TITLE
Corrected reading EXIF metadata without prefix

### DIFF
--- a/Tests/test_file_webp_metadata.py
+++ b/Tests/test_file_webp_metadata.py
@@ -30,6 +30,15 @@ def test_read_exif_metadata():
             assert exif_data == expected_exif
 
 
+def test_read_exif_metadata_without_prefix():
+    with Image.open("Tests/images/flower2.webp") as im:
+        # Assert prefix is not present
+        assert im.info["exif"][:6] != b"Exif\x00\x00"
+
+        exif = im.getexif()
+        assert exif[305] == "Adobe Photoshop CS6 (Macintosh)"
+
+
 def test_write_exif_metadata():
     file_path = "Tests/images/flower.jpg"
     test_buffer = BytesIO()

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3289,7 +3289,9 @@ class Exif(MutableMapping):
         if not data:
             return
 
-        self.fp = io.BytesIO(data[6:])
+        if data.startswith(b"Exif\x00\x00"):
+            data = data[6:]
+        self.fp = io.BytesIO(data)
         self.head = self.fp.read(8)
         # process dictionary
         from . import TiffImagePlugin


### PR DESCRIPTION
Resolves #4676 

`Image.Exif` currently assumes that EXIF data starts with b"Exif\x00\x00". This is not the case though, with the "Raw profile type exif" in the issue's image, or with the EXIF data in [Tests/images/flower2.webp](https://github.com/python-pillow/Pillow/blob/master/Tests/images/flower2.webp).

This PR removes that assumption.