### PR TITLE
Removed GitHub Actions Ubuntu setuptools version requirement

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -33,10 +33,6 @@ python3 -m pip install test-image-results
 # TODO Remove condition when numpy supports 3.10
 if ! [ "$GHA_PYTHON_VERSION" == "3.10-dev" ]; then python3 -m pip install numpy ; fi
 
-# TODO Remove when 3.8 / 3.9 includes setuptools 49.3.2+:
-if [ "$GHA_PYTHON_VERSION" == "3.8" ]; then python3 -m pip install -U "setuptools>=49.3.2" ; fi
-if [ "$GHA_PYTHON_VERSION" == "3.9" ]; then python3 -m pip install -U "setuptools>=49.3.2" ; fi
-
 # PyQt5 doesn't support PyPy3
 # Wheel doesn't yet support 3.10
 if [[ $GHA_PYTHON_VERSION == 3.* && $GHA_PYTHON_VERSION != "3.10-dev" ]]; then


### PR DESCRIPTION
It is no longer necessary to manually upgrade setuptools on GitHub Actions Ubuntu to allow tests to pass.