### PR TITLE
Removed specific setuptools version from AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,7 @@ install:
         c:\pillow\winbuild\build\build_dep_all.cmd
         $host.SetShouldExit(0)
 - path C:\pillow\winbuild\build\bin;%PATH%
-- '%PYTHON%\%EXECUTABLE% -m pip install -U "setuptools>=49.3.2"'
+- '%PYTHON%\%EXECUTABLE% -m pip install -U setuptools'
 
 build_script:
 - ps: |


### PR DESCRIPTION
Tests now pass without it.

While the line was added in #5014, see #4784 for the story behind why that setuptools version is a necessary minimum.