### PR TITLE
Travis CI: Test on Python 3.9 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ matrix:
 
     - python: "pypy3.6-7.3.1"
       name: "PyPy3 Xenial"
-    - python: "3.9-dev"
-      name: "3.9-dev Xenial"
+    - python: "3.9"
+      name: "3.9 Xenial"
       services: xvfb
     - python: "3.8"
       name: "3.8 Xenial"
@@ -42,9 +42,6 @@ matrix:
       name: "3.6 Xenial PYTHONOPTIMIZE=1"
       env: PYTHONOPTIMIZE=1
       services: xvfb
-
-  allow_failures:
-  - python: "3.9-dev"
 
 install:
   - |


### PR DESCRIPTION
For #4953.

Changes proposed in this pull request:

 * Travis CI now has Python 3.9 final available
