### PR TITLE
Removed ImageQt workaround for earlier versions

### DIFF
--- a/src/PIL/ImageQt.py
+++ b/src/PIL/ImageQt.py
@@ -142,12 +142,7 @@ def _toqclass_helper(im):
         data = im.tobytes("raw", "BGRX")
         format = QImage.Format_RGB32
     elif im.mode == "RGBA":
-        try:
-            data = im.tobytes("raw", "BGRA")
-        except SystemError:
-            # workaround for earlier versions
-            r, g, b, a = im.split()
-            im = Image.merge("RGBA", (b, g, r, a))
+        data = im.tobytes("raw", "BGRA")
         format = QImage.Format_ARGB32
     else:
         raise ValueError("unsupported image mode %r" % im.mode)


### PR DESCRIPTION
In ImageQt, there is a 'workaround for earlier versions'. It's been there since the fork, so it's not clear what it's referring to.

However, Qt 5 was released in 2012, after the fork, and we've dropped support for earlier Qt. So whatever these earlier versions are, they are no longer in use.