### PR TITLE
Replace sys.stdout with sys.stdout.buffer when saving

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -713,13 +713,20 @@ class TestFilePng:
             with pytest.raises(EOFError):
                 im.seek(1)
 
-    def test_save_stdout(self):
+    @pytest.mark.parametrize("buffer", (True, False))
+    def test_save_stdout(self, buffer):
         old_stdout = sys.stdout.buffer
 
-        class MyStdOut:
-            buffer = BytesIO()
+        if buffer:
 
-        sys.stdout = mystdout = MyStdOut()
+            class MyStdOut:
+                buffer = BytesIO()
+
+            mystdout = MyStdOut()
+        else:
+            mystdout = BytesIO()
+
+        sys.stdout = mystdout
 
         with Image.open(TEST_PNG_FILE) as im:
             im.save(sys.stdout, "PNG")
@@ -727,7 +734,9 @@ class TestFilePng:
         # Reset stdout
         sys.stdout = old_stdout
 
-        reloaded = Image.open(mystdout.buffer)
+        if buffer:
+            mystdout = mystdout.buffer
+        reloaded = Image.open(mystdout)
         assert_image_equal_tofile(reloaded, TEST_PNG_FILE)
 
 

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -1,4 +1,5 @@
 import re
+import sys
 import zlib
 from io import BytesIO
 
@@ -10,6 +11,7 @@ from .helper import (
     PillowLeakTestCase,
     assert_image,
     assert_image_equal,
+    assert_image_equal_tofile,
     hopper,
     is_big_endian,
     is_win32,
@@ -710,6 +712,23 @@ class TestFilePng:
 
             with pytest.raises(EOFError):
                 im.seek(1)
+
+    def test_save_stdout(self):
+        old_stdout = sys.stdout.buffer
+
+        class MyStdOut:
+            buffer = BytesIO()
+
+        sys.stdout = mystdout = MyStdOut()
+
+        with Image.open(TEST_PNG_FILE) as im:
+            im.save(sys.stdout, "PNG")
+
+        # Reset stdout
+        sys.stdout = old_stdout
+
+        reloaded = Image.open(mystdout.buffer)
+        assert_image_equal_tofile(reloaded, TEST_PNG_FILE)
 
 
 @pytest.mark.skipif(is_win32(), reason="Requires Unix or macOS")

--- a/Tests/test_psdraw.py
+++ b/Tests/test_psdraw.py
@@ -2,6 +2,8 @@ import os
 import sys
 from io import BytesIO
 
+import pytest
+
 from PIL import Image, PSDraw
 
 
@@ -44,14 +46,21 @@ def test_draw_postscript(tmp_path):
     assert os.path.getsize(tempfile) > 0
 
 
-def test_stdout():
+@pytest.mark.parametrize("buffer", (True, False))
+def test_stdout(buffer):
     # Temporarily redirect stdout
     old_stdout = sys.stdout.buffer
 
-    class MyStdOut:
-        buffer = BytesIO()
+    if buffer:
 
-    sys.stdout = mystdout = MyStdOut()
+        class MyStdOut:
+            buffer = BytesIO()
+
+        mystdout = MyStdOut()
+    else:
+        mystdout = BytesIO()
+
+    sys.stdout = mystdout
 
     ps = PSDraw.PSDraw()
     _create_document(ps)
@@ -59,4 +68,6 @@ def test_stdout():
     # Reset stdout
     sys.stdout = old_stdout
 
-    assert mystdout.buffer.getvalue() != b""
+    if buffer:
+        mystdout = mystdout.buffer
+    assert mystdout.getvalue() != b""

--- a/Tests/test_psdraw.py
+++ b/Tests/test_psdraw.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from io import StringIO
+from io import BytesIO
 
 from PIL import Image, PSDraw
 
@@ -46,8 +46,12 @@ def test_draw_postscript(tmp_path):
 
 def test_stdout():
     # Temporarily redirect stdout
-    old_stdout = sys.stdout
-    sys.stdout = mystdout = StringIO()
+    old_stdout = sys.stdout.buffer
+
+    class MyStdOut:
+        buffer = BytesIO()
+
+    sys.stdout = mystdout = MyStdOut()
 
     ps = PSDraw.PSDraw()
     _create_document(ps)
@@ -55,4 +59,4 @@ def test_stdout():
     # Reset stdout
     sys.stdout = old_stdout
 
-    assert mystdout.getvalue() != ""
+    assert mystdout.buffer.getvalue() != b""

--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -424,7 +424,7 @@ Drawing PostScript
         title = "hopper"
         box = (1*72, 2*72, 7*72, 10*72) # in points
 
-        ps = PSDraw.PSDraw() # default is sys.stdout.buffer
+        ps = PSDraw.PSDraw() # default is sys.stdout or sys.stdout.buffer
         ps.begin_document(title)
 
         # draw the image (75 dpi)

--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -424,7 +424,7 @@ Drawing PostScript
         title = "hopper"
         box = (1*72, 2*72, 7*72, 10*72) # in points
 
-        ps = PSDraw.PSDraw() # default is sys.stdout
+        ps = PSDraw.PSDraw() # default is sys.stdout.buffer
         ps.begin_document(title)
 
         # draw the image (75 dpi)

--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -18,6 +18,7 @@ Example: Draw a gray cross over an image
 
 .. code-block:: python
 
+    import sys
     from PIL import Image, ImageDraw
 
     with Image.open("hopper.jpg") as im:

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -354,56 +354,46 @@ def _save(im, fp, filename, eps=1):
     #
     # determine PostScript image mode
     if im.mode == "L":
-        operator = (8, 1, "image")
+        operator = (8, 1, b"image")
     elif im.mode == "RGB":
-        operator = (8, 3, "false 3 colorimage")
+        operator = (8, 3, b"false 3 colorimage")
     elif im.mode == "CMYK":
-        operator = (8, 4, "false 4 colorimage")
+        operator = (8, 4, b"false 4 colorimage")
     else:
         raise ValueError("image mode is not supported")
 
-    base_fp = fp
-    wrapped_fp = False
-    if fp != sys.stdout:
-        fp = io.TextIOWrapper(fp, encoding="latin-1")
-        wrapped_fp = True
-
-    try:
-        if eps:
-            #
-            # write EPS header
-            fp.write("%!PS-Adobe-3.0 EPSF-3.0\n")
-            fp.write("%%Creator: PIL 0.1 EpsEncode\n")
-            # fp.write("%%CreationDate: %s"...)
-            fp.write("%%%%BoundingBox: 0 0 %d %d\n" % im.size)
-            fp.write("%%Pages: 1\n")
-            fp.write("%%EndComments\n")
-            fp.write("%%Page: 1 1\n")
-            fp.write("%%ImageData: %d %d " % im.size)
-            fp.write('%d %d 0 1 1 "%s"\n' % operator)
-
+    if eps:
         #
-        # image header
-        fp.write("gsave\n")
-        fp.write("10 dict begin\n")
-        fp.write(f"/buf {im.size[0] * operator[1]} string def\n")
-        fp.write("%d %d scale\n" % im.size)
-        fp.write("%d %d 8\n" % im.size)  # <= bits
-        fp.write(f"[{im.size[0]} 0 0 -{im.size[1]} 0 {im.size[1]}]\n")
-        fp.write("{ currentfile buf readhexstring pop } bind\n")
-        fp.write(operator[2] + "\n")
-        if hasattr(fp, "flush"):
-            fp.flush()
+        # write EPS header
+        fp.write(b"%!PS-Adobe-3.0 EPSF-3.0\n")
+        fp.write(b"%%Creator: PIL 0.1 EpsEncode\n")
+        # fp.write("%%CreationDate: %s"...)
+        fp.write(b"%%%%BoundingBox: 0 0 %d %d\n" % im.size)
+        fp.write(b"%%Pages: 1\n")
+        fp.write(b"%%EndComments\n")
+        fp.write(b"%%Page: 1 1\n")
+        fp.write(b"%%ImageData: %d %d " % im.size)
+        fp.write(b'%d %d 0 1 1 "%s"\n' % operator)
 
-        ImageFile._save(im, base_fp, [("eps", (0, 0) + im.size, 0, None)])
+    #
+    # image header
+    fp.write(b"gsave\n")
+    fp.write(b"10 dict begin\n")
+    fp.write(b"/buf %d string def\n" % (im.size[0] * operator[1]))
+    fp.write(b"%d %d scale\n" % im.size)
+    fp.write(b"%d %d 8\n" % im.size)  # <= bits
+    fp.write(b"[%d 0 0 -%d 0 %d]\n" % (im.size[0], im.size[1], im.size[1]))
+    fp.write(b"{ currentfile buf readhexstring pop } bind\n")
+    fp.write(operator[2] + b"\n")
+    if hasattr(fp, "flush"):
+        fp.flush()
 
-        fp.write("\n%%%%EndBinary\n")
-        fp.write("grestore end\n")
-        if hasattr(fp, "flush"):
-            fp.flush()
-    finally:
-        if wrapped_fp:
-            fp.detach()
+    ImageFile._save(im, fp, [("eps", (0, 0) + im.size, 0, None)])
+
+    fp.write(b"\n%%%%EndBinary\n")
+    fp.write(b"grestore end\n")
+    if hasattr(fp, "flush"):
+        fp.flush()
 
 
 #

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2135,6 +2135,8 @@ class Image:
         elif isinstance(fp, Path):
             filename = str(fp)
             open_fp = True
+        elif fp == sys.stdout:
+            fp = sys.stdout.buffer
         if not filename and hasattr(fp, "name") and isPath(fp.name):
             # only set the name for metadata purposes
             filename = fp.name

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2136,7 +2136,10 @@ class Image:
             filename = str(fp)
             open_fp = True
         elif fp == sys.stdout:
-            fp = sys.stdout.buffer
+            try:
+                fp = sys.stdout.buffer
+            except AttributeError:
+                pass
         if not filename and hasattr(fp, "name") and isPath(fp.name):
             # only set the name for metadata purposes
             filename = fp.name

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -493,7 +493,7 @@ def _save(im, fp, tile, bufsize=0):
     # But, it would need at least the image size in most cases. RawEncode is
     # a tricky case.
     bufsize = max(MAXBLOCK, bufsize, im.size[0] * 4)  # see RawEncode.c
-    if fp == sys.stdout:
+    if fp == sys.stdout.buffer:
         fp.flush()
         return
     try:

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -493,7 +493,7 @@ def _save(im, fp, tile, bufsize=0):
     # But, it would need at least the image size in most cases. RawEncode is
     # a tricky case.
     bufsize = max(MAXBLOCK, bufsize, im.size[0] * 4)  # see RawEncode.c
-    if fp == sys.stdout.buffer:
+    if fp == sys.stdout or (hasattr(sys.stdout, "buffer") and fp == sys.stdout.buffer):
         fp.flush()
         return
     try:

--- a/src/PIL/PSDraw.py
+++ b/src/PIL/PSDraw.py
@@ -26,12 +26,15 @@ from . import EpsImagePlugin
 class PSDraw:
     """
     Sets up printing to the given file. If ``fp`` is omitted,
-    ``sys.stdout.buffer`` is assumed.
+    ``sys.stdout.buffer`` or ``sys.stdout`` is assumed.
     """
 
     def __init__(self, fp=None):
         if not fp:
-            fp = sys.stdout.buffer
+            try:
+                fp = sys.stdout.buffer
+            except AttributeError:
+                fp = sys.stdout
         self.fp = fp
 
     def begin_document(self, id=None):

--- a/src/PIL/PSDraw.py
+++ b/src/PIL/PSDraw.py
@@ -26,39 +26,33 @@ from . import EpsImagePlugin
 class PSDraw:
     """
     Sets up printing to the given file. If ``fp`` is omitted,
-    :py:data:`sys.stdout` is assumed.
+    ``sys.stdout.buffer`` is assumed.
     """
 
     def __init__(self, fp=None):
         if not fp:
-            fp = sys.stdout
+            fp = sys.stdout.buffer
         self.fp = fp
-
-    def _fp_write(self, to_write):
-        if self.fp == sys.stdout:
-            self.fp.write(to_write)
-        else:
-            self.fp.write(bytes(to_write, "UTF-8"))
 
     def begin_document(self, id=None):
         """Set up printing of a document. (Write PostScript DSC header.)"""
         # FIXME: incomplete
-        self._fp_write(
-            "%!PS-Adobe-3.0\n"
-            "save\n"
-            "/showpage { } def\n"
-            "%%EndComments\n"
-            "%%BeginDocument\n"
+        self.fp.write(
+            b"%!PS-Adobe-3.0\n"
+            b"save\n"
+            b"/showpage { } def\n"
+            b"%%EndComments\n"
+            b"%%BeginDocument\n"
         )
-        # self._fp_write(ERROR_PS)  # debugging!
-        self._fp_write(EDROFF_PS)
-        self._fp_write(VDI_PS)
-        self._fp_write("%%EndProlog\n")
+        # self.fp.write(ERROR_PS)  # debugging!
+        self.fp.write(EDROFF_PS)
+        self.fp.write(VDI_PS)
+        self.fp.write(b"%%EndProlog\n")
         self.isofont = {}
 
     def end_document(self):
         """Ends printing. (Write PostScript DSC footer.)"""
-        self._fp_write("%%EndDocument\nrestore showpage\n%%End\n")
+        self.fp.write(b"%%EndDocument\nrestore showpage\n%%End\n")
         if hasattr(self.fp, "flush"):
             self.fp.flush()
 
@@ -69,12 +63,13 @@ class PSDraw:
         :param font: A PostScript font name
         :param size: Size in points.
         """
+        font = bytes(font, "UTF-8")
         if font not in self.isofont:
             # reencode font
-            self._fp_write(f"/PSDraw-{font} ISOLatin1Encoding /{font} E\n")
+            self.fp.write(b"/PSDraw-%s ISOLatin1Encoding /%s E\n" % (font, font))
             self.isofont[font] = 1
         # rough
-        self._fp_write(f"/F0 {size} /PSDraw-{font} F\n")
+        self.fp.write(b"/F0 %d /PSDraw-%s F\n" % (size, font))
 
     def line(self, xy0, xy1):
         """
@@ -82,7 +77,7 @@ class PSDraw:
         PostScript point coordinates (72 points per inch, (0, 0) is the lower
         left corner of the page).
         """
-        self._fp_write("%d %d %d %d Vl\n" % (*xy0, *xy1))
+        self.fp.write(b"%d %d %d %d Vl\n" % (*xy0, *xy1))
 
     def rectangle(self, box):
         """
@@ -97,16 +92,18 @@ class PSDraw:
 
                         %d %d M %d %d 0 Vr\n
         """
-        self._fp_write("%d %d M %d %d 0 Vr\n" % box)
+        self.fp.write(b"%d %d M %d %d 0 Vr\n" % box)
 
     def text(self, xy, text):
         """
         Draws text at the given position. You must use
         :py:meth:`~PIL.PSDraw.PSDraw.setfont` before calling this method.
         """
-        text = "\\(".join(text.split("("))
-        text = "\\)".join(text.split(")"))
-        self._fp_write(f"{xy[0]} {xy[1]} M ({text}) S\n")
+        text = bytes(text, "UTF-8")
+        text = b"\\(".join(text.split(b"("))
+        text = b"\\)".join(text.split(b")"))
+        xy += (text,)
+        self.fp.write(b"%d %d M (%s) S\n" % xy)
 
     def image(self, box, im, dpi=None):
         """Draw a PIL image, centered in the given box."""
@@ -130,14 +127,14 @@ class PSDraw:
             y = ymax
         dx = (xmax - x) / 2 + box[0]
         dy = (ymax - y) / 2 + box[1]
-        self._fp_write(f"gsave\n{dx:f} {dy:f} translate\n")
+        self.fp.write(b"gsave\n%f %f translate\n" % (dx, dy))
         if (x, y) != im.size:
             # EpsImagePlugin._save prints the image at (0,0,xsize,ysize)
             sx = x / im.size[0]
             sy = y / im.size[1]
-            self._fp_write(f"{sx:f} {sy:f} scale\n")
+            self.fp.write(b"%f %f scale\n" % (sx, sy))
         EpsImagePlugin._save(im, self.fp, None, 0)
-        self._fp_write("\ngrestore\n")
+        self.fp.write(b"\ngrestore\n")
 
 
 # --------------------------------------------------------------------
@@ -153,7 +150,7 @@ class PSDraw:
 #
 
 
-EDROFF_PS = """\
+EDROFF_PS = b"""\
 /S { show } bind def
 /P { moveto show } bind def
 /M { moveto } bind def
@@ -182,7 +179,7 @@ EDROFF_PS = """\
 # Copyright (c) Fredrik Lundh 1994.
 #
 
-VDI_PS = """\
+VDI_PS = b"""\
 /Vm { moveto } bind def
 /Va { newpath arcn stroke } bind def
 /Vl { moveto lineto stroke } bind def
@@ -207,7 +204,7 @@ VDI_PS = """\
 # 89-11-21 fl: created (pslist 1.10)
 #
 
-ERROR_PS = """\
+ERROR_PS = b"""\
 /landscape false def
 /errorBUF 200 string def
 /errorNL { currentpoint 10 sub exch pop 72 exch moveto } def


### PR DESCRIPTION
Resolves #5436

https://pillow.readthedocs.io/en/stable/reference/ImageDraw.html#example-draw-a-gray-cross-over-an-image
```python
from PIL import Image, ImageDraw

with Image.open("hopper.jpg") as im:

    draw = ImageDraw.Draw(im)
    draw.line((0, 0) + im.size, fill=128)
    draw.line((0, im.size[1], im.size[0], 0), fill=128)

    # write to stdout
    im.save(sys.stdout, "PNG")
```

However, running this example code gives
```
Traceback (most recent call last):
  File "<stdin>", line 6, in <module>
  File "PIL/Image.py", line 2172, in save
    save_handler(self, fp, filename)
  File "PIL/PngImagePlugin.py", line 1223, in _save
    fp.write(_MAGIC)
TypeError: write() argument must be str, not bytes
```

This PR suggests fixing this by changing `im.save` so that if it is passed `sys.stdout` (`sys.stdout.mode` is 'w'), then it is replaced with `sys.stdout.buffer` (`sys.stdout.buffer.mode` is 'wb').

It also changes the `PSDraw()` default from `sys.stdout` to `sys.stdout.buffer`, and simplifies EPS saving by abandoning the idea of wrapping `fp` just so that it can write strings.