### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -391,9 +391,12 @@ class pil_build_ext(build_ext):
                     _dbg("Looking for `%s` using pkg-config." % lib_name)
                     root = pkg_config(lib_name)
 
-            winbuil_root = os.path.join('.', 'winbuild', 'build')
-            if root is None and os.path.isdir(winbuil_root):
-                root = os.path.join(winbuil_root, 'lib'), os.path.join(winbuil_root, 'inc')
+            winbuild_root = os.path.join(".", "winbuild", "build")
+            if root is None and os.path.isdir(winbuild_root):
+                root = (
+                    os.path.join(winbuild_root, "lib"),
+                    os.path.join(winbuild_root, "inc")
+                )
 
             if isinstance(root, tuple):
                 lib_root, include_root = root

--- a/setup.py
+++ b/setup.py
@@ -391,6 +391,10 @@ class pil_build_ext(build_ext):
                     _dbg("Looking for `%s` using pkg-config." % lib_name)
                     root = pkg_config(lib_name)
 
+            winbuil_root = os.path.join('.', 'winbuild', 'build')
+            if root is None and os.path.isdir(winbuil_root):
+                root = os.path.join(winbuil_root, 'lib'), os.path.join(winbuil_root, 'inc')
+
             if isinstance(root, tuple):
                 lib_root, include_root = root
             else:

--- a/setup.py
+++ b/setup.py
@@ -395,7 +395,7 @@ class pil_build_ext(build_ext):
             if root is None and os.path.isdir(winbuild_root):
                 root = (
                     os.path.join(winbuild_root, "lib"),
-                    os.path.join(winbuild_root, "inc")
+                    os.path.join(winbuild_root, "inc"),
                 )
 
             if isinstance(root, tuple):


### PR DESCRIPTION
This lets you locally install Pillow on Windows if you built it following the instructions of winbuild with pip install --editable ..\Pillow

Changes proposed in this pull request:

 * You currently can't install Pillow on windows if you don't follow the instructions in winbuild/readme
 * Even if you do you still can't install it as setup script doesn't look here
 * This makes the setup script look into the winbuild build output if you followed the instructions in the readme
