### PR TITLE
Document when deprecations will be removed

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -17,7 +17,7 @@ Image.show command parameter
 
 .. deprecated:: 7.2.0
 
-The ``command`` parameter was deprecated and will be removed in a future release.
+The ``command`` parameter will be removed in Pillow 9.0.0 (2022-01-02).
 Use a subclass of :py:class:`.ImageShow.Viewer` instead.
 
 Image._showxv
@@ -25,26 +25,26 @@ Image._showxv
 
 .. deprecated:: 7.2.0
 
-``Image._showxv`` has been deprecated. Use :py:meth:`.Image.Image.show`
-instead. If custom behaviour is required, use :py:func:`.ImageShow.register` to add
-a custom :py:class:`.ImageShow.Viewer` class.
+``Image._showxv`` will be removed in Pillow 9.0.0 (2022-01-02).
+Use :py:meth:`.Image.Image.show` instead. If custom behaviour is required, use
+:py:func:`.ImageShow.register` to add a custom :py:class:`.ImageShow.Viewer` class.
 
 ImageFile.raise_ioerror
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. deprecated:: 7.2.0
 
-``IOError`` was merged into ``OSError`` in Python 3.3. So, ``ImageFile.raise_ioerror``
-is now deprecated and will be removed in a future release. Use
-``ImageFile.raise_oserror`` instead.
+``IOError`` was merged into ``OSError`` in Python 3.3.
+So, ``ImageFile.raise_ioerror`` will be removed in Pillow 9.0.0 (2022-01-02).
+Use ``ImageFile.raise_oserror`` instead.
 
 PILLOW_VERSION constant
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. deprecated:: 5.2.0
 
-``PILLOW_VERSION`` has been deprecated and will be removed in a future release. Use
-``__version__`` instead.
+``PILLOW_VERSION`` will be removed in Pillow 9.0.0 (2022-01-02).
+Use ``__version__`` instead.
 
 It was initially removed in Pillow 7.0.0, but brought back in 7.1.0 to give projects
 more time to upgrade.

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2197,8 +2197,8 @@ class Image:
 
         if command is not None:
             warnings.warn(
-                "The command parameter is deprecated and will be removed in a future "
-                "release. Use a subclass of ImageShow.Viewer instead.",
+                "The command parameter is deprecated and will be removed in Pillow 9 "
+                "(2022-01-02). Use a subclass of ImageShow.Viewer instead.",
                 DeprecationWarning,
             )
 
@@ -3176,7 +3176,7 @@ def _showxv(image, title=None, **options):
         del options["_internal_pillow"]
     else:
         warnings.warn(
-            "_showxv is deprecated and will be removed in a future release. "
+            "_showxv is deprecated and will be removed in Pillow 9 (2022-01-02). "
             "Use Image.show instead.",
             DeprecationWarning,
         )

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -69,7 +69,7 @@ def raise_oserror(error):
 
 def raise_ioerror(error):
     warnings.warn(
-        "raise_ioerror is deprecated and will be removed in a future release. "
+        "raise_ioerror is deprecated and will be removed in Pillow 9 (2022-01-02). "
         "Use raise_oserror instead.",
         DeprecationWarning,
     )

--- a/src/PIL/__init__.py
+++ b/src/PIL/__init__.py
@@ -26,7 +26,7 @@ __version__ = _version.__version__
 # Use __version__ instead.
 def _raise_version_warning():
     warnings.warn(
-        "PILLOW_VERSION is deprecated and will be removed in a future release. "
+        "PILLOW_VERSION is deprecated and will be removed in Pillow 9 (2022-01-02). "
         "Use __version__ instead.",
         DeprecationWarning,
         stacklevel=3,


### PR DESCRIPTION
Changes proposed in this pull request:

 * Pillow 9 is likely due in Q1 2022, after [Python 3.6's scheduled EOL on 2021-12-23](https://devguide.python.org/#status-of-python-branches)
 * The four remaining deprecations from https://github.com/python-pillow/Pillow/issues/4764#issuecomment-656080258 have warned since 7.1.0 (April 2020) or 7.2.0 (June 2020), long enough for removal in January 2022
 * Let's document the expected removal dates for increased clarity
