### PR TITLE
Fix documentation references: standard library

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,8 @@ extensions = [
     "sphinx_removed_in",
 ]
 
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
+
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -857,7 +857,7 @@ The :py:meth:`~PIL.Image.Image.save` method can take the following keyword argum
 **compression**
     A string containing the desired compression method for the
     file. (valid only with libtiff installed) Valid compression
-    methods are: ``None``, ``"tiff_ccitt"``, ``"group3"``,
+    methods are: :data:`None`, ``"tiff_ccitt"``, ``"group3"``,
     ``"group4"``, ``"tiff_jpeg"``, ``"tiff_adobe_deflate"``,
     ``"tiff_thunderscan"``, ``"tiff_deflate"``, ``"tiff_sgilog"``,
     ``"tiff_sgilog24"``, ``"tiff_raw_16"``

--- a/docs/handbook/writing-your-own-file-decoder.rst
+++ b/docs/handbook/writing-your-own-file-decoder.rst
@@ -132,7 +132,7 @@ The fields are used as follows:
 **parameters**
     Parameters to the decoder. The contents of this field depends on the
     decoder specified by the first field in the tile descriptor tuple. If the
-    decoder doesn’t need any parameters, use ``None`` for this field.
+    decoder doesn’t need any parameters, use :data:`None` for this field.
 
 Note that the :py:attr:`tile` attribute contains a list of tile descriptors,
 not just a single descriptor.

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -285,7 +285,7 @@ Instances of the :py:class:`Image` class have the following attributes:
 
     The file format of the source file. For images created by the library
     itself (via a factory function, or by running a method on an existing
-    image), this attribute is set to ``None``.
+    image), this attribute is set to :data:`None`.
 
 .. py:attribute:: Image.mode
     :type: str
@@ -314,7 +314,7 @@ Instances of the :py:class:`Image` class have the following attributes:
 
     Colour palette table, if any. If mode is "P" or "PA", this should be an
     instance of the :py:class:`~PIL.ImagePalette.ImagePalette` class.
-    Otherwise, it should be set to ``None``.
+    Otherwise, it should be set to :data:`None`.
 
 .. py:attribute:: Image.info
     :type: dict

--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -212,7 +212,7 @@ Methods
         .. versionadded:: 1.1.5
 
         .. note:: This option was broken until version 1.1.6.
-    :param joint: Joint type between a sequence of lines. It can be ``"curve"``, for rounded edges, or ``None``.
+    :param joint: Joint type between a sequence of lines. It can be ``"curve"``, for rounded edges, or :data:`None`.
 
         .. versionadded:: 5.3.0
 

--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -27,7 +27,7 @@ or the clipboard to a PIL image memory.
         .. versionadded:: 6.2.0
 
     :param xdisplay:
-        X11 Display address. Pass ``None`` to grab the default system screen. Pass ``""`` to grab the default X11 screen on Windows or macOS.
+        X11 Display address. Pass :data:`None` to grab the default system screen. Pass ``""`` to grab the default X11 screen on Windows or macOS.
 
         You can check X11 support using :py:func:`PIL.features.check_feature` with ``feature="xcb"``.
 

--- a/docs/releasenotes/5.3.0.rst
+++ b/docs/releasenotes/5.3.0.rst
@@ -34,7 +34,7 @@ Curved joints for line sequences
 ``ImageDraw.Draw.line`` draws a line, or lines, between points. Previously,
 when multiple points are given, for a larger ``width``, the joints between
 these lines looked unsightly. There is now an additional optional argument,
-``joint``, defaulting to ``None``. When it is set to ``curved``, the joints
+``joint``, defaulting to :data:`None`. When it is set to ``curved``, the joints
 between the lines will become rounded.
 
 ImageOps.colorize

--- a/docs/releasenotes/7.0.0.rst
+++ b/docs/releasenotes/7.0.0.rst
@@ -66,7 +66,7 @@ See :ref:`concept-filters` to learn the difference. In short,
 Image.draft() return value
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If the :py:meth:`~PIL.Image.Image.draft` method has no effect, it returns ``None``.
+If the :py:meth:`~PIL.Image.Image.draft` method has no effect, it returns :data:`None`.
 If it does have an effect, then it previously returned the image itself.
 However, unlike other `chain methods`_, :py:meth:`~PIL.Image.Image.draft` does not
 return a modified version of the image, but modifies it in-place. So instead, if
@@ -95,7 +95,7 @@ the closer the result to the fair resampling. The smaller ``reducing_gap``,
 the faster resizing. With ``reducing_gap`` greater or equal to 3.0,
 the result is indistinguishable from fair resampling.
 
-The default value for :py:meth:`~PIL.Image.Image.resize` is ``None``,
+The default value for :py:meth:`~PIL.Image.Image.resize` is :data:`None`,
 which means that the optimization is turned off by default.
 
 The default value for :py:meth:`~PIL.Image.Image.thumbnail` is 2.0,

--- a/docs/releasenotes/7.1.0.rst
+++ b/docs/releasenotes/7.1.0.rst
@@ -63,7 +63,7 @@ Support has been added for ``ImageGrab.grab()`` on Linux using the X server
 with the XCB library.
 
 An optional ``xdisplay`` parameter has been added to select the X server,
-with the default value of ``None`` using the default X server.
+with the default value of :data:`None` using the default X server.
 
 Passing a different value on Windows or macOS will force taking a snapshot
 using the selected X server; pass an empty string to use the default X server.

--- a/src/PIL/PSDraw.py
+++ b/src/PIL/PSDraw.py
@@ -26,7 +26,7 @@ from . import EpsImagePlugin
 class PSDraw:
     """
     Sets up printing to the given file. If **fp** is omitted,
-    :py:attr:`sys.stdout` is assumed.
+    :py:data:`sys.stdout` is assumed.
     """
 
     def __init__(self, fp=None):


### PR DESCRIPTION
Changes proposed in this pull request:

 * Add `intersphinx_mapping` for standard library. A good place to check it out is the [attribute types in `ImageCms.CmsProfile`](https://pillow--4774.org.readthedocs.build/en/4774/reference/ImageCms.html#cmsprofile).
 * Fix typo in PSDraw
 * Use cross-reference instead of code for `None`. I used a grep to replace all instances in rst files, but I can see there are still a lot of references which are neither code or cross-reference. I also did not update docstrings due to line length limit. While linking to the docs for None might be a bit too much, it would be good to decide on a consistent standard to use for all standard library types. There are likely other types that I missed that should be replaced if this is the agreed-upon style.

<details><summary>Fixes 7 nitpicky warnings: (click to expand)</summary><p>

```diff
-C:\Git\Pillow\docs\handbook\tutorial.rst:468: WARNING: py:class reference target not found: io.BytesIO
-C:\Git\Pillow\docs\handbook\writing-your-own-file-decoder.rst:94: WARNING: py:exc reference target not found: struct.error
-c:\git\pillow\src\PIL\Image.py:docstring of PIL.Image.frombytes:10: WARNING: py:class reference target not found: io.BytesIO
-C:\Git\Pillow\docs\reference\ImageCms.rst:: WARNING: py:class reference target not found: datetime.datetime
-c:\git\pillow\src\PIL\PSDraw.py:docstring of PIL.PSDraw.PSDraw:1: WARNING: py:attr reference target not found: sys.stdout
-c:\git\pillow\src\PIL\TiffImagePlugin.py:docstring of PIL.TiffImagePlugin.IFDRational:1: WARNING: py:class reference target not found: numbers.Rational
-c:\git\pillow\src\PIL\TiffImagePlugin.py:docstring of PIL.TiffImagePlugin.ImageFileDirectory_v2:1: WARNING: py:class reference target not found: collections.abc.MutableMapping
```
</p></details>