### PR TITLE
Allow ImageOps.autocontrast to specify low and high cutoffs separately

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -300,3 +300,9 @@ def test_exif_transpose():
                     "Tests/images/hopper_orientation_" + str(i) + ext
                 ) as orientation_im:
                     check(orientation_im)
+
+def test_autocontrast_cutoff():
+    # Test the cutoff argument of autocontrast
+    with Image.open("Tests/images/bw_gradient.png") as img:
+        assert  ImageOps.autocontrast(img, cutoff=10).getdata() == ImageOps.autocontrast(img, cutoff=(10,10)).getdata()
+        assert  ImageOps.autocontrast(img, cutoff=10).getdata() != ImageOps.autocontrast(img, cutoff=(1,10)).getdata()

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -304,5 +304,5 @@ def test_exif_transpose():
 def test_autocontrast_cutoff():
     # Test the cutoff argument of autocontrast
     with Image.open("Tests/images/bw_gradient.png") as img:
-        assert  ImageOps.autocontrast(img, cutoff=10).getdata() == ImageOps.autocontrast(img, cutoff=(10,10)).getdata()
-        assert  ImageOps.autocontrast(img, cutoff=10).getdata() != ImageOps.autocontrast(img, cutoff=(1,10)).getdata()
+        assert  ImageOps.autocontrast(img, cutoff=10).histogram() == ImageOps.autocontrast(img, cutoff=(10,10)).histogram()
+        assert  ImageOps.autocontrast(img, cutoff=10).histogram() != ImageOps.autocontrast(img, cutoff=(1,10)).histogram()

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -301,8 +301,15 @@ def test_exif_transpose():
                 ) as orientation_im:
                     check(orientation_im)
 
+
 def test_autocontrast_cutoff():
     # Test the cutoff argument of autocontrast
     with Image.open("Tests/images/bw_gradient.png") as img:
-        assert  ImageOps.autocontrast(img, cutoff=10).histogram() == ImageOps.autocontrast(img, cutoff=(10,10)).histogram()
-        assert  ImageOps.autocontrast(img, cutoff=10).histogram() != ImageOps.autocontrast(img, cutoff=(1,10)).histogram()
+        assert (
+            ImageOps.autocontrast(img, cutoff=10).histogram()
+            == ImageOps.autocontrast(img, cutoff=(10, 10)).histogram()
+        )
+        assert (
+            ImageOps.autocontrast(img, cutoff=10).histogram()
+            != ImageOps.autocontrast(img, cutoff=(1, 10)).histogram()
+        )

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -88,12 +88,8 @@ def autocontrast(image, cutoff=0, ignore=None):
                     h[ix] = 0
         if cutoff:
             # cut off pixels from both ends of the histogram
-            if isinstance(cutoff, int):
+            if not isinstance(cutoff, tuple):
                 cutoff = (cutoff, cutoff)
-            elif isinstance(cutoff, tuple):
-                pass
-            else:
-                raise ValueError("the cutoff can only be a integer or tuple")
             # get number of pixels
             n = 0
             for ix in range(256):

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -88,12 +88,18 @@ def autocontrast(image, cutoff=0, ignore=None):
                     h[ix] = 0
         if cutoff:
             # cut off pixels from both ends of the histogram
+            if isinstance(cutoff, int):
+                cutoff = (cutoff, cutoff)
+            elif isinstance(cutoff, tuple):
+                pass
+            else:
+                raise ValueError("the cutoff can only be a integer or tuple")
             # get number of pixels
             n = 0
             for ix in range(256):
                 n = n + h[ix]
             # remove cutoff% pixels from the low end
-            cut = n * cutoff // 100
+            cut = n * cutoff[0] // 100
             for lo in range(256):
                 if cut > h[lo]:
                     cut = cut - h[lo]
@@ -104,7 +110,7 @@ def autocontrast(image, cutoff=0, ignore=None):
                 if cut <= 0:
                     break
             # remove cutoff% samples from the hi end
-            cut = n * cutoff // 100
+            cut = n * cutoff[1] // 100
             for hi in range(255, -1, -1):
                 if cut > h[hi]:
                     cut = cut - h[hi]


### PR DESCRIPTION
Fixes #4731 

 ### Autocontrast enhancement:

Added the ability to change the hi and low cutoff separately without causing backwards comparability issue

Changes proposed in this pull request:

The user should be allowed to change the values of the left and right side of the histogram separately so:

 * added a tuple to control the high and low values separately (cutoff[0] is for low end and cutoff[1] is for hi end)
 * to ensure backwards comparability I added a way to turn integer to a tuple so the program works both ways
