### PR TITLE
Added formats parameter to init

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -93,21 +93,24 @@ class TestImage:
             assert len(Image.ID) == 0
             for ext in (".jpg", ".png"):
                 with pytest.raises(UnidentifiedImageError):
-                    Image.open("Tests/images/hopper" + ext)
+                    with Image.open("Tests/images/hopper" + ext):
+                        pass
 
             # Only JPEG
             Image.init(["JPEG"])
             assert len(Image.ID) != 0
             Image.open("Tests/images/hopper.jpg")
             with pytest.raises(UnidentifiedImageError):
-                Image.open("Tests/images/hopper.png")
+                with Image.open("Tests/images/hopper.png"):
+                    pass
 
         finally:
             # All formats
             Image.init(True)
             assert len(Image.ID) != 0
             for ext in (".jpg", ".png"):
-                Image.open("Tests/images/hopper" + ext)
+                with Image.open("Tests/images/hopper" + ext):
+                    pass
 
     def test_width_height(self):
         im = Image.new("RGB", (1, 2))

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -86,6 +86,29 @@ class TestImage:
         # with pytest.raises(MemoryError):
         #   Image.new("L", (1000000, 1000000))
 
+    def test_init(self):
+        try:
+            # No formats
+            Image.init([])
+            assert len(Image.ID) == 0
+            for ext in (".jpg", ".png"):
+                with pytest.raises(UnidentifiedImageError):
+                    Image.open("Tests/images/hopper" + ext)
+
+            # Only JPEG
+            Image.init(["JPEG"])
+            assert len(Image.ID) != 0
+            Image.open("Tests/images/hopper.jpg")
+            with pytest.raises(UnidentifiedImageError):
+                Image.open("Tests/images/hopper.png")
+
+        finally:
+            # All formats
+            Image.init(True)
+            assert len(Image.ID) != 0
+            for ext in (".jpg", ".png"):
+                Image.open("Tests/images/hopper" + ext)
+
     def test_width_height(self):
         im = Image.new("RGB", (1, 2))
         assert im.width == 1

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -204,6 +204,7 @@ if hasattr(core, "DEFAULT_STRATEGY"):
 # Registries
 
 ID = []
+EVERY_ID = []
 OPEN = {}
 MIME = {}
 SAVE = {}
@@ -390,14 +391,24 @@ def preinit():
     _initialized = 1
 
 
-def init():
+def init(formats=None):
     """
     Explicitly initializes the Python Imaging Library. This function
     loads all available file format drivers.
+
+    :param formats: Which formats to use when identifying images. The default value of
+                    ``None`` will load all formats at first, or remember the previous
+                    setting if called repeatedly. If you have previously provided a
+                    list of formats to use, ``True`` must be used to remove the
+                    restriction and use all formats.
     """
 
-    global _initialized
+    global _initialized, ID, EVERY_ID
     if _initialized >= 2:
+        if formats is True:
+            ID = EVERY_ID
+        elif formats is not None:
+            ID = formats
         return 0
 
     for plugin in _plugins:
@@ -406,8 +417,11 @@ def init():
             __import__("PIL.%s" % plugin, globals(), locals(), [])
         except ImportError as e:
             logger.debug("Image: failed to import %s: %s", plugin, e)
+    EVERY_ID = ID
+    if formats is not None and formats is not True:
+        ID = formats
 
-    if OPEN or SAVE:
+    if OPEN or SAVE or (not formats and formats is not None):
         _initialized = 2
         return 1
 

--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -282,7 +282,7 @@ def pilinfo(out=None, supported_formats=True):
         for ext, i in Image.EXTENSION.items():
             extensions[i].append(ext)
 
-        for i in sorted(Image.ID):
+        for i in sorted(Image.EVERY_ID):
             line = "{}".format(i)
             if i in Image.MIME:
                 line = "{} {}".format(line, Image.MIME[i])


### PR DESCRIPTION
Resolves #4826

Throwing out this suggestion. The issue talks about a way to limit the formats considered when opening an image.

At the moment, I think the best way is
```python
from PIL import Image
Image.init()
Image.ID = ['JPEG']
```

This PR suggests adding a `formats` argument to `init()` -

```python
from PIL import Image
Image.init(formats=["JPEG"])
```

With a `True` value to reset to all formats after having limited it.

```python
from PIL import Image
Image.init(formats=True)
```