### PR TITLE
Skip test_photoimage on MinGW due to segmentation fault

### DIFF
--- a/Tests/test_imagetk.py
+++ b/Tests/test_imagetk.py
@@ -2,7 +2,7 @@ import pytest
 
 from PIL import Image
 
-from .helper import assert_image_equal, hopper
+from .helper import assert_image_equal, hopper, is_mingw
 
 try:
     import tkinter as tk
@@ -52,6 +52,7 @@ def test_kw():
     assert im is None
 
 
+@pytest.mark.skipif(is_mingw(), reason="Segmentation fault")
 def test_photoimage():
     for mode in TK_MODES:
         # test as image:


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/4937.

Changes proposed in this pull request:

 * Temporarily skip the `test_photoimage` on MinGW, it otherwise causes a segmentation fault
