### PR TITLE
Do not round dimensions when saving PDF

### DIFF
--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -30,7 +30,7 @@ def helper_save_as_pdf(tmp_path, mode, **kwargs):
     with open(outfile, "rb") as fp:
         contents = fp.read()
     size = tuple(
-        int(d) for d in contents.split(b"/MediaBox [ 0 0 ")[1].split(b"]")[0].split()
+        float(d) for d in contents.split(b"/MediaBox [ 0 0 ")[1].split(b"]")[0].split()
     )
     assert im.size == size
 
@@ -84,6 +84,27 @@ def test_unsupported_mode(tmp_path):
 
     with pytest.raises(ValueError):
         im.save(outfile)
+
+
+def test_resolution(tmp_path):
+    im = hopper()
+
+    outfile = str(tmp_path / "temp.pdf")
+    im.save(outfile, resolution=150)
+
+    with open(outfile, "rb") as fp:
+        contents = fp.read()
+
+    size = tuple(
+        float(d)
+        for d in contents.split(b"stream\nq ")[1].split(b" 0 0 cm")[0].split(b" 0 0 ")
+    )
+    assert size == (61.44, 61.44)
+
+    size = tuple(
+        float(d) for d in contents.split(b"/MediaBox [ 0 0 ")[1].split(b"]")[0].split()
+    )
+    assert size == (61.44, 61.44)
 
 
 @mark_if_feature_version(

--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -202,8 +202,8 @@ def _save(im, fp, filename, save_all=False):
                 MediaBox=[
                     0,
                     0,
-                    int(width * 72.0 / resolution),
-                    int(height * 72.0 / resolution),
+                    width * 72.0 / resolution,
+                    height * 72.0 / resolution,
                 ],
                 Contents=contents_refs[pageNumber],
             )
@@ -211,9 +211,9 @@ def _save(im, fp, filename, save_all=False):
             #
             # page contents
 
-            page_contents = b"q %d 0 0 %d 0 0 cm /image Do Q\n" % (
-                int(width * 72.0 / resolution),
-                int(height * 72.0 / resolution),
+            page_contents = b"q %f 0 0 %f 0 0 cm /image Do Q\n" % (
+                width * 72.0 / resolution,
+                height * 72.0 / resolution,
             )
 
             existing_pdf.write_obj(contents_refs[pageNumber], stream=page_contents)

--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -330,6 +330,8 @@ def pdf_repr(x):
         return bytes(x)
     elif isinstance(x, int):
         return str(x).encode("us-ascii")
+    elif isinstance(x, float):
+        return str(x).encode("us-ascii")
     elif isinstance(x, time.struct_time):
         return b"(D:" + time.strftime("%Y%m%d%H%M%SZ", x).encode("us-ascii") + b")"
     elif isinstance(x, dict):


### PR DESCRIPTION
Resolves #3565

The issue reports that the `resolution` argument when saving PDFs does not appear correctly when opening the resulting PDF in commercial software.

[Crunching the numbers](https://github.com/python-pillow/Pillow/issues/3565#issuecomment-830484468), this is because of rounding that is used by Pillow when saving a PDF.

https://github.com/python-pillow/Pillow/blob/676f4dbefb22c349c2f78f4f6aabf26e00d5efc2/src/PIL/PdfImagePlugin.py#L202-L217



Searching for whether rounding needs to be used, I'm able to use GIMP to export a PDF with MediaBox float values, and I see an example at https://books.google.com.au/books?id=JJN_BAAAQBAJ&pg=PA102#v=onepage&q&f=false. As for `page_contents`, I see float values on page 287 of https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/pdf_reference_archives/PDFReference.pdf

So this PR removes the rounding.