### PR TITLE
Fix IFDRational and Exif equality for NaN values

### DIFF
--- a/Tests/test_tiff_ifdrational.py
+++ b/Tests/test_tiff_ifdrational.py
@@ -49,6 +49,11 @@ def test_nonetype():
     assert xres and yres
 
 
+def test_nan():
+    # usually NaN != NaN, but this would break exif self-equality
+    assert IFDRational(123, 0) == IFDRational(123, 0)
+
+
 def test_ifd_rational_save(tmp_path):
     methods = (True, False)
     if not features.check("libtiff"):

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -354,6 +354,9 @@ class IFDRational(Rational):
 
     def __eq__(self, other):
         if isinstance(other, IFDRational):
+            if self.denominator == 0 and other.denominator == 0:
+                # in this case self._val and other._val would be NaN
+                return self.numerator == other.numerator
             other = other._val
         return self._val == other
 


### PR DESCRIPTION
Fixes equality of `TiffImagePlugin.IFDRational` instances and therefore Exif data.

In Pillow 7.2.0 Exif RATIONALs and SIGNED_RATIONALs are read as `TiffImagePlugin.IFDRational`, instead of as a tuple with a numerator and a denominator. This caused a regression in one of my projects where I compared Exif data for equality. Reading exactly the same Exif data twice and comparing them via `==` yields `False` as the `TiffImagePlugin.IFDRational.__eq__` is broken.

`TiffImagePlugin.IFDRational` redundantly stores `numerator` / `denominator` and there ratio as `_val`. Equality comparison against other `TiffImagePlugin.IFDRational` instances worked only if `numerator` and `denominator` had no common divisors. E.g. `TiffImagePlugin.IFDRational(15, 5)` would not compare equal to itself: 15/5 == 3/1, but 15 != 3 and 5 != 1.

Changes proposed in this pull request:
 * Fix `TiffImagePlugin.IFDRational.__eq__` to compare stored `Fraction` instance against other `Fraction` instance (instead of other `TiffImagePlugin.IFDRational` instance)
* Treat `NaN`-case (i.e. denominator==0) as a special case. Usually `NaN != NaN`, but that would break Exif equality. Therefore, 
`NaN == NaN` if numerators are equal.
* Test cases for `TiffImagePlugin.IFDRational` and Exif equality.