### PR TITLE
Removed OSError in favour of DecompressionBombError for BMP

### DIFF
--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -60,6 +60,10 @@ class TestDecompressionBomb:
         with pytest.raises(Image.DecompressionBombError):
             Image.open("Tests/images/decompression_bomb.gif")
 
+    def test_exception_bmp(self):
+        with pytest.raises(Image.DecompressionBombError):
+            Image.open("Tests/images/bmp/b/reallybig.bmp")
+
 
 class TestDecompressionCrop:
     @classmethod

--- a/docs/releasenotes/8.0.0.rst
+++ b/docs/releasenotes/8.0.0.rst
@@ -86,15 +86,11 @@ A new method :py:meth:`.ImageDraw.regular_polygon`, draws a regular polygon of `
 For example ``draw.regular_polygon(((100, 100), 50), 5)``
 draws a pentagon centered at the point ``(100, 100)`` with a polygon radius of ``50``.
 
-Security
-========
-
-TODO
-
 Other Changes
 =============
 
-TODO
-^^^^
+Error for large BMP files
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-TODO
+Previously, if a BMP file was too large, an ``OSError`` would be raised. Now,
+``DecompressionBombError`` is used instead, as Pillow already uses for other formats.

--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -162,10 +162,6 @@ class BmpImageFile(ImageFile.ImageFile):
             else (1 << file_info["bits"])
         )
 
-        # ------------------------------- Check abnormal values for DOS attacks
-        if file_info["width"] * file_info["height"] > 2 ** 31:
-            raise OSError("Unsupported BMP Size: (%dx%d)" % self.size)
-
         # ---------------------- Check bit depth for unusual unsupported values
         self.mode, raw_mode = BIT2MODE.get(file_info["bits"], (None, None))
         if self.mode is None:


### PR DESCRIPTION
Resolves #4939

At the moment, a very large BMP file does not raise a DecompressionBombError, but instead an OSError. This PR changes it so that the more standard DecompressionBombError is raised.