### PR TITLE
Fixed linear_gradient and radial_gradient I and F modes

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -519,7 +519,7 @@ class TestImage:
 
         # Arrange
         target_file = "Tests/images/linear_gradient.png"
-        for mode in ["L", "P"]:
+        for mode in ["L", "P", "I", "F"]:
 
             # Act
             im = Image.linear_gradient(mode)
@@ -545,7 +545,7 @@ class TestImage:
 
         # Arrange
         target_file = "Tests/images/radial_gradient.png"
-        for mode in ["L", "P"]:
+        for mode in ["L", "P", "I", "F"]:
 
             # Act
             im = Image.radial_gradient(mode)

--- a/src/libImaging/Fill.c
+++ b/src/libImaging/Fill.c
@@ -76,8 +76,21 @@ ImagingFillLinearGradient(const char *mode) {
         return NULL;
     }
 
-    for (y = 0; y < 256; y++) {
-        memset(im->image8[y], (unsigned char)y, 256);
+    if (im->image8) {
+        for (y = 0; y < 256; y++) {
+            memset(im->image8[y], (unsigned char)y, 256);
+        }
+    } else {
+        int x;
+        for (y = 0; y < 256; y++) {
+            for (x = 0; x < 256; x++) {
+                if (im->type == IMAGING_TYPE_FLOAT32) {
+                    IMAGING_PIXEL_FLOAT32(im, x, y) = y;
+                } else {
+                    IMAGING_PIXEL_INT32(im, x, y) = y;
+                }
+            }
+        }
     }
 
     return im;
@@ -103,9 +116,16 @@ ImagingFillRadialGradient(const char *mode) {
             d = (int)sqrt(
                 (double)((x - 128) * (x - 128) + (y - 128) * (y - 128)) * 2.0);
             if (d >= 255) {
-                im->image8[y][x] = 255;
-            } else {
+                d = 255;
+            }
+            if (im->image8) {
                 im->image8[y][x] = d;
+            } else {
+                if (im->type == IMAGING_TYPE_FLOAT32) {
+                    IMAGING_PIXEL_FLOAT32(im, x, y) = d;
+                } else {
+                    IMAGING_PIXEL_INT32(im, x, y) = d;
+                }
             }
         }
     }


### PR DESCRIPTION
Resolves #5272

`Image.linear_gradient("I")`, `Image.linear_gradient("F")`, `Image.radial_gradient("I")` and `Image.radial_gradient("F")` all currently segfault. This fixes them.