### PR TITLE
Add preserve_tone option to autocontrast

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -400,6 +400,6 @@ def test_autocontrast_preserve_one_color(color):
 
     # even if there is a cutoff
     out = ImageOps.autocontrast(
-        img, cutoff=0, preserve_tone=True
+        img, cutoff=10, preserve_tone=True
     )  # single color 10 cutoff
     assert_image_equal(img, out)

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -29,6 +29,7 @@ def test_sanity():
     ImageOps.autocontrast(hopper("L"), cutoff=(2, 10))
     ImageOps.autocontrast(hopper("L"), ignore=[0, 255])
     ImageOps.autocontrast(hopper("L"), mask=hopper("L"))
+    ImageOps.autocontrast(hopper("L"), preserve_tone=True)
 
     ImageOps.colorize(hopper("L"), (0, 0, 0), (255, 255, 255))
     ImageOps.colorize(hopper("L"), "black", "white")

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -376,7 +376,7 @@ def test_autocontrast_preserve_gradient():
 
     # cutoff the top and bottom
     # autocontrast should make the first and list histogram entries equal
-    # and should be 10% of the image pixels (+-, because integers)
+    # and, with rounding, should be 10% of the image pixels
     out = ImageOps.autocontrast(gradient, cutoff=10, preserve_tone=True)
     hist = out.histogram()
     assert hist[0] == hist[-1]

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -375,7 +375,7 @@ def test_autocontrast_preserve_gradient():
     assert_image_equal(gradient, out)
 
     # cutoff the top and bottom
-    # autocontrast should make the first and list histogram entries equal
+    # autocontrast should make the first and last histogram entries equal
     # and, with rounding, should be 10% of the image pixels
     out = ImageOps.autocontrast(gradient, cutoff=10, preserve_tone=True)
     hist = out.histogram()

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -366,7 +366,7 @@ def test_auto_contrast_mask_real_input():
 
 
 def test_autocontrast_preserve_gradient():
-    gradient = Image.linear_gradient("L"))
+    gradient = Image.linear_gradient("L")
 
     # test with a grayscale gradient that extends to 0,255.
     # Should be a noop.
@@ -394,7 +394,6 @@ def test_autocontrast_preserve_onecolor():
 
         # single color images shouldn't change
         out = ImageOps.autocontrast(img, cutoff=0, preserve_tone=True)
-        # remove when production
         assert_image_equal(img, out)  # single color, no cutoff
 
         # even if there is a cutoff
@@ -403,9 +402,7 @@ def test_autocontrast_preserve_onecolor():
         )  # single color 10 cutoff
         assert_image_equal(img, out)
 
-    # succeeding
     _test_one_color((255, 255, 255))
     _test_one_color((127, 255, 0))
-    # failing
     _test_one_color((127, 127, 127))
     _test_one_color((0, 0, 0))

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -337,7 +337,7 @@ def test_autocontrast_mask_toy_input():
         assert ImageStat.Stat(result_nomask).median == [128]
 
 
-def test_auto_contrast_mask_real_input():
+def test_autocontrast_mask_real_input():
     # Test the autocontrast with a rectangular mask
     with Image.open("Tests/images/iptc.jpg") as img:
 

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -366,9 +366,7 @@ def test_auto_contrast_mask_real_input():
 
 
 def test_autocontrast_preserve_gradient():
-    from PIL import _imaging as core
-
-    gradient = Image.Image()._new(core.linear_gradient("L"))
+    gradient = Image.linear_gradient("L"))
 
     # test with a grayscale gradient that extends to 0,255.
     # Should be a noop.

--- a/docs/releasenotes/8.2.0.rst
+++ b/docs/releasenotes/8.2.0.rst
@@ -74,13 +74,13 @@ be specified through a keyword argument::
     im.save("out.tif", icc_profile=...)
 
 
-ImageOps.autocontrast: tone preserving option
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ImageOps.autocontrast: preserve_tone
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The default behaviour of the :py:meth:`~PIL.ImageOps.autocontrast` is to normalize separate
-histograms for each color channel, it changes tone of the image. Added ``preserve_tone``
-argument which avoids changing the tone of the image using one luminance histogram for all
-channels.
+The default behaviour of the :py:meth:`~PIL.ImageOps.autocontrast` is to normalize
+separate histograms for each color channel, changing the tone of the image. The new
+``preserve_tone`` argument keeps the tone unchanged by using one luminance histogram
+for all channels.
 
 Security
 ========

--- a/docs/releasenotes/8.2.0.rst
+++ b/docs/releasenotes/8.2.0.rst
@@ -77,7 +77,7 @@ be specified through a keyword argument::
 ImageOps.autocontrast: preserve_tone
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The default behaviour of the :py:meth:`~PIL.ImageOps.autocontrast` is to normalize
+The default behaviour of :py:meth:`~PIL.ImageOps.autocontrast` is to normalize
 separate histograms for each color channel, changing the tone of the image. The new
 ``preserve_tone`` argument keeps the tone unchanged by using one luminance histogram
 for all channels.

--- a/docs/releasenotes/8.2.0.rst
+++ b/docs/releasenotes/8.2.0.rst
@@ -73,6 +73,15 @@ be specified through a keyword argument::
 
     im.save("out.tif", icc_profile=...)
 
+
+ImageOps.autocontrast: tone preserving option
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The default behaviour of the :py:meth:`~PIL.ImageOps.autocontrast` is to normalize separate
+histograms for each color channel, it changes tone of the image. Added ``preserve_tone``
+argument which avoids changing the tone of the image using one luminance histogram for all
+channels.
+
 Security
 ========
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -78,6 +78,9 @@ def autocontrast(image, cutoff=0, ignore=None, mask=None, preserve_tone=False):
                  within the mask. If no mask is given the entire image is used
                  for histogram computation.
     :param preserve_tone: Preserve image tone in Photoshop-like style autocontrast.
+
+                          .. versionadded:: 1.1.5
+
     :return: An image.
     """
     if preserve_tone:

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -79,7 +79,7 @@ def autocontrast(image, cutoff=0, ignore=None, mask=None, preserve_tone=False):
                  for histogram computation.
     :param preserve_tone: Preserve image tone in Photoshop-like style autocontrast.
 
-                          .. versionadded:: 1.1.5
+                          .. versionadded:: 8.2.0
 
     :return: An image.
     """

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -61,7 +61,7 @@ def _lut(image, lut):
 # actions
 
 
-def autocontrast(image, cutoff=0, ignore=None, mask=None):
+def autocontrast(image, cutoff=0, ignore=None, mask=None, preserve_tone=False):
     """
     Maximize (normalize) image contrast. This function calculates a
     histogram of the input image (or mask region), removes ``cutoff`` percent of the
@@ -77,9 +77,14 @@ def autocontrast(image, cutoff=0, ignore=None, mask=None):
     :param mask: Histogram used in contrast operation is computed using pixels
                  within the mask. If no mask is given the entire image is used
                  for histogram computation.
+    :param preserve_tone: Preserve image tone in Photoshop-like style autocontrast.
     :return: An image.
     """
-    histogram = image.histogram(mask)
+    if preserve_tone:
+        histogram = image.convert("L").histogram(mask)
+    else:
+        histogram = image.histogram(mask)
+
     lut = []
     for layer in range(0, len(histogram), 256):
         h = histogram[layer : layer + 256]


### PR DESCRIPTION
Changes proposed in this pull request:

 * Added **preserve_tone** option to the autocontrast function.

As already have been discussed [here](https://github.com/python-pillow/Pillow/pull/1246) **autocontrast** function changes the tone of the image because of the usage of separate histograms for each channel.

@broxeph, @wiredfool

 Example:
![example](https://user-images.githubusercontent.com/2506482/111916851-ff1c5200-8a8d-11eb-9303-6a69bfa1f7f8.jpg)


