### PR TITLE
Added overview to README and ReadTheDocs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ As of 2019, Pillow development is
     </tr>
 </table>
 
+## Overview
+
+The Python Imaging Library adds image processing capabilities to your Python interpreter.
+
+This library provides extensive file format support, an efficient internal representation, and fairly powerful image processing capabilities.
+
+The core image library is designed for fast access to data stored in a few basic pixel formats. It should provide a solid foundation for a general image processing tool.
+
 ## More Information
 
 - [Documentation](https://pillow.readthedocs.io/)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,6 +57,15 @@ Pillow for enterprise is available via the Tidelift Subscription. `Learn more <h
    :target: https://pypi.org/project/Pillow/
    :alt: Number of PyPI downloads
 
+Overview
+========
+
+The Python Imaging Library adds image processing capabilities to your Python interpreter.
+
+This library provides extensive file format support, an efficient internal representation, and fairly powerful image processing capabilities.
+
+The core image library is designed for fast access to data stored in a few basic pixel formats. It should provide a solid foundation for a general image processing tool.
+
 .. toctree::
    :maxdepth: 2
 


### PR DESCRIPTION
Resolves #4933

The issue reports that the [ReadTheDocs Pillow index page](https://pillow.readthedocs.io/en/latest/) and the [GitHub README](https://github.com/python-pillow/Pillow/blob/master/README.md) don't describe what Pillow is in much detail.

This PR copies the 'Overview' section from https://pillow.readthedocs.io/en/latest/handbook/overview.html