### PR TITLE
3.9-dev: Upgrade setuptools

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -30,7 +30,8 @@ pip install -U pytest-cov
 pip install pyroma
 pip install test-image-results
 pip install numpy
-if [ "$TRAVIS_PYTHON_VERSION" == "3.9-dev" ]; then pip install setuptools==47.3.1 ; fi
+# TODO Remove when Travis/3.9 includes setuptools 49.1.3+:
+if [ "$TRAVIS_PYTHON_VERSION" == "3.9-dev" ]; then pip install -U "setuptools>=49.1.3" ; fi
 if [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then
   # arm64, ppc64le, s390x CPUs:
   # "ERROR: Could not find a version that satisfies the requirement pyqt5"

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -30,8 +30,11 @@ pip install -U pytest-cov
 pip install pyroma
 pip install test-image-results
 pip install numpy
-# TODO Remove when Travis/3.9 includes setuptools 49.3.2+:
+
+# TODO Remove when 3.9-dev includes setuptools 49.3.2+:
 if [ "$TRAVIS_PYTHON_VERSION" == "3.9-dev" ]; then pip install -U "setuptools>=49.3.2" ; fi
+if [ "$GHA_PYTHON_VERSION" == "3.9-dev" ]; then pip install -U "setuptools>=49.3.2" ; fi
+
 if [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then
   # arm64, ppc64le, s390x CPUs:
   # "ERROR: Could not find a version that satisfies the requirement pyqt5"

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -30,8 +30,8 @@ pip install -U pytest-cov
 pip install pyroma
 pip install test-image-results
 pip install numpy
-# TODO Remove when Travis/3.9 includes setuptools 49.1.3+:
-if [ "$TRAVIS_PYTHON_VERSION" == "3.9-dev" ]; then pip install -U "setuptools>=49.1.3" ; fi
+# TODO Remove when Travis/3.9 includes setuptools 49.3.2+:
+if [ "$TRAVIS_PYTHON_VERSION" == "3.9-dev" ]; then pip install -U "setuptools>=49.3.2" ; fi
 if [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then
   # arm64, ppc64le, s390x CPUs:
   # "ERROR: Could not find a version that satisfies the requirement pyqt5"

--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -15,5 +15,8 @@ pip install test-image-results
 echo -e "[openblas]\nlibraries = openblas\nlibrary_dirs = /usr/local/opt/openblas/lib" >> ~/.numpy-site.cfg
 pip install numpy
 
+# TODO Remove when 3.9-dev includes setuptools 49.3.2+:
+if [ "$GHA_PYTHON_VERSION" == "3.9-dev" ]; then pip install -U "setuptools>=49.3.2" ; fi
+
 # extra test images
 pushd depends && ./install_extra_test_images.sh && popd

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -63,6 +63,11 @@ jobs:
     - name: pip install wheel pytest pytest-cov
       run: python -m pip install wheel pytest pytest-cov
 
+    # TODO Remove when 3.9-dev includes setuptools 49.3.2+:
+    - name: Upgrade setuptools
+      if: "contains(matrix.python-version, '3.9-dev')"
+      run: python -m pip install -U "setuptools>=49.3.2"
+
     - name: Prepare dependencies
       run: |
         7z x winbuild\depends\nasm-2.14.02-win64.zip "-o$env:RUNNER_WORKSPACE\"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,8 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         .ci/install.sh
+      env:
+        GHA_PYTHON_VERSION: ${{ matrix.python-version }}
 
     - name: Install macOS dependencies
       if: startsWith(matrix.os, 'macOS')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,8 @@ jobs:
       if: startsWith(matrix.os, 'macOS')
       run: |
         .github/workflows/macos-install.sh
+      env:
+        GHA_PYTHON_VERSION: ${{ matrix.python-version }}
 
     - name: Build
       run: |


### PR DESCRIPTION
The setuptools fix https://github.com/pypa/setuptools/pull/2249 for python-pillow/Pillow#4769  has been released in [setuptools v49.1.3](https://github.com/pypa/setuptools/releases/tag/v49.1.3), so we can require that version or newer.

Created as draft as there are further build problems from new changes in setuptools, will add comments.
