### PR TITLE
Remove excess Travis CI jobs

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -39,13 +39,13 @@ if [ "$GHA_PYTHON_VERSION" == "3.8" ]; then python3 -m pip install -U "setuptool
 if [ "$GHA_PYTHON_VERSION" == "3.9" ]; then python3 -m pip install -U "setuptools>=49.3.2" ; fi
 if [ "$TRAVIS_PYTHON_VERSION" == "pypy3.6-7.3.1" ]; then python3 -m pip install -U "setuptools>=49.3.2" ; fi
 
-if [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then
+# PyQt5 doesn't support PyPy3
+# Wheel doesn't yet support 3.10
+if [[ $GHA_PYTHON_VERSION == 3.* && $GHA_PYTHON_VERSION != "3.10-dev" ]]; then
   # arm64, ppc64le, s390x CPUs:
   # "ERROR: Could not find a version that satisfies the requirement pyqt5"
-  if [[ $TRAVIS_CPU_ARCH == "amd64" ]]; then
     sudo apt-get -qq install libxcb-xinerama0 pyqt5-dev-tools
     python3 -m pip install pyqt5
-  fi
 fi
 
 # docs only on Python 3.9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
         ]
         include:
         - python-version: "3.6"
-          env: PYTHONOPTIMIZE=1
+          PYTHONOPTIMIZE: 1
         - python-version: "3.7"
-          env: PYTHONOPTIMIZE=2
+          PYTHONOPTIMIZE: 2
         # Include new variables for Codecov
         - os: ubuntu-latest
           codecov-flag: GHA_Ubuntu
@@ -80,6 +80,8 @@ jobs:
     - name: Test
       run: |
         .ci/test.sh
+      env:
+        PYTHONOPTIMIZE: ${{ matrix.PYTHONOPTIMIZE }}
 
     - name: Prepare to upload errors
       if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,8 +78,9 @@ jobs:
         .ci/build.sh
 
     - name: Test
-      run: |
-        .ci/test.sh
+      uses: GabrielBB/xvfb-action@v1
+      with:
+        run: .ci/test.sh
       env:
         PYTHONOPTIMIZE: ${{ matrix.PYTHONOPTIMIZE }}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,13 @@
 dist: xenial
 language: python
-cache:
-  pip: true
-  directories:
-    - $HOME/.cache/pre-commit
+cache: pip
 
 notifications:
   irc: "chat.freenode.net#pil"
 
-# Run fast lint first to get fast feedback.
-# Run slower CPUs next, to give them a headstart and reduce waiting time.
-# Then run the remainder.
-
 matrix:
   fast_finish: true
   include:
-    - python: "3.6"
-      name: "Lint"
-      env: LINT="true"
-
     - python: "3.6"
       arch: arm64
     - python: "3.7"
@@ -26,42 +15,15 @@ matrix:
     - python: "3.8"
       arch: s390x
 
-    - python: "pypy3.6-7.3.1"
-      name: "PyPy3 Xenial"
-    - python: "3.9"
-      name: "3.9 Xenial"
-      services: xvfb
-    - python: "3.8"
-      name: "3.8 Xenial"
-      services: xvfb
-    - python: '3.7'
-      name: "3.7 Xenial PYTHONOPTIMIZE=2"
-      env: PYTHONOPTIMIZE=2
-      services: xvfb
-    - python: '3.6'
-      name: "3.6 Xenial PYTHONOPTIMIZE=1"
-      env: PYTHONOPTIMIZE=1
-      services: xvfb
-
 install:
   - |
-    if [ "$LINT" == "true" ]; then
-      python3 -m pip install tox
-    else
-      .ci/install.sh;
-    fi
+    .ci/install.sh;
 
 script:
-- |
-  if [ "$LINT" == "true" ]; then
-    tox -e lint
-  else
+  - |
     .ci/build.sh
     .ci/test.sh
-  fi
 
 after_success:
-- |
-  if [ "$LINT" == "" ]; then
+  - |
     .ci/after_success.sh
-  fi

--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -21,7 +21,7 @@ def test_libimagequant_quantize():
     image = hopper()
     try:
         converted = image.quantize(100, Image.LIBIMAGEQUANT)
-    except ValueError as ex:
+    except ValueError as ex:  # pragma: no cover
         if "dependency" in str(ex).lower():
             pytest.skip("libimagequant support not available")
         else:


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/5028.

Changes proposed in this pull request:

 * Remove jobs which are already run on GitHub Actions

# TODO

 * Check coverage drops and see what's tested on Travis that's not in GHA
    * Ideally add to GHA
    * Or keep a single Travis job for a bit longer
    * Or take the drop

 * There's some redundant bits of scripts that can be removed now or later, e.g. `TRAVIS_PYTHON_VERSION` checks
