### PR TITLE
Fix crash in ImageTk.PhotoImage on mingw64

### DIFF
--- a/Tests/test_imagetk.py
+++ b/Tests/test_imagetk.py
@@ -2,7 +2,7 @@ import pytest
 
 from PIL import Image
 
-from .helper import assert_image_equal, hopper, is_mingw
+from .helper import assert_image_equal, hopper
 
 try:
     import tkinter as tk
@@ -52,7 +52,6 @@ def test_kw():
     assert im is None
 
 
-@pytest.mark.skipif(is_mingw(), reason="Segmentation fault")
 def test_photoimage():
     for mode in TK_MODES:
         # test as image:

--- a/src/Tk/tkImaging.c
+++ b/src/Tk/tkImaging.c
@@ -63,7 +63,7 @@ ImagingFind(const char* name)
     Py_ssize_t id;
 
     /* FIXME: use CObject instead? */
-#if defined(_MSC_VER) && defined(_WIN64)
+#if defined(_WIN64)
     id = _atoi64(name);
 #else
     id = atol(name);


### PR DESCRIPTION
Fixes #4937, reverts #4944.

No need to check for `_MSC_VER`, `_WIN64` is sufficient. Otherwise would need to check for whatever the MSYS2/MinGW64 version is as well.

No idea why this didn't crash earlier. If I had to guess, MSYS2 probably fixed or improved 64-bit support in Tk.

MSYS2 installs really slowly today, but this has fixed the issue for me: https://github.com/nulano/Pillow/runs/1206474319?check_suite_focus=true#step:6:1511

*PS: If anyone knows how to build a Python extension with debugging symbols on MSYS2/MinGW64 that can be read by either GDB or WinDbg, please let me know. This was really hard to track down without it.*
