### PR TITLE
Convert to float for comparison with float in IFDRational __eq__

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -146,25 +146,24 @@ class TestFileTiff:
             "Tests/images/hopper_float_dpi_" + str(resolutionUnit) + ".tif"
         ) as im:
             assert im.tag_v2.get(RESOLUTION_UNIT) == resolutionUnit
-            for reloaded_dpi in im.info["dpi"]:
-                assert float(reloaded_dpi) == dpi
+            assert im.info["dpi"] == (dpi, dpi)
 
     def test_save_float_dpi(self, tmp_path):
         outfile = str(tmp_path / "temp.tif")
         with Image.open("Tests/images/hopper.tif") as im:
-            im.save(outfile, dpi=(72.2, 72.2))
+            dpi = (72.2, 72.2)
+            im.save(outfile, dpi=dpi)
 
             with Image.open(outfile) as reloaded:
-                for dpi in reloaded.info["dpi"]:
-                    assert float(dpi) == 72.2
+                assert reloaded.info["dpi"] == dpi
 
     def test_save_setting_missing_resolution(self):
         b = BytesIO()
         with Image.open("Tests/images/10ct_32bit_128.tiff") as im:
             im.save(b, format="tiff", resolution=123.45)
         with Image.open(b) as im:
-            assert float(im.tag_v2[X_RESOLUTION]) == 123.45
-            assert float(im.tag_v2[Y_RESOLUTION]) == 123.45
+            assert im.tag_v2[X_RESOLUTION] == 123.45
+            assert im.tag_v2[Y_RESOLUTION] == 123.45
 
     def test_invalid_file(self):
         invalid_file = "Tests/images/flower.jpg"

--- a/Tests/test_tiff_ifdrational.py
+++ b/Tests/test_tiff_ifdrational.py
@@ -28,6 +28,8 @@ def test_sanity():
     _test_equal(1, 2, Fraction(1, 2))
     _test_equal(1, 2, IFDRational(1, 2))
 
+    _test_equal(7, 5, 1.4)
+
 
 def test_ranges():
     for num in range(1, 10):

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -354,9 +354,12 @@ class IFDRational(Rational):
         return self._val.__hash__()
 
     def __eq__(self, other):
+        val = self._val
         if isinstance(other, IFDRational):
             other = other._val
-        return self._val == other
+        if isinstance(other, float):
+            val = float(val)
+        return val == other
 
     def __getstate__(self):
         return [self._val, self._numerator, self._denominator]


### PR DESCRIPTION
This one is up for debate.

Consider this behaviour.
```pycon
>>> 7 / 5
1.4
>>> from PIL.TiffImagePlugin import IFDRational
>>> IFDRational(7, 5) == 1.4
False
```
I feel like this is unexpected. Why is this happening? Well,
```pycon
>>> IFDRational(7, 5)._val
Fraction(7, 5)
>>> from fractions import Fraction
>>> Fraction(7, 5) == 1.4
False
```
So despite the fact that
```pycon
>>> float(Fraction(7, 5)) == 1.4
True
```
`Fraction(7, 5)` is not equal to 1.4.

This isn't the case for all values.

```pycon
>>> Fraction(5, 4) == 1.25
True
```

This PR 'fixes' this behaviour in `IFDRational` by casting `Fraction` to `float` when comparing in `IFDRational.__eq__()`.

As I said, open for debate.