### PR TITLE
Fixed bug in Exif __delitem__

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -650,12 +650,14 @@ class TestImage:
         with Image.open("Tests/images/exif-72dpi-int.jpg") as im:  # Little endian
             exif = im.getexif()
             assert 258 not in exif
+            assert 274 in exif
             assert 40960 in exif
             assert exif[40963] == 450
             assert exif[11] == "gThumb 3.0.1"
 
             out = str(tmp_path / "temp.jpg")
             exif[258] = 8
+            del exif[274]
             del exif[40960]
             exif[40963] = 455
             exif[11] = "Pillow test"
@@ -663,6 +665,7 @@ class TestImage:
         with Image.open(out) as reloaded:
             reloaded_exif = reloaded.getexif()
             assert reloaded_exif[258] == 8
+            assert 274 not in reloaded_exif
             assert 40960 not in reloaded_exif
             assert reloaded_exif[40963] == 455
             assert reloaded_exif[11] == "Pillow test"

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3466,7 +3466,8 @@ class Exif(MutableMapping):
     def __delitem__(self, tag):
         if self._info is not None and tag in self._info:
             del self._info[tag]
-        del self._data[tag]
+        else:
+            del self._data[tag]
 
     def __iter__(self):
         keys = set(self._data)


### PR DESCRIPTION
In `Image.Exif`, `_info` refers to the `ImageFileDirectory_v2` instance. `_data` is the dictionary into which `_info` data is moved when it is accessed.

At the moment in `__delitem__`, if a key hasn't been moved from `_info` to `_data`, it is deleted from `_info`, but it then goes on to try and delete the key from `_data` as well, causing a `KeyError`, despite a successful deletion.

This PR changes it to only delete the key from one or the other.