### PR TITLE
Corrected list of relevant dependencies

### DIFF
--- a/docs/releasenotes/8.1.1.rst
+++ b/docs/releasenotes/8.1.1.rst
@@ -31,5 +31,5 @@ Shaffer, Xinran Xie, and Akshay Ajayan of
 Other Changes
 =============
 
-A crash with the feature flags for libjpeg and WebP on unreleased Python 3.10 has been
-fixed (:issue:`5193`).
+A crash with the feature flags for libimagequant, libjpegturbo, WebP and XCB on
+unreleased Python 3.10 has been fixed (:issue:`5193`).

--- a/docs/releasenotes/8.1.1.rst
+++ b/docs/releasenotes/8.1.1.rst
@@ -31,5 +31,5 @@ Shaffer, Xinran Xie, and Akshay Ajayan of
 Other Changes
 =============
 
-A crash with the feature flags for libimagequant, libjpegturbo, WebP and XCB on
+A crash with the feature flags for libimagequant, libjpeg-turbo, WebP and XCB on
 unreleased Python 3.10 has been fixed (:issue:`5193`).


### PR DESCRIPTION
The release notes for 8.1.1 currently read
> A crash with the feature flags for libjpeg and WebP on unreleased Python 3.10 has been fixed (#5193).

Except if you look at the code for the fix - #5194 - this list should be libjpeg**turbo**, WebP, libimagequant and XCB.