### PR TITLE
Improved example plugin documentation

### DIFF
--- a/docs/handbook/writing-your-own-file-decoder.rst
+++ b/docs/handbook/writing-your-own-file-decoder.rst
@@ -159,6 +159,8 @@ can be used with most uncompressed file formats, such as PPM, BMP, uncompressed
 TIFF, and many others. To use the raw decoder with the
 :py:func:`PIL.Image.frombytes` function, use the following syntax::
 
+.. code-block:: python
+
     image = Image.frombytes(
         mode, size, data, "raw",
         raw mode, stride, orientation
@@ -268,6 +270,8 @@ image memory.
 
 To use the bit decoder with the :py:func:`PIL.Image.frombytes` function, use
 the following syntax::
+
+.. code-block:: python
 
     image = Image.frombytes(
         mode, size, data, "bit",

--- a/docs/handbook/writing-your-own-file-decoder.rst
+++ b/docs/handbook/writing-your-own-file-decoder.rst
@@ -87,8 +87,10 @@ true color.
 
     Image.register_open(SpamImageFile.format, SpamImageFile, _accept)
 
-    Image.register_extension(SpamImageFile.format, ".spam")
-    Image.register_extension(SpamImageFile.format, ".spa")  # DOS version
+    Image.register_extensions(SpamImageFile.format, [
+        ".spam",
+        ".spa",  # DOS version
+    ])
 
 
 The format handler must always set the

--- a/docs/handbook/writing-your-own-file-decoder.rst
+++ b/docs/handbook/writing-your-own-file-decoder.rst
@@ -105,6 +105,13 @@ Note that the image plugin must be explicitly registered using
 :py:func:`PIL.Image.register_open`. Although not required, it is also a good
 idea to register any extensions used by this format.
 
+Once the plugin has been imported, it can be used::
+
+    from PIL import Image
+    import SpamImagePlugin
+    with Image.open("hopper.spam") as im:
+        pass
+
 The ``tile`` attribute
 ----------------------
 

--- a/docs/handbook/writing-your-own-file-decoder.rst
+++ b/docs/handbook/writing-your-own-file-decoder.rst
@@ -105,7 +105,9 @@ Note that the image plugin must be explicitly registered using
 :py:func:`PIL.Image.register_open`. Although not required, it is also a good
 idea to register any extensions used by this format.
 
-Once the plugin has been imported, it can be used::
+Once the plugin has been imported, it can be used:
+
+.. code-block:: python
 
     from PIL import Image
     import SpamImagePlugin
@@ -422,5 +424,4 @@ Python-based file decoder:
    called with a buffer of data to be interpreted.
 
 3. Cleanup: The decoder instance's ``cleanup`` method is called.
-
 


### PR DESCRIPTION
- Combine two `register_extension` calls into `register_extensions`
- Added an example importing SpamImagePlugin, to help #4818