### PR TITLE
Switched to saving 1-bit PDFs with DCTDecode

### DIFF
--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -42,7 +42,8 @@ def test_monochrome(tmp_path):
     mode = "1"
 
     # Act / Assert
-    helper_save_as_pdf(tmp_path, mode)
+    outfile = helper_save_as_pdf(tmp_path, mode)
+    assert os.path.getsize(outfile) < 15000
 
 
 def test_greyscale(tmp_path):

--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -124,7 +124,7 @@ def _save(im, fp, filename, save_all=False):
             decode = None
 
             if im.mode == "1":
-                filter = "ASCIIHexDecode"
+                filter = "DCTDecode"
                 colorspace = PdfParser.PdfName("DeviceGray")
                 procset = "ImageB"  # grayscale
                 bits = 1
@@ -161,12 +161,6 @@ def _save(im, fp, filename, save_all=False):
             op = io.BytesIO()
 
             if filter == "ASCIIHexDecode":
-                if bits == 1:
-                    # FIXME: the hex encoder doesn't support packed 1-bit
-                    # images; do things the hard way...
-                    data = im.tobytes("raw", "1")
-                    im = Image.new("L", im.size)
-                    im.putdata(data)
                 ImageFile._save(im, op, [("hex", (0, 0) + im.size, 0, im.mode)])
             elif filter == "DCTDecode":
                 Image.SAVE["JPEG"](im, op, filename)


### PR DESCRIPTION
Resolves #1775 - the remaining part of that issue is a request for compression when saving 1-bit PDFs.

The issue reports that
```python
from PIL import Image
img = Image.new("1", (1400, 2000))
img.save("out.pdf")
```
generates a 5mb file.

Changing the filter to "DCTDecode", it becomes 34kb instead.

I've modified a test to ensure that saving `hopper("1")` as a PDF, that currently creates a 34kb file, stays below 15kb.