### PR TITLE
3.9: Add Trove classifier, update setup.py version check, add to tox.ini

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ TIFF_ROOT = None
 ZLIB_ROOT = None
 
 
-if sys.platform == "win32" and sys.version_info >= (3, 9):
+if sys.platform == "win32" and sys.version_info >= (3, 10):
     warnings.warn(
         f"Pillow {PILLOW_VERSION} does not support Python "
         f"{sys.version_info.major}.{sys.version_info.minor} and does not provide "
@@ -871,6 +871,7 @@ try:
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3 :: Only",
             "Programming Language :: Python :: Implementation :: CPython",
             "Programming Language :: Python :: Implementation :: PyPy",

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 envlist =
     lint
-    py{36,37,38,py3}
+    py{36,37,38,39,py3}
 minversion = 1.9
 
 [testenv]


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/4953.

Changes proposed in this pull request:

 * Add the 3.9 Trove classifier
 * Update the version check for Windows in `setup.py`
 * Add to `tox.ini`
