### PR TITLE
Do not install NumPy 1.19.0 on macOS PyPy

### DIFF
--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -11,7 +11,11 @@ pip install -U pytest
 pip install -U pytest-cov
 pip install pyroma
 pip install test-image-results
-pip install numpy
+if [[ $PYTHON_VERSION == "pypy3" ]]; then
+  pip install numpy!=1.19.0
+else
+  pip install numpy
+fi
 
 # extra test images
 pushd depends && ./install_extra_test_images.sh && popd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,8 @@ jobs:
       if: startsWith(matrix.os, 'macOS')
       run: |
         .github/workflows/macos-install.sh
+      env:
+        PYTHON_VERSION: ${{ matrix.python-version }}
 
     - name: Build
       run: |


### PR DESCRIPTION
The GHA macOS PyPy job has started failing in master.

It currently uses NumPy 1.19.0 - https://github.com/python-pillow/Pillow/runs/791566962#step:8:107
NumPy 1.19.0 has only just been released - https://pypi.org/project/numpy/#history
It last passed with NumPy 1.18.5 - https://github.com/python-pillow/Pillow/runs/790779493#step:8:107

So this PR disables NumPy 1.19.0 for the macOS PyPy test job.