### PR TITLE
Refer to "HPND License" instead of "PIL Software License"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -7,7 +7,7 @@ Pillow is the friendly PIL fork. It is
 
     Copyright © 2010-2020 by Alex Clark and contributors
 
-Like PIL, Pillow is licensed under the open source PIL Software License:
+Like PIL, Pillow is licensed under the open source HPND License:
 
 By obtaining, using, and/or copying this software and/or its associated
 documentation, you agree that you have read, understood, and will comply

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -19,7 +19,7 @@ The fork author's goal is to foster and support active development of PIL throug
 License
 -------
 
-Like PIL, Pillow is `licensed under the open source PIL Software License <https://raw.githubusercontent.com/python-pillow/Pillow/master/LICENSE>`_
+Like PIL, Pillow is `licensed under the open source HPND License <https://raw.githubusercontent.com/python-pillow/Pillow/master/LICENSE>`_
 
 Why a fork?
 -----------


### PR DESCRIPTION
Resolves #5017

Updating LICENSE was suggested in https://github.com/python-pillow/Pillow/issues/5017#issuecomment-718056327. This PR also updates [docs/about.rst](https://pillow.readthedocs.io/en/stable/about.html#license) to be in sync.