### PR TITLE
Do not catch a ValueError only to raise another

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1626,7 +1626,7 @@ class Image:
                     self.im = im
                 self.pyaccess = None
                 self.mode = self.im.mode
-            except (KeyError, ValueError) as e:
+            except KeyError as e:
                 raise ValueError("illegal image mode") from e
 
         if self.mode in ("LA", "PA"):


### PR DESCRIPTION
Helps #4926

The unaddressed part of that issue is that there is a chain of three ValueErrors raised by the following code.

```pycon
>>> from PIL import Image
>>> img = Image.new('F', (200,100), 1.0)
>>> img.putalpha(Image.new('L', (200,100), 255))
Traceback (most recent call last):
  File "PIL/Image.py", line 1620, in putalpha
    self.im.setmode(mode)
ValueError: image has wrong mode

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "PIL/Image.py", line 1623, in putalpha
    im = self.im.convert(mode)
ValueError: conversion from F to LA not supported

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/Image.py", line 1630, in putalpha
    raise ValueError("illegal image mode") from e
ValueError: illegal image mode
```

This PR reduces it to two.

```pycon
>>> from PIL import Image
>>> img = Image.new('F', (200,100), 1.0)
>>> img.putalpha(Image.new('L', (200,100), 255))
Traceback (most recent call last):
  File "PIL/Image.py", line 1620, in putalpha
ValueError: image has wrong mode

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/Image.py", line 1623, in putalpha
ValueError: conversion from F to LA not supported
```