### PR TITLE
init() if one of the formats is unrecognised

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2905,6 +2905,8 @@ def open(fp, mode="r", formats=None):
 
     def _open_core(fp, filename, prefix, formats):
         for i in formats:
+            if i not in OPEN:
+                init()
             try:
                 factory, accept = OPEN[i]
                 result = not accept or accept(prefix)


### PR DESCRIPTION
Resolves #5036 

```python
from PIL import Image
im = Image.open('Tests/images/hopper.webp', formats=('WEBP',))
```
`Image.open` calls `preinit()` first and then expects to loop through them. However, `formats` overrides this, and so `WEBP` is checked, which throws a `KeyError` because `init()` has not been called yet, as `Image.open()` only calls it if the `preinit()` formats do not match.

This PR resolves that.