### PR TITLE
Corrected argument

### DIFF
--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -11,7 +11,7 @@ ORIGINAL_LIMIT = Image.MAX_IMAGE_PIXELS
 
 class TestDecompressionBomb:
     @classmethod
-    def teardown_class(self):
+    def teardown_class(cls):
         Image.MAX_IMAGE_PIXELS = ORIGINAL_LIMIT
 
     def test_no_warning_small_file(self):


### PR DESCRIPTION
https://docs.pytest.org/en/stable/xunit_setup.html#class-level-setup-teardown shows
```python
@classmethod
def teardown_class(cls):
```
whereas we have
https://github.com/python-pillow/Pillow/blob/01cee38b9b02b4be85a1c38cd746e40aa6ed05e1/Tests/test_decompression_bomb.py#L13-L14

This PR replaces `self` with `cls`.