### PR TITLE
Fixed unclosed file warning

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -571,8 +571,8 @@ class TestFilePng:
         assert len(chunks) == 3
 
     def test_read_private_chunks(self):
-        im = Image.open("Tests/images/exif.png")
-        assert im.private_chunks == [(b"orNT", b"\x01")]
+        with Image.open("Tests/images/exif.png") as im:
+            assert im.private_chunks == [(b"orNT", b"\x01")]
 
     def test_roundtrip_private_chunk(self):
         # Check private chunk roundtripping


### PR DESCRIPTION
I noticed this at https://github.com/python-pillow/docker-images/pull/103/checks?check_run_id=1814049272#step:4:4966
> Tests/test_file_png.py::TestFilePng::test_read_private_chunks
>  /vpy3/lib/python3.8/site-packages/_pytest/python.py:183: ResourceWarning: unclosed file <_io.BufferedReader name='Tests/images/exif.png'>
>    result = testfunction(**testargs)