### PR TITLE
setup.py: Get prefix directly from sys instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ import struct
 import subprocess
 import sys
 import warnings
-from distutils import ccompiler, sysconfig
+from distutils import ccompiler
 from distutils.command.build_ext import build_ext
 
 from setuptools import Extension, setup
@@ -418,7 +418,7 @@ class pil_build_ext(build_ext):
                 for d in os.environ[k].split(os.path.pathsep):
                     _add_directory(library_dirs, d)
 
-        prefix = sysconfig.get_config_var("prefix")
+        prefix = os.path.normpath(sys.prefix)
         if prefix:
             _add_directory(library_dirs, os.path.join(prefix, "lib"))
             _add_directory(include_dirs, os.path.join(prefix, "include"))


### PR DESCRIPTION
For #4796.

# distutils

`setup.py` does:

```python
from distutils import sysconfig
prefix = sysconfig.get_config_var("prefix")
```

https://github.com/python/cpython/blob/master/Lib/distutils/sysconfig.py

`get_config_var("prefix")` calls `get_config_vars().get("prefix")`, which initialised it as 
`_config_vars['prefix'] = PREFIX`, where `PREFIX = os.path.normpath(sys.prefix)`

# sysconfig

There's also a `sysconfig` module in the stdlib: 

* https://docs.python.org/3/library/sysconfig.html

This is almost identical to the one in `distutils`:

 `get_config_var("prefix")` calls `get_config_vars().get("prefix")`, which initialised it as 
`_CONFIG_VARS['prefix'] = _PREFIX = _PREFIX`, where `PREFIX = os.path.normpath(sys.prefix)`

https://github.com/python/cpython/blob/master/Lib/sysconfig.py

I tried our `setup.py` with:

```diff
-from distutils import sysconfig
+import sysconfig
 prefix = sysconfig.get_config_var("prefix")
```

Which passed on all CI jobs except MSYS MINGW32 and MINGW64 because the drive letter changed:

```
distutils sysconfig prefix:   C:/msys64/mingw64
stdlib    sysconfig prefix:   D:/msys64/mingw64
```

# os.path.normpath(sys.prefix)

I didn't dig into why they're different, but can we skip `distutils.sysconfig` and `sysconfig` altogether and use `os.path.normpath(sys.prefix)` directly?

```
sys.prefix:                   C:/msys64/mingw64
os.path.normpath(sys.prefix): C:/msys64/mingw64
```
