### PR TITLE
Add `ImageDraw.regular_polygon` to release notes

### DIFF
--- a/docs/releasenotes/8.0.0.rst
+++ b/docs/releasenotes/8.0.0.rst
@@ -78,6 +78,14 @@ high ends.
 
 Now, it can also be a tuple ``(low, high)``.
 
+ImageDraw.regular_polygon
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A new method ``regular_polygon``, draws a regular polygon of ``n_sides``, inscribed in a ``bounding_circle``.
+
+For example ``ImageDraw.regular_polygon(((100, 100), 50), 5)``
+draws a pentagon centered at the point ``(100, 100)`` with a polygon radius of ``50``.
+
 Security
 ========
 

--- a/docs/releasenotes/8.0.0.rst
+++ b/docs/releasenotes/8.0.0.rst
@@ -79,7 +79,7 @@ high ends.
 Now, it can also be a tuple ``(low, high)``.
 
 ImageDraw.regular_polygon
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A new method ``regular_polygon``, draws a regular polygon of ``n_sides``, inscribed in a ``bounding_circle``.
 

--- a/docs/releasenotes/8.0.0.rst
+++ b/docs/releasenotes/8.0.0.rst
@@ -81,9 +81,9 @@ Now, it can also be a tuple ``(low, high)``.
 ImageDraw.regular_polygon
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A new method ``regular_polygon``, draws a regular polygon of ``n_sides``, inscribed in a ``bounding_circle``.
+A new method :py:meth:`.ImageDraw.regular_polygon`, draws a regular polygon of ``n_sides``, inscribed in a ``bounding_circle``.
 
-For example ``ImageDraw.regular_polygon(((100, 100), 50), 5)``
+For example ``draw.regular_polygon(((100, 100), 50), 5)``
 draws a pentagon centered at the point ``(100, 100)`` with a polygon radius of ``50``.
 
 Security


### PR DESCRIPTION
Add `ImageDraw.regular_polygon` to release notes. 

[Reference](https://github.com/python-pillow/Pillow/pull/4846#issuecomment-687366543)
