### PR TITLE
Removed unused function

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3285,7 +3285,7 @@ class Exif(MutableMapping):
         return value
 
     def _fixup_dict(self, src_dict):
-        # Helper function for _getexif()
+        # Helper function
         # returns a dict with any single item tuples/lists as individual values
         return {k: self._fixup(v) for k, v in src_dict.items()}
 

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -475,13 +475,6 @@ class JpegImageFile(ImageFile.ImageFile):
         return _getmp(self)
 
 
-def _fixup_dict(src_dict):
-    # Helper function for _getexif()
-    # returns a dict with any single item tuples/lists as individual values
-    exif = Image.Exif()
-    return exif._fixup_dict(src_dict)
-
-
 def _getexif(self):
     if "exif" not in self.info:
         return None


### PR DESCRIPTION
`JpegImagePlugin._fixup_dict` is an unused function that is, by convention, marked as private.

This PR removes it.