### PR TITLE
Document Image.quantize "method" defaults

### DIFF
--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -479,6 +479,8 @@ Used to specify the pallete to use for the :meth:`~Image.convert` method.
 .. data:: WEB
 .. data:: ADAPTIVE
 
+.. _quantization-methods:
+
 Quantization methods
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -486,11 +488,11 @@ Used to specify the quantization method to use for the :meth:`~Image.quantize` m
 
 .. data:: MEDIANCUT
 
-    Median cut
+    Median cut. RGBA not supported.
 
 .. data:: MAXCOVERAGE
 
-    Maximum coverage
+    Maximum coverage. RGBA not supported.
 
 .. data:: FASTOCTREE
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1053,12 +1053,10 @@ class Image:
         of colors.
 
         :param colors: The desired number of colors, <= 256
-        :param method: :data:`MEDIANCUT` (median cut),
-                       :data:`MAXCOVERAGE` (maximum coverage),
-                       :data:`FASTOCTREE` (fast octree),
-                       :data:`LIBIMAGEQUANT` (libimagequant; check support using
-                       :py:func:`PIL.features.check_feature`
-                       with ``feature="libimagequant"``).
+        :param method: :data:`MEDIANCUT` (default),
+                       :data:`MAXCOVERAGE`,
+                       :data:`FASTOCTREE` (default for RGBA images),
+                       :data:`LIBIMAGEQUANT`.
         :param kmeans: Integer
         :param palette: Quantize to the palette of given
                         :py:class:`PIL.Image.Image`.

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1054,9 +1054,8 @@ class Image:
 
         :param colors: The desired number of colors, <= 256
         :param method: :data:`MEDIANCUT` (default),
-                       :data:`MAXCOVERAGE`,
-                       :data:`FASTOCTREE` (default for RGBA images),
-                       :data:`LIBIMAGEQUANT`.
+                       :data:`FASTOCTREE` (default for "RGBA" mode).
+                       See :ref:`quantization-methods` for all available methods.
         :param kmeans: Integer
         :param palette: Quantize to the palette of given
                         :py:class:`PIL.Image.Image`.


### PR DESCRIPTION
The method uses different defaults for different image modes.

Relates to issue #5217. Maybe enough to fix it, since I think it's just expected behavior that's not documented well enough.

And um, confusing use of the word "method" in the commit message. I mean the `method` parameter to the `Image.quantize` function.