### PR TITLE
Avoid using pkg_resources in PIL.features.pilinfo

### DIFF
--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -224,8 +224,6 @@ def pilinfo(out=None, supported_formats=True):
         If ``True``, a list of all supported image file formats will be printed.
     """
 
-    from pkg_resources import parse_version
-
     if out is None:
         out = sys.stdout
 
@@ -273,7 +271,8 @@ def pilinfo(out=None, supported_formats=True):
             if v is not None:
                 version_static = name in ("pil", "jpg")
                 if name == "littlecms2":
-                    version_static = parse_version(v) < parse_version("2.7.0")
+                    # this check is also in src/_imagingcms.c:setup_module()
+                    version_static = tuple(int(x) for x in v.split(".")) < (2, 7)
                 t = "compiled for" if version_static else "loaded"
                 print("---", feature, "support ok,", t, v, file=out)
             else:

--- a/src/_imagingcms.c
+++ b/src/_imagingcms.c
@@ -1512,6 +1512,7 @@ setup_module(PyObject* m) {
 
     d = PyModule_GetDict(m);
 
+    /* this check is also in PIL.features.pilinfo() */
 #if LCMS_VERSION < 2070
     vn = LCMS_VERSION;
 #else


### PR DESCRIPTION
Instead of using `pkg_resources`, which AFAICT is [part of `setuptools`](https://setuptools.readthedocs.io/en/latest/pkg_resources.html#parsing-utilities), check the LCMS version (check added in #4963) manually.

While `setuptools` is very likely to already be installed, Pillow doesn't actually require it for runtime, only compilation and testing. Additionally, the `pilinfo` function is useful for finding configuration issues and should have as few external dependencies as possible.

Since this version string is being set in the C code, it is safe to break it back into ints and perform a tuple comparison instead.
This PR also adds a comment to make sure the two checks don't get out of sync.