### PR TITLE
Replaced uint16 and uint32 with uint16_t and uint32_t to resolve TIFF deprecations

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -499,7 +499,7 @@ PyImaging_LibTiffDecoderNew(PyObject *self, PyObject *args) {
     char *rawmode;
     char *compname;
     int fp;
-    uint32 ifdoffset;
+    uint32_t ifdoffset;
 
     if (!PyArg_ParseTuple(args, "sssiI", &mode, &rawmode, &compname, &fp, &ifdoffset)) {
         return NULL;

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -181,7 +181,7 @@ _tiffUnmapProc(thandle_t hdata, tdata_t base, toff_t size) {
 }
 
 int
-ImagingLibTiffInit(ImagingCodecState state, int fp, uint32 offset) {
+ImagingLibTiffInit(ImagingCodecState state, int fp, uint32_t offset) {
     TIFFSTATE *clientstate = (TIFFSTATE *)state->context;
 
     TRACE(("initing libtiff\n"));
@@ -213,10 +213,10 @@ ImagingLibTiffInit(ImagingCodecState state, int fp, uint32 offset) {
 }
 
 int
-_pickUnpackers(Imaging im, ImagingCodecState state, TIFF *tiff, uint16 planarconfig, ImagingShuffler *unpackers) {
+_pickUnpackers(Imaging im, ImagingCodecState state, TIFF *tiff, uint16_t planarconfig, ImagingShuffler *unpackers) {
     // if number of bands is 1, there is no difference with contig case
     if (planarconfig == PLANARCONFIG_SEPARATE && im->bands > 1) {
-        uint16 bits_per_sample = 8;
+        uint16_t bits_per_sample = 8;
 
         TIFFGetFieldDefaulted(tiff, TIFFTAG_BITSPERSAMPLE, &bits_per_sample);
         if (bits_per_sample != 8 && bits_per_sample != 16) {
@@ -545,10 +545,10 @@ ImagingLibTiffDecode(
     char *filename = "tempfile.tif";
     char *mode = "r";
     TIFF *tiff;
-    uint16 photometric = 0;  // init to not PHOTOMETRIC_YCBCR
-    uint16 compression;
+    uint16_t photometric = 0;  // init to not PHOTOMETRIC_YCBCR
+    uint16_t compression;
     int readAsRGBA = 0;
-    uint16 planarconfig = 0;
+    uint16_t planarconfig = 0;
     int planes = 1;
     ImagingShuffler unpackers[4];
     UINT32 img_width, img_height;
@@ -639,7 +639,7 @@ ImagingLibTiffDecode(
 
     if (clientstate->ifd) {
         int rv;
-        uint32 ifdoffset = clientstate->ifd;
+        uint32_t ifdoffset = clientstate->ifd;
         TRACE(("reading tiff ifd %u\n", ifdoffset));
         rv = TIFFSetSubDirectory(tiff, ifdoffset);
         if (!rv) {
@@ -697,8 +697,8 @@ ImagingLibTiffDecode(
             // Check if raw mode was RGBa and it was stored on separate planes
             // so we have to convert it to RGBA
             if (planes > 3 && strcmp(im->mode, "RGBA") == 0) {
-                uint16 extrasamples;
-                uint16* sampleinfo;
+                uint16_t extrasamples;
+                uint16_t* sampleinfo;
                 ImagingShuffler shuffle;
                 INT32 y;
 
@@ -810,7 +810,7 @@ ImagingLibTiffMergeFieldInfo(
     ImagingCodecState state, TIFFDataType field_type, int key, int is_var_length) {
     // Refer to libtiff docs (http://www.simplesystems.org/libtiff/addingtags.html)
     TIFFSTATE *clientstate = (TIFFSTATE *)state->context;
-    uint32 n;
+    uint32_t n;
     int status = 0;
 
     // custom fields added with ImagingLibTiffMergeFieldInfo are only used for
@@ -933,7 +933,7 @@ ImagingLibTiffEncode(Imaging im, ImagingCodecState state, UINT8 *buffer, int byt
                 state->xsize);
 
             if (TIFFWriteScanline(
-                    tiff, (tdata_t)(state->buffer), (uint32)state->y, 0) == -1) {
+                    tiff, (tdata_t)(state->buffer), (uint32_t)state->y, 0) == -1) {
                 TRACE(("Encode Error, row %d\n", state->y));
                 state->errcode = IMAGING_CODEC_BROKEN;
                 TIFFClose(tiff);

--- a/src/libImaging/TiffDecode.h
+++ b/src/libImaging/TiffDecode.h
@@ -32,17 +32,17 @@ typedef struct {
     toff_t loc;   /* toff_t == uint32 */
     tsize_t size; /* tsize_t == int32 */
     int fp;
-    uint32 ifd; /* offset of the ifd, used for multipage
-                 * Should be uint32 for libtiff 3.9.x
-                 * uint64 for libtiff 4.0.x
-                 */
+    uint32_t ifd; /* offset of the ifd, used for multipage
+                   * Should be uint32 for libtiff 3.9.x
+                   * uint64 for libtiff 4.0.x
+                   */
     TIFF *tiff; /* Used in write */
     toff_t eof;
     int flrealloc; /* may we realloc */
 } TIFFSTATE;
 
 extern int
-ImagingLibTiffInit(ImagingCodecState state, int fp, uint32 offset);
+ImagingLibTiffInit(ImagingCodecState state, int fp, uint32_t offset);
 extern int
 ImagingLibTiffEncodeInit(ImagingCodecState state, char *filename, int fp);
 extern int


### PR DESCRIPTION
When [compiling on macOS](https://github.com/python-pillow/Pillow/runs/2474943233#step:9:52), deprecation warnings for TIFF have started appearing.

```
In file included from src/decode.c:491:
src/libImaging/TiffDecode.h:35:5: warning: 'uint32' is deprecated [-Wdeprecated-declarations]
    uint32 ifd; /* offset of the ifd, used for multipage
    ^
/usr/local/Cellar/libtiff/4.3.0/include/tiff.h:84:45: note: 'uint32' has been explicitly marked deprecated here
typedef TIFF_MSC_DEPRECATED uint32_t uint32 TIFF_GCC_DEPRECATED;
                                            ^
/usr/local/Cellar/libtiff/4.3.0/include/tiff.h:66:44: note: expanded from macro 'TIFF_GCC_DEPRECATED'
#define TIFF_GCC_DEPRECATED __attribute__((deprecated))
                                           ^
```

This is because of https://gitlab.com/libtiff/libtiff/-/merge_requests/205

This PR resolves the warnings by replacing uint16 and uint32 with uint16_t and uint32_t.