### PR TITLE
Changed register_open calls to be consistent

### DIFF
--- a/Tests/test_file_dds.py
+++ b/Tests/test_file_dds.py
@@ -136,25 +136,25 @@ def test_uncompressed_rgb():
         )
 
 
-def test__validate_true():
+def test__accept_true():
     """Check valid prefix"""
     # Arrange
     prefix = b"DDS etc"
 
     # Act
-    output = DdsImagePlugin._validate(prefix)
+    output = DdsImagePlugin._accept(prefix)
 
     # Assert
     assert output
 
 
-def test__validate_false():
+def test__accept_false():
     """Check invalid prefix"""
     # Arrange
     prefix = b"something invalid"
 
     # Act
-    output = DdsImagePlugin._validate(prefix)
+    output = DdsImagePlugin._accept(prefix)
 
     # Assert
     assert not output

--- a/src/PIL/BlpImagePlugin.py
+++ b/src/PIL/BlpImagePlugin.py
@@ -417,9 +417,11 @@ class BLP2Decoder(_BLPBaseDecoder):
         self.set_as_raw(bytes(data))
 
 
-Image.register_open(
-    BlpImageFile.format, BlpImageFile, lambda p: p[:4] in (b"BLP1", b"BLP2")
-)
+def _accept(prefix):
+    return prefix[:4] in (b"BLP1", b"BLP2")
+
+
+Image.register_open(BlpImageFile.format, BlpImageFile, _accept)
 Image.register_extension(BlpImageFile.format, ".blp")
 
 Image.register_decoder("BLP1", BLP1Decoder)

--- a/src/PIL/DdsImagePlugin.py
+++ b/src/PIL/DdsImagePlugin.py
@@ -182,9 +182,9 @@ class DdsImageFile(ImageFile.ImageFile):
         pass
 
 
-def _validate(prefix):
+def _accept(prefix):
     return prefix[:4] == b"DDS "
 
 
-Image.register_open(DdsImageFile.format, DdsImageFile, _validate)
+Image.register_open(DdsImageFile.format, DdsImageFile, _accept)
 Image.register_extension(DdsImageFile.format, ".dds")

--- a/src/PIL/FtexImagePlugin.py
+++ b/src/PIL/FtexImagePlugin.py
@@ -98,9 +98,9 @@ class FtexImageFile(ImageFile.ImageFile):
         pass
 
 
-def _validate(prefix):
+def _accept(prefix):
     return prefix[:4] == MAGIC
 
 
-Image.register_open(FtexImageFile.format, FtexImageFile, _validate)
+Image.register_open(FtexImageFile.format, FtexImageFile, _accept)
 Image.register_extensions(FtexImageFile.format, [".ftc", ".ftu"])

--- a/src/PIL/IcnsImagePlugin.py
+++ b/src/PIL/IcnsImagePlugin.py
@@ -359,7 +359,11 @@ def _save(im, fp, filename):
                 fp.write(f.read())
 
 
-Image.register_open(IcnsImageFile.format, IcnsImageFile, lambda x: x[:4] == b"icns")
+def _accept(prefix):
+    return prefix[:4] == b"icns"
+
+
+Image.register_open(IcnsImageFile.format, IcnsImageFile, _accept)
 Image.register_extension(IcnsImageFile.format, ".icns")
 
 if sys.platform == "darwin":


### PR DESCRIPTION
Most Pillow plugins call an `_accept` method as the last argument to `Image.register_open`.

https://github.com/python-pillow/Pillow/blob/ee079ae67e7e24ec789d3cc7d180820a70d32fe6/src/PIL/JpegImagePlugin.py#L823

This PR changes four plugins that don't do that, for consistency.