### PR TITLE
Add Release Drafter to draft releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,14 @@
+name-template: "$NEXT_MINOR_VERSION"
+tag-template: "$NEXT_MINOR_VERSION"
+change-template: '- $TITLE #$NUMBER [@$AUTHOR]'
+
+exclude-labels:
+  - "changelog: skip"
+
+template: |
+
+  https://pillow.readthedocs.io/en/stable/releasenotes/$NEXT_MINOR_VERSION.html
+
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,17 @@
+name: Release drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    if: github.repository == 'python-pillow/Pillow'
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next release notes as pull requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I've not been updating [CHANGES.rst](https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst) for a while partly because it became too big/unwieldy to be editable on mobile. Also it's the sort of manual work that could and should be automated.

Let's automate it!

[Release Drafter](https://github.com/release-drafter/release-drafter) is a GitHub Action which runs when PRs are merged and I've been happily using it on other projects.

It takes the titles of PRs merged since the last release, and puts them into a *draft* release at https://github.com/python-pillow/pillow/releases

Drafts are only visible to maintainers, until they're published.

The idea is the draft will fill up, then on release day, the draft is published as usual.

If we still value putting the list into `CHANGES.rst` (do we?), we can copy and paste it during the release process (which includes updating `CHANGES.rst` anyway).

PRs labelled with `changelog: skip` are excluded.

If we want, we can further configure it to automatically put PRs into groups based on labels. Here's a good example:

* https://github.com/release-drafter/release-drafter/releases

I suggest running just with the basic config to begin, and consider categories later, although suggestions welcome! 

The draft is updated each time the action runs, so any final touches should be made just before publishing. Or better: update the PR titles themselves, which is a good idea for future SEO.
