### PR TITLE
Remove unused externs from Imaging.h

### DIFF
--- a/src/libImaging/Imaging.h
+++ b/src/libImaging/Imaging.h
@@ -185,8 +185,6 @@ extern Imaging ImagingNew2Dirty(const char* mode, Imaging imOut, Imaging imIn);
 extern void    ImagingDelete(Imaging im);
 
 extern Imaging ImagingNewBlock(const char* mode, int xsize, int ysize);
-extern Imaging ImagingNewMap(const char* filename, int readonly,
-                             const char* mode, int xsize, int ysize);
 
 extern Imaging ImagingNewPrologue(const char *mode,
                                   int xsize, int ysize);
@@ -348,9 +346,6 @@ extern Imaging ImagingChopAnd(Imaging imIn1, Imaging imIn2);
 extern Imaging ImagingChopOr(Imaging imIn1, Imaging imIn2);
 extern Imaging ImagingChopXor(Imaging imIn1, Imaging imIn2);
 
-/* Image measurement */
-extern void ImagingCrack(Imaging im, int x0, int y0);
-
 /* Graphics */
 extern int ImagingDrawArc(Imaging im, int x0, int y0, int x1, int y1,
                           float start, float end, const void* ink, int width,
@@ -396,10 +391,6 @@ extern Imaging ImagingEffectNoise(int xsize, int ysize, float sigma);
 extern Imaging ImagingEffectMandelbrot(int xsize, int ysize,
                                        double extent[4], int quality);
 
-/* Obsolete */
-extern int ImagingToString(Imaging im, int orientation, char *buffer);
-extern int ImagingFromString(Imaging im, int orientation, char *buffer);
-
 
 /* File I/O */
 /* -------- */
@@ -407,9 +398,6 @@ extern int ImagingFromString(Imaging im, int orientation, char *buffer);
 /* Built-in drivers */
 extern Imaging ImagingOpenPPM(const char* filename);
 extern int ImagingSavePPM(Imaging im, const char* filename);
-
-/* Utility functions */
-extern UINT32 ImagingCRC32(UINT32 crc, UINT8* buffer, int bytes);
 
 /* Codecs */
 typedef struct ImagingCodecStateInstance *ImagingCodecState;
@@ -473,7 +461,6 @@ extern int ImagingRawEncode(Imaging im, ImagingCodecState state,
                             UINT8* buffer, int bytes);
 extern int ImagingSgiRleDecode(Imaging im, ImagingCodecState state,
                                UINT8* buffer, Py_ssize_t bytes);
-extern int ImagingSgiRleDecodeCleanup(ImagingCodecState state);
 extern int ImagingSunRleDecode(Imaging im, ImagingCodecState state,
                                UINT8* buffer, Py_ssize_t bytes);
 extern int ImagingTgaRleDecode(Imaging im, ImagingCodecState state,


### PR DESCRIPTION
There's no other reference to these in the codebase, except this one in the changelog:

```
(0.3a2 released)
...
+ Removed bogus references to the crack coder (ImagingCrack).
```
