### PR TITLE
Changed quantize and quantize2 to static

### DIFF
--- a/src/libImaging/Quant.c
+++ b/src/libImaging/Quant.c
@@ -1243,7 +1243,7 @@ error_1:
     return 0;
 }
 
-int
+static int
 quantize(
     Pixel *pixelData,
     uint32_t nPixels,
@@ -1511,7 +1511,7 @@ compute_distances(const HashTable *h, const Pixel pixel, uint32_t *dist, void *u
     }
 }
 
-int
+static int
 quantize2(
     Pixel *pixelData,
     uint32_t nPixels,


### PR DESCRIPTION
Changed quantize and quantize2 to static, since they are only called from Quant.c

Separated from #5264, because it is independent of that PR. See also https://github.com/python-pillow/Pillow/pull/5367#issuecomment-811616009.