### PR TITLE
GHA: Install Raqm on macOS

### DIFF
--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-brew install libtiff libjpeg openjpeg libimagequant webp little-cms2 freetype openblas
+brew install libtiff libjpeg openjpeg libimagequant webp little-cms2 freetype openblas libraqm
 
 PYTHONOPTIMIZE=0 python3 -m pip install cffi
 python3 -m pip install coverage


### PR DESCRIPTION
Before: https://github.com/python-pillow/Pillow/runs/1447978107#step:10:34
```
*** RAQM (Bidirectional Text) support not installed
```

After: https://github.com/python-pillow/Pillow/runs/1452096925?check_suite_focus=true#step:10:34
```
--- RAQM (Bidirectional Text) support ok, loaded 0.7.0
```