### PR TITLE
chown pip wheels cache in Travis

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -21,6 +21,8 @@ sudo apt-get -qq install libfreetype6-dev liblcms2-dev python3-tk\
                          ghostscript libffi-dev libjpeg-turbo-progs libopenjp2-7-dev\
                          cmake imagemagick libharfbuzz-dev libfribidi-dev
 
+if [[ $TRAVIS_CPU_ARCH == "s390x" ]]; then sudo chown $USER ~/.cache/pip/wheels ; fi
+
 pip install --upgrade pip
 PYTHONOPTIMIZE=0 pip install cffi
 pip install coverage


### PR DESCRIPTION
The TravisCI Python 3.8 s390x job has started failing - https://travis-ci.org/github/python-pillow/Pillow/jobs/727457309

```
Building wheels for collected packages: black, regex, typed-ast, MarkupSafe
  WARNING: Building wheel for black failed: [Errno 13] Permission denied: '/home/travis/.cache/pip/wheels/95'
  WARNING: Building wheel for regex failed: [Errno 13] Permission denied: '/home/travis/.cache/pip/wheels/c1/d2'
  WARNING: Building wheel for typed-ast failed: [Errno 13] Permission denied: '/home/travis/.cache/pip/wheels/90'
  WARNING: Building wheel for MarkupSafe failed: [Errno 13] Permission denied: '/home/travis/.cache/pip/wheels/0c'
Failed to build black regex typed-ast MarkupSafe
ERROR: Could not build wheels for black which use PEP 517 and cannot be installed directly
```

This PR fixes it by using `sudo chown $USER ~/.cache/pip/wheels`. This fix was suggested at https://travis-ci.community/t/permission-issue-while-building-wheels-for-various-python-packages/7822/12