### PR TITLE
Fix PostScript typos

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5587,7 +5587,7 @@ Pre-fork
       any other pixel value means opaque.  This is faster than using an
       "L" transparency mask.
 
-    + Properly writes EPS files (and properly prints images to postscript
+    + Properly writes EPS files (and properly prints images to PostScript
       printers as well).
 
     + Reads 4-bit BMP files, as well as 4 and 8-bit Windows ICO and CUR
@@ -5670,7 +5670,7 @@ Pre-fork
     + Added the "pilfile" utility, which quickly identifies image files
       (without loading them, in most cases).
 
-    + Added the "pilprint" utility, which prints image files to Postscript
+    + Added the "pilprint" utility, which prints image files to PostScript
       printers.
 
     + Added a rudimentary version of the "pilview" utility, which is
@@ -5684,5 +5684,5 @@ Pre-fork
       Jack).  This allows you to read images through the Img extensions file
       format handlers.  See the file "Lib/ImgExtImagePlugin.py" for details.
 
-    + Postscript printing is provided through the PSDraw module.  See the
+    + PostScript printing is provided through the PSDraw module.  See the
       handbook for details.

--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -406,13 +406,13 @@ Using the ImageSequence Iterator class
         # ...do something to frame...
 
 
-Postscript printing
+PostScript printing
 -------------------
 
 The Python Imaging Library includes functions to print images, text and
-graphics on Postscript printers. Here’s a simple example:
+graphics on PostScript printers. Here’s a simple example:
 
-Drawing Postscript
+Drawing PostScript
 ^^^^^^^^^^^^^^^^^^
 
 ::

--- a/docs/reference/PSDraw.rst
+++ b/docs/reference/PSDraw.rst
@@ -4,7 +4,7 @@
 :py:mod:`~PIL.PSDraw` Module
 ============================
 
-The :py:mod:`~PIL.PSDraw` module provides simple print support for Postscript
+The :py:mod:`~PIL.PSDraw` module provides simple print support for PostScript
 printers. You can print text, graphics and images through this module.
 
 .. autoclass:: PIL.PSDraw.PSDraw

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -191,7 +191,7 @@ def _accept(prefix):
 
 
 ##
-# Image plugin for Encapsulated Postscript.  This plugin supports only
+# Image plugin for Encapsulated PostScript.  This plugin supports only
 # a few variants of this format.
 
 
@@ -262,7 +262,7 @@ class EpsImageFile(ImageFile.ImageFile):
                         else:
                             self.info[k] = ""
                     elif s[0] == "%":
-                        # handle non-DSC Postscript comments that some
+                        # handle non-DSC PostScript comments that some
                         # tools mistakenly put in the Comments section
                         pass
                     else:
@@ -352,7 +352,7 @@ def _save(im, fp, filename, eps=1):
     im.load()
 
     #
-    # determine postscript image mode
+    # determine PostScript image mode
     if im.mode == "L":
         operator = (8, 1, "image")
     elif im.mode == "RGB":

--- a/src/PIL/PSDraw.py
+++ b/src/PIL/PSDraw.py
@@ -2,7 +2,7 @@
 # The Python Imaging Library
 # $Id$
 #
-# simple postscript graphics interface
+# Simple PostScript graphics interface
 #
 # History:
 # 1996-04-20 fl   Created
@@ -20,7 +20,7 @@ import sys
 from . import EpsImagePlugin
 
 ##
-# Simple Postscript graphics interface.
+# Simple PostScript graphics interface.
 
 
 class PSDraw:
@@ -41,7 +41,7 @@ class PSDraw:
             self.fp.write(bytes(to_write, "UTF-8"))
 
     def begin_document(self, id=None):
-        """Set up printing of a document. (Write Postscript DSC header.)"""
+        """Set up printing of a document. (Write PostScript DSC header.)"""
         # FIXME: incomplete
         self._fp_write(
             "%!PS-Adobe-3.0\n"
@@ -57,7 +57,7 @@ class PSDraw:
         self.isofont = {}
 
     def end_document(self):
-        """Ends printing. (Write Postscript DSC footer.)"""
+        """Ends printing. (Write PostScript DSC footer.)"""
         self._fp_write("%%EndDocument\nrestore showpage\n%%End\n")
         if hasattr(self.fp, "flush"):
             self.fp.flush()
@@ -66,7 +66,7 @@ class PSDraw:
         """
         Selects which font to use.
 
-        :param font: A Postscript font name
+        :param font: A PostScript font name
         :param size: Size in points.
         """
         if font not in self.isofont:
@@ -79,7 +79,7 @@ class PSDraw:
     def line(self, xy0, xy1):
         """
         Draws a line between the two points. Coordinates are given in
-        Postscript point coordinates (72 points per inch, (0, 0) is the lower
+        PostScript point coordinates (72 points per inch, (0, 0) is the lower
         left corner of the page).
         """
         xy = xy0 + xy1
@@ -143,10 +143,10 @@ class PSDraw:
 
 
 # --------------------------------------------------------------------
-# Postscript driver
+# PostScript driver
 
 #
-# EDROFF.PS -- Postscript driver for Edroff 2
+# EDROFF.PS -- PostScript driver for Edroff 2
 #
 # History:
 # 94-01-25 fl: created (edroff 2.04)
@@ -176,7 +176,7 @@ EDROFF_PS = """\
 """
 
 #
-# VDI.PS -- Postscript driver for VDI meta commands
+# VDI.PS -- PostScript driver for VDI meta commands
 #
 # History:
 # 94-01-25 fl: created (edroff 2.04)


### PR DESCRIPTION
Didn't bother changing this one, to prevent surprising API changes:
```
src/PIL/EpsImagePlugin.py:    format_description = "Encapsulated Postscript"
```