### PR TITLE
Add Mergify config

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,47 +4,11 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - label=automerge
       - status-success=Lint
+      - status-success=Test Successful
+      - status-success=Docker Test Successful
+      - status-success=Windows Test Successful
       - status-success=continuous-integration/appveyor/pr
       - status-success=continuous-integration/travis-ci/pr
-
-      # Test
-      - status-success=macOS-latest Python 3.6
-      - status-success=macOS-latest Python 3.7
-      - status-success=macOS-latest Python 3.8
-      - status-success=macOS-latest Python 3.9-dev
-      - status-success=macOS-latest Python pypy3
-      - status-success=ubuntu-latest Python 3.6
-      - status-success=ubuntu-latest Python 3.7
-      - status-success=ubuntu-latest Python 3.8
-      - status-success=ubuntu-latest Python 3.9-dev
-      - status-success=ubuntu-latest Python pypy3
-
-      # Test Docker
-      - status-success=alpine
-      - status-success=amazon-1-amd64
-      - status-success=amazon-2-amd64
-      - status-success=arch
-      - status-success=centos-6-amd64
-      - status-success=centos-7-amd64
-      - status-success=centos-8-amd64
-      - status-success=debian-10-buster-x86
-      - status-success=fedora-31-amd64
-      - status-success=fedora-32-amd64
-      - status-success=ubuntu-18.04-bionic-amd64
-      - status-success=ubuntu-20.04-focal-amd64
-
-      # Test Windows
-      - status-success=MSYS2 MinGW 32-bit
-      - status-success=MSYS2 MinGW 64-bit
-      - status-success=Python 3.6 x64
-      - status-success=Python 3.6 x86
-      - status-success=Python 3.7 x64
-      - status-success=Python 3.7 x86
-      - status-success=Python 3.8 x64
-      - status-success=Python 3.8 x86
-      - status-success=Python 3.9-dev x64
-      - status-success=Python 3.9-dev x86
-      - status-success=Python pypy3 x86
     actions:
       merge:
         method: merge

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,50 @@
+pull_request_rules:
+  - name: Automatic merge
+    conditions:
+      - "#approved-reviews-by>=1"
+      - label=automerge
+      - status-success=Lint
+      - status-success=continuous-integration/appveyor/pr
+      - status-success=continuous-integration/travis-ci/pr
+
+      # Test
+      - status-success=macOS-latest Python 3.6
+      - status-success=macOS-latest Python 3.7
+      - status-success=macOS-latest Python 3.8
+      - status-success=macOS-latest Python 3.9-dev
+      - status-success=macOS-latest Python pypy3
+      - status-success=ubuntu-latest Python 3.6
+      - status-success=ubuntu-latest Python 3.7
+      - status-success=ubuntu-latest Python 3.8
+      - status-success=ubuntu-latest Python 3.9-dev
+      - status-success=ubuntu-latest Python pypy3
+
+      # Test Docker
+      - status-success=alpine
+      - status-success=amazon-1-amd64
+      - status-success=amazon-2-amd64
+      - status-success=arch
+      - status-success=centos-6-amd64
+      - status-success=centos-7-amd64
+      - status-success=centos-8-amd64
+      - status-success=debian-10-buster-x86
+      - status-success=fedora-31-amd64
+      - status-success=fedora-32-amd64
+      - status-success=ubuntu-18.04-bionic-amd64
+      - status-success=ubuntu-20.04-focal-amd64
+
+      # Test Windows
+      - status-success=MSYS2 MinGW 32-bit
+      - status-success=MSYS2 MinGW 64-bit
+      - status-success=Python 3.6 x64
+      - status-success=Python 3.6 x86
+      - status-success=Python 3.7 x64
+      - status-success=Python 3.7 x86
+      - status-success=Python 3.8 x64
+      - status-success=Python 3.8 x86
+      - status-success=Python 3.9-dev x64
+      - status-success=Python 3.9-dev x86
+      - status-success=Python pypy3 x86
+    actions:
+      merge:
+        method: merge

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -61,3 +61,11 @@ jobs:
       with:
         flags: GHA_Docker
         name: ${{ matrix.docker }}
+
+  success:
+    needs: build
+    runs-on: ubuntu-latest
+    name: Docker Test Successful
+    steps:
+      - name: Success
+        run: echo Docker Test Successful

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -267,3 +267,11 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -F GHA_Windows
         env:
           CODECOV_NAME: ${{ matrix.name }}
+
+  success:
+    needs: [build, msys]
+    runs-on: ubuntu-latest
+    name: Windows Test Successful
+    steps:
+      - name: Success
+        run: echo Windows Test Successful

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,3 +107,11 @@ jobs:
       run: bash <(curl -s https://codecov.io/bash) -F ${{ matrix.codecov-flag }}
       env:
         CODECOV_NAME: ${{ matrix.os }} Python ${{ matrix.python-version }}
+
+  success:
+    needs: build
+    runs-on: ubuntu-latest
+    name: Test Successful
+    steps:
+      - name: Success
+        run: echo Test Successful


### PR DESCRIPTION
Fixes https://github.com/python-pillow/Pillow/issues/4900.

Changes proposed in this pull request:

 * Approval, label and Travis CI rules like in Like https://github.com/python-pillow/docker-images/pull/84 and https://github.com/python-pillow/pillow-wheels/pull/161
 * AppVeyor rule is similar
 * GHA: https://doc.mergify.io/conditions.html#github-actions

> GitHub Actions works slightly differently. To match a status check when using GitHub Action, only the job name is used.
> 
> ![image](https://user-images.githubusercontent.com/1324225/93938734-600edb80-fd32-11ea-9621-b086f304efc1.png)
>
> In the example above, it would be `A job to say hello`:
>
```yml
conditions:
  - status-success=A job to say hello
```

So it's a bit more maintenance for GHA. We could rename the jobs so they don't include Python versions etc., but it's useful to see which one fails at a glance. Let's see how it goes and iterate if necessary.

