### PR TITLE
Docs: add alpha channel to supported hex color specifiers

### DIFF
--- a/docs/reference/ImageColor.rst
+++ b/docs/reference/ImageColor.rst
@@ -16,8 +16,17 @@ Color Names
 
 The ImageColor module supports the following string formats:
 
-* Hexadecimal color specifiers, given as ``#rgb`` or ``#rrggbb``. For example,
-  ``#ff0000`` specifies pure red.
+* Hexadecimal color specifiers, given as ``#rgb``, ``#rgba``, ``#rrggbb`` or ``#rrggbbaa``, 
+  with the following placeholders: 
+    - ``r``: red
+    - ``g``: green
+    - ``b``: blue
+    - ``a``: alpha / opacity (can be used in combination with ``mode="RGBA"`` in :py:mod:`~PIL.ImageDraw`)
+  
+  Examples:
+   - ``#ff0000`` specifies pure red.
+   - ``#ff0000aa`` specifies pure red with an opacity of 66.66% (aa = 170, opacity = 170/255).
+
 
 * RGB functions, given as ``rgb(red, green, blue)`` where the color values are
   integers in the range 0 to 255. Alternatively, the color values can be given


### PR DESCRIPTION
Updates the docs with an example how to specify hexadecimal rgb color values with an alpha channel / opacity.
Related code:

https://github.com/python-pillow/Pillow/blob/d374015504df2c7f0316154deade1bc1fa5075df/src/PIL/ImageColor.py#L48-L65