### PR TITLE
Removed build_distance_tables return value

### DIFF
--- a/src/libImaging/Quant.c
+++ b/src/libImaging/Quant.c
@@ -789,7 +789,7 @@ resort_distance_tables(
     return 1;
 }
 
-static int
+static void
 build_distance_tables(
     uint32_t *avgDist, uint32_t **avgDistSortKey, Pixel *p, uint32_t nEntries) {
     uint32_t i, j;
@@ -811,7 +811,6 @@ build_distance_tables(
             sizeof(uint32_t *),
             _sort_ulong_ptr_keys);
     }
-    return 1;
 }
 
 static int
@@ -1373,9 +1372,7 @@ quantize(
         goto error_6;
     }
 
-    if (!build_distance_tables(avgDist, avgDistSortKey, p, nPaletteEntries)) {
-        goto error_7;
-    }
+    build_distance_tables(avgDist, avgDistSortKey, p, nPaletteEntries);
 
     if (!map_image_pixels_from_median_box(
             pixelData, nPixels, p, nPaletteEntries, h, avgDist, avgDistSortKey, qp)) {
@@ -1580,9 +1577,7 @@ quantize2(
         goto error_3;
     }
 
-    if (!build_distance_tables(avgDist, avgDistSortKey, p, nQuantPixels)) {
-        goto error_4;
-    }
+    build_distance_tables(avgDist, avgDistSortKey, p, nQuantPixels);
 
     if (!map_image_pixels(
             pixelData, nPixels, p, nQuantPixels, avgDist, avgDistSortKey, qp)) {


### PR DESCRIPTION
`build_distance_tables` only ever returns 1 - https://github.com/python-pillow/Pillow/blob/9b69d940827289e806cc19baca4d5291386ef195/src/libImaging/Quant.c#L792-L815

So this PR removes the return value.