### PR TITLE
Corrected CVE number

### DIFF
--- a/src/PIL/PcxImagePlugin.py
+++ b/src/PIL/PcxImagePlugin.py
@@ -111,7 +111,7 @@ class PcxImageFile(ImageFile.ImageFile):
         self._size = bbox[2] - bbox[0], bbox[3] - bbox[1]
 
         # don't trust the passed in stride. Calculate for ourselves.
-        # CVE-2020-35655
+        # CVE-2020-35653
         stride = (self._size[0] * bits + 7) // 8
         stride += stride % 2
 


### PR DESCRIPTION
The PCX vulnerability was https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-35653, not https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-35655 as a comment currently states.