### PR TITLE
Added ImageOps contain()

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -37,6 +37,9 @@ def test_sanity():
     ImageOps.pad(hopper("L"), (128, 128))
     ImageOps.pad(hopper("RGB"), (128, 128))
 
+    ImageOps.contain(hopper("L"), (128, 128))
+    ImageOps.contain(hopper("RGB"), (128, 128))
+
     ImageOps.crop(hopper("L"), 1)
     ImageOps.crop(hopper("RGB"), 1)
 
@@ -97,6 +100,21 @@ def test_fit_same_ratio():
     with Image.new("RGB", (1000, 755)) as im:
         new_im = ImageOps.fit(im, (1000, 755))
         assert new_im.size == (1000, 755)
+
+
+def test_contain():
+    # Same ratio
+    im = hopper()
+    new_size = (im.width * 2, im.height * 2)
+    new_im = ImageOps.contain(im, new_size)
+    assert new_im.size == new_size
+
+    for new_size in [
+        (im.width * 4, im.height * 2),
+        (im.width * 2, im.height * 4),
+    ]:
+        new_im = ImageOps.contain(im, new_size)
+        assert new_im.size == (im.width * 2, im.height * 2)
 
 
 def test_pad():

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -102,19 +102,11 @@ def test_fit_same_ratio():
         assert new_im.size == (1000, 755)
 
 
-def test_contain():
-    # Same ratio
+@pytest.mark.parametrize("new_size", ((256, 256), (512, 256), (256, 512)))
+def test_contain(new_size):
     im = hopper()
-    new_size = (im.width * 2, im.height * 2)
     new_im = ImageOps.contain(im, new_size)
-    assert new_im.size == new_size
-
-    for new_size in [
-        (im.width * 4, im.height * 2),
-        (im.width * 2, im.height * 4),
-    ]:
-        new_im = ImageOps.contain(im, new_size)
-        assert new_im.size == (im.width * 2, im.height * 2)
+    assert new_im.size == (256, 256)
 
 
 def test_pad():

--- a/docs/reference/ImageOps.rst
+++ b/docs/reference/ImageOps.rst
@@ -12,6 +12,7 @@ only work on L and RGB images.
 
 .. autofunction:: autocontrast
 .. autofunction:: colorize
+.. autofunction:: contain
 .. autofunction:: pad
 .. autofunction:: crop
 .. autofunction:: scale

--- a/docs/releasenotes/8.3.0.rst
+++ b/docs/releasenotes/8.3.0.rst
@@ -1,0 +1,49 @@
+8.3.0
+-----
+
+Deprecations
+============
+
+TODO
+^^^^
+
+TODO
+
+API Changes
+===========
+
+TODO
+^^^^
+
+TODO
+
+API Additions
+=============
+
+ImageOps.contain
+^^^^^^^^^^^^^^^^
+
+Returns a resized version of the image, set to the maximum width and height within
+``size``, while maintaining the original aspect ratio.
+
+To compare it to other ImageOps methods:
+- :py:meth:`~PIL.ImageOps.fit` expands an image until is fills ``size``, cropping the
+parts of the image that do not fit.
+- :py:meth:`~PIL.ImageOps.pad` expands an image to fill ``size``, without cropping, but
+instead filling the extra space with ``color``.
+- :py:meth:`~PIL.ImageOps.contain` is similar to :py:meth:`~PIL.ImageOps.pad`, but
+it does not fill the extra space. Instead, the original aspect ratio is maintained. So
+unlike the other two methods, it is not guaranteed to return an image of ``size``.
+
+Security
+========
+
+TODO
+
+Other Changes
+=============
+
+TODO
+^^^^
+
+TODO

--- a/docs/releasenotes/8.3.0.rst
+++ b/docs/releasenotes/8.3.0.rst
@@ -18,6 +18,13 @@ Changed WebP default "method" value when saving
 Previously, it was 0, for the best speed. The default has now been changed to 4, to
 match WebP's default, for higher quality with still some speed optimisation.
 
+Default resampling filter for special image modes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Pillow 7.0 changed the default resampling filter to ``Image.BICUBIC``. However, as this
+is not supported yet for images with a custom number of bits, the default filter for
+those modes has been reverted to ``Image.NEAREST``.
+
 API Additions
 =============
 

--- a/docs/releasenotes/8.3.0.rst
+++ b/docs/releasenotes/8.3.0.rst
@@ -25,6 +25,12 @@ Pillow 7.0 changed the default resampling filter to ``Image.BICUBIC``. However, 
 is not supported yet for images with a custom number of bits, the default filter for
 those modes has been reverted to ``Image.NEAREST``.
 
+ImageMorph incorrect mode errors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For ``apply()``, ``match()`` and ``get_on_pixels()``, if the image mode is not L, an
+:py:exc:`Exception` was thrown. This has now been changed to a :py:exc:`ValueError`.
+
 API Additions
 =============
 
@@ -35,13 +41,14 @@ Returns a resized version of the image, set to the maximum width and height with
 ``size``, while maintaining the original aspect ratio.
 
 To compare it to other ImageOps methods:
+
 - :py:meth:`~PIL.ImageOps.fit` expands an image until is fills ``size``, cropping the
-parts of the image that do not fit.
+  parts of the image that do not fit.
 - :py:meth:`~PIL.ImageOps.pad` expands an image to fill ``size``, without cropping, but
-instead filling the extra space with ``color``.
-- :py:meth:`~PIL.ImageOps.contain` is similar to :py:meth:`~PIL.ImageOps.pad`, but
-it does not fill the extra space. Instead, the original aspect ratio is maintained. So
-unlike the other two methods, it is not guaranteed to return an image of ``size``.
+  instead filling the extra space with ``color``.
+- :py:meth:`~PIL.ImageOps.contain` is similar to :py:meth:`~PIL.ImageOps.pad`, but it
+  does not fill the extra space. Instead, the original aspect ratio is maintained. So
+  unlike the other two methods, it is not guaranteed to return an image of ``size``.
 
 Security
 ========

--- a/docs/releasenotes/8.3.0.rst
+++ b/docs/releasenotes/8.3.0.rst
@@ -12,10 +12,11 @@ TODO
 API Changes
 ===========
 
-TODO
-^^^^
+Changed WebP default "method" value when saving
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-TODO
+Previously, it was 0, for the best speed. The default has now been changed to 4, to
+match WebP's default, for higher quality with still some speed optimisation.
 
 API Additions
 =============

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -14,6 +14,7 @@ expected to be backported to earlier versions.
 .. toctree::
   :maxdepth: 2
 
+  8.3.0
   8.2.0
   8.1.2
   8.1.1

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -238,8 +238,8 @@ def colorize(image, black, white, mid=None, blackpoint=0, whitepoint=255, midpoi
 
 def contain(image, size, method=Image.BICUBIC):
     """
-    Returns a sized version of the image, expanded to fill the requested aspect ratio
-    and size.
+    Returns a resized version of the image, set to the maximum width and height
+    within the requested size, while maintaining the original aspect ratio.
 
     :param image: The image to resize and crop.
     :param size: The requested output size in pixels, given as a
@@ -266,13 +266,13 @@ def contain(image, size, method=Image.BICUBIC):
 
 def pad(image, size, method=Image.BICUBIC, color=None, centering=(0.5, 0.5)):
     """
-    Returns a sized and padded version of the image, expanded to fill the
+    Returns a resized and padded version of the image, expanded to fill the
     requested aspect ratio and size.
 
-    :param image: The image to size and crop.
+    :param image: The image to resize and crop.
     :param size: The requested output size in pixels, given as a
                  (width, height) tuple.
-    :param method: What resampling method to use. Default is
+    :param method: Resampling method to use. Default is
                    :py:attr:`PIL.Image.BICUBIC`. See :ref:`concept-filters`.
     :param color: The background color of the padded image.
     :param centering: Control the position of the original image within the
@@ -322,7 +322,7 @@ def scale(image, factor, resample=Image.BICUBIC):
 
     :param image: The image to rescale.
     :param factor: The expansion factor, as a float.
-    :param resample: What resampling method to use. Default is
+    :param resample: Resampling method to use. Default is
                      :py:attr:`PIL.Image.BICUBIC`. See :ref:`concept-filters`.
     :returns: An :py:class:`~PIL.Image.Image` object.
     """
@@ -399,15 +399,15 @@ def expand(image, border=0, fill=0):
 
 def fit(image, size, method=Image.BICUBIC, bleed=0.0, centering=(0.5, 0.5)):
     """
-    Returns a sized and cropped version of the image, cropped to the
+    Returns a resized and cropped version of the image, cropped to the
     requested aspect ratio and size.
 
     This function was contributed by Kevin Cazabon.
 
-    :param image: The image to size and crop.
+    :param image: The image to resize and crop.
     :param size: The requested output size in pixels, given as a
                  (width, height) tuple.
-    :param method: What resampling method to use. Default is
+    :param method: Resampling method to use. Default is
                    :py:attr:`PIL.Image.BICUBIC`. See :ref:`concept-filters`.
     :param bleed: Remove a border around the outside of the image from all
                   four edges. The value is a decimal percentage (use 0.01 for

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -241,10 +241,10 @@ def contain(image, size, method=Image.BICUBIC):
     Returns a sized version of the image, expanded to fill the requested aspect ratio
     and size.
 
-    :param image: The image to size and crop.
+    :param image: The image to resize and crop.
     :param size: The requested output size in pixels, given as a
                  (width, height) tuple.
-    :param method: What resampling method to use. Default is
+    :param method: Resampling method to use. Default is
                    :py:attr:`PIL.Image.BICUBIC`. See :ref:`concept-filters`.
     :return: An image.
     """


### PR DESCRIPTION
Resolves #5415

Adds a `contain()` method to ImageOps. I would describe it as the inverse of `fit()`.

Running this code for each method in turn for comparison -

```python
from PIL import Image, ImageOps
im = Image.open("Tests/images/hopper.png")
ImageOps.fit(im, (200, 300))
```

|       | Fit                                                                                                        | Pad                                                                                                        | Contain                                                                                                        |
| ----- | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
| Size  |200 x 300                                                                                                   | 200 x 300                                                                                                  | 200 x 200                                                                                                      |
| Image |![fit](https://user-images.githubusercontent.com/3112309/115222169-caafba80-a14d-11eb-9399-ac1e69c864a3.png)|![pad](https://user-images.githubusercontent.com/3112309/115222173-cbe0e780-a14d-11eb-9e6e-70c91260f4db.png)|![contain](https://user-images.githubusercontent.com/3112309/115222160-c97e8d80-a14d-11eb-98b5-7cf0b06a8afe.png)|