### PR TITLE
Moved RGB fix inside ImageQt class

### DIFF
--- a/Tests/test_qt_image_qapplication.py
+++ b/Tests/test_qt_image_qapplication.py
@@ -2,18 +2,26 @@ import pytest
 
 from PIL import ImageQt
 
-from .helper import assert_image_equal, hopper
+from .helper import assert_image_equal, assert_image_equal_tofile, hopper
 
 if ImageQt.qt_is_installed:
     from PIL.ImageQt import QPixmap
 
     if ImageQt.qt_version == "6":
+        from PyQt6.QtCore import QPoint
+        from PyQt6.QtGui import QImage, QPainter, QRegion
         from PyQt6.QtWidgets import QApplication, QHBoxLayout, QLabel, QWidget
     elif ImageQt.qt_version == "side6":
+        from PySide6.QtCore import QPoint
+        from PySide6.QtGui import QImage, QPainter, QRegion
         from PySide6.QtWidgets import QApplication, QHBoxLayout, QLabel, QWidget
     elif ImageQt.qt_version == "5":
+        from PyQt5.QtCore import QPoint
+        from PyQt5.QtGui import QImage, QPainter, QRegion
         from PyQt5.QtWidgets import QApplication, QHBoxLayout, QLabel, QWidget
     elif ImageQt.qt_version == "side2":
+        from PySide2.QtCore import QPoint
+        from PySide2.QtGui import QImage, QPainter, QRegion
         from PySide2.QtWidgets import QApplication, QHBoxLayout, QLabel, QWidget
 
     class Example(QWidget):
@@ -49,7 +57,8 @@ def test_sanity(tmp_path):
 
     for mode in ("1", "RGB", "RGBA", "L", "P"):
         # to QPixmap
-        data = ImageQt.toqpixmap(hopper(mode))
+        im = hopper(mode)
+        data = ImageQt.toqpixmap(im)
 
         assert isinstance(data, QPixmap)
         assert not data.isNull()
@@ -57,6 +66,20 @@ def test_sanity(tmp_path):
         # Test saving the file
         tempfile = str(tmp_path / f"temp_{mode}.png")
         data.save(tempfile)
+
+        # Render the image
+        qimage = ImageQt.ImageQt(im)
+        data = QPixmap.fromImage(qimage)
+        qt_format = QImage.Format if ImageQt.qt_version == "6" else QImage
+        qimage = QImage(128, 128, qt_format.Format_ARGB32)
+        painter = QPainter(qimage)
+        image_label = QLabel()
+        image_label.setPixmap(data)
+        image_label.render(painter, QPoint(0, 0), QRegion(0, 0, 128, 128))
+        painter.end()
+        rendered_tempfile = str(tmp_path / f"temp_rendered_{mode}.png")
+        qimage.save(rendered_tempfile)
+        assert_image_equal_tofile(im.convert("RGBA"), rendered_tempfile)
 
         # from QPixmap
         roundtrip(hopper(mode))

--- a/src/PIL/ImageQt.py
+++ b/src/PIL/ImageQt.py
@@ -153,7 +153,10 @@ def _toqclass_helper(im):
         for i in range(0, len(palette), 3):
             colortable.append(rgb(*palette[i : i + 3]))
     elif im.mode == "RGB":
-        data = im.tobytes("raw", "BGRX")
+        # Populate the 4th channel with 255
+        im = im.convert("RGBA")
+
+        data = im.tobytes("raw", "BGRA")
         format = qt_format.Format_RGB32
     elif im.mode == "RGBA":
         data = im.tobytes("raw", "BGRA")
@@ -206,9 +209,5 @@ def toqpixmap(im):
     # im_data = _toqclass_helper(im)
     # result = QPixmap(im_data["size"][0], im_data["size"][1])
     # result.loadFromData(im_data["data"])
-    # Fix some strange bug that causes
-    if im.mode == "RGB":
-        im = im.convert("RGBA")
-
     qimage = toqimage(im)
     return QPixmap.fromImage(qimage)


### PR DESCRIPTION
Resolves #5266. A workaround suggested in that issue is to change the user code. This PR causes the original code mentioned there to work.

https://github.com/python-pillow/Pillow/blob/fdd8b68b83fd1afdbbe5d0a0460ac1413299dcc5/src/PIL/ImageQt.py#L203-L205

This 'strange bug' is because at https://doc.qt.io/qt-5/qimage.html
> QImage::Format_RGB32... is stored using a 32-bit RGB format (0xffRRGGBB).

QImage is expecting the 4th channel to be populated with 0xff (255). Calling `convert("RGBA")` in Pillow does this.

https://github.com/python-pillow/Pillow/blob/fdd8b68b83fd1afdbbe5d0a0460ac1413299dcc5/src/libImaging/Convert.c#L421-L431

Without 255 values, as seen in the issue, the display in Qt is very washed out.

This PR just documents the fix slightly better, and moves it from `toqpixmap()` to `_toqclass_helper()`, so that it is also run when calling the `ImageQt.ImageQt` class (`toqixmap()` still works, since `toqpixmap()` calls `toqimage()`, which returns an instance of the `ImageQt.ImageQt` class).