### PR TITLE
Revert "Fixed Python 3.10 at alpha.7": use 3.10-dev

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -31,7 +31,7 @@ python3 -m pip install -U pytest-timeout
 python3 -m pip install pyroma
 python3 -m pip install test-image-results
 # TODO Remove condition when numpy supports 3.10
-if ! [ "$GHA_PYTHON_VERSION" == "3.10.0-alpha.7" ]; then python3 -m pip install numpy ; fi
+if ! [ "$GHA_PYTHON_VERSION" == "3.10-dev" ]; then python3 -m pip install numpy ; fi
 
 # TODO Remove when 3.8 / 3.9 includes setuptools 49.3.2+:
 if [ "$GHA_PYTHON_VERSION" == "3.8" ]; then python3 -m pip install -U "setuptools>=49.3.2" ; fi

--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -15,7 +15,7 @@ python3 -m pip install test-image-results
 
 echo -e "[openblas]\nlibraries = openblas\nlibrary_dirs = /usr/local/opt/openblas/lib" >> ~/.numpy-site.cfg
 # TODO Remove condition when numpy supports 3.10
-if ! [ "$GHA_PYTHON_VERSION" == "3.10.0-alpha.7" ]; then python3 -m pip install numpy ; fi
+if ! [ "$GHA_PYTHON_VERSION" == "3.10-dev" ]; then python3 -m pip install numpy ; fi
 
 # TODO Remove when 3.8 / 3.9 includes setuptools 49.3.2+:
 if [ "$GHA_PYTHON_VERSION" == "3.8" ]; then python3 -m pip install -U "setuptools>=49.3.2" ; fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: [
           "pypy-3.7",
           "pypy-3.6",
-          "3.10.0-alpha.7",
+          "3.10-dev",
           "3.9",
           "3.8",
           "3.7",


### PR DESCRIPTION
Reverts python-pillow/Pillow#5447.

I wrote at https://github.com/pytest-dev/pytest/issues/8539#issuecomment-829943392:

---


Good news, the GitHub Actions weirdness has been resolved and latest pytest is working with `3.10-dev` ([example build from today](https://github.com/python-pillow/Pillow/runs/2474120077?check_suite_focus=true)). 🎈 

What happened:

Something caused a premature Python-3.10.0b1.tgz to be released on the Python FTP servers (now removed): https://www.python.org/ftp/python/3.10.0/Python-3.10.0b1.tgz.

GitHub Actions' automation integrated this into `3.10-dev`. This has also been removed and `3.10-dev` now points to the latest 3.10 alpha, in advance of next week's real 3.10 beta release.

More details:
* https://github.com/actions/setup-python/issues/207
* https://github.com/actions/python-versions/pull/92#discussion_r622887491
