### PR TITLE
chown pip wheels cache on ppc64le

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -21,7 +21,7 @@ sudo apt-get -qq install libfreetype6-dev liblcms2-dev python3-tk\
                          ghostscript libffi-dev libjpeg-turbo-progs libopenjp2-7-dev\
                          cmake imagemagick libharfbuzz-dev libfribidi-dev
 
-if [[ $TRAVIS_CPU_ARCH == "s390x" ]]; then sudo chown $USER ~/.cache/pip/wheels ; fi
+if [[ $TRAVIS_CPU_ARCH == "s390x" || $TRAVIS_CPU_ARCH == "ppc64le" ]]; then sudo chown $USER ~/.cache/pip/wheels ; fi
 
 pip install --upgrade pip
 PYTHONOPTIMIZE=0 pip install cffi


### PR DESCRIPTION
master has started failing on [the ppc64le job](https://travis-ci.org/github/python-pillow/Pillow/jobs/735677534). This fixes it, as with #4924 for s390x.