### PR TITLE
Add gitignore to winbuild build directory

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -553,5 +553,6 @@ if __name__ == "__main__":
 
     print()
 
+    write_script(".gitignore", ["*"])
     build_dep_all()
     build_pillow()


### PR DESCRIPTION
The default path is currently ignored with the [`build/` line](https://github.com/python-pillow/Pillow/blob/b4e7202dcb7235642f6e6a050c9485070ae6ea4f/.gitignore#L13), but this would be removed by #3062. Additionally, the directory is configurable with a parameter.

Adding a `*` gitignore to the generated build directory prevents it from being committed by accident in these cases.