### PR TITLE
Added macOS SDK install path to library and include directories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -477,6 +477,18 @@ class pil_build_ext(build_ext):
                 _add_directory(library_dirs, "/usr/X11/lib")
                 _add_directory(include_dirs, "/usr/X11/include")
 
+            # SDK install path
+            try:
+                sdk_path = (
+                    subprocess.check_output(["xcrun", "--show-sdk-path"])
+                    .strip()
+                    .decode("latin1")
+                )
+            except Exception:
+                sdk_path = None
+            if sdk_path:
+                _add_directory(library_dirs, os.path.join(sdk_path, "usr", "lib"))
+                _add_directory(include_dirs, os.path.join(sdk_path, "usr", "include"))
         elif (
             sys.platform.startswith("linux")
             or sys.platform.startswith("gnu")


### PR DESCRIPTION
Resolves #4973 by using ([as suggested](https://github.com/python-pillow/Pillow/issues/4973#issuecomment-707686733)) `xcrun --show-sdk-path` to add the SDK install path for library and include directories.

This same solution was also very popular in https://github.com/python-pillow/Pillow/issues/3438#issuecomment-575161585