### PR TITLE
Fix exception causes in PdfParser.py

### DIFF
--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -251,8 +251,8 @@ class PdfDict(collections.UserDict):
     def __getattr__(self, key):
         try:
             value = self[key.encode("us-ascii")]
-        except KeyError:
-            raise AttributeError(key)
+        except KeyError as e:
+            raise AttributeError(key) from e
         if isinstance(value, bytes):
             value = decode_text(value)
         if key.endswith("Date"):
@@ -811,11 +811,11 @@ class PdfParser:
             if m:
                 try:
                     stream_len = int(result[b"Length"])
-                except (TypeError, KeyError, ValueError):
+                except (TypeError, KeyError, ValueError) as e:
                     raise PdfFormatError(
                         "bad or missing Length in stream dict (%r)"
                         % result.get(b"Length", None)
-                    )
+                    ) from e
                 stream_data = data[m.end() : m.end() + stream_len]
                 m = cls.re_stream_end.match(data, m.end() + stream_len)
                 check_format_condition(m, "stream end not found")


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 