### PR TITLE
Updated extra test images list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,10 @@ docs/_build/
 
 # Extra test images installed from pillow-depends/test_images
 Tests/images/README.md
+Tests/images/crash_1.tif
+Tests/images/crash_2.tif
+Tests/images/string_dimension.tiff
+Tests/images/jpeg2000
 Tests/images/msp
 Tests/images/picins
 Tests/images/sunraster


### PR DESCRIPTION
Updated extra test images list in `.gitignore` to match recent additions to https://github.com/python-pillow/pillow-depends/tree/master/test_images