### PR TITLE
CI: Fail compilation on implicit function declaration warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ install:
 
 .PHONY: install-coverage
 install-coverage:
-	CFLAGS="-coverage" python3 setup.py build_ext install
+	CFLAGS="-coverage -Werror=implicit-function-declaration" python3 setup.py build_ext install
 	python3 selftest.py
 
 .PHONY: debug

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -48,7 +48,7 @@ def test_sanity():
     assert list(map(type, v)) == [str, str, str, str]
 
     # internal version number
-    assert re.search(r"\d+\.\d+$", features.version_module("littlecms2"))
+    assert re.search(r"\d+\.\d+(\.\d+)?$", features.version_module("littlecms2"))
 
     skip_missing()
     i = ImageCms.profileToProfile(hopper(), SRGB, SRGB)

--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -224,6 +224,8 @@ def pilinfo(out=None, supported_formats=True):
         If ``True``, a list of all supported image file formats will be printed.
     """
 
+    from pkg_resources import parse_version
+
     if out is None:
         out = sys.stdout
 
@@ -269,7 +271,10 @@ def pilinfo(out=None, supported_formats=True):
             else:
                 v = version(name)
             if v is not None:
-                t = "compiled for" if name in ("pil", "jpg") else "loaded"
+                version_static = name in ("pil", "jpg")
+                if name == "littlecms2":
+                    version_static = parse_version(v) < parse_version("2.7.0")
+                t = "compiled for" if version_static else "loaded"
                 print("---", feature, "support ok,", t, v, file=out)
             else:
                 print("---", feature, "support ok", file=out)

--- a/src/_imagingcms.c
+++ b/src/_imagingcms.c
@@ -1512,8 +1512,16 @@ setup_module(PyObject* m) {
 
     d = PyModule_GetDict(m);
 
+#if LCMS_VERSION < 2070
+    vn = LCMS_VERSION;
+#else
     vn = cmsGetEncodedCMMversion();
-    v = PyUnicode_FromFormat("%d.%d", vn / 100, vn % 100);
+#endif
+    if (vn % 10) {
+        v = PyUnicode_FromFormat("%d.%d.%d", vn / 1000, (vn / 10) % 100, vn % 10);
+    } else {
+        v = PyUnicode_FromFormat("%d.%d", vn / 1000, (vn / 10) % 100);
+    }
     PyDict_SetItemString(d, "littlecms_version", v);
 
     return 0;


### PR DESCRIPTION
Should help avoid issues such as https://github.com/python-pillow/Pillow/issues/3835#issuecomment-507408755.
Helped find an issue from #4700 linking with LCMS<2.7.
Another one almost snuck in in #4955 (fixed in https://github.com/python-pillow/Pillow/pull/4955/commits/39ae5d62f0293738a5f697cc87a20a2c7c2bda83).

Changes proposed in this pull request:

 * Build Pillow on CIs with the `-Werror=implicit-function-declaration` compiler flag.
   Failed build example: https://github.com/nulano/Pillow/runs/1239867650?check_suite_focus=true#step:5:40
 * Fix issue introduced in #4700, restoring support for LCMS<2.7. Also fix version format string for LCMS.
