### PR TITLE
Fix some documentation references

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -774,7 +774,7 @@ The :py:meth:`~PIL.Image.open` method sets the following
 
 The :py:attr:`~PIL.Image.Image.tag_v2` attribute contains a dictionary
 of TIFF metadata. The keys are numerical indexes from
-:py:attr:`~PIL.TiffTags.TAGS_V2`.  Values are strings or numbers for single
+:py:data:`.TiffTags.TAGS_V2`.  Values are strings or numbers for single
 items, multiple values are returned in a tuple of values. Rational
 numbers are returned as a :py:class:`~PIL.TiffImagePlugin.IFDRational`
 object.
@@ -827,7 +827,7 @@ The :py:meth:`~PIL.Image.Image.save` method can take the following keyword argum
     object and setting the type in
     :py:attr:`~PIL.TiffImagePlugin.ImageFileDirectory_v2.tagtype` with
     the appropriate numerical value from
-    ``TiffTags.TYPES``.
+    :py:data:`.TiffTags.TYPES`.
 
     .. versionadded:: 2.3.0
 
@@ -844,7 +844,7 @@ The :py:meth:`~PIL.Image.Image.save` method can take the following keyword argum
 
     Previous versions only supported some tags when writing using
     libtiff. The supported list is found in
-    :py:attr:`~PIL:TiffTags.LIBTIFF_CORE`.
+    :py:data:`.TiffTags.LIBTIFF_CORE`.
 
     .. versionadded:: 6.1.0
 

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -473,7 +473,7 @@ image formats, EXIF data is not guaranteed to be present in
 :py:attr:`~PIL.Image.Image.info` until :py:meth:`~PIL.Image.Image.load` has been
 called.
 
-The :py:meth:`~PIL.Image.Image.open` method sets the following
+The :py:func:`~PIL.Image.open` function sets the following
 :py:attr:`~PIL.Image.Image.info` properties, when appropriate:
 
 **chromaticity**

--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -453,8 +453,8 @@ If everything goes well, the result is an :py:class:`PIL.Image.Image` object.
 Otherwise, an :exc:`OSError` exception is raised.
 
 You can use a file-like object instead of the filename. The object must
-implement :py:meth:`~file.read`, :py:meth:`~file.seek` and
-:py:meth:`~file.tell` methods, and be opened in binary mode.
+implement ``file.read``, ``file.seek`` and ``file.tell`` methods,
+and be opened in binary mode.
 
 Reading from an open file
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/handbook/writing-your-own-file-decoder.rst
+++ b/docs/handbook/writing-your-own-file-decoder.rst
@@ -175,7 +175,7 @@ The fields are used as follows:
 
 The **raw mode** field is used to determine how the data should be unpacked to
 match PIL’s internal pixel layout. PIL supports a large set of raw modes; for a
-complete list, see the table in the :py:mod:`Unpack.c` module. The following
+complete list, see the table in the :file:`Unpack.c` module. The following
 table describes some commonly used **raw modes**:
 
 +-----------+-----------------------------------------------------------------+

--- a/docs/porting.rst
+++ b/docs/porting.rst
@@ -19,7 +19,8 @@ to this::
 
     from PIL import Image
 
-The :py:mod:`~PIL._imaging` module has been moved. You can now import it like this::
+The :py:mod:`PIL._imaging` module has been moved to :py:mod:`PIL.Image.core`.
+You can now import it like this::
 
     from PIL.Image import core as _imaging
 

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -268,8 +268,8 @@ This flips the input image by using the :data:`FLIP_LEFT_RIGHT` method.
 .. automethod:: PIL.Image.Image.load
 .. automethod:: PIL.Image.Image.close
 
-Attributes
-----------
+Image Attributes
+----------------
 
 Instances of the :py:class:`Image` class have the following attributes:
 
@@ -329,6 +329,12 @@ Instances of the :py:class:`Image` class have the following attributes:
     keep a reference to the info dictionary returned from the open method.
 
     Unless noted elsewhere, this dictionary does not affect saving files.
+
+Classes
+-------
+
+.. autoclass:: PIL.Image.ImagePointHandler
+.. autoclass:: PIL.Image.ImageTransformHandler
 
 Constants
 ---------

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -333,6 +333,10 @@ Instances of the :py:class:`Image` class have the following attributes:
 Classes
 -------
 
+.. autoclass:: PIL.Image.Exif
+    :members:
+    :undoc-members:
+    :show-inheritance:
 .. autoclass:: PIL.Image.ImagePointHandler
 .. autoclass:: PIL.Image.ImageTransformHandler
 

--- a/docs/reference/ImageFilter.rst
+++ b/docs/reference/ImageFilter.rst
@@ -66,3 +66,29 @@ image enhancement filters:
 
 .. autoclass:: PIL.ImageFilter.ModeFilter
     :members:
+
+.. class:: Filter
+
+    An abstract mixin used for filtering images
+    (for use with :py:meth:`~PIL.Image.Image.filter`)
+
+    Implementors must provide the following method:
+
+    .. method:: filter(self, image)
+
+        Applies a filter to a single-band image, or a single band of an image.
+
+        :returns: A filtered copy of the image.
+
+.. class:: MultibandFilter
+
+    An abstract mixin used for filtering multi-band images
+    (for use with :py:meth:`~PIL.Image.Image.filter`)
+
+    Implementors must provide the following method:
+
+    .. method:: filter(self, image)
+
+        Applies a filter to a multi-band image.
+
+        :returns: A filtered copy of the image.

--- a/docs/reference/ImageFilter.rst
+++ b/docs/reference/ImageFilter.rst
@@ -70,7 +70,7 @@ image enhancement filters:
 .. class:: Filter
 
     An abstract mixin used for filtering images
-    (for use with :py:meth:`~PIL.Image.Image.filter`)
+    (for use with :py:meth:`~PIL.Image.Image.filter`).
 
     Implementors must provide the following method:
 
@@ -83,7 +83,7 @@ image enhancement filters:
 .. class:: MultibandFilter
 
     An abstract mixin used for filtering multi-band images
-    (for use with :py:meth:`~PIL.Image.Image.filter`)
+    (for use with :py:meth:`~PIL.Image.Image.filter`).
 
     Implementors must provide the following method:
 

--- a/docs/reference/ImageFont.rst
+++ b/docs/reference/ImageFont.rst
@@ -6,7 +6,7 @@
 
 The :py:mod:`~PIL.ImageFont` module defines a class with the same name. Instances of
 this class store bitmap fonts, and are used with the
-:py:meth:`PIL.ImageDraw.Draw.text` method.
+:py:meth:`PIL.ImageDraw.ImageDraw.text` method.
 
 PIL uses its own font file format to store bitmap fonts. You can use the
 :command:`pilfont` utility from

--- a/docs/reference/ImageQt.rst
+++ b/docs/reference/ImageQt.rst
@@ -9,7 +9,7 @@ objects from PIL images.
 
 .. versionadded:: 1.1.6
 
-.. py:class:: ImageQt.ImageQt(image)
+.. py:class:: ImageQt(image)
 
     Creates an :py:class:`~PIL.ImageQt.ImageQt` object from a PIL
     :py:class:`~PIL.Image.Image` object. This class is a subclass of

--- a/docs/reference/TiffTags.rst
+++ b/docs/reference/TiffTags.rst
@@ -64,4 +64,4 @@ metadata tag numbers, names, and type information.
 .. py:data:: PIL.TiffTags.LIBTIFF_CORE
     :type: list
 
-    A list of supported tag ids when writing using libtiff.
+    A list of supported tag IDs when writing using LibTIFF.

--- a/docs/reference/TiffTags.rst
+++ b/docs/reference/TiffTags.rst
@@ -60,3 +60,8 @@ metadata tag numbers, names, and type information.
 
     The ``TYPES`` dictionary maps the TIFF type short integer to a
     human readable type name.
+
+.. py:data:: PIL.TiffTags.LIBTIFF_CORE
+    :type: list
+
+    A list of supported tag ids when writing using libtiff.

--- a/docs/reference/internal_modules.rst
+++ b/docs/reference/internal_modules.rst
@@ -36,3 +36,12 @@ Internal Modules
 
     This is the master version number for Pillow,
     all other uses reference this module.
+
+:mod:`PIL.Image.core` Module
+----------------------------
+
+.. module:: PIL._imaging
+.. module:: PIL.Image.core
+
+An internal interface module previously known as :mod:`~PIL._imaging`,
+implemented in :file:`_imaging.c`.

--- a/docs/releasenotes/4.1.0.rst
+++ b/docs/releasenotes/4.1.0.rst
@@ -10,9 +10,9 @@ Several deprecated items have been removed.
   resolution', 'resolution unit', and 'date time' has been
   removed. Underscores should be used instead.
 
-* The methods :py:meth:`PIL.ImageDraw.ImageDraw.setink`,
-  :py:meth:`PIL.ImageDraw.ImageDraw.setfill`, and
-  :py:meth:`PIL.ImageDraw.ImageDraw.setfont` have been removed.
+* The methods ``PIL.ImageDraw.ImageDraw.setink``,
+  ``PIL.ImageDraw.ImageDraw.setfill``, and
+  ``PIL.ImageDraw.ImageDraw.setfont`` have been removed.
 
 
 Closing Files When Opening Images

--- a/docs/releasenotes/4.2.0.rst
+++ b/docs/releasenotes/4.2.0.rst
@@ -34,9 +34,9 @@ Removed Deprecated Items
 
 Several deprecated items have been removed.
 
-* The methods :py:meth:`PIL.ImageWin.Dib.fromstring`,
-  :py:meth:`PIL.ImageWin.Dib.tostring` and
-  :py:meth:`PIL.TiffImagePlugin.ImageFileDirectory_v2.as_dict` have
+* The methods ``PIL.ImageWin.Dib.fromstring``,
+  ``PIL.ImageWin.Dib.tostring`` and
+  ``PIL.TiffImagePlugin.ImageFileDirectory_v2.as_dict`` have
   been removed.
 
 * Before Pillow 4.2.0, attempting to save an RGBA image as JPEG would

--- a/docs/releasenotes/4.3.0.rst
+++ b/docs/releasenotes/4.3.0.rst
@@ -124,7 +124,7 @@ This release contains several performance improvements:
 * ``Image.transpose`` has been accelerated 15% or more by using a cache
   friendly algorithm.
 * ImageFilters based on Kernel convolution are significantly faster
-  due to the new MultibandFilter feature.
+  due to the new :py:class:`~PIL.ImageFilter.MultibandFilter` feature.
 * All memory allocation for images is now done in blocks, rather than
   falling back to an allocation for each scan line for images larger
   than the block size.

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1577,6 +1577,13 @@ class Image:
            single argument. The function is called once for each
            possible pixel value, and the resulting table is applied to
            all bands of the image.
+
+           It may also be an :py:class:`~PIL.Image.ImagePointHandler`
+           object::
+
+               class Example(Image.ImagePointHandler):
+                 def point(self, data):
+                   # Return result
         :param mode: Output mode (default is same as input).  In the
            current version, this can only be used if the source image
            has mode "L" or "P", and the output has mode "1" or the
@@ -2534,12 +2541,20 @@ class Image:
 
 
 class ImagePointHandler:
-    # used as a mixin by point transforms (for use with im.point)
+    """
+    Used as a mixin by point transforms
+    (for use with :py:meth:`~PIL.Image.Image.point`)
+    """
+
     pass
 
 
 class ImageTransformHandler:
-    # used as a mixin by geometry transforms (for use with im.transform)
+    """
+    Used as a mixin by geometry transforms
+    (for use with :py:meth:`~PIL.Image.Image.transform`)
+    """
+
     pass
 
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -717,7 +717,7 @@ class Image:
         :param encoder_name: What encoder to use.  The default is to
                              use the standard "raw" encoder.
         :param args: Extra arguments to the encoder.
-        :rtype: A bytes object.
+        :returns: A :py:class:`bytes` object.
         """
 
         # may pass tuple instead of argument list
@@ -2352,10 +2352,10 @@ class Image:
           object::
 
             class Example(Image.ImageTransformHandler):
-                def transform(size, method, data, resample, fill=1):
+                def transform(self, size, data, resample, fill=1):
                     # Return result
 
-          It may also be an object with a :py:meth:`~method.getdata` method
+          It may also be an object with a ``method.getdata`` method
           that returns a tuple supplying new **method** and **data** values::
 
             class Example:
@@ -2847,8 +2847,8 @@ def open(fp, mode="r"):
     :py:func:`~PIL.Image.new`. See :ref:`file-handling`.
 
     :param fp: A filename (string), pathlib.Path object or a file object.
-       The file object must implement :py:meth:`~file.read`,
-       :py:meth:`~file.seek`, and :py:meth:`~file.tell` methods,
+       The file object must implement ``file.read``,
+       ``file.seek`, and ``file.tell`` methods,
        and be opened in binary mode.
     :param mode: The mode.  If given, this argument must be "r".
     :returns: An :py:class:`~PIL.Image.Image` object.

--- a/src/PIL/ImageChops.py
+++ b/src/PIL/ImageChops.py
@@ -293,7 +293,7 @@ def logical_xor(image1, image2):
 
 def blend(image1, image2, alpha):
     """Blend images using constant transparency weight. Alias for
-    :py:meth:`PIL.Image.Image.blend`.
+    :py:func:`PIL.Image.blend`.
 
     :rtype: :py:class:`~PIL.Image.Image`
     """
@@ -303,7 +303,7 @@ def blend(image1, image2, alpha):
 
 def composite(image1, image2, mask):
     """Create composite using transparency mask. Alias for
-    :py:meth:`PIL.Image.Image.composite`.
+    :py:func:`PIL.Image.composite`.
 
     :rtype: :py:class:`~PIL.Image.Image`
     """


### PR DESCRIPTION
Changes proposed in this pull request:

 * Fix several typos related to references
 * Use code formatting instead of cross-references for removed methods (e.g. `ImageDraw.setink`) and local variable methods (e.g. `file.read`)
 * Document `Image.ImagePointHandler`, `Image.ImageTransformHandler`, `Image.Exif`, `ImageFilter.Filter`, `ImageFilter.MultibandFilter`, `TiffTags.LIBTIFF_CORE`
 * Add a one-line description for `_imaging` and `Image.core`

Adds 1 nitpicky warning fixed by #4774:
```diff
+c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Exif:1: WARNING: py:class reference target not found: collections.abc.MutableMapping
```

<details><summary>Fixes 34 nitpicky warnings: (click to expand)</summary><p>

```diff
-c:\git\pillow\src\PIL\ImageTransform.py:docstring of PIL.ImageTransform.Transform:1: WARNING: py:class reference target not found: PIL.Image.ImageTransformHandler
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:476: WARNING: py:meth reference target not found: PIL.Image.Image.open
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:775: WARNING: py:attr reference target not found: PIL.TiffTags.TAGS_V2
-C:\Git\Pillow\docs\handbook\image-file-formats.rst:845: WARNING: py:attr reference target not found: PIL:TiffTags.LIBTIFF_CORE
-C:\Git\Pillow\docs\handbook\tutorial.rst:455: WARNING: py:meth reference target not found: file.read
-C:\Git\Pillow\docs\handbook\tutorial.rst:455: WARNING: py:meth reference target not found: file.seek
-C:\Git\Pillow\docs\handbook\tutorial.rst:455: WARNING: py:meth reference target not found: file.tell
-C:\Git\Pillow\docs\handbook\writing-your-own-file-decoder.rst:176: WARNING: py:mod reference target not found: Unpack.c
-C:\Git\Pillow\docs\porting.rst:22: WARNING: py:mod reference target not found: PIL._imaging
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.open:9: WARNING: py:meth reference target not found: file.read
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.open:9: WARNING: py:meth reference target not found: file.seek
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.open:9: WARNING: py:meth reference target not found: file.tell
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.tobytes:: WARNING: py:class reference target not found: A bytes object.
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transform:14: WARNING: py:class reference target not found: PIL.Image.ImageTransformHandler
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transform:21: WARNING: py:meth reference target not found: method.getdata
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.Image.transform:37: WARNING: py:class reference target not found: PIL.Image.ImageTransformHandler
-c:\git\pillow\src\PIL\ImageChops.py:docstring of PIL.ImageChops.blend:1: WARNING: py:meth reference target not found: PIL.Image.Image.blend
-c:\git\pillow\src\PIL\ImageChops.py:docstring of PIL.ImageChops.composite:1: WARNING: py:meth reference target not found: PIL.Image.Image.composite
-C:\Git\Pillow\docs\reference\ImageFont.rst:7: WARNING: py:meth reference target not found: PIL.ImageDraw.Draw.text
-c:\git\pillow\src\PIL\ImageFont.py:docstring of PIL.ImageFont.ImageFont.getmask:14: WARNING: py:mod reference target not found: PIL.Image.core
-c:\git\pillow\src\PIL\ImageFont.py:docstring of PIL.ImageFont.FreeTypeFont.getmask:47: WARNING: py:mod reference target not found: PIL.Image.core
-c:\git\pillow\src\PIL\ImageFont.py:docstring of PIL.ImageFont.FreeTypeFont.getmask2:47: WARNING: py:mod reference target not found: PIL.Image.core
-C:\Git\Pillow\docs\reference\ImageQt.rst:14: WARNING: py:class reference target not found: PIL.ImageQt.ImageQt
-C:\Git\Pillow\docs\releasenotes\4.1.0.rst:13: WARNING: py:meth reference target not found: PIL.ImageDraw.ImageDraw.setink
-C:\Git\Pillow\docs\releasenotes\4.1.0.rst:13: WARNING: py:meth reference target not found: PIL.ImageDraw.ImageDraw.setfill
-C:\Git\Pillow\docs\releasenotes\4.1.0.rst:13: WARNING: py:meth reference target not found: PIL.ImageDraw.ImageDraw.setfont
-C:\Git\Pillow\docs\releasenotes\4.2.0.rst:37: WARNING: py:meth reference target not found: PIL.ImageWin.Dib.fromstring
-C:\Git\Pillow\docs\releasenotes\4.2.0.rst:37: WARNING: py:meth reference target not found: PIL.ImageWin.Dib.tostring
-C:\Git\Pillow\docs\releasenotes\4.2.0.rst:37: WARNING: py:meth reference target not found: PIL.TiffImagePlugin.ImageFileDirectory_v2.as_dict
-C:\Git\Pillow\docs\releasenotes\4.3.0.rst:84: WARNING: py:class reference target not found: PIL.ImageFilter.MultibandFilter
-C:\Git\Pillow\docs\releasenotes\4.3.0.rst:84: WARNING: py:class reference target not found: PIL.ImageFilter.Filter
-C:\Git\Pillow\docs\releasenotes\6.0.0.rst:171: WARNING: py:class reference target not found: PIL.Image.Exif
-C:\Git\Pillow\docs\releasenotes\7.2.0.rst:18: WARNING: py:meth reference target not found: PIL.Image.Exif.tobytes
-C:\Git\Pillow\docs\releasenotes\7.2.0.rst:25: WARNING: py:class reference target not found: PIL.Image.Exif
```
</p></details>