### PR TITLE
Replaced mkdir command with Python

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -174,7 +174,7 @@ jobs:
       if: failure()
       run: |
         mkdir -p Tests/errors
-      shell: pwsh
+      shell: bash
 
     - name: Upload errors
       uses: actions/upload-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,6 @@ jobs:
       if: failure()
       run: |
         mkdir -p Tests/errors
-      shell: pwsh
 
     - name: Upload errors
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
I recently pushed a [commit](https://github.com/radarhere/Pillow/commit/adf125309e789f5a9568f212d4676010a6852c63) to GitHub Actions. It failed for a perfectly valid reason, but when failing, [test-windows reported](https://github.com/radarhere/Pillow/runs/1751631505?check_suite_focus=true) -

<img width="948" alt="Screen Shot 2021-01-23 at 9 28 54 am" src="https://user-images.githubusercontent.com/3112309/105555410-6e5f1980-5d5d-11eb-926b-7ffff9afe0e0.png">

The '-p' flag is meant to [prevent this error](https://github.com/python-pillow/Pillow/pull/4379), but I guess this doesn't work on Windows (https://en.wikipedia.org/wiki/Mkdir#Options)

So instead, this PR replaces 'mkdir' with a Python command. It also changes test.yml, just for symmetry.

See https://github.com/radarhere/Pillow/runs/1751747364?check_suite_focus=true for my failing case combined with this commit to produce a correct 'Prepare to upload errors'