### PR TITLE
Moved warning to end of execution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,12 +38,16 @@ ZLIB_ROOT = None
 
 
 if sys.platform == "win32" and sys.version_info >= (3, 10):
-    warnings.warn(
-        f"Pillow {PILLOW_VERSION} does not support Python "
-        f"{sys.version_info.major}.{sys.version_info.minor} and does not provide "
-        "prebuilt Windows binaries. We do not recommend building from source on "
-        "Windows.",
-        RuntimeWarning,
+    import atexit
+
+    atexit.register(
+        lambda: warnings.warn(
+            f"Pillow {PILLOW_VERSION} does not support Python "
+            f"{sys.version_info.major}.{sys.version_info.minor} and does not provide "
+            "prebuilt Windows binaries. We do not recommend building from source on "
+            "Windows.",
+            RuntimeWarning,
+        )
     )
 
 


### PR DESCRIPTION
Suggestion to help https://github.com/python-pillow/Pillow/issues/4960#issuecomment-706528502

To make the `RuntimeWarning` (that future versions of Python are not supported by a given Pillow release) more obvious, this PR raises it within the context of `atexit`, so that the warning is shown at the end of the output.