### PR TITLE
Updated Ghostscript to 9.53.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,9 +24,8 @@ install:
 - mv c:\pillow-depends-master c:\pillow-depends
 - xcopy /s c:\pillow-depends\test_images\* c:\pillow\tests\images
 - 7z x ..\pillow-depends\nasm-2.14.02-win64.zip -oc:\
-- curl -fsSL -o gs952.exe https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs952/gs952w32.exe
-- gs952.exe /S
-- path c:\nasm-2.14.02;C:\Program Files (x86)\gs\gs9.52\bin;%PATH%
+- ..\pillow-depends\gs9531w32.exe /S
+- path c:\nasm-2.14.02;C:\Program Files (x86)\gs\gs9.53.1\bin;%PATH%
 - cd c:\pillow\winbuild\
 - ps: |
         c:\python37\python.exe c:\pillow\winbuild\build_prepare.py -v --depends=C:\pillow-depends\

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -73,8 +73,8 @@ jobs:
         7z x winbuild\depends\nasm-2.14.02-win64.zip "-o$env:RUNNER_WORKSPACE\"
         Write-Host "::add-path::$env:RUNNER_WORKSPACE\nasm-2.14.02"
 
-        winbuild\depends\gs950w32.exe /S
-        Write-Host "::add-path::C:\Program Files (x86)\gs\gs9.50\bin"
+        winbuild\depends\gs9531w32.exe /S
+        Write-Host "::add-path::C:\Program Files (x86)\gs\gs9.53.1\bin"
 
         xcopy /s winbuild\depends\test_images\* Tests\images\
       shell: pwsh


### PR DESCRIPTION
Also, having added the binary to pillow-depends - https://github.com/python-pillow/pillow-depends/commit/02e38f069935603a7f83b071b2281f304637d261 - there is a curl command in .appveyor.yml that is not needed.