### PR TITLE
Use python3 in shebang line

### DIFF
--- a/Tests/32bit_segfault_check.py
+++ b/Tests/32bit_segfault_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/Tests/check_fli_oob.py
+++ b/Tests/check_fli_oob.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from PIL import Image
 

--- a/Tests/check_imaging_leaks.py
+++ b/Tests/check_imaging_leaks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import pytest
 
 from PIL import Image

--- a/Tests/check_jp2_overflow.py
+++ b/Tests/check_jp2_overflow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Reproductions/tests for OOB read errors in FliDecode.c
 

--- a/Tests/createfontdatachunk.py
+++ b/Tests/createfontdatachunk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import base64
 import os
 

--- a/Tests/test_sgi_crash.py
+++ b/Tests/test_sgi_crash.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import pytest
 
 from PIL import Image

--- a/docs/Guardfile
+++ b/docs/Guardfile
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from livereload.compiler import shell
 from livereload.task import Task
 

--- a/selftest.py
+++ b/selftest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # minimal sanity check
 
 import sys

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # > pyroma .
 # ------------------------------
 # Checking .


### PR DESCRIPTION
Replaces `#!/usr/bin/env python` with `#!/usr/bin/env python3` in shebang lines.

And removes a shebang line from the only `Tests/test_*.py` file that has it.