### PR TITLE
Deprecate FreeType 2.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Docs
       if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == 3.9
       run: |
-        python3 -m pip install sphinx-removed-in sphinx-rtd-theme
+        python3 -m pip install sphinx-issues sphinx-removed-in sphinx-rtd-theme
         make doccheck
 
     - name: After success

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ doccheck:
 
 .PHONY: docserve
 docserve:
-	cd docs/_build/html && python3 -mSimpleHTTPServer 2> /dev/null&
+	cd docs/_build/html && python3 -m http.server 2> /dev/null&
 
 .PHONY: help
 help:

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -998,3 +998,15 @@ def test_render_mono_size():
 
     draw.text((10, 10), "r" * 10, "black", ttf)
     assert_image_equal_tofile(im, "Tests/images/text_mono.gif")
+
+
+def test_freetype_deprecation(monkeypatch):
+    # Arrange: mock features.version_module to return fake FreeType version
+    def fake_version_module(module):
+        return "2.7"
+
+    monkeypatch.setattr(features, "version_module", fake_version_module)
+
+    # Act / Assert
+    with pytest.warns(DeprecationWarning):
+        ImageFont.truetype(FONT_PATH, FONT_SIZE)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -156,4 +156,4 @@ livehtml: html
 	livereload $(BUILDDIR)/html -p 33233
 
 serve:
-	cd $(BUILDDIR)/html; python -m SimpleHTTPServer
+	cd $(BUILDDIR)/html; python3 -m http.server

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
+    "sphinx_issues",
     "sphinx_removed_in",
 ]
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -12,6 +12,20 @@ Deprecated features
 Below are features which are considered deprecated. Where appropriate,
 a ``DeprecationWarning`` is issued.
 
+FreeType 2.7
+~~~~~~~~~~~~
+
+.. deprecated:: 8.1.0
+
+Support for FreeType 2.7 is deprecated and will be removed in Pillow 9.0.0 (2022-01-02),
+when FreeType 2.8 will be the minimum supported.
+
+We recommend upgrading to at least FreeType `2.10.4`_, which fixed a severe
+vulnerability introduced in FreeType 2.6 (CVE-2020-15999_).
+
+.. _2.10.4: https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/
+.. _CVE-2020-15999: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15999
+
 Image.show command parameter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -21,10 +21,9 @@ Support for FreeType 2.7 is deprecated and will be removed in Pillow 9.0.0 (2022
 when FreeType 2.8 will be the minimum supported.
 
 We recommend upgrading to at least FreeType `2.10.4`_, which fixed a severe
-vulnerability introduced in FreeType 2.6 (CVE-2020-15999_).
+vulnerability introduced in FreeType 2.6 (:cve:`CVE-2020-15999`).
 
 .. _2.10.4: https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/
-.. _CVE-2020-15999: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15999
 
 Image.show command parameter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releasenotes/3.1.1.rst
+++ b/docs/releasenotes/3.1.1.rst
@@ -6,7 +6,7 @@ CVE-2016-0740 -- Buffer overflow in TiffDecode.c
 ------------------------------------------------
 
 Pillow 3.1.0 and earlier when linked against libtiff >= 4.0.0 on x64
-may overflow a buffer when reading a specially crafted tiff file.
+may overflow a buffer when reading a specially crafted tiff file (:cve:`CVE-2016-0740`).
 
 Specifically, libtiff >= 4.0.0 changed the return type of
 ``TIFFScanlineSize`` from ``int32`` to machine dependent
@@ -24,9 +24,11 @@ CVE-2016-0775 -- Buffer overflow in FliDecode.c
 -----------------------------------------------
 
 In all versions of Pillow, dating back at least to the last PIL 1.1.7
-release, FliDecode.c has a buffer overflow error.
+release, FliDecode.c has a buffer overflow error (:cve:`CVE-2016-0775`).
 
-Around line 192::
+Around line 192:
+
+.. code-block:: c
 
   case 16:
       /* COPY chunk */
@@ -45,13 +47,13 @@ is a set of row pointers to segments of memory that are the size of
 the row.  At the max ``y``, this will write the contents of the line
 off the end of the memory buffer, causing a segfault.
 
-This issue was found by Alyssa Besseling at Atlassian
+This issue was found by Alyssa Besseling at Atlassian.
 
 CVE-2016-2533 -- Buffer overflow in PcdDecode.c
 -----------------------------------------------
 
 In all versions of Pillow, dating back at least to the last PIL 1.1.7
-release, ``PcdDecode.c`` has a buffer overflow error.
+release, ``PcdDecode.c`` has a buffer overflow error (:cve:`CVE-2016-2533`).
 
 The ``state.buffer`` for ``PcdDecode.c`` is allocated based on a 3
 bytes per pixel sizing, where ``PcdDecode.c`` wrote into the buffer
@@ -63,14 +65,16 @@ Integer overflow in Resample.c
 ------------------------------
 
 If a large value was passed into the new size for an image, it is
-possible to overflow an int32 value passed into malloc.
+possible to overflow an ``int32`` value passed into malloc.
 
-  kk = malloc(xsize * kmax * sizeof(float));
-  ...
-  xbounds = malloc(xsize * 2 * sizeof(int));
+.. code-block:: c
+
+    kk = malloc(xsize * kmax * sizeof(float));
+    ...
+    xbounds = malloc(xsize * 2 * sizeof(int));
 
 ``xsize`` is trusted user input. These multiplications can overflow,
-leading the malloc'd buffer to be undersized. These allocations are
+leading the ``malloc``'d buffer to be undersized. These allocations are
 followed by a loop that writes out of bounds. This can lead to
 corruption on the heap of the Python process with attacker controlled
 float data.

--- a/docs/releasenotes/3.1.2.rst
+++ b/docs/releasenotes/3.1.2.rst
@@ -7,9 +7,11 @@ CVE-2016-3076 -- Buffer overflow in Jpeg2KEncode.c
 
 Pillow between 2.5.0 and 3.1.1 may overflow a buffer when writing
 large Jpeg2000 files, allowing for code execution or other memory
-corruption.
+corruption (:cve:`CVE-2016-3076`).
 
-This occurs specifically in the function ``j2k_encode_entry``, at the line::
+This occurs specifically in the function ``j2k_encode_entry``, at the line:
+
+.. code-block:: c
 
     state->buffer = malloc (tile_width * tile_height * components * prec / 8);
 

--- a/docs/releasenotes/6.2.0.rst
+++ b/docs/releasenotes/6.2.0.rst
@@ -96,7 +96,7 @@ Other Changes
 Removed bdist_wininst .exe installers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.exe installers fell out of favour with PEP 527, and will be deprecated in
+.exe installers fell out of favour with :pep:`527`, and will be deprecated in
 Python 3.8. Pillow will no longer be distributing them. Wheels should be used
 instead.
 

--- a/docs/releasenotes/6.2.0.rst
+++ b/docs/releasenotes/6.2.0.rst
@@ -73,7 +73,7 @@ Security
 ========
 
 This release catches several buffer overruns, as well as addressing
-CVE-2019-16865. The CVE is regarding DOS problems, such as consuming large
+:cve:`CVE-2019-16865`. The CVE is regarding DOS problems, such as consuming large
 amounts of memory, or taking a large amount of time to process an image.
 
 In RawDecode.c, an error is now thrown if skip is calculated to be less than
@@ -103,7 +103,7 @@ instead.
 Flags for libwebp in wheels
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When building libwebp for inclusion in wheels, Pillow now adds the -O3 and
--DNDEBUG CFLAGS. These flags would be used by default if building libwebp
+When building libwebp for inclusion in wheels, Pillow now adds the ``-O3`` and
+``-DNDEBUG`` CFLAGS. These flags would be used by default if building libwebp
 without debugging, and using them fixes a significant decrease in speed when
 a wheel-installed copy of Pillow performs libwebp operations.

--- a/docs/releasenotes/6.2.2.rst
+++ b/docs/releasenotes/6.2.2.rst
@@ -6,12 +6,13 @@ Security
 
 This release addresses several security problems.
 
-CVE-2019-19911 is regarding FPX images. If an image reports that it has a large number
-of bands, a large amount of resources will be used when trying to process the
+:cve:`CVE-2019-19911` is regarding FPX images. If an image reports that it has a large
+number of bands, a large amount of resources will be used when trying to process the
 image. This is fixed by limiting the number of bands to those usable by Pillow.
 
-Buffer overruns were found when processing an SGI (CVE-2020-5311), PCX (CVE-2020-5312)
-or FLI image (CVE-2020-5313). Checks have been added to prevent this.
+Buffer overruns were found when processing an SGI (:cve:`CVE-2020-5311`),
+PCX (:cve:`CVE-2020-5312`) or FLI image (:cve:`CVE-2020-5313`). Checks have been added
+to prevent this.
 
-CVE-2020-5310: Overflow checks have been added when calculating the size of a memory
-block to be reallocated in the processing of a TIFF image.
+:cve:`CVE-2020-5310`: Overflow checks have been added when calculating the size of a
+memory block to be reallocated in the processing of a TIFF image.

--- a/docs/releasenotes/7.1.0.rst
+++ b/docs/releasenotes/7.1.0.rst
@@ -74,11 +74,11 @@ Security
 
 This release includes security fixes.
 
-* CVE-2020-10177 Fix multiple OOB reads in FLI decoding
-* CVE-2020-10378 Fix bounds overflow in PCX decoding
-* CVE-2020-10379 Fix two buffer overflows in TIFF decoding
-* CVE-2020-10994 Fix bounds overflow in JPEG 2000 decoding
-* CVE-2020-11538 Fix buffer overflow in SGI-RLE decoding
+* :cve:`CVE-2020-10177` Fix multiple OOB reads in FLI decoding
+* :cve:`CVE-2020-10378` Fix bounds overflow in PCX decoding
+* :cve:`CVE-2020-10379` Fix two buffer overflows in TIFF decoding
+* :cve:`CVE-2020-10994` Fix bounds overflow in JPEG 2000 decoding
+* :cve:`CVE-2020-11538` Fix buffer overflow in SGI-RLE decoding
 
 Other Changes
 =============

--- a/docs/releasenotes/8.0.1.rst
+++ b/docs/releasenotes/8.0.1.rst
@@ -4,12 +4,10 @@
 Security
 ========
 
-Update FreeType used in binary wheels to `2.10.4`_ to fix CVE-2020-15999_:
+Update FreeType used in binary wheels to `2.10.4`_ to fix :cve:`CVE-2020-15999`:
 
   - A heap buffer overflow has been found  in the handling of embedded PNG bitmaps,
     introduced in FreeType version 2.6.
-
-      https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15999
 
     If you use option ``FT_CONFIG_OPTION_USE_PNG`` you should upgrade immediately.
 
@@ -22,4 +20,3 @@ Pillow 8.0.0 and earlier are potentially vulnerable releases, including the last
 to support Python 2.7, namely Pillow 6.2.2.
 
 .. _2.10.4: https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/
-.. _CVE-2020-15999: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15999

--- a/docs/releasenotes/8.1.0.rst
+++ b/docs/releasenotes/8.1.0.rst
@@ -1,0 +1,45 @@
+8.1.0
+-----
+
+Deprecations
+============
+
+FreeType 2.7
+^^^^^^^^^^^^
+
+Support for FreeType 2.7 is deprecated and will be removed in Pillow 9.0.0 (2022-01-02),
+when FreeType 2.8 will be the minimum supported.
+
+We recommend upgrading to at least FreeType `2.10.4`_, which fixed a severe
+vulnerability introduced in FreeType 2.6 (:cve:`CVE-2020-15999`).
+
+.. _2.10.4: https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/
+
+API Changes
+===========
+
+TODO
+^^^^
+
+TODO
+
+API Additions
+=============
+
+TODO
+^^^^
+
+TODO
+
+Security
+========
+
+TODO
+
+Other Changes
+=============
+
+TODO
+^^^^
+
+TODO

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -13,6 +13,7 @@ expected to be backported to earlier versions.
 .. toctree::
   :maxdepth: 2
 
+  8.1.0
   8.0.1
   8.0.0
   7.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ pyroma
 pytest
 pytest-cov
 sphinx>=2.4
+sphinx-issues
 sphinx-removed-in
 sphinx-rtd-theme

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -28,9 +28,12 @@
 import base64
 import os
 import sys
+import warnings
 from io import BytesIO
 
-from . import Image
+from packaging.version import parse as parse_version
+
+from . import Image, features
 from ._util import isDirectory, isPath
 
 LAYOUT_BASIC = 0
@@ -163,6 +166,15 @@ class FreeTypeFont:
         self.size = size
         self.index = index
         self.encoding = encoding
+
+        freetype_version = parse_version(features.version_module("freetype2"))
+        if freetype_version < parse_version("2.8"):
+            warnings.warn(
+                "Support for FreeType 2.7 is deprecated and will be removed in Pillow "
+                "9 (2022-01-02). Please upgrade to FreeType 2.8 or newer, preferably "
+                "FreeType 2.10.4 which fixes CVE-2020-15999.",
+                DeprecationWarning,
+            )
 
         if layout_engine not in (LAYOUT_BASIC, LAYOUT_RAQM):
             layout_engine = LAYOUT_BASIC


### PR DESCRIPTION
Fixes #5075.

Changes proposed in this pull request:

 * Add deprecation warning when using ImageFont with FreeType older than 2.8

 * Autolink CVEs with https://github.com/sloria/sphinx-issues
   * :cve:`CVE-2020-15999` becomes https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15999

 * Autolink a PEP with https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-pep
   * :pep:`527` becomes https://www.python.org/dev/peps/pep-0527

 * Update Makefile docs command for Python 3
