### PR TITLE
Download CVE images instead of storing them on disk

### DIFF
--- a/Tests/check_tiff_crashes.py
+++ b/Tests/check_tiff_crashes.py
@@ -14,16 +14,20 @@
 # version.
 
 
+import urllib.request
+
 from PIL import Image
 
 repro_read_strip = (
-    "images/crash_1.tif",
-    "images/crash_2.tif",
+    "crash_1.tif",
+    "crash_2.tif",
 )
 
 for path in repro_read_strip:
-    with Image.open(path) as im:
-        try:
-            im.load()
-        except Exception as msg:
-            print(msg)
+    repo = "https://raw.githubusercontent.com/python-pillow/Pillow/master/"
+    with urllib.request.urlopen(repo + "Tests/images/" + path) as f:
+        with Image.open(f) as im:
+            try:
+                im.load()
+            except Exception as msg:
+                print(msg)


### PR DESCRIPTION
Proof of concept solution for #4730 

The Pillow test suite contains several images to trigger past CVEs, for the purpose of ensuring that they do not recur. However, as the issue describes, antivirus software is not aware that Pillow is up-to-date and so these are no longer vulnerabilities.

The strategy suggested here is to remove the images from Pillow, and instead store them in pillow-depends. To ensure that they are still run each time though, instead of optionally downloading that repository, the tests could download each image as needed.

Obviously the URL need to be changed in this PR, and it could be more widely implemented. Just wanted to create this to provide clarity.