### PR TITLE
Enable libtiff Win32 I/O correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -729,7 +729,7 @@ class pil_build_ext(build_ext):
             defs.append(("HAVE_LIBTIFF", None))
             # FIXME the following define should be detected automatically
             #       based on system libtiff, see #4237
-            if PLATFORM_MINGW:
+            if sys.platform == "win32":
                 defs.append(("USE_WIN32_FILEIO", None))
         if feature.xcb:
             libs.append(feature.xcb)

--- a/winbuild/tiff.opt
+++ b/winbuild/tiff.opt
@@ -124,7 +124,7 @@ OPTFLAGS =	/Ox /MD /EHsc /W3 /D_CRT_SECURE_NO_DEPRECATE
 # instead of Windows specific system calls. See notes on top of tif_unix.c
 # module for details.
 #
-USE_WIN_CRT_LIB = 1
+#USE_WIN_CRT_LIB = 1
 
 # Compiler specific options. You may probably want to adjust compilation
 # parameters in CFLAGS variable. Refer to your compiler documentation


### PR DESCRIPTION
Fixes #4237 (for Pillow static builds and wheels)

NB: Requires all downstream projects to synchronize and rebuild.

Changes proposed in this pull request:

 * Default to USE_WIN32_FILEIO for internal NMake builds (now in sync w/ Cmake and autotools; [see upstream report comment](https://gitlab.com/libtiff/libtiff/-/issues/173#note_317865960))
 * Append USE_WIN32_FILEIO for all Windows builds, not just MinGW
