### PR TITLE
Deprecate Tk/Tcl 8.4, to be removed in Pillow 10 (2023-01-02)

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -25,6 +25,14 @@ vulnerability introduced in FreeType 2.6 (:cve:`CVE-2020-15999`).
 
 .. _2.10.4: https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/
 
+Tk/Tcl 8.4
+~~~~~~~~~~
+
+.. deprecated:: 8.2.0
+
+Support for Tk/Tcl 8.4 is deprecated and will be removed in Pillow 10.0.0 (2023-01-02),
+when Tk/Tcl 8.5 will be the minimum supported.
+
 Image.show command parameter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releasenotes/8.2.0.rst
+++ b/docs/releasenotes/8.2.0.rst
@@ -1,0 +1,40 @@
+8.2.0
+-----
+
+Deprecations
+============
+
+Tk/Tcl 8.4
+^^^^^^^^^^
+
+Support for Tk/Tcl 8.4 is deprecated and will be removed in Pillow 10.0.0 (2023-01-02),
+when Tk/Tcl 8.5 will be the minimum supported.
+
+API Changes
+===========
+
+TODO
+^^^^
+
+TODO
+
+API Additions
+=============
+
+TODO
+^^^^
+
+TODO
+
+Security
+========
+
+TODO
+
+Other Changes
+=============
+
+TODO
+^^^^
+
+TODO

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -14,6 +14,7 @@ expected to be backported to earlier versions.
 .. toctree::
   :maxdepth: 2
 
+  8.2.0
   8.1.0
   8.0.1
   8.0.0

--- a/src/PIL/_tkinter_finder.py
+++ b/src/PIL/_tkinter_finder.py
@@ -2,6 +2,7 @@
 """
 import sys
 import tkinter
+import warnings
 from tkinter import _tkinter as tk
 
 if hasattr(sys, "pypy_find_executable"):
@@ -10,3 +11,10 @@ else:
     TKINTER_LIB = tk.__file__
 
 tk_version = str(tkinter.TkVersion)
+if tk_version == "8.4":
+    warnings.warn(
+        "Support for Tk/Tcl 8.4 is deprecated and will be removed"
+        " in Pillow 10 (2023-01-02). Please upgrade to Tk/Tcl 8.5 "
+        "or newer.",
+        DeprecationWarning,
+    )


### PR DESCRIPTION
Tk/Tcl 8.4.0 was released Sep 18, 2000
Tk/Tcl 8.5.0 was released Dec 20, 2007
Tk/Tcl 8.4.20, the most recent version of 8.4, was released Jun 1, 2013

Support for Tk/Tcl < 8.4 was removed in #1288