### PR TITLE
Corrected documentation syntax

### DIFF
--- a/docs/handbook/writing-your-own-file-decoder.rst
+++ b/docs/handbook/writing-your-own-file-decoder.rst
@@ -269,7 +269,7 @@ decoder that can be used to read various packed formats into a floating point
 image memory.
 
 To use the bit decoder with the :py:func:`PIL.Image.frombytes` function, use
-the following syntax::
+the following syntax:
 
 .. code-block:: python
 


### PR DESCRIPTION
Before - https://pillow.readthedocs.io/en/latest/handbook/writing-your-own-file-decoder.html#the-bit-decoder

<img width="1242" alt="Screen Shot 2021-02-23 at 11 10 41 pm" src="https://user-images.githubusercontent.com/3112309/108841747-5e707900-762c-11eb-9a64-fbbc5d7de556.png">

After - https://pillow--5279.org.readthedocs.build/en/5279/handbook/writing-your-own-file-decoder.html#the-bit-decoder

<img width="1242" alt="Screen Shot 2021-02-23 at 11 15 54 pm" src="https://user-images.githubusercontent.com/3112309/108842252-19007b80-762d-11eb-89e8-ec7906a4b09c.png">