### PR TITLE
OpenJPEG has been updated in pillow-wheels

### DIFF
--- a/docs/releasenotes/8.1.0.rst
+++ b/docs/releasenotes/8.1.0.rst
@@ -39,8 +39,7 @@ already exists for the ICNS format.
 Security
 ========
 
-OpenJPEG in the macOS and Linux wheels has been updated from 2.3.1 to 2.4.0, resolving
-security problems present in the earlier version of that dependency.
+OpenJPEG in the macOS and Linux wheels has been updated from 2.3.1 to 2.4.0, including security fixes.
 
 Other Changes
 =============

--- a/docs/releasenotes/8.1.0.rst
+++ b/docs/releasenotes/8.1.0.rst
@@ -39,7 +39,8 @@ already exists for the ICNS format.
 Security
 ========
 
-TODO
+OpenJPEG in the macOS and Linux wheels has been updated from 2.3.1 to 2.4.0, resolving
+security problems present in the earlier version of that dependency.
 
 Other Changes
 =============


### PR DESCRIPTION
Documents the updating of OpenJPEG 2.3.1 to 2.4.0 in https://github.com/python-pillow/pillow-wheels/pull/179, fixing security problems in that dependency
Suggested in https://github.com/python-pillow/Pillow/pull/5151#issuecomment-751903072