### PR TITLE
Install pytest and pytest-cov using pip rather than pacman

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -249,8 +249,6 @@ jobs:
               ${{ matrix.package }}-python3-olefile \
               ${{ matrix.package }}-python3-pip \
               ${{ matrix.package }}-python3-pyqt5 \
-              ${{ matrix.package }}-python3-pytest \
-              ${{ matrix.package }}-python3-pytest-cov \
               ${{ matrix.package }}-python3-setuptools \
               ${{ matrix.package }}-freetype \
               ${{ matrix.package }}-ghostscript \
@@ -263,7 +261,7 @@ jobs:
               ${{ matrix.package }}-openjpeg2 \
               subversion
 
-          python3 -m pip install pyroma
+          python3 -m pip install pyroma pytest pytest-cov
 
           pushd depends && ./install_extra_test_images.sh && popd
 


### PR DESCRIPTION
Fixes an error that has started appearing on MSYS jobs. Seen in #5230 (https://github.com/python-pillow/Pillow/pull/5230/checks?check_run_id=1779961003#step:6:32) and #5232, and will presumably be seen in master with the next merge.

```
Running selftest:
--- 58 tests passed.
Traceback (most recent call last):
  File "C:/msys64/mingw64/lib/python3.8/runpy.py", line 185, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "C:/msys64/mingw64/lib/python3.8/runpy.py", line 144, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "C:/msys64/mingw64/lib/python3.8/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "C:/msys64/mingw64/lib/python3.8/site-packages/pytest/__init__.py", line 5, in <module>
    from _pytest.assertion import register_assert_rewrite
  File "C:/msys64/mingw64/lib/python3.8/site-packages/_pytest/assertion/__init__.py", line 9, in <module>
    from _pytest.assertion import rewrite
  File "C:/msys64/mingw64/lib/python3.8/site-packages/_pytest/assertion/rewrite.py", line 33, in <module>
    from _pytest._version import version
ModuleNotFoundError: No module named '_pytest._version'
```