### PR TITLE
Replaced tiff_deflate with tiff_adobe_deflate compression when saving TIFF images

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -471,6 +471,14 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open(out) as reloaded:
             assert reloaded.info["compression"] == "jpeg"
 
+    def test_tiff_deflate_compression(self, tmp_path):
+        im = hopper("RGB")
+        out = str(tmp_path / "temp.tif")
+        im.save(out, compression="tiff_deflate")
+
+        with Image.open(out) as reloaded:
+            assert reloaded.info["compression"] == "tiff_adobe_deflate"
+
     def test_quality(self, tmp_path):
         im = hopper("RGB")
         out = str(tmp_path / "temp.tif")

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1442,6 +1442,8 @@ def _save(im, fp, filename):
     elif compression == "tiff_jpeg":
         # OJPEG is obsolete, so use new-style JPEG compression instead
         compression = "jpeg"
+    elif compression == "tiff_deflate":
+        compression = "tiff_adobe_deflate"
 
     libtiff = WRITE_LIBTIFF or compression != "raw"
 


### PR DESCRIPTION
Suggested in https://github.com/python-pillow/Pillow/issues/5335#issuecomment-801742691

> Also, I suggest taking out `tiff_deflate` from this doc list while you're at it, as it should not be used for writing, [see this TIFF tech note](https://www.adobe.io/content/dam/udp/en/open/standards/tiff/TIFFphotoshop.pdf):
> 
> > A proprietary ZIP/Flate compression code (0x80b2) has been used by some software vendors. This code should be considered obsolete. The compression used by the obsolete code is identical to that defined above. We recommend that TIFF implementations recognize and read the obsolete code, but only write the official compression code (8).

Similar to #4627