### PR TITLE
Release notes for TrueType functions and PyPy support

### DIFF
--- a/docs/releasenotes/8.0.0.rst
+++ b/docs/releasenotes/8.0.0.rst
@@ -41,6 +41,20 @@ Removed                   Use instead
 API Changes
 ===========
 
+ImageDraw.text: stroke_width
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Fixed issue where passing ``stroke_width`` with a non-zero value
+to :py:meth:`.ImageDraw.text` would cause the text to be offset by that amount.
+
+ImageDraw.text: anchor
+^^^^^^^^^^^^^^^^^^^^^^
+
+The ``anchor`` parameter of :py:meth:`.ImageDraw.text` has been implemented.
+
+Use this parameter to change the position of text relative to the
+specified ``xy`` point. See :ref:`text-anchors` for details.
+
 Add MIME type to PsdImagePlugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -86,8 +100,51 @@ A new method :py:meth:`.ImageDraw.regular_polygon`, draws a regular polygon of `
 For example ``draw.regular_polygon(((100, 100), 50), 5)``
 draws a pentagon centered at the point ``(100, 100)`` with a polygon radius of ``50``.
 
+ImageDraw.text: embedded_color
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The methods :py:meth:`.ImageDraw.text` and :py:meth:`.ImageDraw.multiline_text`
+now support fonts with embedded color data.
+
+To render text with embedded color data, use the parameter ``embedded_color=True``.
+
+Support for CBDT fonts requires FreeType 2.5 compiled with libpng.
+Support for COLR fonts requires FreeType 2.10.
+SBIX and SVG fonts are not yet supported.
+
+ImageDraw.textlength
+^^^^^^^^^^^^^^^^^^^^
+
+Two new methods :py:meth:`.ImageDraw.textlength` and :py:meth:`.FreeTypeFont.getlength`
+were added, returning the exact advance length of text with 1/64 pixel precision.
+
+These can be used for word-wrapping or rendering text in parts.
+
+ImageDraw.textbbox
+^^^^^^^^^^^^^^^^^^
+
+Three new methods :py:meth:`.ImageDraw.textbbox`, :py:meth:`.ImageDraw.multiline_textbbox`,
+and :py:meth:`.FreeTypeFont.getbbox` return the bounding box of rendered text.
+
+These functions accept an ``anchor`` parameter, see :ref:`text-anchors` for details.
+
+Security
+========
+
+TODO
+
 Other Changes
 =============
+
+ImageDraw.text and ImageDraw.multiline_text
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Fixed multiple issues in methods :py:meth:`.ImageDraw.text` and :py:meth:`.ImageDraw.multiline_text`
+sometimes causing unexpected text alignment issues.
+
+The ``align`` parameter of :py:meth:`.ImageDraw.multiline_text` now gives better results in some cases.
+
+TrueType fonts with embedded bitmaps are now supported.
 
 Error for large BMP files
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/releasenotes/8.0.0.rst
+++ b/docs/releasenotes/8.0.0.rst
@@ -9,6 +9,12 @@ Python 3.5
 
 Pillow has dropped support for Python 3.5, which reached end-of-life on 2020-09-13.
 
+PyPy 7.1.x
+^^^^^^^^^^
+
+Pillow has dropped support for PyPy3 7.1.1.
+PyPy3 7.2.0, released on 2019-10-14, is now the minimum compatible version.
+
 im.offset
 ^^^^^^^^^
 


### PR DESCRIPTION
Adds release notes for the following PRs released in 8.0.0 (#4764):

 * **Refactor font_getsize and font_render (#4910)**; "Other Changes" section; for issues #4553, #4569, #2293
 * **Implement anchor for TrueType fonts (#4930)**; "API Changes" section; for issues #4511
 * **Add `getlength` and `getbbox` functions for TrueType fonts (#4959)**; "API Additions" section; for issues #4651, #3977, #4483, #3921, #4789; brief mention in "Other Changes" section for issue #4553
 * **Add support for CBDT and COLR fonts (#4955)**; "API Additions" section; for issues #3346, #891
 * **Drop support for old PyPy versions (#4964)**; "Backwards Incompatible Changes" section

I also listed the related issues for easier search.
