### PR TITLE
Docs: Give supported Python versions its own header

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,11 +10,10 @@ Warnings
 
 .. warning:: Pillow >= 2.1.0 no longer supports "import _imaging". Please use "from PIL.Image import core as _imaging" instead.
 
-Notes
------
+Python Support
+--------------
 
-.. note:: Pillow is supported on the following Python versions
-
+Pillow supports these Python versions.
 
 +----------------------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+
 | **Python**           |**3.9**|**3.8**|**3.7**|**3.6**|**3.5**|**3.4**|**3.3**|**3.2**|**2.7**|**2.6**|**2.5**|**2.4**|


### PR DESCRIPTION
Changes proposed in this pull request:

 * Right now, linking to the table is really a link to "Notes":
https://pillow.readthedocs.io/en/stable/installation.html#notes
 * It's important enough to deserve its own header, not just "Notes"
 * I think keeping it near the top is good
 * This was the only "Note" under "Notes". If we get more notes in the future, they can be back after "Warnings"

https://pillow--4905.org.readthedocs.build/en/4905/installation.html#python-support