### PR TITLE
Added context managers to documentation

### DIFF
--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -22,8 +22,8 @@ Windows).
 .. code-block:: python
 
     from PIL import Image
-    im = Image.open("hopper.jpg")
-    im.rotate(45).show()
+    with Image.open("hopper.jpg") as im:
+        im.rotate(45).show()
 
 Create thumbnails
 ^^^^^^^^^^^^^^^^^
@@ -40,9 +40,9 @@ current directory preserving aspect ratios with 128x128 max resolution.
 
     for infile in glob.glob("*.jpg"):
         file, ext = os.path.splitext(infile)
-        im = Image.open(infile)
-        im.thumbnail(size)
-        im.save(file + ".thumbnail", "JPEG")
+        with Image.open(infile) as im:
+            im.thumbnail(size)
+            im.save(file + ".thumbnail", "JPEG")
 
 Functions
 ---------
@@ -145,15 +145,15 @@ This crops the input image with the provided coordinates:
 
     from PIL import Image
 
-    im = Image.open("hopper.jpg")
+    with Image.open("hopper.jpg") as im:
 
-    # The crop method from the Image module takes four coordinates as input.
-    # The right can also be represented as (left+width)
-    # and lower can be represented as (upper+height).
-    (left, upper, right, lower) = (20, 20, 100, 100)
+        # The crop method from the Image module takes four coordinates as input.
+        # The right can also be represented as (left+width)
+        # and lower can be represented as (upper+height).
+        (left, upper, right, lower) = (20, 20, 100, 100)
 
-    # Here the image "im" is cropped and assigned to new variable im_crop
-    im_crop = im.crop((left, upper, right, lower))
+        # Here the image "im" is cropped and assigned to new variable im_crop
+        im_crop = im.crop((left, upper, right, lower))
 
 
 .. automethod:: PIL.Image.Image.draft
@@ -167,10 +167,10 @@ This blurs the input image using a filter from the ``ImageFilter`` module:
 
     from PIL import Image, ImageFilter
 
-    im = Image.open("hopper.jpg")
+    with Image.open("hopper.jpg") as im:
 
-    # Blur the input image using the filter ImageFilter.BLUR
-    im_blurred = im.filter(filter=ImageFilter.BLUR)
+        # Blur the input image using the filter ImageFilter.BLUR
+        im_blurred = im.filter(filter=ImageFilter.BLUR)
 
 .. automethod:: PIL.Image.Image.frombytes
 .. automethod:: PIL.Image.Image.getbands
@@ -181,8 +181,8 @@ This helps to get the bands of the input image:
 
     from PIL import Image
 
-    im = Image.open("hopper.jpg")
-    print(im.getbands())  # Returns ('R', 'G', 'B')
+    with Image.open("hopper.jpg") as im:
+        print(im.getbands())  # Returns ('R', 'G', 'B')
 
 .. automethod:: PIL.Image.Image.getbbox
 
@@ -192,9 +192,9 @@ This helps to get the bounding box coordinates of the input image:
 
     from PIL import Image
 
-    im = Image.open("hopper.jpg")
-    print(im.getbbox())
-    # Returns four coordinates in the format (left, upper, right, lower)
+    with Image.open("hopper.jpg") as im:
+        print(im.getbbox())
+        # Returns four coordinates in the format (left, upper, right, lower)
 
 .. automethod:: PIL.Image.Image.getchannel
 .. automethod:: PIL.Image.Image.getcolors
@@ -222,11 +222,11 @@ This resizes the given image from ``(width, height)`` to ``(width/2, height/2)``
 
     from PIL import Image
 
-    im = Image.open("hopper.jpg")
+    with Image.open("hopper.jpg") as im:
 
-    # Provide the target width and height of the image
-    (width, height) = (im.width // 2, im.height // 2)
-    im_resized = im.resize((width, height))
+        # Provide the target width and height of the image
+        (width, height) = (im.width // 2, im.height // 2)
+        im_resized = im.resize((width, height))
 
 .. automethod:: PIL.Image.Image.rotate
 
@@ -236,12 +236,12 @@ This rotates the input image by ``theta`` degrees counter clockwise:
 
     from PIL import Image
 
-    im = Image.open("hopper.jpg")
+    with Image.open("hopper.jpg") as im:
 
-    # Rotate the image by 60 degrees counter clockwise
-    theta = 60
-    # Angle is in degrees counter clockwise
-    im_rotated = im.rotate(angle=theta)
+        # Rotate the image by 60 degrees counter clockwise
+        theta = 60
+        # Angle is in degrees counter clockwise
+        im_rotated = im.rotate(angle=theta)
 
 .. automethod:: PIL.Image.Image.save
 .. automethod:: PIL.Image.Image.seek
@@ -260,12 +260,12 @@ This flips the input image by using the :data:`FLIP_LEFT_RIGHT` method.
 
     from PIL import Image
 
-    im = Image.open("hopper.jpg")
+    with Image.open("hopper.jpg") as im:
 
-    # Flip the image from left to right
-    im_flipped = im.transpose(method=Image.FLIP_LEFT_RIGHT)
-    # To flip the image from top to bottom,
-    # use the method "Image.FLIP_TOP_BOTTOM"
+        # Flip the image from left to right
+        im_flipped = im.transpose(method=Image.FLIP_LEFT_RIGHT)
+        # To flip the image from top to bottom,
+        # use the method "Image.FLIP_TOP_BOTTOM"
 
 
 .. automethod:: PIL.Image.Image.verify

--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -81,24 +81,24 @@ Example: Draw Partial Opacity Text
 
     from PIL import Image, ImageDraw, ImageFont
     # get an image
-    base = Image.open("Pillow/Tests/images/hopper.png").convert("RGBA")
+    with Image.open("Pillow/Tests/images/hopper.png").convert("RGBA") as base:
 
-    # make a blank image for the text, initialized to transparent text color
-    txt = Image.new("RGBA", base.size, (255,255,255,0))
+        # make a blank image for the text, initialized to transparent text color
+        txt = Image.new("RGBA", base.size, (255,255,255,0))
 
-    # get a font
-    fnt = ImageFont.truetype("Pillow/Tests/fonts/FreeMono.ttf", 40)
-    # get a drawing context
-    d = ImageDraw.Draw(txt)
+        # get a font
+        fnt = ImageFont.truetype("Pillow/Tests/fonts/FreeMono.ttf", 40)
+        # get a drawing context
+        d = ImageDraw.Draw(txt)
 
-    # draw text, half opacity
-    d.text((10,10), "Hello", font=fnt, fill=(255,255,255,128))
-    # draw text, full opacity
-    d.text((10,60), "World", font=fnt, fill=(255,255,255,255))
+        # draw text, half opacity
+        d.text((10,10), "Hello", font=fnt, fill=(255,255,255,128))
+        # draw text, full opacity
+        d.text((10,60), "World", font=fnt, fill=(255,255,255,255))
 
-    out = Image.alpha_composite(base, txt)
+        out = Image.alpha_composite(base, txt)
 
-    out.show()
+        out.show()
 
 Example: Draw Multiline Text
 ----------------------------

--- a/docs/reference/ImageMath.rst
+++ b/docs/reference/ImageMath.rst
@@ -15,11 +15,11 @@ Example: Using the :py:mod:`~PIL.ImageMath` module
 
     from PIL import Image, ImageMath
 
-    im1 = Image.open("image1.jpg")
-    im2 = Image.open("image2.jpg")
+    with Image.open("image1.jpg") as im1:
+        with Image.open("image2.jpg") as im2:
 
-    out = ImageMath.eval("convert(min(a, b), 'L')", a=im1, b=im2)
-    out.save("result.png")
+            out = ImageMath.eval("convert(min(a, b), 'L')", a=im1, b=im2)
+            out.save("result.png")
 
 .. py:function:: eval(expression, environment)
 

--- a/docs/reference/c_extension_debugging.rst
+++ b/docs/reference/c_extension_debugging.rst
@@ -63,8 +63,8 @@ Take your test image, and make a really simple harness.
 ::
 
     from PIL import Image
-    im = Image.open(path)
-    im.load()
+    with Image.open(path) as im:
+        im.load()
 
 -  Run this through valgrind, but note that python triggers some issues
    on its own, so you're looking for items within the Pillow hierarchy


### PR DESCRIPTION
Updating documentation to use context managers, per https://pillow.readthedocs.io/en/stable/releasenotes/7.0.0.html#image-del
> Implicitly closing the image’s underlying file in Image.__del__ has been removed. Use a context manager or call close() instead to close the file in a deterministic way.