### PR TITLE
Minor fix: remove str(bytes) call

### DIFF
--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -776,7 +776,7 @@ class ImageFileDirectory_v2(MutableMapping):
                 self.tagtype[tag] = typ
 
                 msg += " - value: " + (
-                    "<table: %d bytes>" % size if size > 32 else str(data)
+                    "<table: %d bytes>" % size if size > 32 else repr(data)
                 )
                 logger.debug(msg)
 

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -993,7 +993,7 @@ class TiffImageFile(ImageFile.ImageFile):
 
         logger.debug("*** TiffImageFile._open ***")
         logger.debug("- __first: {}".format(self.__first))
-        logger.debug("- ifh: {}".format(ifh))
+        logger.debug("- ifh: {!r}".format(ifh))  # Use !r to avoid str(bytes)
 
         # and load the first frame
         self._seek(0)


### PR DESCRIPTION
Some environments have strict mode to catch potential str<>bytes error. This is triggered by this line:

```
TiffImagePlugin.py3", line 996, in _open
    logger.debug("- ifh: {}".format(ifh))
BytesWarning: str() on a bytes instance
```

