### PR TITLE
Add OSError info for load function

### DIFF
--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -120,12 +120,14 @@ class TestImageFile:
     @skip_unless_feature("zlib")
     def test_truncated_with_errors(self):
         with Image.open("Tests/images/truncated_image.png") as im:
-            with pytest.raises(OSError):
+            with pytest.raises(OSError) as oseinfo:
                 im.load()
+            assert "Tests/images/truncated_image.png" in str(oseinfo.value)
 
             # Test that the error is raised if loaded a second time
-            with pytest.raises(OSError):
+            with pytest.raises(OSError) as oseinfo:
                 im.load()
+            assert "Tests/images/truncated_image.png" in str(oseinfo.value)
 
     @skip_unless_feature("zlib")
     def test_truncated_without_errors(self):

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -240,7 +240,8 @@ class ImageFile(Image.Image):
                                 if LOAD_TRUNCATED_IMAGES:
                                     break
                                 else:
-                                    raise OSError("image file is truncated") from e
+                                    raise OSError(None, "image file is truncated",
+                                                  self.filename) from e
 
                             if not s:  # truncated jpeg
                                 if LOAD_TRUNCATED_IMAGES:

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -240,8 +240,9 @@ class ImageFile(Image.Image):
                                 if LOAD_TRUNCATED_IMAGES:
                                     break
                                 else:
-                                    raise OSError(None, "image file is truncated",
-                                                  self.filename) from e
+                                    raise OSError(
+                                        None, "image file is truncated", self.filename
+                                    ) from e
 
                             if not s:  # truncated jpeg
                                 if LOAD_TRUNCATED_IMAGES:


### PR DESCRIPTION
Problem: When a truncated image is loaded, without `LOAD_TRUNCATED_IMAGES` set to `True` the load command fails without specifying which file failed to load.

In the current output the filename is not specified.
```python
>>> from PIL import Image
>>> test_filename = "Tests/images/truncated_image.png"
>>> try:
...     with Image.open(test_filename) as im:
...             im.load()
... except OSError as oe:
...     print(oe)
...     print(oe.args)
...     print(oe.filename)
...     print(oe.filename2)
... 
image file is truncated
('image file is truncated',)
None
None
```

Assuming you don't want to enable the  `LOAD_TRUNCATED_IMAGES` flag.

This makes handling this type of error difficult since when you catch it, you can't recover the name of the troublesome file that caused it. A workaround would be to catch the error and then return the filename that was used to call the function. However other libraries that use Pillow might make this call, and therefore the user does not make the call to that function directly and might not be able to do this. It would be simpler to pass in the filename when generating the error. That way when it is raised back up the user can still track down the troublesome image file.

I wasn't sure what `errno` to use, so I left it as `None`.

Error with more info:
```python
>>> from PIL import Image
>>> test_filename = "Tests/images/truncated_image.png"
>>> try:
...     with Image.open(test_filename) as im:
...             im.load()
... except OSError as oe:
...     print(oe)
...     print(oe.args)
...     print(oe.filename)
...     print(oe.filename2)
... 
[Errno None] image file is truncated: 'Tests/images/truncated_image.png'
(None, 'image file is truncated')
Tests/images/truncated_image.png
None
```