### PR TITLE
Docs: Add 'Release notes' and 'Changelog' links to PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The core image library is designed for fast access to data stored in a few basic
 - [Contribute](https://github.com/python-pillow/Pillow/blob/master/.github/CONTRIBUTING.md)
   - [Issues](https://github.com/python-pillow/Pillow/issues)
   - [Pull requests](https://github.com/python-pillow/Pillow/pulls)
+- [Release notes](https://pillow.readthedocs.io/en/stable/releasenotes/index.html)
 - [Changelog](https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst)
   - [Pre-fork](https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst#pre-fork)
 

--- a/setup.py
+++ b/setup.py
@@ -877,6 +877,10 @@ try:
             "Source": "https://github.com/python-pillow/Pillow",
             "Funding": "https://tidelift.com/subscription/pkg/pypi-pillow?"
             "utm_source=pypi-pillow&utm_medium=pypi",
+            "Release notes": "https://pillow.readthedocs.io/en/stable/releasenotes/"
+            "index.html",
+            "Changelog": "https://github.com/python-pillow/Pillow/blob/master/"
+            "CHANGES.rst",
         },
         classifiers=[
             "Development Status :: 6 - Mature",


### PR DESCRIPTION
Changes proposed in this pull request:

 * We got some good feedback for having a link to the changelog prominently on [PyPI](https://pypi.org/project/Pillow/): https://twitter.com/jugmac00/status/1334136469364088832

 * Let's also add a link to the more-distilled release notes; the README is used as the PyPI long description

 * We can also add them both as "Project URLs" so they appear in the PyPI project sidebar (and can also be accessed programmatically through the PyPI API)
