### PR TITLE
Corrected errors in restoring sys.stdout in tests

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -715,7 +715,7 @@ class TestFilePng:
 
     @pytest.mark.parametrize("buffer", (True, False))
     def test_save_stdout(self, buffer):
-        old_stdout = sys.stdout.buffer
+        old_stdout = sys.stdout
 
         if buffer:
 

--- a/Tests/test_psdraw.py
+++ b/Tests/test_psdraw.py
@@ -49,7 +49,7 @@ def test_draw_postscript(tmp_path):
 @pytest.mark.parametrize("buffer", (True, False))
 def test_stdout(buffer):
     # Temporarily redirect stdout
-    old_stdout = sys.stdout.buffer
+    old_stdout = sys.stdout
 
     if buffer:
 


### PR DESCRIPTION
Fixes errors introduced by #5437

In the PNG test for example,
https://github.com/python-pillow/Pillow/blob/8354fa4929ffd55b01ee78353f15917e1a0a1425/Tests/test_file_png.py#L718
is followed by
https://github.com/python-pillow/Pillow/blob/8354fa4929ffd55b01ee78353f15917e1a0a1425/Tests/test_file_png.py#L734-L735

This does not restore the original setting correctly.