### PR TITLE
Deprecated _showxv

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -5,7 +5,7 @@ import tempfile
 
 import PIL
 import pytest
-from PIL import Image, ImageDraw, ImagePalette, UnidentifiedImageError
+from PIL import Image, ImageDraw, ImagePalette, ImageShow, UnidentifiedImageError
 
 from .helper import (
     assert_image_equal,
@@ -584,6 +584,22 @@ class TestImage:
             im = Image.new("P", (100, 100), color)
             expected = Image.new(mode, (100, 100), color)
             assert_image_equal(im.convert(mode), expected)
+
+    def test_showxv_deprecation(self):
+        class TestViewer(ImageShow.Viewer):
+            def show_image(self, image, **options):
+                return True
+
+        viewer = TestViewer()
+        ImageShow.register(viewer, -1)
+
+        im = Image.new("RGB", (50, 50), "white")
+
+        with pytest.warns(DeprecationWarning):
+            Image._showxv(im)
+
+        # Restore original state
+        ImageShow._viewers.pop(0)
 
     def test_no_resource_warning_on_save(self, tmp_path):
         # https://github.com/python-pillow/Pillow/issues/835

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -20,6 +20,15 @@ Image.show command parameter
 The ``command`` parameter was deprecated and will be removed in a future release.
 Use a subclass of ``ImageShow.Viewer`` instead.
 
+Image._showxv
+~~~~~~~~~~~~~
+
+.. deprecated:: 7.2.0
+
+``Image._showxv`` has been deprecated. Use :py:meth:`~PIL.Image.Image.show`
+instead. If custom behaviour is required, use :py:meth:`~PIL.ImageShow.register` to add
+a custom :py:class:`~PIL.ImageShow.Viewer` class.
+
 ImageFile.raise_ioerror
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releasenotes/7.2.0.rst
+++ b/docs/releasenotes/7.2.0.rst
@@ -43,6 +43,13 @@ Image.show command parameter
 The ``command`` parameter was deprecated and will be removed in a future release.
 Use a subclass of :py:class:`PIL.ImageShow.Viewer` instead.
 
+Image._showxv
+~~~~~~~~~~~~~
+
+``Image._showxv`` has been deprecated. Use :py:meth:`~PIL.Image.Image.show`
+instead. If custom behaviour is required, use :py:meth:`~PIL.ImageShow.register` to add
+a custom :py:class:`~PIL.ImageShow.Viewer` class.
+
 ImageFile.raise_ioerror
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3150,12 +3150,21 @@ def register_encoder(name, encoder):
 
 
 def _show(image, **options):
+    options["_internal_pillow"] = True
     _showxv(image, **options)
 
 
 def _showxv(image, title=None, **options):
     from . import ImageShow
 
+    if "_internal_pillow" in options:
+        del options["_internal_pillow"]
+    else:
+        warnings.warn(
+            "_showxv is deprecated and will be removed in a future release. "
+            "Use Image.show instead.",
+            DeprecationWarning,
+        )
     ImageShow.show(image, title, **options)
 
 


### PR DESCRIPTION
My attempt to deprecate `Image._showxv`, without raising a `DeprecationWarning` when calling `Image.show` or `Image._show`.

Inspired by https://github.com/python-pillow/Pillow/pull/4693#issuecomment-647110867