### PR TITLE
For special image modes, revert default resize resampling to NEAREST

### DIFF
--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -250,3 +250,7 @@ class TestImageResize:
         for mode in "1", "P":
             im = hopper(mode)
             assert im.resize((20, 20), Image.NEAREST) == im.resize((20, 20))
+
+        for mode in "I;16", "I;16L", "I;16B", "BGR;15", "BGR;16":
+            im = hopper(mode)
+            assert im.resize((20, 20), Image.NEAREST) == im.resize((20, 20))

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1849,7 +1849,7 @@ class Image:
             min(self.size[1], math.ceil(box[3] + support_y)),
         )
 
-    def resize(self, size, resample=BICUBIC, box=None, reducing_gap=None):
+    def resize(self, size, resample=None, box=None, reducing_gap=None):
         """
         Returns a resized copy of this image.
 
@@ -1859,9 +1859,11 @@ class Image:
            one of :py:data:`PIL.Image.NEAREST`, :py:data:`PIL.Image.BOX`,
            :py:data:`PIL.Image.BILINEAR`, :py:data:`PIL.Image.HAMMING`,
            :py:data:`PIL.Image.BICUBIC` or :py:data:`PIL.Image.LANCZOS`.
-           Default filter is :py:data:`PIL.Image.BICUBIC`.
-           If the image has mode "1" or "P", it is
-           always set to :py:data:`PIL.Image.NEAREST`.
+           If the image has mode "1" or "P", it is always set to
+           :py:data:`PIL.Image.NEAREST`.
+           If the image mode specifies a number of bits, such as "I;16", then the
+           default filter is :py:data:`PIL.Image.NEAREST`.
+           Otherwise, the default filter is :py:data:`PIL.Image.BICUBIC`.
            See: :ref:`concept-filters`.
         :param box: An optional 4-tuple of floats providing
            the source image region to be scaled.
@@ -1882,7 +1884,10 @@ class Image:
         :returns: An :py:class:`~PIL.Image.Image` object.
         """
 
-        if resample not in (NEAREST, BILINEAR, BICUBIC, LANCZOS, BOX, HAMMING):
+        if resample is None:
+            type_special = ";" in self.mode
+            resample = NEAREST if type_special else BICUBIC
+        elif resample not in (NEAREST, BILINEAR, BICUBIC, LANCZOS, BOX, HAMMING):
             message = f"Unknown resampling filter ({resample})."
 
             filters = [


### PR DESCRIPTION
Helps #4402

#4255 changed the default `resample` argument for `resize()` to BICUBIC, with the goal of being more user-friendly. However, it turned out to not be more user-friendly for IMAGING_TYPE_SPECIAL modes, where we [don't currently support resampling](https://github.com/python-pillow/Pillow/blob/9b6fe1b039e4a70d59a4f0115df813090bb230f6/src/libImaging/Resample.c#L569-L570), except [for NEAREST](https://github.com/python-pillow/Pillow/blob/9b6fe1b039e4a70d59a4f0115df813090bb230f6/src/_imaging.c#L1808-L1822) - leading to the "image has wrong mode" in the issue.

This PR switches back to NEAREST if the image is IMAGING_TYPE_SPECIAL, so that the default `resample` value once again works for those modes.

Looking at the [code](https://github.com/python-pillow/Pillow/blob/9b6fe1b039e4a70d59a4f0115df813090bb230f6/src/libImaging/Storage.c#L123-L161), IMAGING_TYPE_SPECIAL applies to mode with a custom number of bits: a semicolon in their mode.