### PR TITLE
Replace distutils.version with packaging.version.parse

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -1,5 +1,4 @@
 import copy
-import distutils.version
 import os
 import re
 import shutil
@@ -7,6 +6,7 @@ import sys
 from io import BytesIO
 
 import pytest
+from packaging.version import parse as parse_version
 from PIL import Image, ImageDraw, ImageFont, features
 
 from .helper import (
@@ -41,7 +41,7 @@ class TestImageFont:
 
     @classmethod
     def setup_class(self):
-        freetype = distutils.version.StrictVersion(features.version_module("freetype2"))
+        freetype = parse_version(features.version_module("freetype2"))
 
         self.metrics = self.METRICS["Default"]
         for conditions, metrics in self.METRICS.items():
@@ -49,7 +49,7 @@ class TestImageFont:
                 continue
 
             for condition in conditions:
-                version = re.sub("[<=>]", "", condition)
+                version = parse_version(re.sub("[<=>]", "", condition))
                 if (condition.startswith(">=") and freetype >= version) or (
                     condition.startswith("<") and freetype < version
                 ):
@@ -620,8 +620,8 @@ class TestImageFont:
     def test_variation_get(self):
         font = self.get_font()
 
-        freetype = distutils.version.StrictVersion(features.version_module("freetype2"))
-        if freetype < "2.9.1":
+        freetype = parse_version(features.version_module("freetype2"))
+        if freetype < parse_version("2.9.1"):
             with pytest.raises(NotImplementedError):
                 font.get_variation_names()
             with pytest.raises(NotImplementedError):
@@ -692,8 +692,8 @@ class TestImageFont:
     def test_variation_set_by_name(self):
         font = self.get_font()
 
-        freetype = distutils.version.StrictVersion(features.version_module("freetype2"))
-        if freetype < "2.9.1":
+        freetype = parse_version(features.version_module("freetype2"))
+        if freetype < parse_version("2.9.1"):
             with pytest.raises(NotImplementedError):
                 font.set_variation_by_name("Bold")
             return
@@ -716,8 +716,8 @@ class TestImageFont:
     def test_variation_set_by_axes(self):
         font = self.get_font()
 
-        freetype = distutils.version.StrictVersion(features.version_module("freetype2"))
-        if freetype < "2.9.1":
+        freetype = parse_version(features.version_module("freetype2"))
+        if freetype < parse_version("2.9.1"):
             with pytest.raises(NotImplementedError):
                 font.set_variation_by_axes([100])
             return
@@ -742,7 +742,7 @@ class TestImageFont_RaqmLayout(TestImageFont):
 def test_render_mono_size():
     # issue 4177
 
-    if distutils.version.StrictVersion(ImageFont.core.freetype2_version) < "2.4":
+    if parse_version(ImageFont.core.freetype2_version) < parse_version("2.4"):
         pytest.skip("Different metrics")
 
     im = Image.new("P", (100, 30), "white")


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/4796.

Changes proposed in this pull request:

 * distutils will eventually be removed from the stdlib
 * Replace `distutils.version` with `packaging.version.parse`
 * > `packaging.version.parse` is a third-party utility but is used by [setuptools][4] (so you probably already have it installed) and is conformant to the current [PEP 440][5]; it will return a `packaging.version.Version` if the version is compliant and a `packaging.version.LegacyVersion` if not. The latter will always sort before valid versions.
 * https://stackoverflow.com/a/11887885/724176

  [4]: https://pypi.python.org/pypi/setuptools
  [5]: https://www.python.org/dev/peps/pep-0440/