### PR TITLE
Add library version numbers to public API

### DIFF
--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -1,4 +1,5 @@
 import io
+import re
 
 import pytest
 from PIL import features
@@ -21,6 +22,27 @@ def test_check():
         assert features.check_feature(feature) == features.check(feature)
 
 
+def test_version():
+    # Check the correctness of the convenience function
+    # and the format of version numbers
+
+    def test(name, function):
+        version = features.version(name)
+        if not features.check(name):
+            assert version is None
+        else:
+            assert function(name) == version
+            if name != "PIL":
+                assert version is None or re.search(r"\d+(\.\d+)*$", version)
+
+    for module in features.modules:
+        test(module, features.version_module)
+    for codec in features.codecs:
+        test(codec, features.version_codec)
+    for feature in features.features:
+        test(feature, features.version_feature)
+
+
 @skip_unless_feature("webp")
 def test_webp_transparency():
     assert features.check("transp_webp") != _webp.WebPDecoderBuggyAlpha()
@@ -37,9 +59,22 @@ def test_webp_anim():
     assert features.check("webp_anim") == _webp.HAVE_WEBPANIM
 
 
+@skip_unless_feature("libjpeg_turbo")
+def test_libjpeg_turbo_version():
+    assert re.search(r"\d+\.\d+\.\d+$", features.version("libjpeg_turbo"))
+
+
+@skip_unless_feature("libimagequant")
+def test_libimagequant_version():
+    assert re.search(r"\d+\.\d+\.\d+$", features.version("libimagequant"))
+
+
 def test_check_modules():
     for feature in features.modules:
         assert features.check_module(feature) in [True, False]
+
+
+def test_check_codecs():
     for feature in features.codecs:
         assert features.check_codec(feature) in [True, False]
 
@@ -64,6 +99,8 @@ def test_unsupported_codec():
     # Act / Assert
     with pytest.raises(ValueError):
         features.check_codec(codec)
+    with pytest.raises(ValueError):
+        features.version_codec(codec)
 
 
 def test_unsupported_module():
@@ -72,6 +109,8 @@ def test_unsupported_module():
     # Act / Assert
     with pytest.raises(ValueError):
         features.check_module(module)
+    with pytest.raises(ValueError):
+        features.version_module(module)
 
 
 def test_pilinfo():

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -2,14 +2,14 @@ import io
 import sys
 
 import pytest
-from PIL import IcnsImagePlugin, Image
+from PIL import IcnsImagePlugin, Image, features
 
 from .helper import assert_image_equal, assert_image_similar
 
 # sample icon file
 TEST_FILE = "Tests/images/pillow.icns"
 
-ENABLE_JPEG2K = hasattr(Image.core, "jp2klib_version")
+ENABLE_JPEG2K = features.check_codec("jpg_2000")
 
 
 def test_sanity():

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -3,7 +3,7 @@ import re
 from io import BytesIO
 
 import pytest
-from PIL import ExifTags, Image, ImageFile, JpegImagePlugin
+from PIL import ExifTags, Image, ImageFile, JpegImagePlugin, features
 
 from .helper import (
     assert_image,
@@ -41,7 +41,7 @@ class TestFileJpeg:
     def test_sanity(self):
 
         # internal version number
-        assert re.search(r"\d+\.\d+$", Image.core.jpeglib_version)
+        assert re.search(r"\d+\.\d+$", features.version_codec("jpg"))
 
         with Image.open(TEST_FILE) as im:
             im.load()

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -2,7 +2,7 @@ import re
 from io import BytesIO
 
 import pytest
-from PIL import Image, ImageFile, Jpeg2KImagePlugin
+from PIL import Image, ImageFile, Jpeg2KImagePlugin, features
 
 from .helper import (
     assert_image_equal,
@@ -35,7 +35,7 @@ def roundtrip(im, **options):
 
 def test_sanity():
     # Internal version number
-    assert re.search(r"\d+\.\d+\.\d+$", Image.core.jp2klib_version)
+    assert re.search(r"\d+\.\d+\.\d+$", features.version_codec("jpg_2000"))
 
     with Image.open("Tests/images/test-card-lossless.jp2") as im:
         px = im.load()

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -3,11 +3,12 @@ import io
 import itertools
 import logging
 import os
+import re
 from collections import namedtuple
 from ctypes import c_float
 
 import pytest
-from PIL import Image, ImageFilter, TiffImagePlugin, TiffTags
+from PIL import Image, ImageFilter, TiffImagePlugin, TiffTags, features
 
 from .helper import (
     assert_image_equal,
@@ -47,6 +48,9 @@ class LibTiffTestCase:
 
 
 class TestFileLibTiff(LibTiffTestCase):
+    def test_version(self):
+        assert re.search(r"\d+\.\d+\.\d+$", features.version_codec("libtiff"))
+
     def test_g4_tiff(self, tmp_path):
         """Test the ordinary file path load path"""
 

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -3,7 +3,7 @@ import zlib
 from io import BytesIO
 
 import pytest
-from PIL import Image, ImageFile, PngImagePlugin
+from PIL import Image, ImageFile, PngImagePlugin, features
 
 from .helper import (
     PillowLeakTestCase,
@@ -73,7 +73,7 @@ class TestFilePng:
     def test_sanity(self, tmp_path):
 
         # internal version number
-        assert re.search(r"\d+\.\d+\.\d+(\.\d+)?$", Image.core.zlib_version)
+        assert re.search(r"\d+\.\d+\.\d+(\.\d+)?$", features.version_codec("zlib"))
 
         test_file = str(tmp_path / "temp.png")
 

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -1,7 +1,8 @@
 import io
+import re
 
 import pytest
-from PIL import Image, WebPImagePlugin
+from PIL import Image, WebPImagePlugin, features
 
 from .helper import (
     assert_image_similar,
@@ -38,6 +39,7 @@ class TestFileWebp:
     def test_version(self):
         _webp.WebPDecoderVersion()
         _webp.WebPDecoderBuggyAlpha()
+        assert re.search(r"\d+\.\d+\.\d+$", features.version_module("webp"))
 
     def test_read_rgb(self):
         """

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -4,7 +4,7 @@ import re
 from io import BytesIO
 
 import pytest
-from PIL import Image, ImageMode
+from PIL import Image, ImageMode, features
 
 from .helper import assert_image, assert_image_equal, assert_image_similar, hopper
 
@@ -46,7 +46,7 @@ def test_sanity():
     assert list(map(type, v)) == [str, str, str, str]
 
     # internal version number
-    assert re.search(r"\d+\.\d+$", ImageCms.core.littlecms_version)
+    assert re.search(r"\d+\.\d+$", features.version_module("littlecms2"))
 
     skip_missing()
     i = ImageCms.profileToProfile(hopper(), SRGB, SRGB)

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -7,7 +7,7 @@ import sys
 from io import BytesIO
 
 import pytest
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw, ImageFont, features
 
 from .helper import (
     assert_image_equal,
@@ -40,7 +40,7 @@ class TestImageFont:
 
     @classmethod
     def setup_class(self):
-        freetype = distutils.version.StrictVersion(ImageFont.core.freetype2_version)
+        freetype = distutils.version.StrictVersion(features.version_module("freetype2"))
 
         self.metrics = self.METRICS["Default"]
         for conditions, metrics in self.METRICS.items():
@@ -67,7 +67,7 @@ class TestImageFont:
         )
 
     def test_sanity(self):
-        assert re.search(r"\d+\.\d+\.\d+$", ImageFont.core.freetype2_version)
+        assert re.search(r"\d+\.\d+\.\d+$", features.version_module("freetype2"))
 
     def test_font_properties(self):
         ttf = self.get_font()
@@ -619,7 +619,7 @@ class TestImageFont:
     def test_variation_get(self):
         font = self.get_font()
 
-        freetype = distutils.version.StrictVersion(ImageFont.core.freetype2_version)
+        freetype = distutils.version.StrictVersion(features.version_module("freetype2"))
         if freetype < "2.9.1":
             with pytest.raises(NotImplementedError):
                 font.get_variation_names()
@@ -691,7 +691,7 @@ class TestImageFont:
     def test_variation_set_by_name(self):
         font = self.get_font()
 
-        freetype = distutils.version.StrictVersion(ImageFont.core.freetype2_version)
+        freetype = distutils.version.StrictVersion(features.version_module("freetype2"))
         if freetype < "2.9.1":
             with pytest.raises(NotImplementedError):
                 font.set_variation_by_name("Bold")
@@ -715,7 +715,7 @@ class TestImageFont:
     def test_variation_set_by_axes(self):
         font = self.get_font()
 
-        freetype = distutils.version.StrictVersion(ImageFont.core.freetype2_version)
+        freetype = distutils.version.StrictVersion(features.version_module("freetype2"))
         if freetype < "2.9.1":
             with pytest.raises(NotImplementedError):
                 font.set_variation_by_axes([100])

--- a/docs/reference/features.rst
+++ b/docs/reference/features.rst
@@ -8,6 +8,7 @@ The :py:mod:`PIL.features` module can be used to detect which Pillow features ar
 
 .. autofunction:: PIL.features.pilinfo
 .. autofunction:: PIL.features.check
+.. autofunction:: PIL.features.version
 .. autofunction:: PIL.features.get_supported
 
 Modules
@@ -16,28 +17,31 @@ Modules
 Support for the following modules can be checked:
 
 * ``pil``: The Pillow core module, required for all functionality.
-* ``tkinter``: Tkinter support.
+* ``tkinter``: Tkinter support. Version number not available.
 * ``freetype2``: FreeType font support via :py:func:`PIL.ImageFont.truetype`.
 * ``littlecms2``: LittleCMS 2 support via :py:mod:`PIL.ImageCms`.
 * ``webp``: WebP image support.
 
 .. autofunction:: PIL.features.check_module
+.. autofunction:: PIL.features.version_module
 .. autofunction:: PIL.features.get_supported_modules
 
 Codecs
 ------
 
-These are only checked during Pillow compilation.
+Support for these is only checked during Pillow compilation.
 If the required library was uninstalled from the system, the ``pil`` core module may fail to load instead.
+Except for ``jpg``, the version number is checked at run-time.
 
 Support for the following codecs can be checked:
 
-* ``jpg``: (compile time) Libjpeg support, required for JPEG based image formats.
+* ``jpg``: (compile time) Libjpeg support, required for JPEG based image formats. Only compile time version number is available.
 * ``jpg_2000``: (compile time) OpenJPEG support, required for JPEG 2000 image formats.
 * ``zlib``: (compile time) Zlib support, required for zlib compressed formats, such as PNG.
 * ``libtiff``: (compile time) LibTIFF support, required for TIFF based image formats.
 
 .. autofunction:: PIL.features.check_codec
+.. autofunction:: PIL.features.version_codec
 .. autofunction:: PIL.features.get_supported_codecs
 
 Features
@@ -45,16 +49,18 @@ Features
 
 Some of these are only checked during Pillow compilation.
 If the required library was uninstalled from the system, the relevant module may fail to load instead.
+Feature version numbers are available only where stated.
 
 Support for the following features can be checked:
 
-* ``libjpeg_turbo``: (compile time) Whether Pillow was compiled against the libjpeg-turbo version of libjpeg.
+* ``libjpeg_turbo``: (compile time) Whether Pillow was compiled against the libjpeg-turbo version of libjpeg. Compile-time version number is available.
 * ``transp_webp``: Support for transparency in WebP images.
 * ``webp_mux``: (compile time) Support for EXIF data in WebP images.
 * ``webp_anim``: (compile time) Support for animated WebP images.
-* ``raqm``: Raqm library, required for ``ImageFont.LAYOUT_RAQM`` in :py:func:`PIL.ImageFont.truetype`.
-* ``libimagequant``: (compile time) ImageQuant quantization support in :py:func:`PIL.Image.Image.quantize`.
+* ``raqm``: Raqm library, required for ``ImageFont.LAYOUT_RAQM`` in :py:func:`PIL.ImageFont.truetype`. Run-time version number is available for Raqm 0.7.0 or newer.
+* ``libimagequant``: (compile time) ImageQuant quantization support in :py:func:`PIL.Image.Image.quantize`. Run-time version number is available.
 * ``xcb``: (compile time) Support for X11 in :py:func:`PIL.ImageGrab.grab` via the XCB library.
 
 .. autofunction:: PIL.features.check_feature
+.. autofunction:: PIL.features.version_feature
 .. autofunction:: PIL.features.get_supported_features

--- a/src/PIL/IcnsImagePlugin.py
+++ b/src/PIL/IcnsImagePlugin.py
@@ -23,10 +23,10 @@ import subprocess
 import sys
 import tempfile
 
-from PIL import Image, ImageFile, PngImagePlugin
+from PIL import Image, ImageFile, PngImagePlugin, features
 from PIL._binary import i8
 
-enable_jpeg2k = hasattr(Image.core, "jp2klib_version")
+enable_jpeg2k = features.check_codec("jpg_2000")
 if enable_jpeg2k:
     from PIL import Jpeg2KImagePlugin
 

--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -270,7 +270,7 @@ def pilinfo(out=None, supported_formats=True):
                 v = version(name)
             if v is not None:
                 t = "compiled for" if name in ("pil", "jpg") else "loaded"
-                print("---", feature, "support ok,", t, "version", v, file=out)
+                print("---", feature, "support ok,", t, v, file=out)
             else:
                 print("---", feature, "support ok", file=out)
         else:

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -4168,12 +4168,21 @@ setup_module(PyObject* m) {
 
 #ifdef LIBJPEG_TURBO_VERSION
     PyModule_AddObject(m, "HAVE_LIBJPEGTURBO", Py_True);
+    #define tostr1(a) #a
+    #define tostr(a) tostr1(a)
+    PyDict_SetItemString(d, "libjpeg_turbo_version", PyUnicode_FromString(tostr(LIBJPEG_TURBO_VERSION)));
+    #undef tostr
+    #undef tostr1
 #else
     PyModule_AddObject(m, "HAVE_LIBJPEGTURBO", Py_False);
 #endif
 
 #ifdef HAVE_LIBIMAGEQUANT
     PyModule_AddObject(m, "HAVE_LIBIMAGEQUANT", Py_True);
+    {
+        extern const char* ImagingImageQuantVersion(void);
+        PyDict_SetItemString(d, "imagequant_version", PyUnicode_FromString(ImagingImageQuantVersion()));
+    }
 #else
     PyModule_AddObject(m, "HAVE_LIBIMAGEQUANT", Py_False);
 #endif

--- a/src/_imagingcms.c
+++ b/src/_imagingcms.c
@@ -1608,6 +1608,7 @@ static int
 setup_module(PyObject* m) {
     PyObject *d;
     PyObject *v;
+    int vn;
 
     d = PyModule_GetDict(m);
 
@@ -1622,7 +1623,8 @@ setup_module(PyObject* m) {
 
     d = PyModule_GetDict(m);
 
-    v = PyUnicode_FromFormat("%d.%d", LCMS_VERSION / 100, LCMS_VERSION % 100);
+    vn = cmsGetEncodedCMMversion();
+    v = PyUnicode_FromFormat("%d.%d", vn / 100, vn % 100);
     PyDict_SetItemString(d, "littlecms_version", v);
 
     return 0;

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -821,6 +821,16 @@ PyObject* WebPDecoderVersion_wrapper() {
     return Py_BuildValue("i", WebPGetDecoderVersion());
 }
 
+// Version as string
+const char*
+WebPDecoderVersion_str(void)
+{
+    static char version[20];
+    int version_number = WebPGetDecoderVersion();
+    sprintf(version, "%d.%d.%d", version_number >> 16, (version_number >> 8) % 0x100, version_number % 0x100);
+    return version;
+}
+
 /*
  * The version of webp that ships with (0.1.3) Ubuntu 12.04 doesn't handle alpha well.
  * Files that are valid with 0.3 are reported as being invalid.
@@ -872,9 +882,12 @@ void addTransparencyFlagToModule(PyObject* m) {
 }
 
 static int setup_module(PyObject* m) {
+    PyObject* d = PyModule_GetDict(m);
     addMuxFlagToModule(m);
     addAnimFlagToModule(m);
     addTransparencyFlagToModule(m);
+
+    PyDict_SetItemString(d, "webpdecoder_version", PyUnicode_FromString(WebPDecoderVersion_str()));
 
 #ifdef HAVE_WEBPANIM
     /* Ready object types */

--- a/src/libImaging/QuantPngQuant.c
+++ b/src/libImaging/QuantPngQuant.c
@@ -113,4 +113,13 @@ err:
     return result;
 }
 
+const char*
+ImagingImageQuantVersion(void)
+{
+    static char version[20];
+    int number = liq_version();
+    sprintf(version, "%d.%d.%d", number / 10000, (number / 100) % 100, number % 100);
+    return version;
+}
+
 #endif

--- a/src/libImaging/ZipEncode.c
+++ b/src/libImaging/ZipEncode.c
@@ -373,7 +373,7 @@ ImagingZipEncodeCleanup(ImagingCodecState state) {
 const char*
 ImagingZipVersion(void)
 {
-    return ZLIB_VERSION;
+    return zlibVersion();
 }
 
 #endif


### PR DESCRIPTION
Continuation of #4688.
Helps issues such as #4686, #3833.

Changes proposed in this pull request:

 * Add access to library version numbers to public API in `features` module. Update tests to use this instead of private APIs.
 * Use run-time version numbers where available; libjpeg apparently makes it [unnecessarily hard to retrieve the version number](https://stackoverflow.com/a/19116612/1648883).
 * Add version numbers to `pilinfo`. Example from https://github.com/nulano/Pillow/runs/772850897?check_suite_focus=true:
```
--------------------------------------------------------------------
--- PIL CORE support ok, compiled for version 7.2.0.dev0
--- TKINTER support ok
--- FREETYPE2 support ok, loaded version 2.8.1
--- LITTLECMS2 support ok, loaded version 20.90
--- WEBP support ok, loaded version 0.6.1
--- WEBP Transparency support ok
--- WEBPMUX support ok
--- WEBP Animation support ok
--- JPEG support ok, compiled for version libjpeg-turbo 1.5.2
--- OPENJPEG (JPEG2000) support ok, loaded version 2.3.0
--- ZLIB (PNG/ZIP) support ok, loaded version 1.2.11
--- LIBTIFF support ok, loaded version 4.0.9
--- RAQM (Bidirectional Text) support ok, loaded version 0.7.0
--- LIBIMAGEQUANT (Quantization method) support ok, loaded version 2.12.6
--- XCB (X protocol) support ok
--------------------------------------------------------------------
```

I did not add a version number for XCB as I can't easily test it on Windows.