### PR TITLE
Simplify GHA config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           lint-pip-
 
     - name: pre-commit cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.cache/pre-commit
         key: lint-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
@@ -32,7 +32,7 @@ jobs:
           lint-pre-commit-
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    name: Python ${{ matrix.python-version }}
+    name: Lint
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,9 +6,6 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.8"]
 
     name: Python ${{ matrix.python-version }}
 
@@ -31,18 +28,18 @@ jobs:
         restore-keys: |
           lint-pre-commit-
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.8
 
     - name: Build system information
       run: python .github/workflows/system-info.py
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade tox
+        python -m pip install -U pip
+        python -m pip install -U tox
 
     - name: Lint
       run: tox -e lint

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -36,7 +36,7 @@ jobs:
         path: winbuild\depends
 
     - name: Cache pip
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~\AppData\Local\pip\Cache
         key:
@@ -47,7 +47,7 @@ jobs:
 
     # sets env: pythonLocation
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}
@@ -128,7 +128,7 @@ jobs:
       shell: pwsh
 
     - name: Upload errors
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       if: failure()
       with:
         name: errors

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,30 +36,24 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Ubuntu cache
-      uses: actions/cache@v2
-      if: startsWith(matrix.os, 'ubuntu')
-      with:
-        path: ~/.cache/pip
-        key:
-          ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/.ci/*.sh') }}
-        restore-keys: |
-          ${{ matrix.os }}-${{ matrix.python-version }}-
-
-    - name: macOS cache
-      uses: actions/cache@v2
-      if: startsWith(matrix.os, 'macOS')
-      with:
-        path: ~/Library/Caches/pip
-        key:
-          ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/.ci/*.sh') }}
-        restore-keys: |
-          ${{ matrix.os }}-${{ matrix.python-version }}-
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+
+    - name: pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key:
+          ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/.ci/*.sh') }}
+        restore-keys: |
+          ${{ matrix.os }}-${{ matrix.python-version }}-
 
     - name: Build system information
       run: python .github/workflows/system-info.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Ubuntu cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       if: startsWith(matrix.os, 'ubuntu')
       with:
         path: ~/.cache/pip
@@ -47,7 +47,7 @@ jobs:
           ${{ matrix.os }}-${{ matrix.python-version }}-
 
     - name: macOS cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       if: startsWith(matrix.os, 'macOS')
       with:
         path: ~/Library/Caches/pip
@@ -57,7 +57,7 @@ jobs:
           ${{ matrix.os }}-${{ matrix.python-version }}-
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -89,7 +89,7 @@ jobs:
       shell: pwsh
 
     - name: Upload errors
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       if: failure()
       with:
         name: errors


### PR DESCRIPTION
Simplify some GitHub Actions config:

* Don't need a matrix of one version for linting
* Since pip 20.1, we can use `pip cache dir` to combine macOS/Ubuntu cache config ([example](https://github.com/actions/cache/blob/master/examples.md#using-pip-to-get-cache-location))
* Also update some actions to v2