### PR TITLE
Fix exception handling when saving images

### DIFF
--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -507,7 +507,7 @@ def _save(im, fp, tile, bufsize=0):
     try:
         fh = fp.fileno()
         fp.flush()
-    except (AttributeError, io.UnsupportedOperation) as e:
+    except (AttributeError, io.UnsupportedOperation) as exc:
         # compress to Python file-compatible object
         for e, b, o, a in tile:
             e = Image._getencoder(im.mode, e, a, im.encoderconfig)
@@ -524,7 +524,7 @@ def _save(im, fp, tile, bufsize=0):
                     if s:
                         break
             if s < 0:
-                raise OSError("encoder error %d when writing image file" % s) from e
+                raise OSError("encoder error %d when writing image file" % s) from exc
             e.cleanup()
     else:
         # slight speedup: compress to real file object


### PR DESCRIPTION
The e variable is already used in the for loop, use exc to store the exception.