### PR TITLE
Fixed ensuring that GIF previous frame was loaded

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -341,6 +341,17 @@ def test_dispose_previous():
             pass
 
 
+def test_previous_frame_loaded():
+    with Image.open("Tests/images/dispose_none.gif") as img:
+        img.load()
+        img.seek(1)
+        img.load()
+        img.seek(2)
+        with Image.open("Tests/images/dispose_none.gif") as img_skipped:
+            img_skipped.seek(2)
+            assert_image_equal(img_skipped, img)
+
+
 def test_save_dispose(tmp_path):
     out = str(tmp_path / "temp.gif")
     im_list = [

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -148,7 +148,7 @@ class GifImageFile(ImageFile.ImageFile):
             self.disposal_method = 0
         else:
             # ensure that the previous frame was loaded
-            if not self.im:
+            if self.tile:
                 self.load()
 
         if frame != self.__frame + 1:


### PR DESCRIPTION
Resolves #4418. Takes a part of #3434

In `_seek()` in GifImagePlugin,

https://github.com/python-pillow/Pillow/blob/e2ac1d1c3473294c13786c5dc3bc7441dd842215/src/PIL/GifImagePlugin.py#L150-L152

`self.im` is only `None` before the first frame is loaded. After that, there is `self.im` - the image at the time.
So this current code only checks that the image has been loaded at some point in the past. It doesn't check that the previous frame was loaded.

Instead, `self.tile` can be used as an indicator if there is data waiting to be decoded.