### PR TITLE
Fix PDF file format documentation

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1242,8 +1242,9 @@ The :py:meth:`~PIL.Image.Image.save` method can take the following keyword argum
     .. versionadded:: 3.0.0
 
 **append_images**
-    A list of images to append as additional pages. Each of the
-    images in the list can be single or multiframe images.
+    A list of :py:obj:`PIL.Image`s to append as additional pages. Each of the
+    images in the list can be single or multiframe images. The ``save_all``
+    parameter must be present and set to ``True`` in conjunction with ``append_images``.
 
     .. versionadded:: 4.2.0
 

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1242,7 +1242,7 @@ The :py:meth:`~PIL.Image.Image.save` method can take the following keyword argum
     .. versionadded:: 3.0.0
 
 **append_images**
-    A list of :py:obj:`PIL.Image`s to append as additional pages. Each of the
+    A list of :py:obj:`PIL.Image.Image`s to append as additional pages. Each of the
     images in the list can be single or multiframe images. The ``save_all``
     parameter must be present and set to ``True`` in conjunction with ``append_images``.
 

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1242,7 +1242,7 @@ The :py:meth:`~PIL.Image.Image.save` method can take the following keyword argum
     .. versionadded:: 3.0.0
 
 **append_images**
-    A list of :py:obj:`PIL.Image.Image`s to append as additional pages. Each of the
+    A list of :py:class:`PIL.Image.Image`s to append as additional pages. Each of the
     images in the list can be single or multiframe images. The ``save_all``
     parameter must be present and set to ``True`` in conjunction with ``append_images``.
 


### PR DESCRIPTION
Made sure it is documented that both the `append_images` and `save_all` params must be set. Just setting `append_images` does not work.
Documentation only, [ci skip]

Fixes #5398.

Changes proposed in this pull request:

 * Updated documentation about the `append_images` param for saving PDFs
 * Also made it clear that PIL.Image.Image objects must be pass in as the image list for `append_images`
