### PR TITLE
Improved close() docstring

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -586,10 +586,10 @@ class Image:
         This operation will destroy the image core and release its memory.
         The image data will be unusable afterward.
 
-        This function is only required to close images that have not
-        had their file read and closed by the
-        :py:meth:`~PIL.Image.Image.load` method. See
-        :ref:`file-handling` for more information.
+        This function is required to close images that have multiple frames or
+        have not had their file read and closed by the
+        :py:meth:`~PIL.Image.Image.load` method. See :ref:`file-handling` for
+        more information.
         """
         try:
             if hasattr(self, "_close__fp"):


### PR DESCRIPTION
The current `close()` docstring mentions that `load()` closes images
https://github.com/python-pillow/Pillow/blob/b35cf8bddaddd7c77ec0f99baf2c5963c3671854/src/PIL/Image.py#L589-L592

However, https://pillow.readthedocs.io/en/stable/reference/open_files.html#proposed-file-handling mentions that this is not the case for images with multiple frames.
> - Image.Image.load() should close the image file, unless there are multiple frames.
...
> - Users of the library should use a context manager or call Image.Image.close() on any image opened with a filename or Path object to ensure that the underlying file is closed.

This PR updates the `close()` docstring to be mention that as well.