### PR TITLE
Add develop instructions for winbuild

### DIFF
--- a/winbuild/build.rst
+++ b/winbuild/build.rst
@@ -81,6 +81,9 @@ Pillow for the selected version of Python.
 ``winbuild\build\build_pillow.cmd bdist_wheel`` will build wheels
 instead of installing Pillow.
 
+You can also use ``winbuild\build\build_pillow.cmd --inplace develop`` to build
+and install Pillow in develop mode (instead of ``pip install --editable``).
+
 Testing Pillow
 --------------
 


### PR DESCRIPTION
Alternative to #4680, documents how to install Pillow in develop mode using the winbuild scripts.