### PR TITLE
Fixed loading profile with non-ASCII path on Windows

### DIFF
--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import re
+import shutil
 from io import BytesIO
 
 import pytest
@@ -434,6 +435,19 @@ def test_extended_information():
     assert p.version == 2.0
     assert p.viewing_condition == "Reference Viewing Condition in IEC 61966-2-1"
     assert p.xcolor_space == "RGB "
+
+
+def test_non_ascii_path(tmp_path):
+    skip_missing()
+    tempfile = str(tmp_path / ("temp_" + chr(128) + ".icc"))
+    try:
+        shutil.copy(SRGB, tempfile)
+    except UnicodeEncodeError:
+        pytest.skip("Non-ASCII path could not be created")
+
+    o = ImageCms.getOpenProfile(tempfile)
+    p = o.profile
+    assert p.model == "IEC 61966-2-1 Default RGB Colour Space - sRGB"
 
 
 def test_profile_typesafety():

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -111,12 +111,12 @@ class TestImageFont:
         with open(FONT_PATH, "rb") as f:
             self._render(f)
 
-    def test_non_unicode_path(self, tmp_path):
+    def test_non_ascii_path(self, tmp_path):
         tempfile = str(tmp_path / ("temp_" + chr(128) + ".ttf"))
         try:
             shutil.copy(FONT_PATH, tempfile)
         except UnicodeEncodeError:
-            pytest.skip("Unicode path could not be created")
+            pytest.skip("Non-ASCII path could not be created")
 
         ImageFont.truetype(tempfile, FONT_SIZE)
 

--- a/src/PIL/ImageCms.py
+++ b/src/PIL/ImageCms.py
@@ -159,6 +159,14 @@ class ImageCmsProfile:
         """
 
         if isinstance(profile, str):
+            if sys.platform == "win32":
+                profile_bytes_path = profile.encode()
+                try:
+                    profile_bytes_path.decode("ascii")
+                except UnicodeDecodeError:
+                    with open(profile, "rb") as f:
+                        self._set(core.profile_frombytes(f.read()))
+                    return
             self._set(core.profile_open(profile), profile)
         elif hasattr(profile, "read"):
             self._set(core.profile_frombytes(profile.read()))


### PR DESCRIPTION
Resolves #4897 - in the same way that #3785 resolved #3145, by loading data from a non-Unicode path on Windows into memory.

Also corrects a message in the test suite from that PR.