### PR TITLE
Documentation error: Wrong threshold in conversion from L to 1

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -878,7 +878,7 @@ class Image:
         The default method of converting a greyscale ("L") or "RGB"
         image into a bilevel (mode "1") image uses Floyd-Steinberg
         dither to approximate the original image luminosity levels. If
-        dither is :data:`NONE`, all values larger than 128 are set to 255 (white),
+        dither is :data:`NONE`, all values larger than 127 are set to 255 (white),
         all other values to 0 (black). To use other thresholds, use the
         :py:meth:`~PIL.Image.Image.point` method.
 


### PR DESCRIPTION
Fixes #5222

Changes proposed in this pull request:
 * Corrected documentation for conversion method: threshold is 127, not 128

See #5222 for more information
