### PR TITLE
Disable Travis CI from automerge requirements

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,7 +7,7 @@ pull_request_rules:
       - status-success=Test Successful
       - status-success=Docker Test Successful
       - status-success=Windows Test Successful
-      - status-success=Travis CI - Pull Request
+#      - status-success=Travis CI - Pull Request
       - status-success=continuous-integration/appveyor/pr
     actions:
       merge:


### PR DESCRIPTION
Travis has been (temporarily?) disabled to conserve credits whilst we await more (https://github.com/python-pillow/Pillow/issues/5028#issuecomment-743359683), so remove it from the required automerge checks.

By the way, GitHub will have automerge in a week or two, we can check it when it's out.

https://github.blog/2020-12-08-new-from-universe-2020-dark-mode-github-sponsors-for-companies-and-more/#%e2%9c%a8-improved-daily-experience