### PR TITLE
Changed wording to avoid confusion with IMAGING_TYPE_SPECIAL

### DIFF
--- a/docs/handbook/concepts.rst
+++ b/docs/handbook/concepts.rst
@@ -44,7 +44,7 @@ supports the following standard modes:
     * ``I`` (32-bit signed integer pixels)
     * ``F`` (32-bit floating point pixels)
 
-Pillow also provides limited support for a few special modes, including:
+Pillow also provides limited support for a few additional modes, including:
 
     * ``LA`` (L with alpha)
     * ``PA`` (P with alpha)


### PR DESCRIPTION
If you look through the types in [Storage.c](https://github.com/python-pillow/Pillow/blob/9b6fe1b039e4a70d59a4f0115df813090bb230f6/src/libImaging/Storage.c#L66), you will find that LA, PA, RGBX, RGBa and La are not IMAGING_TYPE_SPECIAL.

However, in https://pillow.readthedocs.io/en/latest/handbook/concepts.html#modes, these modes are listed as "special modes". 

This PR changes that text to "additional modes" to avoid confusion with IMAGING_TYPE_SPECIAL.