### PR TITLE
Fixed comparison warning

### DIFF
--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -503,8 +503,8 @@ ImagingLibTiffDecode(
     isYCbCr = photometric == PHOTOMETRIC_YCBCR;
 
     if (TIFFIsTiled(tiff)) {
-        INT32 x, y, tile_y;
-        UINT32 tile_width, tile_length, current_tile_length, current_line,
+        INT32 x, y, tile_y, current_tile_length;
+        UINT32 tile_width, tile_length, current_line,
             current_tile_width, row_byte_size;
         UINT8 *new_data;
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/runs/1649086275#step:9:118
> src/libImaging/TiffDecode.c:241:22: warning: comparison of integers of different signs: 'int' and 'uint32' (aka 'unsigned int') [-Wsign-compare]
    if (state->xsize != img.width || state->ysize != img.height) {
        ~~~~~~~~~~~~ ^  ~~~~~~~~~
src/libImaging/TiffDecode.c:241:51: warning: comparison of integers of different signs: 'int' and 'uint32' (aka 'unsigned int') [-Wsign-compare]
    if (state->xsize != img.width || state->ysize != img.height) {
                                     ~~~~~~~~~~~~ ^  ~~~~~~~~~~
src/libImaging/TiffDecode.c:582:41: warning: comparison of integers of different signs: 'int' and 'unsigned int' [-Wsign-compare]
                for (tile_y = 0; tile_y < current_tile_length; tile_y++) {
                                 ~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~
3 warnings generated.