### PR TITLE
Removed comments suggesting users override functions

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3139,11 +3139,10 @@ def register_encoder(name, encoder):
 
 
 # --------------------------------------------------------------------
-# Simple display support.  User code may override this.
+# Simple display support.
 
 
 def _show(image, **options):
-    # override me, as necessary
     _showxv(image, **options)
 
 


### PR DESCRIPTION
It's not clear why there is a need for users to do this. They should be able to change behaviour using `ImageShow.register`. This PR doesn't change any functionality, it just stops pointing users in that direction.