### PR TITLE
Document #5321

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -901,6 +901,9 @@ using the general tags available through tiffinfo.
 **copyright**
     Strings
 
+**icc_profile**
+    The ICC Profile to include in the saved file.
+
 **resolution_unit**
     An integer. 1 for no unit, 2 for inches and 3 for centimeters.
 

--- a/docs/releasenotes/8.2.0.rst
+++ b/docs/releasenotes/8.2.0.rst
@@ -51,6 +51,14 @@ instances, so it will only be used by ``im.show()`` or :py:func:`.ImageShow.show
 if none of the other viewers are available. This means that the behaviour of
 :py:class:`PIL.ImageShow` will stay the same for most Pillow users.
 
+Saving TIFF with ICC profile
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As is already possible for JPEG, PNG and WebP, the ICC profile for TIFF files can now
+be specified through a keyword argument::
+
+    im.save("out.tif", icc_profile=...)
+
 Security
 ========
 


### PR DESCRIPTION
`icc_profile` is now a keyword argument when saving TIFF files