### PR TITLE
Use command argument in Image.show

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -12,6 +12,7 @@ from .helper import (
     assert_image_similar,
     assert_not_all_same,
     hopper,
+    is_mingw,
     is_win32,
 )
 
@@ -608,6 +609,24 @@ class TestImage:
                 im.load()
 
             assert not fp.closed
+
+    def test_show_command(self, tmp_path):
+        # Arrange
+        temp_file = str(tmp_path / "opened")
+        with open(temp_file, "a") as f:
+            f.close()
+        assert os.path.exists(temp_file)
+        im = hopper()
+
+        # Act
+        im.show(
+            command=("del" if (is_win32() and not is_mingw()) else "rm")
+            + " "
+            + temp_file
+        )
+
+        # Assert
+        assert not os.path.exists(temp_file)
 
     @pytest.mark.parametrize(
         "test_module", [PIL, Image],

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -48,8 +48,9 @@ def show(image, title=None, **options):
     if command:
 
         class CommandViewer(Viewer):
-            def get_command(self, file):
-                return command + " " + file
+            def show_file(self, file, **options):
+                subprocess.Popen([command, file])
+                return 1
 
         CommandViewer().show(image)
         return 1

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -44,9 +44,19 @@ def show(image, title=None, **options):
     :param \**options: Additional viewer options.
     :returns: True if a suitable viewer was found, false otherwise.
     """
-    for viewer in _viewers:
-        if viewer.show(image, title=title, **options):
-            return 1
+    command = options.get("command")
+    if command:
+
+        class CommandViewer(Viewer):
+            def get_command(self, file):
+                return command + " " + file
+
+        CommandViewer().show(image)
+        return 1
+    else:
+        for viewer in _viewers:
+            if viewer.show(image, title=title, **options):
+                return 1
     return 0
 
 


### PR DESCRIPTION
See #4643

The issue reports that the `command` argument is not used by Image `show()`. It should be a way to provide a custom command to use on the command line to show the image. PR #4646 suggests deprecating it as a solution.

As an alternative, this PR actually implements the `command` argument.