### PR TITLE
Link OSS-Fuzz in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ JPEG_ROOT = None
 LCMS_ROOT = None
 TIFF_ROOT = None
 ZLIB_ROOT = None
-
+FUZZING_BUILD = 'LIB_FUZZING_ENGINE' in os.environ
 
 if sys.platform == "win32" and sys.version_info >= (3, 10):
     import atexit
@@ -346,6 +346,9 @@ class pil_build_ext(build_ext):
                     extension.define_macros += define_macros
                 if include_dirs is not None:
                     extension.include_dirs += include_dirs
+                if FUZZING_BUILD:
+                    extension.language = "c++"
+                    extension.extra_link_args = ["--stdlib=libc++"]
                 break
 
     def _remove_extension(self, name):
@@ -840,9 +843,7 @@ class pil_build_ext(build_ext):
 
 
 def debug_build():
-    return hasattr(sys, "gettotalrefcount") or os.environ.get(
-        "LIB_FUZZING_ENGINE", None
-    )
+    return hasattr(sys, "gettotalrefcount") or FUZZING_BUILD
 
 
 files = ["src/_imaging.c"]

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ JPEG_ROOT = None
 LCMS_ROOT = None
 TIFF_ROOT = None
 ZLIB_ROOT = None
-FUZZING_BUILD = 'LIB_FUZZING_ENGINE' in os.environ
+FUZZING_BUILD = "LIB_FUZZING_ENGINE" in os.environ
 
 if sys.platform == "win32" and sys.version_info >= (3, 10):
     import atexit


### PR DESCRIPTION
Do fuzzing linking in setup.py options, rather than post-hoc manually linking.

This links all of the extensions with the fuzzer, rather than just _imaging.so

This is a prerequisite for changing the build script upstream. 