### PR TITLE
Replaced PyErr_NoMemory with ImagingError_MemoryError

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -2711,8 +2711,7 @@ _font_getmask(ImagingFontObject* self, PyObject* args)
     im = ImagingNew(self->bitmap->mode, textwidth(self, text), self->ysize);
     if (!im) {
         free(text);
-        ImagingError_MemoryError();
-        return NULL;
+        return ImagingError_MemoryError();
     }
 
     b = 0;
@@ -3933,8 +3932,7 @@ _set_blocks_max(PyObject* self, PyObject* args)
 
 
     if ( ! ImagingMemorySetBlocksMax(&ImagingDefaultArena, blocks_max)) {
-        ImagingError_MemoryError();
-        return NULL;
+        return ImagingError_MemoryError();
     }
 
     Py_INCREF(Py_None);

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -377,7 +377,7 @@ getlist(PyObject* arg, Py_ssize_t* length, const char* wrong_length, int type)
        calloc checks for overflow */
     list = calloc(n, type & 0xff);
     if ( ! list) {
-        return PyErr_NoMemory();
+        return ImagingError_MemoryError();
     }
 
     seq = PySequence_Fast(arg, must_be_sequence);
@@ -789,7 +789,7 @@ _prepare_lut_table(PyObject* table, Py_ssize_t table_size)
         if (free_table_data) {
             free(table_data);
         }
-        return (INT16*) PyErr_NoMemory();
+        return (INT16*) ImagingError_MemoryError();
     }
 
     for (i = 0; i < table_size; i++) {
@@ -2234,7 +2234,7 @@ _getprojection(ImagingObject* self, PyObject* args)
     if (xprofile == NULL || yprofile == NULL) {
         free(xprofile);
         free(yprofile);
-        return PyErr_NoMemory();
+        return ImagingError_MemoryError();
     }
 
     ImagingGetProjection(self->image, (unsigned char *)xprofile, (unsigned char *)yprofile);

--- a/src/decode.c
+++ b/src/decode.c
@@ -80,7 +80,7 @@ PyImaging_DecoderNew(int contextsize)
         context = (void*) calloc(1, contextsize);
         if (!context) {
             Py_DECREF(decoder);
-            (void) PyErr_NoMemory();
+            (void) ImagingError_MemoryError();
             return NULL;
         }
     } else {
@@ -204,14 +204,14 @@ _setimage(ImagingDecoderObject* decoder, PyObject* args)
     if (state->bits > 0) {
         if (!state->bytes) {
             if (state->xsize > ((INT_MAX / state->bits)-7)){
-                return PyErr_NoMemory();
+                return ImagingError_MemoryError();
             }
             state->bytes = (state->bits * state->xsize+7)/8;
         }
         /* malloc check ok, overflow checked above */
         state->buffer = (UINT8*) malloc(state->bytes);
         if (!state->buffer) {
-            return PyErr_NoMemory();
+            return ImagingError_MemoryError();
         }
     }
 

--- a/src/encode.c
+++ b/src/encode.c
@@ -1005,8 +1005,7 @@ static unsigned int* get_qtables_arrays(PyObject* qtables, int* qtablesLen) {
     qarrays = (unsigned int*) malloc(num_tables * DCTSIZE2 * sizeof(unsigned int));
     if (!qarrays) {
         Py_DECREF(tables);
-        ImagingError_MemoryError();
-        return NULL;
+        return ImagingError_MemoryError();
     }
     for (i = 0; i < num_tables; i++) {
         table = PySequence_Fast_GET_ITEM(tables, i);

--- a/src/encode.c
+++ b/src/encode.c
@@ -72,7 +72,7 @@ PyImaging_EncoderNew(int contextsize)
         context = (void*) calloc(1, contextsize);
         if (!context) {
             Py_DECREF(encoder);
-            (void) PyErr_NoMemory();
+            (void) ImagingError_MemoryError();
             return NULL;
         }
     } else {
@@ -194,7 +194,7 @@ _encode_to_file(ImagingEncoderObject* encoder, PyObject* args)
     /* malloc check ok, either constant int, or checked by PyArg_ParseTuple */
     buf = (UINT8*) malloc(bufsize);
     if (!buf) {
-        return PyErr_NoMemory();
+        return ImagingError_MemoryError();
     }
 
     ImagingSectionEnter(&cookie);
@@ -271,13 +271,13 @@ _setimage(ImagingEncoderObject* encoder, PyObject* args)
     /* Allocate memory buffer (if bits field is set) */
     if (state->bits > 0) {
         if (state->xsize > ((INT_MAX / state->bits)-7)) {
-            return PyErr_NoMemory();
+            return ImagingError_MemoryError();
         }
         state->bytes = (state->bits * state->xsize+7)/8;
         /* malloc check ok, overflow checked above */
         state->buffer = (UINT8*) malloc(state->bytes);
         if (!state->buffer) {
-            return PyErr_NoMemory();
+            return ImagingError_MemoryError();
         }
     }
 
@@ -604,7 +604,7 @@ PyImaging_ZipEncoderNew(PyObject* self, PyObject* args)
         /* malloc check ok, size comes from PyArg_ParseTuple */
         char* p = malloc(dictionary_size);
         if (!p) {
-            return PyErr_NoMemory();
+            return ImagingError_MemoryError();
         }
         memcpy(p, dictionary, dictionary_size);
         dictionary = p;
@@ -1005,7 +1005,7 @@ static unsigned int* get_qtables_arrays(PyObject* qtables, int* qtablesLen) {
     qarrays = (unsigned int*) malloc(num_tables * DCTSIZE2 * sizeof(unsigned int));
     if (!qarrays) {
         Py_DECREF(tables);
-        PyErr_NoMemory();
+        ImagingError_MemoryError();
         return NULL;
     }
     for (i = 0; i < num_tables; i++) {
@@ -1091,7 +1091,7 @@ PyImaging_JpegEncoderNew(PyObject* self, PyObject* args)
         /* malloc check ok, length is from python parsearg */
         char* p = malloc(extra_size); // Freed in JpegEncode, Case 5
         if (!p) {
-            return PyErr_NoMemory();
+            return ImagingError_MemoryError();
         }
         memcpy(p, extra, extra_size);
         extra = p;
@@ -1106,7 +1106,7 @@ PyImaging_JpegEncoderNew(PyObject* self, PyObject* args)
             if (extra) {
                 free(extra);
             }
-            return PyErr_NoMemory();
+            return ImagingError_MemoryError();
         }
         memcpy(pp, rawExif, rawExifLen);
         rawExif = pp;

--- a/src/path.c
+++ b/src/path.c
@@ -53,12 +53,10 @@ alloc_array(Py_ssize_t count)
 {
     double* xy;
     if (count < 0) {
-        ImagingError_MemoryError();
-        return NULL;
+        return ImagingError_MemoryError();
     }
     if ((unsigned long long)count > (SIZE_MAX / (2 * sizeof(double))) - 1 ) {
-        ImagingError_MemoryError();
-        return NULL;
+        return ImagingError_MemoryError();
     }
     xy = malloc(2 * count * sizeof(double) + 1);
     if (!xy) {

--- a/src/path.c
+++ b/src/path.c
@@ -53,16 +53,16 @@ alloc_array(Py_ssize_t count)
 {
     double* xy;
     if (count < 0) {
-        PyErr_NoMemory();
+        ImagingError_MemoryError();
         return NULL;
     }
     if ((unsigned long long)count > (SIZE_MAX / (2 * sizeof(double))) - 1 ) {
-        PyErr_NoMemory();
+        ImagingError_MemoryError();
         return NULL;
     }
     xy = malloc(2 * count * sizeof(double) + 1);
     if (!xy) {
-        PyErr_NoMemory();
+        ImagingError_MemoryError();
     }
     return xy;
 }


### PR DESCRIPTION
In several locations,
- Replaced PyErr_NoMemory with ImagingError_MemoryError
https://github.com/python-pillow/Pillow/blob/c1707d5d55c80255fec3fa671cda313f1a3cbfad/src/_imaging.c#L279-L283
- Simplified
```c
ImagingError_MemoryError();
return NULL;
```
into
```c
return ImagingError_MemoryError();
```