### PR TITLE
Ensure file is closed if it is opened by ImageQt.ImageQt

### DIFF
--- a/Tests/test_imageqt.py
+++ b/Tests/test_imageqt.py
@@ -4,11 +4,14 @@ from PIL import ImageQt
 
 from .helper import hopper
 
+pytestmark = pytest.mark.skipif(
+    not ImageQt.qt_is_installed, reason="Qt bindings are not installed"
+)
+
 if ImageQt.qt_is_installed:
     from PIL.ImageQt import qRgba
 
 
-@pytest.mark.skipif(not ImageQt.qt_is_installed, reason="Qt bindings are not installed")
 def test_rgb():
     # from https://doc.qt.io/archives/qt-4.8/qcolor.html
     # typedef QRgb
@@ -38,7 +41,13 @@ def test_rgb():
     checkrgb(0, 0, 255)
 
 
-@pytest.mark.skipif(not ImageQt.qt_is_installed, reason="Qt bindings are not installed")
 def test_image():
     for mode in ("1", "RGB", "RGBA", "L", "P"):
         ImageQt.ImageQt(hopper(mode))
+
+
+def test_closed_file():
+    with pytest.warns(None) as record:
+        ImageQt.ImageQt("Tests/images/hopper.gif")
+
+    assert not record


### PR DESCRIPTION
If the `ImageQt.ImageQt` class is passed a path, it opens the file - but it doesn't close it with `close()` or a context manager. This PR fixes that, closing `im` within `_toqclass_helper`.

`_toqclass_helper` previously returned `im`, but only for so that `ImageQt.ImageQt` could extract the size from it. So I've changed that to just return the size directly, and keep `im` within `_toqclass_helper`. This should be fine in terms of backwards compatibility, as the method is indicated to be for private use by the leading `_`.