### PR TITLE
Fixed comparison warnings

### DIFF
--- a/src/libImaging/Jpeg2KDecode.c
+++ b/src/libImaging/Jpeg2KDecode.c
@@ -742,8 +742,8 @@ j2k_decode_entry(Imaging im, ImagingCodecState state)
            swapped), bail. */
         if (tile_info.x0 >= tile_info.x1
             || tile_info.y0 >= tile_info.y1
-            || tile_info.x0 < image->x0
-            || tile_info.y0 < image->y0
+            || tile_info.x0 < (OPJ_INT32)image->x0
+            || tile_info.y0 < (OPJ_INT32)image->y0
             || tile_info.x1 - image->x0 > im->xsize
             || tile_info.y1 - image->y0 > im->ysize) {
             state->errcode = IMAGING_CODEC_BROKEN;

--- a/src/path.c
+++ b/src/path.c
@@ -56,7 +56,7 @@ alloc_array(Py_ssize_t count)
         PyErr_NoMemory();
         return NULL;
     }
-    if (count > (SIZE_MAX / (2 * sizeof(double))) - 1 ) {
+    if ((unsigned long long)count > (SIZE_MAX / (2 * sizeof(double))) - 1 ) {
         PyErr_NoMemory();
         return NULL;
     }


### PR DESCRIPTION
Helps #4586

Jpeg2KDecode.c - [before](https://travis-ci.org/github/python-pillow/Pillow/jobs/703615504#L2422-L2435) and [after](https://travis-ci.org/github/python-pillow/Pillow/jobs/703893359#L2337-L2344)
path.c - [before](https://travis-ci.org/github/python-pillow/Pillow/jobs/703615504#L2319-L2323) and [after](https://travis-ci.org/github/python-pillow/Pillow/jobs/703893359#L2237)