### PR TITLE
Allow PixelAccess to use Python __int__ when parsing x and y

### DIFF
--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -23,6 +23,11 @@ else:
     except ImportError:
         cffi = None
 
+try:
+    import numpy
+except ImportError:
+    numpy = None
+
 
 class AccessTest:
     # initial value
@@ -108,6 +113,13 @@ class TestImagePutPixel(AccessTest):
                 pix2[x, y] = pix1[x, y]
 
         assert_image_equal(im1, im2)
+
+    @pytest.mark.skipif(numpy is None, reason="NumPy not installed")
+    def test_numpy(self):
+        im = hopper()
+        pix = im.load()
+
+        assert pix[numpy.int32(1), numpy.int32(2)] == (18, 20, 59)
 
 
 class TestImageGetPixel(AccessTest):

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -71,6 +71,10 @@ class TestImagePutPixel(AccessTest):
         pix1 = im1.load()
         pix2 = im2.load()
 
+        for x, y in ((0, "0"), ("0", 0)):
+            with pytest.raises(TypeError):
+                pix1[x, y]
+
         for y in range(im1.size[1]):
             for x in range(im1.size[0]):
                 pix2[x, y] = pix1[x, y]

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1109,7 +1109,12 @@ _getxy(PyObject *xy, int *x, int *y) {
     } else if (PyFloat_Check(value)) {
         *x = (int)PyFloat_AS_DOUBLE(value);
     } else {
-        goto badval;
+        PyObject *int_value = PyObject_CallMethod(value, "__int__", NULL);
+        if (int_value != NULL && PyLong_Check(int_value)) {
+            *x = PyLong_AS_LONG(int_value);
+        } else {
+            goto badval;
+        }
     }
 
     value = PyTuple_GET_ITEM(xy, 1);
@@ -1118,7 +1123,12 @@ _getxy(PyObject *xy, int *x, int *y) {
     } else if (PyFloat_Check(value)) {
         *y = (int)PyFloat_AS_DOUBLE(value);
     } else {
-        goto badval;
+        PyObject *int_value = PyObject_CallMethod(value, "__int__", NULL);
+        if (int_value != NULL && PyLong_Check(int_value)) {
+            *y = PyLong_AS_LONG(int_value);
+        } else {
+            goto badval;
+        }
     }
 
     return 0;


### PR DESCRIPTION
Resolves #5048

The issue reports that
```python
px = im.load()
px[numpy.int32(5), numpy.int32(5)]
```
returns
```
TypeError: an integer is required
```

This PR calls `__int__()` on the object passed in, which should provide support for other kinds of objects as well.