### PR TITLE
Include code in WebP error

### DIFF
--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -1,5 +1,6 @@
 import io
 import re
+import sys
 
 import pytest
 
@@ -118,6 +119,14 @@ class TestFileWebp:
         """
 
         self._roundtrip(tmp_path, "P", 50.0)
+
+    @pytest.mark.skipif(sys.maxsize <= 2 ** 32, reason="Requires 64-bit system")
+    def test_write_encoding_error_message(self, tmp_path):
+        temp_file = str(tmp_path / "temp.webp")
+        im = Image.new("RGB", (15000, 15000))
+        with pytest.raises(ValueError) as e:
+            im.save(temp_file, method=0)
+        assert str(e.value) == "encoding error 6"
 
     def test_WebPEncode_with_invalid_args(self):
         """

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -663,7 +663,7 @@ WebPEncode_wrapper(PyObject *self, PyObject *args) {
 
     WebPPictureFree(&pic);
     if (!ok) {
-        PyErr_SetString(PyExc_ValueError, "encoding error");
+        PyErr_Format(PyExc_ValueError, "encoding error %d", (&pic)->error_code);
         return NULL;
     }
     output = writer.mem;


### PR DESCRIPTION
Resolves #5461

Provides more information to the user on a WebP encoding error by including the error code - changing from "encoding error" to "encoding error 6", for example.