### PR TITLE
Update lint: rst-backticks and isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         types: []
 
   - repo: https://github.com/timothycrosley/isort
-    rev: 7c29dd9d55161704cfc45998c6f5c2c43d39264b  # frozen: 4.3.21
+    rev: 9ae09866e278fbc6ec0383ccb16b5c84e78e6e4d  # frozen: 5.3.2
     hooks:
       - id: isort
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,30 +14,30 @@ repos:
       - id: isort
 
   - repo: https://github.com/asottile/yesqa
-    rev: b13a51aa54142c59219c764e9f9362c049b439ed  # frozen: v1.2.0
+    rev: 7a009f3ee493c796827ee334f9058b110a0e0db8  # frozen: v1.2.1
     hooks:
       - id: yesqa
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: ffbd448645bad2e7ca13f96fca5830058d27ccd5  # frozen: v1.1.7
+    rev: f30f4974a08a6b2f6a1eeaf30a4d501cf909163a  # frozen: v1.1.9
     hooks:
       - id: remove-tabs
         exclude: (Makefile$|\.bat$|\.cmake$|\.eps$|\.fits$|\.opt$)
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 735cfe7e1c57a8e05f660ba75de72313005af54a  # frozen: 3.8.2
+    rev: 05f6544aef321e2fee03a1277ce2eef8880fb927  # frozen: 3.8.3
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: 0d7d077d6ed5624854f93ac601739c1804ebeb98  # frozen: v1.5.1
+    rev: 20b9ac745c5adaab12b845b3564c773dcc051d0e  # frozen: v1.5.2
     hooks:
       - id: python-check-blanket-noqa
       - id: rst-backticks
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: ebc15addedad713c86ef18ae9632c88e187dd0af  # frozen: v3.1.0
+    rev: e1668fe86af3810fbca72b8653fe478e66a0afdc  # frozen: v3.2.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml

--- a/Tests/check_imaging_leaks.py
+++ b/Tests/check_imaging_leaks.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import pytest
+
 from PIL import Image
 
 from .helper import is_win32
@@ -11,7 +12,7 @@ pytestmark = pytest.mark.skipif(is_win32(), reason="requires Unix or macOS")
 
 
 def _get_mem_usage():
-    from resource import getpagesize, getrusage, RUSAGE_SELF
+    from resource import RUSAGE_SELF, getpagesize, getrusage
 
     mem = getrusage(RUSAGE_SELF).ru_maxrss
     return mem * getpagesize() / 1024 / 1024

--- a/Tests/check_j2k_leaks.py
+++ b/Tests/check_j2k_leaks.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 
 import pytest
+
 from PIL import Image
 
 from .helper import is_win32, skip_unless_feature
@@ -18,7 +19,7 @@ pytestmark = [
 
 
 def test_leak_load():
-    from resource import setrlimit, RLIMIT_AS, RLIMIT_STACK
+    from resource import RLIMIT_AS, RLIMIT_STACK, setrlimit
 
     setrlimit(RLIMIT_STACK, (stack_size, stack_size))
     setrlimit(RLIMIT_AS, (mem_limit, mem_limit))
@@ -28,7 +29,7 @@ def test_leak_load():
 
 
 def test_leak_save():
-    from resource import setrlimit, RLIMIT_AS, RLIMIT_STACK
+    from resource import RLIMIT_AS, RLIMIT_STACK, setrlimit
 
     setrlimit(RLIMIT_STACK, (stack_size, stack_size))
     setrlimit(RLIMIT_AS, (mem_limit, mem_limit))

--- a/Tests/check_j2k_overflow.py
+++ b/Tests/check_j2k_overflow.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image
 
 

--- a/Tests/check_large_memory.py
+++ b/Tests/check_large_memory.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+
 from PIL import Image
 
 # This test is not run automatically.

--- a/Tests/check_large_memory_numpy.py
+++ b/Tests/check_large_memory_numpy.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+
 from PIL import Image
 
 # This test is not run automatically.

--- a/Tests/check_libtiff_segfault.py
+++ b/Tests/check_libtiff_segfault.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image
 
 TEST_FILE = "Tests/images/libtiff_segfault.tif"

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -11,6 +11,7 @@ import tempfile
 from io import BytesIO
 
 import pytest
+
 from PIL import Image, ImageMath, features
 
 logger = logging.getLogger(__name__)
@@ -184,7 +185,7 @@ class PillowLeakTestCase:
         :returns: memory usage in kilobytes
         """
 
-        from resource import getrusage, RUSAGE_SELF
+        from resource import RUSAGE_SELF, getrusage
 
         mem = getrusage(RUSAGE_SELF).ru_maxrss
         if sys.platform == "darwin":

--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+
 from PIL import Image
 
 from .helper import assert_image_similar

--- a/Tests/test_box_blur.py
+++ b/Tests/test_box_blur.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, ImageFilter
 
 sample = Image.new("L", (7, 5))

--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -1,6 +1,7 @@
 from array import array
 
 import pytest
+
 from PIL import Image, ImageFilter
 
 from .helper import assert_image_equal

--- a/Tests/test_core_resources.py
+++ b/Tests/test_core_resources.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+
 from PIL import Image
 
 from .helper import is_pypy

--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image
 
 from .helper import hopper

--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -2,6 +2,7 @@ import io
 import re
 
 import pytest
+
 from PIL import features
 
 from .helper import skip_unless_feature

--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, ImageSequence, PngImagePlugin
 
 

--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -1,6 +1,7 @@
 import io
 
 import pytest
+
 from PIL import BmpImagePlugin, Image
 
 from .helper import assert_image_equal, hopper

--- a/Tests/test_file_bufrstub.py
+++ b/Tests/test_file_bufrstub.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import BufrStubImagePlugin, Image
 
 from .helper import hopper

--- a/Tests/test_file_cur.py
+++ b/Tests/test_file_cur.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import CurImagePlugin, Image
 
 TEST_FILE = "Tests/images/deerstalker.cur"

--- a/Tests/test_file_dcx.py
+++ b/Tests/test_file_dcx.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import DcxImagePlugin, Image
 
 from .helper import assert_image_equal, hopper, is_pypy

--- a/Tests/test_file_dds.py
+++ b/Tests/test_file_dds.py
@@ -2,6 +2,7 @@
 from io import BytesIO
 
 import pytest
+
 from PIL import DdsImagePlugin, Image
 
 from .helper import assert_image_equal

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -1,6 +1,7 @@
 import io
 
 import pytest
+
 from PIL import EpsImagePlugin, Image, features
 
 from .helper import assert_image_similar, hopper, skip_unless_feature

--- a/Tests/test_file_fitsstub.py
+++ b/Tests/test_file_fitsstub.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import FitsStubImagePlugin, Image
 
 TEST_FILE = "Tests/images/hopper.fits"

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import FliImagePlugin, Image
 
 from .helper import assert_image_equal, is_pypy

--- a/Tests/test_file_fpx.py
+++ b/Tests/test_file_fpx.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image
 
 FpxImagePlugin = pytest.importorskip(

--- a/Tests/test_file_gbr.py
+++ b/Tests/test_file_gbr.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import GbrImagePlugin, Image
 
 from .helper import assert_image_equal

--- a/Tests/test_file_gd.py
+++ b/Tests/test_file_gd.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import GdImageFile, UnidentifiedImageError
 
 TEST_GD_FILE = "Tests/images/hopper.gd"

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 
 import pytest
+
 from PIL import GifImagePlugin, Image, ImageDraw, ImagePalette, features
 
 from .helper import (

--- a/Tests/test_file_gimppalette.py
+++ b/Tests/test_file_gimppalette.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL.GimpPaletteFile import GimpPaletteFile
 
 

--- a/Tests/test_file_gribstub.py
+++ b/Tests/test_file_gribstub.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import GribStubImagePlugin, Image
 
 from .helper import hopper

--- a/Tests/test_file_hdf5stub.py
+++ b/Tests/test_file_hdf5stub.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Hdf5StubImagePlugin, Image
 
 TEST_FILE = "Tests/images/hdf5.h5"

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -2,6 +2,7 @@ import io
 import sys
 
 import pytest
+
 from PIL import IcnsImagePlugin, Image, features
 
 from .helper import assert_image_equal, assert_image_similar

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -1,6 +1,7 @@
 import io
 
 import pytest
+
 from PIL import IcoImagePlugin, Image, ImageDraw
 
 from .helper import assert_image_equal, hopper

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -1,6 +1,7 @@
 import filecmp
 
 import pytest
+
 from PIL import Image, ImImagePlugin
 
 from .helper import assert_image_equal, hopper, is_pypy

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -3,6 +3,7 @@ import re
 from io import BytesIO
 
 import pytest
+
 from PIL import (
     ExifTags,
     Image,

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -2,6 +2,7 @@ import re
 from io import BytesIO
 
 import pytest
+
 from PIL import Image, ImageFile, Jpeg2KImagePlugin, features
 
 from .helper import (

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 from ctypes import c_float
 
 import pytest
+
 from PIL import Image, ImageFilter, TiffImagePlugin, TiffTags, features
 
 from .helper import (

--- a/Tests/test_file_mcidas.py
+++ b/Tests/test_file_mcidas.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, McIdasImagePlugin
 
 from .helper import assert_image_equal

--- a/Tests/test_file_mic.py
+++ b/Tests/test_file_mic.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, ImagePalette
 
 from .helper import assert_image_similar, hopper, skip_unless_feature

--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 
 import pytest
+
 from PIL import Image
 
 from .helper import assert_image_similar, is_pypy, skip_unless_feature

--- a/Tests/test_file_msp.py
+++ b/Tests/test_file_msp.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+
 from PIL import Image, MspImagePlugin
 
 from .helper import assert_image_equal, hopper

--- a/Tests/test_file_palm.py
+++ b/Tests/test_file_palm.py
@@ -2,6 +2,7 @@ import os.path
 import subprocess
 
 import pytest
+
 from PIL import Image
 
 from .helper import IMCONVERT, assert_image_equal, hopper, imagemagick_available

--- a/Tests/test_file_pcx.py
+++ b/Tests/test_file_pcx.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, ImageFile, PcxImagePlugin
 
 from .helper import assert_image_equal, hopper

--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -5,6 +5,7 @@ import tempfile
 import time
 
 import pytest
+
 from PIL import Image, PdfParser
 
 from .helper import hopper

--- a/Tests/test_file_pixar.py
+++ b/Tests/test_file_pixar.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, PixarImagePlugin
 
 from .helper import assert_image_similar, hopper

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -3,6 +3,7 @@ import zlib
 from io import BytesIO
 
 import pytest
+
 from PIL import Image, ImageFile, PngImagePlugin, features
 
 from .helper import (

--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image
 
 from .helper import assert_image_equal, assert_image_similar, hopper

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, PsdImagePlugin
 
 from .helper import assert_image_similar, hopper, is_pypy

--- a/Tests/test_file_sgi.py
+++ b/Tests/test_file_sgi.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, SgiImagePlugin
 
 from .helper import assert_image_equal, assert_image_similar, hopper

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -2,6 +2,7 @@ import tempfile
 from io import BytesIO
 
 import pytest
+
 from PIL import Image, ImageSequence, SpiderImagePlugin
 
 from .helper import assert_image_equal, hopper, is_pypy

--- a/Tests/test_file_sun.py
+++ b/Tests/test_file_sun.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+
 from PIL import Image, SunImagePlugin
 
 from .helper import assert_image_equal, assert_image_similar, hopper

--- a/Tests/test_file_tar.py
+++ b/Tests/test_file_tar.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, TarIO, features
 
 from .helper import is_pypy

--- a/Tests/test_file_tga.py
+++ b/Tests/test_file_tga.py
@@ -3,6 +3,7 @@ from glob import glob
 from itertools import product
 
 import pytest
+
 from PIL import Image
 
 from .helper import assert_image_equal, hopper

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -2,6 +2,7 @@ import os
 from io import BytesIO
 
 import pytest
+
 from PIL import Image, TiffImagePlugin
 from PIL.TiffImagePlugin import RESOLUTION_UNIT, X_RESOLUTION, Y_RESOLUTION
 

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -2,6 +2,7 @@ import io
 import struct
 
 import pytest
+
 from PIL import Image, TiffImagePlugin, TiffTags
 from PIL.TiffImagePlugin import IFDRational
 

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -2,6 +2,7 @@ import io
 import re
 
 import pytest
+
 from PIL import Image, WebPImagePlugin, features
 
 from .helper import (

--- a/Tests/test_file_webp_alpha.py
+++ b/Tests/test_file_webp_alpha.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image
 
 from .helper import assert_image_equal, assert_image_similar, hopper

--- a/Tests/test_file_webp_animated.py
+++ b/Tests/test_file_webp_animated.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image
 
 from .helper import (

--- a/Tests/test_file_webp_lossless.py
+++ b/Tests/test_file_webp_lossless.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image
 
 from .helper import assert_image_equal, hopper

--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, WmfImagePlugin
 
 from .helper import assert_image_similar, hopper

--- a/Tests/test_file_xbm.py
+++ b/Tests/test_file_xbm.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 
 import pytest
+
 from PIL import Image
 
 from .helper import hopper

--- a/Tests/test_file_xpm.py
+++ b/Tests/test_file_xpm.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, XpmImagePlugin
 
 from .helper import assert_image_similar, hopper

--- a/Tests/test_file_xvthumb.py
+++ b/Tests/test_file_xvthumb.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, XVThumbImagePlugin
 
 from .helper import assert_image_similar, hopper

--- a/Tests/test_font_bdf.py
+++ b/Tests/test_font_bdf.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import BdfFontFile, FontFile
 
 filename = "Tests/images/courB08.bdf"

--- a/Tests/test_font_pcf.py
+++ b/Tests/test_font_pcf.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+
 from PIL import FontFile, Image, ImageDraw, ImageFont, PcfFontFile
 
 from .helper import assert_image_equal, assert_image_similar, skip_unless_feature

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -3,8 +3,9 @@ import os
 import shutil
 import tempfile
 
-import PIL
 import pytest
+
+import PIL
 from PIL import Image, ImageDraw, ImagePalette, ImageShow, UnidentifiedImageError
 
 from .helper import (

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -4,9 +4,9 @@ import subprocess
 import sys
 import sysconfig
 
+import pytest
 from setuptools.command.build_ext import new_compiler
 
-import pytest
 from PIL import Image
 
 from .helper import assert_image_equal, hopper, is_win32, on_ci
@@ -17,8 +17,9 @@ if os.environ.get("PYTHONOPTIMIZE") == "2":
     cffi = None
 else:
     try:
-        from PIL import PyAccess
         import cffi
+
+        from PIL import PyAccess
     except ImportError:
         cffi = None
 

--- a/Tests/test_image_array.py
+++ b/Tests/test_image_array.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image
 
 from .helper import hopper

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image
 
 from .helper import assert_image, assert_image_equal, assert_image_similar, hopper

--- a/Tests/test_image_crop.py
+++ b/Tests/test_image_crop.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image
 
 from .helper import assert_image_equal, hopper

--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, ImageFilter
 
 from .helper import assert_image_equal, hopper

--- a/Tests/test_image_fromqimage.py
+++ b/Tests/test_image_fromqimage.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, ImageQt
 
 from .helper import assert_image_equal, hopper

--- a/Tests/test_image_load.py
+++ b/Tests/test_image_load.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+
 from PIL import Image
 
 from .helper import hopper

--- a/Tests/test_image_putpalette.py
+++ b/Tests/test_image_putpalette.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import ImagePalette
 
 from .helper import hopper

--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image
 
 from .helper import assert_image, assert_image_similar, hopper

--- a/Tests/test_image_reduce.py
+++ b/Tests/test_image_reduce.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, ImageMath, ImageMode
 
 from .helper import convert_to_comparable, skip_unless_feature

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 
 import pytest
+
 from PIL import Image, ImageDraw
 
 from .helper import assert_image_equal, assert_image_similar, hopper

--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -4,6 +4,7 @@ Tests for resize functionality.
 from itertools import permutations
 
 import pytest
+
 from PIL import Image
 
 from .helper import assert_image_equal, assert_image_similar, hopper

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image
 
 from .helper import (

--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -1,6 +1,7 @@
 import math
 
 import pytest
+
 from PIL import Image, ImageTransform
 
 from .helper import assert_image_equal, assert_image_similar, hopper

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -4,6 +4,7 @@ import re
 from io import BytesIO
 
 import pytest
+
 from PIL import Image, ImageMode, features
 
 from .helper import assert_image, assert_image_equal, assert_image_similar, hopper

--- a/Tests/test_imagecolor.py
+++ b/Tests/test_imagecolor.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, ImageColor
 
 

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -1,6 +1,7 @@
 import os.path
 
 import pytest
+
 from PIL import Image, ImageColor, ImageDraw, ImageFont
 
 from .helper import (

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 
 import pytest
+
 from PIL import EpsImagePlugin, Image, ImageFile, features
 
 from .helper import (

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -7,6 +7,7 @@ from io import BytesIO
 
 import pytest
 from packaging.version import parse as parse_version
+
 from PIL import Image, ImageDraw, ImageFont, features
 
 from .helper import (

--- a/Tests/test_imagefont_bitmap.py
+++ b/Tests/test_imagefont_bitmap.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, ImageDraw, ImageFont
 
 from .helper import assert_image_similar

--- a/Tests/test_imagefontctl.py
+++ b/Tests/test_imagefontctl.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, ImageDraw, ImageFont
 
 from .helper import assert_image_similar, skip_unless_feature

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 
 import pytest
+
 from PIL import Image, ImageGrab
 
 from .helper import assert_image, assert_image_equal_tofile, skip_unless_feature

--- a/Tests/test_imagemorph.py
+++ b/Tests/test_imagemorph.py
@@ -1,5 +1,6 @@
 # Test the ImageMorphology functionality
 import pytest
+
 from PIL import Image, ImageMorph, _imagingmorph
 
 from .helper import assert_image_equal, hopper

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, ImageOps, features
 
 from .helper import (

--- a/Tests/test_imageops_usm.py
+++ b/Tests/test_imageops_usm.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, ImageFilter
 
 

--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, ImagePalette
 
 from .helper import assert_image_equal

--- a/Tests/test_imagepath.py
+++ b/Tests/test_imagepath.py
@@ -2,6 +2,7 @@ import array
 import struct
 
 import pytest
+
 from PIL import Image, ImagePath
 
 

--- a/Tests/test_imageqt.py
+++ b/Tests/test_imageqt.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import ImageQt
 
 from .helper import hopper

--- a/Tests/test_imagesequence.py
+++ b/Tests/test_imagesequence.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, ImageSequence, TiffImagePlugin
 
 from .helper import assert_image_equal, hopper, skip_unless_feature

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, ImageShow
 
 from .helper import hopper, is_win32, on_ci

--- a/Tests/test_imagestat.py
+++ b/Tests/test_imagestat.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, ImageStat
 
 from .helper import hopper

--- a/Tests/test_imagetk.py
+++ b/Tests/test_imagetk.py
@@ -1,12 +1,13 @@
 import pytest
+
 from PIL import Image
 
 from .helper import assert_image_equal, hopper
 
 try:
-    from PIL import ImageTk
-
     import tkinter as tk
+
+    from PIL import ImageTk
 
     dir(ImageTk)
     HAS_TK = True

--- a/Tests/test_imagewin.py
+++ b/Tests/test_imagewin.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import ImageWin
 
 from .helper import hopper, is_win32

--- a/Tests/test_lib_image.py
+++ b/Tests/test_lib_image.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image
 
 

--- a/Tests/test_lib_pack.py
+++ b/Tests/test_lib_pack.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+
 from PIL import Image
 
 X = 255

--- a/Tests/test_locale.py
+++ b/Tests/test_locale.py
@@ -1,6 +1,7 @@
 import locale
 
 import pytest
+
 from PIL import Image
 
 # ref https://github.com/python-pillow/Pillow/issues/272

--- a/Tests/test_map.py
+++ b/Tests/test_map.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+
 from PIL import Image
 
 from .helper import is_win32

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image
 
 from .helper import assert_deep_equal, assert_image, hopper

--- a/Tests/test_pdfparser.py
+++ b/Tests/test_pdfparser.py
@@ -1,6 +1,7 @@
 import time
 
 import pytest
+
 from PIL.PdfParser import (
     IndirectObjectDef,
     IndirectReference,

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -1,6 +1,7 @@
 import pickle
 
 import pytest
+
 from PIL import Image
 
 from .helper import skip_unless_feature

--- a/Tests/test_pyroma.py
+++ b/Tests/test_pyroma.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import __version__
 
 pyroma = pytest.importorskip("pyroma", reason="Pyroma not installed")

--- a/Tests/test_qt_image_toqimage.py
+++ b/Tests/test_qt_image_toqimage.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import Image, ImageQt
 
 from .helper import assert_image_equal, hopper
@@ -12,10 +13,10 @@ if ImageQt.qt_is_installed:
 
     try:
         from PyQt5 import QtGui
-        from PyQt5.QtWidgets import QWidget, QHBoxLayout, QLabel, QApplication
+        from PyQt5.QtWidgets import QApplication, QHBoxLayout, QLabel, QWidget
     except (ImportError, RuntimeError):
         from PySide2 import QtGui
-        from PySide2.QtWidgets import QWidget, QHBoxLayout, QLabel, QApplication
+        from PySide2.QtWidgets import QApplication, QHBoxLayout, QLabel, QWidget
 
 
 def test_sanity(tmp_path):

--- a/Tests/test_sgi_crash.py
+++ b/Tests/test_sgi_crash.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import pytest
+
 from PIL import Image
 
 

--- a/Tests/test_shell_injection.py
+++ b/Tests/test_shell_injection.py
@@ -1,6 +1,7 @@
 import shutil
 
 import pytest
+
 from PIL import GifImagePlugin, Image, JpegImagePlugin
 
 from .helper import cjpeg_available, djpeg_available, is_win32, netpbm_available

--- a/Tests/test_util.py
+++ b/Tests/test_util.py
@@ -1,4 +1,5 @@
 import pytest
+
 from PIL import _util
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,8 +16,9 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath('.'))
 
-import PIL
 import sphinx_rtd_theme
+
+import PIL
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/reference/block_allocator.rst
+++ b/docs/reference/block_allocator.rst
@@ -40,7 +40,7 @@ variables:
 
   * ``PILLOW_BLOCK_SIZE``, in bytes, K, or M.  Specifies the maximum
     block size for ``ImagingAllocateArray``. Valid values are
-    integers, with an optional `k` or `m` suffix. Defaults to 16M.
+    integers, with an optional ``k`` or ``m`` suffix. Defaults to 16M.
 
   * ``PILLOW_BLOCKS_MAX`` Specifies the number of freed blocks to
     retain to fill future memory requests. Any freed blocks over this

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,7 @@ extend-ignore = E203, W503
 max-line-length = 88
 
 [isort]
-combine_as_imports = True
-include_trailing_comma = True
-line_length = 88
-multi_line_output = 3
+profile = black
 
 [tool:pytest]
 addopts = -ra --color=yes

--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -25,7 +25,12 @@
 
 
 from . import Image, ImageFile, ImagePalette
-from ._binary import i8, i16le as i16, i32le as i32, o8, o16le as o16, o32le as o32
+from ._binary import i8
+from ._binary import i16le as i16
+from ._binary import i32le as i32
+from ._binary import o8
+from ._binary import o16le as o16
+from ._binary import o32le as o32
 
 #
 # --------------------------------------------------------------------

--- a/src/PIL/CurImagePlugin.py
+++ b/src/PIL/CurImagePlugin.py
@@ -16,7 +16,9 @@
 # See the README file for information on usage and redistribution.
 #
 from . import BmpImagePlugin, Image
-from ._binary import i8, i16le as i16, i32le as i32
+from ._binary import i8
+from ._binary import i16le as i16
+from ._binary import i32le as i32
 
 #
 # --------------------------------------------------------------------

--- a/src/PIL/FliImagePlugin.py
+++ b/src/PIL/FliImagePlugin.py
@@ -17,7 +17,10 @@
 
 
 from . import Image, ImageFile, ImagePalette
-from ._binary import i8, i16le as i16, i32le as i32, o8
+from ._binary import i8
+from ._binary import i16le as i16
+from ._binary import i32le as i32
+from ._binary import o8
 
 #
 # decoder

--- a/src/PIL/FpxImagePlugin.py
+++ b/src/PIL/FpxImagePlugin.py
@@ -17,7 +17,8 @@
 import olefile
 
 from . import Image, ImageFile
-from ._binary import i8, i32le as i32
+from ._binary import i8
+from ._binary import i32le as i32
 
 # we map from colour field tuples to (mode, rawmode) descriptors
 MODES = {

--- a/src/PIL/GdImageFile.py
+++ b/src/PIL/GdImageFile.py
@@ -28,7 +28,9 @@
 
 
 from . import ImageFile, ImagePalette, UnidentifiedImageError
-from ._binary import i8, i16be as i16, i32be as i32
+from ._binary import i8
+from ._binary import i16be as i16
+from ._binary import i32be as i32
 
 
 class GdImageFile(ImageFile.ImageFile):

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -30,7 +30,10 @@ import os
 import subprocess
 
 from . import Image, ImageChops, ImageFile, ImagePalette, ImageSequence
-from ._binary import i8, i16le as i16, o8, o16le as o16
+from ._binary import i8
+from ._binary import i16le as i16
+from ._binary import o8
+from ._binary import o16le as o16
 
 # --------------------------------------------------------------------
 # Identify/read GIF files

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -28,7 +28,9 @@ from io import BytesIO
 from math import ceil, log
 
 from . import BmpImagePlugin, Image, ImageFile, PngImagePlugin
-from ._binary import i8, i16le as i16, i32le as i32
+from ._binary import i8
+from ._binary import i16le as i16
+from ._binary import i32le as i32
 
 #
 # --------------------------------------------------------------------

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -35,7 +35,6 @@ import numbers
 
 from . import Image, ImageColor
 
-
 """
 A simple 2D drawing interface for PIL images.
 <p>

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -21,8 +21,8 @@ from . import Image
 
 if sys.platform == "darwin":
     import os
-    import tempfile
     import subprocess
+    import tempfile
 
 
 def grab(bbox=None, include_layered_windows=False, all_screens=False, xdisplay=None):

--- a/src/PIL/ImageQt.py
+++ b/src/PIL/ImageQt.py
@@ -29,11 +29,11 @@ qt_versions.sort(key=lambda qt_version: qt_version[1] in sys.modules, reverse=Tr
 for qt_version, qt_module in qt_versions:
     try:
         if qt_module == "PyQt5":
-            from PyQt5.QtGui import QImage, qRgba, QPixmap
             from PyQt5.QtCore import QBuffer, QIODevice
+            from PyQt5.QtGui import QImage, QPixmap, qRgba
         elif qt_module == "PySide2":
-            from PySide2.QtGui import QImage, qRgba, QPixmap
             from PySide2.QtCore import QBuffer, QIODevice
+            from PySide2.QtGui import QImage, QPixmap, qRgba
     except (ImportError, RuntimeError):
         continue
     qt_is_installed = True

--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -18,7 +18,10 @@ import os
 import tempfile
 
 from . import Image, ImageFile
-from ._binary import i8, i16be as i16, i32be as i32, o8
+from ._binary import i8
+from ._binary import i16be as i16
+from ._binary import i32be as i32
+from ._binary import o8
 
 COMPRESSION = {1: "raw", 5: "jpeg"}
 
@@ -181,8 +184,9 @@ def getiptcinfo(im):
     :returns: A dictionary containing IPTC information, or None if
         no IPTC information block was found.
     """
-    from . import TiffImagePlugin, JpegImagePlugin
     import io
+
+    from . import JpegImagePlugin, TiffImagePlugin
 
     data = None
 

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -40,7 +40,10 @@ import tempfile
 import warnings
 
 from . import Image, ImageFile, TiffImagePlugin
-from ._binary import i8, i16be as i16, i32be as i32, o8
+from ._binary import i8
+from ._binary import i16be as i16
+from ._binary import i32be as i32
+from ._binary import o8
 from .JpegPresets import presets
 
 #

--- a/src/PIL/MspImagePlugin.py
+++ b/src/PIL/MspImagePlugin.py
@@ -27,7 +27,9 @@ import io
 import struct
 
 from . import Image, ImageFile
-from ._binary import i8, i16le as i16, o16le as o16
+from ._binary import i8
+from ._binary import i16le as i16
+from ._binary import o16le as o16
 
 #
 # read MSP files

--- a/src/PIL/PalmImagePlugin.py
+++ b/src/PIL/PalmImagePlugin.py
@@ -8,7 +8,8 @@
 ##
 
 from . import Image, ImageFile
-from ._binary import o8, o16be as o16b
+from ._binary import o8
+from ._binary import o16be as o16b
 
 # fmt: off
 _Palm8BitColormapValues = (

--- a/src/PIL/PcfFontFile.py
+++ b/src/PIL/PcfFontFile.py
@@ -19,7 +19,11 @@
 import io
 
 from . import FontFile, Image
-from ._binary import i8, i16be as b16, i16le as l16, i32be as b32, i32le as l32
+from ._binary import i8
+from ._binary import i16be as b16
+from ._binary import i16le as l16
+from ._binary import i32be as b32
+from ._binary import i32le as l32
 
 # --------------------------------------------------------------------
 # declarations

--- a/src/PIL/PcxImagePlugin.py
+++ b/src/PIL/PcxImagePlugin.py
@@ -29,7 +29,10 @@ import io
 import logging
 
 from . import Image, ImageFile, ImagePalette
-from ._binary import i8, i16le as i16, o8, o16le as o16
+from ._binary import i8
+from ._binary import i16le as i16
+from ._binary import o8
+from ._binary import o16le as o16
 
 logger = logging.getLogger(__name__)
 

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -39,7 +39,12 @@ import warnings
 import zlib
 
 from . import Image, ImageChops, ImageFile, ImagePalette, ImageSequence
-from ._binary import i8, i16be as i16, i32be as i32, o8, o16be as o16, o32be as o32
+from ._binary import i8
+from ._binary import i16be as i16
+from ._binary import i32be as i32
+from ._binary import o8
+from ._binary import o16be as o16
+from ._binary import o32be as o32
 
 logger = logging.getLogger(__name__)
 

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -19,7 +19,9 @@
 import io
 
 from . import Image, ImageFile, ImagePalette
-from ._binary import i8, i16be as i16, i32be as i32
+from ._binary import i8
+from ._binary import i16be as i16
+from ._binary import i32be as i32
 
 MODES = {
     # (photoshop mode, bits) -> (pil mode, required channels)

--- a/src/PIL/SgiImagePlugin.py
+++ b/src/PIL/SgiImagePlugin.py
@@ -26,7 +26,9 @@ import os
 import struct
 
 from . import Image, ImageFile
-from ._binary import i8, i16be as i16, o8
+from ._binary import i8
+from ._binary import i16be as i16
+from ._binary import o8
 
 
 def _accept(prefix):

--- a/src/PIL/TgaImagePlugin.py
+++ b/src/PIL/TgaImagePlugin.py
@@ -20,7 +20,10 @@
 import warnings
 
 from . import Image, ImageFile, ImagePalette
-from ._binary import i8, i16le as i16, o8, o16le as o16
+from ._binary import i8
+from ._binary import i16le as i16
+from ._binary import o8
+from ._binary import o16le as o16
 
 #
 # --------------------------------------------------------------------

--- a/src/PIL/WmfImagePlugin.py
+++ b/src/PIL/WmfImagePlugin.py
@@ -20,7 +20,10 @@
 # http://wvware.sourceforge.net/caolan/ora-wmf.html
 
 from . import Image, ImageFile
-from ._binary import i16le as word, i32le as dword, si16le as short, si32le as _long
+from ._binary import i16le as word
+from ._binary import i32le as dword
+from ._binary import si16le as short
+from ._binary import si32le as _long
 
 _handler = None
 

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -356,8 +356,8 @@ def find_msvs():
 
 
 def extract_dep(url, filename):
-    import urllib.request
     import tarfile
+    import urllib.request
     import zipfile
 
     file = os.path.join(depends_dir, filename)


### PR DESCRIPTION
Changes proposed in this pull request:

 * Update pre-commit linters 
 * The new `rst-backticks` found some single-chars with single backticks 
 * The new isort v5 has a Black profile (see `setup.cfg`) and some other updates
   * https://timothycrosley.github.io/isort/docs/upgrade_guides/5.0.0/
 * The other new linters still passed
