### PR TITLE
Nit typo fix

### DIFF
--- a/src/PIL/ImageFilter.py
+++ b/src/PIL/ImageFilter.py
@@ -49,7 +49,7 @@ class Kernel(BuiltinFilter):
                     version, this must be (3,3) or (5,5).
     :param kernel: A sequence containing kernel weights.
     :param scale: Scale factor. If given, the result for each pixel is
-                    divided by this value.  the default is the sum of the
+                    divided by this value.  The default is the sum of the
                     kernel weights.
     :param offset: Offset. If given, this value is added to the result,
                     after it has been divided by the scale factor.


### PR DESCRIPTION
nit - typo fix:

`the` -> `The`

[ci skip]