### PR TITLE
Remove redundant check (addition to #5364)

### DIFF
--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -427,15 +427,6 @@ _decodeTile(Imaging im, ImagingCodecState state, TIFF *tiff, int planes, Imaging
         for (plane = 0; plane < planes; plane++) {
             ImagingShuffler shuffler = unpackers[plane];
             for (x = state->xoff; x < state->xsize; x += tile_width) {
-                /* Sanity Check. Apparently in some cases, the TiffReadRGBA* functions
-                   have a different view of the size of the tiff than we're getting from
-                   other functions. So, we need to check here. 
-                */
-                if (!TIFFCheckTile(tiff, x, y, 0, plane)) {
-                    TRACE(("Check Tile Error, Tile at %dx%d\n", x, y));
-                    state->errcode = IMAGING_CODEC_BROKEN;
-                    return -1;
-                }
                 if (TIFFReadTile(tiff, (tdata_t)state->buffer, x, y, 0, plane) == -1) {
                     TRACE(("Decode Error, Tile at %dx%d\n", x, y));
                     state->errcode = IMAGING_CODEC_BROKEN;


### PR DESCRIPTION
It's duplicated inside following call of TIFFReadTile

Since adding tiff reading using libtiff's TIFFReadRGBA* functions got extracted into it's own code path, there is no need to double check tiles. For more context https://github.com/python-pillow/Pillow/pull/5364#discussion_r603494127
Original commit to fix the CVE added a test image as well: https://github.com/python-pillow/Pillow/commit/cbdce6c5d054fccaf4af34b47f212355c64ace7a 