### PR TITLE
Deprecated categories

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1,6 +1,7 @@
 import io
 import os
 import shutil
+import sys
 import tempfile
 
 import pytest
@@ -768,6 +769,20 @@ class TestImage:
         reloaded_exif = Image.Exif()
         reloaded_exif.load(exif.tobytes())
         assert reloaded_exif.get_ifd(0x8769) == exif.get_ifd(0x8769)
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 7), reason="Python 3.7 or greater required"
+    )
+    def test_categories_deprecation(self):
+        with pytest.warns(DeprecationWarning):
+            assert hopper().category == 0
+
+        with pytest.warns(DeprecationWarning):
+            assert Image.NORMAL == 0
+        with pytest.warns(DeprecationWarning):
+            assert Image.SEQUENCE == 1
+        with pytest.warns(DeprecationWarning):
+            assert Image.CONTAINER == 2
 
     @pytest.mark.parametrize(
         "test_module",

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -33,6 +33,18 @@ Tk/Tcl 8.4
 Support for Tk/Tcl 8.4 is deprecated and will be removed in Pillow 10.0.0 (2023-01-02),
 when Tk/Tcl 8.5 will be the minimum supported.
 
+Categories
+~~~~~~~~~~
+
+.. deprecated:: 8.2.0
+
+``im.category`` is deprecated and will be removed in Pillow 10.0.0 (2023-01-02),
+along with the related ``Image.NORMAL``, ``Image.SEQUENCE`` and
+``Image.CONTAINER`` attributes.
+
+To determine if an image has multiple frames or not,
+``getattr(im, "is_animated", False)`` can be used instead.
+
 Image.show command parameter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -502,10 +502,3 @@ Used to specify the quantization method to use for the :meth:`~Image.quantize` m
 
     Check support using :py:func:`PIL.features.check_feature`
     with ``feature="libimagequant"``.
-
-.. comment: These are not referenced anywhere?
-    Categories
-    ^^^^^^^^^^
-    .. data:: NORMAL
-    .. data:: SEQUENCE
-    .. data:: CONTAINER

--- a/docs/releasenotes/8.2.0.rst
+++ b/docs/releasenotes/8.2.0.rst
@@ -10,6 +10,16 @@ Tk/Tcl 8.4
 Support for Tk/Tcl 8.4 is deprecated and will be removed in Pillow 10.0.0 (2023-01-02),
 when Tk/Tcl 8.5 will be the minimum supported.
 
+Categories
+^^^^^^^^^^
+
+``im.category`` is deprecated and will be removed in Pillow 10.0.0 (2023-01-02),
+along with the related ``Image.NORMAL``, ``Image.SEQUENCE`` and
+``Image.CONTAINER`` attributes.
+
+To determine if an image has multiple frames or not,
+``getattr(im, "is_animated", False)`` can be used instead.
+
 API Changes
 ===========
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -59,6 +59,16 @@ if sys.version_info >= (3, 7):
         if name == "PILLOW_VERSION":
             _raise_version_warning()
             return __version__
+        else:
+            categories = {"NORMAL": 0, "SEQUENCE": 1, "CONTAINER": 2}
+            if name in categories:
+                warnings.warn(
+                    "Image categories are deprecated and will be removed in Pillow 10 "
+                    "(2023-01-02). Use is_animated instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                return categories[name]
         raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 
@@ -68,6 +78,11 @@ else:
 
     # Silence warning
     assert PILLOW_VERSION
+
+    # categories
+    NORMAL = 0
+    SEQUENCE = 1
+    CONTAINER = 2
 
 
 logger = logging.getLogger(__name__)
@@ -186,11 +201,6 @@ MEDIANCUT = 0
 MAXCOVERAGE = 1
 FASTOCTREE = 2
 LIBIMAGEQUANT = 3
-
-# categories
-NORMAL = 0
-SEQUENCE = 1
-CONTAINER = 2
 
 if hasattr(core, "DEFAULT_STRATEGY"):
     DEFAULT_STRATEGY = core.DEFAULT_STRATEGY
@@ -535,10 +545,21 @@ class Image:
         self._size = (0, 0)
         self.palette = None
         self.info = {}
-        self.category = NORMAL
+        self._category = 0
         self.readonly = 0
         self.pyaccess = None
         self._exif = None
+
+    def __getattr__(self, name):
+        if name == "category":
+            warnings.warn(
+                "Image categories are deprecated and will be removed in Pillow 10 "
+                "(2023-01-02). Use is_animated instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return self._category
+        raise AttributeError(name)
 
     @property
     def width(self):
@@ -648,7 +669,7 @@ class Image:
             and self.mode == other.mode
             and self.size == other.size
             and self.info == other.info
-            and self.category == other.category
+            and self._category == other._category
             and self.readonly == other.readonly
             and self.getpalette() == other.getpalette()
             and self.tobytes() == other.tobytes()

--- a/src/PIL/MicImagePlugin.py
+++ b/src/PIL/MicImagePlugin.py
@@ -68,7 +68,7 @@ class MicImageFile(TiffImagePlugin.TiffImageFile):
         self.is_animated = self._n_frames > 1
 
         if len(self.images) > 1:
-            self.category = Image.CONTAINER
+            self._category = Image.CONTAINER
 
         self.seek(0)
 


### PR DESCRIPTION
Images have a ``category`` property. It is set to ``Image.NORMAL``
https://github.com/python-pillow/Pillow/blob/aa35f6b572c3491976e2336b28f481dad0a2a353/src/PIL/Image.py#L538

Unless the image format is MIC and there are multiple frames, in which case it is ``Image.CONTAINER``.
https://github.com/python-pillow/Pillow/blob/aa35f6b572c3491976e2336b28f481dad0a2a353/src/PIL/MicImagePlugin.py#L70-L71

There is also the unused attribute ``Image.SEQUENCE``.
https://github.com/python-pillow/Pillow/blob/aa35f6b572c3491976e2336b28f481dad0a2a353/src/PIL/Image.py#L190-L193

This minimal support across formats shows the feature has clearly not kept up with our other changes around multi-frames images, and can be deprecated in favour of `is_animated`.