### PR TITLE
Removed CC0 notices

### DIFF
--- a/docs/example/DdsImagePlugin.py
+++ b/docs/example/DdsImagePlugin.py
@@ -4,10 +4,6 @@ Jerome Leclanche <jerome@leclan.ch>
 
 Documentation:
   https://web.archive.org/web/20170802060935/http://oss.sgi.com/projects/ogl-sample/registry/EXT/texture_compression_s3tc.txt
-
-The contents of this file are hereby released in the public domain (CC0)
-Full text of the CC0 license:
-  https://creativecommons.org/publicdomain/zero/1.0/
 """
 
 import struct

--- a/src/PIL/BlpImagePlugin.py
+++ b/src/PIL/BlpImagePlugin.py
@@ -2,10 +2,6 @@
 Blizzard Mipmap Format (.blp)
 Jerome Leclanche <jerome@leclan.ch>
 
-The contents of this file are hereby released in the public domain (CC0)
-Full text of the CC0 license:
-  https://creativecommons.org/publicdomain/zero/1.0/
-
 BLP1 files, used mostly in Warcraft III, are not fully supported.
 All types of BLP2 files used in World of Warcraft are supported.
 

--- a/src/PIL/DdsImagePlugin.py
+++ b/src/PIL/DdsImagePlugin.py
@@ -4,10 +4,6 @@ Jerome Leclanche <jerome@leclan.ch>
 
 Documentation:
   https://web.archive.org/web/20170802060935/http://oss.sgi.com/projects/ogl-sample/registry/EXT/texture_compression_s3tc.txt
-
-The contents of this file are hereby released in the public domain (CC0)
-Full text of the CC0 license:
-  https://creativecommons.org/publicdomain/zero/1.0/
 """
 
 import struct

--- a/src/PIL/FtexImagePlugin.py
+++ b/src/PIL/FtexImagePlugin.py
@@ -2,10 +2,6 @@
 A Pillow loader for .ftc and .ftu files (FTEX)
 Jerome Leclanche <jerome@leclan.ch>
 
-The contents of this file are hereby released in the public domain (CC0)
-Full text of the CC0 license:
-  https://creativecommons.org/publicdomain/zero/1.0/
-
 Independence War 2: Edge Of Chaos - Texture File Format - 16 October 2001
 
 The textures used for 3D objects in Independence War 2: Edge Of Chaos are in a

--- a/src/libImaging/BcnDecode.c
+++ b/src/libImaging/BcnDecode.c
@@ -5,10 +5,6 @@
  *
  * Format documentation:
  *   https://web.archive.org/web/20170802060935/http://oss.sgi.com/projects/ogl-sample/registry/EXT/texture_compression_s3tc.txt
- *
- * The contents of this file are in the public domain (CC0)
- * Full text of the CC0 license:
- *   https://creativecommons.org/publicdomain/zero/1.0/
  */
 
 #include "Imaging.h"


### PR DESCRIPTION
One of the comments in https://github.com/python-pillow/Pillow/issues/4591#issuecomment-619537811 is
> Several files matching {docs/example,src/PIL}/*ImagePlugin.py and src/libImaging/BcnDecode.c are public domain/CC0.

While the original authors may have released their code into the public domain, we do modify these files over time. Removing these notices simplifies our licensing situation - IANAL, but there shouldn't be anything stopping us from effectively taking this public domain code and stamping it with our more restrictive license instead.