### PR TITLE
Added IPythonViewer

### DIFF
--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -62,4 +62,20 @@ def test_viewer():
 
 def test_viewers():
     for viewer in ImageShow._viewers:
-        viewer.get_command("test.jpg")
+        try:
+            viewer.get_command("test.jpg")
+        except NotImplementedError:
+            pass
+
+
+def test_ipythonviewer():
+    pytest.importorskip("IPython", reason="IPython not installed")
+    for viewer in ImageShow._viewers:
+        if isinstance(viewer, ImageShow.IPythonViewer):
+            test_viewer = viewer
+            break
+    else:
+        assert False
+
+    im = hopper()
+    assert test_viewer.show(im) == 1

--- a/docs/reference/ImageShow.rst
+++ b/docs/reference/ImageShow.rst
@@ -9,6 +9,7 @@ All default viewers convert the image to be shown to PNG format.
 
 .. autofunction:: PIL.ImageShow.show
 
+.. autoclass:: IPythonViewer
 .. autoclass:: WindowsViewer
 .. autoclass:: MacViewer
 

--- a/docs/releasenotes/8.2.0.rst
+++ b/docs/releasenotes/8.2.0.rst
@@ -21,10 +21,17 @@ TODO
 API Additions
 =============
 
-TODO
-^^^^
+ImageShow.IPythonViewer
+^^^^^^^^^^^^^^^^^^^^^^^
 
-TODO
+If IPython is present, this new ``ImageShow.Viewer`` subclass will be
+registered. It displays images on all IPython frontends. This will be helpful
+to users of Google Colab, allowing ``im.show()`` to display images.
+
+It is lower in priority than the other default Viewer instances, so it will
+only be used by ``im.show()`` or ``ImageShow.show()`` if none of the other
+viewers are available. This means that the behaviour of ``ImageShow`` will stay
+the same for most Pillow users.
 
 Security
 ========

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -228,12 +228,12 @@ if sys.platform not in ("win32", "darwin"):  # unixoids
 
 class IPythonViewer(Viewer):
     def show_image(self, image, **options):
-        display(image)
+        ipython_display(image)
         return 1
 
 
 try:
-    from IPython.display import display
+    from IPython.display import display as ipython_display
 except ImportError:
     pass
 else:

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -225,6 +225,21 @@ if sys.platform not in ("win32", "darwin"):  # unixoids
     if shutil.which("xv"):
         register(XVViewer)
 
+
+class IPythonViewer(Viewer):
+    def show_image(self, image, **options):
+        display(image)
+        return 1
+
+
+try:
+    from IPython.display import display
+except ImportError:
+    pass
+else:
+    register(IPythonViewer)
+
+
 if __name__ == "__main__":
 
     if len(sys.argv) < 2:

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -227,6 +227,8 @@ if sys.platform not in ("win32", "darwin"):  # unixoids
 
 
 class IPythonViewer(Viewer):
+    """The viewer for IPython frontends."""
+
     def show_image(self, image, **options):
         ipython_display(image)
         return 1


### PR DESCRIPTION
Resolves #5286 by adding a new `ImageShow.Viewer` - `IPythonViewer`. It calls the `display()` method to allow `ImageShow` to work with IPython... and Google Colab.

Here is my demonstration of it working in Google Colab.
<img width="1126" alt="Screen Shot 2021-02-26 at 11 09 38 pm" src="https://user-images.githubusercontent.com/3112309/109298511-d1296080-7887-11eb-852b-61b927e4d081.png">
```python
from PIL import Image, ImageShow
im = Image.new("RGB", (100, 100))
im.show()
```
```python
from PIL import ImageShow
class IPythonViewer(ImageShow.Viewer):
    def show_image(self, image, **options):
        display(image)
        return 1

try:
    from IPython.display import display
except ImportError:
    pass
else:
    ImageShow.register(IPythonViewer)

from PIL import Image
im = Image.new("RGB", (100, 100))
im.show()

# Cleanup
ImageShow._viewers = [v for v in ImageShow._viewers if v.__class__ != IPythonViewer]
```