### PR TITLE
Add release notes for 8.0.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,12 @@ Changelog (Pillow)
 - Support raw rgba8888 for DDS #4760
   [qiankanglai]
 
+8.0.1 (2020-10-22)
+------------------
+
+- Update FreeType used in binary wheels to 2.10.4 to fix CVE-2020-15999.
+  [radarhere]
+
 8.0.0 (2020-10-15)
 ------------------
 

--- a/docs/releasenotes/8.0.1.rst
+++ b/docs/releasenotes/8.0.1.rst
@@ -1,0 +1,23 @@
+8.0.1
+-----
+
+Security
+========
+
+Update FreeType used in binary wheels to `2.10.4`_ to fix CVE-2020-15999_:
+
+  - A heap buffer overflow has been found  in the handling of embedded PNG bitmaps,
+    introduced in FreeType version 2.6.
+
+      https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15999
+
+    If you use option ``FT_CONFIG_OPTION_USE_PNG`` you should upgrade immediately.
+
+Before Pillow 8.0.0 bitmap fonts were disabled with ``FT_LOAD_NO_BITMAP``, but it is not
+clear if this prevents the exploit and we recommend updating to Pillow 8.0.1.
+
+Pillow 8.0.0 and earlier are potentially vulnerable releases, including the last release
+to support Python 2.7, namely Pillow 6.2.2.
+
+.. _2.10.4: https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/
+.. _CVE-2020-15999: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15999

--- a/docs/releasenotes/8.0.1.rst
+++ b/docs/releasenotes/8.0.1.rst
@@ -13,7 +13,9 @@ Update FreeType used in binary wheels to `2.10.4`_ to fix CVE-2020-15999_:
 
     If you use option ``FT_CONFIG_OPTION_USE_PNG`` you should upgrade immediately.
 
-Before Pillow 8.0.0 bitmap fonts were disabled with ``FT_LOAD_NO_BITMAP``, but it is not
+We strongly recommend updating to Pillow 8.0.1 if you are using Pillow 8.0.0, which improved support for bitmap fonts.
+
+In Pillow 7.2.0 and earlier bitmap fonts were disabled with ``FT_LOAD_NO_BITMAP``, but it is not
 clear if this prevents the exploit and we recommend updating to Pillow 8.0.1.
 
 Pillow 8.0.0 and earlier are potentially vulnerable releases, including the last release

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -13,6 +13,7 @@ expected to be backported to earlier versions.
 .. toctree::
   :maxdepth: 2
 
+  8.0.1
   8.0.0
   7.2.0
   7.1.2


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/4764.

Changes proposed in this pull request:

 * Release notes for the FreeType security update.
