### PR TITLE
GHA: Remove obsolete code for old PyPy

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -52,11 +52,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}
 
-    - name: Set up TCL
-      if: "contains(matrix.python-version, 'pypy')"
-      run: echo "TCL_LIBRARY=$env:pythonLocation\tcl\tcl8.5" >> $env:GITHUB_ENV
-      shell: pwsh
-
     - name: Print build system information
       run: python .github/workflows/system-info.py
 


### PR DESCRIPTION
Missed this as part of #4964.

* Revert #4702 now that the fix is released in PyPy 7.3.2.

The tests now pass without the workaround:
https://github.com/python-pillow/Pillow/pull/4984/checks?check_run_id=1262633517#step:27:1628
 ```
Tests/test_imagetk.py::test_kw PASSED                                    [ 94%]
Tests/test_imagetk.py::test_photoimage PASSED                            [ 94%]
Tests/test_imagetk.py::test_photoimage_blank PASSED                      [ 94%]
Tests/test_imagetk.py::test_bitmapimage PASSED                           [ 94%]
```
