### PR TITLE
Add line breaks in test-windows

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -91,25 +91,32 @@ jobs:
     - name: Build dependencies / libjpeg-turbo
       if: steps.build-cache.outputs.cache-hit != 'true'
       run: "& winbuild\\build\\build_dep_libjpeg.cmd"
+
     - name: Build dependencies / zlib
       if: steps.build-cache.outputs.cache-hit != 'true'
       run: "& winbuild\\build\\build_dep_zlib.cmd"
+
     - name: Build dependencies / LibTiff
       if: steps.build-cache.outputs.cache-hit != 'true'
       run: "& winbuild\\build\\build_dep_libtiff.cmd"
+
     - name: Build dependencies / WebP
       if: steps.build-cache.outputs.cache-hit != 'true'
       run: "& winbuild\\build\\build_dep_libwebp.cmd"
+
     # for FreeType CBDT font support
     - name: Build dependencies / libpng
       if: steps.build-cache.outputs.cache-hit != 'true'
       run: "& winbuild\\build\\build_dep_libpng.cmd"
+
     - name: Build dependencies / FreeType
       if: steps.build-cache.outputs.cache-hit != 'true'
       run: "& winbuild\\build\\build_dep_freetype.cmd"
+
     - name: Build dependencies / LCMS2
       if: steps.build-cache.outputs.cache-hit != 'true'
       run: "& winbuild\\build\\build_dep_lcms2.cmd"
+
     - name: Build dependencies / OpenJPEG
       if: steps.build-cache.outputs.cache-hit != 'true'
       run: "& winbuild\\build\\build_dep_openjpeg.cmd"
@@ -123,9 +130,11 @@ jobs:
     - name: Build dependencies / HarfBuzz
       if: steps.build-cache.outputs.cache-hit != 'true'
       run: "& winbuild\\build\\build_dep_harfbuzz.cmd"
+
     - name: Build dependencies / FriBidi
       if: steps.build-cache.outputs.cache-hit != 'true'
       run: "& winbuild\\build\\build_dep_fribidi.cmd"
+
     - name: Build dependencies / Raqm
       if: steps.build-cache.outputs.cache-hit != 'true'
       run: "& winbuild\\build\\build_dep_libraqm.cmd"


### PR DESCRIPTION
Fixes #5051 by resetting the cache.

Changes proposed in this pull request:

 * Add extra line breaks to improve readability.
 * This changes the cache key and fixes the build.
 * I'll try to have a look at whether it is possible to include the compiler version in the cache key hopefully tomorrow.
