### PR TITLE
Remove W503 from flake8 ignore list (ignored by default)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-extend-ignore = E203, W503
+extend-ignore = E203
 max-line-length = 88
 
 [isort]


### PR DESCRIPTION
See:
https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes

> In the default configuration, the checks E121, E123, E126, E133, E226,
> E241, E242, E704, W503, W504 and W505 are ignored because they are not
> rules unanimously accepted, and PEP 8 does not enforce them.