### PR TITLE
Update FriBiDi to 1.0.10

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -287,9 +287,9 @@ deps = {
         "libs": [r"*.lib"],
     },
     "fribidi": {
-        "url": "https://github.com/fribidi/fribidi/archive/v1.0.9.zip",
-        "filename": "fribidi-1.0.9.zip",
-        "dir": "fribidi-1.0.9",
+        "url": "https://github.com/fribidi/fribidi/archive/v1.0.10.zip",
+        "filename": "fribidi-1.0.10.zip",
+        "dir": "fribidi-1.0.10",
         "build": [
             cmd_copy(r"{winbuild_dir}\fribidi.cmake", r"CMakeLists.txt"),
             cmd_cmake(),

--- a/winbuild/fribidi.cmake
+++ b/winbuild/fribidi.cmake
@@ -99,4 +99,4 @@ add_library(fribidi STATIC
 	${FRIBIDI_SOURCES_GENERATED})
 fribidi_definitions(fribidi)
 target_compile_definitions(fribidi
-	PUBLIC -DFRIBIDI_ENTRY=extern)
+	PUBLIC -DFRIBIDI_LIB_STATIC)

--- a/winbuild/raqm.cmake
+++ b/winbuild/raqm.cmake
@@ -7,7 +7,7 @@ find_library(fribidi NAMES fribidi)
 find_library(harfbuzz NAMES harfbuzz)
 find_library(freetype NAMES freetype)
 
-add_definitions(-DFRIBIDI_ENTRY=extern)
+add_definitions(-DFRIBIDI_LIB_STATIC)
 
 
 function(raqm_conf)


### PR DESCRIPTION
> This version fixed various compilation problems and symbol exports necessary for proper compilation under Windows