### PR TITLE
Fix documentation references: Image constants

### DIFF
--- a/docs/handbook/concepts.rst
+++ b/docs/handbook/concepts.rst
@@ -121,39 +121,47 @@ Filters
 For geometry operations that may map multiple input pixels to a single output
 pixel, the Python Imaging Library provides different resampling *filters*.
 
-``NEAREST``
+.. py:currentmodule:: PIL.Image
+
+.. data:: NEAREST
+
     Pick one nearest pixel from the input image. Ignore all other input pixels.
 
-``BOX``
+.. data:: BOX
+
     Each pixel of source image contributes to one pixel of the
     destination image with identical weights.
-    For upscaling is equivalent of ``NEAREST``.
+    For upscaling is equivalent of :data:`NEAREST`.
     This filter can only be used with the :py:meth:`~PIL.Image.Image.resize`
     and :py:meth:`~PIL.Image.Image.thumbnail` methods.
 
     .. versionadded:: 3.4.0
 
-``BILINEAR``
+.. data:: BILINEAR
+
     For resize calculate the output pixel value using linear interpolation
     on all pixels that may contribute to the output value.
     For other transformations linear interpolation over a 2x2 environment
     in the input image is used.
 
-``HAMMING``
-    Produces a sharper image than ``BILINEAR``, doesn't have dislocations
-    on local level like with ``BOX``.
+.. data:: HAMMING
+
+    Produces a sharper image than :data:`BILINEAR`, doesn't have dislocations
+    on local level like with :data:`BOX`.
     This filter can only be used with the :py:meth:`~PIL.Image.Image.resize`
     and :py:meth:`~PIL.Image.Image.thumbnail` methods.
 
     .. versionadded:: 3.4.0
 
-``BICUBIC``
+.. data:: BICUBIC
+
     For resize calculate the output pixel value using cubic interpolation
     on all pixels that may contribute to the output value.
     For other transformations cubic interpolation over a 4x4 environment
     in the input image is used.
 
-``LANCZOS``
+.. data:: LANCZOS
+
     Calculate the output pixel value using a high-quality Lanczos filter (a
     truncated sinc) on all pixels that may contribute to the output value.
     This filter can only be used with the :py:meth:`~PIL.Image.Image.resize`
@@ -165,19 +173,19 @@ pixel, the Python Imaging Library provides different resampling *filters*.
 Filters comparison table
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-+------------+-------------+-----------+-------------+
-| Filter     | Downscaling | Upscaling | Performance |
-|            | quality     | quality   |             |
-+============+=============+===========+=============+
-|``NEAREST`` |             |           | ⭐⭐⭐⭐⭐  |
-+------------+-------------+-----------+-------------+
-|``BOX``     | ⭐          |           | ⭐⭐⭐⭐    |
-+------------+-------------+-----------+-------------+
-|``BILINEAR``| ⭐          | ⭐        | ⭐⭐⭐      |
-+------------+-------------+-----------+-------------+
-|``HAMMING`` | ⭐⭐        |           | ⭐⭐⭐      |
-+------------+-------------+-----------+-------------+
-|``BICUBIC`` | ⭐⭐⭐      | ⭐⭐⭐    | ⭐⭐        |
-+------------+-------------+-----------+-------------+
-|``LANCZOS`` | ⭐⭐⭐⭐    | ⭐⭐⭐⭐  | ⭐          |
-+------------+-------------+-----------+-------------+
++----------------+-------------+-----------+-------------+
+| Filter         | Downscaling | Upscaling | Performance |
+|                | quality     | quality   |             |
++================+=============+===========+=============+
+|:data:`NEAREST` |             |           | ⭐⭐⭐⭐⭐  |
++----------------+-------------+-----------+-------------+
+|:data:`BOX`     | ⭐          |           | ⭐⭐⭐⭐    |
++----------------+-------------+-----------+-------------+
+|:data:`BILINEAR`| ⭐          | ⭐        | ⭐⭐⭐      |
++----------------+-------------+-----------+-------------+
+|:data:`HAMMING` | ⭐⭐        |           | ⭐⭐⭐      |
++----------------+-------------+-----------+-------------+
+|:data:`BICUBIC` | ⭐⭐⭐      | ⭐⭐⭐    | ⭐⭐        |
++----------------+-------------+-----------+-------------+
+|:data:`LANCZOS` | ⭐⭐⭐⭐    | ⭐⭐⭐⭐  | ⭐          |
++----------------+-------------+-----------+-------------+

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -234,7 +234,7 @@ This rotates the input image by ``theta`` degrees counter clockwise:
 .. automethod:: PIL.Image.Image.transform
 .. automethod:: PIL.Image.Image.transpose
 
-This flips the input image by using the ``Image.FLIP_LEFT_RIGHT`` method.
+This flips the input image by using the :data:`FLIP_LEFT_RIGHT` method.
 
 .. code-block:: python
 
@@ -324,3 +324,134 @@ Instances of the :py:class:`Image` class have the following attributes:
     Unless noted elsewhere, this dictionary does not affect saving files.
 
     :type: :py:class:`dict`
+
+Constants
+---------
+
+.. data:: NONE
+
+Transpose methods
+^^^^^^^^^^^^^^^^^
+
+Used to specify the :meth:`Image.transpose` method to use.
+
+.. data:: FLIP_LEFT_RIGHT
+.. data:: FLIP_TOP_BOTTOM
+.. data:: ROTATE_90
+.. data:: ROTATE_180
+.. data:: ROTATE_270
+.. data:: TRANSPOSE
+.. data:: TRANSVERSE
+
+Transform methods
+^^^^^^^^^^^^^^^^^
+
+Used to specify the :meth:`Image.transform` method to use.
+
+.. data:: AFFINE
+
+    Affine transform
+
+.. data:: EXTENT
+
+    Cut out a rectangular subregion
+
+.. data:: PERSPECTIVE
+
+    Perspective transform
+
+.. data:: QUAD
+
+    Map a quadrilateral to a rectangle
+
+.. data:: MESH
+
+    Map a number of source quadrilaterals in one operation
+
+Resampling filters
+^^^^^^^^^^^^^^^^^^
+
+See :ref:`concept-filters` for details.
+
+.. data:: NEAREST
+    :noindex:
+.. data:: BOX
+    :noindex:
+.. data:: BILINEAR
+    :noindex:
+.. data:: HAMMING
+    :noindex:
+.. data:: BICUBIC
+    :noindex:
+.. data:: LANCZOS
+    :noindex:
+
+Some filters are also available under the following names for backwards compatibility:
+
+.. data:: NONE
+    :noindex:
+    :value: NEAREST
+.. data:: LINEAR
+    :value: BILINEAR
+.. data:: CUBIC
+    :value: BICUBIC
+.. data:: ANTIALIAS
+    :value: LANCZOS
+
+Dither modes
+^^^^^^^^^^^^
+
+Used to specify the dithering method to use for the
+:meth:`~Image.convert` and :meth:`~Image.quantize` methods.
+
+.. data:: NONE
+    :noindex:
+
+    No dither
+
+.. comment: (not implemented)
+    .. data:: ORDERED
+    .. data:: RASTERIZE
+
+.. data:: FLOYDSTEINBERG
+
+    Floyd-Steinberg dither
+
+Palettes
+^^^^^^^^
+
+Used to specify the pallete to use for the :meth:`~Image.convert` method.
+
+.. data:: WEB
+.. data:: ADAPTIVE
+
+Quantization methods
+^^^^^^^^^^^^^^^^^^^^
+
+Used to specify the quantization method to use for the :meth:`~Image.quantize` method.
+
+.. data:: MEDIANCUT
+
+    Median cut
+
+.. data:: MAXCOVERAGE
+
+    Maximum coverage
+
+.. data:: FASTOCTREE
+
+    Fast octree
+
+.. data:: LIBIMAGEQUANT
+
+    libimagequant
+
+    Check support using :py:func:`PIL.features.check_feature`
+    with ``feature="libimagequant"``.
+
+.. comment: These are not referenced anywhere?
+    Categories
+    ^^^^^^^^^^
+    .. data:: NORMAL
+    .. data:: SEQUENCE
+    .. data:: CONTAINER

--- a/docs/releasenotes/2.7.0.rst
+++ b/docs/releasenotes/2.7.0.rst
@@ -29,53 +29,53 @@ Image resizing filters
 Image resizing methods :py:meth:`~PIL.Image.Image.resize` and
 :py:meth:`~PIL.Image.Image.thumbnail` take a ``resample`` argument, which tells
 which filter should be used for resampling. Possible values are:
-:py:attr:`PIL.Image.NEAREST`, :py:attr:`PIL.Image.BILINEAR`,
-:py:attr:`PIL.Image.BICUBIC` and :py:attr:`PIL.Image.ANTIALIAS`.
+:py:data:`PIL.Image.NEAREST`, :py:data:`PIL.Image.BILINEAR`,
+:py:data:`PIL.Image.BICUBIC` and :py:data:`PIL.Image.ANTIALIAS`.
 Almost all of them were changed in this version.
 
 Bicubic and bilinear downscaling
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-From the beginning :py:attr:`~PIL.Image.BILINEAR` and
-:py:attr:`~PIL.Image.BICUBIC` filters were based on affine transformations
+From the beginning :py:data:`~PIL.Image.BILINEAR` and
+:py:data:`~PIL.Image.BICUBIC` filters were based on affine transformations
 and used a fixed number of pixels from the source image for every destination
-pixel (2x2 pixels for :py:attr:`~PIL.Image.BILINEAR` and 4x4 for
-:py:attr:`~PIL.Image.BICUBIC`). This gave an unsatisfactory result for
+pixel (2x2 pixels for :py:data:`~PIL.Image.BILINEAR` and 4x4 for
+:py:data:`~PIL.Image.BICUBIC`). This gave an unsatisfactory result for
 downscaling. At the same time, a high quality convolutions-based algorithm with
-flexible kernel was used for :py:attr:`~PIL.Image.ANTIALIAS` filter.
+flexible kernel was used for :py:data:`~PIL.Image.ANTIALIAS` filter.
 
 Starting from Pillow 2.7.0, a high quality convolutions-based algorithm is used
 for all of these three filters.
 
 If you have previously used any tricks to maintain quality when downscaling with
-:py:attr:`~PIL.Image.BILINEAR` and :py:attr:`~PIL.Image.BICUBIC` filters
+:py:data:`~PIL.Image.BILINEAR` and :py:data:`~PIL.Image.BICUBIC` filters
 (for example, reducing within several steps), they are unnecessary now.
 
 Antialias renamed to Lanczos
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A new :py:attr:`PIL.Image.LANCZOS` constant was added instead of
-:py:attr:`~PIL.Image.ANTIALIAS`.
+A new :py:data:`PIL.Image.LANCZOS` constant was added instead of
+:py:data:`~PIL.Image.ANTIALIAS`.
 
-When :py:attr:`~PIL.Image.ANTIALIAS` was initially added, it was the only
+When :py:data:`~PIL.Image.ANTIALIAS` was initially added, it was the only
 high-quality filter based on convolutions. It's name was supposed to reflect
 this. Starting from Pillow 2.7.0 all resize method are based on convolutions.
 All of them are antialias from now on. And the real name of the
-:py:attr:`~PIL.Image.ANTIALIAS` filter is Lanczos filter.
+:py:data:`~PIL.Image.ANTIALIAS` filter is Lanczos filter.
 
-The :py:attr:`~PIL.Image.ANTIALIAS` constant is left for backward compatibility
-and is an alias for :py:attr:`~PIL.Image.LANCZOS`.
+The :py:data:`~PIL.Image.ANTIALIAS` constant is left for backward compatibility
+and is an alias for :py:data:`~PIL.Image.LANCZOS`.
 
 Lanczos upscaling quality
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The image upscaling quality with :py:attr:`~PIL.Image.LANCZOS` filter was
-almost the same as :py:attr:`~PIL.Image.BILINEAR` due to bug. This has been fixed.
+The image upscaling quality with :py:data:`~PIL.Image.LANCZOS` filter was
+almost the same as :py:data:`~PIL.Image.BILINEAR` due to bug. This has been fixed.
 
 Bicubic upscaling quality
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :py:attr:`~PIL.Image.BICUBIC` filter for affine transformations produced
+The :py:data:`~PIL.Image.BICUBIC` filter for affine transformations produced
 sharp, slightly pixelated image for upscaling. Bicubic for convolutions is
 more soft.
 
@@ -84,42 +84,42 @@ Resize performance
 
 In most cases, convolution is more a expensive algorithm for downscaling
 because it takes into account all the pixels of source image. Therefore
-:py:attr:`~PIL.Image.BILINEAR` and :py:attr:`~PIL.Image.BICUBIC` filters'
+:py:data:`~PIL.Image.BILINEAR` and :py:data:`~PIL.Image.BICUBIC` filters'
 performance can be lower than before. On the other hand the quality of
-:py:attr:`~PIL.Image.BILINEAR` and :py:attr:`~PIL.Image.BICUBIC` was close to
-:py:attr:`~PIL.Image.NEAREST`. So if such quality is suitable for your tasks
-you can switch to :py:attr:`~PIL.Image.NEAREST` filter for downscaling,
+:py:data:`~PIL.Image.BILINEAR` and :py:data:`~PIL.Image.BICUBIC` was close to
+:py:data:`~PIL.Image.NEAREST`. So if such quality is suitable for your tasks
+you can switch to :py:data:`~PIL.Image.NEAREST` filter for downscaling,
 which will give a huge improvement in performance.
 
 At the same time performance of convolution resampling for downscaling has been
 improved by around a factor of two compared to the previous version.
-The upscaling performance of the :py:attr:`~PIL.Image.LANCZOS` filter has
-remained the same. For :py:attr:`~PIL.Image.BILINEAR` filter it has improved by
-1.5 times and for :py:attr:`~PIL.Image.BICUBIC` by four times.
+The upscaling performance of the :py:data:`~PIL.Image.LANCZOS` filter has
+remained the same. For :py:data:`~PIL.Image.BILINEAR` filter it has improved by
+1.5 times and for :py:data:`~PIL.Image.BICUBIC` by four times.
 
 Default filter for thumbnails
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In Pillow 2.5 the default filter for :py:meth:`~PIL.Image.Image.thumbnail` was
-changed from :py:attr:`~PIL.Image.NEAREST` to :py:attr:`~PIL.Image.ANTIALIAS`.
+changed from :py:data:`~PIL.Image.NEAREST` to :py:data:`~PIL.Image.ANTIALIAS`.
 Antialias was chosen because all the other filters gave poor quality for
-reduction. Starting from Pillow 2.7.0, :py:attr:`~PIL.Image.ANTIALIAS` has been
-replaced with :py:attr:`~PIL.Image.BICUBIC`, because it's faster and
-:py:attr:`~PIL.Image.ANTIALIAS` doesn't give any advantages after
+reduction. Starting from Pillow 2.7.0, :py:data:`~PIL.Image.ANTIALIAS` has been
+replaced with :py:data:`~PIL.Image.BICUBIC`, because it's faster and
+:py:data:`~PIL.Image.ANTIALIAS` doesn't give any advantages after
 downscaling with libjpeg, which uses supersampling internally, not convolutions.
 
 Image transposition
 -------------------
 
-A new method :py:attr:`PIL.Image.TRANSPOSE` has been added for the
+A new method :py:data:`PIL.Image.TRANSPOSE` has been added for the
 :py:meth:`~PIL.Image.Image.transpose` operation in addition to
-:py:attr:`~PIL.Image.FLIP_LEFT_RIGHT`, :py:attr:`~PIL.Image.FLIP_TOP_BOTTOM`,
-:py:attr:`~PIL.Image.ROTATE_90`, :py:attr:`~PIL.Image.ROTATE_180`,
-:py:attr:`~PIL.Image.ROTATE_270`. :py:attr:`~PIL.Image.TRANSPOSE` is an algebra
+:py:data:`~PIL.Image.FLIP_LEFT_RIGHT`, :py:data:`~PIL.Image.FLIP_TOP_BOTTOM`,
+:py:data:`~PIL.Image.ROTATE_90`, :py:data:`~PIL.Image.ROTATE_180`,
+:py:data:`~PIL.Image.ROTATE_270`. :py:data:`~PIL.Image.TRANSPOSE` is an algebra
 transpose, with an image reflected across its main diagonal.
 
-The speed of :py:attr:`~PIL.Image.ROTATE_90`, :py:attr:`~PIL.Image.ROTATE_270`
-and :py:attr:`~PIL.Image.TRANSPOSE` has been significantly improved for large
+The speed of :py:data:`~PIL.Image.ROTATE_90`, :py:data:`~PIL.Image.ROTATE_270`
+and :py:data:`~PIL.Image.TRANSPOSE` has been significantly improved for large
 images which don't fit in the processor cache.
 
 Gaussian blur and unsharp mask

--- a/docs/releasenotes/4.2.0.rst
+++ b/docs/releasenotes/4.2.0.rst
@@ -27,7 +27,7 @@ New DecompressionBomb Warning
 
 :py:meth:`PIL.Image.Image.crop` now may raise a DecompressionBomb
 warning if the crop region enlarges the image over the threshold
-specified by :py:attr:`PIL.Image.MAX_PIXELS`.
+specified by :py:data:`PIL.Image.MAX_PIXELS`.
 
 Removed Deprecated Items
 ========================

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -876,7 +876,7 @@ class Image:
         The default method of converting a greyscale ("L") or "RGB"
         image into a bilevel (mode "1") image uses Floyd-Steinberg
         dither to approximate the original image luminosity levels. If
-        dither is NONE, all values larger than 128 are set to 255 (white),
+        dither is :data:`NONE`, all values larger than 128 are set to 255 (white),
         all other values to 0 (black). To use other thresholds, use the
         :py:meth:`~PIL.Image.Image.point` method.
 
@@ -889,11 +889,11 @@ class Image:
            should be 4- or 12-tuple containing floating point values.
         :param dither: Dithering method, used when converting from
            mode "RGB" to "P" or from "RGB" or "L" to "1".
-           Available methods are NONE or FLOYDSTEINBERG (default).
+           Available methods are :data:`NONE` or :data:`FLOYDSTEINBERG` (default).
            Note that this is not used when **matrix** is supplied.
         :param palette: Palette to use when converting from mode "RGB"
-           to "P".  Available palettes are WEB or ADAPTIVE.
-        :param colors: Number of colors to use for the ADAPTIVE palette.
+           to "P".  Available palettes are :data:`WEB` or :data:`ADAPTIVE`.
+        :param colors: Number of colors to use for the :data:`ADAPTIVE` palette.
            Defaults to 256.
         :rtype: :py:class:`~PIL.Image.Image`
         :returns: An :py:class:`~PIL.Image.Image` object.
@@ -1051,10 +1051,10 @@ class Image:
         of colors.
 
         :param colors: The desired number of colors, <= 256
-        :param method: ``Image.MEDIANCUT=0`` (median cut),
-                       ``Image.MAXCOVERAGE=1`` (maximum coverage),
-                       ``Image.FASTOCTREE=2`` (fast octree),
-                       ``Image.LIBIMAGEQUANT=3`` (libimagequant; check support using
+        :param method: :data:`MEDIANCUT` (median cut),
+                       :data:`MAXCOVERAGE` (maximum coverage),
+                       :data:`FASTOCTREE` (fast octree),
+                       :data:`LIBIMAGEQUANT` (libimagequant; check support using
                        :py:func:`PIL.features.check_feature`
                        with ``feature="libimagequant"``).
         :param kmeans: Integer
@@ -1062,7 +1062,7 @@ class Image:
                         :py:class:`PIL.Image.Image`.
         :param dither: Dithering method, used when converting from
            mode "RGB" to "P" or from "RGB" or "L" to "1".
-           Available methods are NONE or FLOYDSTEINBERG (default).
+           Available methods are :data:`NONE` or :data:`FLOYDSTEINBERG` (default).
            Default: 1 (legacy setting)
         :returns: A new image
 
@@ -1842,12 +1842,12 @@ class Image:
         :param size: The requested size in pixels, as a 2-tuple:
            (width, height).
         :param resample: An optional resampling filter.  This can be
-           one of :py:attr:`PIL.Image.NEAREST`, :py:attr:`PIL.Image.BOX`,
-           :py:attr:`PIL.Image.BILINEAR`, :py:attr:`PIL.Image.HAMMING`,
-           :py:attr:`PIL.Image.BICUBIC` or :py:attr:`PIL.Image.LANCZOS`.
-           Default filter is :py:attr:`PIL.Image.BICUBIC`.
+           one of :py:data:`PIL.Image.NEAREST`, :py:data:`PIL.Image.BOX`,
+           :py:data:`PIL.Image.BILINEAR`, :py:data:`PIL.Image.HAMMING`,
+           :py:data:`PIL.Image.BICUBIC` or :py:data:`PIL.Image.LANCZOS`.
+           Default filter is :py:data:`PIL.Image.BICUBIC`.
            If the image has mode "1" or "P", it is
-           always set to :py:attr:`PIL.Image.NEAREST`.
+           always set to :py:data:`PIL.Image.NEAREST`.
            See: :ref:`concept-filters`.
         :param box: An optional 4-tuple of floats providing
            the source image region to be scaled.
@@ -1977,12 +1977,12 @@ class Image:
 
         :param angle: In degrees counter clockwise.
         :param resample: An optional resampling filter.  This can be
-           one of :py:attr:`PIL.Image.NEAREST` (use nearest neighbour),
-           :py:attr:`PIL.Image.BILINEAR` (linear interpolation in a 2x2
-           environment), or :py:attr:`PIL.Image.BICUBIC`
+           one of :py:data:`PIL.Image.NEAREST` (use nearest neighbour),
+           :py:data:`PIL.Image.BILINEAR` (linear interpolation in a 2x2
+           environment), or :py:data:`PIL.Image.BICUBIC`
            (cubic spline interpolation in a 4x4 environment).
            If omitted, or if the image has mode "1" or "P", it is
-           set to :py:attr:`PIL.Image.NEAREST`. See :ref:`concept-filters`.
+           set to :py:data:`PIL.Image.NEAREST`. See :ref:`concept-filters`.
         :param expand: Optional expansion flag.  If true, expands the output
            image to make it large enough to hold the entire rotated image.
            If false or omitted, make the output image the same size as the
@@ -2274,10 +2274,10 @@ class Image:
 
         :param size: Requested size.
         :param resample: Optional resampling filter.  This can be one
-           of :py:attr:`PIL.Image.NEAREST`, :py:attr:`PIL.Image.BILINEAR`,
-           :py:attr:`PIL.Image.BICUBIC`, or :py:attr:`PIL.Image.LANCZOS`.
-           If omitted, it defaults to :py:attr:`PIL.Image.BICUBIC`.
-           (was :py:attr:`PIL.Image.NEAREST` prior to version 2.5.0).
+           of :py:data:`PIL.Image.NEAREST`, :py:data:`PIL.Image.BILINEAR`,
+           :py:data:`PIL.Image.BICUBIC`, or :py:data:`PIL.Image.LANCZOS`.
+           If omitted, it defaults to :py:data:`PIL.Image.BICUBIC`.
+           (was :py:data:`PIL.Image.NEAREST` prior to version 2.5.0).
            See: :ref:`concept-filters`.
         :param reducing_gap: Apply optimization by resizing the image
            in two steps. First, reducing the image by integer times
@@ -2341,11 +2341,11 @@ class Image:
 
         :param size: The output size.
         :param method: The transformation method.  This is one of
-          :py:attr:`PIL.Image.EXTENT` (cut out a rectangular subregion),
-          :py:attr:`PIL.Image.AFFINE` (affine transform),
-          :py:attr:`PIL.Image.PERSPECTIVE` (perspective transform),
-          :py:attr:`PIL.Image.QUAD` (map a quadrilateral to a rectangle), or
-          :py:attr:`PIL.Image.MESH` (map a number of source quadrilaterals
+          :py:data:`PIL.Image.EXTENT` (cut out a rectangular subregion),
+          :py:data:`PIL.Image.AFFINE` (affine transform),
+          :py:data:`PIL.Image.PERSPECTIVE` (perspective transform),
+          :py:data:`PIL.Image.QUAD` (map a quadrilateral to a rectangle), or
+          :py:data:`PIL.Image.MESH` (map a number of source quadrilaterals
           in one operation).
 
           It may also be an :py:class:`~PIL.Image.ImageTransformHandler`
@@ -2365,11 +2365,11 @@ class Image:
                     return method, data
         :param data: Extra data to the transformation method.
         :param resample: Optional resampling filter.  It can be one of
-           :py:attr:`PIL.Image.NEAREST` (use nearest neighbour),
-           :py:attr:`PIL.Image.BILINEAR` (linear interpolation in a 2x2
-           environment), or :py:attr:`PIL.Image.BICUBIC` (cubic spline
+           :py:data:`PIL.Image.NEAREST` (use nearest neighbour),
+           :py:data:`PIL.Image.BILINEAR` (linear interpolation in a 2x2
+           environment), or :py:data:`PIL.Image.BICUBIC` (cubic spline
            interpolation in a 4x4 environment). If omitted, or if the image
-           has mode "1" or "P", it is set to :py:attr:`PIL.Image.NEAREST`.
+           has mode "1" or "P", it is set to :py:data:`PIL.Image.NEAREST`.
            See: :ref:`concept-filters`.
         :param fill: If **method** is an
           :py:class:`~PIL.Image.ImageTransformHandler` object, this is one of
@@ -2493,10 +2493,10 @@ class Image:
         """
         Transpose image (flip or rotate in 90 degree steps)
 
-        :param method: One of :py:attr:`PIL.Image.FLIP_LEFT_RIGHT`,
-          :py:attr:`PIL.Image.FLIP_TOP_BOTTOM`, :py:attr:`PIL.Image.ROTATE_90`,
-          :py:attr:`PIL.Image.ROTATE_180`, :py:attr:`PIL.Image.ROTATE_270`,
-          :py:attr:`PIL.Image.TRANSPOSE` or :py:attr:`PIL.Image.TRANSVERSE`.
+        :param method: One of :py:data:`PIL.Image.FLIP_LEFT_RIGHT`,
+          :py:data:`PIL.Image.FLIP_TOP_BOTTOM`, :py:data:`PIL.Image.ROTATE_90`,
+          :py:data:`PIL.Image.ROTATE_180`, :py:data:`PIL.Image.ROTATE_270`,
+          :py:data:`PIL.Image.TRANSPOSE` or :py:data:`PIL.Image.TRANSVERSE`.
         :returns: Returns a flipped or rotated copy of this image.
         """
 


### PR DESCRIPTION
Splitting up #4715.

Add Image constants to docs. Most have a simple note for now, can be expanded if necessary. Filters are linked to concepts as before, I just listed them in `Image` for completeness.

<details><summary>Fixes 81 nitpicky warnings: (click to expand)</summary><p>

```
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.resize:5: WARNING: py:attr reference target not found: PIL.Image.NEAREST
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.resize:5: WARNING: py:attr reference target not found: PIL.Image.BOX
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.resize:5: WARNING: py:attr reference target not found: PIL.Image.BILINEAR
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.resize:5: WARNING: py:attr reference target not found: PIL.Image.HAMMING
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.resize:5: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.resize:5: WARNING: py:attr reference target not found: PIL.Image.LANCZOS
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.resize:5: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.resize:5: WARNING: py:attr reference target not found: PIL.Image.NEAREST
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.rotate:6: WARNING: py:attr reference target not found: PIL.Image.NEAREST
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.rotate:6: WARNING: py:attr reference target not found: PIL.Image.BILINEAR
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.rotate:6: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.rotate:6: WARNING: py:attr reference target not found: PIL.Image.NEAREST
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.thumbnail:14: WARNING: py:attr reference target not found: PIL.Image.NEAREST
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.thumbnail:14: WARNING: py:attr reference target not found: PIL.Image.BILINEAR
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.thumbnail:14: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.thumbnail:14: WARNING: py:attr reference target not found: PIL.Image.LANCZOS
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.thumbnail:14: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.thumbnail:14: WARNING: py:attr reference target not found: PIL.Image.NEAREST
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transform:6: WARNING: py:attr reference target not found: PIL.Image.EXTENT
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transform:6: WARNING: py:attr reference target not found: PIL.Image.AFFINE
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transform:6: WARNING: py:attr reference target not found: PIL.Image.PERSPECTIVE
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transform:6: WARNING: py:attr reference target not found: PIL.Image.QUAD
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transform:6: WARNING: py:attr reference target not found: PIL.Image.MESH
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transform:30: WARNING: py:attr reference target not found: PIL.Image.NEAREST
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transform:30: WARNING: py:attr reference target not found: PIL.Image.BILINEAR
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transform:30: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transform:30: WARNING: py:attr reference target not found: PIL.Image.NEAREST
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transpose:3: WARNING: py:attr reference target not found: PIL.Image.FLIP_LEFT_RIGHT
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transpose:3: WARNING: py:attr reference target not found: PIL.Image.FLIP_TOP_BOTTOM
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transpose:3: WARNING: py:attr reference target not found: PIL.Image.ROTATE_90
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transpose:3: WARNING: py:attr reference target not found: PIL.Image.ROTATE_180
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transpose:3: WARNING: py:attr reference target not found: PIL.Image.ROTATE_270
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transpose:3: WARNING: py:attr reference target not found: PIL.Image.TRANSPOSE
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transpose:3: WARNING: py:attr reference target not found: PIL.Image.TRANSVERSE
-c:\git\pillow\src\PIL\ImageOps.py:docstring of PIL.ImageOps.pad:7: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-c:\git\pillow\src\PIL\ImageOps.py:docstring of PIL.ImageOps.scale:7: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-c:\git\pillow\src\PIL\ImageOps.py:docstring of PIL.ImageOps.fit:9: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:29: WARNING: py:attr reference target not found: PIL.Image.NEAREST
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:29: WARNING: py:attr reference target not found: PIL.Image.BILINEAR
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:29: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:29: WARNING: py:attr reference target not found: PIL.Image.ANTIALIAS
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:39: WARNING: py:attr reference target not found: PIL.Image.BILINEAR
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:39: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:39: WARNING: py:attr reference target not found: PIL.Image.BILINEAR
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:39: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:39: WARNING: py:attr reference target not found: PIL.Image.ANTIALIAS
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:50: WARNING: py:attr reference target not found: PIL.Image.BILINEAR
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:50: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:57: WARNING: py:attr reference target not found: PIL.Image.LANCZOS
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:57: WARNING: py:attr reference target not found: PIL.Image.ANTIALIAS
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:60: WARNING: py:attr reference target not found: PIL.Image.ANTIALIAS
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:60: WARNING: py:attr reference target not found: PIL.Image.ANTIALIAS
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:66: WARNING: py:attr reference target not found: PIL.Image.ANTIALIAS
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:66: WARNING: py:attr reference target not found: PIL.Image.LANCZOS
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:72: WARNING: py:attr reference target not found: PIL.Image.LANCZOS
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:72: WARNING: py:attr reference target not found: PIL.Image.BILINEAR
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:78: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:85: WARNING: py:attr reference target not found: PIL.Image.BILINEAR
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:85: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:85: WARNING: py:attr reference target not found: PIL.Image.BILINEAR
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:85: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:85: WARNING: py:attr reference target not found: PIL.Image.NEAREST
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:85: WARNING: py:attr reference target not found: PIL.Image.NEAREST
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:94: WARNING: py:attr reference target not found: PIL.Image.LANCZOS
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:94: WARNING: py:attr reference target not found: PIL.Image.BILINEAR
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:94: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:103: WARNING: py:attr reference target not found: PIL.Image.NEAREST
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:103: WARNING: py:attr reference target not found: PIL.Image.ANTIALIAS
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:103: WARNING: py:attr reference target not found: PIL.Image.ANTIALIAS
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:103: WARNING: py:attr reference target not found: PIL.Image.BICUBIC
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:103: WARNING: py:attr reference target not found: PIL.Image.ANTIALIAS
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:114: WARNING: py:attr reference target not found: PIL.Image.TRANSPOSE
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:114: WARNING: py:attr reference target not found: PIL.Image.FLIP_LEFT_RIGHT
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:114: WARNING: py:attr reference target not found: PIL.Image.FLIP_TOP_BOTTOM
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:114: WARNING: py:attr reference target not found: PIL.Image.ROTATE_90
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:114: WARNING: py:attr reference target not found: PIL.Image.ROTATE_180
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:114: WARNING: py:attr reference target not found: PIL.Image.ROTATE_270
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:114: WARNING: py:attr reference target not found: PIL.Image.TRANSPOSE
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:121: WARNING: py:attr reference target not found: PIL.Image.ROTATE_90
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:121: WARNING: py:attr reference target not found: PIL.Image.ROTATE_270
-C:\Git\Pillow\docs\releasenotes\2.7.0.rst:121: WARNING: py:attr reference target not found: PIL.Image.TRANSPOSE
```

</p></details>