### PR TITLE
Increased use of _tofile helper functions

### DIFF
--- a/Tests/test_file_blp.py
+++ b/Tests/test_file_blp.py
@@ -1,21 +1,18 @@
 from PIL import Image
 
-from .helper import assert_image_equal
+from .helper import assert_image_equal_tofile
 
 
 def test_load_blp2_raw():
     with Image.open("Tests/images/blp/blp2_raw.blp") as im:
-        with Image.open("Tests/images/blp/blp2_raw.png") as target:
-            assert_image_equal(im, target)
+        assert_image_equal_tofile(im, "Tests/images/blp/blp2_raw.png")
 
 
 def test_load_blp2_dxt1():
     with Image.open("Tests/images/blp/blp2_dxt1.blp") as im:
-        with Image.open("Tests/images/blp/blp2_dxt1.png") as target:
-            assert_image_equal(im, target)
+        assert_image_equal_tofile(im, "Tests/images/blp/blp2_dxt1.png")
 
 
 def test_load_blp2_dxt1a():
     with Image.open("Tests/images/blp/blp2_dxt1a.blp") as im:
-        with Image.open("Tests/images/blp/blp2_dxt1a.png") as target:
-            assert_image_equal(im, target)
+        assert_image_equal_tofile(im, "Tests/images/blp/blp2_dxt1a.png")

--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -4,7 +4,7 @@ import pytest
 
 from PIL import BmpImagePlugin, Image
 
-from .helper import assert_image_equal, hopper
+from .helper import assert_image_equal, assert_image_equal_tofile, hopper
 
 
 def test_sanity(tmp_path):
@@ -111,8 +111,7 @@ def test_load_dib():
         assert im.format == "DIB"
         assert im.get_format_mimetype() == "image/bmp"
 
-        with Image.open("Tests/images/clipboard_target.png") as target:
-            assert_image_equal(im, target)
+        assert_image_equal_tofile(im, "Tests/images/clipboard_target.png")
 
 
 def test_save_dib(tmp_path):
@@ -136,5 +135,4 @@ def test_rgba_bitfields():
         b, g, r = im.split()[1:]
         im = Image.merge("RGB", (r, g, b))
 
-    with Image.open("Tests/images/bmp/q/rgb32bf-xbgr.bmp") as target:
-        assert_image_equal(im, target)
+    assert_image_equal_tofile(im, "Tests/images/bmp/q/rgb32bf-xbgr.bmp")

--- a/Tests/test_file_dds.py
+++ b/Tests/test_file_dds.py
@@ -5,7 +5,7 @@ import pytest
 
 from PIL import DdsImagePlugin, Image
 
-from .helper import assert_image_equal
+from .helper import assert_image_equal, assert_image_equal_tofile
 
 TEST_FILE_DXT1 = "Tests/images/dxt1-rgb-4bbp-noalpha_MipMaps-1.dds"
 TEST_FILE_DXT3 = "Tests/images/dxt3-argb-8bbp-explicitalpha_MipMaps-1.dds"
@@ -41,22 +41,20 @@ def test_sanity_dxt5():
     assert im.mode == "RGBA"
     assert im.size == (256, 256)
 
-    with Image.open(TEST_FILE_DXT5.replace(".dds", ".png")) as target:
-        assert_image_equal(target, im)
+    assert_image_equal_tofile(im, TEST_FILE_DXT5.replace(".dds", ".png"))
 
 
 def test_sanity_dxt3():
     """Check DXT3 images can be opened"""
 
-    with Image.open(TEST_FILE_DXT3.replace(".dds", ".png")) as target:
-        with Image.open(TEST_FILE_DXT3) as im:
-            im.load()
+    with Image.open(TEST_FILE_DXT3) as im:
+        im.load()
 
-            assert im.format == "DDS"
-            assert im.mode == "RGBA"
-            assert im.size == (256, 256)
+        assert im.format == "DDS"
+        assert im.mode == "RGBA"
+        assert im.size == (256, 256)
 
-            assert_image_equal(target, im)
+        assert_image_equal_tofile(im, TEST_FILE_DXT3.replace(".dds", ".png"))
 
 
 def test_dx10_bc7():
@@ -69,8 +67,7 @@ def test_dx10_bc7():
         assert im.mode == "RGBA"
         assert im.size == (256, 256)
 
-        with Image.open(TEST_FILE_DX10_BC7.replace(".dds", ".png")) as target:
-            assert_image_equal(target, im)
+        assert_image_equal_tofile(im, TEST_FILE_DX10_BC7.replace(".dds", ".png"))
 
 
 def test_dx10_bc7_unorm_srgb():
@@ -84,10 +81,9 @@ def test_dx10_bc7_unorm_srgb():
         assert im.size == (16, 16)
         assert im.info["gamma"] == 1 / 2.2
 
-        with Image.open(
-            TEST_FILE_DX10_BC7_UNORM_SRGB.replace(".dds", ".png")
-        ) as target:
-            assert_image_equal(target, im)
+        assert_image_equal_tofile(
+            im, TEST_FILE_DX10_BC7_UNORM_SRGB.replace(".dds", ".png")
+        )
 
 
 def test_dx10_r8g8b8a8():
@@ -100,8 +96,7 @@ def test_dx10_r8g8b8a8():
         assert im.mode == "RGBA"
         assert im.size == (256, 256)
 
-        with Image.open(TEST_FILE_DX10_R8G8B8A8.replace(".dds", ".png")) as target:
-            assert_image_equal(target, im)
+        assert_image_equal_tofile(im, TEST_FILE_DX10_R8G8B8A8.replace(".dds", ".png"))
 
 
 def test_dx10_r8g8b8a8_unorm_srgb():
@@ -115,10 +110,9 @@ def test_dx10_r8g8b8a8_unorm_srgb():
         assert im.size == (16, 16)
         assert im.info["gamma"] == 1 / 2.2
 
-        with Image.open(
-            TEST_FILE_DX10_R8G8B8A8_UNORM_SRGB.replace(".dds", ".png")
-        ) as target:
-            assert_image_equal(target, im)
+        assert_image_equal_tofile(
+            im, TEST_FILE_DX10_R8G8B8A8_UNORM_SRGB.replace(".dds", ".png")
+        )
 
 
 def test_unimplemented_dxgi_format():
@@ -137,8 +131,9 @@ def test_uncompressed_rgb():
         assert im.mode == "RGBA"
         assert im.size == (800, 600)
 
-        with Image.open(TEST_FILE_UNCOMPRESSED_RGB.replace(".dds", ".png")) as target:
-            assert_image_equal(target, im)
+        assert_image_equal_tofile(
+            im, TEST_FILE_UNCOMPRESSED_RGB.replace(".dds", ".png")
+        )
 
 
 def test__validate_true():

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -4,7 +4,12 @@ import pytest
 
 from PIL import EpsImagePlugin, Image, features
 
-from .helper import assert_image_similar, hopper, skip_unless_feature
+from .helper import (
+    assert_image_similar,
+    assert_image_similar_tofile,
+    hopper,
+    skip_unless_feature,
+)
 
 HAS_GHOSTSCRIPT = EpsImagePlugin.has_ghostscript()
 
@@ -72,8 +77,9 @@ def test_cmyk():
         assert cmyk_image.mode == "RGB"
 
         if features.check("jpg"):
-            with Image.open("Tests/images/pil_sample_rgb.jpg") as target:
-                assert_image_similar(cmyk_image, target, 10)
+            assert_image_similar_tofile(
+                cmyk_image, "Tests/images/pil_sample_rgb.jpg", 10
+            )
 
 
 @pytest.mark.skipif(not HAS_GHOSTSCRIPT, reason="Ghostscript not available")

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -2,7 +2,7 @@ import pytest
 
 from PIL import FliImagePlugin, Image
 
-from .helper import assert_image_equal, is_pypy
+from .helper import assert_image_equal_tofile, is_pypy
 
 # created as an export of a palette image from Gimp2.6
 # save as...-> hopper.fli, default options.
@@ -122,5 +122,4 @@ def test_seek():
     with Image.open(animated_test_file) as im:
         im.seek(50)
 
-        with Image.open("Tests/images/a_fli.png") as expected:
-            assert_image_equal(im, expected)
+        assert_image_equal_tofile(im, "Tests/images/a_fli.png")

--- a/Tests/test_file_ftex.py
+++ b/Tests/test_file_ftex.py
@@ -1,12 +1,11 @@
 from PIL import Image
 
-from .helper import assert_image_equal, assert_image_similar
+from .helper import assert_image_equal_tofile, assert_image_similar
 
 
 def test_load_raw():
     with Image.open("Tests/images/ftex_uncompressed.ftu") as im:
-        with Image.open("Tests/images/ftex_uncompressed.png") as target:
-            assert_image_equal(im, target)
+        assert_image_equal_tofile(im, "Tests/images/ftex_uncompressed.png")
 
 
 def test_load_dxt1():

--- a/Tests/test_file_gbr.py
+++ b/Tests/test_file_gbr.py
@@ -2,7 +2,7 @@ import pytest
 
 from PIL import GbrImagePlugin, Image
 
-from .helper import assert_image_equal
+from .helper import assert_image_equal_tofile
 
 
 def test_invalid_file():
@@ -14,13 +14,11 @@ def test_invalid_file():
 
 def test_gbr_file():
     with Image.open("Tests/images/gbr.gbr") as im:
-        with Image.open("Tests/images/gbr.png") as target:
-            assert_image_equal(target, im)
+        assert_image_equal_tofile(im, "Tests/images/gbr.png")
 
 
 def test_multiple_load_operations():
     with Image.open("Tests/images/gbr.gbr") as im:
         im.load()
         im.load()
-        with Image.open("Tests/images/gbr.png") as target:
-            assert_image_equal(target, im)
+        assert_image_equal_tofile(im, "Tests/images/gbr.png")

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -6,6 +6,7 @@ from PIL import GifImagePlugin, Image, ImageDraw, ImagePalette, features
 
 from .helper import (
     assert_image_equal,
+    assert_image_equal_tofile,
     assert_image_similar,
     hopper,
     is_pypy,
@@ -317,8 +318,7 @@ def test_dispose_none_load_end():
     with Image.open("Tests/images/dispose_none_load_end.gif") as img:
         img.seek(1)
 
-        with Image.open("Tests/images/dispose_none_load_end_second.gif") as expected:
-            assert_image_equal(img, expected)
+        assert_image_equal_tofile(img, "Tests/images/dispose_none_load_end_second.gif")
 
 
 def test_dispose_background():
@@ -629,8 +629,7 @@ def test_comment_over_255(tmp_path):
 
 def test_zero_comment_subblocks():
     with Image.open("Tests/images/hopper_zero_comment_subblocks.gif") as im:
-        with Image.open(TEST_GIF) as expected:
-            assert_image_equal(im, expected)
+        assert_image_equal_tofile(im, TEST_GIF)
 
 
 def test_version(tmp_path):

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -5,7 +5,7 @@ import pytest
 
 from PIL import IcnsImagePlugin, Image, features
 
-from .helper import assert_image_equal, assert_image_similar
+from .helper import assert_image_equal, assert_image_similar_tofile
 
 # sample icon file
 TEST_FILE = "Tests/images/pillow.icns"
@@ -49,8 +49,7 @@ def test_save_append_images(tmp_path):
     with Image.open(TEST_FILE) as im:
         im.save(temp_file, append_images=[provided_im])
 
-        with Image.open(temp_file) as reread:
-            assert_image_similar(reread, im, 1)
+        assert_image_similar_tofile(im, temp_file, 1)
 
         with Image.open(temp_file) as reread:
             reread.size = (16, 16, 2)

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -4,7 +4,7 @@ import pytest
 
 from PIL import IcoImagePlugin, Image, ImageDraw
 
-from .helper import assert_image_equal, hopper
+from .helper import assert_image_equal, assert_image_equal_tofile, hopper
 
 TEST_ICO_FILE = "Tests/images/hopper.ico"
 
@@ -120,5 +120,4 @@ def test_draw_reloaded(tmp_path):
 
     with Image.open(outfile) as im:
         im.save("Tests/images/hopper_draw.ico")
-        with Image.open("Tests/images/hopper_draw.ico") as reloaded:
-            assert_image_equal(im, reloaded)
+        assert_image_equal_tofile(im, "Tests/images/hopper_draw.ico")

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -4,7 +4,7 @@ import pytest
 
 from PIL import Image, ImImagePlugin
 
-from .helper import assert_image_equal, hopper, is_pypy
+from .helper import assert_image_equal_tofile, hopper, is_pypy
 
 # sample im
 TEST_IM = "Tests/images/hopper.im"
@@ -86,8 +86,7 @@ def test_roundtrip(tmp_path):
         out = str(tmp_path / "temp.im")
         im = hopper(mode)
         im.save(out)
-        with Image.open(out) as reread:
-            assert_image_equal(reread, im)
+        assert_image_equal_tofile(im, out)
 
     for mode in ["RGB", "P", "PA"]:
         roundtrip(mode)

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -17,6 +17,7 @@ from PIL import (
 from .helper import (
     assert_image,
     assert_image_equal,
+    assert_image_equal_tofile,
     assert_image_similar,
     cjpeg_available,
     djpeg_available,
@@ -767,8 +768,7 @@ class TestFileJpeg:
 
             # Test that the image can still load, even with broken Photoshop data
             # This image had the APP13 length hexedited to be smaller
-            with Image.open("Tests/images/photoshop-200dpi-broken.jpg") as im_broken:
-                assert_image_equal(im_broken, im)
+            assert_image_equal_tofile(im, "Tests/images/photoshop-200dpi-broken.jpg")
 
         # This image does not contain a Photoshop header string
         with Image.open("Tests/images/app13.jpg") as im:

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -19,6 +19,7 @@ from .helper import (
     assert_image_equal,
     assert_image_equal_tofile,
     assert_image_similar,
+    assert_image_similar_tofile,
     cjpeg_available,
     djpeg_available,
     hopper,
@@ -578,7 +579,7 @@ class TestFileJpeg:
     def test_load_djpeg(self):
         with Image.open(TEST_FILE) as img:
             img.load_djpeg()
-            assert_image_similar(img, Image.open(TEST_FILE), 5)
+            assert_image_similar_tofile(img, TEST_FILE, 5)
 
     @pytest.mark.skipif(not cjpeg_available(), reason="cjpeg not available")
     def test_save_cjpeg(self, tmp_path):
@@ -586,7 +587,7 @@ class TestFileJpeg:
             tempfile = str(tmp_path / "temp.jpg")
             JpegImagePlugin._save_cjpeg(img, 0, tempfile)
             # Default save quality is 75%, so a tiny bit of difference is alright
-            assert_image_similar(img, Image.open(tempfile), 17)
+            assert_image_similar_tofile(img, tempfile, 17)
 
     def test_no_duplicate_0x1001_tag(self):
         # Arrange

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -8,6 +8,7 @@ from PIL import Image, ImageFile, Jpeg2KImagePlugin, features
 from .helper import (
     assert_image_equal,
     assert_image_similar,
+    assert_image_similar_tofile,
     is_big_endian,
     skip_unless_feature,
 )
@@ -62,9 +63,7 @@ def test_invalid_file():
 def test_bytesio():
     with open("Tests/images/test-card-lossless.jp2", "rb") as f:
         data = BytesIO(f.read())
-    with Image.open(data) as im:
-        im.load()
-        assert_image_similar(im, test_card, 1.0e-3)
+    assert_image_similar_tofile(test_card, data, 1.0e-3)
 
 
 # These two test pre-written JPEG 2000 files that were not written with
@@ -80,9 +79,9 @@ def test_lossless(tmp_path):
 
 
 def test_lossy_tiled():
-    with Image.open("Tests/images/test-card-lossy-tiled.jp2") as im:
-        im.load()
-        assert_image_similar(im, test_card, 2.0)
+    assert_image_similar_tofile(
+        test_card, "Tests/images/test-card-lossy-tiled.jp2", 2.0
+    )
 
 
 def test_lossless_rt():
@@ -193,15 +192,13 @@ def test_16bit_monochrome_has_correct_mode():
 @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
 def test_16bit_monochrome_jp2_like_tiff():
     with Image.open("Tests/images/16bit.cropped.tif") as tiff_16bit:
-        with Image.open("Tests/images/16bit.cropped.jp2") as jp2:
-            assert_image_similar(jp2, tiff_16bit, 1e-3)
+        assert_image_similar_tofile(tiff_16bit, "Tests/images/16bit.cropped.jp2", 1e-3)
 
 
 @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
 def test_16bit_monochrome_j2k_like_tiff():
     with Image.open("Tests/images/16bit.cropped.tif") as tiff_16bit:
-        with Image.open("Tests/images/16bit.cropped.j2k") as j2k:
-            assert_image_similar(j2k, tiff_16bit, 1e-3)
+        assert_image_similar_tofile(tiff_16bit, "Tests/images/16bit.cropped.j2k", 1e-3)
 
 
 def test_16bit_j2k_roundtrips():

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -99,15 +99,13 @@ class TestFileLibTiff(LibTiffTestCase):
     def test_g4_eq_png(self):
         """ Checking that we're actually getting the data that we expect"""
         with Image.open("Tests/images/hopper_bw_500.png") as png:
-            with Image.open("Tests/images/hopper_g4_500.tif") as g4:
-                assert_image_equal(g4, png)
+            assert_image_equal_tofile(png, "Tests/images/hopper_g4_500.tif")
 
     # see https://github.com/python-pillow/Pillow/issues/279
     def test_g4_fillorder_eq_png(self):
         """ Checking that we're actually getting the data that we expect"""
-        with Image.open("Tests/images/g4-fillorder-test.png") as png:
-            with Image.open("Tests/images/g4-fillorder-test.tif") as g4:
-                assert_image_equal(g4, png)
+        with Image.open("Tests/images/g4-fillorder-test.tif") as g4:
+            assert_image_equal_tofile(g4, "Tests/images/g4-fillorder-test.png")
 
     def test_g4_write(self, tmp_path):
         """Checking to see that the saved image is the same as what we wrote"""
@@ -437,10 +435,7 @@ class TestFileLibTiff(LibTiffTestCase):
         im = im.filter(ImageFilter.GaussianBlur(4))
         im.save(out, compression="tiff_adobe_deflate")
 
-        with Image.open(out) as im2:
-            im2.load()
-
-            assert_image_equal(im, im2)
+        assert_image_equal_tofile(im, out)
 
     def test_compressions(self, tmp_path):
         # Test various tiff compressions and assert similar image content but reduced
@@ -453,8 +448,7 @@ class TestFileLibTiff(LibTiffTestCase):
         for compression in ("packbits", "tiff_lzw"):
             im.save(out, compression=compression)
             size_compressed = os.path.getsize(out)
-            with Image.open(out) as im2:
-                assert_image_equal(im, im2)
+            assert_image_equal_tofile(im, out)
 
         im.save(out, compression="jpeg")
         size_jpeg = os.path.getsize(out)
@@ -498,8 +492,7 @@ class TestFileLibTiff(LibTiffTestCase):
         out = str(tmp_path / "temp.tif")
 
         im.save(out, compression="tiff_adobe_deflate")
-        with Image.open(out) as im2:
-            assert_image_equal(im, im2)
+        assert_image_equal_tofile(im, out)
 
     def test_palette_save(self, tmp_path):
         im = hopper("P")

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -457,8 +457,7 @@ class TestFileLibTiff(LibTiffTestCase):
 
         im.save(out, compression="jpeg", quality=30)
         size_jpeg_30 = os.path.getsize(out)
-        with Image.open(out) as im3:
-            assert_image_similar(im2, im3, 30)
+        assert_image_similar_tofile(im2, out, 30)
 
         assert size_raw > size_compressed
         assert size_compressed > size_jpeg
@@ -642,8 +641,7 @@ class TestFileLibTiff(LibTiffTestCase):
             pilim.save(buffer_io, format="tiff", compression=compression)
             buffer_io.seek(0)
 
-            with Image.open(buffer_io) as pilim_load:
-                assert_image_similar(pilim, pilim_load, 0)
+            assert_image_similar_tofile(pilim, buffer_io, 0)
 
         save_bytesio()
         save_bytesio("raw")

--- a/Tests/test_file_mcidas.py
+++ b/Tests/test_file_mcidas.py
@@ -2,7 +2,7 @@ import pytest
 
 from PIL import Image, McIdasImagePlugin
 
-from .helper import assert_image_equal
+from .helper import assert_image_equal_tofile
 
 
 def test_invalid_file():
@@ -27,5 +27,4 @@ def test_valid_file():
         assert im.format == "MCIDAS"
         assert im.mode == "I"
         assert im.size == (1800, 400)
-        with Image.open(saved_file) as im2:
-            assert_image_equal(im, im2)
+        assert_image_equal_tofile(im, saved_file)

--- a/Tests/test_file_msp.py
+++ b/Tests/test_file_msp.py
@@ -4,7 +4,7 @@ import pytest
 
 from PIL import Image, MspImagePlugin
 
-from .helper import assert_image_equal, hopper
+from .helper import assert_image_equal, assert_image_equal_tofile, hopper
 
 TEST_FILE = "Tests/images/hopper.msp"
 EXTRA_DIR = "Tests/images/picins"
@@ -52,8 +52,7 @@ def test_open_windows_v1():
 
 def _assert_file_image_equal(source_path, target_path):
     with Image.open(source_path) as im:
-        with Image.open(target_path) as target:
-            assert_image_equal(im, target)
+        assert_image_equal_tofile(im, target_path)
 
 
 @pytest.mark.skipif(

--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -2,7 +2,7 @@ import pytest
 
 from PIL import Image
 
-from .helper import assert_image_equal, assert_image_similar, hopper
+from .helper import assert_image_equal_tofile, assert_image_similar, hopper
 
 # sample ppm stream
 TEST_FILE = "Tests/images/hopper.ppm"
@@ -24,8 +24,7 @@ def test_16bit_pgm():
         assert im.size == (20, 100)
         assert im.get_format_mimetype() == "image/x-portable-graymap"
 
-        with Image.open("Tests/images/16_bit_binary_pgm.png") as tgt:
-            assert_image_equal(im, tgt)
+        assert_image_equal_tofile(im, "Tests/images/16_bit_binary_pgm.png")
 
 
 def test_16bit_pgm_write(tmp_path):
@@ -35,8 +34,7 @@ def test_16bit_pgm_write(tmp_path):
         f = str(tmp_path / "temp.pgm")
         im.save(f, "PPM")
 
-        with Image.open(f) as reloaded:
-            assert_image_equal(im, reloaded)
+        assert_image_equal_tofile(im, f)
 
 
 def test_pnm(tmp_path):
@@ -46,8 +44,7 @@ def test_pnm(tmp_path):
         f = str(tmp_path / "temp.pnm")
         im.save(f)
 
-        with Image.open(f) as reloaded:
-            assert_image_equal(im, reloaded)
+        assert_image_equal_tofile(im, f)
 
 
 def test_truncated_file(tmp_path):

--- a/Tests/test_file_sgi.py
+++ b/Tests/test_file_sgi.py
@@ -2,7 +2,12 @@ import pytest
 
 from PIL import Image, SgiImagePlugin
 
-from .helper import assert_image_equal, assert_image_similar, hopper
+from .helper import (
+    assert_image_equal,
+    assert_image_equal_tofile,
+    assert_image_similar,
+    hopper,
+)
 
 
 def test_rgb():
@@ -16,10 +21,7 @@ def test_rgb():
 
 
 def test_rgb16():
-    test_file = "Tests/images/hopper16.rgb"
-
-    with Image.open(test_file) as im:
-        assert_image_equal(im, hopper())
+    assert_image_equal_tofile(hopper(), "Tests/images/hopper16.rgb")
 
 
 def test_l():
@@ -38,8 +40,7 @@ def test_rgba():
     test_file = "Tests/images/transparent.sgi"
 
     with Image.open(test_file) as im:
-        with Image.open("Tests/images/transparent.png") as target:
-            assert_image_equal(im, target)
+        assert_image_equal_tofile(im, "Tests/images/transparent.png")
         assert im.get_format_mimetype() == "image/sgi"
 
 
@@ -49,16 +50,14 @@ def test_rle():
     test_file = "Tests/images/hopper.sgi"
 
     with Image.open(test_file) as im:
-        with Image.open("Tests/images/hopper.rgb") as target:
-            assert_image_equal(im, target)
+        assert_image_equal_tofile(im, "Tests/images/hopper.rgb")
 
 
 def test_rle16():
     test_file = "Tests/images/tv16.sgi"
 
     with Image.open(test_file) as im:
-        with Image.open("Tests/images/tv.rgb") as target:
-            assert_image_equal(im, target)
+        assert_image_equal_tofile(im, "Tests/images/tv.rgb")
 
 
 def test_invalid_file():
@@ -72,8 +71,7 @@ def test_write(tmp_path):
     def roundtrip(img):
         out = str(tmp_path / "temp.sgi")
         img.save(out, format="sgi")
-        with Image.open(out) as reloaded:
-            assert_image_equal(img, reloaded)
+        assert_image_equal_tofile(img, out)
 
     for mode in ("L", "RGB", "RGBA"):
         roundtrip(hopper(mode))
@@ -89,8 +87,7 @@ def test_write16(tmp_path):
         out = str(tmp_path / "temp.sgi")
         im.save(out, format="sgi", bpc=2)
 
-        with Image.open(out) as reloaded:
-            assert_image_equal(im, reloaded)
+        assert_image_equal_tofile(im, out)
 
 
 def test_unsupported_mode(tmp_path):

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -5,7 +5,7 @@ import pytest
 
 from PIL import Image, ImageSequence, SpiderImagePlugin
 
-from .helper import assert_image_equal, hopper, is_pypy
+from .helper import assert_image_equal_tofile, hopper, is_pypy
 
 TEST_FILE = "Tests/images/hopper.spider"
 
@@ -160,5 +160,4 @@ def test_odd_size():
     im.save(data, format="SPIDER")
 
     data.seek(0)
-    with Image.open(data) as im2:
-        assert_image_equal(im, im2)
+    assert_image_equal_tofile(im, data)

--- a/Tests/test_file_sun.py
+++ b/Tests/test_file_sun.py
@@ -4,7 +4,7 @@ import pytest
 
 from PIL import Image, SunImagePlugin
 
-from .helper import assert_image_equal, assert_image_similar, hopper
+from .helper import assert_image_equal_tofile, assert_image_similar, hopper
 
 EXTRA_DIR = "Tests/images/sunraster"
 
@@ -29,8 +29,7 @@ def test_sanity():
 
 def test_im1():
     with Image.open("Tests/images/sunraster.im1") as im:
-        with Image.open("Tests/images/sunraster.im1.png") as target:
-            assert_image_equal(im, target)
+        assert_image_equal_tofile(im, "Tests/images/sunraster.im1.png")
 
 
 @pytest.mark.skipif(
@@ -46,7 +45,4 @@ def test_others():
         with Image.open(path) as im:
             im.load()
             assert isinstance(im, SunImagePlugin.SunImageFile)
-            target_path = f"{os.path.splitext(path)[0]}.png"
-            # im.save(target_file)
-            with Image.open(target_path) as target:
-                assert_image_equal(im, target)
+            assert_image_equal_tofile(im, f"{os.path.splitext(path)[0]}.png")

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -483,8 +483,7 @@ class TestFileTiff:
             tmpfile = str(tmp_path / "temp.tif")
             im.save(tmpfile)
 
-            with Image.open(tmpfile) as reloaded:
-                assert_image_equal(im, reloaded)
+            assert_image_equal_tofile(im, tmpfile)
 
     def test_strip_raw(self):
         infile = "Tests/images/tiff_strip_raw.tif"

--- a/Tests/test_file_webp_alpha.py
+++ b/Tests/test_file_webp_alpha.py
@@ -2,7 +2,12 @@ import pytest
 
 from PIL import Image
 
-from .helper import assert_image_equal, assert_image_similar, hopper
+from .helper import (
+    assert_image_equal,
+    assert_image_similar,
+    assert_image_similar_tofile,
+    hopper,
+)
 
 _webp = pytest.importorskip("PIL._webp", reason="WebP support not installed")
 
@@ -29,8 +34,7 @@ def test_read_rgba():
 
         image.tobytes()
 
-        with Image.open("Tests/images/transparent.png") as target:
-            assert_image_similar(image, target, 20.0)
+        assert_image_similar_tofile(image, "Tests/images/transparent.png", 20.0)
 
 
 def test_write_lossless_rgb(tmp_path):

--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -2,7 +2,7 @@ import pytest
 
 from PIL import Image, WmfImagePlugin
 
-from .helper import assert_image_similar, hopper
+from .helper import assert_image_similar_tofile, hopper
 
 
 def test_load_raw():
@@ -13,9 +13,7 @@ def test_load_raw():
             # Currently, support for WMF/EMF is Windows-only
             im.load()
             # Compare to reference rendering
-            with Image.open("Tests/images/drawing_emf_ref.png") as imref:
-                imref.load()
-                assert_image_similar(im, imref, 0)
+            assert_image_similar_tofile(im, "Tests/images/drawing_emf_ref.png", 0)
 
     # Test basic WMF open and rendering
     with Image.open("Tests/images/drawing.wmf") as im:
@@ -23,9 +21,7 @@ def test_load_raw():
             # Currently, support for WMF/EMF is Windows-only
             im.load()
             # Compare to reference rendering
-            with Image.open("Tests/images/drawing_wmf_ref.png") as imref:
-                imref.load()
-                assert_image_similar(im, imref, 2.0)
+            assert_image_similar_tofile(im, "Tests/images/drawing_wmf_ref.png", 2.0)
 
 
 def test_register_handler(tmp_path):
@@ -66,8 +62,7 @@ def test_load_set_dpi():
             im.load(144)
             assert im.size == (164, 164)
 
-            with Image.open("Tests/images/drawing_wmf_ref_144.png") as expected:
-                assert_image_similar(im, expected, 2.1)
+            assert_image_similar_tofile(im, "Tests/images/drawing_wmf_ref_144.png", 2.1)
 
 
 def test_save(tmp_path):

--- a/Tests/test_font_pcf.py
+++ b/Tests/test_font_pcf.py
@@ -6,7 +6,7 @@ from PIL import FontFile, Image, ImageDraw, ImageFont, PcfFontFile
 
 from .helper import (
     assert_image_equal_tofile,
-    assert_image_similar,
+    assert_image_similar_tofile,
     skip_unless_feature,
 )
 
@@ -61,8 +61,7 @@ def test_draw(request, tmp_path):
     im = Image.new("L", (130, 30), "white")
     draw = ImageDraw.Draw(im)
     draw.text((0, 0), message, "black", font=font)
-    with Image.open("Tests/images/test_draw_pbm_target.png") as target:
-        assert_image_similar(im, target, 0)
+    assert_image_similar_tofile(im, "Tests/images/test_draw_pbm_target.png", 0)
 
 
 def test_textsize(request, tmp_path):
@@ -83,8 +82,7 @@ def _test_high_characters(request, tmp_path, message):
     im = Image.new("L", (750, 30), "white")
     draw = ImageDraw.Draw(im)
     draw.text((0, 0), message, "black", font=font)
-    with Image.open("Tests/images/high_ascii_chars.png") as target:
-        assert_image_similar(im, target, 0)
+    assert_image_similar_tofile(im, "Tests/images/high_ascii_chars.png", 0)
 
 
 def test_high_characters(request, tmp_path):

--- a/Tests/test_font_pcf.py
+++ b/Tests/test_font_pcf.py
@@ -4,7 +4,11 @@ import pytest
 
 from PIL import FontFile, Image, ImageDraw, ImageFont, PcfFontFile
 
-from .helper import assert_image_equal, assert_image_similar, skip_unless_feature
+from .helper import (
+    assert_image_equal_tofile,
+    assert_image_similar,
+    skip_unless_feature,
+)
 
 fontname = "Tests/fonts/10x20-ISO8859-1.pcf"
 
@@ -33,8 +37,7 @@ def save_font(request, tmp_path):
     font.save(tempname)
 
     with Image.open(tempname.replace(".pil", ".pbm")) as loaded:
-        with Image.open("Tests/fonts/10x20.pbm") as target:
-            assert_image_equal(loaded, target)
+        assert_image_equal_tofile(loaded, "Tests/fonts/10x20.pbm")
 
     with open(tempname, "rb") as f_loaded:
         with open("Tests/fonts/10x20.pil", "rb") as f_target:

--- a/Tests/test_font_pcf_charsets.py
+++ b/Tests/test_font_pcf_charsets.py
@@ -2,7 +2,11 @@ import os
 
 from PIL import FontFile, Image, ImageDraw, ImageFont, PcfFontFile
 
-from .helper import assert_image_equal, assert_image_similar, skip_unless_feature
+from .helper import (
+    assert_image_equal_tofile,
+    assert_image_similar,
+    skip_unless_feature,
+)
 
 fontname = "Tests/fonts/ter-x20b.pcf"
 
@@ -47,8 +51,7 @@ def save_font(request, tmp_path, encoding):
     font.save(tempname)
 
     with Image.open(tempname.replace(".pil", ".pbm")) as loaded:
-        with Image.open(f"Tests/fonts/ter-x20b-{encoding}.pbm") as target:
-            assert_image_equal(loaded, target)
+        assert_image_equal_tofile(loaded, f"Tests/fonts/ter-x20b-{encoding}.pbm")
 
     with open(tempname, "rb") as f_loaded:
         with open(f"Tests/fonts/ter-x20b-{encoding}.pil", "rb") as f_target:

--- a/Tests/test_font_pcf_charsets.py
+++ b/Tests/test_font_pcf_charsets.py
@@ -4,7 +4,7 @@ from PIL import FontFile, Image, ImageDraw, ImageFont, PcfFontFile
 
 from .helper import (
     assert_image_equal_tofile,
-    assert_image_similar,
+    assert_image_similar_tofile,
     skip_unless_feature,
 )
 
@@ -82,8 +82,7 @@ def _test_draw(request, tmp_path, encoding):
     draw = ImageDraw.Draw(im)
     message = charsets[encoding]["message"].encode(encoding)
     draw.text((0, 0), message, "black", font=font)
-    with Image.open(charsets[encoding]["image1"]) as target:
-        assert_image_similar(im, target, 0)
+    assert_image_similar_tofile(im, charsets[encoding]["image1"], 0)
 
 
 def test_draw_iso8859_1(request, tmp_path):

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -10,6 +10,7 @@ from PIL import Image, ImageDraw, ImagePalette, ImageShow, UnidentifiedImageErro
 
 from .helper import (
     assert_image_equal,
+    assert_image_equal_tofile,
     assert_image_similar,
     assert_not_all_same,
     hopper,
@@ -413,8 +414,7 @@ class TestImage:
 
         # Assert
         assert im.size == (512, 512)
-        with Image.open("Tests/images/effect_mandelbrot.png") as im2:
-            assert_image_equal(im, im2)
+        assert_image_equal_tofile(im, "Tests/images/effect_mandelbrot.png")
 
     def test_effect_mandelbrot_bad_arguments(self):
         # Arrange

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -11,7 +11,7 @@ from PIL import Image, ImageDraw, ImagePalette, ImageShow, UnidentifiedImageErro
 from .helper import (
     assert_image_equal,
     assert_image_equal_tofile,
-    assert_image_similar,
+    assert_image_similar_tofile,
     assert_not_all_same,
     hopper,
     is_win32,
@@ -172,8 +172,7 @@ class TestImage:
         with tempfile.TemporaryFile() as fp:
             im.save(fp, "JPEG")
             fp.seek(0)
-            with Image.open(fp) as reloaded:
-                assert_image_similar(im, reloaded, 20)
+            assert_image_similar_tofile(im, fp, 20)
 
     def test_unknown_extension(self, tmp_path):
         im = hopper()
@@ -456,8 +455,7 @@ class TestImage:
 
         # Assert
         assert im.size == (128, 128)
-        with Image.open("Tests/images/effect_spread.png") as im3:
-            assert_image_similar(im2, im3, 110)
+        assert_image_similar_tofile(im2, "Tests/images/effect_spread.png", 110)
 
     def test_effect_spread_zero(self):
         # Arrange

--- a/Tests/test_image_rotate.py
+++ b/Tests/test_image_rotate.py
@@ -1,6 +1,11 @@
 from PIL import Image
 
-from .helper import assert_image_equal, assert_image_similar, hopper
+from .helper import (
+    assert_image_equal,
+    assert_image_equal_tofile,
+    assert_image_similar,
+    hopper,
+)
 
 
 def rotate(im, mode, angle, center=None, translate=None):
@@ -113,15 +118,13 @@ def test_center():
 def test_rotate_no_fill():
     im = Image.new("RGB", (100, 100), "green")
     im = im.rotate(45)
-    with Image.open("Tests/images/rotate_45_no_fill.png") as target:
-        assert_image_equal(im, target)
+    assert_image_equal_tofile(im, "Tests/images/rotate_45_no_fill.png")
 
 
 def test_rotate_with_fill():
     im = Image.new("RGB", (100, 100), "green")
     im = im.rotate(45, fillcolor="white")
-    with Image.open("Tests/images/rotate_45_with_fill.png") as target:
-        assert_image_equal(im, target)
+    assert_image_equal_tofile(im, "Tests/images/rotate_45_with_fill.png")
 
 
 def test_alpha_rotate_no_fill():

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -8,7 +8,13 @@ import pytest
 
 from PIL import Image, ImageMode, features
 
-from .helper import assert_image, assert_image_equal, assert_image_similar, hopper
+from .helper import (
+    assert_image,
+    assert_image_equal,
+    assert_image_similar,
+    assert_image_similar_tofile,
+    hopper,
+)
 
 try:
     from PIL import ImageCms
@@ -240,8 +246,7 @@ def test_lab_color():
 
     # i.save('temp.lab.tif')  # visually verified vs PS.
 
-    with Image.open("Tests/images/hopper.Lab.tif") as target:
-        assert_image_similar(i, target, 3.5)
+    assert_image_similar_tofile(i, "Tests/images/hopper.Lab.tif", 3.5)
 
 
 def test_lab_srgb():

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -6,6 +6,7 @@ from PIL import Image, ImageColor, ImageDraw, ImageFont
 
 from .helper import (
     assert_image_equal,
+    assert_image_equal_tofile,
     assert_image_similar_tofile,
     hopper,
     skip_unless_feature,
@@ -96,7 +97,7 @@ def test_arc_end_le_start():
     draw.arc(BBOX1, start=start, end=end)
 
     # Assert
-    assert_image_equal(im, Image.open("Tests/images/imagedraw_arc_end_le_start.png"))
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_arc_end_le_start.png")
 
 
 def test_arc_no_loops():
@@ -174,7 +175,7 @@ def test_arc_high():
     draw.arc([110, 10, 189, 189], 20, 150, width=20, fill="white")
 
     # Assert
-    assert_image_equal(im, Image.open("Tests/images/imagedraw_arc_high.png"))
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_arc_high.png")
 
 
 def test_bitmap():
@@ -188,7 +189,7 @@ def test_bitmap():
         draw.bitmap((10, 10), small)
 
     # Assert
-    assert_image_equal(im, Image.open("Tests/images/imagedraw_bitmap.png"))
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_bitmap.png")
 
 
 def helper_chord(mode, bbox, start, end):
@@ -247,8 +248,7 @@ def test_chord_zero_width():
     draw.chord(BBOX1, 10, 260, fill="red", outline="yellow", width=0)
 
     # Assert
-    with Image.open("Tests/images/imagedraw_chord_zero_width.png") as expected:
-        assert_image_equal(im, expected)
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_chord_zero_width.png")
 
 
 def test_chord_too_fat():
@@ -260,7 +260,7 @@ def test_chord_too_fat():
     draw.chord([-150, -150, 99, 99], 15, 60, width=10, fill="white", outline="red")
 
     # Assert
-    assert_image_equal(im, Image.open("Tests/images/imagedraw_chord_too_fat.png"))
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_chord_too_fat.png")
 
 
 def helper_ellipse(mode, bbox):
@@ -367,8 +367,7 @@ def test_ellipse_zero_width():
     draw.ellipse(BBOX1, fill="green", outline="blue", width=0)
 
     # Assert
-    with Image.open("Tests/images/imagedraw_ellipse_zero_width.png") as expected:
-        assert_image_equal(im, expected)
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_ellipse_zero_width.png")
 
 
 def ellipse_various_sizes_helper(filled):
@@ -395,17 +394,15 @@ def ellipse_various_sizes_helper(filled):
 def test_ellipse_various_sizes():
     im = ellipse_various_sizes_helper(False)
 
-    with Image.open("Tests/images/imagedraw_ellipse_various_sizes.png") as expected:
-        assert_image_equal(im, expected)
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_ellipse_various_sizes.png")
 
 
 def test_ellipse_various_sizes_filled():
     im = ellipse_various_sizes_helper(True)
 
-    with Image.open(
-        "Tests/images/imagedraw_ellipse_various_sizes_filled.png"
-    ) as expected:
-        assert_image_equal(im, expected)
+    assert_image_equal_tofile(
+        im, "Tests/images/imagedraw_ellipse_various_sizes_filled.png"
+    )
 
 
 def helper_line(points):
@@ -417,7 +414,7 @@ def helper_line(points):
     draw.line(points, fill="yellow", width=2)
 
     # Assert
-    assert_image_equal(im, Image.open("Tests/images/imagedraw_line.png"))
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_line.png")
 
 
 def test_line1():
@@ -446,7 +443,7 @@ def test_shape1():
     draw.shape(s, fill=1)
 
     # Assert
-    assert_image_equal(im, Image.open("Tests/images/imagedraw_shape1.png"))
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_shape1.png")
 
 
 def test_shape2():
@@ -467,7 +464,7 @@ def test_shape2():
     draw.shape(s, outline="blue")
 
     # Assert
-    assert_image_equal(im, Image.open("Tests/images/imagedraw_shape2.png"))
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_shape2.png")
 
 
 def helper_pieslice(bbox, start, end):
@@ -526,8 +523,7 @@ def test_pieslice_zero_width():
     draw.pieslice(BBOX1, 10, 260, fill="white", outline="blue", width=0)
 
     # Assert
-    with Image.open("Tests/images/imagedraw_pieslice_zero_width.png") as expected:
-        assert_image_equal(im, expected)
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_pieslice_zero_width.png")
 
 
 def test_pieslice_wide():
@@ -539,7 +535,7 @@ def test_pieslice_wide():
     draw.pieslice([0, 0, 199, 99], 190, 170, width=10, fill="white", outline="red")
 
     # Assert
-    assert_image_equal(im, Image.open("Tests/images/imagedraw_pieslice_wide.png"))
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_pieslice_wide.png")
 
 
 def helper_point(points):
@@ -551,7 +547,7 @@ def helper_point(points):
     draw.point(points, fill="yellow")
 
     # Assert
-    assert_image_equal(im, Image.open("Tests/images/imagedraw_point.png"))
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_point.png")
 
 
 def test_point1():
@@ -571,7 +567,7 @@ def helper_polygon(points):
     draw.polygon(points, fill="red", outline="blue")
 
     # Assert
-    assert_image_equal(im, Image.open("Tests/images/imagedraw_polygon.png"))
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_polygon.png")
 
 
 def test_polygon1():
@@ -595,7 +591,7 @@ def test_polygon_kite():
         draw.polygon(KITE_POINTS, fill="blue", outline="yellow")
 
         # Assert
-        assert_image_equal(im, Image.open(expected))
+        assert_image_equal_tofile(im, expected)
 
 
 def test_polygon_1px_high():
@@ -609,7 +605,7 @@ def test_polygon_1px_high():
     draw.polygon([(0, 1), (0, 1), (2, 1), (2, 1)], "#f00")
 
     # Assert
-    assert_image_equal(im, Image.open(expected))
+    assert_image_equal_tofile(im, expected)
 
 
 def helper_rectangle(bbox):
@@ -621,7 +617,7 @@ def helper_rectangle(bbox):
     draw.rectangle(bbox, fill="black", outline="green")
 
     # Assert
-    assert_image_equal(im, Image.open("Tests/images/imagedraw_rectangle.png"))
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_rectangle.png")
 
 
 def test_rectangle1():
@@ -656,7 +652,7 @@ def test_rectangle_width():
     draw.rectangle(BBOX1, outline="green", width=5)
 
     # Assert
-    assert_image_equal(im, Image.open(expected))
+    assert_image_equal_tofile(im, expected)
 
 
 def test_rectangle_width_fill():
@@ -669,7 +665,7 @@ def test_rectangle_width_fill():
     draw.rectangle(BBOX1, fill="blue", outline="green", width=5)
 
     # Assert
-    assert_image_equal(im, Image.open(expected))
+    assert_image_equal_tofile(im, expected)
 
 
 def test_rectangle_zero_width():
@@ -681,8 +677,7 @@ def test_rectangle_zero_width():
     draw.rectangle(BBOX1, fill="blue", outline="green", width=0)
 
     # Assert
-    with Image.open("Tests/images/imagedraw_rectangle_zero_width.png") as expected:
-        assert_image_equal(im, expected)
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_rectangle_zero_width.png")
 
 
 def test_rectangle_I16():
@@ -694,9 +689,7 @@ def test_rectangle_I16():
     draw.rectangle(BBOX1, fill="black", outline="green")
 
     # Assert
-    assert_image_equal(
-        im.convert("I"), Image.open("Tests/images/imagedraw_rectangle_I.png")
-    )
+    assert_image_equal_tofile(im.convert("I"), "Tests/images/imagedraw_rectangle_I.png")
 
 
 def test_floodfill():
@@ -749,7 +742,7 @@ def test_floodfill_border():
     )
 
     # Assert
-    assert_image_equal(im, Image.open("Tests/images/imagedraw_floodfill2.png"))
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_floodfill2.png")
 
 
 def test_floodfill_thresh():
@@ -765,7 +758,7 @@ def test_floodfill_thresh():
     ImageDraw.floodfill(im, centre_point, ImageColor.getrgb("red"), thresh=30)
 
     # Assert
-    assert_image_equal(im, Image.open("Tests/images/imagedraw_floodfill2.png"))
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_floodfill2.png")
 
 
 def test_floodfill_not_negative():
@@ -782,9 +775,7 @@ def test_floodfill_not_negative():
     ImageDraw.floodfill(im, (int(W / 4), int(H / 4)), ImageColor.getrgb("red"))
 
     # Assert
-    assert_image_equal(
-        im, Image.open("Tests/images/imagedraw_floodfill_not_negative.png")
-    )
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_floodfill_not_negative.png")
 
 
 def create_base_image_draw(
@@ -816,32 +807,29 @@ def test_square():
 
 
 def test_triangle_right():
-    with Image.open(os.path.join(IMAGES_PATH, "triangle_right.png")) as expected:
-        expected.load()
-        img, draw = create_base_image_draw((20, 20))
-        draw.polygon([(3, 5), (17, 5), (10, 12)], BLACK)
-        assert_image_equal(img, expected, "triangle right failed")
+    img, draw = create_base_image_draw((20, 20))
+    draw.polygon([(3, 5), (17, 5), (10, 12)], BLACK)
+    assert_image_equal_tofile(
+        img, os.path.join(IMAGES_PATH, "triangle_right.png"), "triangle right failed"
+    )
 
 
 def test_line_horizontal():
-    with Image.open(
-        os.path.join(IMAGES_PATH, "line_horizontal_w2px_normal.png")
-    ) as expected:
-        expected.load()
-        img, draw = create_base_image_draw((20, 20))
-        draw.line((5, 5, 14, 5), BLACK, 2)
-        assert_image_equal(
-            img, expected, "line straight horizontal normal 2px wide failed"
-        )
-    with Image.open(
-        os.path.join(IMAGES_PATH, "line_horizontal_w2px_inverted.png")
-    ) as expected:
-        expected.load()
-        img, draw = create_base_image_draw((20, 20))
-        draw.line((14, 5, 5, 5), BLACK, 2)
-        assert_image_equal(
-            img, expected, "line straight horizontal inverted 2px wide failed"
-        )
+    img, draw = create_base_image_draw((20, 20))
+    draw.line((5, 5, 14, 5), BLACK, 2)
+    assert_image_equal_tofile(
+        img,
+        os.path.join(IMAGES_PATH, "line_horizontal_w2px_normal.png"),
+        "line straight horizontal normal 2px wide failed",
+    )
+
+    img, draw = create_base_image_draw((20, 20))
+    draw.line((14, 5, 5, 5), BLACK, 2)
+    assert_image_equal_tofile(
+        img,
+        os.path.join(IMAGES_PATH, "line_horizontal_w2px_inverted.png"),
+        "line straight horizontal inverted 2px wide failed",
+    )
     with Image.open(os.path.join(IMAGES_PATH, "line_horizontal_w3px.png")) as expected:
         expected.load()
         img, draw = create_base_image_draw((20, 20))
@@ -854,45 +842,43 @@ def test_line_horizontal():
         assert_image_equal(
             img, expected, "line straight horizontal inverted 3px wide failed"
         )
-    with Image.open(
-        os.path.join(IMAGES_PATH, "line_horizontal_w101px.png")
-    ) as expected:
-        expected.load()
-        img, draw = create_base_image_draw((200, 110))
-        draw.line((5, 55, 195, 55), BLACK, 101)
-        assert_image_equal(img, expected, "line straight horizontal 101px wide failed")
+
+    img, draw = create_base_image_draw((200, 110))
+    draw.line((5, 55, 195, 55), BLACK, 101)
+    assert_image_equal_tofile(
+        img,
+        os.path.join(IMAGES_PATH, "line_horizontal_w101px.png"),
+        "line straight horizontal 101px wide failed",
+    )
 
 
 def test_line_h_s1_w2():
     pytest.skip("failing")
-    with Image.open(
-        os.path.join(IMAGES_PATH, "line_horizontal_slope1px_w2px.png")
-    ) as expected:
-        expected.load()
-        img, draw = create_base_image_draw((20, 20))
-        draw.line((5, 5, 14, 6), BLACK, 2)
-        assert_image_equal(img, expected, "line horizontal 1px slope 2px wide failed")
+    img, draw = create_base_image_draw((20, 20))
+    draw.line((5, 5, 14, 6), BLACK, 2)
+    assert_image_equal_tofile(
+        img,
+        os.path.join(IMAGES_PATH, "line_horizontal_slope1px_w2px.png"),
+        "line horizontal 1px slope 2px wide failed",
+    )
 
 
 def test_line_vertical():
-    with Image.open(
-        os.path.join(IMAGES_PATH, "line_vertical_w2px_normal.png")
-    ) as expected:
-        expected.load()
-        img, draw = create_base_image_draw((20, 20))
-        draw.line((5, 5, 5, 14), BLACK, 2)
-        assert_image_equal(
-            img, expected, "line straight vertical normal 2px wide failed"
-        )
-    with Image.open(
-        os.path.join(IMAGES_PATH, "line_vertical_w2px_inverted.png")
-    ) as expected:
-        expected.load()
-        img, draw = create_base_image_draw((20, 20))
-        draw.line((5, 14, 5, 5), BLACK, 2)
-        assert_image_equal(
-            img, expected, "line straight vertical inverted 2px wide failed"
-        )
+    img, draw = create_base_image_draw((20, 20))
+    draw.line((5, 5, 5, 14), BLACK, 2)
+    assert_image_equal_tofile(
+        img,
+        os.path.join(IMAGES_PATH, "line_vertical_w2px_normal.png"),
+        "line straight vertical normal 2px wide failed",
+    )
+
+    img, draw = create_base_image_draw((20, 20))
+    draw.line((5, 14, 5, 5), BLACK, 2)
+    assert_image_equal_tofile(
+        img,
+        os.path.join(IMAGES_PATH, "line_vertical_w2px_inverted.png"),
+        "line straight vertical inverted 2px wide failed",
+    )
     with Image.open(os.path.join(IMAGES_PATH, "line_vertical_w3px.png")) as expected:
         expected.load()
         img, draw = create_base_image_draw((20, 20))
@@ -905,18 +891,21 @@ def test_line_vertical():
         assert_image_equal(
             img, expected, "line straight vertical inverted 3px wide failed"
         )
-    with Image.open(os.path.join(IMAGES_PATH, "line_vertical_w101px.png")) as expected:
-        expected.load()
-        img, draw = create_base_image_draw((110, 200))
-        draw.line((55, 5, 55, 195), BLACK, 101)
-        assert_image_equal(img, expected, "line straight vertical 101px wide failed")
-    with Image.open(
-        os.path.join(IMAGES_PATH, "line_vertical_slope1px_w2px.png")
-    ) as expected:
-        expected.load()
-        img, draw = create_base_image_draw((20, 20))
-        draw.line((5, 5, 6, 14), BLACK, 2)
-        assert_image_equal(img, expected, "line vertical 1px slope 2px wide failed")
+    img, draw = create_base_image_draw((110, 200))
+    draw.line((55, 5, 55, 195), BLACK, 101)
+    assert_image_equal_tofile(
+        img,
+        os.path.join(IMAGES_PATH, "line_vertical_w101px.png"),
+        "line straight vertical 101px wide failed",
+    )
+
+    img, draw = create_base_image_draw((20, 20))
+    draw.line((5, 5, 6, 14), BLACK, 2)
+    assert_image_equal_tofile(
+        img,
+        os.path.join(IMAGES_PATH, "line_vertical_slope1px_w2px.png"),
+        "line vertical 1px slope 2px wide failed",
+    )
 
 
 def test_line_oblique_45():
@@ -1185,7 +1174,7 @@ def test_draw_regular_polygon(n_sides, rotation, polygon_name):
     draw = ImageDraw.Draw(im)
     bounding_circle = ((W // 2, H // 2), 25)
     draw.regular_polygon(bounding_circle, n_sides, rotation=rotation, fill="red")
-    assert_image_equal(im, Image.open(filename))
+    assert_image_equal_tofile(im, filename)
 
 
 @pytest.mark.parametrize(

--- a/Tests/test_imagedraw2.py
+++ b/Tests/test_imagedraw2.py
@@ -4,6 +4,7 @@ from PIL import Image, ImageDraw, ImageDraw2
 
 from .helper import (
     assert_image_equal,
+    assert_image_equal_tofile,
     assert_image_similar,
     hopper,
     skip_unless_feature,
@@ -95,7 +96,7 @@ def helper_line(points):
     draw.line(points, pen)
 
     # Assert
-    assert_image_equal(im, Image.open("Tests/images/imagedraw_line.png"))
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_line.png")
 
 
 def test_line1_pen():
@@ -118,7 +119,7 @@ def test_line_pen_as_brush():
     draw.line(POINTS1, pen, brush)
 
     # Assert
-    assert_image_equal(im, Image.open("Tests/images/imagedraw_line.png"))
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_line.png")
 
 
 def helper_polygon(points):
@@ -132,7 +133,7 @@ def helper_polygon(points):
     draw.polygon(points, pen, brush)
 
     # Assert
-    assert_image_equal(im, Image.open("Tests/images/imagedraw_polygon.png"))
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_polygon.png")
 
 
 def test_polygon1():
@@ -154,7 +155,7 @@ def helper_rectangle(bbox):
     draw.rectangle(bbox, pen, brush)
 
     # Assert
-    assert_image_equal(im, Image.open("Tests/images/imagedraw_rectangle.png"))
+    assert_image_equal_tofile(im, "Tests/images/imagedraw_rectangle.png")
 
 
 def test_rectangle1():

--- a/Tests/test_imagedraw2.py
+++ b/Tests/test_imagedraw2.py
@@ -5,7 +5,7 @@ from PIL import Image, ImageDraw, ImageDraw2
 from .helper import (
     assert_image_equal,
     assert_image_equal_tofile,
-    assert_image_similar,
+    assert_image_similar_tofile,
     hopper,
     skip_unless_feature,
 )
@@ -62,7 +62,7 @@ def helper_ellipse(mode, bbox):
     draw.ellipse(bbox, pen, brush)
 
     # Assert
-    assert_image_similar(im, Image.open(expected), 1)
+    assert_image_similar_tofile(im, expected, 1)
 
 
 def test_ellipse1():
@@ -83,7 +83,7 @@ def test_ellipse_edge():
     draw.ellipse(((0, 0), (W - 1, H - 1)), brush)
 
     # Assert
-    assert_image_similar(im, Image.open("Tests/images/imagedraw_ellipse_edge.png"), 1)
+    assert_image_similar_tofile(im, "Tests/images/imagedraw_ellipse_edge.png", 1)
 
 
 def helper_line(points):
@@ -179,7 +179,7 @@ def test_big_rectangle():
     draw.rectangle(bbox, brush)
 
     # Assert
-    assert_image_similar(im, Image.open(expected), 1)
+    assert_image_similar_tofile(im, expected, 1)
 
 
 @skip_unless_feature("freetype2")
@@ -194,7 +194,7 @@ def test_text():
     draw.text((5, 5), "ImageDraw2", font)
 
     # Assert
-    assert_image_similar(im, Image.open(expected), 13)
+    assert_image_similar_tofile(im, expected, 13)
 
 
 @skip_unless_feature("freetype2")

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -423,15 +423,12 @@ class TestImageFont:
         im = Image.new(mode="RGB", size=(300, 100))
         draw = ImageDraw.Draw(im)
 
-        target = "Tests/images/default_font.png"
-        with Image.open(target) as target_img:
+        # Act
+        default_font = ImageFont.load_default()
+        draw.text((10, 10), txt, font=default_font)
 
-            # Act
-            default_font = ImageFont.load_default()
-            draw.text((10, 10), txt, font=default_font)
-
-            # Assert
-            assert_image_equal(im, target_img)
+        # Assert
+        assert_image_equal_tofile(im, "Tests/images/default_font.png")
 
     def test_getsize_empty(self):
         # issue #2614

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -13,7 +13,6 @@ from PIL import Image, ImageDraw, ImageFont, features
 from .helper import (
     assert_image_equal,
     assert_image_equal_tofile,
-    assert_image_similar,
     assert_image_similar_tofile,
     is_win32,
     skip_unless_feature,
@@ -130,8 +129,7 @@ class TestImageFont:
         draw.text((10, 10), txt, font=ttf)
 
         target = "Tests/images/transparent_background_text.png"
-        with Image.open(target) as target_img:
-            assert_image_similar(im, target_img, 4.09)
+        assert_image_similar_tofile(im, target, 4.09)
 
     def test_textsize_equal(self):
         im = Image.new(mode="RGB", size=(300, 100))
@@ -143,11 +141,10 @@ class TestImageFont:
         draw.text((10, 10), txt, font=ttf)
         draw.rectangle((10, 10, 10 + size[0], 10 + size[1]))
 
-        target = "Tests/images/rectangle_surrounding_text.png"
-        with Image.open(target) as target_img:
-
-            # Epsilon ~.5 fails with FreeType 2.7
-            assert_image_similar(im, target_img, 2.5)
+        # Epsilon ~.5 fails with FreeType 2.7
+        assert_image_similar_tofile(
+            im, "Tests/images/rectangle_surrounding_text.png", 2.5
+        )
 
     @pytest.mark.parametrize(
         "text, mode, font, size, length_basic, length_raqm",
@@ -191,13 +188,10 @@ class TestImageFont:
             draw.text((0, y), line, font=ttf)
             y += line_spacing
 
-        target = "Tests/images/multiline_text.png"
-        with Image.open(target) as target_img:
-
-            # some versions of freetype have different horizontal spacing.
-            # setting a tight epsilon, I'm showing the original test failure
-            # at epsilon = ~38.
-            assert_image_similar(im, target_img, 6.2)
+        # some versions of freetype have different horizontal spacing.
+        # setting a tight epsilon, I'm showing the original test failure
+        # at epsilon = ~38.
+        assert_image_similar_tofile(im, "Tests/images/multiline_text.png", 6.2)
 
     def test_render_multiline_text(self):
         ttf = self.get_font()
@@ -208,11 +202,8 @@ class TestImageFont:
         draw = ImageDraw.Draw(im)
         draw.text((0, 0), TEST_TEXT, font=ttf)
 
-        target = "Tests/images/multiline_text.png"
-        with Image.open(target) as target_img:
-
-            # Epsilon ~.5 fails with FreeType 2.7
-            assert_image_similar(im, target_img, 6.2)
+        # Epsilon ~.5 fails with FreeType 2.7
+        assert_image_similar_tofile(im, "Tests/images/multiline_text.png", 6.2)
 
         # Test that text() can pass on additional arguments
         # to multiline_text()
@@ -227,11 +218,10 @@ class TestImageFont:
             draw = ImageDraw.Draw(im)
             draw.multiline_text((0, 0), TEST_TEXT, font=ttf, align=align)
 
-            target = "Tests/images/multiline_text" + ext + ".png"
-            with Image.open(target) as target_img:
-
-                # Epsilon ~.5 fails with FreeType 2.7
-                assert_image_similar(im, target_img, 6.2)
+            # Epsilon ~.5 fails with FreeType 2.7
+            assert_image_similar_tofile(
+                im, "Tests/images/multiline_text" + ext + ".png", 6.2
+            )
 
     def test_unknown_align(self):
         im = Image.new(mode="RGB", size=(300, 100))
@@ -285,11 +275,8 @@ class TestImageFont:
         draw = ImageDraw.Draw(im)
         draw.multiline_text((0, 0), TEST_TEXT, font=ttf, spacing=10)
 
-        target = "Tests/images/multiline_text_spacing.png"
-        with Image.open(target) as target_img:
-
-            # Epsilon ~.5 fails with FreeType 2.7
-            assert_image_similar(im, target_img, 6.2)
+        # Epsilon ~.5 fails with FreeType 2.7
+        assert_image_similar_tofile(im, "Tests/images/multiline_text_spacing.png", 6.2)
 
     def test_rotated_transposed_font(self):
         img_grey = Image.new("L", (100, 100))
@@ -677,13 +664,11 @@ class TestImageFont:
         d.text((10, 10), "Text", font=font, fill="black")
 
         try:
-            with Image.open(path) as expected:
-                assert_image_similar(im, expected, epsilon)
+            assert_image_similar_tofile(im, path, epsilon)
         except AssertionError:
             if "_adobe" in path:
                 path = path.replace("_adobe", "_adobe_older_harfbuzz")
-                with Image.open(path) as expected:
-                    assert_image_similar(im, expected, epsilon)
+                assert_image_similar_tofile(im, path, epsilon)
             else:
                 raise
 
@@ -774,8 +759,7 @@ class TestImageFont:
 
         assert d.textbbox((0, 0), text, f, anchor=anchor) == bbox_expected
 
-        with Image.open(path) as expected:
-            assert_image_similar(im, expected, 7)
+        assert_image_similar_tofile(im, path, 7)
 
     @pytest.mark.parametrize(
         "anchor, align",
@@ -813,8 +797,7 @@ class TestImageFont:
             (300, 200), text, fill="black", anchor=anchor, font=f, align=align
         )
 
-        with Image.open(target) as expected:
-            assert_image_similar(im, expected, 4)
+        assert_image_similar_tofile(im, target, 4)
 
     def test_anchor_invalid(self):
         font = self.get_font()
@@ -872,8 +855,7 @@ class TestImageFont:
         d = ImageDraw.Draw(im)
         d.text((10, 10), txt, font=ttf, fill="#fa6", embedded_color=True)
 
-        with Image.open("Tests/images/standard_embedded.png") as expected:
-            assert_image_similar(im, expected, 6.2)
+        assert_image_similar_tofile(im, "Tests/images/standard_embedded.png", 6.2)
 
     @skip_unless_feature_version("freetype2", "2.5.0")
     def test_cbdt(self):
@@ -889,8 +871,7 @@ class TestImageFont:
 
             d.text((10, 10), "\U0001f469", embedded_color=True, font=font)
 
-            with Image.open("Tests/images/cbdt_notocoloremoji.png") as expected:
-                assert_image_similar(im, expected, 6.2)
+            assert_image_similar_tofile(im, "Tests/images/cbdt_notocoloremoji.png", 6.2)
         except IOError as e:
             assert str(e) in ("unimplemented feature", "unknown file format")
             pytest.skip("freetype compiled without libpng or unsupported")
@@ -909,8 +890,9 @@ class TestImageFont:
 
             d.text((10, 10), "\U0001f469", "black", font=font)
 
-            with Image.open("Tests/images/cbdt_notocoloremoji_mask.png") as expected:
-                assert_image_similar(im, expected, 6.2)
+            assert_image_similar_tofile(
+                im, "Tests/images/cbdt_notocoloremoji_mask.png", 6.2
+            )
         except IOError as e:
             assert str(e) in ("unimplemented feature", "unknown file format")
             pytest.skip("freetype compiled without libpng or unsupported")
@@ -928,8 +910,7 @@ class TestImageFont:
 
         d.text((15, 5), "Bungee", embedded_color=True, font=font)
 
-        with Image.open("Tests/images/colr_bungee.png") as expected:
-            assert_image_similar(im, expected, 21)
+        assert_image_similar_tofile(im, "Tests/images/colr_bungee.png", 21)
 
     @skip_unless_feature_version("freetype2", "2.10.0")
     def test_colr_mask(self):
@@ -944,8 +925,7 @@ class TestImageFont:
 
         d.text((15, 5), "Bungee", "black", font=font)
 
-        with Image.open("Tests/images/colr_bungee_mask.png") as expected:
-            assert_image_similar(im, expected, 22)
+        assert_image_similar_tofile(im, "Tests/images/colr_bungee_mask.png", 22)
 
 
 @skip_unless_feature("raqm")

--- a/Tests/test_imagefontctl.py
+++ b/Tests/test_imagefontctl.py
@@ -4,7 +4,7 @@ from packaging.version import parse as parse_version
 from PIL import Image, ImageDraw, ImageFont, features
 
 from .helper import (
-    assert_image_similar,
+    assert_image_similar_tofile,
     skip_unless_feature,
     skip_unless_feature_version,
 )
@@ -31,8 +31,7 @@ def test_complex_text():
     draw.text((0, 0), "اهلا عمان", font=ttf, fill=500)
 
     target = "Tests/images/test_text.png"
-    with Image.open(target) as target_img:
-        assert_image_similar(im, target_img, 0.5)
+    assert_image_similar_tofile(im, target, 0.5)
 
 
 def test_y_offset():
@@ -43,8 +42,7 @@ def test_y_offset():
     draw.text((0, 0), "العالم العربي", font=ttf, fill=500)
 
     target = "Tests/images/test_y_offset.png"
-    with Image.open(target) as target_img:
-        assert_image_similar(im, target_img, 1.7)
+    assert_image_similar_tofile(im, target, 1.7)
 
 
 def test_complex_unicode_text():
@@ -55,8 +53,7 @@ def test_complex_unicode_text():
     draw.text((0, 0), "السلام عليكم", font=ttf, fill=500)
 
     target = "Tests/images/test_complex_unicode_text.png"
-    with Image.open(target) as target_img:
-        assert_image_similar(im, target_img, 0.5)
+    assert_image_similar_tofile(im, target, 0.5)
 
     ttf = ImageFont.truetype("Tests/fonts/KhmerOSBattambang-Regular.ttf", FONT_SIZE)
 
@@ -65,8 +62,7 @@ def test_complex_unicode_text():
     draw.text((0, 0), "លោកុប្បត្តិ", font=ttf, fill=500)
 
     target = "Tests/images/test_complex_unicode_text2.png"
-    with Image.open(target) as target_img:
-        assert_image_similar(im, target_img, 2.33)
+    assert_image_similar_tofile(im, target, 2.33)
 
 
 def test_text_direction_rtl():
@@ -77,8 +73,7 @@ def test_text_direction_rtl():
     draw.text((0, 0), "English عربي", font=ttf, fill=500, direction="rtl")
 
     target = "Tests/images/test_direction_rtl.png"
-    with Image.open(target) as target_img:
-        assert_image_similar(im, target_img, 0.5)
+    assert_image_similar_tofile(im, target, 0.5)
 
 
 def test_text_direction_ltr():
@@ -89,8 +84,7 @@ def test_text_direction_ltr():
     draw.text((0, 0), "سلطنة عمان Oman", font=ttf, fill=500, direction="ltr")
 
     target = "Tests/images/test_direction_ltr.png"
-    with Image.open(target) as target_img:
-        assert_image_similar(im, target_img, 0.5)
+    assert_image_similar_tofile(im, target, 0.5)
 
 
 def test_text_direction_rtl2():
@@ -101,8 +95,7 @@ def test_text_direction_rtl2():
     draw.text((0, 0), "Oman سلطنة عمان", font=ttf, fill=500, direction="rtl")
 
     target = "Tests/images/test_direction_ltr.png"
-    with Image.open(target) as target_img:
-        assert_image_similar(im, target_img, 0.5)
+    assert_image_similar_tofile(im, target, 0.5)
 
 
 def test_text_direction_ttb():
@@ -117,8 +110,7 @@ def test_text_direction_ttb():
             pytest.skip("libraqm 0.7 or greater not available")
 
     target = "Tests/images/test_direction_ttb.png"
-    with Image.open(target) as target_img:
-        assert_image_similar(im, target_img, 2.8)
+    assert_image_similar_tofile(im, target, 2.8)
 
 
 def test_text_direction_ttb_stroke():
@@ -141,8 +133,7 @@ def test_text_direction_ttb_stroke():
             pytest.skip("libraqm 0.7 or greater not available")
 
     target = "Tests/images/test_direction_ttb_stroke.png"
-    with Image.open(target) as target_img:
-        assert_image_similar(im, target_img, 19.4)
+    assert_image_similar_tofile(im, target, 19.4)
 
 
 def test_ligature_features():
@@ -152,8 +143,7 @@ def test_ligature_features():
     draw = ImageDraw.Draw(im)
     draw.text((0, 0), "filling", font=ttf, fill=500, features=["-liga"])
     target = "Tests/images/test_ligature_features.png"
-    with Image.open(target) as target_img:
-        assert_image_similar(im, target_img, 0.5)
+    assert_image_similar_tofile(im, target, 0.5)
 
     liga_size = ttf.getsize("fi", features=["-liga"])
     assert liga_size == (13, 19)
@@ -167,8 +157,7 @@ def test_kerning_features():
     draw.text((0, 0), "TeToAV", font=ttf, fill=500, features=["-kern"])
 
     target = "Tests/images/test_kerning_features.png"
-    with Image.open(target) as target_img:
-        assert_image_similar(im, target_img, 0.5)
+    assert_image_similar_tofile(im, target, 0.5)
 
 
 def test_arabictext_features():
@@ -185,8 +174,7 @@ def test_arabictext_features():
     )
 
     target = "Tests/images/test_arabictext_features.png"
-    with Image.open(target) as target_img:
-        assert_image_similar(im, target_img, 0.5)
+    assert_image_similar_tofile(im, target, 0.5)
 
 
 def test_x_max_and_y_offset():
@@ -197,8 +185,7 @@ def test_x_max_and_y_offset():
     draw.text((0, 0), "لح", font=ttf, fill=500)
 
     target = "Tests/images/test_x_max_and_y_offset.png"
-    with Image.open(target) as target_img:
-        assert_image_similar(im, target_img, 0.5)
+    assert_image_similar_tofile(im, target, 0.5)
 
 
 def test_language():
@@ -209,8 +196,7 @@ def test_language():
     draw.text((0, 0), "абвг", font=ttf, fill=500, language="sr")
 
     target = "Tests/images/test_language.png"
-    with Image.open(target) as target_img:
-        assert_image_similar(im, target_img, 0.5)
+    assert_image_similar_tofile(im, target, 0.5)
 
 
 @pytest.mark.parametrize("mode", ("L", "1"))
@@ -287,8 +273,7 @@ def test_anchor_ttb(anchor):
         if str(ex) == "libraqm 0.7 or greater required for 'ttb' direction":
             pytest.skip("libraqm 0.7 or greater not available")
 
-    with Image.open(path) as expected:
-        assert_image_similar(im, expected, 1)  # fails at 5
+    assert_image_similar_tofile(im, path, 1)  # fails at 5
 
 
 combine_tests = (
@@ -351,8 +336,7 @@ def test_combine(name, text, dir, anchor, epsilon):
         if str(ex) == "libraqm 0.7 or greater required for 'ttb' direction":
             pytest.skip("libraqm 0.7 or greater not available")
 
-    with Image.open(path) as expected:
-        assert_image_similar(im, expected, epsilon)
+    assert_image_similar_tofile(im, path, epsilon)
 
 
 @pytest.mark.parametrize(
@@ -384,8 +368,7 @@ def test_combine_multiline(anchor, align):
     d.rectangle(bbox, outline="red")
     d.multiline_text((200, 200), text, fill="black", anchor=anchor, font=f, align=align)
 
-    with Image.open(path) as expected:
-        assert_image_similar(im, expected, 0.015)
+    assert_image_similar_tofile(im, path, 0.015)
 
 
 def test_anchor_invalid_ttb():

--- a/Tests/test_imagemorph.py
+++ b/Tests/test_imagemorph.py
@@ -3,7 +3,7 @@ import pytest
 
 from PIL import Image, ImageMorph, _imagingmorph
 
-from .helper import assert_image_equal, hopper
+from .helper import assert_image_equal_tofile, hopper
 
 
 def string_to_img(image_string):
@@ -57,8 +57,7 @@ def assert_img_equal_img_string(A, Bstring):
 
 
 def test_str_to_img():
-    with Image.open("Tests/images/morph_a.png") as im:
-        assert_image_equal(A, im)
+    assert_image_equal_tofile(A, "Tests/images/morph_a.png")
 
 
 def create_lut():

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -5,6 +5,7 @@ from PIL import Image, ImageDraw, ImageOps, ImageStat, features
 from .helper import (
     assert_image_equal,
     assert_image_similar,
+    assert_image_similar_tofile,
     assert_tuple_approx_equal,
     hopper,
 )
@@ -112,10 +113,9 @@ def test_pad():
             new_im = ImageOps.pad(im, new_size, color=color, centering=centering)
             assert new_im.size == new_size
 
-            with Image.open(
-                "Tests/images/imageops_pad_" + label + "_" + str(i) + ".jpg"
-            ) as target:
-                assert_image_similar(new_im, target, 6)
+            assert_image_similar_tofile(
+                new_im, "Tests/images/imageops_pad_" + label + "_" + str(i) + ".jpg", 6
+            )
 
 
 def test_pil163():

--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -2,7 +2,7 @@ import pytest
 
 from PIL import Image, ImagePalette
 
-from .helper import assert_image_equal
+from .helper import assert_image_equal_tofile
 
 
 def test_sanity():
@@ -141,8 +141,7 @@ def test_2bit_palette(tmp_path):
     img.putpalette(b"\xFF\x00\x00\x00\xFF\x00\x00\x00\xFF")  # RGB
     img.save(outfile, format="PNG")
 
-    with Image.open(outfile) as reloaded:
-        assert_image_equal(img, reloaded)
+    assert_image_equal_tofile(img, outfile)
 
 
 def test_invalid_palette():

--- a/Tests/test_qt_image_toqimage.py
+++ b/Tests/test_qt_image_toqimage.py
@@ -1,8 +1,8 @@
 import pytest
 
-from PIL import Image, ImageQt
+from PIL import ImageQt
 
-from .helper import assert_image_equal, hopper
+from .helper import assert_image_equal, assert_image_equal_tofile, hopper
 
 pytestmark = pytest.mark.skipif(
     not ImageQt.qt_is_installed, reason="Qt bindings are not installed"
@@ -40,5 +40,4 @@ def test_sanity(tmp_path):
         data.save(tempfile)
 
         # Check that it actually worked.
-        with Image.open(tempfile) as reloaded:
-            assert_image_equal(reloaded, src)
+        assert_image_equal_tofile(src, tempfile)


### PR DESCRIPTION
- Replaced various instances of assert_image_equal with assert_image_equal_tofile
- Replaced various instances of assert_image_similar with assert_image_similar_tofile

Suggested in https://github.com/python-pillow/Pillow/pull/5270#issuecomment-780546837