### PR TITLE
Docs: Enable nitpicky warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,6 +103,17 @@ pygments_style = "sphinx"
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+# If true, Sphinx will warn about all references where the target cannot be found.
+# Default is False. You can activate this mode temporarily using the -n command-line
+# switch.
+nitpicky = True
+
+# A list of (type, target) tuples (by default empty) that should be ignored when
+# generating warnings in “nitpicky mode”. Note that type should include the domain name
+# if present. Example entries would be ('py:func', 'int') or
+# ('envvar', 'LD_LIBRARY_PATH').
+# nitpick_ignore = []
+
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,7 +112,20 @@ nitpicky = True
 # generating warnings in “nitpicky mode”. Note that type should include the domain name
 # if present. Example entries would be ('py:func', 'int') or
 # ('envvar', 'LD_LIBRARY_PATH').
-# nitpick_ignore = []
+nitpick_ignore = [
+    ("py:meth", "_open"),
+    ("py:attr", "tile"),
+    ("py:meth", "CDC.GetHandleAttrib"),
+    ("py:meth", "PIL.Image.Image.convert2byte"),
+    ("py:attr", "PIL.Image.Image.tag"),
+    ("py:attr", "PIL.Image.Image.tag_v2"),
+    ("py:attr", "PIL.Image.Image.tile"),
+    ("py:data", "PIL.Image.MAX_PIXELS"),
+    ("py:func", "PIL.ImageMath.convert"),
+    ("py:func", "PIL.ImageMath.float"),
+    ("py:func", "PIL.ImageMath.int"),
+    ("py:attr", "PIL.TiffImagePlugin.ImageFileDirectory_v2.tagtype"),
+]
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,7 +122,7 @@ nitpick_ignore = [
     ("py:attr", "PIL.Image.Image.tag"),
     ("py:attr", "PIL.Image.Image.tag_v2"),
     ("py:attr", "PIL.Image.Image.tile"),
-    ("py:data", "PIL.Image.MAX_PIXELS"),
+    ("py:data", "PIL.Image.MAX_IMAGE_PIXELS"),
     ("py:func", "PIL.ImageMath.convert"),
     ("py:func", "PIL.ImageMath.float"),
     ("py:func", "PIL.ImageMath.int"),

--- a/docs/releasenotes/4.2.0.rst
+++ b/docs/releasenotes/4.2.0.rst
@@ -27,7 +27,7 @@ New DecompressionBomb Warning
 
 :py:meth:`PIL.Image.Image.crop` now may raise a DecompressionBomb
 warning if the crop region enlarges the image over the threshold
-specified by :py:data:`PIL.Image.MAX_PIXELS`.
+specified by :py:data:`PIL.Image.MAX_IMAGE_PIXELS`.
 
 Removed Deprecated Items
 ========================


### PR DESCRIPTION
Enable nitpicky warnings in the config to find them earlier on CIs.

This will fail until #4739, ~#4771, #4773, #4774~ are merged.

I added the warnings mentioned in #4775 to `nitpick_ignore` for now until they are resolved to allow the build to pass (once the above PRs are merged). I will remove relevant lines if someone resolves them before this is merged.