### PR TITLE
Raise proper TypeError in putpixel

### DIFF
--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -329,33 +329,36 @@ class TestCffi(AccessTest):
 
 
 class TestImagePutPixelError(AccessTest):
-    def test_putpixel_error_message(self):
-        for mode, reason, accept_tuple in [
-            ("L", "color must be int or tuple", True),
-            ("LA", "color must be int or tuple", True),
-            ("RGB", "color must be int or tuple", True),
-            ("RGBA", "color must be int or tuple", True),
-            ("I", "color must be int", False),
-            ("I;16", "color must be int", False),
-            ("BGR;15", "color must be int", False),
-        ]:
-            im = hopper(mode)
+    IMAGE_MODES1 = ["L", "LA", "RGB", "RGBA"]
+    INVALID_TYPES1 = ["foo", 1.0, None]
 
-            for v in ["foo", 1.0, None]:
-                with pytest.raises(TypeError, match=reason):
-                    im.putpixel((0, 0), v)
+    @pytest.mark.parametrize("mode", IMAGE_MODES1)
+    def test_putpixel_type_error1(self, mode):
+        im = hopper(mode)
+        for v in self.INVALID_TYPES1:
+            with pytest.raises(TypeError, match="color must be int or tuple"):
+                im.putpixel((0, 0), v)
 
-            if not accept_tuple:
-                with pytest.raises(TypeError, match=reason):
-                    im.putpixel((0, 0), (10,))
+    IMAGE_MODES2 = ["I", "I;16", "BGR;15"]
+    INVALID_TYPES2 = [*INVALID_TYPES1, (10,)]
 
-            with pytest.raises(OverflowError):
-                im.putpixel((0, 0), 2 ** 80)
+    @pytest.mark.parametrize("mode", IMAGE_MODES2)
+    def test_putpixel_type_error2(self, mode):
+        im = hopper(mode)
+        for v in self.INVALID_TYPES2:
+            with pytest.raises(TypeError, match="color must be int"):
+                im.putpixel((0, 0), v)
 
-        for mode in ["BGR;15"]:
-            im = hopper(mode)
-            with pytest.raises(ValueError, match="unrecognized image mode"):
-                im.putpixel((0, 0), 0)
+    @pytest.mark.parametrize("mode", IMAGE_MODES1 + IMAGE_MODES2)
+    def test_putpixel_overflow_error(self, mode):
+        im = hopper(mode)
+        with pytest.raises(OverflowError):
+            im.putpixel((0, 0), 2 ** 80)
+
+    def test_putpixel_unrecognized_mode(self):
+        im = hopper("BGR;15")
+        with pytest.raises(ValueError, match="unrecognized image mode"):
+            im.putpixel((0, 0), 0)
 
 
 class TestEmbeddable:

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -330,7 +330,9 @@ class TestCffi(AccessTest):
 
 class TestImagePutPixelError(AccessTest):
     IMAGE_MODES1 = ["L", "LA", "RGB", "RGBA"]
+    IMAGE_MODES2 = ["I", "I;16", "BGR;15"]
     INVALID_TYPES1 = ["foo", 1.0, None]
+    INVALID_TYPES2 = [*INVALID_TYPES1, (10,)]
 
     @pytest.mark.parametrize("mode", IMAGE_MODES1)
     def test_putpixel_type_error1(self, mode):
@@ -338,9 +340,6 @@ class TestImagePutPixelError(AccessTest):
         for v in self.INVALID_TYPES1:
             with pytest.raises(TypeError, match="color must be int or tuple"):
                 im.putpixel((0, 0), v)
-
-    IMAGE_MODES2 = ["I", "I;16", "BGR;15"]
-    INVALID_TYPES2 = [*INVALID_TYPES1, (10,)]
 
     @pytest.mark.parametrize("mode", IMAGE_MODES2)
     def test_putpixel_type_error2(self, mode):


### PR DESCRIPTION
Fixes #4876:

* The existing code silently ignores an `OverflowError` for 8bpp images, hoping that the int will become a tuple in the next few lines.
* It also fails to check that the given parameter is a tuple before trying to unpack it, giving the less than useful message `SystemError: new style getargs format but argument is not a tuple`.
* Last but not least, passing a non-int value for non-8bpp non-float images (e.g. `I;16`) gives an even less useful message `SystemError: <method 'putpixel' of 'ImagingCore' objects> returned NULL without setting an error`.

This PR resolves all of these issues by explicitly raising a TypeError if the parameter can't be converted to an int, or a tuple for an 8bpp image.