### PR TITLE
Changed example image file name

### DIFF
--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -22,7 +22,7 @@ Windows).
 .. code-block:: python
 
     from PIL import Image
-    im = Image.open("bride.jpg")
+    im = Image.open("hopper.jpg")
     im.rotate(45).show()
 
 Create thumbnails


### PR DESCRIPTION
Minor. Changes example image file name to be 'hopper.jpg', for consistency with the other examples.