### PR TITLE
Add release notes for 8.0.0 and a template

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build"]
+exclude_patterns = ["_build", "releasenotes/template.rst"]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -18,16 +18,16 @@ Image.show command parameter
 .. deprecated:: 7.2.0
 
 The ``command`` parameter was deprecated and will be removed in a future release.
-Use a subclass of ``ImageShow.Viewer`` instead.
+Use a subclass of :py:class:`.ImageShow.Viewer` instead.
 
 Image._showxv
 ~~~~~~~~~~~~~
 
 .. deprecated:: 7.2.0
 
-``Image._showxv`` has been deprecated. Use :py:meth:`~PIL.Image.Image.show`
-instead. If custom behaviour is required, use :py:meth:`~PIL.ImageShow.register` to add
-a custom :py:class:`~PIL.ImageShow.Viewer` class.
+``Image._showxv`` has been deprecated. Use :py:meth:`.Image.Image.show`
+instead. If custom behaviour is required, use :py:func:`.ImageShow.register` to add
+a custom :py:class:`.ImageShow.Viewer` class.
 
 ImageFile.raise_ioerror
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ im.offset
 .. deprecated:: 1.1.2
 .. versionremoved:: 8.0.0
 
-``im.offset()`` has been removed, call ``ImageChops.offset()`` instead.
+``im.offset()`` has been removed, call :py:func:`.ImageChops.offset()` instead.
 
 It was documented as deprecated in PIL 1.1.2,
 raised a ``DeprecationWarning`` since 1.1.5,
@@ -88,20 +88,20 @@ ImageCms.CmsProfile attributes
 .. deprecated:: 3.2.0
 .. versionremoved:: 8.0.0
 
-Some attributes in ``ImageCms.CmsProfile`` have been removed. From 6.0.0, they issued a
-``DeprecationWarning``:
+Some attributes in :py:class:`PIL.ImageCms.CmsProfile` have been removed. From 6.0.0,
+they issued a ``DeprecationWarning``:
 
-========================  ===============================
+========================  ===============================================================
 Removed                   Use instead
-========================  ===============================
-``color_space``           Padded ``xcolor_space``
-``pcs``                   Padded ``connection_space``
-``product_copyright``     Unicode ``copyright``
-``product_desc``          Unicode ``profile_description``
-``product_description``   Unicode ``profile_description``
-``product_manufacturer``  Unicode ``manufacturer``
-``product_model``         Unicode ``model``
-========================  ===============================
+========================  ===============================================================
+``color_space``           Padded :py:attr:`~PIL.ImageCms.CmsProfile.xcolor_space`
+``pcs``                   Padded :py:attr:`~PIL.ImageCms.CmsProfile.connection_space`
+``product_copyright``     Unicode :py:attr:`~PIL.ImageCms.CmsProfile.copyright`
+``product_desc``          Unicode :py:attr:`~PIL.ImageCms.CmsProfile.profile_description`
+``product_description``   Unicode :py:attr:`~PIL.ImageCms.CmsProfile.profile_description`
+``product_manufacturer``  Unicode :py:attr:`~PIL.ImageCms.CmsProfile.manufacturer`
+``product_model``         Unicode :py:attr:`~PIL.ImageCms.CmsProfile.model`
+========================  ===============================================================
 
 Python 2.7
 ~~~~~~~~~~

--- a/docs/reference/ImageChops.rst
+++ b/docs/reference/ImageChops.rst
@@ -39,12 +39,7 @@ operations in this module).
 .. autofunction:: PIL.ImageChops.soft_light
 .. autofunction:: PIL.ImageChops.hard_light
 .. autofunction:: PIL.ImageChops.overlay
-.. py:method:: PIL.ImageChops.offset(image, xoffset, yoffset=None)
-
-    Returns a copy of the image where data has been offset by the given
-    distances. Data wraps around the edges. If **yoffset** is omitted, it
-    is assumed to be equal to **xoffset**.
-
+.. autofunction:: PIL.ImageChops.offset
 .. autofunction:: PIL.ImageChops.screen
 .. autofunction:: PIL.ImageChops.subtract
 .. autofunction:: PIL.ImageChops.subtract_modulo

--- a/docs/releasenotes/8.0.0.rst
+++ b/docs/releasenotes/8.0.0.rst
@@ -54,7 +54,7 @@ ImageOps.autocontrast cutoffs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Previously, the ``cutoff`` parameter of :py:func:`.ImageOps.autocontrast` could only
-be a single integer, used as the percent to cut off from the histogram on the low and
+be a single number, used as the percent to cut off from the histogram on the low and
 high ends.
 
 Now, it can also be a tuple ``(low, high)``.

--- a/docs/releasenotes/8.0.0.rst
+++ b/docs/releasenotes/8.0.0.rst
@@ -1,0 +1,73 @@
+8.0.0
+-----
+
+Backwards Incompatible Changes
+==============================
+
+Python 3.5
+^^^^^^^^^^
+
+Pillow has dropped support for Python 3.5, which reached end-of-life on 2020-09-13.
+
+im.offset
+^^^^^^^^^
+
+``im.offset()`` has been removed, call :py:func:`.ImageChops.offset()` instead.
+
+Image.fromstring, im.fromstring and im.tostring
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``Image.fromstring()`` has been removed, call :py:func:`.Image.frombytes()` instead.
+* ``im.fromstring()`` has been removed, call :py:meth:`~PIL.Image.Image.frombytes()` instead.
+* ``im.tostring()`` has been removed, call :py:meth:`~PIL.Image.Image.tobytes()` instead.
+
+ImageCms.CmsProfile attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some attributes in :py:class:`PIL.ImageCms.CmsProfile` have been removed:
+
+========================  ===============================================================
+Removed                   Use instead
+========================  ===============================================================
+``color_space``           Padded :py:attr:`~PIL.ImageCms.CmsProfile.xcolor_space`
+``pcs``                   Padded :py:attr:`~PIL.ImageCms.CmsProfile.connection_space`
+``product_copyright``     Unicode :py:attr:`~PIL.ImageCms.CmsProfile.copyright`
+``product_desc``          Unicode :py:attr:`~PIL.ImageCms.CmsProfile.profile_description`
+``product_description``   Unicode :py:attr:`~PIL.ImageCms.CmsProfile.profile_description`
+``product_manufacturer``  Unicode :py:attr:`~PIL.ImageCms.CmsProfile.manufacturer`
+``product_model``         Unicode :py:attr:`~PIL.ImageCms.CmsProfile.model`
+========================  ===============================================================
+
+API Changes
+===========
+
+Add MIME type to PsdImagePlugin
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+"image/vnd.adobe.photoshop" is now registered as the
+:py:class:`.PsdImagePlugin.PsdImageFile` MIME type.
+
+API Additions
+=============
+
+ImageOps.autocontrast cutoffs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Previously, the ``cutoff`` parameter of :py:func:`.ImageOps.autocontrast` could only
+be a single integer, used as the percent to cut off from the histogram on the low and
+high ends.
+
+Now, it can also be a tuple ``(low, high)``.
+
+Security
+========
+
+TODO
+
+Other Changes
+=============
+
+TODO
+^^^^
+
+TODO

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -13,6 +13,7 @@ expected to be backported to earlier versions.
 .. toctree::
   :maxdepth: 2
 
+  8.0.0
   7.2.0
   7.1.2
   7.1.1

--- a/docs/releasenotes/template.rst
+++ b/docs/releasenotes/template.rst
@@ -1,0 +1,45 @@
+x.y.z
+-----
+
+Backwards Incompatible Changes
+==============================
+
+TODO
+^^^^
+
+Deprecations
+============
+
+TODO
+^^^^
+
+TODO
+
+API Changes
+===========
+
+TODO
+^^^^
+
+TODO
+
+API Additions
+=============
+
+TODO
+^^^^
+
+TODO
+
+Security
+========
+
+TODO
+
+Other Changes
+=============
+
+TODO
+^^^^
+
+TODO


### PR DESCRIPTION
Changes proposed in this pull request:

 * Add release notes for 8.0.0
 * Add a release note template for future copy/paste, with the sections in the usual order
 * Exclude the template from `make doc`, to silence a `make doc` error as it's not linked in the toctree
 * Put `PIL.ImageChops.offset` as `autodoc`, as it has a good docstring
 * A few other minor doc updates related to autolinking to classes, methods or functions
