### PR TITLE
Changed TIFF tag 33723 length to 1

### DIFF
--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -179,6 +179,12 @@ def test_no_duplicate_50741_tag():
     assert TAG_IDS["BestQualityScale"] == 50780
 
 
+def test_iptc(tmp_path):
+    out = str(tmp_path / "temp.tiff")
+    with Image.open("Tests/images/hopper.Lab.tif") as im:
+        im.save(out)
+
+
 def test_empty_metadata():
     f = io.BytesIO(b"II*\x00\x08\x00\x00\x00")
     head = f.read(8)

--- a/src/PIL/TiffTags.py
+++ b/src/PIL/TiffTags.py
@@ -178,7 +178,7 @@ TAGS_V2 = {
     532: ("ReferenceBlackWhite", RATIONAL, 6),
     700: ("XMP", BYTE, 0),
     33432: ("Copyright", ASCII, 1),
-    33723: ("IptcNaaInfo", UNDEFINED, 0),
+    33723: ("IptcNaaInfo", UNDEFINED, 1),
     34377: ("PhotoshopInfo", BYTE, 0),
     # FIXME add more tags here
     34665: ("ExifIFD", LONG, 1),


### PR DESCRIPTION
Resolves #2278

The issue reports that a TIFF image cannot be opened and saved - `AttributeError: 'tuple' object has no attribute 'ljust'`. The problem comes from tag 33723 - https://www.awaresystems.be/imaging/tiff/tifftags/iptc.html

https://github.com/python-pillow/Pillow/blob/ab8955b48e84b18c578d165e7d10868794311ce2/src/PIL/TiffTags.py#L181

Loading and saving existing test image hopper.Lab.tif currently triggers the same bug.

This PR changes the tag length to 1, allowing the image to save without an error.

It also produces nicer values for the tag.

```python
from PIL import Image
im = Image.open("00000001.tif")
print(im.tag_v2[33723])
im = Image.open("Tests/images/hopper.Lab.tif")
print(im.tag_v2[33723])
```
Currently gives
```
(b'\x1c\x01Z\x00\x03\x1b%G\x1c\x02\x00\x00\x02\x00\x00\x1c\x02P\x00\tULB Halle\x1c\x02t\x00\r(c) ULB Halle',)
(b'\x1c\x01Z\x00\x03\x1b%G\x1c\x02\x00\x00\x02\xcf\xc0',)
```
But with this PR, it gives
```
b'\x1c\x01Z\x00\x03\x1b%G\x1c\x02\x00\x00\x02\x00\x00\x1c\x02P\x00\tULB Halle\x1c\x02t\x00\r(c) ULB Halle'
b'\x1c\x01Z\x00\x03\x1b%G\x1c\x02\x00\x00\x02\xcf\xc0'
```