### PR TITLE
Fix PyAccess docs using deferred_error

### DIFF
--- a/src/PIL/PyAccess.py
+++ b/src/PIL/PyAccess.py
@@ -23,21 +23,27 @@
 import logging
 import sys
 
-from cffi import FFI
+try:
+    from cffi import FFI
+
+    defs = """
+    struct Pixel_RGBA {
+        unsigned char r,g,b,a;
+    };
+    struct Pixel_I16 {
+        unsigned char l,r;
+    };
+    """
+    ffi = FFI()
+    ffi.cdef(defs)
+except ImportError as ex:
+    # Allow error import for doc purposes, but error out when accessing
+    # anything in core.
+    from ._util import deferred_error
+
+    FFI = ffi = deferred_error(ex)
 
 logger = logging.getLogger(__name__)
-
-
-defs = """
-struct Pixel_RGBA {
-    unsigned char r,g,b,a;
-};
-struct Pixel_I16 {
-    unsigned char l,r;
-};
-"""
-ffi = FFI()
-ffi.cdef(defs)
 
 
 class PyAccess:


### PR DESCRIPTION
Current docs are missing due to ImportError for cffi: https://pillow.readthedocs.io/en/stable/reference/PyAccess.html?highlight=pyaccess#pyaccess-class
```
WARNING: autodoc: failed to import class 'PyAccess.PyAccess' from module 'PIL'; the following exception was raised:
No module named 'cffi'
```

![image](https://user-images.githubusercontent.com/3819630/84587211-937dc800-ae1d-11ea-8ad7-7aa24751b2bf.png)

---

This PR fixes the docs using `deferred_error`: https://pillow--4694.org.readthedocs.build/en/4694/reference/PyAccess.html#PIL.PyAccess.PyAccess

![image](https://user-images.githubusercontent.com/3819630/84587198-7943ea00-ae1d-11ea-9f4a-a1a2557f5f11.png)
