### PR TITLE
Throw error on incorrect type in Image.putpixel

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1733,11 +1733,13 @@ class Image:
         ):
             # RGB or RGBA value for a P image
             value = self.palette.getcolor(value)
-            
-        if self.mode = "L":
+
+        if self.mode == "L":
             if (type(xy[0]) is not int) or (type(xy[1]) is not int):
-                raise TypeError(f"Expected argument xy to be a tuple (int, int) but got { xy }")
-                
+                raise TypeError(
+                    f"Expected argument xy to be a tuple (int, int) but got { xy }"
+                )
+
         return self.im.putpixel(xy, value)
 
     def remap_palette(self, dest_map, source_palette=None):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1733,6 +1733,11 @@ class Image:
         ):
             # RGB or RGBA value for a P image
             value = self.palette.getcolor(value)
+            
+        if self.mode = "L":
+            if (type(xy[0]) is not int) or (type(xy[1]) is not int):
+                raise TypeError(f"Expected argument xy to be a tuple (int, int) but got { xy }")
+                
         return self.im.putpixel(xy, value)
 
     def remap_palette(self, dest_map, source_palette=None):


### PR DESCRIPTION
For `Image` objects with mode `L` (greyscale), when running `img.putpixel`, if the argument `xy` is not a tuple with types (int, int), the code raises a rather cryptic error:
```
SystemError: new style getargs format but argument is not a tuple
```
Again, if the argument **is** a tuple, but not with the types `(int, int)`, this error will come up, which is likely to confuse many people. I propose adding an `if` statement in the `putpixel` function to catch this case, and then to throw a clearer error message:
```
Expected argument xy to be a tuple (int, int) but got { xy }
```
Where `xy` is replaced by whatever acutal value of `xy` caused the error.
____________
 * Related: [#2802](https://github.com/python-pillow/Pillow/issues/2802)
 * I got the idea to submit this pull request after reading [this issue](https://stackoverflow.com/a/43656642/11151112) on StackOverflow

