### PR TITLE
Do not ignore viewer if ImageShow.register order is zero

### DIFF
--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -17,19 +17,21 @@ def test_register():
     ImageShow._viewers.pop()
 
 
-def test_viewer_show():
+@pytest.mark.parametrize(
+    "order", [-1, 0],
+)
+def test_viewer_show(order):
     class TestViewer(ImageShow.Viewer):
-        methodCalled = False
-
         def show_image(self, image, **options):
             self.methodCalled = True
             return True
 
     viewer = TestViewer()
-    ImageShow.register(viewer, -1)
+    ImageShow.register(viewer, order)
 
     for mode in ("1", "I;16", "LA", "RGB", "RGBA"):
-        with hopper() as im:
+        viewer.methodCalled = False
+        with hopper(mode) as im:
             assert ImageShow.show(im)
         assert viewer.methodCalled
 

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -31,7 +31,7 @@ def register(viewer, order=1):
         pass  # raised if viewer wasn't a class
     if order > 0:
         _viewers.append(viewer)
-    elif order < 0:
+    else:
         _viewers.insert(0, viewer)
 
 


### PR DESCRIPTION
Suggested by https://github.com/python-pillow/Pillow/issues/4643#issuecomment-645868757

If you set `order` to zero when registering an ImageShow viewer, like so, `ImageShow.register(viewer, order=0)`, the viewer is silently ignored.

This PR changes that to treat it as a negative number instead, inserting it at the beginning of the list of viewers.