### PR TITLE
Add Fedora 33

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -21,6 +21,7 @@ jobs:
           amazon-1-amd64,
           amazon-2-amd64,
           fedora-32-amd64,
+          fedora-33-amd64,
         ]
         dockerTag: [master]
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * Fedora 33 was released on Tuesday, 27 October 2020
 * Partner to https://github.com/python-pillow/docker-images/pull/92
