### PR TITLE
Set all transparent colors to be equal in quantize()

### DIFF
--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -74,3 +74,13 @@ def test_quantize_dither_diff():
     nodither = image.quantize(dither=0, palette=palette)
 
     assert dither.tobytes() != nodither.tobytes()
+
+
+def test_transparent_colors_equal():
+    im = Image.new("RGBA", (1, 2), (0, 0, 0, 0))
+    px = im.load()
+    px[0, 1] = (255, 255, 255, 0)
+
+    converted = im.quantize()
+    converted_px = converted.load()
+    assert converted_px[0, 0] == converted_px[0, 1]

--- a/src/libImaging/Quant.c
+++ b/src/libImaging/Quant.c
@@ -1688,9 +1688,26 @@ ImagingQuantize(Imaging im, int colors, int mode, int kmeans) {
     } else if (!strcmp(im->mode, "RGB") || !strcmp(im->mode, "RGBA")) {
         /* true colour */
 
+        withAlpha = !strcmp(im->mode, "RGBA");
+        int transparency = 0;
+        unsigned char r, g, b;
         for (i = y = 0; y < im->ysize; y++) {
             for (x = 0; x < im->xsize; x++, i++) {
                 p[i].v = im->image32[y][x];
+                if (withAlpha && p[i].c.a == 0) {
+                    if (transparency == 0) {
+                        transparency = 1;
+                        r = p[i].c.r;
+                        g = p[i].c.g;
+                        b = p[i].c.b;
+                    } else {
+                        /* Set all subsequent transparent pixels
+                        to the same colour as the first */
+                        p[i].c.r = r;
+                        p[i].c.g = g;
+                        p[i].c.b = b;
+                    }
+                }
             }
         }
 
@@ -1725,9 +1742,6 @@ ImagingQuantize(Imaging im, int colors, int mode, int kmeans) {
                 kmeans);
             break;
         case 2:
-            if (!strcmp(im->mode, "RGBA")) {
-                withAlpha = 1;
-            }
             result = quantize_octree(
                 p,
                 im->xsize * im->ysize,
@@ -1739,9 +1753,6 @@ ImagingQuantize(Imaging im, int colors, int mode, int kmeans) {
             break;
         case 3:
 #ifdef HAVE_LIBIMAGEQUANT
-            if (!strcmp(im->mode, "RGBA")) {
-                withAlpha = 1;
-            }
             result = quantize_pngquant(
                 p,
                 im->xsize,


### PR DESCRIPTION
When `quantize()` converts an RGBA image to P mode, it currently translates two pixels with full transparency as different if they have different RGB values. This PR sets all transparent pixels to have the same RGB values as the first transparent pixel, so that they all end up with the same P value.

This improvement is also helpful when it comes to GIFs, which can only mark one color in the palette as transparent. This resolves the second part of #3603