### PR TITLE
Corrected documentation syntax

### DIFF
--- a/docs/handbook/writing-your-own-file-decoder.rst
+++ b/docs/handbook/writing-your-own-file-decoder.rst
@@ -157,7 +157,7 @@ The raw decoder
 The ``raw`` decoder is used to read uncompressed data from an image file. It
 can be used with most uncompressed file formats, such as PPM, BMP, uncompressed
 TIFF, and many others. To use the raw decoder with the
-:py:func:`PIL.Image.frombytes` function, use the following syntax::
+:py:func:`PIL.Image.frombytes` function, use the following syntax:
 
 .. code-block:: python
 


### PR DESCRIPTION
https://pillow.readthedocs.io/en/latest/handbook/writing-your-own-file-decoder.html#the-raw-decoder

![Screen Shot 2020-11-28 at 12 14 57 pm](https://user-images.githubusercontent.com/3112309/100490888-5c089b00-3173-11eb-9dc8-bac29047fb35.png)

This PR fixes the problem where 'code-block' is not correctly understood - https://pillow--5068.org.readthedocs.build/en/5068/handbook/writing-your-own-file-decoder.html#the-raw-decoder