### PR TITLE
Remove long-deprecated Image.py functions

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -466,18 +466,6 @@ class TestImage:
         with pytest.raises(ValueError):
             Image.core.fill("RGB", (2, -2), (0, 0, 0))
 
-    def test_offset_not_implemented(self):
-        # Arrange
-        with hopper() as im:
-
-            # Act / Assert
-            with pytest.raises(NotImplementedError):
-                im.offset(None)
-
-    def test_fromstring(self):
-        with pytest.raises(NotImplementedError):
-            Image.fromstring()
-
     def test_linear_gradient_wrong_mode(self):
         # Arrange
         wrong_mode = "RGB"

--- a/Tests/test_image_frombytes.py
+++ b/Tests/test_image_frombytes.py
@@ -1,4 +1,3 @@
-import pytest
 from PIL import Image
 
 from .helper import assert_image_equal, hopper
@@ -9,8 +8,3 @@ def test_sanity():
     im2 = Image.frombytes(im1.mode, im1.size, im1.tobytes())
 
     assert_image_equal(im1, im2)
-
-
-def test_not_implemented():
-    with pytest.raises(NotImplementedError):
-        Image.fromstring()

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -68,8 +68,8 @@ raised a ``DeprecationWarning`` since 1.1.5,
 an ``Exception`` since Pillow 3.0.0
 and ``NotImplementedError`` since 3.3.0.
 
-im.fromstring and tostring
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Image.fromstring, im.fromstring and im.tostring
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. deprecated:: 2.0.0
 .. versionremoved:: 8.0.0

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -55,6 +55,33 @@ Removed features
 Deprecated features are only removed in major releases after an appropriate
 period of deprecation has passed.
 
+im.offset
+~~~~~~~~~
+
+.. deprecated:: 1.1.2
+.. versionremoved:: 8.0.0
+
+``im.offset()`` has been removed, call ``ImageChops.offset()`` instead.
+
+It was documented as deprecated in PIL 1.1.2,
+raised a ``DeprecationWarning`` since 1.1.5,
+an ``Exception`` since Pillow 3.0.0
+and ``NotImplementedError`` since 3.3.0.
+
+im.fromstring and tostring
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 2.0.0
+.. versionremoved:: 8.0.0
+
+* ``Image.fromstring()`` has been removed, call ``frombytes()`` instead.
+* ``im.fromstring()`` has been removed, call ``frombytes()`` instead.
+* ``im.tostring()`` has been removed, call ``tobytes()`` instead.
+
+They issued a ``DeprecationWarning`` since 2.0.0,
+an ``Exception`` since 3.0.0
+and ``NotImplementedError`` since 3.3.0.
+
 ImageCms.CmsProfile attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -74,9 +74,9 @@ im.fromstring and tostring
 .. deprecated:: 2.0.0
 .. versionremoved:: 8.0.0
 
-* ``Image.fromstring()`` has been removed, call ``frombytes()`` instead.
-* ``im.fromstring()`` has been removed, call ``frombytes()`` instead.
-* ``im.tostring()`` has been removed, call ``tobytes()`` instead.
+* ``Image.fromstring()`` has been removed, call :py:func:`.Image.frombytes()` instead.
+* ``im.fromstring()`` has been removed, call :py:meth:`~PIL.Image.Image.frombytes()` instead.
+* ``im.tostring()`` has been removed, call :py:meth:`~PIL.Image.Image.tobytes()` instead.
 
 They issued a ``DeprecationWarning`` since 2.0.0,
 an ``Exception`` since 3.0.0

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -151,6 +151,7 @@ This crops the input image with the provided coordinates:
 .. automethod:: PIL.Image.Image.draft
 .. automethod:: PIL.Image.Image.effect_spread
 .. automethod:: PIL.Image.Image.entropy
+.. automethod:: PIL.Image.Image.frombytes
 .. automethod:: PIL.Image.Image.filter
 
 This blurs the input image using a filter from the ``ImageFilter`` module:

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -151,8 +151,8 @@ This crops the input image with the provided coordinates:
 .. automethod:: PIL.Image.Image.draft
 .. automethod:: PIL.Image.Image.effect_spread
 .. automethod:: PIL.Image.Image.entropy
-.. automethod:: PIL.Image.Image.frombytes
 .. automethod:: PIL.Image.Image.filter
+.. automethod:: PIL.Image.Image.frombytes
 
 This blurs the input image using a filter from the ``ImageFilter`` module:
 

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -196,7 +196,6 @@ This helps to get the bounding box coordinates of the input image:
 .. automethod:: PIL.Image.Image.getpixel
 .. automethod:: PIL.Image.Image.getprojection
 .. automethod:: PIL.Image.Image.histogram
-.. automethod:: PIL.Image.Image.offset
 .. automethod:: PIL.Image.Image.paste
 .. automethod:: PIL.Image.Image.point
 .. automethod:: PIL.Image.Image.putalpha
@@ -243,7 +242,6 @@ This rotates the input image by ``theta`` degrees counter clockwise:
 .. automethod:: PIL.Image.Image.thumbnail
 .. automethod:: PIL.Image.Image.tobitmap
 .. automethod:: PIL.Image.Image.tobytes
-.. automethod:: PIL.Image.Image.tostring
 .. automethod:: PIL.Image.Image.transform
 .. automethod:: PIL.Image.Image.transpose
 
@@ -262,8 +260,6 @@ This flips the input image by using the :data:`FLIP_LEFT_RIGHT` method.
 
 
 .. automethod:: PIL.Image.Image.verify
-
-.. automethod:: PIL.Image.Image.fromstring
 
 .. automethod:: PIL.Image.Image.load
 .. automethod:: PIL.Image.Image.close

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -746,11 +746,6 @@ class Image:
 
         return b"".join(data)
 
-    def tostring(self, *args, **kw):
-        raise NotImplementedError(
-            "tostring() has been removed. Please call tobytes() instead."
-        )
-
     def tobitmap(self, name="image"):
         """
         Returns the image converted to an X11 bitmap.
@@ -801,11 +796,6 @@ class Image:
             raise ValueError("not enough image data")
         if s[1] != 0:
             raise ValueError("cannot decode image data")
-
-    def fromstring(self, *args, **kw):
-        raise NotImplementedError(
-            "fromstring() has been removed. Please call frombytes() instead."
-        )
 
     def load(self):
         """
@@ -1433,11 +1423,6 @@ class Image:
                 extrema = self.getextrema()
             return self.im.entropy(extrema)
         return self.im.entropy()
-
-    def offset(self, xoffset, yoffset=None):
-        raise NotImplementedError(
-            "offset() has been removed. Please call ImageChops.offset() instead."
-        )
 
     def paste(self, im, box=None, mask=None):
         """
@@ -2670,12 +2655,6 @@ def frombytes(mode, size, data, decoder_name="raw", *args):
     im = new(mode, size)
     im.frombytes(data, decoder_name, args)
     return im
-
-
-def fromstring(*args, **kw):
-    raise NotImplementedError(
-        "fromstring() has been removed. Please call frombytes() instead."
-    )
 
 
 def frombuffer(mode, size, data, decoder_name="raw", *args):


### PR DESCRIPTION
Our [current approach](https://pillow.readthedocs.io/en/latest/deprecations.html) has been to deprecate for at least a year, and then remove in the next major version. I think this has been working fine (except for `PILLOW_VERSION` which didn't raise deprecation warnings; so we reinstated it with warnings).

`Image.tostring` and `fromstring` were deprecated in 2013, and `Image.offset` in 2001. They've raised either a `DeprecationWarning`, `Exception` or `NotImplementedError` for a long time. Let's remove them.

---

# im.tostring and fromstring

## 2000: added

`Image.tostring`, `im.tostring` and `im.fromstring` date back to at least PIL 1.1.1 (Oct 2000), probably earlier.

## 2013: DeprecationWarning

In Pillow 2.0.0 (March 2013), when adding support for Python 3, `tobytes` was added, and `tostring` was deprecated, raising `DeprecationWarning: tostring() is deprecated. Please call tobytes() instead.` And similarly with `fromstring`/`frombytes` (https://github.com/python-pillow/Pillow/pull/35 & https://github.com/python-pillow/Pillow/pull/71).

## 2015: Exception

In Pillow 3.0.0 (Oct 2015), the `DeprecationWarning` was replaced with an `Exception` (https://github.com/python-pillow/Pillow/pull/1343).

## 2016: NotImplementedError

In Pillow 3.3.0 (July 2016), the `Exception` was replaced with a `NotImplementedError` (https://github.com/python-pillow/Pillow/pull/1862).

`NotImplementedError` means this, and doesn't quite fit:

> In user defined base classes, abstract methods should raise this exception when they require derived classes to override the method, or while the class is being developed to indicate that the real implementation still needs to be added.
>
> Note: It should not be used to indicate that an operator or method is not meant to be supported at all – in that case either leave the operator / method undefined or, if a subclass, set it to None.

https://docs.python.org/3/library/exceptions.html#NotImplementedError

# im.offset

## 2001: deprecated
## 2005: DeprecationWarning
## 2015: Exception
## 2001: NotImplementedError

`Image.offset` followed a similar path, except it was documented as deprecated in PIL 1.1.2 (May 2001), raised a `DeprecationWarning` in 1.1.5 (March 2005), then as above: `Exception` in Pillow 3.0.0 (Oct 2015), `NotImplementedError` in 3.3.0 (July 2016).
