### PR TITLE
CI: Replace test images from pillow-depends

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ install:
 - curl -fsSL -o pillow-depends.zip https://github.com/python-pillow/pillow-depends/archive/master.zip
 - 7z x pillow-depends.zip -oc:\
 - mv c:\pillow-depends-master c:\pillow-depends
-- xcopy /s c:\pillow-depends\test_images\* c:\pillow\tests\images
+- xcopy /S /Y c:\pillow-depends\test_images\* c:\pillow\tests\images
 - 7z x ..\pillow-depends\nasm-2.14.02-win64.zip -oc:\
 - ..\pillow-depends\gs9533w32.exe /S
 - path c:\nasm-2.14.02;C:\Program Files (x86)\gs\gs9.53.3\bin;%PATH%

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -76,7 +76,7 @@ jobs:
         winbuild\depends\gs9533w32.exe /S
         echo "C:\Program Files (x86)\gs\gs9.53.3\bin" >> $env:GITHUB_PATH
 
-        xcopy /s winbuild\depends\test_images\* Tests\images\
+        xcopy /S /Y winbuild\depends\test_images\* Tests\images\
       shell: pwsh
 
     - name: Cache build


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/4764#issuecomment-714547692:

> [GHA Window CI](https://github.com/python-pillow/Pillow/actions/runs/322256390) failed with "Overwrite D:\a\Pillow\Pillow\Tests\images\string_dimension.tiff (Yes/No/All)?", will be because of #4993 / [python-pillow/pillow-depends#34](https://github.com/python-pillow/pillow-depends/pull/34), so will include that too: [f886bc9](https://github.com/python-pillow/Pillow/commit/f886bc973bb972a796756d9c0a728795d203dd97).

Do not prompt to overwrite when copying test images from pillow-depends on Windows CIs so the above will not be needed for future point releases or when working on an old branch.

Successful test from my repo (does not include #4993): https://github.com/nulano/Pillow/runs/1293222859?check_suite_focus=true#step:10:32