### PR TITLE
Fixed effect_spread bug for zero distance

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -454,6 +454,17 @@ class TestImage:
         with Image.open("Tests/images/effect_spread.png") as im3:
             assert_image_similar(im2, im3, 110)
 
+    def test_effect_spread_zero(self):
+        # Arrange
+        im = hopper()
+        distance = 0
+
+        # Act
+        im2 = im.effect_spread(distance)
+
+        # Assert
+        assert_image_equal(im, im2)
+
     def test_check_size(self):
         # Checking that the _check_size function throws value errors when we want it to
         with pytest.raises(ValueError):

--- a/src/libImaging/Effects.c
+++ b/src/libImaging/Effects.c
@@ -133,13 +133,17 @@ ImagingEffectSpread(Imaging imIn, int distance)
 #define SPREAD(type, image)\
     for (y = 0; y < imOut->ysize; y++) {\
         for (x = 0; x < imOut->xsize; x++) {\
-            int xx = x + (rand() % distance) - distance/2;\
-            int yy = y + (rand() % distance) - distance/2;\
-            if (xx >= 0 && xx < imIn->xsize && yy >= 0 && yy < imIn->ysize) {\
-                imOut->image[yy][xx] = imIn->image[y][x];\
-                imOut->image[y][x]   = imIn->image[yy][xx];\
+            if (distance == 0) {\
+                imOut->image[y][x] = imIn->image[y][x];\
             } else {\
-                imOut->image[y][x]   = imIn->image[y][x];\
+                int xx = x + (rand() % distance) - distance/2;\
+                int yy = y + (rand() % distance) - distance/2;\
+                if (xx >= 0 && xx < imIn->xsize && yy >= 0 && yy < imIn->ysize) {\
+                    imOut->image[yy][xx] = imIn->image[y][x];\
+                    imOut->image[y][x]   = imIn->image[yy][xx];\
+                } else {\
+                    imOut->image[y][x]   = imIn->image[y][x];\
+                }\
             }\
         }\
     }


### PR DESCRIPTION
Resolves #4906

https://github.com/python-pillow/Pillow/blob/9e6dabf0e51b96146e4fa53642d3f8bf4a1ca460/src/PIL/Image.py#L2505-L2507

If you supply a `distance` of zero to `im.effect_spread`, then mod zero is attempted.

https://github.com/python-pillow/Pillow/blob/9e6dabf0e51b96146e4fa53642d3f8bf4a1ca460/src/libImaging/Effects.c#L136-L137

This PR resolves that. Afterwards, a `distance` of zero simply copies the pixels. This makes sense to me - if you are spreading the pixels by a distance of zero, nothing changes.