### PR TITLE
Fixed formatting

### DIFF
--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -212,8 +212,7 @@ Methods
         .. versionadded:: 1.1.5
 
         .. note:: This option was broken until version 1.1.6.
-    :param joint: Joint type between a sequence of lines. It can be ``"curve"``,
-         for rounded edges, or ``None``.
+    :param joint: Joint type between a sequence of lines. It can be ``"curve"``, for rounded edges, or ``None``.
 
         .. versionadded:: 5.3.0
 


### PR DESCRIPTION
Before - https://pillow.readthedocs.io/en/latest/reference/ImageDraw.html#PIL.ImageDraw.PIL.ImageDraw.ImageDraw.line
![before](https://user-images.githubusercontent.com/3112309/83989868-1ff63980-a98b-11ea-83df-933549544b54.png)

After - https://pillow--4679.org.readthedocs.build/en/4679/reference/ImageDraw.html#PIL.ImageDraw.PIL.ImageDraw.ImageDraw.line
![after](https://user-images.githubusercontent.com/3112309/83989863-1b318580-a98b-11ea-9681-67e5437903cf.png)