### PR TITLE
Fixed asserting that no warnings were raised

### DIFF
--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -20,7 +20,7 @@ def test_bad():
     either"""
     for f in get_files("b"):
 
-        def open(f):
+        with pytest.warns(None) as record:
             try:
                 with Image.open(f) as im:
                     im.load()
@@ -28,7 +28,7 @@ def test_bad():
                 pass
 
         # Assert that there is no unclosed file warning
-        pytest.warns(None, open, f)
+        assert len(record) == 0
 
 
 def test_questionable():

--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -28,7 +28,7 @@ def test_bad():
                 pass
 
         # Assert that there is no unclosed file warning
-        assert len(record) == 0
+        assert not record
 
 
 def test_questionable():

--- a/Tests/test_file_dcx.py
+++ b/Tests/test_file_dcx.py
@@ -31,20 +31,20 @@ def test_unclosed_file():
 
 
 def test_closed_file():
-    def open():
+    with pytest.warns(None) as record:
         im = Image.open(TEST_FILE)
         im.load()
         im.close()
 
-    pytest.warns(None, open)
+    assert len(record) == 0
 
 
 def test_context_manager():
-    def open():
+    with pytest.warns(None) as record:
         with Image.open(TEST_FILE) as im:
             im.load()
 
-    pytest.warns(None, open)
+    assert len(record) == 0
 
 
 def test_invalid_file():

--- a/Tests/test_file_dcx.py
+++ b/Tests/test_file_dcx.py
@@ -36,7 +36,7 @@ def test_closed_file():
         im.load()
         im.close()
 
-    assert len(record) == 0
+    assert not record
 
 
 def test_context_manager():
@@ -44,7 +44,7 @@ def test_context_manager():
         with Image.open(TEST_FILE) as im:
             im.load()
 
-    assert len(record) == 0
+    assert not record
 
 
 def test_invalid_file():

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -43,7 +43,7 @@ def test_closed_file():
         im.load()
         im.close()
 
-    assert len(record) == 0
+    assert not record
 
 
 def test_context_manager():
@@ -51,7 +51,7 @@ def test_context_manager():
         with Image.open(static_test_file) as im:
             im.load()
 
-    assert len(record) == 0
+    assert not record
 
 
 def test_tell():

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -38,20 +38,20 @@ def test_unclosed_file():
 
 
 def test_closed_file():
-    def open():
+    with pytest.warns(None) as record:
         im = Image.open(static_test_file)
         im.load()
         im.close()
 
-    pytest.warns(None, open)
+    assert len(record) == 0
 
 
 def test_context_manager():
-    def open():
+    with pytest.warns(None) as record:
         with Image.open(static_test_file) as im:
             im.load()
 
-    pytest.warns(None, open)
+    assert len(record) == 0
 
 
 def test_tell():

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -38,20 +38,20 @@ def test_unclosed_file():
 
 
 def test_closed_file():
-    def open():
+    with pytest.warns(None) as record:
         im = Image.open(TEST_GIF)
         im.load()
         im.close()
 
-    pytest.warns(None, open)
+    assert len(record) == 0
 
 
 def test_context_manager():
-    def open():
+    with pytest.warns(None) as record:
         with Image.open(TEST_GIF) as im:
             im.load()
 
-    pytest.warns(None, open)
+    assert len(record) == 0
 
 
 def test_invalid_file():

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -43,7 +43,7 @@ def test_closed_file():
         im.load()
         im.close()
 
-    assert len(record) == 0
+    assert not record
 
 
 def test_context_manager():
@@ -51,7 +51,7 @@ def test_context_manager():
         with Image.open(TEST_GIF) as im:
             im.load()
 
-    assert len(record) == 0
+    assert not record
 
 
 def test_invalid_file():

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -21,7 +21,7 @@ def test_sanity():
         # Assert that there is no unclosed file warning
         with pytest.warns(None) as record:
             im.load()
-        assert len(record) == 0
+        assert not record
 
         assert im.mode == "RGBA"
         assert im.size == (1024, 1024)

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -19,7 +19,9 @@ def test_sanity():
     with Image.open(TEST_FILE) as im:
 
         # Assert that there is no unclosed file warning
-        pytest.warns(None, im.load)
+        with pytest.warns(None) as record:
+            im.load()
+        assert len(record) == 0
 
         assert im.mode == "RGBA"
         assert im.size == (1024, 1024)

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -40,7 +40,7 @@ def test_closed_file():
         im.load()
         im.close()
 
-    assert len(record) == 0
+    assert not record
 
 
 def test_context_manager():
@@ -48,7 +48,7 @@ def test_context_manager():
         with Image.open(TEST_IM) as im:
             im.load()
 
-    assert len(record) == 0
+    assert not record
 
 
 def test_tell():

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -35,20 +35,20 @@ def test_unclosed_file():
 
 
 def test_closed_file():
-    def open():
+    with pytest.warns(None) as record:
         im = Image.open(TEST_IM)
         im.load()
         im.close()
 
-    pytest.warns(None, open)
+    assert len(record) == 0
 
 
 def test_context_manager():
-    def open():
+    with pytest.warns(None) as record:
         with Image.open(TEST_IM) as im:
             im.load()
 
-    pytest.warns(None, open)
+    assert len(record) == 0
 
 
 def test_tell():

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -733,7 +733,7 @@ class TestFileJpeg:
             out = str(tmp_path / "out.jpg")
             with pytest.warns(None) as record:
                 im.save(out, exif=exif)
-            assert len(record) == 0
+            assert not record
 
         with Image.open(out) as reloaded:
             assert reloaded.getexif()[282] == 180

--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -46,7 +46,7 @@ def test_closed_file():
         im.load()
         im.close()
 
-    assert len(record) == 0
+    assert not record
 
 
 def test_context_manager():
@@ -54,7 +54,7 @@ def test_context_manager():
         with Image.open(test_files[0]) as im:
             im.load()
 
-    assert len(record) == 0
+    assert not record
 
 
 def test_app():

--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -41,20 +41,20 @@ def test_unclosed_file():
 
 
 def test_closed_file():
-    def open():
+    with pytest.warns(None) as record:
         im = Image.open(test_files[0])
         im.load()
         im.close()
 
-    pytest.warns(None, open)
+    assert len(record) == 0
 
 
 def test_context_manager():
-    def open():
+    with pytest.warns(None) as record:
         with Image.open(test_files[0]) as im:
             im.load()
 
-    pytest.warns(None, open)
+    assert len(record) == 0
 
 
 def test_app():

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -326,7 +326,7 @@ class TestFilePng:
             # Assert that there is no unclosed file warning
             with pytest.warns(None) as record:
                 im.verify()
-            assert len(record) == 0
+            assert not record
 
         with Image.open(TEST_PNG_FILE) as im:
             im.load()

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -324,7 +324,9 @@ class TestFilePng:
 
         with Image.open(TEST_PNG_FILE) as im:
             # Assert that there is no unclosed file warning
-            pytest.warns(None, im.verify)
+            with pytest.warns(None) as record:
+                im.verify()
+            assert len(record) == 0
 
         with Image.open(TEST_PNG_FILE) as im:
             im.load()

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -34,7 +34,7 @@ def test_closed_file():
         im.load()
         im.close()
 
-    assert len(record) == 0
+    assert not record
 
 
 def test_context_manager():
@@ -42,7 +42,7 @@ def test_context_manager():
         with Image.open(test_file) as im:
             im.load()
 
-    assert len(record) == 0
+    assert not record
 
 
 def test_invalid_file():

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -29,20 +29,20 @@ def test_unclosed_file():
 
 
 def test_closed_file():
-    def open():
+    with pytest.warns(None) as record:
         im = Image.open(test_file)
         im.load()
         im.close()
 
-    pytest.warns(None, open)
+    assert len(record) == 0
 
 
 def test_context_manager():
-    def open():
+    with pytest.warns(None) as record:
         with Image.open(test_file) as im:
             im.load()
 
-    pytest.warns(None, open)
+    assert len(record) == 0
 
 
 def test_invalid_file():

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -33,7 +33,7 @@ def test_closed_file():
         im.load()
         im.close()
 
-    assert len(record) == 0
+    assert not record
 
 
 def test_context_manager():
@@ -41,7 +41,7 @@ def test_context_manager():
         with Image.open(TEST_FILE) as im:
             im.load()
 
-    assert len(record) == 0
+    assert not record
 
 
 def test_save(tmp_path):

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -28,20 +28,20 @@ def test_unclosed_file():
 
 
 def test_closed_file():
-    def open():
+    with pytest.warns(None) as record:
         im = Image.open(TEST_FILE)
         im.load()
         im.close()
 
-    pytest.warns(None, open)
+    assert len(record) == 0
 
 
 def test_context_manager():
-    def open():
+    with pytest.warns(None) as record:
         with Image.open(TEST_FILE) as im:
             im.load()
 
-    pytest.warns(None, open)
+    assert len(record) == 0
 
 
 def test_save(tmp_path):

--- a/Tests/test_file_tar.py
+++ b/Tests/test_file_tar.py
@@ -35,7 +35,7 @@ def test_close():
         tar = TarIO.TarIO(TEST_TAR_FILE, "hopper.jpg")
         tar.close()
 
-    assert len(record) == 0
+    assert not record
 
 
 def test_contextmanager():
@@ -43,4 +43,4 @@ def test_contextmanager():
         with TarIO.TarIO(TEST_TAR_FILE, "hopper.jpg"):
             pass
 
-    assert len(record) == 0
+    assert not record

--- a/Tests/test_file_tar.py
+++ b/Tests/test_file_tar.py
@@ -31,16 +31,16 @@ def test_unclosed_file():
 
 
 def test_close():
-    def open():
+    with pytest.warns(None) as record:
         tar = TarIO.TarIO(TEST_TAR_FILE, "hopper.jpg")
         tar.close()
 
-    pytest.warns(None, open)
+    assert len(record) == 0
 
 
 def test_contextmanager():
-    def open():
+    with pytest.warns(None) as record:
         with TarIO.TarIO(TEST_TAR_FILE, "hopper.jpg"):
             pass
 
-    pytest.warns(None, open)
+    assert len(record) == 0

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -59,19 +59,19 @@ class TestFileTiff:
         pytest.warns(ResourceWarning, open)
 
     def test_closed_file(self):
-        def open():
+        with pytest.warns(None) as record:
             im = Image.open("Tests/images/multipage.tiff")
             im.load()
             im.close()
 
-        pytest.warns(None, open)
+        assert len(record) == 0
 
     def test_context_manager(self):
-        def open():
+        with pytest.warns(None) as record:
             with Image.open("Tests/images/multipage.tiff") as im:
                 im.load()
 
-        pytest.warns(None, open)
+        assert len(record) == 0
 
     def test_mac_tiff(self):
         # Read RGBa images from macOS [@PIL136]

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -64,14 +64,14 @@ class TestFileTiff:
             im.load()
             im.close()
 
-        assert len(record) == 0
+        assert not record
 
     def test_context_manager(self):
         with pytest.warns(None) as record:
             with Image.open("Tests/images/multipage.tiff") as im:
                 im.load()
 
-        assert len(record) == 0
+        assert not record
 
     def test_mac_tiff(self):
         # Read RGBa images from macOS [@PIL136]

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -145,7 +145,9 @@ class TestFileWebp:
         file_path = "Tests/images/hopper.webp"
         with Image.open(file_path) as image:
             temp_file = str(tmp_path / "temp.webp")
-            pytest.warns(None, image.save, temp_file)
+            with pytest.warns(None) as record:
+                image.save(temp_file)
+            assert len(record) == 0
 
     def test_file_pointer_could_be_reused(self):
         file_path = "Tests/images/hopper.webp"

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -147,7 +147,7 @@ class TestFileWebp:
             temp_file = str(tmp_path / "temp.webp")
             with pytest.warns(None) as record:
                 image.save(temp_file)
-            assert len(record) == 0
+            assert not record
 
     def test_file_pointer_could_be_reused(self):
         file_path = "Tests/images/hopper.webp"

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -636,7 +636,9 @@ class TestImage:
 
         # Act/Assert
         with Image.open(test_file) as im:
-            pytest.warns(None, im.save, temp_file)
+            with pytest.warns(None) as record:
+                im.save(temp_file)
+            assert len(record) == 0
 
     def test_load_on_nonexclusive_multiframe(self):
         with open("Tests/images/frozenpond.mpo", "rb") as fp:

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -638,7 +638,7 @@ class TestImage:
         with Image.open(test_file) as im:
             with pytest.warns(None) as record:
                 im.save(temp_file)
-            assert len(record) == 0
+            assert not record
 
     def test_load_on_nonexclusive_multiframe(self):
         with open("Tests/images/frozenpond.mpo", "rb") as fp:

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -236,4 +236,4 @@ def test_no_resource_warning_for_numpy_array():
         # Act/Assert
         with pytest.warns(None) as record:
             array(im)
-        assert len(record) == 0
+        assert not record

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -234,4 +234,6 @@ def test_no_resource_warning_for_numpy_array():
     with Image.open(test_file) as im:
 
         # Act/Assert
-        pytest.warns(None, lambda: array(im))
+        with pytest.warns(None) as record:
+            array(im)
+        assert len(record) == 0


### PR DESCRIPTION
The following test is intended to check that no warnings are raised when opening and closing an image.
https://github.com/python-pillow/Pillow/blob/cc4ed21f191760fbf36417d79eca3ed3555245ea/Tests/test_file_fli.py#L40-L46

If I [change it like so](https://github.com/radarhere/Pillow/commit/418069e0ecce94c29c0e5cd5d2195d45e2b11d68)
```python
def test_closed_file():
    def open():
        Image.open(static_test_file)

    pytest.warns(ResourceWarning, open)
```
It [passes (except in PyPy).](https://github.com/radarhere/Pillow/actions/runs/554673724) So we know that a ResourceWarning is raised by my modification.

But if I [change it back to assert that there are no warnings,](https://github.com/radarhere/Pillow/commit/e7ebc16499d32e4bf0774b8cca968a68beac9013)
```python
def test_closed_file():
    def open():
        Image.open(static_test_file)

    pytest.warns(None, open)
```
It [still passes.](https://github.com/radarhere/Pillow/actions/runs/554674612)

This is because we are not using pytest correctly.

https://docs.pytest.org/en/stable/warnings.html
> To record with func:pytest.warns without asserting anything about the warnings, pass None as the expected warning type:
>
> ```python
> with pytest.warns(None) as record:
>    warnings.warn("user", UserWarning)
>    warnings.warn("runtime", RuntimeWarning)
> 
> assert len(record) == 2
> ```

This PR corrects our usage in various tests.