### PR TITLE
Mark new test failures on non-x86 as xfail

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -278,6 +278,12 @@ def is_big_endian():
     return sys.byteorder == "big"
 
 
+def is_ppc64le():
+    import platform
+
+    return platform.machine() == "ppc64le"
+
+
 def is_win32():
     return sys.platform.startswith("win32")
 

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -16,6 +16,7 @@ from .helper import (
     assert_image_similar,
     assert_image_similar_tofile,
     hopper,
+    is_big_endian,
     skip_unless_feature,
 )
 
@@ -813,11 +814,13 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open(infile) as im:
             assert_image_similar_tofile(im, "Tests/images/pil_sample_cmyk.jpg", 0.5)
 
+    @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_strip_ycbcr_jpeg_2x2_sampling(self):
         infile = "Tests/images/tiff_strip_ycbcr_jpeg_2x2_sampling.tif"
         with Image.open(infile) as im:
             assert_image_similar_tofile(im, "Tests/images/flower.jpg", 0.5)
 
+    @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_strip_ycbcr_jpeg_1x1_sampling(self):
         infile = "Tests/images/tiff_strip_ycbcr_jpeg_1x1_sampling.tif"
         with Image.open(infile) as im:
@@ -828,16 +831,19 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open(infile) as im:
             assert_image_similar_tofile(im, "Tests/images/pil_sample_cmyk.jpg", 0.5)
 
+    @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_tiled_ycbcr_jpeg_1x1_sampling(self):
         infile = "Tests/images/tiff_tiled_ycbcr_jpeg_1x1_sampling.tif"
         with Image.open(infile) as im:
             assert_image_equal_tofile(im, "Tests/images/flower2.jpg")
 
+    @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_tiled_ycbcr_jpeg_2x2_sampling(self):
         infile = "Tests/images/tiff_tiled_ycbcr_jpeg_2x2_sampling.tif"
         with Image.open(infile) as im:
             assert_image_similar_tofile(im, "Tests/images/flower.jpg", 0.5)
 
+    @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_old_style_jpeg(self):
         infile = "Tests/images/old-style-jpeg-compression.tif"
         with Image.open(infile) as im:

--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -2,7 +2,7 @@ import pytest
 
 from PIL import Image
 
-from .helper import assert_image, assert_image_similar, hopper
+from .helper import assert_image, assert_image_similar, hopper, is_ppc64le
 
 
 def test_sanity():
@@ -17,6 +17,7 @@ def test_sanity():
     assert_image_similar(converted.convert("RGB"), image, 60)
 
 
+@pytest.mark.xfail(is_ppc64le(), reason="failing on ppc64le on GHA")
 def test_libimagequant_quantize():
     image = hopper()
     try:


### PR DESCRIPTION
The first part of #5088, to unblock the "latest" jobs in https://github.com/python-pillow/docker-images/pull/98.

Changes proposed in this pull request:

* Add xfail to libtiff tests that are failing on big-endian (see also https://github.com/python-pillow/Pillow/issues/4213#issuecomment-721425032).
* Add xfail to `test_libimagequant_quantize` failing on ppc64le (not sure why).

See passing run targeting this branch: https://github.com/nulano/docker-images/runs/1542638808?check_suite_focus=true#step:5:5021
