### PR TITLE
Removed 32-bit MinGW job

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -171,7 +171,7 @@ jobs:
       CHERE_INVOKING: 1
 
     timeout-minutes: 30
-    name: MSYS2 MINGW64
+    name: MSYS2 MinGW 64-bit
 
     steps:
       - uses: actions/checkout@v2
@@ -221,4 +221,4 @@ jobs:
           python3 -m pip install codecov
           bash <(curl -s https://codecov.io/bash) -F GHA_Windows
         env:
-          CODECOV_NAME: MSYS2 MINGW64
+          CODECOV_NAME: MSYS2 MinGW 64-bit

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -163,25 +163,15 @@ jobs:
   msys:
     runs-on: windows-2019
 
-    strategy:
-      fail-fast: false
-      matrix:
-        mingw: ["MINGW32", "MINGW64"]
-        include:
-          - mingw: "MINGW32"
-            package: "mingw-w64-i686"
-          - mingw: "MINGW64"
-            package: "mingw-w64-x86_64"
-
     defaults:
       run:
         shell: bash.exe --login -eo pipefail "{0}"
     env:
-      MSYSTEM: ${{ matrix.mingw }}
+      MSYSTEM: MINGW64
       CHERE_INVOKING: 1
 
     timeout-minutes: 30
-    name: MSYS2 ${{ matrix.mingw }}
+    name: MSYS2 MINGW64
 
     steps:
       - uses: actions/checkout@v2
@@ -193,23 +183,23 @@ jobs:
       - name: Install Dependencies
         run: |
           pacman -S --noconfirm \
-              ${{ matrix.package }}-python3-pip \
-              ${{ matrix.package }}-python3-setuptools \
-              ${{ matrix.package }}-python3-pytest \
-              ${{ matrix.package }}-python3-pytest-cov \
-              ${{ matrix.package }}-python3-cffi \
-              ${{ matrix.package }}-python3-olefile \
-              ${{ matrix.package }}-python3-numpy \
-              ${{ matrix.package }}-python3-pyqt5 \
-              ${{ matrix.package }}-python3-numpy \
-              ${{ matrix.package }}-freetype \
-              ${{ matrix.package }}-lcms2 \
-              ${{ matrix.package }}-libwebp \
-              ${{ matrix.package }}-libjpeg-turbo \
-              ${{ matrix.package }}-openjpeg2 \
-              ${{ matrix.package }}-libimagequant \
-              ${{ matrix.package }}-libraqm \
-              ${{ matrix.package }}-ghostscript \
+              mingw-w64-x86_64-python3-pip \
+              mingw-w64-x86_64-python3-setuptools \
+              mingw-w64-x86_64-python3-pytest \
+              mingw-w64-x86_64-python3-pytest-cov \
+              mingw-w64-x86_64-python3-cffi \
+              mingw-w64-x86_64-python3-olefile \
+              mingw-w64-x86_64-python3-numpy \
+              mingw-w64-x86_64-python3-pyqt5 \
+              mingw-w64-x86_64-python3-numpy \
+              mingw-w64-x86_64-freetype \
+              mingw-w64-x86_64-lcms2 \
+              mingw-w64-x86_64-libwebp \
+              mingw-w64-x86_64-libjpeg-turbo \
+              mingw-w64-x86_64-openjpeg2 \
+              mingw-w64-x86_64-libimagequant \
+              mingw-w64-x86_64-libraqm \
+              mingw-w64-x86_64-ghostscript \
               subversion
 
           python3 -m pip install pyroma
@@ -231,4 +221,4 @@ jobs:
           python3 -m pip install codecov
           bash <(curl -s https://codecov.io/bash) -F GHA_Windows
         env:
-          CODECOV_NAME: MSYS2 ${{ matrix.mingw }}
+          CODECOV_NAME: MSYS2 MINGW64


### PR DESCRIPTION
Removes 32-bit MinGW in light of https://www.msys2.org/news/#2020-05-17-32-bit-msys2-no-longer-actively-supported