### PR TITLE
Support for ignoring tests when running valgrind

### DIFF
--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -24,7 +24,7 @@ def pytest_configure(config):
         warnings.simplefilter("error")
         try:
             getattr(pytest.mark, "valgrind_known_error")
-        except:
+        except Exception:
             config.addinivalue_line(
                 "markers",
                 "valgrind_known_error: Tests that have known issues with valgrind",

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -10,3 +10,18 @@ def pytest_report_header(config):
             return out.getvalue()
     except Exception as e:
         return f"pytest_report_header failed: {e}"
+
+def pytest_configure(config):
+    # We're marking some tests to ignore valgrind errors and XFAIL them.
+    # Ensure that the mark is defined even in cases where pytest-valgrind isn't installed
+
+    import pytest
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        try:
+            getattr(pytest.mark, "valgrind_known_error")
+        except:
+            config.addinivalue_line("markers",
+                                    "valgrind_known_error: Tests that have known issues with valgrind")

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -11,17 +11,22 @@ def pytest_report_header(config):
     except Exception as e:
         return f"pytest_report_header failed: {e}"
 
+
 def pytest_configure(config):
     # We're marking some tests to ignore valgrind errors and XFAIL them.
-    # Ensure that the mark is defined even in cases where pytest-valgrind isn't installed
+    # Ensure that the mark is defined
+    # even in cases where pytest-valgrind isn't installed
+
+    import warnings
 
     import pytest
-    import warnings
 
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         try:
             getattr(pytest.mark, "valgrind_known_error")
         except:
-            config.addinivalue_line("markers",
-                                    "valgrind_known_error: Tests that have known issues with valgrind")
+            config.addinivalue_line(
+                "markers",
+                "valgrind_known_error: Tests that have known issues with valgrind",
+            )

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -1,4 +1,7 @@
 import io
+import warnings
+
+import pytest
 
 
 def pytest_report_header(config):
@@ -16,10 +19,6 @@ def pytest_configure(config):
     # We're marking some tests to ignore valgrind errors and XFAIL them.
     # Ensure that the mark is defined
     # even in cases where pytest-valgrind isn't installed
-
-    import warnings
-
-    import pytest
 
     with warnings.catch_warnings():
         warnings.simplefilter("error")

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -58,7 +58,7 @@ def test_invalid_file():
     with pytest.raises(SyntaxError):
         EpsImagePlugin.EpsImageFile(invalid_file)
 
-
+@pytest.mark.valgrind_known_error(reason="Known Failing")
 @pytest.mark.skipif(not HAS_GHOSTSCRIPT, reason="Ghostscript not available")
 def test_cmyk():
     with Image.open("Tests/images/pil_sample_cmyk.eps") as cmyk_image:

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -58,6 +58,7 @@ def test_invalid_file():
     with pytest.raises(SyntaxError):
         EpsImagePlugin.EpsImageFile(invalid_file)
 
+
 @pytest.mark.valgrind_known_error(reason="Known Failing")
 @pytest.mark.skipif(not HAS_GHOSTSCRIPT, reason="Ghostscript not available")
 def test_cmyk():

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -114,6 +114,7 @@ class TestFileJpeg:
         assert test(100, 200) == (100, 200)
         assert test(0) is None  # square pixels
 
+    @pytest.mark.valgrind_known_error(reason="Known Failing")
     def test_icc(self, tmp_path):
         # Test ICC support
         with Image.open("Tests/images/rgb.jpg") as im1:
@@ -153,6 +154,7 @@ class TestFileJpeg:
         test(ImageFile.MAXBLOCK + 1)  # full buffer block plus one byte
         test(ImageFile.MAXBLOCK * 4 + 3)  # large block
 
+    @pytest.mark.valgrind_known_error(reason="Known Failing")
     def test_large_icc_meta(self, tmp_path):
         # https://github.com/python-pillow/Pillow/issues/148
         # Sometimes the meta data on the icc_profile block is bigger than
@@ -419,6 +421,7 @@ class TestFileJpeg:
         with Image.open(filename):
             pass
 
+    @pytest.mark.valgrind_known_error(reason="Known Failing")
     def test_truncated_jpeg_should_read_all_the_data(self):
         filename = "Tests/images/truncated_jpeg.jpg"
         ImageFile.LOAD_TRUNCATED_IMAGES = True
@@ -437,6 +440,7 @@ class TestFileJpeg:
             with pytest.raises(OSError):
                 im.load()
 
+    @pytest.mark.valgrind_known_error(reason="Known Failing")
     def test_qtables(self, tmp_path):
         def _n_qtables_helper(n, test_file):
             with Image.open(test_file) as im:
@@ -720,6 +724,7 @@ class TestFileJpeg:
             # OSError for unidentified image.
             assert im.info.get("dpi") == (72, 72)
 
+    @pytest.mark.valgrind_known_error(reason="Known Failing")
     def test_exif_x_resolution(self, tmp_path):
         with Image.open("Tests/images/flower.jpg") as im:
             exif = im.getexif()
@@ -750,6 +755,7 @@ class TestFileJpeg:
             # Act / Assert
             assert im._getexif()[306] == "2017:03:13 23:03:09"
 
+    @pytest.mark.valgrind_known_error(reason="Backtrace in Python Core")
     def test_photoshop(self):
         with Image.open("Tests/images/photoshop-200dpi.jpg") as im:
             assert im.info["photoshop"][0x03ED] == {

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -185,7 +185,7 @@ class TestFileLibTiff(LibTiffTestCase):
             for field in requested_fields:
                 assert field in reloaded, f"{field} not in metadata"
 
-    @pytest.mark.valgrind_known_error(reason="Known Invalid Metadata")
+    @pytest.mark.valgrind_known_error(reason="Known invalid metadata")
     def test_additional_metadata(self, tmp_path):
         # these should not crash. Seriously dummy data, most of it doesn't make
         # any sense, so we're running up against limits where we're asking

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -185,6 +185,7 @@ class TestFileLibTiff(LibTiffTestCase):
             for field in requested_fields:
                 assert field in reloaded, f"{field} not in metadata"
 
+    @pytest.mark.valgrind_known_error(reason="Known Invalid Metadata")
     def test_additional_metadata(self, tmp_path):
         # these should not crash. Seriously dummy data, most of it doesn't make
         # any sense, so we're running up against limits where we're asking

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -815,12 +815,14 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open(infile) as im:
             assert_image_similar_tofile(im, "Tests/images/pil_sample_cmyk.jpg", 0.5)
 
+    @pytest.mark.valgrind_known_error(reason="Known Failing")
     @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_strip_ycbcr_jpeg_2x2_sampling(self):
         infile = "Tests/images/tiff_strip_ycbcr_jpeg_2x2_sampling.tif"
         with Image.open(infile) as im:
             assert_image_similar_tofile(im, "Tests/images/flower.jpg", 0.5)
 
+    @pytest.mark.valgrind_known_error(reason="Known Failing")
     @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_strip_ycbcr_jpeg_1x1_sampling(self):
         infile = "Tests/images/tiff_strip_ycbcr_jpeg_1x1_sampling.tif"
@@ -832,12 +834,14 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open(infile) as im:
             assert_image_similar_tofile(im, "Tests/images/pil_sample_cmyk.jpg", 0.5)
 
+    @pytest.mark.valgrind_known_error(reason="Known Failing")
     @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_tiled_ycbcr_jpeg_1x1_sampling(self):
         infile = "Tests/images/tiff_tiled_ycbcr_jpeg_1x1_sampling.tif"
         with Image.open(infile) as im:
             assert_image_equal_tofile(im, "Tests/images/flower2.jpg")
 
+    @pytest.mark.valgrind_known_error(reason="Known Failing")
     @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_tiled_ycbcr_jpeg_2x2_sampling(self):
         infile = "Tests/images/tiff_tiled_ycbcr_jpeg_2x2_sampling.tif"
@@ -865,6 +869,7 @@ class TestFileLibTiff(LibTiffTestCase):
 
                     assert_image_similar(base_im, im, 0.7)
 
+    @pytest.mark.valgrind_known_error(reason="Backtrace in Python Core")
     def test_sampleformat_not_corrupted(self):
         # Assert that a TIFF image with SampleFormat=UINT tag is not corrupted
         # when saving to a new file.

--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -84,7 +84,7 @@ def test_unsupported_mode(tmp_path):
     with pytest.raises(ValueError):
         im.save(outfile)
 
-
+@pytest.mark.valgrind_known_error(reason="Known Failing")
 def test_save_all(tmp_path):
     # Single frame image
     helper_save_as_pdf(tmp_path, "RGB", save_all=True)

--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -84,6 +84,7 @@ def test_unsupported_mode(tmp_path):
     with pytest.raises(ValueError):
         im.save(outfile)
 
+
 @pytest.mark.valgrind_known_error(reason="Known Failing")
 def test_save_all(tmp_path):
     # Single frame image

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -654,6 +654,7 @@ class TestFilePng:
             exif = reloaded._getexif()
         assert exif[274] == 1
 
+    @pytest.mark.valgrind_known_error(reason="Known Failing")
     def test_exif_from_jpg(self, tmp_path):
         with Image.open("Tests/images/pil_sample_rgb.jpg") as im:
             test_file = str(tmp_path / "temp.png")

--- a/Tests/test_file_webp_metadata.py
+++ b/Tests/test_file_webp_metadata.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-
+import pytest
 from PIL import Image
 
 from .helper import skip_unless_feature
@@ -38,7 +38,7 @@ def test_read_exif_metadata_without_prefix():
         exif = im.getexif()
         assert exif[305] == "Adobe Photoshop CS6 (Macintosh)"
 
-
+@pytest.mark.valgrind_known_error(reason="Known Failing")
 def test_write_exif_metadata():
     file_path = "Tests/images/flower.jpg"
     test_buffer = BytesIO()
@@ -70,7 +70,7 @@ def test_read_icc_profile():
 
             assert icc == expected_icc
 
-
+@pytest.mark.valgrind_known_error(reason="Known Failing")
 def test_write_icc_metadata():
     file_path = "Tests/images/flower2.jpg"
     test_buffer = BytesIO()
@@ -87,7 +87,7 @@ def test_write_icc_metadata():
     if webp_icc_profile:
         assert webp_icc_profile == expected_icc_profile, "Webp ICC didn't match"
 
-
+@pytest.mark.valgrind_known_error(reason="Known Failing")
 def test_read_no_exif():
     file_path = "Tests/images/flower.jpg"
     test_buffer = BytesIO()

--- a/Tests/test_file_webp_metadata.py
+++ b/Tests/test_file_webp_metadata.py
@@ -1,5 +1,7 @@
 from io import BytesIO
+
 import pytest
+
 from PIL import Image
 
 from .helper import skip_unless_feature
@@ -38,6 +40,7 @@ def test_read_exif_metadata_without_prefix():
         exif = im.getexif()
         assert exif[305] == "Adobe Photoshop CS6 (Macintosh)"
 
+
 @pytest.mark.valgrind_known_error(reason="Known Failing")
 def test_write_exif_metadata():
     file_path = "Tests/images/flower.jpg"
@@ -70,6 +73,7 @@ def test_read_icc_profile():
 
             assert icc == expected_icc
 
+
 @pytest.mark.valgrind_known_error(reason="Known Failing")
 def test_write_icc_metadata():
     file_path = "Tests/images/flower2.jpg"
@@ -86,6 +90,7 @@ def test_write_icc_metadata():
     assert webp_icc_profile
     if webp_icc_profile:
         assert webp_icc_profile == expected_icc_profile, "Webp ICC didn't match"
+
 
 @pytest.mark.valgrind_known_error(reason="Known Failing")
 def test_read_no_exif():

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -652,6 +652,7 @@ class TestImage:
 
             assert not fp.closed
 
+    @pytest.mark.valgrind_known_error(reason="Known Failing")
     def test_exif_jpeg(self, tmp_path):
         with Image.open("Tests/images/exif-72dpi-int.jpg") as im:  # Little endian
             exif = im.getexif()

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -455,6 +455,7 @@ class TestCoreResampleBox:
                 tiled.paste(tile, (x0, y0))
         return tiled
 
+    @pytest.mark.valgrind_known_error(reason="Known Failing")
     def test_tiles(self):
         with Image.open("Tests/images/flower.jpg") as im:
             assert im.size == (480, 360)
@@ -465,6 +466,7 @@ class TestCoreResampleBox:
                 tiled = self.resize_tiled(im, dst_size, *tiles)
                 assert_image_similar(reference, tiled, 0.01)
 
+    @pytest.mark.valgrind_known_error(reason="Known Failing")
     def test_subsample(self):
         # This test shows advantages of the subpixel resizing
         # after supersampling (e.g. during JPEG decoding).

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -87,7 +87,7 @@ def test_no_resize():
         im.thumbnail((64, 64))
         assert im.size == (64, 64)
 
-
+@pytest.mark.valgrind_known_error(reason="Known Failing")
 def test_DCT_scaling_edges():
     # Make an image with red borders and size (N * 8) + 1 to cross DCT grid
     im = Image.new("RGB", (257, 257), "red")

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -87,6 +87,7 @@ def test_no_resize():
         im.thumbnail((64, 64))
         assert im.size == (64, 64)
 
+
 @pytest.mark.valgrind_known_error(reason="Known Failing")
 def test_DCT_scaling_edges():
     # Make an image with red borders and size (N * 8) + 1 to cross DCT grid


### PR DESCRIPTION
Before we can add valgrind as an experimental docker test target, we need to have all of the tests passing or known ignored.

This adds:

* a pytest configuration for ignoring the error when pytest-valgrind isn't installed. 
* Ignores the tiff_additional_metadata test, because we're sending some illogical values to it. 

WIP -- there are more tests to investigate. 