### PR TITLE
Use quantization method attributes

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1074,11 +1074,11 @@ class Image:
 
         if method is None:
             # defaults:
-            method = 0
+            method = MEDIANCUT
             if self.mode == "RGBA":
-                method = 2
+                method = FASTOCTREE
 
-        if self.mode == "RGBA" and method not in (2, 3):
+        if self.mode == "RGBA" and method not in (FASTOCTREE, LIBIMAGEQUANT):
             # Caller specified an invalid mode.
             raise ValueError(
                 "Fast Octree (method == 2) and libimagequant (method == 3) "


### PR DESCRIPTION
Instead of using `0`, `2` and `3` in `im.quantize`, use the more meaningful `MEDIANCUT`, `FASTOCTREE` and `LIBIMAGEQUANT`.