### PR TITLE
Travis CI: Allow 3.9-dev to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,9 @@ matrix:
       env: PYTHONOPTIMIZE=2
       services: xvfb
 
+  allow_failures:
+  - python: "3.9-dev"
+
 install:
   - |
     if [ "$LINT" == "true" ]; then


### PR DESCRIPTION
We should figure out https://github.com/python-pillow/Pillow/issues/4769, but shall we not let pre-releases fail PRs?

![image](https://user-images.githubusercontent.com/1324225/87134609-95626c00-c2a1-11ea-8439-886f4e1c6c3c.png)

* https://docs.travis-ci.com/user/customizing-the-build#jobs-that-are-allowed-to-fail

(For some visibility we could use a conditional: so PRs can pass but `master` would still fail?)

* https://docs.travis-ci.com/user/customizing-the-build#conditionally-allowing-jobs-to-fail