### PR TITLE
Updated libtiff to 4.2.0

### DIFF
--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -378,7 +378,7 @@ int ImagingLibTiffDecode(Imaging im, ImagingCodecState state, UINT8* buffer, Py_
             TIFFClose(tiff);
             return -1;
         }
-        
+
         state->bytes = row_byte_size * tile_length;
 
         if (TIFFTileSize(tiff) > state->bytes) {
@@ -578,7 +578,7 @@ int ImagingLibTiffMergeFieldInfo(ImagingCodecState state, TIFFDataType field_typ
 
     // custom fields added with ImagingLibTiffMergeFieldInfo are only used for
     // decoding, ignore readcount;
-    int readcount = 0;
+    int readcount = 1;
     // we support writing a single value, or a variable number of values
     int writecount = 1;
     // whether the first value should encode the number of values.

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -141,9 +141,9 @@ deps = {
         "libs": [r"*.lib"],
     },
     "libtiff": {
-        "url": "https://download.osgeo.org/libtiff/tiff-4.1.0.tar.gz",
-        "filename": "tiff-4.1.0.tar.gz",
-        "dir": "tiff-4.1.0",
+        "url": "https://download.osgeo.org/libtiff/tiff-4.2.0.tar.gz",
+        "filename": "tiff-4.2.0.tar.gz",
+        "dir": "tiff-4.2.0",
         "build": [
             cmd_copy(r"{winbuild_dir}\tiff.opt", "nmake.opt"),
             cmd_nmake("makefile.vc", "clean"),

--- a/winbuild/tiff.opt
+++ b/winbuild/tiff.opt
@@ -66,6 +66,10 @@ ZIP_SUPPORT	= 1
 ZLIB_INCLUDE	= -I$(INCLIB)
 ZLIB_LIB 	= $(INCLIB)/zlib.lib
 
+# Indicate if the compiler provides strtoll/strtoull (default 1)
+# Users of MSVC++ 14.0 ("Visual Studio 2015") and later should set this to 1
+HAVE_STRTOLL = 1
+
 #
 # Uncomment and edit following lines to enable ISO JBIG support
 #


### PR DESCRIPTION
Resolves #5157

Updated libtiff to 4.2.0, adding a setting to 'winbuild/tiff.opt' because of https://gitlab.com/libtiff/libtiff/-/commit/58b16f47a82323c05ec81f0a821700beb8c2c5a0 (later [simplified](https://gitlab.com/libtiff/libtiff/-/commit/7a335a32ebbce103d429c82a8d60d25ead1ccf0e)).

However, from the first commit here, you can see that a test fails.

Investigating, it is failing specifically because of https://github.com/python-pillow/Pillow/blob/18ee51a5a80592bf9a09e9fd9b0674e4f58a5d15/Tests/test_file_libtiff.py#L256

libtiff 4.2.0 added the ['Rational2Double' block in this code](https://gitlab.com/libtiff/libtiff/-/blob/v4.2.0/libtiff/tif_dir.c#L563-566) (if you're interested, it was part of https://gitlab.com/Su_Laus/libtiff/-/commit/6df997c786928757caea0dd68d26ea5f098f49df) -

```c
tv_size = _TIFFDataSize(fip->field_type);
/*--: Rational2Double: For Rationals evaluate "set_field_type" to determine internal storage size. */
if (fip->field_type == TIFF_RATIONAL || fip->field_type == TIFF_SRATIONAL) {
	tv_size = _TIFFSetGetFieldSize(fip->set_field_type);
}
if (tv_size == 0) {
	status = 0;
	TIFFErrorExt(tif->tif_clientdata, module,
		"%s: Bad field type %d for \"%s\"",
		tif->tif_name, fip->field_type,
		fip->field_name);
	goto end;
}
```
These lines are returning zero for `tv_size` - I conclude it is because `fip->set_field_type` is not properly set from https://gitlab.com/libtiff/libtiff/-/blob/v4.2.0/libtiff/tif_dirinfo.c#L1106-1109 in `TIFFMergeFieldInfo`.
```c
tp->set_field_type =
	 _TIFFSetGetType(info[i].field_type,
		info[i].field_readcount,
		info[i].field_passcount);
```
This is because [`_TIFFSetGetType`](https://gitlab.com/libtiff/libtiff/-/blob/v4.2.0/libtiff/tif_dirinfo.c#L908-1056) has a few conditions to match against `TIFF_RATIONAL` -
```c
if (type == TIFF_ASCII && count == TIFF_VARIABLE && passcount == 0)
...
else if (count == 1 && passcount == 0) {
...
else if (count >= 1 && passcount == 0) {
...
else if (count == TIFF_VARIABLE && passcount == 1) {
...
else if (count == TIFF_VARIABLE2 && passcount == 1) {
```
but none involve `count` (`readcount` in TiffDecode.c) being zero.

https://github.com/python-pillow/Pillow/blob/18ee51a5a80592bf9a09e9fd9b0674e4f58a5d15/src/libImaging/TiffDecode.c#L581

So this PR changes that value, and the test now passes.

This also then fixes https://github.com/python-pillow/pillow-wheels/pull/180.