### PR TITLE
Update some doc code blocks to the 'pycon' lexer

### DIFF
--- a/docs/releasenotes/7.1.1.rst
+++ b/docs/releasenotes/7.1.1.rst
@@ -7,7 +7,7 @@ Fix regression seeking PNG files
 This fixes a regression introduced in 7.1.0 when adding support for APNG files when calling
 ``seek`` and ``tell``:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from PIL import Image
     >>> with Image.open("Tests/images/hopper.png") as im:

--- a/docs/releasenotes/7.1.2.rst
+++ b/docs/releasenotes/7.1.2.rst
@@ -9,7 +9,7 @@ This fixes a regression introduced in 7.1.0 when adding support for APNG files.
 When calling ``seek(n)`` on a regular PNG where ``n > 0``, it failed to raise an
 ``EOFError`` as it should have done, resulting in:
 
-.. code-block:: python
+.. code-block:: pycon
 
     AttributeError: 'NoneType' object has no attribute 'read'
 


### PR DESCRIPTION
These code blocks represent Python console sessions, not Python source
code. The pycon lexer understands the ">>>" prompt and output (e.g. a
traceback).
