### PR TITLE
Block TIFFTAG_SUBIFD

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -4,7 +4,7 @@ from io import BytesIO
 import pytest
 
 from PIL import Image, TiffImagePlugin
-from PIL.TiffImagePlugin import RESOLUTION_UNIT, X_RESOLUTION, Y_RESOLUTION
+from PIL.TiffImagePlugin import RESOLUTION_UNIT, SUBIFD, X_RESOLUTION, Y_RESOLUTION
 
 from .helper import (
     assert_image_equal,
@@ -160,6 +160,14 @@ class TestFileTiff:
                 with Image.open(outfile) as reloaded:
                     reloaded.load()
                     assert (round(dpi), round(dpi)) == reloaded.info["dpi"]
+
+    def test_subifd(self, tmp_path):
+        outfile = str(tmp_path / "temp.tif")
+        with Image.open("Tests/images/g4_orientation_6.tif") as im:
+            im.tag_v2[SUBIFD] = 10000
+
+            # Should not segfault
+            im.save(outfile)
 
     def test_save_setting_missing_resolution(self):
         b = BytesIO()

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -89,6 +89,7 @@ ARTIST = 315
 PREDICTOR = 317
 COLORMAP = 320
 TILEOFFSETS = 324
+SUBIFD = 330
 EXTRASAMPLES = 338
 SAMPLEFORMAT = 339
 JPEGTABLES = 347
@@ -1559,12 +1560,14 @@ def _save(im, fp, filename):
         # The other tags expect arrays with a certain length (fixed or depending on
         # BITSPERSAMPLE, etc), passing arrays with a different length will result in
         # segfaults. Block these tags until we add extra validation.
+        # SUBIFD may also cause a segfault.
         blocklist = [
             REFERENCEBLACKWHITE,
             SAMPLEFORMAT,
             STRIPBYTECOUNTS,
             STRIPOFFSETS,
             TRANSFERFUNCTION,
+            SUBIFD,
         ]
 
         atts = {}


### PR DESCRIPTION
Resolves #5119

The image from the issue is crashing when trying to set [TIFFTAG_SUBIFD](https://www.awaresystems.be/imaging/tiff/tifftags/subifds.html) - specifying offsets to more data.

However, given that we aren't writing data to these arbitrary locations, we might as well as just block the tag.