### PR TITLE
Corrected documentation syntax

### DIFF
--- a/docs/releasenotes/versioning.rst
+++ b/docs/releasenotes/versioning.rst
@@ -3,7 +3,7 @@
 Versioning
 ==========
 
-Pillow follows [Semantic Versioning](https://semver.org/):
+Pillow follows `Semantic Versioning <https://semver.org/>`_:
 
     Given a version number MAJOR.MINOR.PATCH, increment the:
 


### PR DESCRIPTION
At https://pillow.readthedocs.io/en/latest/releasenotes/versioning.html, you can see that the 'Semantic Versioning' link is not correctly formatted.

This PR fixes it.