### PR TITLE
Release notes for LibTIFF update in pillow-wheels

### DIFF
--- a/docs/releasenotes/8.1.0.rst
+++ b/docs/releasenotes/8.1.0.rst
@@ -53,6 +53,9 @@ Dependencies
 OpenJPEG in the macOS and Linux wheels has been updated from 2.3.1 to 2.4.0, including
 security fixes.
 
+LibTIFF in the macOS and Linux wheels has been updated from 4.1.0 to 4.2.0, including
+security fixes discovered by fuzzers.
+
 Other Changes
 =============
 


### PR DESCRIPTION
Release notes for https://github.com/python-pillow/pillow-wheels/pull/180, similar to #5152.

Based on http://simplesystems.org/libtiff/v4.2.0.html#highlights

I'm not sure if it is important to mention every dependency update with security fixes in the release notes, but it seems reasonable to me.