### PR TITLE
Fix TCL in Windows PyPy tests

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -52,6 +52,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}
 
+    - name: Set up TCL
+      if: "contains(matrix.python-version, 'pypy')"
+      run: Write-Host "::set-env name=TCL_LIBRARY::$env:pythonLocation\tcl\tcl8.5"
+      shell: pwsh
+
     - name: Print build system information
       run: python .github/workflows/system-info.py
 


### PR DESCRIPTION
Before: https://github.com/python-pillow/Pillow/runs/771448368#step:22:1806
```
SKIPPED [4] d:\a\Pillow\Pillow\Tests\test_imagetk.py:29: TCL Error: Can't find a usable init.tcl in the following directories: 
    C:/hostedtoolcache/windows/PyPy/3.6.9/x86/lib_pypy/lib/tcl8.5 C:/hostedtoolcache/windows/PyPy/3.6.9/lib/tcl8.5 C:/hostedtoolcache/windows/PyPy/lib/tcl8.5 C:/hostedtoolcache/windows/PyPy/3.6.9/library C:/hostedtoolcache/windows/PyPy/library C:/hostedtoolcache/windows/PyPy/tcl8.5.2/library C:/hostedtoolcache/windows/tcl8.5.2/library
```

After: https://github.com/nulano/Pillow/runs/774933672?check_suite_focus=true#step:23:1395
```
Tests/test_imagetk.py::test_kw PASSED                                    [ 93%]
Tests/test_imagetk.py::test_photoimage PASSED                            [ 93%]
Tests/test_imagetk.py::test_photoimage_blank PASSED                      [ 93%]
Tests/test_imagetk.py::test_bitmapimage PASSED                           [ 93%]
```

---

On Ubuntu there is a different error (below), but adding `export DISPLAY=:0.0` only gives a different error (can't connect). There is probably no X server running on Ubuntu.
```
SKIPPED [4] /home/runner/work/Pillow/Pillow/Tests/test_imagetk.py:29: TCL Error: no display name and no $DISPLAY environment variable
```

---

Edit: I submitted the issue to pypy, should be fixed in next release, see [pypy/pypy#3247](https://foss.heptapod.net/pypy/pypy/issues/3247). This can be reverted then.