### PR TITLE
Remove unused Travis CI config

### DIFF
--- a/.ci/after_success.sh
+++ b/.ci/after_success.sh
@@ -7,7 +7,3 @@ if [[ $MATRIX_DOCKER ]]; then
 else
   coverage xml
 fi
-
-if [[ $TRAVIS ]]; then
-    codecov --flags TravisCI
-fi

--- a/.ci/after_success.sh
+++ b/.ci/after_success.sh
@@ -11,9 +11,3 @@ fi
 if [[ $TRAVIS ]]; then
     codecov --flags TravisCI
 fi
-
-if [ "$TRAVIS_PYTHON_VERSION" == "3.9" ]; then
-    # Coverage and quality reports on just the latest diff.
-    depends/diffcover-install.sh
-    depends/diffcover-run.sh
-fi

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -21,8 +21,6 @@ sudo apt-get -qq install libfreetype6-dev liblcms2-dev python3-tk\
                          ghostscript libffi-dev libjpeg-turbo-progs libopenjp2-7-dev\
                          cmake imagemagick libharfbuzz-dev libfribidi-dev
 
-if [[ $TRAVIS_CPU_ARCH == "s390x" ]]; then sudo chown $USER ~/.cache/pip/wheels ; fi
-
 python3 -m pip install --upgrade pip
 PYTHONOPTIMIZE=0 python3 -m pip install cffi
 python3 -m pip install coverage

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -34,10 +34,9 @@ python3 -m pip install test-image-results
 # TODO Remove condition when numpy supports 3.10
 if ! [ "$GHA_PYTHON_VERSION" == "3.10-dev" ]; then python3 -m pip install numpy ; fi
 
-# TODO Remove when 3.8 / 3.9 / PyPy3 includes setuptools 49.3.2+:
+# TODO Remove when 3.8 / 3.9 includes setuptools 49.3.2+:
 if [ "$GHA_PYTHON_VERSION" == "3.8" ]; then python3 -m pip install -U "setuptools>=49.3.2" ; fi
 if [ "$GHA_PYTHON_VERSION" == "3.9" ]; then python3 -m pip install -U "setuptools>=49.3.2" ; fi
-if [ "$TRAVIS_PYTHON_VERSION" == "pypy3.6-7.3.1" ]; then python3 -m pip install -U "setuptools>=49.3.2" ; fi
 
 # PyQt5 doesn't support PyPy3
 # Wheel doesn't yet support 3.10
@@ -47,9 +46,6 @@ if [[ $GHA_PYTHON_VERSION == 3.* && $GHA_PYTHON_VERSION != "3.10-dev" ]]; then
     sudo apt-get -qq install libxcb-xinerama0 pyqt5-dev-tools
     python3 -m pip install pyqt5
 fi
-
-# docs only on Python 3.9
-if [ "$TRAVIS_PYTHON_VERSION" == "3.9" ]; then python3 -m pip install -r requirements.txt ; fi
 
 # webp
 pushd depends && ./install_webp.sh && popd

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -3,8 +3,3 @@
 set -e
 
 python -bb -m pytest -v -x -W always --cov PIL --cov Tests --cov-report term Tests
-
-# Docs
-if [ "$TRAVIS_PYTHON_VERSION" == "3.9" ] && [ "$TRAVIS_CPU_ARCH" == "amd64" ]; then
-    make doccheck
-fi

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Please send a pull request to the master branch. Please include [documentation](
 - Fork the Pillow repository.
 - Create a branch from master.
 - Develop bug fixes, features, tests, etc.
-- Run the test suite. You can enable [Travis CI](https://travis-ci.com/account/repositories) and [AppVeyor](https://ci.appveyor.com/projects/new) on your repo to catch test failures prior to the pull request, and [Codecov](https://codecov.io/gh) to see if the changed code is covered by tests.
+- Run the test suite. You can enable [GitHub Actions](http://github.com/MY-USERNAME/Pillow/actions) and [AppVeyor](https://ci.appveyor.com/projects/new) on your repo to catch test failures prior to the pull request, and [Codecov](https://codecov.io/gh) to see if the changed code is covered by tests.
 - Create a pull request to pull the changes from your branch to the Pillow master.
 
 ### Guidelines
@@ -17,7 +17,7 @@ Please send a pull request to the master branch. Please include [documentation](
 - Separate code commits from reformatting commits.
 - Provide tests for any newly added code.
 - Follow PEP 8.
-- When committing only documentation changes please include `[ci skip]` in the commit message to avoid running tests on Travis CI and AppVeyor.
+- When committing only documentation changes please include `[ci skip]` in the commit message to avoid running tests on AppVeyor.
 
 ## Reporting Issues
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Please send a pull request to the master branch. Please include [documentation](
 - Fork the Pillow repository.
 - Create a branch from master.
 - Develop bug fixes, features, tests, etc.
-- Run the test suite. You can enable [GitHub Actions](http://github.com/MY-USERNAME/Pillow/actions) and [AppVeyor](https://ci.appveyor.com/projects/new) on your repo to catch test failures prior to the pull request, and [Codecov](https://codecov.io/gh) to see if the changed code is covered by tests.
+- Run the test suite. You can enable GitHub Actions (https://github.com/MY-USERNAME/Pillow/actions) and [AppVeyor](https://ci.appveyor.com/projects/new) on your repo to catch test failures prior to the pull request, and [Codecov](https://codecov.io/gh) to see if the changed code is covered by tests.
 - Create a pull request to pull the changes from your branch to the Pillow master.
 
 ### Guidelines

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,7 +7,6 @@ pull_request_rules:
       - status-success=Test Successful
       - status-success=Docker Test Successful
       - status-success=Windows Test Successful
-#      - status-success=Travis CI - Pull Request
       - status-success=continuous-integration/appveyor/pr
     actions:
       merge:

--- a/README.md
+++ b/README.md
@@ -24,15 +24,6 @@ As of 2019, Pillow development is
     <tr>
         <th>tests</th>
         <td>
-            <a href="https://travis-ci.com/github/python-pillow/Pillow"><img
-                alt="Travis CI build status (Linux)"
-                src="https://img.shields.io/travis/com/python-pillow/Pillow/master.svg?label=Linux%20build"></a>
-            <a href="https://travis-ci.com/github/python-pillow/pillow-wheels"><img
-                alt="Travis CI build status (macOS)"
-                src="https://img.shields.io/travis/com/python-pillow/pillow-wheels/master.svg?label=macOS%20build"></a>
-            <a href="https://ci.appveyor.com/project/python-pillow/Pillow"><img
-                alt="AppVeyor CI build status (Windows)"
-                src="https://img.shields.io/appveyor/build/python-pillow/Pillow/master.svg?label=Windows%20build"></a>
             <a href="https://github.com/python-pillow/Pillow/actions?query=workflow%3ALint"><img
                 alt="GitHub Actions build status (Lint)"
                 src="https://github.com/python-pillow/Pillow/workflows/Lint/badge.svg"></a>
@@ -45,6 +36,12 @@ As of 2019, Pillow development is
             <a href="https://github.com/python-pillow/Pillow/actions?query=workflow%3A%22Test+Docker%22"><img
                 alt="GitHub Actions build status (Test Docker)"
                 src="https://github.com/python-pillow/Pillow/workflows/Test%20Docker/badge.svg"></a>
+            <a href="https://ci.appveyor.com/project/python-pillow/Pillow"><img
+                alt="AppVeyor CI build status (Windows)"
+                src="https://img.shields.io/appveyor/build/python-pillow/Pillow/master.svg?label=Windows%20build"></a>
+            <a href="https://travis-ci.com/github/python-pillow/pillow-wheels"><img
+                alt="Travis CI build status (macOS)"
+                src="https://img.shields.io/travis/com/python-pillow/pillow-wheels/master.svg?label=macOS%20build"></a>
             <a href="https://codecov.io/gh/python-pillow/Pillow"><img
                 alt="Code coverage"
                 src="https://codecov.io/gh/python-pillow/Pillow/branch/master/graph/badge.svg"></a>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,7 +7,7 @@ Released quarterly on January 2nd, April 1st, July 1st and October 15th.
 * [ ] Open a release ticket e.g. https://github.com/python-pillow/Pillow/issues/3154
 * [ ] Develop and prepare release in `master` branch.
 * [ ] Check [GitHub Actions](https://github.com/python-pillow/Pillow/actions) and [AppVeyor](https://ci.appveyor.com/project/python-pillow/Pillow) to confirm passing tests in `master` branch.
-* [ ] Check that all of the wheel builds [Pillow Wheel Builder](https://github.com/python-pillow/pillow-wheels) pass the tests in Travis CI.
+* [ ] Check that all of the wheel builds [Pillow Wheel Builder](https://github.com/python-pillow/pillow-wheels) pass the tests in Travis CI and GitHub Actions.
 * [ ] In compliance with [PEP 440](https://www.python.org/dev/peps/pep-0440/), update version identifier in `src/PIL/_version.py`
 * [ ] Update `CHANGES.rst`.
 * [ ] Run pre-release check via `make release-test` in a freshly cloned repo.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@ Released quarterly on January 2nd, April 1st, July 1st and October 15th.
 
 * [ ] Open a release ticket e.g. https://github.com/python-pillow/Pillow/issues/3154
 * [ ] Develop and prepare release in `master` branch.
-* [ ] Check [GitHub Actions](https://github.com/python-pillow/Pillow/actions), [Travis CI](https://travis-ci.com/github/python-pillow/Pillow) and [AppVeyor](https://ci.appveyor.com/project/python-pillow/Pillow) to confirm passing tests in `master` branch.
+* [ ] Check [GitHub Actions](https://github.com/python-pillow/Pillow/actions) and [AppVeyor](https://ci.appveyor.com/project/python-pillow/Pillow) to confirm passing tests in `master` branch.
 * [ ] Check that all of the wheel builds [Pillow Wheel Builder](https://github.com/python-pillow/pillow-wheels) pass the tests in Travis CI.
 * [ ] In compliance with [PEP 440](https://www.python.org/dev/peps/pep-0440/), update version identifier in `src/PIL/_version.py`
 * [ ] Update `CHANGES.rst`.
@@ -41,7 +41,7 @@ Released as needed for security, installation or critical bug fixes.
 
 
 
-* [ ] Check [GitHub Actions](https://github.com/python-pillow/Pillow/actions), [Travis CI](https://travis-ci.com/github/python-pillow/Pillow) and [AppVeyor](https://ci.appveyor.com/project/python-pillow/Pillow) to confirm passing tests in release branch e.g. `5.2.x`.
+* [ ] Check [GitHub Actions](https://github.com/python-pillow/Pillow/actions) and [AppVeyor](https://ci.appveyor.com/project/python-pillow/Pillow) to confirm passing tests in release branch e.g. `5.2.x`.
 * [ ] In compliance with [PEP 440](https://www.python.org/dev/peps/pep-0440/), update version identifier in `src/PIL/_version.py`
 * [ ] Run pre-release check via `make release-test`.
 * [ ] Create tag for release e.g.:

--- a/Tests/bench_cffi_access.py
+++ b/Tests/bench_cffi_access.py
@@ -4,7 +4,7 @@ from PIL import PyAccess
 
 from .helper import hopper
 
-# Not running this test by default. No DOS against Travis CI.
+# Not running this test by default. No DOS against CI.
 
 
 def iterate_get(size, access):

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -270,7 +270,7 @@ def on_github_actions():
 
 
 def on_ci():
-    # GitHub Actions, Travis and AppVeyor have "CI"
+    # GitHub Actions and AppVeyor have "CI"
     return "CI" in os.environ
 
 

--- a/depends/README.rst
+++ b/depends/README.rst
@@ -3,7 +3,7 @@ Depends
 
 ``install_openjpeg.sh``, ``install_webp.sh``, ``install_imagequant.sh``,
 ``install_raqm.sh`` and  ``install_raqm_cmake.sh`` can be used to download,
-build & install non-packaged dependencies; useful for testing with Travis CI.
+build & install non-packaged dependencies; useful for testing on CI.
 
 ``install_extra_test_images.sh`` can be used to install additional test images
-that are used for Travis CI and AppVeyor.
+that are used by CI.

--- a/depends/diffcover-install.sh
+++ b/depends/diffcover-install.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-# Fetch the remote master branch before running diff-cover on Travis CI.
-# https://github.com/Bachmann1234/diff-cover#troubleshooting
-git fetch origin master:refs/remotes/origin/master
-
-# CFLAGS=-O0 means build with no optimisation.
-# Makes build much quicker for lxml and other dependencies.
-time CFLAGS=-O0 python3 -m pip install diff_cover

--- a/depends/diffcover-run.sh
+++ b/depends/diffcover-run.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-coverage xml
-diff-cover coverage.xml
-diff-quality --violation=pyflakes
-diff-quality --violation=pycodestyle

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -6,13 +6,13 @@ Goals
 
 The fork author's goal is to foster and support active development of PIL through:
 
-- Continuous integration testing via `Travis CI`_, `AppVeyor`_ and `GitHub Actions`_
+- Continuous integration testing via `GitHub Actions`_, `AppVeyor`_ and `Travis CI`_
 - Publicized development activity on `GitHub`_
 - Regular releases to the `Python Package Index`_
 
-.. _Travis CI: https://travis-ci.com/github/python-pillow/Pillow
-.. _AppVeyor: https://ci.appveyor.com/project/Python-pillow/pillow
 .. _GitHub Actions: https://github.com/python-pillow/Pillow/actions
+.. _AppVeyor: https://ci.appveyor.com/project/Python-pillow/pillow
+.. _Travis CI: https://travis-ci.com/github/python-pillow/pillow-wheels
 .. _GitHub: https://github.com/python-pillow/Pillow
 .. _Python Package Index: https://pypi.org/project/Pillow/
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,18 +9,6 @@ Pillow for enterprise is available via the Tidelift Subscription. `Learn more <h
    :target: https://pillow.readthedocs.io/?badge=latest
    :alt: Documentation Status
 
-.. image:: https://img.shields.io/travis/com/python-pillow/Pillow/master.svg?label=Linux%20build
-   :target: https://travis-ci.com/github/python-pillow/Pillow
-   :alt: Travis CI build status (Linux)
-
-.. image:: https://img.shields.io/travis/com/python-pillow/pillow-wheels/master.svg?label=macOS%20build
-   :target: https://travis-ci.com/github/python-pillow/pillow-wheels
-   :alt: Travis CI build status (macOS)
-
-.. image:: https://img.shields.io/appveyor/build/python-pillow/Pillow/master.svg?label=Windows%20build
-   :target: https://ci.appveyor.com/project/python-pillow/Pillow
-   :alt: AppVeyor CI build status (Windows)
-
 .. image:: https://github.com/python-pillow/Pillow/workflows/Lint/badge.svg
    :target: https://github.com/python-pillow/Pillow/actions?query=workflow%3ALint
    :alt: GitHub Actions build status (Lint)
@@ -36,6 +24,14 @@ Pillow for enterprise is available via the Tidelift Subscription. `Learn more <h
 .. image:: https://github.com/python-pillow/Pillow/workflows/Test%20Windows/badge.svg
    :target: https://github.com/python-pillow/Pillow/actions?query=workflow%3A%22Test+Windows%22
    :alt: GitHub Actions build status (Test Windows)
+
+.. image:: https://img.shields.io/appveyor/build/python-pillow/Pillow/master.svg?label=Windows%20build
+   :target: https://ci.appveyor.com/project/python-pillow/Pillow
+   :alt: AppVeyor CI build status (Windows)
+
+.. image:: https://img.shields.io/travis/com/python-pillow/pillow-wheels/master.svg?label=macOS%20build
+   :target: https://travis-ci.com/github/python-pillow/pillow-wheels
+   :alt: Travis CI build status (macOS)
 
 .. image:: https://codecov.io/gh/python-pillow/Pillow/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/python-pillow/Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@ check-manifest
 coverage
 jarn.viewdoc
 olefile
-pycodestyle
-pyflakes
 pyroma
 pytest
 pytest-cov


### PR DESCRIPTION
Follow up to https://github.com/python-pillow/Pillow/pull/5029, for https://github.com/python-pillow/Pillow/issues/5028.

Changes proposed in this pull request:

 * Remove some unused Travis config after reducing testing in #5029 

 * Removes the diffcover stuff, not run since #5029, and I've not checked it in a while, so let's just remove it (unless anyone else wants it), and we have linting on the CI anyway

PS Due to a git mistake I accidentally pushed this change directly to `upstream/master`, so I reset and force-pushed.
