### PR TITLE
Avoid implying that _show always uses xv

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3142,13 +3142,12 @@ def register_encoder(name, encoder):
 
 def _show(image, **options):
     # override me, as necessary
-    _showxv(image, **options)
-
-
-def _showxv(image, title=None, **options):
     from . import ImageShow
 
-    ImageShow.show(image, title, **options)
+    ImageShow.show(image, **options)
+
+
+_showxv = _show
 
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
This code in Image.py implies that `_show` always uses xv.
https://github.com/python-pillow/Pillow/blob/41a75210b5460640d41e4f0ded56f588b88c97fb/src/PIL/Image.py#L3143-L3151

This PR rearranges the code into the following to avoid that implication.

```python
def _show(image, **options):
    # override me, as necessary
    from . import ImageShow

    ImageShow.show(image, **options)


_showxv = _show
```

`title` still has a default value of `None` because
https://github.com/python-pillow/Pillow/blob/41a75210b5460640d41e4f0ded56f588b88c97fb/src/PIL/ImageShow.py#L38