### PR TITLE
Added tk version to pilinfo

### DIFF
--- a/docs/reference/features.rst
+++ b/docs/reference/features.rst
@@ -17,7 +17,7 @@ Modules
 Support for the following modules can be checked:
 
 * ``pil``: The Pillow core module, required for all functionality.
-* ``tkinter``: Tkinter support. Version number not available.
+* ``tkinter``: Tkinter support.
 * ``freetype2``: FreeType font support via :py:func:`PIL.ImageFont.truetype`.
 * ``littlecms2``: LittleCMS 2 support via :py:mod:`PIL.ImageCms`.
 * ``webp``: WebP image support.

--- a/src/PIL/_tkinter_finder.py
+++ b/src/PIL/_tkinter_finder.py
@@ -1,9 +1,12 @@
 """ Find compiled module linking to Tcl / Tk libraries
 """
 import sys
+import tkinter
 from tkinter import _tkinter as tk
 
 if hasattr(sys, "pypy_find_executable"):
     TKINTER_LIB = tk.tklib_cffi.__file__
 else:
     TKINTER_LIB = tk.__file__
+
+tk_version = str(tkinter.TkVersion)

--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -9,7 +9,7 @@ from . import Image
 
 modules = {
     "pil": ("PIL._imaging", "PILLOW_VERSION"),
-    "tkinter": ("PIL._tkinter_finder", None),
+    "tkinter": ("PIL._tkinter_finder", "tk_version"),
     "freetype2": ("PIL._imagingft", "freetype2_version"),
     "littlecms2": ("PIL._imagingcms", "littlecms_version"),
     "webp": ("PIL._webp", "webpdecoder_version"),


### PR DESCRIPTION
Changes pilinfo from
```
--- PIL CORE support ok, compiled for 8.1.0
--- TKINTER support ok
--- FREETYPE2 support ok, loaded 2.10.4
```
to
```
--- PIL CORE support ok, compiled for 8.2.0.dev0
--- TKINTER support ok, loaded 8.6
--- FREETYPE2 support ok, loaded 2.10.4
```