### PR TITLE
Fix expected failures on big endian systems without CI

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -8,7 +8,6 @@ from .helper import (
     assert_image_equal,
     assert_image_similar,
     is_big_endian,
-    on_ci,
     skip_unless_feature,
 )
 
@@ -190,14 +189,14 @@ def test_16bit_monochrome_has_correct_mode():
         assert jp2.mode == "I;16"
 
 
-@pytest.mark.xfail(is_big_endian() and on_ci(), reason="Fails on big-endian")
+@pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
 def test_16bit_monochrome_jp2_like_tiff():
     with Image.open("Tests/images/16bit.cropped.tif") as tiff_16bit:
         with Image.open("Tests/images/16bit.cropped.jp2") as jp2:
             assert_image_similar(jp2, tiff_16bit, 1e-3)
 
 
-@pytest.mark.xfail(is_big_endian() and on_ci(), reason="Fails on big-endian")
+@pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
 def test_16bit_monochrome_j2k_like_tiff():
     with Image.open("Tests/images/16bit.cropped.tif") as tiff_16bit:
         with Image.open("Tests/images/16bit.cropped.j2k") as j2k:

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -12,7 +12,6 @@ from .helper import (
     hopper,
     is_big_endian,
     is_win32,
-    on_ci,
     skip_unless_feature,
 )
 
@@ -69,7 +68,7 @@ class TestFilePng:
                     png.crc(cid, s)
         return chunks
 
-    @pytest.mark.xfail(is_big_endian() and on_ci(), reason="Fails on big-endian")
+    @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_sanity(self, tmp_path):
 
         # internal version number

--- a/Tests/test_file_webp_animated.py
+++ b/Tests/test_file_webp_animated.py
@@ -5,7 +5,6 @@ from .helper import (
     assert_image_equal,
     assert_image_similar,
     is_big_endian,
-    on_ci,
     skip_unless_feature,
 )
 
@@ -27,7 +26,7 @@ def test_n_frames():
         assert im.is_animated
 
 
-@pytest.mark.xfail(is_big_endian() and on_ci(), reason="Fails on big-endian")
+@pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
 def test_write_animation_L(tmp_path):
     """
     Convert an animated GIF to animated WebP, then compare the frame count, and first
@@ -53,7 +52,7 @@ def test_write_animation_L(tmp_path):
             assert_image_similar(im, orig.convert("RGBA"), 25.0)
 
 
-@pytest.mark.xfail(is_big_endian() and on_ci(), reason="Fails on big-endian")
+@pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
 def test_write_animation_RGB(tmp_path):
     """
     Write an animated WebP from RGB frames, and ensure the frames


### PR DESCRIPTION
Changes proposed in this pull request:

 * remove `on_ci` checks from endianess related `xfail` decorators. It doesn't matter whether tests are running on CI or not for those tests to fail (we are running those tests without CI).