### PR TITLE
Added more CVE numbers to 8.1.1 release notes

### DIFF
--- a/docs/releasenotes/8.1.1.rst
+++ b/docs/releasenotes/8.1.1.rst
@@ -20,11 +20,11 @@ that could be used as a DOS attack.
 :cve:`CVE-2021-25293`: There is an out-of-bounds read in ``SgiRleDecode.c``,
 since Pillow 4.3.0.
 
-There is an exhaustion of memory DOS in the ICNS, ICO, and BLP
-container formats where Pillow did not properly check the reported
-size of the contained image. These images could cause arbitrarily
-large memory allocations. This was reported by Jiayi Lin, Luke
-Shaffer, Xinran Xie, and Akshay Ajayan of
+There is an exhaustion of memory DOS in the BLP (:cve:`CVE-2021-27921`),
+ICNS (:cve:`CVE-2021-27922`) and ICO (:cve:`CVE-2021-27923`) container formats
+where Pillow did not properly check the reported size of the contained image.
+These images could cause arbitrarily large memory allocations. This was reported
+by Jiayi Lin, Luke Shaffer, Xinran Xie, and Akshay Ajayan of
 `Arizona State University <https://www.asu.edu/>`_.
 
 


### PR DESCRIPTION
Tidelift reported the existence of
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-27921
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-27922
and
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-27923

This PR adds them to the 8.1.1 release notes