### PR TITLE
Fix documentation references: omitted Image functions

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -8,7 +8,7 @@ Over 30 different file formats can be identified and read by the library.
 Write support is less extensive, but most common interchange and presentation
 formats are supported.
 
-The :py:meth:`~PIL.Image.Image.open` function identifies files from their
+The :py:meth:`~PIL.Image.open` function identifies files from their
 contents, not their names, but the :py:meth:`~PIL.Image.Image.save` method
 looks at the name to determine which format to use, unless the format is given
 explicitly.
@@ -25,7 +25,7 @@ Pillow reads and writes Windows and OS/2 BMP files containing ``1``, ``L``, ``P`
 or ``RGB`` data. 16-colour images are read as ``P`` images. Run-length encoding
 is not supported.
 
-The :py:meth:`~PIL.Image.Image.open` method sets the following
+The :py:meth:`~PIL.Image.open` method sets the following
 :py:attr:`~PIL.Image.Image.info` properties:
 
 **compression**
@@ -74,7 +74,7 @@ are used or GIF89a is already in use.
 Note that GIF files are always read as grayscale (``L``)
 or palette mode (``P``) images.
 
-The :py:meth:`~PIL.Image.Image.open` method sets the following
+The :py:meth:`~PIL.Image.open` method sets the following
 :py:attr:`~PIL.Image.Image.info` properties:
 
 **background**
@@ -203,7 +203,7 @@ ICNS
 Pillow reads and (macOS only) writes macOS ``.icns`` files.  By default, the
 largest available icon is read, though you can override this by setting the
 :py:attr:`~PIL.Image.Image.size` property before calling
-:py:meth:`~PIL.Image.Image.load`.  The :py:meth:`~PIL.Image.Image.open` method
+:py:meth:`~PIL.Image.Image.load`.  The :py:meth:`~PIL.Image.open` method
 sets the following :py:attr:`~PIL.Image.Image.info` property:
 
 **sizes**
@@ -257,7 +257,7 @@ Using the :py:meth:`~PIL.Image.Image.draft` method, you can speed things up by
 converting ``RGB`` images to ``L``, and resize images to 1/2, 1/4 or 1/8 of
 their original size while loading them.
 
-The :py:meth:`~PIL.Image.Image.open` method may set the following
+The :py:meth:`~PIL.Image.open` method may set the following
 :py:attr:`~PIL.Image.Image.info` properties if available:
 
 **jfif**
@@ -697,7 +697,7 @@ Pillow also reads SPIDER stack files containing sequences of SPIDER images. The
 :py:meth:`~PIL.Image.Image.seek` and :py:meth:`~PIL.Image.Image.tell` methods are supported, and
 random access is allowed.
 
-The :py:meth:`~PIL.Image.Image.open` method sets the following attributes:
+The :py:meth:`~PIL.Image.open` method sets the following attributes:
 
 **format**
     Set to ``SPIDER``
@@ -750,7 +750,7 @@ uncompressed files.
     support for reading Packbits, LZW and JPEG compressed TIFFs
     without using libtiff.
 
-The :py:meth:`~PIL.Image.Image.open` method sets the following
+The :py:meth:`~PIL.Image.open` method sets the following
 :py:attr:`~PIL.Image.Image.info` properties:
 
 **compression**
@@ -1021,7 +1021,7 @@ FLI, FLC
 
 Pillow reads Autodesk FLI and FLC animations.
 
-The :py:meth:`~PIL.Image.Image.open` method sets the following
+The :py:meth:`~PIL.Image.open` method sets the following
 :py:attr:`~PIL.Image.Image.info` properties:
 
 **duration**
@@ -1054,7 +1054,7 @@ GBR
 
 The GBR decoder reads GIMP brush files, version 1 and 2.
 
-The :py:meth:`~PIL.Image.Image.open` method sets the following
+The :py:meth:`~PIL.Image.open` method sets the following
 :py:attr:`~PIL.Image.Image.info` properties:
 
 **comment**
@@ -1069,7 +1069,7 @@ GD
 Pillow reads uncompressed GD2 files. Note that you must use
 :py:func:`PIL.GdImageFile.open` to read such a file.
 
-The :py:meth:`~PIL.Image.Image.open` method sets the following
+The :py:meth:`~PIL.Image.open` method sets the following
 :py:attr:`~PIL.Image.Image.info` properties:
 
 **transparency**
@@ -1185,7 +1185,7 @@ XPM
 
 Pillow reads X pixmap files (mode ``P``) with 256 colors or less.
 
-The :py:meth:`~PIL.Image.Image.open` method sets the following
+The :py:meth:`~PIL.Image.open` method sets the following
 :py:attr:`~PIL.Image.Image.info` properties:
 
 **transparency**

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -76,8 +76,15 @@ Constructing images
 .. autofunction:: new
 .. autofunction:: fromarray
 .. autofunction:: frombytes
-.. autofunction:: fromstring
 .. autofunction:: frombuffer
+
+Generating images
+^^^^^^^^^^^^^^^^^
+
+.. autofunction:: effect_mandelbrot
+.. autofunction:: effect_noise
+.. autofunction:: linear_gradient
+.. autofunction:: radial_gradient
 
 Registering plugins
 ^^^^^^^^^^^^^^^^^^^
@@ -88,12 +95,14 @@ Registering plugins
     ignore them.
 
 .. autofunction:: register_open
-.. autofunction:: register_decoder
 .. autofunction:: register_mime
 .. autofunction:: register_save
-.. autofunction:: register_encoder
+.. autofunction:: register_save_all
 .. autofunction:: register_extension
-
+.. autofunction:: register_extensions
+.. autofunction:: registered_extensions
+.. autofunction:: register_decoder
+.. autofunction:: register_encoder
 
 The Image Class
 ---------------
@@ -140,6 +149,8 @@ This crops the input image with the provided coordinates:
 
 
 .. automethod:: PIL.Image.Image.draft
+.. automethod:: PIL.Image.Image.effect_spread
+.. automethod:: PIL.Image.Image.entropy
 .. automethod:: PIL.Image.Image.filter
 
 This blurs the input image using a filter from the ``ImageFilter`` module:
@@ -176,12 +187,14 @@ This helps to get the bounding box coordinates of the input image:
     print(im.getbbox())
     # Returns four coordinates in the format (left, upper, right, lower)
 
+.. automethod:: PIL.Image.Image.getchannel
 .. automethod:: PIL.Image.Image.getcolors
 .. automethod:: PIL.Image.Image.getdata
-.. automethod:: PIL.Image.Image.getextrema
 .. automethod:: PIL.Image.Image.getexif
+.. automethod:: PIL.Image.Image.getextrema
 .. automethod:: PIL.Image.Image.getpalette
 .. automethod:: PIL.Image.Image.getpixel
+.. automethod:: PIL.Image.Image.getprojection
 .. automethod:: PIL.Image.Image.histogram
 .. automethod:: PIL.Image.Image.offset
 .. automethod:: PIL.Image.Image.paste
@@ -191,6 +204,8 @@ This helps to get the bounding box coordinates of the input image:
 .. automethod:: PIL.Image.Image.putpalette
 .. automethod:: PIL.Image.Image.putpixel
 .. automethod:: PIL.Image.Image.quantize
+.. automethod:: PIL.Image.Image.reduce
+.. automethod:: PIL.Image.Image.remap_palette
 .. automethod:: PIL.Image.Image.resize
 
 This resizes the given image from ``(width, height)`` to ``(width/2, height/2)``:
@@ -205,7 +220,6 @@ This resizes the given image from ``(width, height)`` to ``(width/2, height/2)``
     (width, height) = (im.width // 2, im.height // 2)
     im_resized = im.resize((width, height))
 
-.. automethod:: PIL.Image.Image.remap_palette
 .. automethod:: PIL.Image.Image.rotate
 
 This rotates the input image by ``theta`` degrees counter clockwise:
@@ -225,7 +239,6 @@ This rotates the input image by ``theta`` degrees counter clockwise:
 .. automethod:: PIL.Image.Image.seek
 .. automethod:: PIL.Image.Image.show
 .. automethod:: PIL.Image.Image.split
-.. automethod:: PIL.Image.Image.getchannel
 .. automethod:: PIL.Image.Image.tell
 .. automethod:: PIL.Image.Image.thumbnail
 .. automethod:: PIL.Image.Image.tobitmap

--- a/src/PIL/ImageDraw2.py
+++ b/src/PIL/ImageDraw2.py
@@ -106,7 +106,7 @@ class Draw:
 
     def chord(self, xy, start, end, *options):
         """
-        Same as :py:meth:`~PIL.ImageDraw2.ImageDraw.arc`, but connects the end points
+        Same as :py:meth:`~PIL.ImageDraw2.Draw.arc`, but connects the end points
         with a straight line.
 
         .. seealso:: :py:meth:`PIL.ImageDraw.ImageDraw.chord`


### PR DESCRIPTION
Splitting up #4715.

Add docs for functions omitted from `Image`, and sort them. There are still a few more missing functions, but most of them seem to be quite obscure.

Also fix a typo in `ImageDraw2` docs.

<details><summary>Fixes 15 nitpicky warnings: (click to expand)</summary><p>

```
-c:\git\pillow\src\PIL\ImageDraw2.py:docstring of PIL.ImageDraw2.Draw.chord:1: WARNING: py:meth reference target not found: PIL.ImageDraw2.ImageDraw.arc
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:11: WARNING: py:meth reference target not found: PIL.Image.Image.open
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:28: WARNING: py:meth reference target not found: PIL.Image.Image.open
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:77: WARNING: py:meth reference target not found: PIL.Image.Image.open
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:203: WARNING: py:meth reference target not found: PIL.Image.Image.open
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:260: WARNING: py:meth reference target not found: PIL.Image.Image.open
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:700: WARNING: py:meth reference target not found: PIL.Image.Image.open
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:753: WARNING: py:meth reference target not found: PIL.Image.Image.open
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:1024: WARNING: py:meth reference target not found: PIL.Image.Image.open
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:1057: WARNING: py:meth reference target not found: PIL.Image.Image.open
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:1072: WARNING: py:meth reference target not found: PIL.Image.Image.open
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:1188: WARNING: py:meth reference target not found: PIL.Image.Image.open
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.resize:17: WARNING: py:meth reference target not found: PIL.Image.Image.reduce
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.thumbnail:20: WARNING: py:meth reference target not found: PIL.Image.Image.reduce
-C:\Git\Pillow\docs\releasenotes\7.0.0.rst:112: WARNING: py:meth reference target not found: PIL.Image.Image.reduce
```

</p></details>