### PR TITLE
Changed WebP default "method" value to 4

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -940,7 +940,7 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
     files compared to the slowest, but best, 100.
 
 **method**
-    Quality/speed trade-off (0=fast, 6=slower-better). Defaults to 0.
+    Quality/speed trade-off (0=fast, 6=slower-better). Defaults to 4.
 
 **icc_profile**
     The ICC Profile to include in the saved file. Only supported if

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -314,7 +314,7 @@ def _save(im, fp, filename):
     if isinstance(exif, Image.Exif):
         exif = exif.tobytes()
     xmp = im.encoderinfo.get("xmp", "")
-    method = im.encoderinfo.get("method", 0)
+    method = im.encoderinfo.get("method", 4)
 
     if im.mode not in _VALID_WEBP_LEGACY_MODES:
         alpha = (


### PR DESCRIPTION
Resolves #4786

When #4547 added the "method" argument to single frame WebP saving, it used our existing "method" default for multiple frame WebP saving - 0.

However, WebP sets "method" to 4 by default - https://chromium.googlesource.com/webm/libwebp/+/refs/heads/master/src/enc/config_enc.c#34 - so we changed the "method" that was used if none was specified by the user.

This PR changes it to 4 to line up with WebP's default.