### PR TITLE
Changed Image.open formats parameter to be case-insensitive

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -94,7 +94,7 @@ class TestImage:
         with pytest.raises(TypeError):
             Image.open(PNGFILE, formats=123)
 
-        for formats in [["jPeG"], ("JpEg",)]:
+        for formats in [["JPEG"], ("JPEG",), ["jpeg"], ["Jpeg"], ["jPeG"], ["JpEg"]]:
             with pytest.raises(UnidentifiedImageError):
                 Image.open(PNGFILE, formats=formats)
 

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -94,7 +94,7 @@ class TestImage:
         with pytest.raises(TypeError):
             Image.open(PNGFILE, formats=123)
 
-        for formats in [["JPEG"], ("JPEG",)]:
+        for formats in [["jPeG"], ("JpEg",)]:
             with pytest.raises(UnidentifiedImageError):
                 Image.open(PNGFILE, formats=formats)
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2925,7 +2925,7 @@ def open(fp, mode="r", formats=None):
             if i not in OPEN:
                 init()
             try:
-                factory, accept = OPEN[i]
+                factory, accept = OPEN[i.upper()]
                 result = not accept or accept(prefix)
                 if type(result) in [str, bytes]:
                     accept_warnings.append(result)


### PR DESCRIPTION
Changes proposed in this pull request:
* Make `formats` parameter in `Image.open` accept aNy cAsE.

Before this commit
```python
Image.open("Tests/images/hopper.png", formats=['png'])
```
would fail, because the format is not upper case (`'PNG'`). This PR makes `'PNG'`, `'Png'`, `'pNG'` and all other variants equivalent in the `formats` list (or tuple).