### PR TITLE
Document quantize method defaults and mode support

### DIFF
--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -486,11 +486,12 @@ Used to specify the quantization method to use for the :meth:`~Image.quantize` m
 
 .. data:: MEDIANCUT
 
-    Median cut. Default method, except for RGBA images.
+    Median cut. Default method, except for RGBA images. This method does not support
+    RGBA images.
 
 .. data:: MAXCOVERAGE
 
-    Maximum coverage.
+    Maximum coverage. This method does not support RGBA images.
 
 .. data:: FASTOCTREE
 

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -486,15 +486,15 @@ Used to specify the quantization method to use for the :meth:`~Image.quantize` m
 
 .. data:: MEDIANCUT
 
-    Median cut
+    Median cut. Default method, except for RGBA images.
 
 .. data:: MAXCOVERAGE
 
-    Maximum coverage
+    Maximum coverage.
 
 .. data:: FASTOCTREE
 
-    Fast octree
+    Fast octree. Default method for RGBA images.
 
 .. data:: LIBIMAGEQUANT
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1062,8 +1062,9 @@ class Image:
 
                        By default, :data:`MEDIANCUT` will be used.
 
-                       The exception to this is RGBA images. RGBA images use
-                       :data:`FASTOCTREE` by default instead.
+                       The exception to this is RGBA images. :data:`MEDIANCUT` and
+                       :data:`MAXCOVERAGE` do not support RGBA images, so
+                       :data:`FASTOCTREE` is used by default instead.
         :param kmeans: Integer
         :param palette: Quantize to the palette of given
                         :py:class:`PIL.Image.Image`.

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1059,6 +1059,11 @@ class Image:
                        :data:`LIBIMAGEQUANT` (libimagequant; check support using
                        :py:func:`PIL.features.check_feature`
                        with ``feature="libimagequant"``).
+
+                       By default, :data:`MEDIANCUT` will be used.
+
+                       The exception to this is RGBA images. RGBA images use
+                       :data:`FASTOCTREE` by default instead.
         :param kmeans: Integer
         :param palette: Quantize to the palette of given
                         :py:class:`PIL.Image.Image`.


### PR DESCRIPTION
Alternative to #5251. The same information is added, just arranged differently.