### PR TITLE
Fixed warnings assigning to "unsigned char *" from "char *"

### DIFF
--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -1084,7 +1084,7 @@ font_render(FontObject* self, PyObject* args)
                 if (color) {
                     /* target[RGB] returns the color, target[A] returns the mask */
                     /* target bands get split again in ImageDraw.text */
-                    target = im->image[yy] + xx * 4;
+                    target = (unsigned char*)im->image[yy] + xx * 4;
                 } else {
                     target = im->image8[yy] + xx;
                 }

--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -198,7 +198,7 @@ ImagingGetExtrema(Imaging im, void *extrema)
           imin = imax = v;
           for (y = 0; y < im->ysize; y++) {
               for (x = 0; x < im->xsize; x++) {
-                  pixel = im->image[y] + x * sizeof(v);
+                  pixel = (UINT8*)im->image[y] + x * sizeof(v);
 #ifdef WORDS_BIGENDIAN
                   v = pixel[0] + (pixel[1] << 8);
 #else


### PR DESCRIPTION
Resolves #4586

Current warnings - https://github.com/python-pillow/Pillow/runs/1595213891#step:9:25 and https://github.com/python-pillow/Pillow/runs/1595213891#step:9:94

These changes are both for `im->image`. Casting from `im->image` to `UINT8*` is done multiple times in Convert.c, so this PR casts here as well.
https://github.com/python-pillow/Pillow/blob/ce3d80e7136710ea81b206fd160484013f913c2e/src/libImaging/Convert.c#L1427
https://github.com/python-pillow/Pillow/blob/ce3d80e7136710ea81b206fd160484013f913c2e/src/libImaging/Convert.c#L1681
https://github.com/python-pillow/Pillow/blob/ce3d80e7136710ea81b206fd160484013f913c2e/src/libImaging/Convert.c#L1754