### PR TITLE
Fixed unclosed file warning

### DIFF
--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -143,8 +143,8 @@ def test_not_an_icns_file():
 
 
 def test_icns_decompression_bomb():
-    with pytest.raises(Image.DecompressionBombError):
-        im = Image.open(
-            "Tests/images/oom-8ed3316a4109213ca96fb8a256a0bfefdece1461.icns"
-        )
-        im.load()
+    with Image.open(
+        "Tests/images/oom-8ed3316a4109213ca96fb8a256a0bfefdece1461.icns"
+    ) as im:
+        with pytest.raises(Image.DecompressionBombError):
+            im.load()


### PR DESCRIPTION
See the warning at https://github.com/python-pillow/Pillow/runs/2085790744#step:10:1904

> Tests/test_file_icns.py::test_icns_decompression_bomb
>  /opt/hostedtoolcache/Python/3.9.2/x64/lib/python3.9/site-packages/_pytest/python.py:183: ResourceWarning: unclosed file <_io.BufferedReader name='Tests/images/oom-8ed3316a4109213ca96fb8a256a0bfefdece1461.icns'>
>    result = testfunction(**testargs)