### PR TITLE
Add MIME type to PsdImagePlugin

### DIFF
--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -12,6 +12,7 @@ def test_sanity():
         assert im.mode == "RGB"
         assert im.size == (128, 128)
         assert im.format == "PSD"
+        assert im.get_format_mimetype() == "image/vnd.adobe.photoshop"
 
         im2 = hopper()
         assert_image_similar(im, im2, 4.8)

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -307,3 +307,5 @@ def _maketile(file, mode, bbox, channels):
 Image.register_open(PsdImageFile.format, PsdImageFile, _accept)
 
 Image.register_extension(PsdImageFile.format, ".psd")
+
+Image.register_mime(PsdImageFile.format, "image/vnd.adobe.photoshop")


### PR DESCRIPTION
Fixes #4787

Changes proposed in this pull request:

 * Register "image/vnd.adobe.photoshop" as PsdImageFile MIME type
