### PR TITLE
Removed TravisCI setuptools version requirement

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -32,7 +32,6 @@ pip install test-image-results
 pip install numpy
 
 # TODO Remove when 3.9-dev includes setuptools 49.3.2+:
-if [ "$TRAVIS_PYTHON_VERSION" == "3.9-dev" ]; then pip install -U "setuptools>=49.3.2" ; fi
 if [ "$GHA_PYTHON_VERSION" == "3.9-dev" ]; then pip install -U "setuptools>=49.3.2" ; fi
 
 if [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then


### PR DESCRIPTION
Specifying the version of setuptools is no longer necessary on TravisCI, removing the fix for #4769 added in #4779 and then adjusted in #4784