### PR TITLE
Do not convert I;16 image when showing PNG

### DIFF
--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -71,7 +71,8 @@ class Viewer:
 
         # save temporary image to disk
         if not (
-            image.mode in ("1", "RGBA") or (self.format == "PNG" and image.mode == "LA")
+            image.mode in ("1", "RGBA")
+            or (self.format == "PNG" and image.mode in ("I;16", "LA"))
         ):
             base = Image.getmodebase(image.mode)
             if image.mode != base:


### PR DESCRIPTION
Resolves #4729

As explained in https://github.com/python-pillow/Pillow/issues/4729#issuecomment-650178611, PNG can save I;16 images. Since Pillow has flawed I;16 conversion, avoiding conversion in this case fixes incorrect displaying of the image.