### PR TITLE
Fix Out of bounds read when saving GIF of xsize=1

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -74,10 +74,10 @@ def test_optimize():
         im.save(test_file, "GIF", optimize=optimize)
         return len(test_file.getvalue())
 
-    assert test_grayscale(0) == 800
-    assert test_grayscale(1) == 44
-    assert test_bilevel(0) == 800
-    assert test_bilevel(1) == 800
+    assert test_grayscale(0) == 799
+    assert test_grayscale(1) == 43
+    assert test_bilevel(0) == 799
+    assert test_bilevel(1) == 799
 
 
 def test_optimize_correctness():

--- a/src/libImaging/GifEncode.c
+++ b/src/libImaging/GifEncode.c
@@ -241,8 +241,6 @@ ImagingGifEncode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
                     break;
                 }
 
-                this = state->buffer[state->x++];
-
                 if (this == context->last) {
                     context->count++;
                 } else {

--- a/src/libImaging/GifEncode.c
+++ b/src/libImaging/GifEncode.c
@@ -233,6 +233,13 @@ ImagingGifEncode(Imaging im, ImagingCodecState state, UINT8* buf, int bytes)
                         }
 
                 }
+                /* Potential special case for xsize==1 */
+                if (state->x < state->xsize) {
+                    this = state->buffer[state->x++];
+                } else {
+                    EMIT_RUN(label0);
+                    break;
+                }
 
                 this = state->buffer[state->x++];
 


### PR DESCRIPTION
Triggered in Tests/test_file_gif.py::test_optimize

There is a OOB read of size 1 when the width of the image is 1. 

Valgrind output:
```
Tests/test_file_gif.py::test_optimize **70** 
**70** **********************************************************************
**70** Tests/test_file_gif.py::test_optimize
**70** **********************************************************************
==70== Invalid read of size 1
==70==    at 0x87A7194: ImagingGifEncode (GifEncode.c:237)
==70==    by 0x877D519: _encode (encode.c:141)
==70==    by 0x64BF47: method_vectorcall_VARARGS (descrobject.c:300)
```