### PR TITLE
Use duration from info dictionary when saving WebP

### DIFF
--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -176,3 +176,16 @@ class TestFileWebp:
             [abs(original_value[i] - reread_value[i]) for i in range(0, 3)]
         )
         assert difference < 5
+
+    @skip_unless_feature("webp")
+    @skip_unless_feature("webp_anim")
+    def test_duration(self, tmp_path):
+        with Image.open("Tests/images/dispose_bgnd.gif") as im:
+            assert im.info["duration"] == 1000
+
+            out_webp = str(tmp_path / "temp.webp")
+            im.save(out_webp, save_all=True)
+
+        with Image.open(out_webp) as reloaded:
+            reloaded.load()
+            assert reloaded.info["duration"] == 1000

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -192,7 +192,7 @@ def _save_all(im, fp, filename):
                 r, g, b = palette[background * 3 : (background + 1) * 3]
                 background = (r, g, b, 0)
 
-    duration = im.encoderinfo.get("duration", 0)
+    duration = im.encoderinfo.get("duration", im.info.get("duration"))
     loop = im.encoderinfo.get("loop", 0)
     minimize_size = im.encoderinfo.get("minimize_size", False)
     kmin = im.encoderinfo.get("kmin", None)


### PR DESCRIPTION
Helps #4313

When saving GIF, if `duration` is not passed in through a keyword argument, it defaults to the duration from the `info` dictionary - https://github.com/python-pillow/Pillow/blob/9dcb1f402cf0921b22e456eeb2ac0ad1ebbdee6d/src/PIL/GifImagePlugin.py#L426

This PR adds that behaviour to WebP.