### PR TITLE
Fix -Wformat error in TiffDecode

### DIFF
--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -56,7 +56,7 @@ _tiffReadProc(thandle_t hdata, tdata_t buf, tsize_t size) {
     dump_state(state);
 
     if (state->loc > state->eof) {
-        TIFFError("_tiffReadProc", "Invalid Read at loc %d, eof: %d", state->loc, state->eof);
+        TIFFError("_tiffReadProc", "Invalid Read at loc %lu, eof: %lu", state->loc, state->eof);
         return 0;
     }
     to_read = min(size, min(state->size, (tsize_t)state->eof) - (tsize_t)state->loc);

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -56,7 +56,7 @@ _tiffReadProc(thandle_t hdata, tdata_t buf, tsize_t size) {
     dump_state(state);
 
     if (state->loc > state->eof) {
-        TIFFError("_tiffReadProc", "Invalid Read at loc %lu, eof: %lu", state->loc, state->eof);
+        TIFFError("_tiffReadProc", "Invalid Read at loc %llu, eof: %llu", state->loc, state->eof);
         return 0;
     }
     to_read = min(size, min(state->size, (tsize_t)state->eof) - (tsize_t)state->loc);


### PR DESCRIPTION
When building under an environment with -Werror=format, TiffDecode.c no longer builds:

```
src/libImaging/TiffDecode.c: In function ‘_tiffReadProc’:
src/libImaging/TiffDecode.c:59:58: error: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘toff_t’ {aka ‘long unsigned int’} [-Werror=format=]
src/libImaging/TiffDecode.c:59:67: error: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘toff_t’ {aka ‘long unsigned int’} [-Werror=format=]
```