### PR TITLE
Add support for PySide6

### DIFF
--- a/Tests/test_imageqt.py
+++ b/Tests/test_imageqt.py
@@ -14,7 +14,9 @@ def test_rgb():
     # typedef QRgb
     # An ARGB quadruplet on the format #AARRGGBB,
     # equivalent to an unsigned int.
-    if ImageQt.qt_version == "5":
+    if ImageQt.qt_version == "side6":
+        from PySide6.QtGui import qRgb
+    elif ImageQt.qt_version == "5":
         from PyQt5.QtGui import qRgb
     elif ImageQt.qt_version == "side2":
         from PySide2.QtGui import qRgb

--- a/Tests/test_qt_image_qapplication.py
+++ b/Tests/test_qt_image_qapplication.py
@@ -7,7 +7,10 @@ from .helper import assert_image_equal, hopper
 if ImageQt.qt_is_installed:
     from PIL.ImageQt import QPixmap
 
-    if ImageQt.qt_version == "5":
+    if ImageQt.qt_version == "side6":
+        from PySide6 import QtGui
+        from PySide6.QtWidgets import QApplication, QHBoxLayout, QLabel, QWidget
+    elif ImageQt.qt_version == "5":
         from PyQt5 import QtGui
         from PyQt5.QtWidgets import QApplication, QHBoxLayout, QLabel, QWidget
     elif ImageQt.qt_version == "side2":

--- a/Tests/test_qt_image_qapplication.py
+++ b/Tests/test_qt_image_qapplication.py
@@ -8,13 +8,10 @@ if ImageQt.qt_is_installed:
     from PIL.ImageQt import QPixmap
 
     if ImageQt.qt_version == "side6":
-        from PySide6 import QtGui
         from PySide6.QtWidgets import QApplication, QHBoxLayout, QLabel, QWidget
     elif ImageQt.qt_version == "5":
-        from PyQt5 import QtGui
         from PyQt5.QtWidgets import QApplication, QHBoxLayout, QLabel, QWidget
     elif ImageQt.qt_version == "side2":
-        from PySide2 import QtGui
         from PySide2.QtWidgets import QApplication, QHBoxLayout, QLabel, QWidget
 
     class Example(QWidget):
@@ -25,7 +22,7 @@ if ImageQt.qt_is_installed:
 
             qimage = ImageQt.ImageQt(img)
 
-            pixmap1 = QtGui.QPixmap.fromImage(qimage)
+            pixmap1 = ImageQt.QPixmap.fromImage(qimage)
 
             QHBoxLayout(self)  # hbox
 

--- a/src/PIL/ImageQt.py
+++ b/src/PIL/ImageQt.py
@@ -22,13 +22,20 @@ from io import BytesIO
 from . import Image
 from ._util import isPath
 
-qt_versions = [["5", "PyQt5"], ["side2", "PySide2"]]
+qt_versions = [
+    ["side6", "PySide6"],
+    ["5", "PyQt5"],
+    ["side2", "PySide2"],
+]
 
 # If a version has already been imported, attempt it first
 qt_versions.sort(key=lambda qt_version: qt_version[1] in sys.modules, reverse=True)
 for qt_version, qt_module in qt_versions:
     try:
-        if qt_module == "PyQt5":
+        if qt_module == "PySide6":
+            from PySide6.QtCore import QBuffer, QIODevice
+            from PySide6.QtGui import QImage, QPixmap, qRgba
+        elif qt_module == "PyQt5":
             from PyQt5.QtCore import QBuffer, QIODevice
             from PyQt5.QtGui import QImage, QPixmap, qRgba
         elif qt_module == "PySide2":


### PR DESCRIPTION
Fixes https://github.com/python-pillow/Pillow/issues/5145.

There are two sets of Python bindings for Qt, called PyQt and PySide. 

> Why are there two packages?
>
> PyQt has been developed by Phil Thompson of Riverbank Computing Ltd. for a very long time — supporting versions of Qt going back to 2.x. Back in 2009 Nokia, who owned the Qt toolkit at the time, wanted to have Python bindings for Qt available under the LGPL license (like Qt itself). Unable to come to agreement with Riverbank (who would lose money from this, so fair enough) they then released their own bindings as PySide (also, fair enough).

https://www.learnpyqt.com/tutorials/pyqt5-vs-pyside2/

We support:

* PySide2 for Qt 5
* PyQt5 for Qt 5

Qt 6 has been recently released: https://www.qt.io/blog/qt-6.0-released

* PyQt6 is still in development: https://riverbankcomputing.com/software/pyqt/download Let's add it when it's available.
* PySide6 for Qt 6 is out: https://www.qt.io/blog/qt-for-python-6-released (they bumped the PySide version to match the Qt version)


Changes proposed in this pull request:

 * Add support for PySide6. Take precedence over PyQt5 and PySide2, if they're also installed.
