### PR TITLE
Added info about mode when saving ICO for Windows

### DIFF
--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -267,7 +267,8 @@ class IcoImageFile(ImageFile.ImageFile):
     Handles classic, XP and Vista icon formats.
 
     When saving, PNG compression is used. Support for this was only added in
-    Windows Vista.
+    Windows Vista. If you are unable to view the icon in Windows, convert the
+    image to "RGBA" mode before saving.
 
     This plugin is a refactored version of Win32IconImagePlugin by Bryan Davis
     <casadebender@gmail.com>.


### PR DESCRIPTION
Resolves #3773

The report is a user saving an ICO from an RGB image, and it not appearing in Windows. The solution turned out to be saving an RGBA image instead.

This adds a note about that to the docstring.