### PR TITLE
Fix build with libraqm < 0.7.0

### DIFF
--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -277,7 +277,7 @@ text_layout_raqm(
             direction = RAQM_DIRECTION_LTR;
         } else if (strcmp(dir, "ttb") == 0) {
             direction = RAQM_DIRECTION_TTB;
-#if !defined(RAQM_VERSION_ATLEAST) || !RAQM_VERSION_ATLEAST(0, 7, 0)
+#if !defined(RAQM_VERSION_ATLEAST)
             PyErr_SetString(
                 PyExc_ValueError,
                 "libraqm 0.7 or greater required for 'ttb' direction");

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -278,6 +278,7 @@ text_layout_raqm(
         } else if (strcmp(dir, "ttb") == 0) {
             direction = RAQM_DIRECTION_TTB;
 #if !defined(RAQM_VERSION_ATLEAST)
+            /* RAQM_VERSION_ATLEAST was added in Raqm 0.7.0 */
             PyErr_SetString(
                 PyExc_ValueError,
                 "libraqm 0.7 or greater required for 'ttb' direction");


### PR DESCRIPTION
gcc's cpp doesn't short-circuit when RAQM_VERSION_ATLEAST is undefined
so building fails on systems with old libraqm (e.g. Debian 10 for
raspberry pi where wheels w/libraqm support may not be available).
RAQM_VERSION_ATLEAST was introduced with 0.7.0, so the test is
effectively equivalent.
