### PR TITLE
Fix documentation references: missing types

### DIFF
--- a/docs/reference/ImageCms.rst
+++ b/docs/reference/ImageCms.rst
@@ -8,9 +8,30 @@ The :py:mod:`ImageCms` module provides color profile management
 support using the LittleCMS2 color management engine, based on Kevin
 Cazabon's PyCMS library.
 
-.. automodule:: PIL.ImageCms
-    :members:
-    :noindex:
+.. autoclass:: ImageCmsTransform
+.. autoexception:: PyCMSError
+
+Functions
+---------
+
+.. autofunction:: applyTransform
+.. autofunction:: buildProofTransform
+.. autofunction:: buildProofTransformFromOpenProfiles
+.. autofunction:: buildTransform
+.. autofunction:: buildTransformFromOpenProfiles
+.. autofunction:: createProfile
+.. autofunction:: getDefaultIntent
+.. autofunction:: getOpenProfile
+.. autofunction:: getProfileCopyright
+.. autofunction:: getProfileDescription
+.. autofunction:: getProfileInfo
+.. autofunction:: getProfileManufacturer
+.. autofunction:: getProfileModel
+.. autofunction:: getProfileName
+.. autofunction:: get_display_profile
+.. autofunction:: isIntentSupported
+.. autofunction:: profileToProfile
+.. autofunction:: versions
 
 CmsProfile
 ----------

--- a/docs/reference/ImageFile.rst
+++ b/docs/reference/ImageFile.rst
@@ -34,14 +34,21 @@ Example: Parse an image
     im.save("copy.jpg")
 
 
-:py:class:`~PIL.ImageFile.Parser`
----------------------------------
+Classes
+-------
 
 .. autoclass:: PIL.ImageFile.Parser()
     :members:
 
-:py:class:`~PIL.ImageFile.PyDecoder`
-------------------------------------
-
 .. autoclass:: PIL.ImageFile.PyDecoder()
     :members:
+
+.. autoclass:: PIL.ImageFile.ImageFile()
+    :member-order: bysource
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: PIL.ImageFile.StubImageFile()
+    :members:
+    :show-inheritance:

--- a/src/PIL/ImageCms.py
+++ b/src/PIL/ImageCms.py
@@ -295,11 +295,12 @@ def profileToProfile(
     ``inputProfile`` to ``outputProfile``.
 
     If the input or output profiles specified are not valid filenames, a
-    ``PyCMSError`` will be raised.  If ``inPlace`` is ``True`` and
-    ``outputMode != im.mode``, a ``PyCMSError`` will be raised.  If an error
-    occurs during application of the profiles, a ``PyCMSError`` will be raised.
+    :exc:`PyCMSError` will be raised.  If ``inPlace`` is ``True`` and
+    ``outputMode != im.mode``, a :exc:`PyCMSError` will be raised.
+    If an error occurs during application of the profiles,
+    a :exc:`PyCMSError` will be raised.
     If ``outputMode`` is not a mode supported by the ``outputProfile`` (or by pyCMS),
-    a ``PyCMSError`` will be raised.
+    a :exc:`PyCMSError` will be raised.
 
     This function applies an ICC transformation to im from ``inputProfile``'s
     color space to ``outputProfile``'s color space using the specified rendering
@@ -381,8 +382,8 @@ def getOpenProfile(profileFilename):
     The PyCMSProfile object can be passed back into pyCMS for use in creating
     transforms and such (as in ImageCms.buildTransformFromOpenProfiles()).
 
-    If ``profileFilename`` is not a valid filename for an ICC profile, a ``PyCMSError``
-    will be raised.
+    If ``profileFilename`` is not a valid filename for an ICC profile,
+    a :exc:`PyCMSError` will be raised.
 
     :param profileFilename: String, as a valid filename path to the ICC profile
         you wish to open, or a file-like object.
@@ -410,11 +411,11 @@ def buildTransform(
     image.
 
     If the input or output profiles specified are not valid filenames, a
-    ``PyCMSError`` will be raised. If an error occurs during creation of the
-    transform, a ``PyCMSError`` will be raised.
+    :exc:`PyCMSError` will be raised. If an error occurs during creation
+    of the transform, a :exc:`PyCMSError` will be raised.
 
     If ``inMode`` or ``outMode`` are not a mode supported by the ``outputProfile``
-    (or by pyCMS), a ``PyCMSError`` will be raised.
+    (or by pyCMS), a :exc:`PyCMSError` will be raised.
 
     This function builds and returns an ICC transform from the ``inputProfile``
     to the ``outputProfile`` using the ``renderingIntent`` to determine what to do
@@ -493,13 +494,13 @@ def buildProofTransform(
     obtained on the ``proofProfile`` device.
 
     If the input, output, or proof profiles specified are not valid
-    filenames, a ``PyCMSError`` will be raised.
+    filenames, a :exc:`PyCMSError` will be raised.
 
-    If an error occurs during creation of the transform, a ``PyCMSError``
-    will be raised.
+    If an error occurs during creation of the transform,
+    a :exc:`PyCMSError` will be raised.
 
     If ``inMode`` or ``outMode`` are not a mode supported by the ``outputProfile``
-    (or by pyCMS), a ``PyCMSError`` will be raised.
+    (or by pyCMS), a :exc:`PyCMSError` will be raised.
 
     This function builds and returns an ICC transform from the ``inputProfile``
     to the ``outputProfile``, but tries to simulate the result that would be
@@ -596,17 +597,17 @@ def applyTransform(im, transform, inPlace=False):
     """
     (pyCMS) Applies a transform to a given image.
 
-    If ``im.mode != transform.inMode``, a ``PyCMSError`` is raised.
+    If ``im.mode != transform.inMode``, a :exc:`PyCMSError` is raised.
 
     If ``inPlace`` is ``True`` and ``transform.inMode != transform.outMode``, a
-    ``PyCMSError`` is raised.
+    :exc:`PyCMSError` is raised.
 
     If ``im.mode``, ``transform.inMode`` or ``transform.outMode`` is not
     supported by pyCMSdll or the profiles you used for the transform, a
-    ``PyCMSError`` is raised.
+    :exc:`PyCMSError` is raised.
 
-    If an error occurs while the transform is being applied, a ``PyCMSError``
-    is raised.
+    If an error occurs while the transform is being applied,
+    a :exc:`PyCMSError` is raised.
 
     This function applies a pre-calculated transform (from
     ImageCms.buildTransform() or ImageCms.buildTransformFromOpenProfiles())
@@ -649,12 +650,14 @@ def createProfile(colorSpace, colorTemp=-1):
     """
     (pyCMS) Creates a profile.
 
-    If colorSpace not in ``["LAB", "XYZ", "sRGB"]``, a ``PyCMSError`` is raised.
+    If colorSpace not in ``["LAB", "XYZ", "sRGB"]``,
+    a :exc:`PyCMSError` is raised.
 
-    If using LAB and ``colorTemp`` is not a positive integer, a ``PyCMSError`` is
-    raised.
+    If using LAB and ``colorTemp`` is not a positive integer,
+    a :exc:`PyCMSError` is raised.
 
-    If an error occurs while creating the profile, a ``PyCMSError`` is raised.
+    If an error occurs while creating the profile,
+    a :exc:`PyCMSError` is raised.
 
     Use this function to create common profiles on-the-fly instead of
     having to supply a profile on disk and knowing the path to it.  It
@@ -699,8 +702,8 @@ def getProfileName(profile):
     (pyCMS) Gets the internal product name for the given profile.
 
     If ``profile`` isn't a valid CmsProfile object or filename to a profile,
-    a ``PyCMSError`` is raised If an error occurs while trying to obtain the
-    name tag, a ``PyCMSError`` is raised.
+    a :exc:`PyCMSError` is raised If an error occurs while trying
+    to obtain the name tag, a :exc:`PyCMSError` is raised.
 
     Use this function to obtain the INTERNAL name of the profile (stored
     in an ICC tag in the profile itself), usually the one used when the
@@ -740,10 +743,10 @@ def getProfileInfo(profile):
     (pyCMS) Gets the internal product information for the given profile.
 
     If ``profile`` isn't a valid CmsProfile object or filename to a profile,
-    a ``PyCMSError`` is raised.
+    a :exc:`PyCMSError` is raised.
 
-    If an error occurs while trying to obtain the info tag, a ``PyCMSError``
-    is raised.
+    If an error occurs while trying to obtain the info tag,
+    a :exc:`PyCMSError` is raised.
 
     Use this function to obtain the information stored in the profile's
     info tag.  This often contains details about the profile, and how it
@@ -780,10 +783,10 @@ def getProfileCopyright(profile):
     (pyCMS) Gets the copyright for the given profile.
 
     If ``profile`` isn't a valid CmsProfile object or filename to a profile, a
-    ``PyCMSError`` is raised.
+    :exc:`PyCMSError` is raised.
 
-    If an error occurs while trying to obtain the copyright tag, a ``PyCMSError``
-    is raised.
+    If an error occurs while trying to obtain the copyright tag,
+    a :exc:`PyCMSError` is raised.
 
     Use this function to obtain the information stored in the profile's
     copyright tag.
@@ -808,10 +811,10 @@ def getProfileManufacturer(profile):
     (pyCMS) Gets the manufacturer for the given profile.
 
     If ``profile`` isn't a valid CmsProfile object or filename to a profile, a
-    ``PyCMSError`` is raised.
+    :exc:`PyCMSError` is raised.
 
     If an error occurs while trying to obtain the manufacturer tag, a
-    ``PyCMSError`` is raised.
+    :exc:`PyCMSError` is raised.
 
     Use this function to obtain the information stored in the profile's
     manufacturer tag.
@@ -836,10 +839,10 @@ def getProfileModel(profile):
     (pyCMS) Gets the model for the given profile.
 
     If ``profile`` isn't a valid CmsProfile object or filename to a profile, a
-    ``PyCMSError`` is raised.
+    :exc:`PyCMSError` is raised.
 
-    If an error occurs while trying to obtain the model tag, a ``PyCMSError``
-    is raised.
+    If an error occurs while trying to obtain the model tag,
+    a :exc:`PyCMSError` is raised.
 
     Use this function to obtain the information stored in the profile's
     model tag.
@@ -865,10 +868,10 @@ def getProfileDescription(profile):
     (pyCMS) Gets the description for the given profile.
 
     If ``profile`` isn't a valid CmsProfile object or filename to a profile, a
-    ``PyCMSError`` is raised.
+    :exc:`PyCMSError` is raised.
 
-    If an error occurs while trying to obtain the description tag, a ``PyCMSError``
-    is raised.
+    If an error occurs while trying to obtain the description tag,
+    a :exc:`PyCMSError` is raised.
 
     Use this function to obtain the information stored in the profile's
     description tag.
@@ -894,10 +897,10 @@ def getDefaultIntent(profile):
     (pyCMS) Gets the default intent name for the given profile.
 
     If ``profile`` isn't a valid CmsProfile object or filename to a profile, a
-    ``PyCMSError`` is raised.
+    :exc:`PyCMSError` is raised.
 
     If an error occurs while trying to obtain the default intent, a
-    ``PyCMSError`` is raised.
+    :exc:`PyCMSError` is raised.
 
     Use this function to determine the default (and usually best optimized)
     rendering intent for this profile.  Most profiles support multiple
@@ -940,8 +943,8 @@ def isIntentSupported(profile, intent, direction):
     be used for others. Some profiles can only be used for certain
     rendering intents, so it's best to either verify this before trying
     to create a transform with them (using this function), or catch the
-    potential ``PyCMSError`` that will occur if they don't support the modes
-    you select.
+    potential :exc:`PyCMSError` that will occur if they don't
+    support the modes you select.
 
     :param profile: EITHER a valid CmsProfile object, OR a string of the
         filename of an ICC profile.

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -85,7 +85,7 @@ def _tilesort(t):
 
 
 class ImageFile(Image.Image):
-    "Base class for image file format handlers."
+    """Base class for image file format handlers."""
 
     def __init__(self, fp=None, filename=None):
         super().__init__()


### PR DESCRIPTION
Splitting up #4715.

Add autodocs for missing types `ImageFile`, `StubImageFile`, and fix references to `PyCMSError`. Also replace code references to `PyCMSError` with actual references.

I had to remove the `:noindex:` in `ImageCMS.rst` to let sphinx find the missing types. Unfortunately this conflicts with the `:module:` at the top of the file, and removing `:module:` would cause a (mildly) confusing scroll target, so I replaced `automodule` with several `autofunction`s.

<details><summary>Fixes 55 nitpicky warnings: (click to expand)</summary><p>

```
-c:\git\pillow\src\PIL\GdImageFile.py:docstring of PIL.GdImageFile.GdImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:564: WARNING: py:meth reference target not found: PIL.ImageFile.ImageFile.get_format_mimetype
-C:\Git\Pillow\docs\handbook\writing-your-own-file-decoder.rst:29: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\ImageCms.py:docstring of PIL.ImageCms.applyTransform:: WARNING: py:exc reference target not found: PyCMSError
-c:\git\pillow\src\PIL\ImageCms.py:docstring of PIL.ImageCms.buildProofTransform:: WARNING: py:exc reference target not found: PyCMSError
-c:\git\pillow\src\PIL\ImageCms.py:docstring of PIL.ImageCms.buildProofTransformFromOpenProfiles:: WARNING: py:exc reference target not found: PyCMSError
-c:\git\pillow\src\PIL\ImageCms.py:docstring of PIL.ImageCms.buildTransform:: WARNING: py:exc reference target not found: PyCMSError
-c:\git\pillow\src\PIL\ImageCms.py:docstring of PIL.ImageCms.buildTransformFromOpenProfiles:: WARNING: py:exc reference target not found: PyCMSError
-c:\git\pillow\src\PIL\ImageCms.py:docstring of PIL.ImageCms.createProfile:: WARNING: py:exc reference target not found: PyCMSError
-c:\git\pillow\src\PIL\ImageCms.py:docstring of PIL.ImageCms.getDefaultIntent:: WARNING: py:exc reference target not found: PyCMSError
-c:\git\pillow\src\PIL\ImageCms.py:docstring of PIL.ImageCms.getOpenProfile:: WARNING: py:exc reference target not found: PyCMSError
-c:\git\pillow\src\PIL\ImageCms.py:docstring of PIL.ImageCms.getProfileCopyright:: WARNING: py:exc reference target not found: PyCMSError
-c:\git\pillow\src\PIL\ImageCms.py:docstring of PIL.ImageCms.getProfileDescription:: WARNING: py:exc reference target not found: PyCMSError
-c:\git\pillow\src\PIL\ImageCms.py:docstring of PIL.ImageCms.getProfileInfo:: WARNING: py:exc reference target not found: PyCMSError
-c:\git\pillow\src\PIL\ImageCms.py:docstring of PIL.ImageCms.getProfileManufacturer:: WARNING: py:exc reference target not found: PyCMSError
-c:\git\pillow\src\PIL\ImageCms.py:docstring of PIL.ImageCms.getProfileModel:: WARNING: py:exc reference target not found: PyCMSError
-c:\git\pillow\src\PIL\ImageCms.py:docstring of PIL.ImageCms.getProfileName:: WARNING: py:exc reference target not found: PyCMSError
-c:\git\pillow\src\PIL\ImageCms.py:docstring of PIL.ImageCms.isIntentSupported:: WARNING: py:exc reference target not found: PyCMSError
-c:\git\pillow\src\PIL\ImageCms.py:docstring of PIL.ImageCms.profileToProfile:: WARNING: py:exc reference target not found: PyCMSError
-c:\git\pillow\src\PIL\BmpImagePlugin.py:docstring of PIL.BmpImagePlugin.BmpImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\BufrStubImagePlugin.py:docstring of PIL.BufrStubImagePlugin.BufrStubImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.StubImageFile
-c:\git\pillow\src\PIL\EpsImagePlugin.py:docstring of PIL.EpsImagePlugin.EpsImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\FitsStubImagePlugin.py:docstring of PIL.FitsStubImagePlugin.FITSStubImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.StubImageFile
-c:\git\pillow\src\PIL\FliImagePlugin.py:docstring of PIL.FliImagePlugin.FliImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\FpxImagePlugin.py:docstring of PIL.FpxImagePlugin.FpxImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\GbrImagePlugin.py:docstring of PIL.GbrImagePlugin.GbrImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\GifImagePlugin.py:docstring of PIL.GifImagePlugin.GifImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\GribStubImagePlugin.py:docstring of PIL.GribStubImagePlugin.GribStubImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.StubImageFile
-c:\git\pillow\src\PIL\Hdf5StubImagePlugin.py:docstring of PIL.Hdf5StubImagePlugin.HDF5StubImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.StubImageFile
-c:\git\pillow\src\PIL\IcnsImagePlugin.py:docstring of PIL.IcnsImagePlugin.IcnsImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\IcoImagePlugin.py:docstring of PIL.IcoImagePlugin.IcoImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\ImImagePlugin.py:docstring of PIL.ImImagePlugin.ImImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\ImtImagePlugin.py:docstring of PIL.ImtImagePlugin.ImtImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\IptcImagePlugin.py:docstring of PIL.IptcImagePlugin.IptcImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\JpegImagePlugin.py:docstring of PIL.JpegImagePlugin.JpegImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\Jpeg2KImagePlugin.py:docstring of PIL.Jpeg2KImagePlugin.Jpeg2KImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\McIdasImagePlugin.py:docstring of PIL.McIdasImagePlugin.McIdasImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\MpegImagePlugin.py:docstring of PIL.MpegImagePlugin.MpegImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\MspImagePlugin.py:docstring of PIL.MspImagePlugin.MspImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\PcdImagePlugin.py:docstring of PIL.PcdImagePlugin.PcdImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\PcxImagePlugin.py:docstring of PIL.PcxImagePlugin.PcxImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\PixarImagePlugin.py:docstring of PIL.PixarImagePlugin.PixarImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\PngImagePlugin.py:docstring of PIL.PngImagePlugin.PngImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\PpmImagePlugin.py:docstring of PIL.PpmImagePlugin.PpmImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\PsdImagePlugin.py:docstring of PIL.PsdImagePlugin.PsdImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\SgiImagePlugin.py:docstring of PIL.SgiImagePlugin.SgiImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\SpiderImagePlugin.py:docstring of PIL.SpiderImagePlugin.SpiderImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\SunImagePlugin.py:docstring of PIL.SunImagePlugin.SunImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\TgaImagePlugin.py:docstring of PIL.TgaImagePlugin.TgaImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\TiffImagePlugin.py:docstring of PIL.TiffImagePlugin.TiffImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\WebPImagePlugin.py:docstring of PIL.WebPImagePlugin.WebPImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\WmfImagePlugin.py:docstring of PIL.WmfImagePlugin.WmfStubImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.StubImageFile
-c:\git\pillow\src\PIL\XVThumbImagePlugin.py:docstring of PIL.XVThumbImagePlugin.XVThumbImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\XbmImagePlugin.py:docstring of PIL.XbmImagePlugin.XbmImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
-c:\git\pillow\src\PIL\XpmImagePlugin.py:docstring of PIL.XpmImagePlugin.XpmImageFile:1: WARNING: py:class reference target not found: PIL.ImageFile.ImageFile
```

</p></details>