### PR TITLE
Add #4523 ellipse-drawing algorithm changes to release notes

### DIFF
--- a/docs/releasenotes/8.0.0.rst
+++ b/docs/releasenotes/8.0.0.rst
@@ -137,6 +137,13 @@ These functions accept an ``anchor`` parameter, see :ref:`text-anchors` for deta
 Other Changes
 =============
 
+Improved ellipse-drawing algorithm
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ellipse-drawing algorithm has been changed from drawing a 360-sided polygon to one
+which resembles Bresenham's algorithm's for circles. It should be faster and produce
+smoother curves, especially for smaller ellipses.
+
 ImageDraw.text and ImageDraw.multiline_text
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/releasenotes/8.0.0.rst
+++ b/docs/releasenotes/8.0.0.rst
@@ -141,7 +141,7 @@ Improved ellipse-drawing algorithm
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ellipse-drawing algorithm has been changed from drawing a 360-sided polygon to one
-which resembles Bresenham's algorithm's for circles. It should be faster and produce
+which resembles Bresenham's algorithm for circles. It should be faster and produce
 smoother curves, especially for smaller ellipses.
 
 ImageDraw.text and ImageDraw.multiline_text


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/4764.

Add #4523's ellipse-drawing algorithm changes to release notes.