### PR TITLE
Removed comment

### DIFF
--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -69,7 +69,6 @@ class Viewer:
         Converts the given image to the target format and displays it.
         """
 
-        # save temporary image to disk
         if not (
             image.mode in ("1", "RGBA")
             or (self.format == "PNG" and image.mode in ("I;16", "LA"))


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/585683ce258cb5e3362bf22e165d3a739efc27c6/src/PIL/ImageShow.py#L66-L81

This, to me, looks like the https://github.com/python-pillow/Pillow/blob/585683ce258cb5e3362bf22e165d3a739efc27c6/src/PIL/ImageShow.py#L73-L79 block should "save temporary image to disk" - except it doesn't.

This PR just removes that comment.