### PR TITLE
Clarified error message

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -298,7 +298,7 @@ get_unpacker(ImagingDecoderObject *decoder, const char *mode, const char *rawmod
     unpack = ImagingFindUnpacker(mode, rawmode, &bits);
     if (!unpack) {
         Py_DECREF(decoder);
-        PyErr_SetString(PyExc_ValueError, "unknown raw mode");
+        PyErr_SetString(PyExc_ValueError, "unknown raw mode for given image mode");
         return -1;
     }
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/256372724b6648a94234fcb989bf696285edd3a0/src/decode.c#L298-L301

https://github.com/python-pillow/Pillow/issues/4818#issuecomment-725201654 suggests that "unknown raw mode" is not completely descriptive here. This is a fair comment - it's not that the raw mode is unknown, it's that our list of unpackers doesn't have a mapping from the raw mode to the mode. The particular raw mode may be valid for other modes.

So this PR changes the text, mostly using the suggestion from the comment.