### PR TITLE
APNG - use previous frame with dispose action to draw the next frame

### DIFF
--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -868,6 +868,11 @@ class PngImageFile(ImageFile.ImageFile):
             self.decoderconfig = self.decoderconfig + (1,)
 
         self.__idat = self.__prepare_idat  # used by load_read()
+
+        # Use prev_im as base image
+        if self.is_animated and self._prev_im:
+            self.im = self._prev_im.copy()
+
         ImageFile.ImageFile.load_prepare(self)
 
     def load_read(self, read_bytes):


### PR DESCRIPTION
APNG defines a dispose operation after each frame. This dispose should
be done before drawing the next frame. PNG code stores this frame on _prev_im
but it is not used to draw the next frame.
This change use the _prev_im as the base to draw the next frame.

Helps #5032 

Changes proposed in this pull request:

 * Fixes APNG load. Use previous frame with dispose action applied to draw the next frame.
 
Tested with the files in the issue #5032 
