### PR TITLE
Image.thumbnail docstring: added missing filters

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2273,8 +2273,8 @@ class Image:
         :param size: Requested size.
         :param resample: Optional resampling filter.  This can be one
            of :py:data:`PIL.Image.NEAREST`, :py:data:`PIL.Image.BILINEAR`,
-           :py:data:`PIL.Image.BICUBIC`, :py:data:`PIL.Image.BOX`, or 
-           :py:data:`PIL.Image.LANCZOS`. If omitted, it defaults to 
+           :py:data:`PIL.Image.BICUBIC`, :py:data:`PIL.Image.BOX`, or
+           :py:data:`PIL.Image.LANCZOS`. If omitted, it defaults to
            :py:data:`PIL.Image.BICUBIC`. (was :py:data:`PIL.Image.NEAREST`
            prior to version 2.5.0). See: :ref:`concept-filters`.
         :param reducing_gap: Apply optimization by resizing the image

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2273,10 +2273,10 @@ class Image:
         :param size: Requested size.
         :param resample: Optional resampling filter.  This can be one
            of :py:data:`PIL.Image.NEAREST`, :py:data:`PIL.Image.BILINEAR`,
-           :py:data:`PIL.Image.BICUBIC`, :py:data:`PIL.Image.BOX`, or :py:data:`PIL.Image.LANCZOS`.
-           If omitted, it defaults to :py:data:`PIL.Image.BICUBIC`.
-           (was :py:data:`PIL.Image.NEAREST` prior to version 2.5.0).
-           See: :ref:`concept-filters`.
+           :py:data:`PIL.Image.BICUBIC`, :py:data:`PIL.Image.BOX`, or 
+           :py:data:`PIL.Image.LANCZOS`. If omitted, it defaults to 
+           :py:data:`PIL.Image.BICUBIC`. (was :py:data:`PIL.Image.NEAREST`
+           prior to version 2.5.0). See: :ref:`concept-filters`.
         :param reducing_gap: Apply optimization by resizing the image
            in two steps. First, reducing the image by integer times
            using :py:meth:`~PIL.Image.Image.reduce` or

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2272,11 +2272,12 @@ class Image:
 
         :param size: Requested size.
         :param resample: Optional resampling filter.  This can be one
-           of :py:data:`PIL.Image.NEAREST`, :py:data:`PIL.Image.BILINEAR`,
-           :py:data:`PIL.Image.BICUBIC`, :py:data:`PIL.Image.BOX`, or
-           :py:data:`PIL.Image.LANCZOS`. If omitted, it defaults to
-           :py:data:`PIL.Image.BICUBIC`. (was :py:data:`PIL.Image.NEAREST`
-           prior to version 2.5.0). See: :ref:`concept-filters`.
+           of :py:data:`PIL.Image.NEAREST`, :py:data:`PIL.Image.BOX`,
+           :py:data:`PIL.Image.BILINEAR`, :py:data:`PIL.Image.HAMMING`,
+           :py:data:`PIL.Image.BICUBIC` or :py:data:`PIL.Image.LANCZOS`.
+           If omitted, it defaults to :py:data:`PIL.Image.BICUBIC`.
+           (was :py:data:`PIL.Image.NEAREST` prior to version 2.5.0).
+           See: :ref:`concept-filters`.
         :param reducing_gap: Apply optimization by resizing the image
            in two steps. First, reducing the image by integer times
            using :py:meth:`~PIL.Image.Image.reduce` or

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2273,7 +2273,7 @@ class Image:
         :param size: Requested size.
         :param resample: Optional resampling filter.  This can be one
            of :py:data:`PIL.Image.NEAREST`, :py:data:`PIL.Image.BILINEAR`,
-           :py:data:`PIL.Image.BICUBIC`, or :py:data:`PIL.Image.LANCZOS`.
+           :py:data:`PIL.Image.BICUBIC`, :py:data:`PIL.Image.BOX`, or :py:data:`PIL.Image.LANCZOS`.
            If omitted, it defaults to :py:data:`PIL.Image.BICUBIC`.
            (was :py:data:`PIL.Image.NEAREST` prior to version 2.5.0).
            See: :ref:`concept-filters`.


### PR DESCRIPTION
Updated the docstring of PIL.Image.thumbnail to include PIL.Image.BOX filter as a resampling option, which was not previously listed in the documentation.