### PR TITLE
Clarify that modes are raw strings, not constants

### DIFF
--- a/docs/handbook/concepts.rst
+++ b/docs/handbook/concepts.rst
@@ -24,7 +24,7 @@ To get the number and names of bands in an image, use the
 Modes
 -----
 
-The :term:`mode` of an image defines the type and depth of a pixel in the
+The :term:`mode` of an image is a string that defines the type and depth of a pixel in the
 image. The current release supports the following standard modes:
 
     * ``1`` (1-bit pixels, black and white, stored with one pixel per byte)


### PR DESCRIPTION
Fixes # a small mistake I made while reading the docs. I was trying to initialize an image and didn't know whether modes were constants (like in tkinter.CENTER) or raw strings (like in open(filename, 'rwb').

Changes proposed in this pull request:

 *  change one line in concepts.rst
