### PR TITLE
Improved ImageQt documentation

### DIFF
--- a/docs/reference/ImageQt.rst
+++ b/docs/reference/ImageQt.rst
@@ -4,8 +4,8 @@
 :py:mod:`~PIL.ImageQt` Module
 =============================
 
-The :py:mod:`~PIL.ImageQt` module contains support for creating PyQt5 or PySide2 QImage
-objects from PIL images.
+The :py:mod:`~PIL.ImageQt` module contains support for creating PyQt6, PySide6, PyQt5
+or PySide2 QImage objects from PIL images.
 
 .. versionadded:: 1.1.6
 
@@ -14,7 +14,7 @@ objects from PIL images.
     Creates an :py:class:`~PIL.ImageQt.ImageQt` object from a PIL
     :py:class:`~PIL.Image.Image` object. This class is a subclass of
     QtGui.QImage, which means that you can pass the resulting objects directly
-    to PyQt5/PySide2 API functions and methods.
+    to PyQt6/PySide6/PyQt5/PySide2 API functions and methods.
 
     This operation is currently supported for mode 1, L, P, RGB, and RGBA
     images. To handle other modes, you need to convert the image first.

--- a/src/PIL/ImageQt.py
+++ b/src/PIL/ImageQt.py
@@ -63,8 +63,7 @@ def rgb(r, g, b, a=255):
 
 def fromqimage(im):
     """
-    :param im: A PIL Image object, or a file name
-    (given either as Python string or a PyQt string object)
+    :param im: QImage or PIL ImageQt object
     """
     buffer = QBuffer()
     qt_openmode = QIODevice.OpenMode if qt_version == "6" else QIODevice


### PR DESCRIPTION
- Added PyQt6 and PySide6 to list of modules
- Corrected `ImageQt.fromqimage()` docstring. It currently states that it takes "A PIL Image object, or a file name", but then calls `hasAlphaChannel()`.
https://github.com/python-pillow/Pillow/blob/fdd8b68b83fd1afdbbe5d0a0460ac1413299dcc5/src/PIL/ImageQt.py#L74
This is a `QImage` method - https://doc.qt.io/qt-5/qimage.html#hasAlphaChannel - not a PIL method or something that you can call on a file name. So this PR updates the docstring to state that it takes a `QImage` or `ImageQt.ImageQt` object (a subclass of `QImage`).