### PR TITLE
Updated ImageColor.getrgb docstring

### DIFF
--- a/src/PIL/ImageColor.py
+++ b/src/PIL/ImageColor.py
@@ -24,8 +24,8 @@ from . import Image
 
 def getrgb(color):
     """
-     Convert a color string to an RGB tuple. If the string cannot be parsed,
-     this function raises a :py:exc:`ValueError` exception.
+     Convert a color string to an RGB or RGBA tuple. If the string cannot be
+     parsed, this function raises a :py:exc:`ValueError` exception.
 
     .. versionadded:: 1.1.4
 


### PR DESCRIPTION
The `ImageColor.getrgb()` docstring states that it results in "an RGB tuple" - but later it mentions it might also return alpha values, and indeed, RGBA support was added in #309.

This PR updates it to "Convert a color string to an RGB or RGBA tuple."

https://github.com/python-pillow/Pillow/blob/f118a21d557c0446e4d0b7730105d0fd0f55f045/src/PIL/ImageColor.py#L25-L34