### PR TITLE
Add test for CVE-2021-25292 ReDoS

### DIFF
--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -286,3 +286,13 @@ def test_pdf_append_to_bytesio():
     f = io.BytesIO(f.getvalue())
     im.save(f, format="PDF", append=True)
     assert len(f.getvalue()) > initial_size
+
+
+@pytest.mark.timeout(1)
+def test_redos():
+    malicious = b" trailer<<>>" + b"\n" * 3456
+
+    # This particular exception isn't relevant here.
+    # The important thing is it doesn't timeout, cause a ReDoS (CVE-2021-25292).
+    with pytest.raises(PdfParser.PdfFormatError):
+        PdfParser.PdfParser(buf=malicious)


### PR DESCRIPTION
Fixes https://github.com/python-pillow/Pillow/issues/5392.

Changes proposed in this pull request:

 * Add a test to check the ReDoS fixed in CVE-2021-25292
 * The raised exception isn't relevant
 * The important thing is it doesn't timeout aka trigger the ReDoS
