### PR TITLE
Save ICC profile from TIFF encoderinfo

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -517,6 +517,8 @@ class TestFilePng:
 
     def test_discard_icc_profile(self):
         with Image.open("Tests/images/icc_profile.png") as im:
+            assert "icc_profile" in im.info
+
             im = roundtrip(im, icc_profile=None)
         assert "icc_profile" not in im.info
 

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -568,6 +568,28 @@ class TestFileTiff:
         with Image.open(tmpfile) as reloaded:
             assert b"Dummy value" == reloaded.info["icc_profile"]
 
+    def test_save_icc_profile(self, tmp_path):
+        im = hopper()
+        assert "icc_profile" not in im.info
+
+        outfile = str(tmp_path / "temp.tif")
+        icc_profile = b"Dummy value"
+        im.save(outfile, icc_profile=icc_profile)
+
+        with Image.open(outfile) as reloaded:
+            assert reloaded.info["icc_profile"] == icc_profile
+
+    def test_discard_icc_profile(self, tmp_path):
+        outfile = str(tmp_path / "temp.tif")
+
+        with Image.open("Tests/images/icc_profile.png") as im:
+            assert "icc_profile" in im.info
+
+            im.save(outfile, icc_profile=None)
+
+        with Image.open(outfile) as reloaded:
+            assert "icc_profile" not in reloaded.info
+
     def test_close_on_load_exclusive(self, tmp_path):
         # similar to test_fd_leak, but runs on unixlike os
         tmpfile = str(tmp_path / "temp.tif")

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1481,8 +1481,9 @@ def _save(im, fp, filename):
 
     # preserve ICC profile (should also work when saving other formats
     # which support profiles as TIFF) -- 2008-06-06 Florian Hoech
-    if "icc_profile" in im.info:
-        ifd[ICCPROFILE] = im.info["icc_profile"]
+    icc = im.encoderinfo.get("icc_profile", im.info.get("icc_profile"))
+    if icc:
+        ifd[ICCPROFILE] = icc
 
     for key, name in [
         (IMAGEDESCRIPTION, "description"),


### PR DESCRIPTION
Resolves #5225

As #1909 allowed `im.save("out.png", icc_profile=icc_profile)`, so this PR allows `icc_profile` to be specified through arguments for TIFF.