### PR TITLE
Removed outdated limits documentation

### DIFF
--- a/docs/reference/limits.rst
+++ b/docs/reference/limits.rst
@@ -25,13 +25,6 @@ Internal Limits
   is smaller than 2GB, as calculated by ``y*stride`` (so 2Gpx for 'L'
   images, and .5Gpx for 'RGB'
 
-* Any call to internal python size functions for buffers or strings
-  are currently returned as int32, not py_ssize_t. This limits the
-  maximum buffer to 2GB for operations like frombytes and frombuffer.
-
-* This also limits the size of buffers converted using a
-  decoder. (decode.c:127)
-
 Format Size Limits
 ==================
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/master/docs/reference/limits.rst
> * Any call to internal python size functions for buffers or strings are currently returned as int32, not py_ssize_t. This limits the	maximum buffer to 2GB for operations like frombytes and frombuffer.	
>
> * This also limits the size of buffers converted using a decoder. (decode.c:127)

#3791 replaced `int`s with `py_ssize_t`, so this is no longer correct.

For clarity, 'decode.c:127' was https://github.com/python-pillow/Pillow/blob/937199e54556dae5882e3d2a65d804365a8cca67/decode.c#L127 at the time.