### PR TITLE
Added test for saving PNG with bits keyword

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -625,6 +625,15 @@ class TestFilePng:
         with Image.open("Tests/images/hopper_idat_after_image_end.png") as im:
             assert im.text == {"TXT": "VALUE", "ZIP": "VALUE"}
 
+    def test_specify_bits(self, tmp_path):
+        im = hopper("P")
+
+        out = str(tmp_path / "temp.png")
+        im.save(out, bits=4)
+
+        with Image.open(out) as reloaded:
+            assert len(reloaded.png.im_palette[1]) == 48
+
     def test_exif(self):
         # With an EXIF chunk
         with Image.open("Tests/images/exif.png") as im:


### PR DESCRIPTION
Line 1189 is currently untested

https://github.com/python-pillow/Pillow/blob/8064e04e963e3061918564d3c5fff35074577f29/src/PIL/PngImagePlugin.py#L1187-L1189