### PR TITLE
Fix pytest valgrind warnings

### DIFF
--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -19,13 +19,11 @@ def pytest_configure(config):
     # We're marking some tests to ignore valgrind errors and XFAIL them.
     # Ensure that the mark is defined
     # even in cases where pytest-valgrind isn't installed
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        try:
-            getattr(pytest.mark, "valgrind_known_error")
-        except Exception:
-            config.addinivalue_line(
-                "markers",
-                "valgrind_known_error: Tests that have known issues with valgrind",
-            )
+    try:
+        config.addinivalue_line(
+            "markers",
+            "valgrind_known_error: Tests that have known issues with valgrind",
+        )
+    except Exception:
+        # valgrind is already installed
+        pass

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -1,7 +1,4 @@
 import io
-import warnings
-
-import pytest
 
 
 def pytest_report_header(config):


### PR DESCRIPTION
Potential fix for pytest-valgrind mark not defined for non-valgrind docker tests. 