### PR TITLE
Revert "skip wheels on 3.10-dev due to wheel#354"

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -197,16 +197,14 @@ jobs:
 
     - name: Build wheel
       id: wheel
-      # Skip wheels on 3.10 due to https://github.com/pypa/wheel/issues/354
-      if: "github.event_name == 'push' && !contains(matrix.python-version, '3.10')"
+      if: "github.event_name == 'push'"
       run: |
         for /f "tokens=3 delims=/" %%a in ("${{ github.ref }}") do echo ::set-output name=dist::dist-%%a
         winbuild\\build\\build_pillow.cmd --disable-imagequant bdist_wheel
       shell: cmd
 
     - uses: actions/upload-artifact@v2
-      # Skip wheels on 3.10 due to https://github.com/pypa/wheel/issues/354
-      if: "github.event_name == 'push' && !contains(matrix.python-version, '3.10')"
+      if: "github.event_name == 'push'"
       with:
         name: ${{ steps.wheel.outputs.dist }}
         path: dist\*.whl


### PR DESCRIPTION
https://github.com/pypa/wheel/issues/354 has been closed.

Reverts part of #4980