### PR TITLE
Drop support for old PyPy versions

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -33,9 +33,10 @@ pip install pyroma
 pip install test-image-results
 pip install numpy
 
-# TODO Remove when 3.8 / 3.9 includes setuptools 49.3.2+:
+# TODO Remove when 3.8 / 3.9 / PyPy3 includes setuptools 49.3.2+:
 if [ "$GHA_PYTHON_VERSION" == "3.8" ]; then pip install -U "setuptools>=49.3.2" ; fi
 if [ "$GHA_PYTHON_VERSION" == "3.9" ]; then pip install -U "setuptools>=49.3.2" ; fi
+if [ "$TRAVIS_PYTHON_VERSION" == "pypy3.6-7.3.1" ]; then pip install -U "setuptools>=49.3.2" ; fi
 
 if [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then
   # arm64, ppc64le, s390x CPUs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
     - python: "3.8"
       arch: s390x
 
-    - python: "pypy3"
+    - python: "pypy3.6-7.3.1"
       name: "PyPy3 Xenial"
     - python: "3.9-dev"
       name: "3.9-dev Xenial"

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -15,7 +15,6 @@ from .helper import (
     assert_image_equal_tofile,
     assert_image_similar,
     assert_image_similar_tofile,
-    is_pypy,
     is_win32,
     skip_unless_feature,
 )
@@ -474,7 +473,6 @@ class TestImageFont:
         with pytest.raises(UnicodeEncodeError):
             font.getsize("’")
 
-    @pytest.mark.xfail(is_pypy(), reason="failing on PyPy with Raqm")
     def test_unicode_extended(self):
         # issue #3777
         text = "A\u278A\U0001F12B"

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -364,27 +364,6 @@ text_layout_raqm(PyObject* string, FontObject* self, const char* dir, PyObject *
         goto failed;
     }
 
-#if (defined(PYPY_VERSION_NUM) && (PYPY_VERSION_NUM < 0x07020000))
-    if (PyUnicode_Check(string)) {
-        Py_UNICODE *text = PyUnicode_AS_UNICODE(string);
-        Py_ssize_t size = PyUnicode_GET_SIZE(string);
-        if (! size) {
-            /* return 0 and clean up, no glyphs==no size,
-               and raqm fails with empty strings */
-            goto failed;
-        }
-        if (!(*p_raqm.set_text)(rq, (const uint32_t *)(text), size)) {
-            PyErr_SetString(PyExc_ValueError, "raqm_set_text() failed");
-            goto failed;
-        }
-        if (lang) {
-            if (!(*p_raqm.set_language)(rq, lang, start, size)) {
-                PyErr_SetString(PyExc_ValueError, "raqm_set_language() failed");
-                goto failed;
-            }
-        }
-    }
-#else
     if (PyUnicode_Check(string)) {
         Py_UCS4 *text = PyUnicode_AsUCS4Copy(string);
         Py_ssize_t size = PyUnicode_GET_LENGTH(string);
@@ -406,7 +385,6 @@ text_layout_raqm(PyObject* string, FontObject* self, const char* dir, PyObject *
             }
         }
     }
-#endif
     else {
         PyErr_SetString(PyExc_TypeError, "expected string");
         goto failed;


### PR DESCRIPTION
Is it time to remove compatibility code for PyPy3<7.2.0 [released a year ago on 2019-10-14](https://morepypy.blogspot.com/2019/10/pypy-v72-released.html)? See also https://github.com/python-pillow/Pillow/pull/4145#discussion_r335667230.

Changes proposed in this pull request:

 * Remove compatibility code in `_imagingft.c` for PyPy3<7.2.0.

 * Pin Travis to `pypy3.6-7.3.1`. The simple `pypy3` is currently pointing to the over-year-and-a-half-old 7.1.1-beta0 version, see https://docs.travis-ci.com/user/languages/python/#pypy-support. This version also needs the setuptools update.

   Travis does not yet support 7.3.2 released two weeks ago, see https://travis-ci.community/t/add-pypy-7-3-2-support/10007.

 * PyPy3.6-7.3.2 is now available on GHA and fixes the issue in `test_imagefont.test_unicode_extended` on Windows. Remove `pytest.mark.xfail`. This will also be needed for `test_cbdt[_mask]` tests from #4955. 

   I don't remember if this was needed on MacOS with PyPy 7.3.1 or older, but the wheels for the 8.0.0 release (#4764) should ideally (I'm assuming) target the latest 7.3.2 version.

I did not remove the distutils envars from https://github.com/python-pillow/Pillow/pull/4746#discussion_r453307511 which are no longer necessary as of 7.3.2. I think it makes sense to keep these until Python 3.6 support is dropped at which point users will have to upgrade PyPy anyway (PyPy 7.3.2 is the first to support Python 3.7).