### PR TITLE
Changed error type to allow for incremental WebP parsing

### DIFF
--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -82,6 +82,19 @@ class TestImageFile:
             p.feed(data)
             assert (48, 48) == p.image.size
 
+    @skip_unless_feature("webp")
+    @skip_unless_feature("webp_anim")
+    def test_incremental_webp(self):
+        with ImageFile.Parser() as p:
+            with open("Tests/images/hopper.webp", "rb") as f:
+                p.feed(f.read(1024))
+
+                # Check that insufficient data was given in the first feed
+                assert not p.image
+
+                p.feed(f.read())
+            assert (128, 128) == p.image.size
+
     @skip_unless_feature("zlib")
     def test_safeblock(self):
         im1 = hopper()

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -395,7 +395,7 @@ _anim_decoder_new(PyObject *self, PyObject *args) {
         }
         PyObject_Del(decp);
     }
-    PyErr_SetString(PyExc_RuntimeError, "could not create decoder object");
+    PyErr_SetString(PyExc_OSError, "could not create decoder object");
     return NULL;
 }
 


### PR DESCRIPTION
Resolves #4745

Running code from the issue on a test image,
```python
from PIL import ImageFile

p = ImageFile.Parser()
with open("Tests/images/hopper.webp", "rb") as f:
    new_data = f.read(1024)
    while not p.image and new_data:
        p.feed(new_data)
```
an error is triggered.
https://github.com/python-pillow/Pillow/blob/45003b78ed4003f6bf68e3a921b78539a64c7337/src/_webp.c#L398

This is effectively an error being raised because the the image is truncated, and most truncation errors are OSError. So if we change it to an OSError, then it is handled by `feed()`.
https://github.com/python-pillow/Pillow/blob/45003b78ed4003f6bf68e3a921b78539a64c7337/src/PIL/ImageFile.py#L413-L418

This fixes the problem.