### PR TITLE
Releasing: Add a 'git push' to point release, adjust MD formatting

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,10 +6,7 @@ Released quarterly on January 2nd, April 1st, July 1st and October 15th.
 
 * [ ] Open a release ticket e.g. https://github.com/python-pillow/Pillow/issues/3154
 * [ ] Develop and prepare release in `master` branch.
-* [ ] Check [GitHub Actions](https://github.com/python-pillow/Pillow/actions),
-      [Travis CI](https://travis-ci.org/github/python-pillow/Pillow) and
-      [AppVeyor](https://ci.appveyor.com/project/python-pillow/Pillow) to confirm
-      passing tests in `master` branch.
+* [ ] Check [GitHub Actions](https://github.com/python-pillow/Pillow/actions), [Travis CI](https://travis-ci.org/github/python-pillow/Pillow) and [AppVeyor](https://ci.appveyor.com/project/python-pillow/Pillow) to confirm passing tests in `master` branch.
 * [ ] Check that all of the wheel builds [Pillow Wheel Builder](https://github.com/python-pillow/pillow-wheels) pass the tests in Travis CI.
 * [ ] In compliance with [PEP 440](https://www.python.org/dev/peps/pep-0440/), update version identifier in `src/PIL/_version.py`
 * [ ] Update `CHANGES.rst`.
@@ -40,14 +37,11 @@ Released as needed for security, installation or critical bug fixes.
   ```bash
   git checkout -t remotes/origin/5.2.x
   ```
-* [ ] Cherry pick individual commits from `master` branch to release branch e.g. `5.2.x`.
+* [ ] Cherry pick individual commits from `master` branch to release branch e.g. `5.2.x`, then `git push`.
 
 
 
-* [ ] Check [GitHub Actions](https://github.com/python-pillow/Pillow/actions),
-      [Travis CI](https://travis-ci.org/github/python-pillow/Pillow) and
-      [AppVeyor](https://ci.appveyor.com/project/python-pillow/Pillow) to confirm
-      passing tests in release branch e.g. `5.2.x`.
+* [ ] Check [GitHub Actions](https://github.com/python-pillow/Pillow/actions), [Travis CI](https://travis-ci.org/github/python-pillow/Pillow) and [AppVeyor](https://ci.appveyor.com/project/python-pillow/Pillow) to confirm passing tests in release branch e.g. `5.2.x`.
 * [ ] In compliance with [PEP 440](https://www.python.org/dev/peps/pep-0440/), update version identifier in `src/PIL/_version.py`
 * [ ] Run pre-release check via `make release-test`.
 * [ ] Create tag for release e.g.:


### PR DESCRIPTION
A couple of minor fixes after doing the 8.0.1 release.

---

Add an explicit `git push` after the cherry pick.

* [ ] Cherry pick individual commits from `master` branch to release branch e.g. `5.2.x`, then `git push`.


---

This bit renders fine in https://github.com/python-pillow/Pillow/blob/master/RELEASING.md:

```md
* [ ] Check [GitHub Actions](https://github.com/python-pillow/Pillow/actions),
      [Travis CI](https://travis-ci.org/github/python-pillow/Pillow) and
      [AppVeyor](https://ci.appveyor.com/project/python-pillow/Pillow) to confirm
      passing tests in `master` branch.
```

![image](https://user-images.githubusercontent.com/1324225/97107484-8a0c4280-16d0-11eb-9500-6c4d391c9cb7.png)

But not so well when pasted into release issues (https://github.com/python-pillow/Pillow/issues/4764):

* [ ] Check [GitHub Actions](https://github.com/python-pillow/Pillow/actions),
      [Travis CI](https://travis-ci.org/github/python-pillow/Pillow) and
      [AppVeyor](https://ci.appveyor.com/project/python-pillow/Pillow) to confirm
      passing tests in `master` branch.

![image](https://user-images.githubusercontent.com/1324225/97107504-a5774d80-16d0-11eb-8b14-2b140420cdd8.png)

So stick it all on one line:

* [ ] Check [GitHub Actions](https://github.com/python-pillow/Pillow/actions), [Travis CI](https://travis-ci.org/github/python-pillow/Pillow) and [AppVeyor](https://ci.appveyor.com/project/python-pillow/Pillow) to confirm passing tests in `master` branch.

![image](https://user-images.githubusercontent.com/1324225/97107534-d22b6500-16d0-11eb-82ca-5f5f53d69f26.png)
