### PR TITLE
Initialize offset memory for PyImagingPhotoPut

### DIFF
--- a/src/Tk/tkImaging.c
+++ b/src/Tk/tkImaging.c
@@ -114,7 +114,7 @@ PyImagingPhotoPut(ClientData clientdata, Tcl_Interp* interp,
 
     if (strcmp(im->mode, "1") == 0 || strcmp(im->mode, "L") == 0) {
         block.pixelSize = 1;
-        block.offset[0] = block.offset[1] = block.offset[2] = 0;
+        block.offset[0] = block.offset[1] = block.offset[2] = block.offset[3] = 0;
     } else if (strncmp(im->mode, "RGB", 3) == 0) {
         block.pixelSize = 4;
         block.offset[0] = 0;


### PR DESCRIPTION
When using image mode "1" or "L" block.offset[3] is never initialized. In some use cases the block is passed to Tk_PhotoPutBlock (https://github.com/tcltk/tk/blob/master/generic/tkImgPhoto.c#L2752) and block.offset[3] is stored in alphaoffset which is later referenced.

This change initializes block.offset[3] to 0 when using mode "1" or "L".