### PR TITLE
GHA: Test Python 3.9-dev

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "pypy3"]
+        python-version: ["3.6", "3.7", "3.8", "3.9-dev", "pypy3"]
         architecture: ["x86", "x64"]
         include:
           - architecture: "x86"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
         ]
         python-version: [
           "pypy3",
+          "3.9-dev",
           "3.8",
           "3.7",
           "3.6",


### PR DESCRIPTION
GHA now provides Python 3.9 beta 4 ~if the full version number `3.9.0-beta.4` is specified~, add it to the matrix.
(https://github.com/actions/setup-python/issues/20#issuecomment-660026867)

~Or perhaps this can wait until beta 5 is available (possibly later this week?).~

Edit: Actually, specifying `3.9-dev` also seems to work fine.