### PR TITLE
Build docs with sphinx_copybutton and sphinxext.opengraph

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Docs
       if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == 3.9
       run: |
-        python3 -m pip install sphinx-issues sphinx-removed-in sphinx-rtd-theme
+        python3 -m pip install sphinx_copybutton sphinx-issues sphinx-removed-in sphinx-rtd-theme sphinxext-opengraph
         make doccheck
 
     - name: After success

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Docs
       if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == 3.9
       run: |
-        python3 -m pip install sphinx_copybutton sphinx-issues sphinx-removed-in sphinx-rtd-theme sphinxext-opengraph
+        python3 -m pip install sphinx-copybutton sphinx-issues sphinx-removed-in sphinx-rtd-theme sphinxext-opengraph
         make doccheck
 
     - name: After success

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -318,3 +318,9 @@ def setup(app):
 
 # GitHub repo for sphinx-issues
 issues_github_path = "python-pillow/Pillow"
+
+# sphinxext.opengraph
+ogp_image = (
+    "https://raw.githubusercontent.com/python-pillow/pillow-logo/master/"
+    "pillow-logo-dark-text-1280x640.png"
+)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,11 +29,13 @@ needs_sphinx = "2.4"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "sphinx_copybutton",
+    "sphinx_issues",
+    "sphinx_removed_in",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
-    "sphinx_issues",
-    "sphinx_removed_in",
+    "sphinxext.opengraph",
 ]
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,9 +6,9 @@ Warnings
 
 .. warning:: Pillow and PIL cannot co-exist in the same environment. Before installing Pillow, please uninstall PIL.
 
-.. warning:: Pillow >= 1.0 no longer supports "import Image". Please use "from PIL import Image" instead.
+.. warning:: Pillow >= 1.0 no longer supports ``import Image``. Please use ``from PIL import Image`` instead.
 
-.. warning:: Pillow >= 2.1.0 no longer supports "import _imaging". Please use "from PIL.Image import core as _imaging" instead.
+.. warning:: Pillow >= 2.1.0 no longer supports ``import _imaging``. Please use ``from PIL.Image import core as _imaging`` instead.
 
 Python Support
 --------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@ pytest
 pytest-cov
 pytest-timeout
 sphinx>=2.4
+sphinx-copybutton
 sphinx-issues
 sphinx-removed-in
 sphinx-rtd-theme
+sphinxext-opengraph


### PR DESCRIPTION
Changes proposed in this pull request:

 * Add a couple of useful Sphinx plugins, as recommended by https://pradyunsg.me/furo/recommendations/

 * [sphinxext-opengraph](https://github.com/wpilibsuite/sphinxext-opengraph): adds OpenGraph metadata (https://ogp.me), makes previews better on Facebook and Twitter (probably helps Google results too)

 * [sphinx-copybutton](https://github.com/executablebooks/sphinx-copybutton): adds a copy button to code snippets, to make it easy to copy them and try them out
 * Plus use code formatting for some text on the installation page



# Open graph

For example, These tags are inserted into the tutorial page:

```html
<meta property="og:title" content="Tutorial" />
<meta property="og:type" content="website" />
<meta property="og:url" content="https://pillow.readthedocs.io/en/stable/handbook/tutorial.html" />
<meta property="og:description" content="Using the Image class: The most important class in the Python Imaging Library is the Image class, defined in the module with the same name. You can create instances of this class in several ways; e..." />
```

https://pillow--5498.org.readthedocs.build/en/5498/handbook/tutorial.html

Can compare what Facebook extracts from the PR:

https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fpillow--5498.org.readthedocs.build%2Fen%2F5498%2Fhandbook%2Ftutorial.html

with stable:

https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fpillow.readthedocs.io%2Fen%2Fstable%2Fhandbook%2Ftutorial.html

# Copy button

The button at the top right copies the code block to the clipboard

![image](https://user-images.githubusercontent.com/1324225/118303897-a5b12c00-b4ee-11eb-9274-eaa8863a190d.png)

https://pillow--5498.org.readthedocs.build/en/5498/handbook/tutorial.html#convert-files-to-jpeg

# TODO

* [x] Install plugins in `.github/workflows/test.yml`
* [x] I'll update the PR to include the logo in `og:image`
