### PR TITLE
8.0.0.dev0 version bump

### DIFF
--- a/src/PIL/_version.py
+++ b/src/PIL/_version.py
@@ -1,2 +1,2 @@
 # Master version for Pillow
-__version__ = "7.3.0.dev0"
+__version__ = "8.0.0.dev0"


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/4764

Changes proposed in this pull request:

 * A major bump because the next release will drop EOL Python 3.5 (#4746).
