### PR TITLE
Remove ImageCms.CmsProfile attributes deprecated since 3.2.0

### DIFF
--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -435,39 +435,6 @@ def test_extended_information():
     assert p.xcolor_space == "RGB "
 
 
-def test_deprecations():
-    skip_missing()
-    o = ImageCms.getOpenProfile(SRGB)
-    p = o.profile
-
-    def helper_deprecated(attr, expected):
-        result = pytest.warns(DeprecationWarning, getattr, p, attr)
-        assert result == expected
-
-    # p.color_space
-    helper_deprecated("color_space", "RGB")
-
-    # p.pcs
-    helper_deprecated("pcs", "XYZ")
-
-    # p.product_copyright
-    helper_deprecated(
-        "product_copyright", "Copyright International Color Consortium, 2009"
-    )
-
-    # p.product_desc
-    helper_deprecated("product_desc", "sRGB IEC61966-2-1 black scaled")
-
-    # p.product_description
-    helper_deprecated("product_description", "sRGB IEC61966-2-1 black scaled")
-
-    # p.product_manufacturer
-    helper_deprecated("product_manufacturer", "")
-
-    # p.product_model
-    helper_deprecated("product_model", "IEC 61966-2-1 Default RGB Colour Space - sRGB")
-
-
 def test_profile_typesafety():
     """ Profile init type safety
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -49,16 +49,23 @@ PILLOW_VERSION constant
 It was initially removed in Pillow 7.0.0, but brought back in 7.1.0 to give projects
 more time to upgrade.
 
+Removed features
+----------------
+
+Deprecated features are only removed in major releases after an appropriate
+period of deprecation has passed.
+
 ImageCms.CmsProfile attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. deprecated:: 3.2.0
+.. versionremoved:: 8.0.0
 
-Some attributes in ``ImageCms.CmsProfile`` are deprecated. From 6.0.0, they issue a
+Some attributes in ``ImageCms.CmsProfile`` have been removed. From 6.0.0, they issued a
 ``DeprecationWarning``:
 
 ========================  ===============================
-Deprecated                Use instead
+Removed                   Use instead
 ========================  ===============================
 ``color_space``           Padded ``xcolor_space``
 ``pcs``                   Padded ``connection_space``
@@ -68,12 +75,6 @@ Deprecated                Use instead
 ``product_manufacturer``  Unicode ``manufacturer``
 ``product_model``         Unicode ``model``
 ========================  ===============================
-
-Removed features
-----------------
-
-Deprecated features are only removed in major releases after an appropriate
-period of deprecation has passed.
 
 Python 2.7
 ~~~~~~~~~~

--- a/docs/reference/ImageCms.rst
+++ b/docs/reference/ImageCms.rst
@@ -75,19 +75,12 @@ can be easily displayed in a chromaticity diagram, for example).
         space, e.g. ``XYZ␣``, ``RGB␣`` or ``CMYK`` (see 7.2.6 of
         ICC.1:2010 for details).
 
-        Note that the deprecated attribute ``color_space`` contains an
-        interpreted (non-padded) variant of this (but can be empty on
-        unknown input).
-
     .. py:attribute:: connection_space
         :type: str
 
         4-character string (padded with whitespace) identifying the color
         space on the B-side of the transform (see 7.2.7 of ICC.1:2010 for
         details).
-
-        Note that the deprecated attribute ``pcs`` contains an interpreted
-        (non-padded) variant of this (but can be empty on unknown input).
 
     .. py:attribute:: header_flags
         :type: int
@@ -349,55 +342,6 @@ can be easily displayed in a chromaticity diagram, for example).
 
         The elements of the tuple are booleans.  If the value is ``True``,
         that intent is supported for that direction.
-
-    .. py:attribute:: color_space
-        :type: str
-
-        Deprecated but retained for backwards compatibility.
-        Interpreted value of :py:attr:`.xcolor_space`.  May be the
-        empty string if value could not be decoded.
-
-    .. py:attribute:: pcs
-        :type: str
-
-        Deprecated but retained for backwards compatibility.
-        Interpreted value of :py:attr:`.connection_space`.  May be
-        the empty string if value could not be decoded.
-
-    .. py:attribute:: product_model
-        :type: str
-
-        Deprecated but retained for backwards compatibility.
-        ASCII-encoded value of :py:attr:`.model`.
-
-    .. py:attribute:: product_manufacturer
-        :type: str
-
-        Deprecated but retained for backwards compatibility.
-        ASCII-encoded value of :py:attr:`.manufacturer`.
-
-    .. py:attribute:: product_copyright
-        :type: str
-
-        Deprecated but retained for backwards compatibility.
-        ASCII-encoded value of :py:attr:`.copyright`.
-
-    .. py:attribute:: product_description
-        :type: str
-
-        Deprecated but retained for backwards compatibility.
-        ASCII-encoded value of :py:attr:`.profile_description`.
-
-    .. py:attribute:: product_desc
-        :type: str
-
-        Deprecated but retained for backwards compatibility.
-        ASCII-encoded value of :py:attr:`.profile_description`.
-
-        This alias of :py:attr:`.product_description` used to
-        contain a derived informative string about the profile,
-        depending on the value of the description, copyright,
-        manufacturer and model fields).
 
     There is one function defined on the class:
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * These have been deprecated since Pillow 3.2.0 (April 2016)
 * and given `DeprecationWarning` since 6.0.0 (April 2019)
 * and can be removed in 8.0.0 (October 2020)
