### PR TITLE
Corrected inverted PDF CMYK colors

### DIFF
--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -121,6 +121,7 @@ def _save(im, fp, filename, save_all=False):
 
             bits = 8
             params = None
+            decode = None
 
             if im.mode == "1":
                 filter = "ASCIIHexDecode"
@@ -150,6 +151,7 @@ def _save(im, fp, filename, save_all=False):
                 filter = "DCTDecode"
                 colorspace = PdfParser.PdfName("DeviceCMYK")
                 procset = "ImageC"  # color images
+                decode = [1, 0, 1, 0, 1, 0, 1, 0]
             else:
                 raise ValueError("cannot save mode %s" % im.mode)
 
@@ -189,6 +191,7 @@ def _save(im, fp, filename, save_all=False):
                 Height=height,  # * 72.0 / resolution,
                 Filter=PdfParser.PdfName(filter),
                 BitsPerComponent=bits,
+                Decode=decode,
                 DecodeParams=params,
                 ColorSpace=colorspace,
             )


### PR DESCRIPTION
Resolves #4860

Saving a CMYK image to PDF currently inverts the colors.

Googling, I found https://stackoverflow.com/questions/30352913/how-to-insert-cmyk-image-into-pdf-using-postscript about writing PostScript, which suggests that 'the samples returned from the JPEG image are simply inverted with respect to the PostScript CMYK colour model'.

This PR adds a Decode line, as per [this suggestion](https://graphicdesign.stackexchange.com/questions/12894/cmyk-jpegs-extracted-from-pdf-appear-inverted/15906#comment80828_15906), fixing the problem.

Given that Pillow can't read PDFs, I haven't added a test for this.