### PR TITLE
Removed distutils from MinGW detection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ import struct
 import subprocess
 import sys
 import warnings
-from distutils import ccompiler
 from distutils.command.build_ext import build_ext
 
 from setuptools import Extension, setup
@@ -131,7 +130,7 @@ class RequiredDependencyException(Exception):
     pass
 
 
-PLATFORM_MINGW = "mingw" in ccompiler.get_default_compiler()
+PLATFORM_MINGW = os.name == "nt" and "GCC" in sys.version
 PLATFORM_PYPY = hasattr(sys, "pypy_version_info")
 
 if sys.platform == "win32" and PLATFORM_MINGW:


### PR DESCRIPTION
Helps #4796

In setup.py, there is
```python
PLATFORM_MINGW = "mingw" in ccompiler.get_default_compiler()
```

Looking at `ccompiler.get_default_compiler()` on MinGW -

```python
def get_default_compiler(osname=None, platform=None):
    ...
    if get_platform().startswith('mingw'):
        return 'mingw32'
```
```python
def get_platform():
    if os.name == 'nt':
        TARGET_TO_PLAT = {
            'x86' : 'win32',
            'x64' : 'win-amd64',
            'arm' : 'win-arm32',
        }
        return TARGET_TO_PLAT.get(os.environ.get('VSCMD_ARG_TGT_ARCH')) or get_host_platform()
    else:
        return get_host_platform()
```
```python
def get_host_platform():
    ...
    if os.name == 'nt':
        if 'GCC' in sys.version:
            return 'mingw'
```

Note that I find the code on MinGW slightly different to the one on my machine - mine does not include the MinGW lines.

So then the setup.py line can be replaced with
```python
PLATFORM_MINGW = os.name == "nt" and "GCC" in sys.version
```