### PR TITLE
Use sphinx_removed_in and re-document deprecated versions of removals

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Docs
       if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == 3.8
       run: |
-        pip install sphinx-rtd-theme
+        pip install sphinx-removed-in sphinx-rtd-theme
         make doccheck
 
     - name: After success

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,12 @@ needs_sphinx = "2.4"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode", "sphinx.ext.intersphinx"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
+    "sphinx_removed_in",
+]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -78,6 +78,7 @@ period of deprecation has passed.
 Python 2.7
 ~~~~~~~~~~
 
+.. deprecated:: 6.0.0
 .. versionremoved:: 7.0.0
 
 Python 2.7 reached end-of-life on 2020-01-01. Pillow 6.x was the last series to
@@ -86,6 +87,7 @@ support Python 2.
 Image.__del__
 ~~~~~~~~~~~~~
 
+.. deprecated:: 6.1.0
 .. versionremoved:: 7.0.0
 
 Implicitly closing the image's underlying file in ``Image.__del__`` has been removed.
@@ -109,6 +111,7 @@ Use instead:
 PIL.*ImagePlugin.__version__ attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. deprecated:: 6.0.0
 .. versionremoved:: 7.0.0
 
 The version constants of individual plugins have been removed. Use ``PIL.__version__``
@@ -134,6 +137,7 @@ Removed                          Removed                            Removed
 PyQt4 and PySide
 ~~~~~~~~~~~~~~~~
 
+.. deprecated:: 6.0.0
 .. versionremoved:: 7.0.0
 
 Qt 4 reached end-of-life on 2015-12-19. Its Python bindings are also EOL: PyQt4 since
@@ -145,6 +149,7 @@ or PySide2.
 Setting the size of TIFF images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. deprecated:: 5.3.0
 .. versionremoved:: 7.0.0
 
 Setting the size of a TIFF image directly (eg. ``im.size = (256, 256)``) throws
@@ -153,6 +158,7 @@ an error. Use ``Image.resize`` instead.
 VERSION constant
 ~~~~~~~~~~~~~~~~
 
+.. deprecated:: 5.2.0
 .. versionremoved:: 6.0.0
 
 ``VERSION`` (the old PIL version, always 1.1.7) has been removed. Use
@@ -161,6 +167,7 @@ VERSION constant
 Undocumented ImageOps functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. deprecated:: 4.3.0
 .. versionremoved:: 6.0.0
 
 Several undocumented functions in ``ImageOps`` have been removed. Use the equivalents
@@ -179,6 +186,7 @@ Removed                     Use instead
 PIL.OleFileIO
 ~~~~~~~~~~~~~
 
+.. deprecated:: 4.0.0
 .. versionremoved:: 6.0.0
 
 PIL.OleFileIO was removed as a vendored file and in Pillow 4.0.0 (2017-01) in favour of

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -78,7 +78,7 @@ period of deprecation has passed.
 Python 2.7
 ~~~~~~~~~~
 
-*Removed in version 7.0.0.*
+.. versionremoved:: 7.0.0
 
 Python 2.7 reached end-of-life on 2020-01-01. Pillow 6.x was the last series to
 support Python 2.
@@ -86,7 +86,7 @@ support Python 2.
 Image.__del__
 ~~~~~~~~~~~~~
 
-*Removed in version 7.0.0.*
+.. versionremoved:: 7.0.0
 
 Implicitly closing the image's underlying file in ``Image.__del__`` has been removed.
 Use a context manager or call ``Image.close()`` instead to close the file in a
@@ -109,7 +109,7 @@ Use instead:
 PIL.*ImagePlugin.__version__ attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 7.0.0.*
+.. versionremoved:: 7.0.0
 
 The version constants of individual plugins have been removed. Use ``PIL.__version__``
 instead.
@@ -134,7 +134,7 @@ Removed                          Removed                            Removed
 PyQt4 and PySide
 ~~~~~~~~~~~~~~~~
 
-*Removed in version 7.0.0.*
+.. versionremoved:: 7.0.0
 
 Qt 4 reached end-of-life on 2015-12-19. Its Python bindings are also EOL: PyQt4 since
 2018-08-31 and PySide since 2015-10-14.
@@ -145,7 +145,7 @@ or PySide2.
 Setting the size of TIFF images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 7.0.0.*
+.. versionremoved:: 7.0.0
 
 Setting the size of a TIFF image directly (eg. ``im.size = (256, 256)``) throws
 an error. Use ``Image.resize`` instead.
@@ -153,7 +153,7 @@ an error. Use ``Image.resize`` instead.
 VERSION constant
 ~~~~~~~~~~~~~~~~
 
-*Removed in version 6.0.0.*
+.. versionremoved:: 6.0.0
 
 ``VERSION`` (the old PIL version, always 1.1.7) has been removed. Use
 ``__version__`` instead.
@@ -161,7 +161,7 @@ VERSION constant
 Undocumented ImageOps functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Removed in version 6.0.0.*
+.. versionremoved:: 6.0.0
 
 Several undocumented functions in ``ImageOps`` have been removed. Use the equivalents
 in ``ImageFilter`` instead:
@@ -179,7 +179,7 @@ Removed                     Use instead
 PIL.OleFileIO
 ~~~~~~~~~~~~~
 
-*Removed in version 6.0.0.*
+.. versionremoved:: 6.0.0
 
 PIL.OleFileIO was removed as a vendored file and in Pillow 4.0.0 (2017-01) in favour of
 the upstream olefile Python package, and replaced with an ``ImportError`` in 5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ pyroma
 pytest
 pytest-cov
 sphinx>=2.4
+sphinx-removed-in
 sphinx-rtd-theme


### PR DESCRIPTION
Changes proposed in this pull request:

 * Use the `sphinx_removed_in` extension for the `.. versionremoved::` directive
 * Re-document deprecated versions of removals, it could be useful to know

