### PR TITLE
Replaced distutils in test_image_access.py

### DIFF
--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -2,7 +2,8 @@ import ctypes
 import os
 import subprocess
 import sys
-from distutils import ccompiler, sysconfig
+import sysconfig
+from distutils import ccompiler
 
 import pytest
 from PIL import Image
@@ -360,12 +361,11 @@ int main(int argc, char* argv[])
             )
 
         compiler = ccompiler.new_compiler()
-        compiler.add_include_dir(sysconfig.get_python_inc())
+        compiler.add_include_dir(sysconfig.get_config_var("INCLUDEPY"))
 
-        libdir = sysconfig.get_config_var(
-            "LIBDIR"
-        ) or sysconfig.get_python_inc().replace("include", "libs")
-        print(libdir)
+        libdir = sysconfig.get_config_var("LIBDIR") or sysconfig.get_config_var(
+            "INCLUDEPY"
+        ).replace("include", "libs")
         compiler.add_library_dir(libdir)
         objects = compiler.compile(["embed_pil.c"])
         compiler.link_executable(objects, "embed_pil")

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -3,7 +3,8 @@ import os
 import subprocess
 import sys
 import sysconfig
-from distutils import ccompiler
+
+from setuptools.command.build_ext import new_compiler
 
 import pytest
 from PIL import Image
@@ -360,7 +361,7 @@ int main(int argc, char* argv[])
                 % sys.prefix.replace("\\", "\\\\")
             )
 
-        compiler = ccompiler.new_compiler()
+        compiler = new_compiler()
         compiler.add_include_dir(sysconfig.get_config_var("INCLUDEPY"))
 
         libdir = sysconfig.get_config_var("LIBDIR") or sysconfig.get_config_var(


### PR DESCRIPTION
For #4796, similar to #4809

Replaces
```python
from distutils import sysconfig
```
with
```python
import sysconfig
```
and
```python
sysconfig.get_python_inc()
```
with
```python
sysconfig.get_config_var("INCLUDEPY")
```
Also removes a `print` statement.

However, this test is skipped on CIs, so this PR passing is not good evidence that my changes are correct. Instead, I created https://github.com/radarhere/Pillow/commit/73f8d40df22f1203c01f9103c978835234d9c36d to check that the values with and without distutils are the same - passing on [AppVeyor](https://ci.appveyor.com/project/radarhere/pillow/builds/34296603) and [MSYS2 MINGW32](https://github.com/radarhere/Pillow/runs/909551283).