### PR TITLE
Clarify that modes are strings, not constants

### DIFF
--- a/docs/handbook/concepts.rst
+++ b/docs/handbook/concepts.rst
@@ -24,7 +24,7 @@ To get the number and names of bands in an image, use the
 Modes
 -----
 
-The ``mode`` of an image defines the type and depth of a pixel in the image.
+The ``mode`` of an image is a string which defines the type and depth of a pixel in the image.
 Each pixel uses the full range of the bit depth. So a 1-bit pixel has a range
 of 0-1, an 8-bit pixel has a range of 0-255 and so on. The current release
 supports the following standard modes:


### PR DESCRIPTION
I misunderstood this section of the documentation the first time I read it. I hope this change will clarify how to request a mode such as from Image.new("RGBA", size).

Changes proposed in this pull request:

 * Add that modes are strings, as opposed to constants used like tkinter.NW