### PR TITLE
Fix internal Sphinx link to installation doc

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -561,8 +561,8 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
 .. note::
 
     To enable PNG support, you need to build and install the ZLIB compression
-    library before building the Python Imaging Library. See the `installation
-    documentation <../installation.html>`_ for details.
+    library before building the Python Imaging Library. See the
+    :doc:`installation documentation <../installation>` for details.
 
 .. _apng-sequences:
 

--- a/docs/releasenotes/4.2.0.rst
+++ b/docs/releasenotes/4.2.0.rst
@@ -6,10 +6,9 @@ Added Complex Text Rendering
 
 Pillow now supports complex text rendering for scripts requiring glyph
 composition and bidirectional flow. This optional feature adds three
-dependencies: harfbuzz, fribidi, and raqm. See the `install
-documentation <../installation.html>`_  for further details. This feature is
-tested and works on Unix and Mac, but has not yet been built on Windows
-platforms.
+dependencies: harfbuzz, fribidi, and raqm. See the :doc:`install documentation
+<../installation>` for further details. This feature is tested and works on
+Unix and Mac, but has not yet been built on Windows platforms.
 
 New Optional Parameters
 =======================


### PR DESCRIPTION
Fixes linkcheck warnings:

    handbook/image-file-formats.rst:563: [broken] ../installation.html:
    releasenotes/4.2.0.rst:7: [broken] ../installation.html:
