### PR TITLE
Fix open JPEG file if wrong or unknown 8BIM tag

### DIFF
--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -133,7 +133,7 @@ def APP(self, marker):
                 photoshop[code] = data
                 offset += size
                 offset += offset & 1  # align
-            except struct.error:
+            except (struct.error, IndexError):
                 break  # insufficient data
 
     elif marker == 0xFFEE and s[:5] == b"Adobe":


### PR DESCRIPTION
During opening the JPEG file, I found in the APP13 (0xFFED) marker the 0x07db tag, and the code of this tag was last 2 bytes in an array and after `name_len = i8(s[offset])` produces IndexError. 
0x07D0-0x0BB6  is path information and probably encoding differently - https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577409_17587

anyway, IndexError shouldn't stop opening a file. 
I have an example but it's Not Safe For Work!!! (sorry) - https://images.anime-pictures.net/1b2/1b2bdec5fedac951d02805ecc48c813e.jpeg