### PR TITLE
Fix documentation references: modules

### DIFF
--- a/docs/PIL.rst
+++ b/docs/PIL.rst
@@ -12,56 +12,56 @@ can be found here.
 .. autoexception:: UnidentifiedImageError
     :show-inheritance:
 
-:mod:`BdfFontFile` Module
--------------------------
+:mod:`~PIL.BdfFontFile` Module
+------------------------------
 
 .. automodule:: PIL.BdfFontFile
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`ContainerIO` Module
--------------------------
+:mod:`~PIL.ContainerIO` Module
+------------------------------
 
 .. automodule:: PIL.ContainerIO
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`FontFile` Module
-----------------------
+:mod:`~PIL.FontFile` Module
+---------------------------
 
 .. automodule:: PIL.FontFile
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`GdImageFile` Module
--------------------------
+:mod:`~PIL.GdImageFile` Module
+------------------------------
 
 .. automodule:: PIL.GdImageFile
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`GimpGradientFile` Module
-------------------------------
+:mod:`~PIL.GimpGradientFile` Module
+-----------------------------------
 
 .. automodule:: PIL.GimpGradientFile
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`GimpPaletteFile` Module
------------------------------
+:mod:`~PIL.GimpPaletteFile` Module
+----------------------------------
 
 .. automodule:: PIL.GimpPaletteFile
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`ImageDraw2` Module
-------------------------
+:mod:`~PIL.ImageDraw2` Module
+-----------------------------
 
 .. automodule:: PIL.ImageDraw2
     :members:
@@ -69,24 +69,24 @@ can be found here.
     :undoc-members:
     :show-inheritance:
 
-:mod:`ImageTransform` Module
-----------------------------
+:mod:`~PIL.ImageTransform` Module
+---------------------------------
 
 .. automodule:: PIL.ImageTransform
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`PaletteFile` Module
--------------------------
+:mod:`~PIL.PaletteFile` Module
+------------------------------
 
 .. automodule:: PIL.PaletteFile
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`PcfFontFile` Module
--------------------------
+:mod:`~PIL.PcfFontFile` Module
+------------------------------
 
 .. automodule:: PIL.PcfFontFile
     :members:
@@ -116,16 +116,16 @@ can be found here.
     :show-inheritance:
 
 
-:mod:`TarIO` Module
--------------------
+:mod:`~PIL.TarIO` Module
+------------------------
 
 .. automodule:: PIL.TarIO
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`WalImageFile` Module
---------------------------
+:mod:`~PIL.WalImageFile` Module
+-------------------------------
 
 .. automodule:: PIL.WalImageFile
     :members:

--- a/docs/porting.rst
+++ b/docs/porting.rst
@@ -19,7 +19,7 @@ to this::
 
     from PIL import Image
 
-The :py:mod:`_imaging` module has been moved. You can now import it like this::
+The :py:mod:`~PIL._imaging` module has been moved. You can now import it like this::
 
     from PIL.Image import core as _imaging
 

--- a/docs/reference/ExifTags.rst
+++ b/docs/reference/ExifTags.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ExifTags
 .. py:currentmodule:: PIL.ExifTags
 
-:py:mod:`ExifTags` Module
-==========================
+:py:mod:`~PIL.ExifTags` Module
+==============================
 
-The :py:mod:`ExifTags` module exposes two dictionaries which
+The :py:mod:`~PIL.ExifTags` module exposes two dictionaries which
 provide constants and clear-text names for various well-known EXIF tags.
 
 .. py:data:: TAGS

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -1,8 +1,8 @@
 .. py:module:: PIL.Image
 .. py:currentmodule:: PIL.Image
 
-:py:mod:`Image` Module
-======================
+:py:mod:`~PIL.Image` Module
+===========================
 
 The :py:mod:`~PIL.Image` module provides a class with the same name which is
 used to represent a PIL image. The module also provides a number of factory

--- a/docs/reference/ImageChops.rst
+++ b/docs/reference/ImageChops.rst
@@ -1,15 +1,15 @@
 .. py:module:: PIL.ImageChops
 .. py:currentmodule:: PIL.ImageChops
 
-:py:mod:`ImageChops` ("Channel Operations") Module
-==================================================
+:py:mod:`~PIL.ImageChops` ("Channel Operations") Module
+=======================================================
 
-The :py:mod:`ImageChops` module contains a number of arithmetical image
+The :py:mod:`~PIL.ImageChops` module contains a number of arithmetical image
 operations, called channel operations (“chops”). These can be used for various
 purposes, including special effects, image compositions, algorithmic painting,
 and more.
 
-For more pre-made operations, see :py:mod:`ImageOps`.
+For more pre-made operations, see :py:mod:`~PIL.ImageOps`.
 
 At this time, most channel operations are only implemented for 8-bit images
 (e.g. “L” and “RGB”).

--- a/docs/reference/ImageCms.rst
+++ b/docs/reference/ImageCms.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageCms
 .. py:currentmodule:: PIL.ImageCms
 
-:py:mod:`ImageCms` Module
-=========================
+:py:mod:`~PIL.ImageCms` Module
+==============================
 
-The :py:mod:`ImageCms` module provides color profile management
+The :py:mod:`~PIL.ImageCms` module provides color profile management
 support using the LittleCMS2 color management engine, based on Kevin
 Cazabon's PyCMS library.
 

--- a/docs/reference/ImageColor.rst
+++ b/docs/reference/ImageColor.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageColor
 .. py:currentmodule:: PIL.ImageColor
 
-:py:mod:`ImageColor` Module
-===========================
+:py:mod:`~PIL.ImageColor` Module
+================================
 
-The :py:mod:`ImageColor` module contains color tables and converters from
+The :py:mod:`~PIL.ImageColor` module contains color tables and converters from
 CSS3-style color specifiers to RGB tuples. This module is used by
 :py:meth:`PIL.Image.new` and the :py:mod:`~PIL.ImageDraw` module, among
 others.

--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageDraw
 .. py:currentmodule:: PIL.ImageDraw
 
-:py:mod:`ImageDraw` Module
-==========================
+:py:mod:`~PIL.ImageDraw` Module
+===============================
 
-The :py:mod:`ImageDraw` module provides simple 2D graphics for
+The :py:mod:`~PIL.ImageDraw` module provides simple 2D graphics for
 :py:class:`~PIL.Image.Image` objects.  You can use this module to create new
 images, annotate or retouch existing images, and to generate graphics on the
 fly for web use.

--- a/docs/reference/ImageEnhance.rst
+++ b/docs/reference/ImageEnhance.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageEnhance
 .. py:currentmodule:: PIL.ImageEnhance
 
-:py:mod:`ImageEnhance` Module
-=============================
+:py:mod:`~PIL.ImageEnhance` Module
+==================================
 
-The :py:mod:`ImageEnhance` module contains a number of classes that can be used
+The :py:mod:`~PIL.ImageEnhance` module contains a number of classes that can be used
 for image enhancement.
 
 Example: Vary the sharpness of an image

--- a/docs/reference/ImageFile.rst
+++ b/docs/reference/ImageFile.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageFile
 .. py:currentmodule:: PIL.ImageFile
 
-:py:mod:`ImageFile` Module
-==========================
+:py:mod:`~PIL.ImageFile` Module
+===============================
 
-The :py:mod:`ImageFile` module provides support functions for the image open
+The :py:mod:`~PIL.ImageFile` module provides support functions for the image open
 and save functions.
 
 In addition, it provides a :py:class:`Parser` class which can be used to decode

--- a/docs/reference/ImageFilter.rst
+++ b/docs/reference/ImageFilter.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageFilter
 .. py:currentmodule:: PIL.ImageFilter
 
-:py:mod:`ImageFilter` Module
-============================
+:py:mod:`~PIL.ImageFilter` Module
+=================================
 
-The :py:mod:`ImageFilter` module contains definitions for a pre-defined set of
+The :py:mod:`~PIL.ImageFilter` module contains definitions for a pre-defined set of
 filters, which can be be used with the :py:meth:`Image.filter()
 <PIL.Image.Image.filter>` method.
 

--- a/docs/reference/ImageFont.rst
+++ b/docs/reference/ImageFont.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageFont
 .. py:currentmodule:: PIL.ImageFont
 
-:py:mod:`ImageFont` Module
-==========================
+:py:mod:`~PIL.ImageFont` Module
+===============================
 
-The :py:mod:`ImageFont` module defines a class with the same name. Instances of
+The :py:mod:`~PIL.ImageFont` module defines a class with the same name. Instances of
 this class store bitmap fonts, and are used with the
 :py:meth:`PIL.ImageDraw.Draw.text` method.
 

--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageGrab
 .. py:currentmodule:: PIL.ImageGrab
 
-:py:mod:`ImageGrab` Module
-==========================
+:py:mod:`~PIL.ImageGrab` Module
+===============================
 
-The :py:mod:`ImageGrab` module can be used to copy the contents of the screen
+The :py:mod:`~PIL.ImageGrab` module can be used to copy the contents of the screen
 or the clipboard to a PIL image memory.
 
 .. versionadded:: 1.1.3

--- a/docs/reference/ImageMath.rst
+++ b/docs/reference/ImageMath.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageMath
 .. py:currentmodule:: PIL.ImageMath
 
-:py:mod:`ImageMath` Module
-==========================
+:py:mod:`~PIL.ImageMath` Module
+===============================
 
-The :py:mod:`ImageMath` module can be used to evaluate “image expressions”. The
+The :py:mod:`~PIL.ImageMath` module can be used to evaluate “image expressions”. The
 module provides a single :py:meth:`~PIL.ImageMath.eval` function, which takes
 an expression string and one or more images.
 

--- a/docs/reference/ImageMorph.rst
+++ b/docs/reference/ImageMorph.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageMorph
 .. py:currentmodule:: PIL.ImageMorph
 
-:py:mod:`ImageMorph` Module
-===========================
+:py:mod:`~PIL.ImageMorph` Module
+================================
 
-The :py:mod:`ImageMorph` module provides morphology operations on images.
+The :py:mod:`~PIL.ImageMorph` module provides morphology operations on images.
 
 .. automodule:: PIL.ImageMorph
     :members:

--- a/docs/reference/ImageOps.rst
+++ b/docs/reference/ImageOps.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageOps
 .. py:currentmodule:: PIL.ImageOps
 
-:py:mod:`ImageOps` Module
-==========================
+:py:mod:`~PIL.ImageOps` Module
+==============================
 
-The :py:mod:`ImageOps` module contains a number of ‘ready-made’ image
+The :py:mod:`~PIL.ImageOps` module contains a number of ‘ready-made’ image
 processing operations. This module is somewhat experimental, and most operators
 only work on L and RGB images.
 

--- a/docs/reference/ImagePalette.rst
+++ b/docs/reference/ImagePalette.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImagePalette
 .. py:currentmodule:: PIL.ImagePalette
 
-:py:mod:`ImagePalette` Module
-=============================
+:py:mod:`~PIL.ImagePalette` Module
+==================================
 
-The :py:mod:`ImagePalette` module contains a class of the same name to
+The :py:mod:`~PIL.ImagePalette` module contains a class of the same name to
 represent the color palette of palette mapped images.
 
 .. note::

--- a/docs/reference/ImagePath.rst
+++ b/docs/reference/ImagePath.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImagePath
 .. py:currentmodule:: PIL.ImagePath
 
-:py:mod:`ImagePath` Module
-==========================
+:py:mod:`~PIL.ImagePath` Module
+===============================
 
-The :py:mod:`ImagePath` module is used to store and manipulate 2-dimensional
+The :py:mod:`~PIL.ImagePath` module is used to store and manipulate 2-dimensional
 vector data. Path objects can be passed to the methods on the
 :py:mod:`~PIL.ImageDraw` module.
 

--- a/docs/reference/ImageQt.rst
+++ b/docs/reference/ImageQt.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageQt
 .. py:currentmodule:: PIL.ImageQt
 
-:py:mod:`ImageQt` Module
-========================
+:py:mod:`~PIL.ImageQt` Module
+=============================
 
-The :py:mod:`ImageQt` module contains support for creating PyQt5 or PySide2 QImage
+The :py:mod:`~PIL.ImageQt` module contains support for creating PyQt5 or PySide2 QImage
 objects from PIL images.
 
 .. versionadded:: 1.1.6

--- a/docs/reference/ImageSequence.rst
+++ b/docs/reference/ImageSequence.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageSequence
 .. py:currentmodule:: PIL.ImageSequence
 
-:py:mod:`ImageSequence` Module
-==============================
+:py:mod:`~PIL.ImageSequence` Module
+===================================
 
-The :py:mod:`ImageSequence` module contains a wrapper class that lets you
+The :py:mod:`~PIL.ImageSequence` module contains a wrapper class that lets you
 iterate over the frames of an image sequence.
 
 Extracting frames from an animation

--- a/docs/reference/ImageShow.rst
+++ b/docs/reference/ImageShow.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageShow
 .. py:currentmodule:: PIL.ImageShow
 
-:py:mod:`ImageShow` Module
-==========================
+:py:mod:`~PIL.ImageShow` Module
+===============================
 
-The :py:mod:`ImageShow` Module is used to display images.
+The :py:mod:`~PIL.ImageShow` Module is used to display images.
 All default viewers convert the image to be shown to PNG format.
 
 .. autofunction:: PIL.ImageShow.show

--- a/docs/reference/ImageStat.rst
+++ b/docs/reference/ImageStat.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageStat
 .. py:currentmodule:: PIL.ImageStat
 
-:py:mod:`ImageStat` Module
-==========================
+:py:mod:`~PIL.ImageStat` Module
+===============================
 
-The :py:mod:`ImageStat` module calculates global statistics for an image, or
+The :py:mod:`~PIL.ImageStat` module calculates global statistics for an image, or
 for a region of an image.
 
 .. py:class:: Stat(image_or_list, mask=None)

--- a/docs/reference/ImageTk.rst
+++ b/docs/reference/ImageTk.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageTk
 .. py:currentmodule:: PIL.ImageTk
 
-:py:mod:`ImageTk` Module
-========================
+:py:mod:`~PIL.ImageTk` Module
+=============================
 
-The :py:mod:`ImageTk` module contains support to create and modify Tkinter
+The :py:mod:`~PIL.ImageTk` module contains support to create and modify Tkinter
 BitmapImage and PhotoImage objects from PIL images.
 
 For examples, see the demo programs in the Scripts directory.

--- a/docs/reference/ImageWin.rst
+++ b/docs/reference/ImageWin.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageWin
 .. py:currentmodule:: PIL.ImageWin
 
-:py:mod:`ImageWin` Module (Windows-only)
-========================================
+:py:mod:`~PIL.ImageWin` Module (Windows-only)
+=============================================
 
-The :py:mod:`ImageWin` module contains support to create and display images on
+The :py:mod:`~PIL.ImageWin` module contains support to create and display images on
 Windows.
 
 ImageWin can be used with PythonWin and other user interface toolkits that

--- a/docs/reference/JpegPresets.rst
+++ b/docs/reference/JpegPresets.rst
@@ -1,7 +1,7 @@
 .. py:currentmodule:: PIL.JpegPresets
 
-:py:mod:`JpegPresets` Module
-============================
+:py:mod:`~PIL.JpegPresets` Module
+=================================
 
 .. automodule:: PIL.JpegPresets
 

--- a/docs/reference/PSDraw.rst
+++ b/docs/reference/PSDraw.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.PSDraw
 .. py:currentmodule:: PIL.PSDraw
 
-:py:mod:`PSDraw` Module
-=======================
+:py:mod:`~PIL.PSDraw` Module
+============================
 
-The :py:mod:`PSDraw` module provides simple print support for Postscript
+The :py:mod:`~PIL.PSDraw` module provides simple print support for Postscript
 printers. You can print text, graphics and images through this module.
 
 .. autoclass:: PIL.PSDraw.PSDraw

--- a/docs/reference/PyAccess.rst
+++ b/docs/reference/PyAccess.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.PyAccess
 .. py:currentmodule:: PIL.PyAccess
 
-:py:mod:`PyAccess` Module
-=========================
+:py:mod:`~PIL.PyAccess` Module
+==============================
 
-The :py:mod:`PyAccess` module provides a CFFI/Python implementation of the :ref:`PixelAccess`. This implementation is far faster on PyPy than the PixelAccess version.
+The :py:mod:`~PIL.PyAccess` module provides a CFFI/Python implementation of the :ref:`PixelAccess`. This implementation is far faster on PyPy than the PixelAccess version.
 
 .. note:: Accessing individual pixels is fairly slow. If you are
            looping over all of the pixels in an image, there is likely

--- a/docs/reference/TiffTags.rst
+++ b/docs/reference/TiffTags.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.TiffTags
 .. py:currentmodule:: PIL.TiffTags
 
-:py:mod:`TiffTags` Module
-=========================
+:py:mod:`~PIL.TiffTags` Module
+==============================
 
-The :py:mod:`TiffTags` module exposes many of the standard TIFF
+The :py:mod:`~PIL.TiffTags` module exposes many of the standard TIFF
 metadata tag numbers, names, and type information.
 
 .. method:: lookup(tag)

--- a/docs/reference/features.rst
+++ b/docs/reference/features.rst
@@ -1,8 +1,8 @@
 .. py:module:: PIL.features
 .. py:currentmodule:: PIL.features
 
-:py:mod:`features` Module
-==========================
+:py:mod:`~PIL.features` Module
+==============================
 
 The :py:mod:`PIL.features` module can be used to detect which Pillow features are available on your system.
 

--- a/docs/reference/internal_modules.rst
+++ b/docs/reference/internal_modules.rst
@@ -1,32 +1,32 @@
 Internal Modules
 ================
 
-:mod:`_binary` Module
----------------------
+:mod:`~PIL._binary` Module
+--------------------------
 
 .. automodule:: PIL._binary
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`_tkinter_finder` Module
------------------------------
+:mod:`~PIL._tkinter_finder` Module
+----------------------------------
 
 .. automodule:: PIL._tkinter_finder
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`_util` Module
--------------------
+:mod:`~PIL._util` Module
+------------------------
 
 .. automodule:: PIL._util
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`_version` Module
-----------------------
+:mod:`~PIL._version` Module
+---------------------------
 
 .. module:: PIL._version
 

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -1,232 +1,232 @@
 Plugin reference
 ================
 
-:mod:`BmpImagePlugin` Module
-----------------------------
+:mod:`~PIL.BmpImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.BmpImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`BufrStubImagePlugin` Module
----------------------------------
+:mod:`~PIL.BufrStubImagePlugin` Module
+--------------------------------------
 
 .. automodule:: PIL.BufrStubImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`CurImagePlugin` Module
-----------------------------
+:mod:`~PIL.CurImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.CurImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`DcxImagePlugin` Module
-----------------------------
+:mod:`~PIL.DcxImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.DcxImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`EpsImagePlugin` Module
-----------------------------
+:mod:`~PIL.EpsImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.EpsImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`FitsStubImagePlugin` Module
----------------------------------
+:mod:`~PIL.FitsStubImagePlugin` Module
+--------------------------------------
 
 .. automodule:: PIL.FitsStubImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`FliImagePlugin` Module
-----------------------------
+:mod:`~PIL.FliImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.FliImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`FpxImagePlugin` Module
-----------------------------
+:mod:`~PIL.FpxImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.FpxImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`GbrImagePlugin` Module
-----------------------------
+:mod:`~PIL.GbrImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.GbrImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`GifImagePlugin` Module
-----------------------------
+:mod:`~PIL.GifImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.GifImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`GribStubImagePlugin` Module
----------------------------------
+:mod:`~PIL.GribStubImagePlugin` Module
+--------------------------------------
 
 .. automodule:: PIL.GribStubImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`Hdf5StubImagePlugin` Module
----------------------------------
+:mod:`~PIL.Hdf5StubImagePlugin` Module
+--------------------------------------
 
 .. automodule:: PIL.Hdf5StubImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`IcnsImagePlugin` Module
------------------------------
+:mod:`~PIL.IcnsImagePlugin` Module
+----------------------------------
 
 .. automodule:: PIL.IcnsImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`IcoImagePlugin` Module
-----------------------------
+:mod:`~PIL.IcoImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.IcoImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`ImImagePlugin` Module
----------------------------
+:mod:`~PIL.ImImagePlugin` Module
+--------------------------------
 
 .. automodule:: PIL.ImImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`ImtImagePlugin` Module
-----------------------------
+:mod:`~PIL.ImtImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.ImtImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`IptcImagePlugin` Module
------------------------------
+:mod:`~PIL.IptcImagePlugin` Module
+----------------------------------
 
 .. automodule:: PIL.IptcImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`JpegImagePlugin` Module
------------------------------
+:mod:`~PIL.JpegImagePlugin` Module
+----------------------------------
 
 .. automodule:: PIL.JpegImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`Jpeg2KImagePlugin` Module
--------------------------------
+:mod:`~PIL.Jpeg2KImagePlugin` Module
+------------------------------------
 
 .. automodule:: PIL.Jpeg2KImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`McIdasImagePlugin` Module
--------------------------------
+:mod:`~PIL.McIdasImagePlugin` Module
+------------------------------------
 
 .. automodule:: PIL.McIdasImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`MicImagePlugin` Module
-----------------------------
+:mod:`~PIL.MicImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.MicImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`MpegImagePlugin` Module
------------------------------
+:mod:`~PIL.MpegImagePlugin` Module
+----------------------------------
 
 .. automodule:: PIL.MpegImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`MspImagePlugin` Module
-----------------------------
+:mod:`~PIL.MspImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.MspImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`PalmImagePlugin` Module
------------------------------
+:mod:`~PIL.PalmImagePlugin` Module
+----------------------------------
 
 .. automodule:: PIL.PalmImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`PcdImagePlugin` Module
-----------------------------
+:mod:`~PIL.PcdImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.PcdImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`PcxImagePlugin` Module
-----------------------------
+:mod:`~PIL.PcxImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.PcxImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`PdfImagePlugin` Module
-----------------------------
+:mod:`~PIL.PdfImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.PdfImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`PixarImagePlugin` Module
-------------------------------
+:mod:`~PIL.PixarImagePlugin` Module
+-----------------------------------
 
 .. automodule:: PIL.PixarImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`PngImagePlugin` Module
-----------------------------
+:mod:`~PIL.PngImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.PngImagePlugin
     :members: ChunkStream, PngStream, getchunks, is_cid, putchunk
@@ -245,96 +245,96 @@ Plugin reference
     :show-inheritance:
 
 
-:mod:`PpmImagePlugin` Module
-----------------------------
+:mod:`~PIL.PpmImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.PpmImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`PsdImagePlugin` Module
-----------------------------
+:mod:`~PIL.PsdImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.PsdImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`SgiImagePlugin` Module
-----------------------------
+:mod:`~PIL.SgiImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.SgiImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`SpiderImagePlugin` Module
--------------------------------
+:mod:`~PIL.SpiderImagePlugin` Module
+------------------------------------
 
 .. automodule:: PIL.SpiderImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`SunImagePlugin` Module
-----------------------------
+:mod:`~PIL.SunImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.SunImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`TgaImagePlugin` Module
-----------------------------
+:mod:`~PIL.TgaImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.TgaImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`TiffImagePlugin` Module
------------------------------
+:mod:`~PIL.TiffImagePlugin` Module
+----------------------------------
 
 .. automodule:: PIL.TiffImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`WebPImagePlugin` Module
------------------------------
+:mod:`~PIL.WebPImagePlugin` Module
+----------------------------------
 
 .. automodule:: PIL.WebPImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`WmfImagePlugin` Module
-----------------------------
+:mod:`~PIL.WmfImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.WmfImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`XVThumbImagePlugin` Module
---------------------------------
+:mod:`~PIL.XVThumbImagePlugin` Module
+-------------------------------------
 
 .. automodule:: PIL.XVThumbImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`XbmImagePlugin` Module
-----------------------------
+:mod:`~PIL.XbmImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.XbmImagePlugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`XpmImagePlugin` Module
-----------------------------
+:mod:`~PIL.XpmImagePlugin` Module
+---------------------------------
 
 .. automodule:: PIL.XpmImagePlugin
     :members:


### PR DESCRIPTION
Splitting up #4715.

Always use the PIL prefix for modules, adding `~` to hide it.

I used a regular expression to find them all:
```
:mod:`~?(?!PIL)\.([^`]+)`
```

<details><summary>Fixes 109 nitpicky warnings: (click to expand)</summary><p>

```
-C:\Git\Pillow\docs\PIL.rst:15: WARNING: py:mod reference target not found: BdfFontFile
-C:\Git\Pillow\docs\PIL.rst:23: WARNING: py:mod reference target not found: ContainerIO
-C:\Git\Pillow\docs\PIL.rst:31: WARNING: py:mod reference target not found: FontFile
-C:\Git\Pillow\docs\PIL.rst:39: WARNING: py:mod reference target not found: GdImageFile
-C:\Git\Pillow\docs\PIL.rst:47: WARNING: py:mod reference target not found: GimpGradientFile
-C:\Git\Pillow\docs\PIL.rst:55: WARNING: py:mod reference target not found: GimpPaletteFile
-C:\Git\Pillow\docs\PIL.rst:63: WARNING: py:mod reference target not found: ImageDraw2
-C:\Git\Pillow\docs\PIL.rst:72: WARNING: py:mod reference target not found: ImageTransform
-C:\Git\Pillow\docs\PIL.rst:80: WARNING: py:mod reference target not found: PaletteFile
-C:\Git\Pillow\docs\PIL.rst:88: WARNING: py:mod reference target not found: PcfFontFile
-C:\Git\Pillow\docs\PIL.rst:119: WARNING: py:mod reference target not found: TarIO
-C:\Git\Pillow\docs\PIL.rst:127: WARNING: py:mod reference target not found: WalImageFile
-C:\Git\Pillow\docs\reference\ExifTags.rst:4: WARNING: py:mod reference target not found: ExifTags
-C:\Git\Pillow\docs\reference\ExifTags.rst:7: WARNING: py:mod reference target not found: ExifTags
-C:\Git\Pillow\docs\reference\Image.rst:4: WARNING: py:mod reference target not found: Image
-C:\Git\Pillow\docs\reference\ImageChops.rst:4: WARNING: py:mod reference target not found: ImageChops
-C:\Git\Pillow\docs\reference\ImageChops.rst:7: WARNING: py:mod reference target not found: ImageChops
-C:\Git\Pillow\docs\reference\ImageChops.rst:12: WARNING: py:mod reference target not found: ImageOps
-C:\Git\Pillow\docs\reference\ImageCms.rst:4: WARNING: py:mod reference target not found: ImageCms
-C:\Git\Pillow\docs\reference\ImageCms.rst:7: WARNING: py:mod reference target not found: ImageCms
-C:\Git\Pillow\docs\reference\ImageColor.rst:4: WARNING: py:mod reference target not found: ImageColor
-C:\Git\Pillow\docs\reference\ImageColor.rst:7: WARNING: py:mod reference target not found: ImageColor
-C:\Git\Pillow\docs\reference\ImageDraw.rst:4: WARNING: py:mod reference target not found: ImageDraw
-C:\Git\Pillow\docs\reference\ImageDraw.rst:7: WARNING: py:mod reference target not found: ImageDraw
-C:\Git\Pillow\docs\reference\ImageEnhance.rst:4: WARNING: py:mod reference target not found: ImageEnhance
-C:\Git\Pillow\docs\reference\ImageEnhance.rst:7: WARNING: py:mod reference target not found: ImageEnhance
-C:\Git\Pillow\docs\reference\ImageFile.rst:4: WARNING: py:mod reference target not found: ImageFile
-C:\Git\Pillow\docs\reference\ImageFile.rst:7: WARNING: py:mod reference target not found: ImageFile
-C:\Git\Pillow\docs\reference\ImageFilter.rst:4: WARNING: py:mod reference target not found: ImageFilter
-C:\Git\Pillow\docs\reference\ImageFilter.rst:7: WARNING: py:mod reference target not found: ImageFilter
-C:\Git\Pillow\docs\reference\ImageFont.rst:4: WARNING: py:mod reference target not found: ImageFont
-C:\Git\Pillow\docs\reference\ImageFont.rst:7: WARNING: py:mod reference target not found: ImageFont
-C:\Git\Pillow\docs\reference\ImageGrab.rst:4: WARNING: py:mod reference target not found: ImageGrab
-C:\Git\Pillow\docs\reference\ImageGrab.rst:7: WARNING: py:mod reference target not found: ImageGrab
-C:\Git\Pillow\docs\reference\ImageMath.rst:4: WARNING: py:mod reference target not found: ImageMath
-C:\Git\Pillow\docs\reference\ImageMath.rst:7: WARNING: py:mod reference target not found: ImageMath
-C:\Git\Pillow\docs\reference\ImageMorph.rst:4: WARNING: py:mod reference target not found: ImageMorph
-C:\Git\Pillow\docs\reference\ImageMorph.rst:7: WARNING: py:mod reference target not found: ImageMorph
-C:\Git\Pillow\docs\reference\ImageOps.rst:4: WARNING: py:mod reference target not found: ImageOps
-C:\Git\Pillow\docs\reference\ImageOps.rst:7: WARNING: py:mod reference target not found: ImageOps
-C:\Git\Pillow\docs\reference\ImagePalette.rst:4: WARNING: py:mod reference target not found: ImagePalette
-C:\Git\Pillow\docs\reference\ImagePalette.rst:7: WARNING: py:mod reference target not found: ImagePalette
-C:\Git\Pillow\docs\reference\ImagePath.rst:4: WARNING: py:mod reference target not found: ImagePath
-C:\Git\Pillow\docs\reference\ImagePath.rst:7: WARNING: py:mod reference target not found: ImagePath
-C:\Git\Pillow\docs\reference\ImageQt.rst:4: WARNING: py:mod reference target not found: ImageQt
-C:\Git\Pillow\docs\reference\ImageQt.rst:7: WARNING: py:mod reference target not found: ImageQt
-C:\Git\Pillow\docs\reference\ImageSequence.rst:4: WARNING: py:mod reference target not found: ImageSequence
-C:\Git\Pillow\docs\reference\ImageSequence.rst:7: WARNING: py:mod reference target not found: ImageSequence
-C:\Git\Pillow\docs\reference\ImageShow.rst:4: WARNING: py:mod reference target not found: ImageShow
-C:\Git\Pillow\docs\reference\ImageShow.rst:7: WARNING: py:mod reference target not found: ImageShow
-C:\Git\Pillow\docs\reference\ImageStat.rst:4: WARNING: py:mod reference target not found: ImageStat
-C:\Git\Pillow\docs\reference\ImageStat.rst:7: WARNING: py:mod reference target not found: ImageStat
-C:\Git\Pillow\docs\reference\ImageTk.rst:4: WARNING: py:mod reference target not found: ImageTk
-C:\Git\Pillow\docs\reference\ImageTk.rst:7: WARNING: py:mod reference target not found: ImageTk
-C:\Git\Pillow\docs\reference\ImageWin.rst:4: WARNING: py:mod reference target not found: ImageWin
-C:\Git\Pillow\docs\reference\ImageWin.rst:7: WARNING: py:mod reference target not found: ImageWin
-C:\Git\Pillow\docs\reference\JpegPresets.rst:3: WARNING: py:mod reference target not found: JpegPresets
-C:\Git\Pillow\docs\reference\PSDraw.rst:4: WARNING: py:mod reference target not found: PSDraw
-C:\Git\Pillow\docs\reference\PSDraw.rst:7: WARNING: py:mod reference target not found: PSDraw
-C:\Git\Pillow\docs\reference\PyAccess.rst:4: WARNING: py:mod reference target not found: PyAccess
-C:\Git\Pillow\docs\reference\PyAccess.rst:7: WARNING: py:mod reference target not found: PyAccess
-C:\Git\Pillow\docs\reference\TiffTags.rst:4: WARNING: py:mod reference target not found: TiffTags
-C:\Git\Pillow\docs\reference\TiffTags.rst:7: WARNING: py:mod reference target not found: TiffTags
-C:\Git\Pillow\docs\reference\features.rst:4: WARNING: py:mod reference target not found: features
-C:\Git\Pillow\docs\reference\internal_modules.rst:4: WARNING: py:mod reference target not found: _binary
-C:\Git\Pillow\docs\reference\internal_modules.rst:12: WARNING: py:mod reference target not found: _tkinter_finder
-C:\Git\Pillow\docs\reference\internal_modules.rst:20: WARNING: py:mod reference target not found: _util
-C:\Git\Pillow\docs\reference\internal_modules.rst:28: WARNING: py:mod reference target not found: _version
-C:\Git\Pillow\docs\reference\plugins.rst:4: WARNING: py:mod reference target not found: BmpImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:12: WARNING: py:mod reference target not found: BufrStubImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:20: WARNING: py:mod reference target not found: CurImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:28: WARNING: py:mod reference target not found: DcxImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:36: WARNING: py:mod reference target not found: EpsImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:44: WARNING: py:mod reference target not found: FitsStubImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:52: WARNING: py:mod reference target not found: FliImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:60: WARNING: py:mod reference target not found: FpxImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:68: WARNING: py:mod reference target not found: GbrImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:76: WARNING: py:mod reference target not found: GifImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:84: WARNING: py:mod reference target not found: GribStubImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:92: WARNING: py:mod reference target not found: Hdf5StubImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:100: WARNING: py:mod reference target not found: IcnsImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:108: WARNING: py:mod reference target not found: IcoImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:116: WARNING: py:mod reference target not found: ImImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:124: WARNING: py:mod reference target not found: ImtImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:132: WARNING: py:mod reference target not found: IptcImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:140: WARNING: py:mod reference target not found: JpegImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:148: WARNING: py:mod reference target not found: Jpeg2KImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:156: WARNING: py:mod reference target not found: McIdasImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:164: WARNING: py:mod reference target not found: MicImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:172: WARNING: py:mod reference target not found: MpegImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:180: WARNING: py:mod reference target not found: MspImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:188: WARNING: py:mod reference target not found: PalmImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:196: WARNING: py:mod reference target not found: PcdImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:204: WARNING: py:mod reference target not found: PcxImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:212: WARNING: py:mod reference target not found: PdfImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:220: WARNING: py:mod reference target not found: PixarImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:228: WARNING: py:mod reference target not found: PngImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:248: WARNING: py:mod reference target not found: PpmImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:256: WARNING: py:mod reference target not found: PsdImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:264: WARNING: py:mod reference target not found: SgiImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:272: WARNING: py:mod reference target not found: SpiderImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:280: WARNING: py:mod reference target not found: SunImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:288: WARNING: py:mod reference target not found: TgaImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:296: WARNING: py:mod reference target not found: TiffImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:304: WARNING: py:mod reference target not found: WebPImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:312: WARNING: py:mod reference target not found: WmfImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:320: WARNING: py:mod reference target not found: XVThumbImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:328: WARNING: py:mod reference target not found: XbmImagePlugin
-C:\Git\Pillow\docs\reference\plugins.rst:336: WARNING: py:mod reference target not found: XpmImagePlugin
```

</p></details>