### PR TITLE
Added exception explaining that _repr_png_ saves to PNG

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -537,6 +537,12 @@ class TestFilePng:
             assert repr_png.format == "PNG"
             assert_image_equal(im, repr_png)
 
+    def test_repr_png_error(self):
+        im = hopper("F")
+
+        with pytest.raises(ValueError):
+            im._repr_png_()
+
     def test_chunk_order(self, tmp_path):
         with Image.open("Tests/images/icc_profile.png") as im:
             test_file = str(tmp_path / "temp.png")

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -670,7 +670,10 @@ class Image:
         :returns: png version of the image as bytes
         """
         b = io.BytesIO()
-        self.save(b, "PNG")
+        try:
+            self.save(b, "PNG")
+        except Exception as e:
+            raise ValueError("Could not save to PNG for display") from e
         return b.getvalue()
 
     @property


### PR DESCRIPTION
Resolves #5116, in the absence of better solutions

The issue requests a clearer error message when an image fails to display in IPython. This PR catches any error raised when saving to PNG for display, and states "Could not save to PNG for display".