### PR TITLE
Updated references

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,17 +115,10 @@ nitpicky = True
 # if present. Example entries would be ('py:func', 'int') or
 # ('envvar', 'LD_LIBRARY_PATH').
 nitpick_ignore = [
-    ("py:meth", "_open"),
-    ("py:attr", "tile"),
-    ("py:meth", "CDC.GetHandleAttrib"),
-    ("py:meth", "PIL.Image.Image.convert2byte"),
     ("py:attr", "PIL.Image.Image.tag"),
     ("py:attr", "PIL.Image.Image.tag_v2"),
     ("py:attr", "PIL.Image.Image.tile"),
     ("py:data", "PIL.Image.MAX_IMAGE_PIXELS"),
-    ("py:func", "PIL.ImageMath.convert"),
-    ("py:func", "PIL.ImageMath.float"),
-    ("py:func", "PIL.ImageMath.int"),
     ("py:attr", "PIL.TiffImagePlugin.ImageFileDirectory_v2.tagtype"),
 ]
 

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -712,8 +712,8 @@ The :py:meth:`~PIL.Image.open` method sets the following attributes:
 **n_frames**
     Set to the number of images in the stack.
 
-A convenience method, :py:meth:`~PIL.Image.Image.convert2byte`, is provided for
-converting floating point data to byte data (mode ``L``)::
+A convenience method, :py:meth:`~PIL.SpiderImagePlugin.SpiderImageFile.convert2byte`,
+is provided for converting floating point data to byte data (mode ``L``)::
 
     im = Image.open('image001.spi').convert2byte()
 

--- a/docs/handbook/writing-your-own-file-decoder.rst
+++ b/docs/handbook/writing-your-own-file-decoder.rst
@@ -28,16 +28,16 @@ Pillow decodes files in two stages:
 
 An image plugin should contain a format handler derived from the
 :py:class:`PIL.ImageFile.ImageFile` base class. This class should
-provide an :py:meth:`_open` method, which reads the file header and
+provide an ``_open`` method, which reads the file header and
 sets up at least the :py:attr:`~PIL.Image.Image.mode` and
 :py:attr:`~PIL.Image.Image.size` attributes. To be able to load the
-file, the method must also create a list of :py:attr:`tile`
-descriptors, which contain a decoder name, extents of the tile, and
+file, the method must also create a list of ``tile`` descriptors,
+which contain a decoder name, extents of the tile, and
 any decoder-specific data. The format handler class must be explicitly
 registered, via a call to the :py:mod:`~PIL.Image` module.
 
 .. note:: For performance reasons, it is important that the
-  :py:meth:`_open` method quickly rejects files that do not have the
+  ``_open`` method quickly rejects files that do not have the
   appropriate contents.
 
 Example
@@ -103,10 +103,10 @@ Note that the image plugin must be explicitly registered using
 :py:func:`PIL.Image.register_open`. Although not required, it is also a good
 idea to register any extensions used by this format.
 
-The :py:attr:`tile` attribute
------------------------------
+The ``tile`` attribute
+----------------------
 
-To be able to read the file as well as just identifying it, the :py:attr:`tile`
+To be able to read the file as well as just identifying it, the ``tile``
 attribute must also be set. This attribute consists of a list of tile
 descriptors, where each descriptor specifies how data should be loaded to a
 given region in the image. In most cases, only a single descriptor is used,
@@ -134,7 +134,7 @@ The fields are used as follows:
     decoder specified by the first field in the tile descriptor tuple. If the
     decoder doesn’t need any parameters, use :data:`None` for this field.
 
-Note that the :py:attr:`tile` attribute contains a list of tile descriptors,
+Note that the ``tile`` attribute contains a list of tile descriptors,
 not just a single descriptor.
 
 Decoders

--- a/docs/reference/ImageMath.rst
+++ b/docs/reference/ImageMath.rst
@@ -60,9 +60,8 @@ point values, as necessary. For example, if you add two 8-bit images, the
 result will be a 32-bit integer image. If you add a floating point constant to
 an 8-bit image, the result will be a 32-bit floating point image.
 
-You can force conversion using the :py:func:`~PIL.ImageMath.convert`,
-:py:func:`~PIL.ImageMath.float`, and :py:func:`~PIL.ImageMath.int` functions
-described below.
+You can force conversion using the ``convert()``, ``float()``, and ``int()``
+functions described below.
 
 Bitwise Operators
 ^^^^^^^^^^^^^^^^^

--- a/src/PIL/ImageWin.py
+++ b/src/PIL/ImageWin.py
@@ -88,8 +88,8 @@ class Dib:
         Copy the bitmap contents to a device context.
 
         :param handle: Device context (HDC), cast to a Python integer, or an
-                       HDC or HWND instance.  In PythonWin, you can use the
-                       :py:meth:`CDC.GetHandleAttrib` to get a suitable handle.
+                       HDC or HWND instance.  In PythonWin, you can use
+                       ``CDC.GetHandleAttrib()`` to get a suitable handle.
         """
         if isinstance(handle, HWND):
             dc = self.image.getdc(handle)


### PR DESCRIPTION
Suggestions for #4775 

- Corrected reference
    - Replaced 'PIL.Image.Image.convert2byte' with 'PIL.SpiderImagePlugin.SpiderImageFile.convert2byte'
- Removed domain references from image expressions
    - 'convert()', 'float()' and 'int()' are not Python methods in this context
- Removed domain references when referring to hypothetical code
    - In the context of writing your own file decoder, `_open` and `tile` are only hypothetical.
- Removed domain reference for external method
    - `CDC.GetHandleAttrib()` is in PythonWin, not Pillow