### PR TITLE
Migrated from deprecated numpy bool and float

### DIFF
--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -31,7 +31,7 @@ def test_numpy_to_image():
         return i
 
     # Check supported 1-bit integer formats
-    assert_image(to_image(numpy.bool, 1, 1), "1", TEST_IMAGE_SIZE)
+    assert_image(to_image(bool, 1, 1), "1", TEST_IMAGE_SIZE)
     assert_image(to_image(numpy.bool8, 1, 1), "1", TEST_IMAGE_SIZE)
 
     # Check supported 8-bit integer formats
@@ -65,7 +65,7 @@ def test_numpy_to_image():
         to_image(numpy.int64)
 
     # Check floating-point formats
-    assert_image(to_image(numpy.float), "F", TEST_IMAGE_SIZE)
+    assert_image(to_image(float), "F", TEST_IMAGE_SIZE)
     with pytest.raises(TypeError):
         to_image(numpy.float16)
     assert_image(to_image(numpy.float32), "F", TEST_IMAGE_SIZE)
@@ -191,7 +191,7 @@ def test_putdata():
 
 def test_roundtrip_eye():
     for dtype in (
-        numpy.bool,
+        bool,
         numpy.bool8,
         numpy.int8,
         numpy.int16,
@@ -199,7 +199,7 @@ def test_roundtrip_eye():
         numpy.uint8,
         numpy.uint16,
         numpy.uint32,
-        numpy.float,
+        float,
         numpy.float32,
         numpy.float64,
     ):
@@ -218,7 +218,7 @@ def test_zero_size():
 
 def test_bool():
     # https://github.com/python-pillow/Pillow/issues/2044
-    a = numpy.zeros((10, 2), dtype=numpy.bool)
+    a = numpy.zeros((10, 2), dtype=bool)
     a[0][0] = True
 
     im2 = Image.fromarray(a)


### PR DESCRIPTION
Replaces `np.bool` with `bool` and `np.float` and `float`, as per https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

Warnings about this can currently be seen at https://github.com/python-pillow/Pillow/runs/1968656801#step:10:1890
> Tests/test_numpy.py::test_numpy_to_image
>   /home/runner/work/Pillow/Pillow/Tests/test_numpy.py:34: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
>   Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
>     assert_image(to_image(numpy.bool, 1, 1), "1", TEST_IMAGE_SIZE)
> 
> Tests/test_numpy.py::test_numpy_to_image
>   /home/runner/work/Pillow/Pillow/Tests/test_numpy.py:68: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
>   Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
>     assert_image(to_image(numpy.float), "F", TEST_IMAGE_SIZE)
> 
> Tests/test_numpy.py::test_roundtrip_eye
>   /home/runner/work/Pillow/Pillow/Tests/test_numpy.py:194: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
>   Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
>     numpy.bool,
> 
> Tests/test_numpy.py::test_roundtrip_eye
>   /home/runner/work/Pillow/Pillow/Tests/test_numpy.py:202: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
>   Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
>     numpy.float,
> 
> Tests/test_numpy.py::test_bool
>   /home/runner/work/Pillow/Pillow/Tests/test_numpy.py:221: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
>   Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
>     a = numpy.zeros((10, 2), dtype=numpy.bool)