### PR TITLE
PyModule_AddObject fix for Python 3.10

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,6 +45,7 @@ test_script:
 - cd c:\pillow
 - '%PYTHON%\%EXECUTABLE% -m pip install pytest pytest-cov'
 - c:\"Program Files (x86)"\"Windows Kits"\10\Debuggers\x86\gflags.exe /p /enable %PYTHON%\%EXECUTABLE%
+- '%PYTHON%\%EXECUTABLE% -c "from PIL import Image"'
 - '%PYTHON%\%EXECUTABLE% -m pytest -vx --cov PIL --cov Tests --cov-report term --cov-report xml Tests'
 #- '%PYTHON%\%EXECUTABLE% test-installed.py -v -s %TEST_OPTIONS%' TODO TEST_OPTIONS with pytest?
 

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -2,4 +2,6 @@
 
 set -e
 
+python3 -c "from PIL import Image"
+
 python3 -bb -m pytest -v -x -W always --cov PIL --cov Tests --cov-report term Tests

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -273,6 +273,7 @@ jobs:
       - name: Test Pillow
         run: |
           python3 selftest.py --installed
+          python3 -c "from PIL import Image"
           python3 -m pytest -vx --cov PIL --cov Tests --cov-report term --cov-report xml Tests
 
       - name: Upload coverage

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -4134,8 +4134,9 @@ setup_module(PyObject *m) {
     }
 #endif
 
+    PyObject *have_libjpegturbo;
 #ifdef LIBJPEG_TURBO_VERSION
-    PyModule_AddObject(m, "HAVE_LIBJPEGTURBO", Py_True);
+    have_libjpegturbo = Py_True;
 #define tostr1(a) #a
 #define tostr(a) tostr1(a)
     PyDict_SetItemString(
@@ -4143,19 +4144,24 @@ setup_module(PyObject *m) {
 #undef tostr
 #undef tostr1
 #else
-    PyModule_AddObject(m, "HAVE_LIBJPEGTURBO", Py_False);
+    have_libjpegturbo = Py_False;
 #endif
+    Py_INCREF(have_libjpegturbo);
+    PyModule_AddObject(m, "HAVE_LIBJPEGTURBO", have_libjpegturbo);
 
+    PyObject *have_libimagequant;
 #ifdef HAVE_LIBIMAGEQUANT
-    PyModule_AddObject(m, "HAVE_LIBIMAGEQUANT", Py_True);
+    have_libimagequant = Py_True;
     {
         extern const char *ImagingImageQuantVersion(void);
         PyDict_SetItemString(
             d, "imagequant_version", PyUnicode_FromString(ImagingImageQuantVersion()));
     }
 #else
-    PyModule_AddObject(m, "HAVE_LIBIMAGEQUANT", Py_False);
+    have_libimagequant = Py_False;
 #endif
+    Py_INCREF(have_libimagequant);
+    PyModule_AddObject(m, "HAVE_LIBIMAGEQUANT", have_libimagequant);
 
 #ifdef HAVE_LIBZ
     /* zip encoding strategies */
@@ -4189,11 +4195,14 @@ setup_module(PyObject *m) {
     }
 #endif
 
+    PyObject *have_xcb;
 #ifdef HAVE_XCB
-    PyModule_AddObject(m, "HAVE_XCB", Py_True);
+    have_xcb = Py_True;
 #else
-    PyModule_AddObject(m, "HAVE_XCB", Py_False);
+    have_xcb = Py_False;
 #endif
+    Py_INCREF(have_xcb);
+    PyModule_AddObject(m, "HAVE_XCB", have_xcb);
 
     PyDict_SetItemString(d, "PILLOW_VERSION", PyUnicode_FromString(version));
 

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -920,20 +920,26 @@ static PyMethodDef webpMethods[] = {
 
 void
 addMuxFlagToModule(PyObject *m) {
+    PyObject *have_webpmux;
 #ifdef HAVE_WEBPMUX
-    PyModule_AddObject(m, "HAVE_WEBPMUX", Py_True);
+    have_webpmux = Py_True;
 #else
-    PyModule_AddObject(m, "HAVE_WEBPMUX", Py_False);
+    have_webpmux = Py_False;
 #endif
+    Py_INCREF(have_webpmux);
+    PyModule_AddObject(m, "HAVE_WEBPMUX", have_webpmux);
 }
 
 void
 addAnimFlagToModule(PyObject *m) {
+    PyObject *have_webpanim;
 #ifdef HAVE_WEBPANIM
-    PyModule_AddObject(m, "HAVE_WEBPANIM", Py_True);
+    have_webpanim = Py_True;
 #else
-    PyModule_AddObject(m, "HAVE_WEBPANIM", Py_False);
+    have_webpanim = Py_False;
 #endif
+    Py_INCREF(have_webpanim);
+    PyModule_AddObject(m, "HAVE_WEBPANIM", have_webpanim);
 }
 
 void


### PR DESCRIPTION
Resolves #5193

The first commit adds `python3 -c "from PIL import Image"` to .ci/test.sh - for whatever reason, this fails in Python 3.10, while our pytest command does not.

The second commit replaces instances like

```c
#ifdef HAVE_XCB
    PyModule_AddObject(m, "HAVE_XCB", Py_True);
#else
    PyModule_AddObject(m, "HAVE_XCB", Py_False);
#endif
```

with

```c
    PyObject *have_xcb;
#ifdef HAVE_XCB
    have_xcb = Py_True;
#else
    have_xcb = Py_False;
#endif
    Py_INCREF(have_xcb);
    PyModule_AddObject(m, "HAVE_XCB", have_xcb);
```

This is per the example in https://docs.python.org/3/c-api/module.html#c.PyModule_AddObject, which calls `Py_INCREF` before `PyModule_AddObject`.