### PR TITLE
Fixed Python 3.10 at alpha.7

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -31,7 +31,7 @@ python3 -m pip install -U pytest-timeout
 python3 -m pip install pyroma
 python3 -m pip install test-image-results
 # TODO Remove condition when numpy supports 3.10
-if ! [ "$GHA_PYTHON_VERSION" == "3.10-dev" ]; then python3 -m pip install numpy ; fi
+if ! [ "$GHA_PYTHON_VERSION" == "3.10.0-alpha.7" ]; then python3 -m pip install numpy ; fi
 
 # TODO Remove when 3.8 / 3.9 includes setuptools 49.3.2+:
 if [ "$GHA_PYTHON_VERSION" == "3.8" ]; then python3 -m pip install -U "setuptools>=49.3.2" ; fi

--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -15,7 +15,7 @@ python3 -m pip install test-image-results
 
 echo -e "[openblas]\nlibraries = openblas\nlibrary_dirs = /usr/local/opt/openblas/lib" >> ~/.numpy-site.cfg
 # TODO Remove condition when numpy supports 3.10
-if ! [ "$GHA_PYTHON_VERSION" == "3.10-dev" ]; then python3 -m pip install numpy ; fi
+if ! [ "$GHA_PYTHON_VERSION" == "3.10.0-alpha.7" ]; then python3 -m pip install numpy ; fi
 
 # TODO Remove when 3.8 / 3.9 includes setuptools 49.3.2+:
 if [ "$GHA_PYTHON_VERSION" == "3.8" ]; then python3 -m pip install -U "setuptools>=49.3.2" ; fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: [
           "pypy-3.7",
           "pypy-3.6",
-          "3.10-dev",
+          "3.10.0-alpha.7",
           "3.9",
           "3.8",
           "3.7",


### PR DESCRIPTION
Fix the failures on Python 3.10 in master - https://github.com/python-pillow/Pillow/runs/2431607308 - by changing the Python 3.10 version to be static at alpha.7

The failures do not come from Pillow, but from pytest - https://github.com/pytest-dev/pytest/issues/8539