### PR TITLE
Contributing docs: Include release notes as needed or appropriate

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,6 +18,7 @@ Please send a pull request to the master branch. Please include [documentation](
 - Provide tests for any newly added code.
 - Follow PEP 8.
 - When committing only documentation changes please include `[ci skip]` in the commit message to avoid running tests on AppVeyor.
+- Include [release notes](https://github.com/python-pillow/Pillow/tree/master/docs/releasenotes) as needed or appropriate with your bug fixes, feature additions and tests.
 
 ## Reporting Issues
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * As suggested https://github.com/python-pillow/Pillow/pull/5349#issuecomment-804281592, ask contributors to include release notes as needed or appropriate.
 * Similar to the info at https://github.com/python-pillow/Pillow/blob/master/docs/releasenotes/index.rst

