### PR TITLE
GHA: Add PyPy3.7

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev", "pypy3"]
+        python-version: ["pypy-3.6", "pypy-3.7", "3.6", "3.7", "3.8", "3.9", "3.10-dev"]
         architecture: ["x86", "x64"]
         include:
           - architecture: "x86"
@@ -19,7 +19,9 @@ jobs:
             platform-msbuild: "x64"
         exclude:
           # PyPy does not support 64-bit on Windows
-          - python-version: "pypy3"
+          - python-version: "pypy-3.6"
+            architecture: "x64"
+          - python-version: "pypy-3.7"
             architecture: "x64"
     timeout-minutes: 30
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,8 @@ jobs:
           "macOS-latest",
         ]
         python-version: [
-          "pypy3",
+          "pypy-3.7",
+          "pypy-3.6",
           "3.10-dev",
           "3.9",
           "3.8",


### PR DESCRIPTION
GHA just added support for PyPy3.7 (https://github.com/actions/setup-python/pull/168), add it to the matrix.
Also put the slower Windows PyPy jobs first.

It currently takes ~1m to install, but this is supposed to be resolved on the next GHA image rollout, see https://github.com/actions/setup-python/pull/168#issuecomment-747546240.