### PR TITLE
Changed ImageMorph incorrect mode errors to ValueError

### DIFF
--- a/Tests/test_imagemorph.py
+++ b/Tests/test_imagemorph.py
@@ -235,19 +235,19 @@ def test_negate():
     )
 
 
-def test_non_binary_images():
+def test_incorrect_mode():
     im = hopper("RGB")
     mop = ImageMorph.MorphOp(op_name="erosion8")
 
-    with pytest.raises(Exception) as e:
+    with pytest.raises(ValueError) as e:
         mop.apply(im)
-    assert str(e.value) == "Image must be binary, meaning it must use mode L"
-    with pytest.raises(Exception) as e:
+    assert str(e.value) == "Image mode must be L"
+    with pytest.raises(ValueError) as e:
         mop.match(im)
-    assert str(e.value) == "Image must be binary, meaning it must use mode L"
-    with pytest.raises(Exception) as e:
+    assert str(e.value) == "Image mode must be L"
+    with pytest.raises(ValueError) as e:
         mop.get_on_pixels(im)
-    assert str(e.value) == "Image must be binary, meaning it must use mode L"
+    assert str(e.value) == "Image mode must be L"
 
 
 def test_add_patterns():

--- a/src/PIL/ImageMorph.py
+++ b/src/PIL/ImageMorph.py
@@ -196,7 +196,7 @@ class MorphOp:
             raise Exception("No operator loaded")
 
         if image.mode != "L":
-            raise Exception("Image must be binary, meaning it must use mode L")
+            raise ValueError("Image mode must be L")
         outimage = Image.new(image.mode, image.size, None)
         count = _imagingmorph.apply(bytes(self.lut), image.im.id, outimage.im.id)
         return count, outimage
@@ -211,7 +211,7 @@ class MorphOp:
             raise Exception("No operator loaded")
 
         if image.mode != "L":
-            raise Exception("Image must be binary, meaning it must use mode L")
+            raise ValueError("Image mode must be L")
         return _imagingmorph.match(bytes(self.lut), image.im.id)
 
     def get_on_pixels(self, image):
@@ -221,7 +221,7 @@ class MorphOp:
         of all matching pixels. See :ref:`coordinate-system`."""
 
         if image.mode != "L":
-            raise Exception("Image must be binary, meaning it must use mode L")
+            raise ValueError("Image mode must be L")
         return _imagingmorph.get_on_pixels(image.im.id)
 
     def load_lut(self, filename):


### PR DESCRIPTION
ImageMorph features these two lines three times.

https://github.com/python-pillow/Pillow/blob/28eb57888d6906fa57da101d33206daf38553903/src/PIL/ImageMorph.py#L223-L224

`Exception` is very generic, and L is not the only black and white mode that we have - [there is also '1'.](https://pillow.readthedocs.io/en/latest/handbook/concepts.html#modes)

This PR suggests changing it instead to
```python
raise ValueError("Image mode must be L")
```
