### PR TITLE
Improved efficiency when creating GIF disposal images

### DIFF
--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -265,12 +265,15 @@ class GifImageFile(ImageFile.ImageFile):
                 self.dispose = None
             elif self.disposal_method == 2:
                 # replace with background colour
-                Image._decompression_bomb_check(self.size)
-                self.dispose = Image.core.fill("P", self.size, self.info["background"])
 
                 # only dispose the extent in this frame
-                if self.dispose:
-                    self.dispose = self._crop(self.dispose, self.dispose_extent)
+                x0, y0, x1, y1 = self.dispose_extent
+                dispose_size = (x1 - x0, y1 - y0)
+
+                Image._decompression_bomb_check(dispose_size)
+                self.dispose = Image.core.fill(
+                    "P", dispose_size, self.info["background"]
+                )
             else:
                 # replace with previous contents
                 if self.im:

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -267,14 +267,15 @@ class GifImageFile(ImageFile.ImageFile):
                 # replace with background colour
                 Image._decompression_bomb_check(self.size)
                 self.dispose = Image.core.fill("P", self.size, self.info["background"])
+
+                # only dispose the extent in this frame
+                if self.dispose:
+                    self.dispose = self._crop(self.dispose, self.dispose_extent)
             else:
                 # replace with previous contents
                 if self.im:
-                    self.dispose = self.im.copy()
-
-            # only dispose the extent in this frame
-            if self.dispose:
-                self.dispose = self._crop(self.dispose, self.dispose_extent)
+                    # only dispose the extent in this frame
+                    self.dispose = self._crop(self.im, self.dispose_extent)
         except (AttributeError, KeyError):
             pass
 


### PR DESCRIPTION
Two changes.

1. Do not call `self.im.copy()`, only to then call `self._crop` - `self._crop` already creates a copy of the image.
2. Instead of creating a solid color image of `self.size` and then cropping it, just create the solid color image at the necessary size.