### PR TITLE
Fixed UNDEFINED TIFF tag of length 0 being changed in roundtrip

### DIFF
--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -185,6 +185,21 @@ def test_iptc(tmp_path):
         im.save(out)
 
 
+def test_undefined_zero(tmp_path):
+    # Check that the tag has not been changed since this test was created
+    tag = TiffTags.TAGS_V2[45059]
+    assert tag.type == TiffTags.UNDEFINED
+    assert tag.length == 0
+
+    info = TiffImagePlugin.ImageFileDirectory(b"II*\x00\x08\x00\x00\x00")
+    info[45059] = b"test"
+
+    # Assert that the tag value does not change by setting it to itself
+    original = info[45059]
+    info[45059] = info[45059]
+    assert info[45059] == original
+
+
 def test_empty_metadata():
     f = io.BytesIO(b"II*\x00\x08\x00\x00\x00")
     head = f.read(8)

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -565,7 +565,8 @@ class ImageFileDirectory_v2(MutableMapping):
 
         if self.tagtype[tag] == TiffTags.UNDEFINED:
             values = [
-                value.encode("ascii", "replace") if isinstance(value, str) else value
+                v.encode("ascii", "replace") if isinstance(v, str) else v
+                for v in values
             ]
         elif self.tagtype[tag] == TiffTags.RATIONAL:
             values = [float(v) if isinstance(v, int) else v for v in values]


### PR DESCRIPTION
```python
from PIL import Image
im = Image.open("Tests/images/hopper.tif")
im.tag_v2[45059] = b"test"
print(im.tag_v2[45059])  # (b'test',)

# You would think that self-assignment shouldn't change the value
im.tag_v2[45059] = im.tag_v2[45059]

# But it does
print(im.tag_v2[45059])  # ((b'test',),)
```

I would maintain that this should not be the case, so this PR fixes that.

What is special about this tag is that it is UNDEFINED with length 0.
https://github.com/python-pillow/Pillow/blob/ab8955b48e84b18c578d165e7d10868794311ce2/src/PIL/TiffTags.py#L192

The value of an UNDEFINED tag is always turned into a list in `_setitem` - meaning that if it is already a sequence, it gets wrapped again.

https://github.com/python-pillow/Pillow/blob/ab8955b48e84b18c578d165e7d10868794311ce2/src/PIL/TiffImagePlugin.py#L566-L569

And because the length is 0, at the end of `_setitem` it isn't unwrapped.

https://github.com/python-pillow/Pillow/blob/ab8955b48e84b18c578d165e7d10868794311ce2/src/PIL/TiffImagePlugin.py#L584-L608

While I think this problem is worth fixing in it's own right, this does also resolve #2278. So if this is merged first, then #5425 becomes just about tidying up the tag value by turning it from a tuple into a bytestring.