### PR TITLE
Add categories to Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,7 +4,7 @@ change-template: '- $TITLE #$NUMBER [@$AUTHOR]'
 
 categories:
   - title: "Dependencies"
-    label: "Dependencies"
+    label: "Dependency"
   - title: "Deprecations"
     label: "Deprecation"
   - title: "Documentation"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,6 +2,18 @@ name-template: "$NEXT_MINOR_VERSION"
 tag-template: "$NEXT_MINOR_VERSION"
 change-template: '- $TITLE #$NUMBER [@$AUTHOR]'
 
+categories:
+  - title: "Dependencies"
+    label: "Dependencies"
+  - title: "Deprecations"
+    label: "Deprecation"
+  - title: "Documentation"
+    label: "Documentation"
+  - title: "Removals"
+    label: "Removal"
+  - title: "Testing"
+    label: "Testing"
+
 exclude-labels:
   - "changelog: skip"
 


### PR DESCRIPTION
Follow on from #5058.

Changes proposed in this pull request:

 * Looking at the PRs listed at the [8.1.0 draft](https://github.com/python-pillow/Pillow/releases), they mainly fall into three categories:
   * Dependencies
   * Documentation
   * Testing

 * Let's configure Release Drafter to group PRs with these labels into categories with these titles

 * "Deprecations" and "Removals" would be useful for the future, to make those changes clear

 * Everything else falls into the blanket "Changes" section

 * By design, if a PR falls into multiple categories, it'll be listed in both. If we want to avoid it, we can use explicit `changelog: foo` labels

 * It is possible to have multiple labels per category too 
