### PR TITLE
Do not premultiply alpha when resizing with Image.NEAREST resampling

### DIFF
--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -145,9 +145,8 @@ class TestImageTransform:
 
     def _test_nearest(self, op, mode):
         # create white image with half transparent,
-        # with the black half transparent.
         # do op,
-        # the image should be white with half transparent
+        # the image should remain white with half transparent
         transparent, opaque = {
             "RGBA": ((255, 255, 255, 0), (255, 255, 255, 255)),
             "LA": ((255, 0), (255, 255)),

--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -143,6 +143,42 @@ class TestImageTransform:
 
         self._test_alpha_premult(op)
 
+    def _test_nearest(self, op, mode):
+        # create white image with half transparent,
+        # with the black half transparent.
+        # do op,
+        # the image should be white with half transparent
+        transparent, opaque = {
+            "RGBA": ((255, 255, 255, 0), (255, 255, 255, 255)),
+            "LA": ((255, 0), (255, 255)),
+        }[mode]
+        im = Image.new(mode, (10, 10), transparent)
+        im2 = Image.new(mode, (5, 10), opaque)
+        im.paste(im2, (0, 0))
+
+        im = op(im, (40, 10))
+
+        colors = im.getcolors()
+        assert colors == [
+            (20 * 10, opaque),
+            (20 * 10, transparent),
+        ]
+
+    @pytest.mark.parametrize("mode", ("RGBA", "LA"))
+    def test_nearest_resize(self, mode):
+        def op(im, sz):
+            return im.resize(sz, Image.NEAREST)
+
+        self._test_nearest(op, mode)
+
+    @pytest.mark.parametrize("mode", ("RGBA", "LA"))
+    def test_nearest_transform(self, mode):
+        def op(im, sz):
+            (w, h) = im.size
+            return im.transform(sz, Image.EXTENT, (0, 0, w, h), Image.NEAREST)
+
+        self._test_nearest(op, mode)
+
     def test_blank_fill(self):
         # attempting to hit
         # https://github.com/python-pillow/Pillow/issues/254 reported

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1910,7 +1910,7 @@ class Image:
         if self.mode in ("1", "P"):
             resample = NEAREST
 
-        if self.mode in ["LA", "RGBA"]:
+        if self.mode in ["LA", "RGBA"] and resample != NEAREST:
             im = self.convert(self.mode[:-1] + "a")
             im = im.resize(size, resample, box)
             return im.convert(self.mode)
@@ -2394,14 +2394,14 @@ class Image:
         :returns: An :py:class:`~PIL.Image.Image` object.
         """
 
-        if self.mode == "LA":
+        if self.mode == "LA" and resample != NEAREST:
             return (
                 self.convert("La")
                 .transform(size, method, data, resample, fill, fillcolor)
                 .convert("LA")
             )
 
-        if self.mode == "RGBA":
+        if self.mode == "RGBA" and resample != NEAREST:
             return (
                 self.convert("RGBa")
                 .transform(size, method, data, resample, fill, fillcolor)


### PR DESCRIPTION
Fixes #5300.

Test is based on the previous tests that make sure premultiplied alpha is used with BILINEAR resampling.

From https://pillow.readthedocs.io/en/stable/handbook/concepts.html#PIL.Image.NEAREST:

> Pick one nearest pixel from the input image. Ignore all other input pixels.

I would interpret that as meaning that each pixel in the output will be equal to one of the original pixels, i.e. not introducing new values.