### PR TITLE
Allow tuples with one item to give single color value in getink

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -498,6 +498,12 @@ class TestImage:
         with pytest.raises(ValueError):
             Image.core.fill("RGB", (2, -2), (0, 0, 0))
 
+    def test_one_item_tuple(self):
+        for mode in ("I", "F", "L"):
+            im = Image.new(mode, (100, 100), (5,))
+            px = im.load()
+            assert px[0, 0] == 5
+
     def test_linear_gradient_wrong_mode(self):
         # Arrange
         wrong_mode = "RGB"

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -328,17 +328,27 @@ class TestCffi(AccessTest):
 
 
 class TestImagePutPixelError(AccessTest):
-    IMAGE_MODES = ["L", "LA", "RGB", "RGBA", "I", "I;16", "BGR;15"]
+    IMAGE_MODES1 = ["L", "LA", "RGB", "RGBA"]
+    IMAGE_MODES2 = ["I", "I;16", "BGR;15"]
     INVALID_TYPES = ["foo", 1.0, None]
 
-    @pytest.mark.parametrize("mode", IMAGE_MODES)
-    def test_putpixel_type_error(self, mode):
+    @pytest.mark.parametrize("mode", IMAGE_MODES1)
+    def test_putpixel_type_error1(self, mode):
         im = hopper(mode)
         for v in self.INVALID_TYPES:
             with pytest.raises(TypeError, match="color must be int or tuple"):
                 im.putpixel((0, 0), v)
 
-    @pytest.mark.parametrize("mode", IMAGE_MODES)
+    @pytest.mark.parametrize("mode", IMAGE_MODES2)
+    def test_putpixel_type_error2(self, mode):
+        im = hopper(mode)
+        for v in self.INVALID_TYPES:
+            with pytest.raises(
+                TypeError, match="color must be int or single-element tuple"
+            ):
+                im.putpixel((0, 0), v)
+
+    @pytest.mark.parametrize("mode", IMAGE_MODES1 + IMAGE_MODES2)
     def test_putpixel_overflow_error(self, mode):
         im = hopper(mode)
         with pytest.raises(OverflowError):

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -328,26 +328,17 @@ class TestCffi(AccessTest):
 
 
 class TestImagePutPixelError(AccessTest):
-    IMAGE_MODES1 = ["L", "LA", "RGB", "RGBA"]
-    IMAGE_MODES2 = ["I", "I;16", "BGR;15"]
-    INVALID_TYPES1 = ["foo", 1.0, None]
-    INVALID_TYPES2 = [*INVALID_TYPES1, (10,)]
+    IMAGE_MODES = ["L", "LA", "RGB", "RGBA", "I", "I;16", "BGR;15"]
+    INVALID_TYPES = ["foo", 1.0, None]
 
-    @pytest.mark.parametrize("mode", IMAGE_MODES1)
-    def test_putpixel_type_error1(self, mode):
+    @pytest.mark.parametrize("mode", IMAGE_MODES)
+    def test_putpixel_type_error(self, mode):
         im = hopper(mode)
-        for v in self.INVALID_TYPES1:
+        for v in self.INVALID_TYPES:
             with pytest.raises(TypeError, match="color must be int or tuple"):
                 im.putpixel((0, 0), v)
 
-    @pytest.mark.parametrize("mode", IMAGE_MODES2)
-    def test_putpixel_type_error2(self, mode):
-        im = hopper(mode)
-        for v in self.INVALID_TYPES2:
-            with pytest.raises(TypeError, match="color must be int"):
-                im.putpixel((0, 0), v)
-
-    @pytest.mark.parametrize("mode", IMAGE_MODES1 + IMAGE_MODES2)
+    @pytest.mark.parametrize("mode", IMAGE_MODES)
     def test_putpixel_overflow_error(self, mode):
         im = hopper(mode)
         with pytest.raises(OverflowError):

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -518,6 +518,9 @@ getink(PyObject* color, Imaging im, char* ink)
        be cast to either UINT8 or INT32 */
 
     int rIsInt = 0;
+    if (PyTuple_Check(color) && PyTuple_Size(color) == 1) {
+        color = PyTuple_GetItem(color, 0);
+    }
     if (im->type == IMAGING_TYPE_UINT8 ||
         im->type == IMAGING_TYPE_INT32 ||
         im->type == IMAGING_TYPE_SPECIAL) {
@@ -533,7 +536,7 @@ getink(PyObject* color, Imaging im, char* ink)
                 return NULL;
             }
         } else {
-            PyErr_SetString(PyExc_TypeError, "color must be int");
+            PyErr_SetString(PyExc_TypeError, "color must be int or tuple");
             return NULL;
         }
     }

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -536,7 +536,7 @@ getink(PyObject* color, Imaging im, char* ink)
                 return NULL;
             }
         } else {
-            PyErr_SetString(PyExc_TypeError, "color must be int or tuple");
+            PyErr_SetString(PyExc_TypeError, "color must be int or single-element tuple");
             return NULL;
         }
     }


### PR DESCRIPTION
Resolves #4925

Normally, a user would run `Image.new('F', (100,100), 255)` and `Image.new('I', (100,100), 255)`, providing a single value for `color` for those modes.

This PR allows users to also provide that single value inside a tuple, `Image.new('F', (200,100), (255,))` and `Image.new('I', (200,100), (255,))`, which would have previously thrown an error.