### PR TITLE
Moved test that requires libtiff

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -9,6 +9,7 @@ from ctypes import c_float
 import pytest
 
 from PIL import Image, ImageFilter, TiffImagePlugin, TiffTags, features
+from PIL.TiffImagePlugin import SUBIFD
 
 from .helper import (
     assert_image_equal,
@@ -323,6 +324,14 @@ class TestFileLibTiff(LibTiffTestCase):
                 }
             )
         TiffImagePlugin.WRITE_LIBTIFF = False
+
+    def test_subifd(self, tmp_path):
+        outfile = str(tmp_path / "temp.tif")
+        with Image.open("Tests/images/g4_orientation_6.tif") as im:
+            im.tag_v2[SUBIFD] = 10000
+
+            # Should not segfault
+            im.save(outfile)
 
     def test_xmlpacket_tag(self, tmp_path):
         TiffImagePlugin.WRITE_LIBTIFF = True

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -4,7 +4,7 @@ from io import BytesIO
 import pytest
 
 from PIL import Image, TiffImagePlugin
-from PIL.TiffImagePlugin import RESOLUTION_UNIT, SUBIFD, X_RESOLUTION, Y_RESOLUTION
+from PIL.TiffImagePlugin import RESOLUTION_UNIT, X_RESOLUTION, Y_RESOLUTION
 
 from .helper import (
     assert_image_equal,
@@ -160,14 +160,6 @@ class TestFileTiff:
                 with Image.open(outfile) as reloaded:
                     reloaded.load()
                     assert (round(dpi), round(dpi)) == reloaded.info["dpi"]
-
-    def test_subifd(self, tmp_path):
-        outfile = str(tmp_path / "temp.tif")
-        with Image.open("Tests/images/g4_orientation_6.tif") as im:
-            im.tag_v2[SUBIFD] = 10000
-
-            # Should not segfault
-            im.save(outfile)
 
     def test_save_setting_missing_resolution(self):
         b = BytesIO()


### PR DESCRIPTION
Helps #5229

[Removing libtiff from our GHA Windows jobs](https://github.com/radarhere/Pillow/commit/4ce30cd10e7cf6f89f79a46f7da60609dcae7870) causes [a failure from the TestFileTiff::test_subifd](https://github.com/radarhere/Pillow/runs/1782858485?check_suite_focus=true#step:26:664).

So this PR moves that test into test_file_libtiff, so that [it is skipped if libtiff is not available](https://github.com/python-pillow/Pillow/blob/d79c656fe75c5de2916b9889a726c33b11dab020/Tests/test_file_libtiff.py#L24) - [the change](https://github.com/radarhere/Pillow/commits/no_libtiff_with_fix) fixes the [failing test](https://github.com/radarhere/Pillow/actions/runs/517609733)