### PR TITLE
Fix IFDRational __eq__ bug

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -241,7 +241,7 @@ class TestFileJpeg:
 
         # Assert
         assert exif[gps_index] == expected_exif_gps
-    
+
     def test_exif_equality(self):
         # in 7.2.0 Exif rationals are read as TiffImagePlugin.IFDRational
         # which broke self-equality of Exif data

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -241,6 +241,15 @@ class TestFileJpeg:
 
         # Assert
         assert exif[gps_index] == expected_exif_gps
+    
+    def test_exif_equality(self):
+        # in 7.2.0 Exif rationals are read as TiffImagePlugin.IFDRational
+        # which broke self-equality of Exif data
+        exifs = []
+        for i in range(2):
+            with Image.open("Tests/images/exif-200dpcm.jpg") as im:
+                exifs.append(im._getexif())
+        assert exifs[0] == exifs[1]
 
     def test_exif_rollback(self):
         # rolling back exif support in 3.1 to pre-3.0 formatting.

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -243,8 +243,9 @@ class TestFileJpeg:
         assert exif[gps_index] == expected_exif_gps
 
     def test_exif_equality(self):
-        # in 7.2.0 Exif rationals are read as TiffImagePlugin.IFDRational
-        # which broke self-equality of Exif data
+        # In 7.2.0, Exif rationals were changed to be read as
+        # TiffImagePlugin.IFDRational. This class had a bug in __eq__,
+        # breaking the self-equality of Exif data
         exifs = []
         for i in range(2):
             with Image.open("Tests/images/exif-200dpcm.jpg") as im:

--- a/Tests/test_tiff_ifdrational.py
+++ b/Tests/test_tiff_ifdrational.py
@@ -30,7 +30,6 @@ def test_sanity():
 
 
 def test_ranges():
-
     for num in range(1, 10):
         for denom in range(1, 10):
             assert IFDRational(num, denom) == IFDRational(num, denom)
@@ -48,12 +47,6 @@ def test_nonetype():
 
     assert xres and 1
     assert xres and yres
-
-
-def test_nan():
-    # usually NaN != NaN, but this would break exif self-equality
-
-    assert IFDRational(123, 0) == IFDRational(123, 0)
 
 
 def test_ifd_rational_save(tmp_path):

--- a/Tests/test_tiff_ifdrational.py
+++ b/Tests/test_tiff_ifdrational.py
@@ -29,6 +29,13 @@ def test_sanity():
     _test_equal(1, 2, IFDRational(1, 2))
 
 
+def test_ranges():
+
+    for num in range(1, 10):
+        for denom in range(1, 10):
+            assert IFDRational(num, denom) == IFDRational(num, denom)
+
+
 def test_nonetype():
     # Fails if the _delegate function doesn't return a valid function
 
@@ -41,6 +48,12 @@ def test_nonetype():
 
     assert xres and 1
     assert xres and yres
+
+
+def test_nan():
+    # usually NaN != NaN, but this would break exif self-equality
+
+    assert IFDRational(123, 0) == IFDRational(123, 0)
 
 
 def test_ifd_rational_save(tmp_path):

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -354,12 +354,8 @@ class IFDRational(Rational):
 
     def __eq__(self, other):
         if isinstance(other, IFDRational):
-            if self.denominator == 0 and other.denominator == 0:
-                # in this case self._val and other._val would be NaN
-                return self.numerator == other.numerator
-            return self._val == other._val
-        else:
-            return self._val == other
+            other = other._val
+        return self._val == other
 
     def _delegate(op):
         def delegate(self, *args):

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -353,7 +353,13 @@ class IFDRational(Rational):
         return self._val.__hash__()
 
     def __eq__(self, other):
-        return self._val == other
+        if isinstance(other, IFDRational):
+            if self.denominator == 0 and other.denominator == 0:
+                # in this case self._val and other._val would be NaN
+                return self.numerator == other.numerator
+            return self._val == other._val
+        else:
+            return self._val == other
 
     def _delegate(op):
         def delegate(self, *args):


### PR DESCRIPTION
Variation on #4813

At the moment,
```python
from PIL.TiffImagePlugin import IFDRational
print(IFDRational(2,2) == IFDRational(2, 2))  # False
```
This also causes problems in `im._getexif()`. The changes in this PR fix that.

#4813 has that fix, as well as making `IFDRational(1, 0) == IFDRational(1, 0)`. I'm not convinced of that part, since standard behaviour dictates that NaN != NaN. So this PR removes the NaN change, to try and get the less controversial part merged in at least.