### PR TITLE
Updated list of TIFF compression methods

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -876,10 +876,10 @@ The :py:meth:`~PIL.Image.Image.save` method can take the following keyword argum
 **compression**
     A string containing the desired compression method for the
     file. (valid only with libtiff installed) Valid compression
-    methods are: :data:`None`, ``"tiff_ccitt"``, ``"group3"``,
-    ``"group4"``, ``"tiff_jpeg"``, ``"tiff_adobe_deflate"``,
-    ``"tiff_thunderscan"``, ``"tiff_deflate"``, ``"tiff_sgilog"``,
-    ``"tiff_sgilog24"``, ``"tiff_raw_16"``
+    methods are: :data:`None`, ``"tiff_ccitt"``, ``"group3"``, ``"group4"``,
+    ``"tiff_lzw"``, ``"jpeg"``, ``"tiff_adobe_deflate"``, ``"tiff_raw_16"``,
+    ``"packbits"``, ``"tiff_thunderscan"``, ``"tiff_deflate"``, ``"tiff_sgilog"``,
+    ``"tiff_sgilog24"``, ``"lzma"``, ``"zstd"``, ``"webp"``
 
 **quality**
     The image quality for JPEG compression, on a scale from 0 (worst) to 100

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -876,10 +876,10 @@ The :py:meth:`~PIL.Image.Image.save` method can take the following keyword argum
 **compression**
     A string containing the desired compression method for the
     file. (valid only with libtiff installed) Valid compression
-    methods are: :data:`None`, ``"tiff_ccitt"``, ``"group3"``, ``"group4"``,
-    ``"tiff_lzw"``, ``"jpeg"``, ``"tiff_adobe_deflate"``, ``"tiff_raw_16"``,
-    ``"packbits"``, ``"tiff_thunderscan"``, ``"tiff_deflate"``, ``"tiff_sgilog"``,
-    ``"tiff_sgilog24"``, ``"lzma"``, ``"zstd"``, ``"webp"``
+    methods are: :data:`None`, ``"group3"``, ``"group4"``, ``"jpeg"``, ``"lzma"``,
+    ``"packbits"``, ``"tiff_adobe_deflate"``, ``"tiff_ccitt"``, ``"tiff_deflate"``,
+    ``"tiff_lzw"``, ``"tiff_raw_16"``, ``"tiff_sgilog"``, ``"tiff_sgilog24"``,
+    ``"tiff_thunderscan"``, ``"webp"`, ``"zstd"``
 
 **quality**
     The image quality for JPEG compression, on a scale from 0 (worst) to 100

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -877,9 +877,9 @@ The :py:meth:`~PIL.Image.Image.save` method can take the following keyword argum
     A string containing the desired compression method for the
     file. (valid only with libtiff installed) Valid compression
     methods are: :data:`None`, ``"group3"``, ``"group4"``, ``"jpeg"``, ``"lzma"``,
-    ``"packbits"``, ``"tiff_adobe_deflate"``, ``"tiff_ccitt"``, ``"tiff_deflate"``,
-    ``"tiff_lzw"``, ``"tiff_raw_16"``, ``"tiff_sgilog"``, ``"tiff_sgilog24"``,
-    ``"tiff_thunderscan"``, ``"webp"`, ``"zstd"``
+    ``"packbits"``, ``"tiff_adobe_deflate"``, ``"tiff_ccitt"``, ``"tiff_lzw"``,
+    ``"tiff_raw_16"``, ``"tiff_sgilog"``, ``"tiff_sgilog24"``, ``"tiff_thunderscan"``,
+    ``"webp"`, ``"zstd"``
 
 **quality**
     The image quality for JPEG compression, on a scale from 0 (worst) to 100


### PR DESCRIPTION
Resolves #5335, that states that the "compression" list at https://pillow.readthedocs.io/en/latest/handbook/image-file-formats.html#saving-tiff-images is incorrect.

I've added "tiff_lzw", "jpeg", "packbits", "lzma", "zstd" and "webp" from https://github.com/python-pillow/Pillow/blob/8064e04e963e3061918564d3c5fff35074577f29/src/PIL/TiffImagePlugin.py#L109-L128
and removed "tiff_jpeg" (since it is obsolete, see #4627, let's stop advertising it).