### PR TITLE
More OSS-Fuzz support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ Tests/images/jpeg2000
 Tests/images/msp
 Tests/images/picins
 Tests/images/sunraster
+
+# pyinstaller
+*.spec

--- a/Tests/oss-fuzz/build.sh
+++ b/Tests/oss-fuzz/build.sh
@@ -31,6 +31,7 @@ for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
       --add-binary /usr/local/lib/libwebp.so.7:. \
       --add-binary /usr/local/lib/libwebpdemux.so.2:. \
       --add-binary /usr/local/lib/libwebpmux.so.3:. \
+      --add-binary /usr/local/lib/libxcb.so.1:. \
       --distpath $OUT --onefile --name $fuzzer_package $fuzzer
 
   # Create execution wrapper.

--- a/Tests/oss-fuzz/build.sh
+++ b/Tests/oss-fuzz/build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -eu
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+python3 setup.py build --build-base=/tmp/build install
+
+# Build fuzzers in $OUT.
+for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
+  fuzzer_basename=$(basename -s .py $fuzzer)
+  fuzzer_package=${fuzzer_basename}.pkg
+  pyinstaller \
+      --add-binary /usr/local/lib/libjpeg.so.9:. \
+      --add-binary /usr/local/lib/libfreetype.so.6:. \
+      --add-binary /usr/local/lib/liblcms2.so.2:. \
+      --add-binary /usr/local/lib/libopenjp2.so.7:. \
+      --add-binary /usr/local/lib/libpng16.so.16:. \
+      --add-binary /usr/local/lib/libtiff.so.5:. \
+      --add-binary /usr/local/lib/libwebp.so.7:. \
+      --add-binary /usr/local/lib/libwebpdemux.so.2:. \
+      --add-binary /usr/local/lib/libwebpmux.so.3:. \
+      --distpath $OUT --onefile --name $fuzzer_package $fuzzer
+
+  # Create execution wrapper.
+  echo "#!/bin/sh
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\$(dirname \"\$0\")
+LD_PRELOAD=\$this_dir/sanitizer_with_fuzzer.so \
+ASAN_OPTIONS=\$ASAN_OPTIONS:symbolize=1:external_symbolizer_path=\$this_dir/llvm-symbolizer:detect_leaks=0 \
+\$this_dir/$fuzzer_package \$@" > $OUT/$fuzzer_basename
+  chmod u+x $OUT/$fuzzer_basename
+done
+
+find Tests/images Tests/icc Tests/fonts -print | zip -q $OUT/fuzz_pillow_seed_corpus.zip -@

--- a/Tests/oss-fuzz/build.sh
+++ b/Tests/oss-fuzz/build.sh
@@ -43,4 +43,5 @@ ASAN_OPTIONS=\$ASAN_OPTIONS:symbolize=1:external_symbolizer_path=\$this_dir/llvm
   chmod u+x $OUT/$fuzzer_basename
 done
 
-find Tests/images Tests/icc Tests/fonts -print | zip -q $OUT/fuzz_pillow_seed_corpus.zip -@
+find Tests/images Tests/icc -print | zip -q $OUT/fuzz_pillow_seed_corpus.zip -@
+find Tests/fonts -print | zip -q $OUT/fuzz_font_seed_corpus.zip -@

--- a/Tests/oss-fuzz/build_dictionaries.sh
+++ b/Tests/oss-fuzz/build_dictionaries.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eu
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Generate image dictionaries here for each of the fuzzers and put them in the
+# $OUT directory, named for the fuzzer
+
+git clone --depth 1 https://github.com/google/fuzzing
+cat fuzzing/dictionaries/bmp.dict \
+    fuzzing/dictionaries/dds.dict \
+    fuzzing/dictionaries/gif.dict \
+    fuzzing/dictionaries/icns.dict \
+    fuzzing/dictionaries/jpeg.dict \
+    fuzzing/dictionaries/jpeg2000.dict \
+    fuzzing/dictionaries/pbm.dict \
+    fuzzing/dictionaries/png.dict \
+    fuzzing/dictionaries/psd.dict \
+    fuzzing/dictionaries/tiff.dict \
+    fuzzing/dictionaries/webp.dict \
+    > $OUT/fuzz_pillow.dict

--- a/Tests/oss-fuzz/fuzz_font.py
+++ b/Tests/oss-fuzz/fuzz_font.py
@@ -19,8 +19,8 @@ import sys
 import warnings
 
 import atheris_no_libfuzzer as atheris
-
 import fuzzers
+
 
 def TestOneInput(data):
     try:

--- a/Tests/oss-fuzz/fuzz_font.py
+++ b/Tests/oss-fuzz/fuzz_font.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python3
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import sys
+import warnings
+
+import atheris_no_libfuzzer as atheris
+
+from PIL import Image, ImageDraw, ImageFont
+
+
+def TestOneInput(data):
+    try:
+        with ImageFont.load(io.BytesIO(data)) as font:
+            font.getsize_multiline("ABC\nAaaa")
+            font.getmask("test text")
+            with Image.new(mode="RGBA", size=(200, 200)) as im:
+                draw = ImageDraw.Draw(im)
+                draw.text((10,10), "Test Text", font)
+    except Exception:
+        # We're catching all exceptions because Pillow's exceptions are
+        # directly inheriting from Exception.
+        return
+    return
+
+
+def main():
+    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/Tests/oss-fuzz/fuzz_font.py
+++ b/Tests/oss-fuzz/fuzz_font.py
@@ -31,6 +31,7 @@ def TestOneInput(data):
 
 
 def main():
+    fuzzers.enable_decompressionbomb_error()
     atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
     atheris.Fuzz()
 

--- a/Tests/oss-fuzz/fuzz_font.py
+++ b/Tests/oss-fuzz/fuzz_font.py
@@ -14,9 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
 import sys
-import warnings
 
 import atheris_no_libfuzzer as atheris
 import fuzzers

--- a/Tests/oss-fuzz/fuzz_font.py
+++ b/Tests/oss-fuzz/fuzz_font.py
@@ -20,17 +20,11 @@ import warnings
 
 import atheris_no_libfuzzer as atheris
 
-from PIL import Image, ImageDraw, ImageFont
-
+import fuzzers
 
 def TestOneInput(data):
     try:
-        with ImageFont.load(io.BytesIO(data)) as font:
-            font.getsize_multiline("ABC\nAaaa")
-            font.getmask("test text")
-            with Image.new(mode="RGBA", size=(200, 200)) as im:
-                draw = ImageDraw.Draw(im)
-                draw.text((10,10), "Test Text", font)
+        fuzzers.fuzz_font(data)
     except Exception:
         # We're catching all exceptions because Pillow's exceptions are
         # directly inheriting from Exception.

--- a/Tests/oss-fuzz/fuzz_pillow.py
+++ b/Tests/oss-fuzz/fuzz_pillow.py
@@ -18,9 +18,9 @@ import io
 import sys
 import warnings
 
+import atheris_no_libfuzzer as atheris
 import fuzzers
 
-import atheris_no_libfuzzer as atheris
 
 def TestOneInput(data):
     try:
@@ -30,6 +30,7 @@ def TestOneInput(data):
         # directly inheriting from Exception.
         return
     return
+
 
 def main():
     fuzzers.enable_decompressionbomb_error()

--- a/Tests/oss-fuzz/fuzz_pillow.py
+++ b/Tests/oss-fuzz/fuzz_pillow.py
@@ -18,28 +18,21 @@ import io
 import sys
 import warnings
 
+import fuzzers
+
 import atheris_no_libfuzzer as atheris
-
-from PIL import Image, ImageFile, ImageFilter
-
 
 def TestOneInput(data):
     try:
-        with Image.open(io.BytesIO(data)) as im:
-            im.rotate(45)
-            im.filter(ImageFilter.DETAIL)
-            im.save(io.BytesIO(), "BMP")
+        fuzzers.fuzz_image(data)
     except Exception:
         # We're catching all exceptions because Pillow's exceptions are
         # directly inheriting from Exception.
         return
     return
 
-
 def main():
-    ImageFile.LOAD_TRUNCATED_IMAGES = True
-    warnings.filterwarnings("ignore")
-    warnings.simplefilter("error", Image.DecompressionBombWarning)
+    fuzzers.enable_decompressionbomb_error()
     atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
     atheris.Fuzz()
 

--- a/Tests/oss-fuzz/fuzz_pillow.py
+++ b/Tests/oss-fuzz/fuzz_pillow.py
@@ -14,9 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
 import sys
-import warnings
 
 import atheris_no_libfuzzer as atheris
 import fuzzers

--- a/Tests/oss-fuzz/fuzzers.py
+++ b/Tests/oss-fuzz/fuzzers.py
@@ -1,0 +1,33 @@
+import warnings
+import io
+
+from PIL import Image, ImageFont, ImageDraw, ImageFilter, ImageFile, PcfFontFile
+
+def enable_decompressionbomb_error():
+    ImageFile.LOAD_TRUNCATED_IMAGES = True
+    warnings.filterwarnings("ignore")
+    warnings.simplefilter("error", Image.DecompressionBombWarning)
+
+def fuzz_image(data):
+    # This will fail on some images in the corpus, as we have many
+    # invalid images in the test suite.
+    with Image.open(io.BytesIO(data)) as im:
+        im.rotate(45)
+        im.filter(ImageFilter.DETAIL)
+        im.save(io.BytesIO(), "BMP")
+
+def fuzz_font(data):
+    # This should not fail on a valid font load for any of the fonts in the corpus
+    wrapper = io.BytesIO(data)
+    try:
+        font = ImageFont.truetype(wrapper)
+    except OSError:
+        # pcf/pilfonts/random garbage here here. They're different.
+        return
+
+    font.getsize_multiline("ABC\nAaaa")
+    font.getmask("test text")
+    with Image.new(mode="RGBA", size=(200, 200)) as im:
+        draw = ImageDraw.Draw(im)
+        draw.multiline_textsize("ABC\nAaaa", font, stroke_width=2)
+        draw.text((10,10), "Test Text", font=font, fill="#000")

--- a/Tests/oss-fuzz/fuzzers.py
+++ b/Tests/oss-fuzz/fuzzers.py
@@ -1,7 +1,7 @@
 import io
 import warnings
 
-from PIL import Image, ImageDraw, ImageFile, ImageFilter, ImageFont, PcfFontFile
+from PIL import Image, ImageDraw, ImageFile, ImageFilter, ImageFont
 
 
 def enable_decompressionbomb_error():

--- a/Tests/oss-fuzz/fuzzers.py
+++ b/Tests/oss-fuzz/fuzzers.py
@@ -1,12 +1,14 @@
-import warnings
 import io
+import warnings
 
-from PIL import Image, ImageFont, ImageDraw, ImageFilter, ImageFile, PcfFontFile
+from PIL import Image, ImageDraw, ImageFile, ImageFilter, ImageFont, PcfFontFile
+
 
 def enable_decompressionbomb_error():
     ImageFile.LOAD_TRUNCATED_IMAGES = True
     warnings.filterwarnings("ignore")
     warnings.simplefilter("error", Image.DecompressionBombWarning)
+
 
 def fuzz_image(data):
     # This will fail on some images in the corpus, as we have many
@@ -15,6 +17,7 @@ def fuzz_image(data):
         im.rotate(45)
         im.filter(ImageFilter.DETAIL)
         im.save(io.BytesIO(), "BMP")
+
 
 def fuzz_font(data):
     # This should not fail on a valid font load for any of the fonts in the corpus
@@ -30,4 +33,4 @@ def fuzz_font(data):
     with Image.new(mode="RGBA", size=(200, 200)) as im:
         draw = ImageDraw.Draw(im)
         draw.multiline_textsize("ABC\nAaaa", font, stroke_width=2)
-        draw.text((10,10), "Test Text", font=font, fill="#000")
+        draw.text((10, 10), "Test Text", font=font, fill="#000")

--- a/Tests/oss-fuzz/fuzzers.py
+++ b/Tests/oss-fuzz/fuzzers.py
@@ -20,12 +20,12 @@ def fuzz_image(data):
 
 
 def fuzz_font(data):
-    # This should not fail on a valid font load for any of the fonts in the corpus
     wrapper = io.BytesIO(data)
     try:
         font = ImageFont.truetype(wrapper)
     except OSError:
-        # pcf/pilfonts/random garbage here here. They're different.
+        # Catch pcf/pilfonts/random garbage here. They return
+        # different font objects.
         return
 
     font.getsize_multiline("ABC\nAaaa")

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -46,5 +46,9 @@ def test_fuzz_fonts(path):
     if not path:
         return
     with open(path, "rb") as f:
-        fuzzers.fuzz_font(f.read())
+        try:
+            fuzzers.fuzz_font(f.read())
+        except (Image.DecompressionBombError,
+                Image.DecompressionBombWarning):
+            pass
         assert True

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -7,11 +7,10 @@ import pytest
 from PIL import Image
 
 
-def is_win32():
-    sys.platform.startswith("win32")
+if sys.platform.startswith("win32"):
+    pytest.skip("Fuzzer is linux only", true)
 
 
-@pytest.mark.skipif(is_win32(), reason="Fuzzer is linux only")
 @pytest.mark.parametrize(
     "path",
     subprocess.check_output("find Tests/images -type f", shell=True).split(b"\n"),
@@ -41,7 +40,6 @@ def test_fuzz_images(path):
         assert True
 
 
-@pytest.mark.skipif(is_win32(), reason="Fuzzer is linux only")
 @pytest.mark.parametrize(
     "path", subprocess.check_output("find Tests/fonts -type f", shell=True).split(b"\n")
 )

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -43,7 +43,7 @@ def test_fuzz_images(path):
     "path", subprocess.check_output("find Tests/fonts -type f", shell=True).split(b"\n")
 )
 def test_fuzz_fonts(path):
-    if not path or b"LICENSE.txt" in path or b".pil" in path:
+    if not path:
         return
     with open(path, "rb") as f:
         fuzzers.fuzz_font(f.read())

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -1,0 +1,31 @@
+import pytest
+
+import fuzzers
+import glob
+import subprocess
+
+from PIL import Image
+
+@pytest.mark.parametrize("path", subprocess.check_output('find Tests/images -type f', shell=True).split(b'\n'))
+def test_fuzz_images(path):
+    fuzzers.enable_decompressionbomb_error()
+    try:
+        with open(path, 'rb') as f:
+            fuzzers.fuzz_image(f.read())
+            assert True
+    except (OSError, SyntaxError, MemoryError, ValueError, NotImplementedError):
+        # Known exceptions that are through from Pillow
+        assert True
+    except (Image.DecompressionBombError, Image.DecompressionBombWarning,
+            Image.UnidentifiedImageError):
+        # Known Image.* exceptions
+        assert True
+
+
+@pytest.mark.parametrize("path", subprocess.check_output('find Tests/fonts -type f', shell=True).split(b'\n'))
+def test_fuzz_fonts(path):
+    if not path or b'LICENSE.txt' in path or b'.pil' in path:
+        return
+    with open(path, 'rb') as f:
+        fuzzers.fuzz_font(f.read())
+        assert True

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -1,11 +1,15 @@
 import subprocess
+import sys
 
 import fuzzers
 import pytest
 
 from PIL import Image
 
+def is_win32():
+    sys.platform.startswith("win32")
 
+@pytest.mark.skipif(is_win32(), reason="Fuzzer is linux only")
 @pytest.mark.parametrize(
     "path",
     subprocess.check_output("find Tests/images -type f", shell=True).split(b"\n"),
@@ -27,7 +31,7 @@ def test_fuzz_images(path):
         # Known Image.* exceptions
         assert True
 
-
+@pytest.mark.skipif(is_win32(), reason="Fuzzer is linux only")
 @pytest.mark.parametrize(
     "path", subprocess.check_output("find Tests/fonts -type f", shell=True).split(b"\n")
 )

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -48,7 +48,6 @@ def test_fuzz_fonts(path):
     with open(path, "rb") as f:
         try:
             fuzzers.fuzz_font(f.read())
-        except (Image.DecompressionBombError,
-                Image.DecompressionBombWarning):
+        except (Image.DecompressionBombError, Image.DecompressionBombWarning):
             pass
         assert True

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -6,8 +6,10 @@ import pytest
 
 from PIL import Image
 
+
 def is_win32():
     sys.platform.startswith("win32")
+
 
 @pytest.mark.skipif(is_win32(), reason="Fuzzer is linux only")
 @pytest.mark.parametrize(
@@ -20,12 +22,14 @@ def test_fuzz_images(path):
         with open(path, "rb") as f:
             fuzzers.fuzz_image(f.read())
             assert True
-    except (OSError,
-            SyntaxError,
-            MemoryError,
-            ValueError,
-            NotImplementedError,
-            OverflowError):
+    except (
+        OSError,
+        SyntaxError,
+        MemoryError,
+        ValueError,
+        NotImplementedError,
+        OverflowError,
+    ):
         # Known exceptions that are through from Pillow
         assert True
     except (
@@ -35,6 +39,7 @@ def test_fuzz_images(path):
     ):
         # Known Image.* exceptions
         assert True
+
 
 @pytest.mark.skipif(is_win32(), reason="Fuzzer is linux only")
 @pytest.mark.parametrize(

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -1,4 +1,3 @@
-import glob
 import subprocess
 
 import fuzzers

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -6,7 +6,6 @@ import pytest
 
 from PIL import Image
 
-
 if sys.platform.startswith("win32"):
     pytest.skip("Fuzzer is linux only", allow_module_level=True)
 

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -1,31 +1,40 @@
-import pytest
-
-import fuzzers
 import glob
 import subprocess
 
+import fuzzers
+import pytest
+
 from PIL import Image
 
-@pytest.mark.parametrize("path", subprocess.check_output('find Tests/images -type f', shell=True).split(b'\n'))
+
+@pytest.mark.parametrize(
+    "path",
+    subprocess.check_output("find Tests/images -type f", shell=True).split(b"\n"),
+)
 def test_fuzz_images(path):
     fuzzers.enable_decompressionbomb_error()
     try:
-        with open(path, 'rb') as f:
+        with open(path, "rb") as f:
             fuzzers.fuzz_image(f.read())
             assert True
     except (OSError, SyntaxError, MemoryError, ValueError, NotImplementedError):
         # Known exceptions that are through from Pillow
         assert True
-    except (Image.DecompressionBombError, Image.DecompressionBombWarning,
-            Image.UnidentifiedImageError):
+    except (
+        Image.DecompressionBombError,
+        Image.DecompressionBombWarning,
+        Image.UnidentifiedImageError,
+    ):
         # Known Image.* exceptions
         assert True
 
 
-@pytest.mark.parametrize("path", subprocess.check_output('find Tests/fonts -type f', shell=True).split(b'\n'))
+@pytest.mark.parametrize(
+    "path", subprocess.check_output("find Tests/fonts -type f", shell=True).split(b"\n")
+)
 def test_fuzz_fonts(path):
-    if not path or b'LICENSE.txt' in path or b'.pil' in path:
+    if not path or b"LICENSE.txt" in path or b".pil" in path:
         return
-    with open(path, 'rb') as f:
+    with open(path, "rb") as f:
         fuzzers.fuzz_font(f.read())
         assert True

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -8,7 +8,7 @@ from PIL import Image
 
 
 if sys.platform.startswith("win32"):
-    pytest.skip("Fuzzer is linux only", True)
+    pytest.skip("Fuzzer is linux only", allow_module_level=True)
 
 
 @pytest.mark.parametrize(

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -20,7 +20,12 @@ def test_fuzz_images(path):
         with open(path, "rb") as f:
             fuzzers.fuzz_image(f.read())
             assert True
-    except (OSError, SyntaxError, MemoryError, ValueError, NotImplementedError):
+    except (OSError,
+            SyntaxError,
+            MemoryError,
+            ValueError,
+            NotImplementedError,
+            OverflowError):
         # Known exceptions that are through from Pillow
         assert True
     except (

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -8,7 +8,7 @@ from PIL import Image
 
 
 if sys.platform.startswith("win32"):
-    pytest.skip("Fuzzer is linux only", true)
+    pytest.skip("Fuzzer is linux only", True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Changes proposed in this pull request:

 * Delegate build.sh, build-dictionaries to Pillow. This requires a further commit in oss-fuzz after this merges to master
 * Add a fuzzer for font files. This opens truetype files and performs some basic operations with them. 
 * Refactor and add tests for the fuzzers. This should catch any cases of the fuzzers totally failing with unexpected errors, but we are still expecting that there are a reasonable number of exceptions thrown due to attempting to load broken input. 
 * Lint fixes
