### PR TITLE
Fix documentation references: :type:

### DIFF
--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -260,57 +260,51 @@ Attributes
 
 Instances of the :py:class:`Image` class have the following attributes:
 
-.. py:attribute:: filename
+.. py:attribute:: Image.filename
+    :type: str
 
     The filename or path of the source file. Only images created with the
     factory function ``open`` have a filename attribute. If the input is a
     file like object, the filename attribute is set to an empty string.
 
-    :type: :py:class:`string`
-
-.. py:attribute:: format
+.. py:attribute:: Image.format
+    :type: Optional[str]
 
     The file format of the source file. For images created by the library
     itself (via a factory function, or by running a method on an existing
     image), this attribute is set to ``None``.
 
-    :type: :py:class:`string` or ``None``
-
-.. py:attribute:: mode
+.. py:attribute:: Image.mode
+    :type: str
 
     Image mode. This is a string specifying the pixel format used by the image.
     Typical values are “1”, “L”, “RGB”, or “CMYK.” See
     :ref:`concept-modes` for a full list.
 
-    :type: :py:class:`string`
-
-.. py:attribute:: size
+.. py:attribute:: Image.size
+    :type: tuple[int]
 
     Image size, in pixels. The size is given as a 2-tuple (width, height).
 
-    :type: ``(width, height)``
-
-.. py:attribute:: width
+.. py:attribute:: Image.width
+    :type: int
 
     Image width, in pixels.
 
-    :type: :py:class:`int`
-
-.. py:attribute:: height
+.. py:attribute:: Image.height
+    :type: int
 
     Image height, in pixels.
 
-    :type: :py:class:`int`
-
-.. py:attribute:: palette
+.. py:attribute:: Image.palette
+    :type: Optional[PIL.ImagePalette.ImagePalette]
 
     Colour palette table, if any. If mode is "P" or "PA", this should be an
     instance of the :py:class:`~PIL.ImagePalette.ImagePalette` class.
     Otherwise, it should be set to ``None``.
 
-    :type: :py:class:`~PIL.ImagePalette.ImagePalette` or ``None``
-
-.. py:attribute:: info
+.. py:attribute:: Image.info
+    :type: dict
 
     A dictionary holding data associated with the image. This dictionary is
     used by file handlers to pass on various non-image information read from
@@ -322,5 +316,3 @@ Instances of the :py:class:`Image` class have the following attributes:
     keep a reference to the info dictionary returned from the open method.
 
     Unless noted elsewhere, this dictionary does not affect saving files.
-
-    :type: :py:class:`dict`

--- a/docs/reference/ImageCms.rst
+++ b/docs/reference/ImageCms.rst
@@ -25,31 +25,30 @@ can be easily displayed in a chromaticity diagram, for example).
 .. py:class:: CmsProfile
 
     .. py:attribute:: creation_date
+        :type: Optional[datetime.datetime]
 
         Date and time this profile was first created (see 7.2.1 of ICC.1:2010).
 
-        :type: :py:class:`datetime.datetime` or ``None``
-
     .. py:attribute:: version
+        :type: float
 
         The version number of the ICC standard that this profile follows
         (e.g. ``2.0``).
 
-        :type: :py:class:`float`
-
     .. py:attribute:: icc_version
+        :type: int
 
         Same as ``version``, but in encoded format (see 7.2.4 of ICC.1:2010).
 
     .. py:attribute:: device_class
+        :type: str
 
         4-character string identifying the profile class.  One of
         ``scnr``, ``mntr``, ``prtr``, ``link``, ``spac``, ``abst``,
         ``nmcl`` (see 7.2.5 of ICC.1:2010 for details).
 
-        :type: :py:class:`string`
-
     .. py:attribute:: xcolor_space
+        :type: str
 
         4-character string (padded with whitespace) identifying the color
         space, e.g. ``XYZ␣``, ``RGB␣`` or ``CMYK`` (see 7.2.6 of
@@ -59,9 +58,8 @@ can be easily displayed in a chromaticity diagram, for example).
         interpreted (non-padded) variant of this (but can be empty on
         unknown input).
 
-        :type: :py:class:`string`
-
     .. py:attribute:: connection_space
+        :type: str
 
         4-character string (padded with whitespace) identifying the color
         space on the B-side of the transform (see 7.2.7 of ICC.1:2010 for
@@ -70,42 +68,37 @@ can be easily displayed in a chromaticity diagram, for example).
         Note that the deprecated attribute ``pcs`` contains an interpreted
         (non-padded) variant of this (but can be empty on unknown input).
 
-        :type: :py:class:`string`
-
     .. py:attribute:: header_flags
+        :type: int
 
         The encoded header flags of the profile (see 7.2.11 of ICC.1:2010
         for details).
 
-        :type: :py:class:`int`
-
     .. py:attribute:: header_manufacturer
+        :type: str
 
         4-character string (padded with whitespace) identifying the device
         manufacturer, which shall match the signature contained in the
         appropriate section of the ICC signature registry found at
         www.color.org (see 7.2.12 of ICC.1:2010).
 
-        :type: :py:class:`string`
-
     .. py:attribute:: header_model
+        :type: str
 
         4-character string (padded with whitespace) identifying the device
         model, which shall match the signature contained in the
         appropriate section of the ICC signature registry found at
         www.color.org (see 7.2.13 of ICC.1:2010).
 
-        :type: :py:class:`string`
-
     .. py:attribute:: attributes
+        :type: int
 
         Flags used to identify attributes unique to the particular device
         setup for which the profile is applicable (see 7.2.14 of
         ICC.1:2010 for details).
 
-        :type: :py:class:`int`
-
     .. py:attribute:: rendering_intent
+        :type: int
 
         The rendering intent to use when combining this profile with
         another profile (usually overridden at run-time, but provided here
@@ -114,84 +107,82 @@ can be easily displayed in a chromaticity diagram, for example).
         One of ``ImageCms.INTENT_ABSOLUTE_COLORIMETRIC``, ``ImageCms.INTENT_PERCEPTUAL``,
         ``ImageCms.INTENT_RELATIVE_COLORIMETRIC`` and ``ImageCms.INTENT_SATURATION``.
 
-        :type: :py:class:`int`
-
     .. py:attribute:: profile_id
+        :type: bytes
 
         A sequence of 16 bytes identifying the profile (via a specially
         constructed MD5 sum), or 16 binary zeroes if the profile ID has
         not been calculated (see 7.2.18 of ICC.1:2010).
 
-        :type: :py:class:`bytes`
-
     .. py:attribute:: copyright
+        :type: Optional[str]
 
         The text copyright information for the profile (see 9.2.21 of ICC.1:2010).
 
-        :type: :py:class:`unicode` or ``None``
-
     .. py:attribute:: manufacturer
+        :type: Optional[str]
 
         The (English) display string for the device manufacturer (see
         9.2.22 of ICC.1:2010).
 
-        :type: :py:class:`unicode` or ``None``
-
     .. py:attribute:: model
+        :type: Optional[str]
 
         The (English) display string for the device model of the device
         for which this profile is created (see 9.2.23 of ICC.1:2010).
 
-        :type: :py:class:`unicode` or ``None``
-
     .. py:attribute:: profile_description
+        :type: Optional[str]
 
         The (English) display string for the profile description (see
         9.2.41 of ICC.1:2010).
 
-        :type: :py:class:`unicode` or ``None``
-
     .. py:attribute:: target
+        :type: Optional[str]
 
         The name of the registered characterization data set, or the
         measurement data for a characterization target (see 9.2.14 of
         ICC.1:2010).
 
-        :type: :py:class:`unicode` or ``None``
-
     .. py:attribute:: red_colorant
+        :type: Optional[tuple[tuple[float]]]
 
         The first column in the matrix used in matrix/TRC transforms (see 9.2.44 of ICC.1:2010).
 
-        :type: ``((X, Y, Z), (x, y, Y))`` or ``None``
+        The value is in the format ``((X, Y, Z), (x, y, Y))``, if available.
 
     .. py:attribute:: green_colorant
+        :type: Optional[tuple[tuple[float]]]
 
         The second column in the matrix used in matrix/TRC transforms (see 9.2.30 of ICC.1:2010).
 
-        :type: ``((X, Y, Z), (x, y, Y))`` or ``None``
+        The value is in the format ``((X, Y, Z), (x, y, Y))``, if available.
 
     .. py:attribute:: blue_colorant
+        :type: Optional[tuple[tuple[float]]]
 
         The third column in the matrix used in matrix/TRC transforms (see 9.2.4 of ICC.1:2010).
 
-        :type: ``((X, Y, Z), (x, y, Y))`` or ``None``
+        The value is in the format ``((X, Y, Z), (x, y, Y))``, if available.
 
     .. py:attribute:: luminance
+        :type: Optional[tuple[tuple[float]]]
 
         The absolute luminance of emissive devices in candelas per square
         metre as described by the Y channel (see 9.2.32 of ICC.1:2010).
 
-        :type: ``((X, Y, Z), (x, y, Y))`` or ``None``
+        The value is in the format ``((X, Y, Z), (x, y, Y))``, if available.
 
     .. py:attribute:: chromaticity
+        :type: Optional[tuple[tuple[float]]]
 
         The data of the phosphor/colorant chromaticity set used (red,
         green and blue channels, see 9.2.16 of ICC.1:2010).
 
-        :type: ``((x, y, Y), (x, y, Y), (x, y, Y))`` or ``None``
+        The value is in the format ``((x, y, Y), (x, y, Y), (x, y, Y))``, if available.
 
     .. py:attribute:: chromatic_adaption
+        :type: tuple[tuple[float]]
 
         The chromatic adaption matrix converts a color measured using the
         actual illumination conditions and relative to the actual adopted
@@ -199,58 +190,52 @@ can be easily displayed in a chromaticity diagram, for example).
         complete adaptation from the actual adopted white chromaticity to
         the PCS adopted white chromaticity (see 9.2.15 of ICC.1:2010).
 
-        Two matrices are returned, one in (X, Y, Z) space and one in (x, y, Y) space.
-
-        :type: 2-tuple of 3-tuple, the first with (X, Y, Z) and the second with (x, y, Y) values
+        Two 3-tuples of floats are returned in a 2-tuple,
+        one in (X, Y, Z) space and one in (x, y, Y) space.
 
     .. py:attribute:: colorant_table
+        :type: list[str]
 
         This tag identifies the colorants used in the profile by a unique
         name and set of PCSXYZ or PCSLAB values (see 9.2.19 of
         ICC.1:2010).
 
-        :type: list of strings
-
     .. py:attribute:: colorant_table_out
+        :type: list[str]
 
         This tag identifies the colorants used in the profile by a unique
         name and set of PCSLAB values (for DeviceLink profiles only, see
         9.2.19 of ICC.1:2010).
 
-        :type: list of strings
-
     .. py:attribute:: colorimetric_intent
+        :type: Optional[str]
 
         4-character string (padded with whitespace) identifying the image
         state of PCS colorimetry produced using the colorimetric intent
         transforms (see 9.2.20 of ICC.1:2010 for details).
 
-        :type: :py:class:`string` or ``None``
-
     .. py:attribute:: perceptual_rendering_intent_gamut
+        :type: Optional[str]
 
         4-character string (padded with whitespace) identifying the (one)
         standard reference medium gamut (see 9.2.37 of ICC.1:2010 for
         details).
-
-        :type: :py:class:`string` or ``None``
 
     .. py:attribute:: saturation_rendering_intent_gamut
+        :type: Optional[str]
 
         4-character string (padded with whitespace) identifying the (one)
         standard reference medium gamut (see 9.2.37 of ICC.1:2010 for
         details).
 
-        :type: :py:class:`string` or ``None``
-
     .. py:attribute:: technology
+        :type: Optional[str]
 
         4-character string (padded with whitespace) identifying the device
         technology (see 9.2.47 of ICC.1:2010 for details).
 
-        :type: :py:class:`string` or ``None``
-
     .. py:attribute:: media_black_point
+        :type: Optional[tuple[tuple[float]]]
 
         This tag specifies the media black point and is used for
         generating absolute colorimetry.
@@ -258,57 +243,57 @@ can be easily displayed in a chromaticity diagram, for example).
         This tag was available in ICC 3.2, but it is removed from
         version 4.
 
-        :type: ``((X, Y, Z), (x, y, Y))`` or ``None``
+        The value is in the format ``((X, Y, Z), (x, y, Y))``, if available.
 
     .. py:attribute:: media_white_point_temperature
+        :type: Optional[float]
 
         Calculates the white point temperature (see the LCMS documentation
         for more information).
 
-        :type: :py:class:`float` or ``None``
-
     .. py:attribute:: viewing_condition
+        :type: Optional[str]
 
         The (English) display string for the viewing conditions (see
         9.2.48 of ICC.1:2010).
 
-        :type: :py:class:`unicode` or ``None``
-
     .. py:attribute:: screening_description
+        :type: Optional[str]
 
         The (English) display string for the screening conditions.
 
         This tag was available in ICC 3.2, but it is removed from
         version 4.
 
-        :type: :py:class:`unicode` or ``None``
-
     .. py:attribute:: red_primary
+        :type: Optional[tuple[tuple[float]]]
 
         The XYZ-transformed of the RGB primary color red (1, 0, 0).
 
-        :type: ``((X, Y, Z), (x, y, Y))`` or ``None``
+        The value is in the format ``((X, Y, Z), (x, y, Y))``, if available.
 
     .. py:attribute:: green_primary
+        :type: Optional[tuple[tuple[float]]]
 
         The XYZ-transformed of the RGB primary color green (0, 1, 0).
 
-        :type: ``((X, Y, Z), (x, y, Y))`` or ``None``
+        The value is in the format ``((X, Y, Z), (x, y, Y))``, if available.
 
     .. py:attribute:: blue_primary
+        :type: Optional[tuple[tuple[float]]]
 
         The XYZ-transformed of the RGB primary color blue (0, 0, 1).
 
-        :type: ``((X, Y, Z), (x, y, Y))`` or ``None``
+        The value is in the format ``((X, Y, Z), (x, y, Y))``, if available.
 
     .. py:attribute:: is_matrix_shaper
+        :type: bool
 
         True if this profile is implemented as a matrix shaper (see
         documentation on LCMS).
 
-        :type: :py:class:`bool`
-
     .. py:attribute:: clut
+        :type: dict[tuple[bool]]
 
         Returns a dictionary of all supported intents and directions for
         the CLUT model.
@@ -326,9 +311,8 @@ can be easily displayed in a chromaticity diagram, for example).
         The elements of the tuple are booleans.  If the value is ``True``,
         that intent is supported for that direction.
 
-        :type: :py:class:`dict` of boolean 3-tuples
-
     .. py:attribute:: intent_supported
+        :type: dict[tuple[bool]]
 
         Returns a dictionary of all supported intents and directions.
 
@@ -345,53 +329,46 @@ can be easily displayed in a chromaticity diagram, for example).
         The elements of the tuple are booleans.  If the value is ``True``,
         that intent is supported for that direction.
 
-        :type: :py:class:`dict` of boolean 3-tuples
-
     .. py:attribute:: color_space
+        :type: str
 
         Deprecated but retained for backwards compatibility.
         Interpreted value of :py:attr:`.xcolor_space`.  May be the
         empty string if value could not be decoded.
 
-        :type: :py:class:`string`
-
     .. py:attribute:: pcs
+        :type: str
 
         Deprecated but retained for backwards compatibility.
         Interpreted value of :py:attr:`.connection_space`.  May be
         the empty string if value could not be decoded.
 
-        :type: :py:class:`string`
-
     .. py:attribute:: product_model
+        :type: str
 
         Deprecated but retained for backwards compatibility.
         ASCII-encoded value of :py:attr:`.model`.
 
-        :type: :py:class:`string`
-
     .. py:attribute:: product_manufacturer
+        :type: str
 
         Deprecated but retained for backwards compatibility.
         ASCII-encoded value of :py:attr:`.manufacturer`.
 
-        :type: :py:class:`string`
-
     .. py:attribute:: product_copyright
+        :type: str
 
         Deprecated but retained for backwards compatibility.
         ASCII-encoded value of :py:attr:`.copyright`.
 
-        :type: :py:class:`string`
-
     .. py:attribute:: product_description
+        :type: str
 
         Deprecated but retained for backwards compatibility.
         ASCII-encoded value of :py:attr:`.profile_description`.
 
-        :type: :py:class:`string`
-
     .. py:attribute:: product_desc
+        :type: str
 
         Deprecated but retained for backwards compatibility.
         ASCII-encoded value of :py:attr:`.profile_description`.
@@ -400,8 +377,6 @@ can be easily displayed in a chromaticity diagram, for example).
         contain a derived informative string about the profile,
         depending on the value of the description, copyright,
         manufacturer and model fields).
-
-        :type: :py:class:`string`
 
     There is one function defined on the class:
 

--- a/docs/reference/ImageMath.rst
+++ b/docs/reference/ImageMath.rst
@@ -98,20 +98,24 @@ These functions are applied to each individual pixel.
 .. py:currentmodule:: None
 
 .. py:function:: abs(image)
+    :noindex:
 
     Absolute value.
 
 .. py:function:: convert(image, mode)
+    :noindex:
 
     Convert image to the given mode. The mode must be given as a string
     constant.
 
 .. py:function:: float(image)
+    :noindex:
 
     Convert image to 32-bit floating point. This is equivalent to
     convert(image, “F”).
 
 .. py:function:: int(image)
+    :noindex:
 
     Convert image to 32-bit integer. This is equivalent to convert(image, “I”).
 
@@ -119,9 +123,11 @@ These functions are applied to each individual pixel.
     integers if necessary to get a correct result.
 
 .. py:function:: max(image1, image2)
+    :noindex:
 
     Maximum value.
 
 .. py:function:: min(image1, image2)
+    :noindex:
 
     Minimum value.


### PR DESCRIPTION
Splitting up #4715.

`:type:` should be directly following an attribute/data to give a cleaner (modern) output. It automatically treats the value as a `:py:class` reference. I used `Optional` from builtin `typing` to fix the resulting reference errors where applicable.

I added `:noindex:` to `ImageMath` functions as some (`int` and `float`) were being picked up by as the target instead of builtin Python types. There were 3 references to them that were already broken, I'm not sure what is the best way to fix these.

Also add `Image.` prefix to Image attributes to fix several more references.

<details><summary>Fixes 69 nitpicky warnings: (click to expand)</summary><p>

```
-C:\Git\Pillow\docs\handbook\concepts.rst:66: WARNING: py:attr reference target not found: PIL.Image.Image.mode
-C:\Git\Pillow\docs\handbook\concepts.rst:72: WARNING: py:attr reference target not found: PIL.Image.Image.size
-C:\Git\Pillow\docs\handbook\concepts.rst:99: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\handbook\concepts.rst:102: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\handbook\concepts.rst:110: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:28: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:77: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:163: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:163: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:186: WARNING: py:attr reference target not found: PIL.Image.Image.size
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:203: WARNING: py:attr reference target not found: PIL.Image.Image.size
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:203: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:210: WARNING: py:attr reference target not found: PIL.Image.Image.size
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:210: WARNING: py:attr reference target not found: PIL.Image.Image.size
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:260: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:471: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:476: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:577: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:753: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:1024: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:1057: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:1072: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:1188: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\handbook\tutorial.rst:24: WARNING: py:attr reference target not found: PIL.Image.Image.format
-C:\Git\Pillow\docs\handbook\tutorial.rst:24: WARNING: py:attr reference target not found: PIL.Image.Image.mode
-C:\Git\Pillow\docs\handbook\writing-your-own-file-decoder.rst:29: WARNING: py:attr reference target not found: PIL.Image.Image.mode
-C:\Git\Pillow\docs\handbook\writing-your-own-file-decoder.rst:29: WARNING: py:attr reference target not found: PIL.Image.Image.size
-C:\Git\Pillow\docs\handbook\writing-your-own-file-decoder.rst:94: WARNING: py:attr reference target not found: PIL.Image.Image.size
-C:\Git\Pillow\docs\handbook\writing-your-own-file-decoder.rst:94: WARNING: py:attr reference target not found: PIL.Image.Image.mode
-C:\Git\Pillow\docs\reference\Image.rst:269: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\Image.rst:277: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\Image.rst:285: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\ImageCms.rst:50: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\ImageCms.rst:62: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\ImageCms.rst:73: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\ImageCms.rst:89: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\ImageCms.rst:98: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\ImageCms.rst:131: WARNING: py:class reference target not found: unicode
-C:\Git\Pillow\docs\reference\ImageCms.rst:138: WARNING: py:class reference target not found: unicode
-C:\Git\Pillow\docs\reference\ImageCms.rst:145: WARNING: py:class reference target not found: unicode
-C:\Git\Pillow\docs\reference\ImageCms.rst:152: WARNING: py:class reference target not found: unicode
-C:\Git\Pillow\docs\reference\ImageCms.rst:160: WARNING: py:class reference target not found: unicode
-C:\Git\Pillow\docs\reference\ImageCms.rst:204: WARNING: py:class reference target not found: 2-tuple of 3-tuple
-C:\Git\Pillow\docs\reference\ImageCms.rst:204: WARNING: py:class reference target not found: the first with
-C:\Git\Pillow\docs\reference\ImageCms.rst:204: WARNING: py:class reference target not found: X
-C:\Git\Pillow\docs\reference\ImageCms.rst:204: WARNING: py:class reference target not found: Y
-C:\Git\Pillow\docs\reference\ImageCms.rst:204: WARNING: py:class reference target not found: Z
-C:\Git\Pillow\docs\reference\ImageCms.rst:204: WARNING: py:class reference target not found: and the second with
-C:\Git\Pillow\docs\reference\ImageCms.rst:204: WARNING: py:class reference target not found: x
-C:\Git\Pillow\docs\reference\ImageCms.rst:204: WARNING: py:class reference target not found: y
-C:\Git\Pillow\docs\reference\ImageCms.rst:204: WARNING: py:class reference target not found: Y
-C:\Git\Pillow\docs\reference\ImageCms.rst:204: WARNING: py:class reference target not found: values
-C:\Git\Pillow\docs\reference\ImageCms.rst:212: WARNING: py:class reference target not found: list of strings
-C:\Git\Pillow\docs\reference\ImageCms.rst:220: WARNING: py:class reference target not found: list of strings
-C:\Git\Pillow\docs\reference\ImageCms.rst:228: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\ImageCms.rst:236: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\ImageCms.rst:244: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\ImageCms.rst:251: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\ImageCms.rst:275: WARNING: py:class reference target not found: unicode
-C:\Git\Pillow\docs\reference\ImageCms.rst:284: WARNING: py:class reference target not found: unicode
-C:\Git\Pillow\docs\reference\ImageCms.rst:356: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\ImageCms.rst:364: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\ImageCms.rst:371: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\ImageCms.rst:378: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\ImageCms.rst:385: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\ImageCms.rst:392: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\reference\ImageCms.rst:404: WARNING: py:class reference target not found: string
-C:\Git\Pillow\docs\releasenotes\6.0.0.rst:185: WARNING: py:attr reference target not found: PIL.Image.Image.info
-C:\Git\Pillow\docs\releasenotes\7.1.0.rst:42: WARNING: py:attr reference target not found: PIL.Image.Image.info
```

</p></details>