### PR TITLE
Updated PIL repository link

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4008,7 +4008,7 @@ Pre-fork
     This section may not be fully complete.  For changes since this file
     was last updated, see the repository revision history:
 
-      https://bitbucket.org/effbot/pil-2009-raclette/commits/all
+      http://svn.effbot.org/public/pil/
 
     (1.1.7 final)
 


### PR DESCRIPTION
Suggestion for #4881. Replaces the link to https://bitbucket.org/effbot/pil-2009-raclette/commits/all with http://svn.effbot.org/public/pil/