### PR TITLE
Fix OOB Read when writing TIFF with custom Metadata

### DIFF
--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -573,7 +573,6 @@ int ImagingLibTiffEncodeInit(ImagingCodecState state, char *filename, int fp) {
 int ImagingLibTiffMergeFieldInfo(ImagingCodecState state, TIFFDataType field_type, int key, int is_var_length){
     // Refer to libtiff docs (http://www.simplesystems.org/libtiff/addingtags.html)
     TIFFSTATE *clientstate = (TIFFSTATE *)state->context;
-    char field_name[10];
     uint32 n;
     int status = 0;
 
@@ -586,7 +585,7 @@ int ImagingLibTiffMergeFieldInfo(ImagingCodecState state, TIFFDataType field_typ
     int passcount = 0;
 
     TIFFFieldInfo info[] = {
-        { key, readcount, writecount, field_type, FIELD_CUSTOM, 1, passcount, field_name }
+        { key, readcount, writecount, field_type, FIELD_CUSTOM, 1, passcount, "CustomField" }
     };
 
     if (is_var_length) {


### PR DESCRIPTION
(triggered in Tests/test_file_libtiff.py::TestFileLibTiff::test_custom_metadata)

Valgrind output: 

```
**88** **********************************************************************
**88** Tests/test_file_libtiff.py::TestFileLibTiff::test_custom_metadata
**88** **********************************************************************
==88== Invalid read of size 1
==88==    at 0x890596C: _TIFFSetupFields (in /usr/lib/x86_64-linux-gnu/libtiff.so.5.5.0)
==88==    by 0x8904EEC: TIFFDefaultDirectory (in /usr/lib/x86_64-linux-gnu/libtiff.so.5.5.0)
==88==    by 0x890504C: TIFFCreateDirectory (in /usr/lib/x86_64-linux-gnu/libtiff.so.5.5.0)
==88==    by 0x8912141: ??? (in /usr/lib/x86_64-linux-gnu/libtiff.so.5.5.0)
==88==    by 0x89126EF: TIFFRewriteDirectory (in /usr/lib/x86_64-linux-gnu/libtiff.so.5.5.0)
==88==    by 0x891A2ED: TIFFFlush (in /usr/lib/x86_64-linux-gnu/libtiff.so.5.5.0)
==88==    by 0x87BD5CC: ImagingLibTiffEncode (TiffDecode.c:678)
==88==    by 0x877D519: _encode (encode.c:141)
```

Passing in a stack allocated array is going to fail, as a reference
is retained to the name and used later when flushing the Tiff to
the file.

