### PR TITLE
Add support for multiple component transformation to JPEG2000

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -271,7 +271,6 @@ def test_mct():
         test_card.save(out, "JPEG2000", mct=val, no_jp2=True)
         out.seek(0)
         with Image.open(out) as im:
-            im.load()
             assert_image_similar(im, test_card, 1.0e-3)
             assert out.getvalue()[59] == val
 
@@ -283,7 +282,6 @@ def test_mct():
 
         out.seek(0)
         with Image.open(out) as im:
-            im.load()
             assert_image_similar(im, jp2, 1.0e-3)
             assert out.getvalue()[53] == 0
 

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -209,6 +209,37 @@ def test_layers():
         assert_image_similar(im, test_card, 0.4)
 
 
+def test_use_jp2():
+    out = BytesIO()
+    test_card.save(out, "JPEG2000", use_jp2=False)
+    out.seek(0)
+    assert out.read(2) == b"\xff\x4f"
+
+
+def test_mct():
+    # Three component
+    for val in (0, 1):
+        out = BytesIO()
+        test_card.save(out, "JPEG2000", mct=val, use_jp2=False)
+        out.seek(0)
+        with Image.open(out) as im:
+            im.load()
+            assert_image_similar(im, test_card, 1.0e-3)
+            assert out.getvalue()[59] == val
+
+    # Single component
+    for val in (0, 1):
+        out = BytesIO()
+        with Image.open("Tests/images/16bit.cropped.jp2") as jp2:
+            jp2.save(out, "JPEG2000", mct=val, use_jp2=False)
+
+        out.seek(0)
+        with Image.open(out) as im:
+            im.load()
+            assert_image_similar(im, jp2, 1.0e-3)
+            assert out.getvalue()[53] == 0
+
+
 def test_rgba():
     # Arrange
     with Image.open("Tests/images/rgb_trns_ycbc.j2k") as j2k:

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -209,59 +209,26 @@ def test_layers():
         assert_image_similar(im, test_card, 0.4)
 
 
-def test_no_jp2():
+@pytest.mark.parametrize(
+    "name, args, offset, data",
+    (
+        ("foo.j2k", {}, 0, b"\xff\x4f"),
+        ("foo.jp2", {}, 4, b"jP"),
+        (None, {"no_jp2": True}, 0, b"\xff\x4f"),
+        ("foo.j2k", {"no_jp2": True}, 0, b"\xff\x4f"),
+        ("foo.jp2", {"no_jp2": True}, 0, b"\xff\x4f"),
+        ("foo.j2k", {"no_jp2": False}, 0, b"\xff\x4f"),
+        ("foo.jp2", {"no_jp2": False}, 4, b"jP"),
+        ("foo.jp2", {"no_jp2": False}, 4, b"jP"),
+    ),
+)
+def test_no_jp2(name, args, offset, data):
     out = BytesIO()
-    out.name = "foo.j2k"
-    test_card.save(out, "JPEG2000")
-    out.seek(0)
-    assert out.read(2) == b"\xff\x4f"
-
-    out = BytesIO()
-    out.name = "foo.jp2"
-    test_card.save(out, "JPEG2000")
-    out.seek(4)
-    assert out.read(2) == b"jP"
-
-    out = BytesIO()
-    test_card.save(out, "JPEG2000", no_jp2=True)
-    out.seek(0)
-    assert out.read(2) == b"\xff\x4f"
-
-    out = BytesIO()
-    test_card.save(out, "JPEG2000", no_jp2=True)
-    out.seek(0)
-    assert out.read(2) == b"\xff\x4f"
-
-    out = BytesIO()
-    out.name = "foo.j2k"
-    test_card.save(out, "JPEG2000", no_jp2=True)
-    out.seek(0)
-    assert out.read(2) == b"\xff\x4f"
-
-    out = BytesIO()
-    out.name = "foo.jp2"
-    test_card.save(out, "JPEG2000", no_jp2=True)
-    out.seek(0)
-    assert out.read(2) == b"\xff\x4f"
-
-    # Use the filename extension to determine format
-    out = BytesIO()
-    out.name = "foo.j2k"
-    test_card.save(out, "JPEG2000", no_jp2=False)
-    out.seek(0)
-    assert out.read(2) == b"\xff\x4f"
-
-    out = BytesIO()
-    out.name = "foo.jp2"
-    test_card.save(out, "JPEG2000", no_jp2=False)
-    out.seek(4)
-    assert out.read(2) == b"jP"
-
-    # Default to JP2 if no filename
-    out = BytesIO()
-    test_card.save(out, "JPEG2000", no_jp2=False)
-    out.seek(4)
-    assert out.read(2) == b"jP"
+    if name:
+        out.name = name
+    test_card.save(out, "JPEG2000", **args)
+    out.seek(offset)
+    assert out.read(2) == data
 
 
 def test_mct():

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -263,11 +263,6 @@ def test_no_jp2():
     out.seek(4)
     assert out.read(2) == b"jP"
 
-    out = BytesIO()
-    test_card.save(out, "JPEG2000", no_jp2=False)
-    out.seek(4)
-    assert out.read(2) == b"jP"
-
 
 def test_mct():
     # Three component

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -209,41 +209,82 @@ def test_layers():
         assert_image_similar(im, test_card, 0.4)
 
 
-def test_use_jp2():
-    out = BytesIO()
-    test_card.save(out, "JPEG2000", use_jp2=False)
-    out.seek(0)
-    assert out.read(2) == b"\xff\x4f"
-
+def test_no_jp2():
     out = BytesIO()
     out.name = "foo.j2k"
-    test_card.save(out, "JPEG2000", use_jp2=False)
+    test_card.save(out, "JPEG2000")
     out.seek(0)
     assert out.read(2) == b"\xff\x4f"
 
     out = BytesIO()
     out.name = "foo.jp2"
-    test_card.save(out, "JPEG2000", use_jp2=False)
+    test_card.save(out, "JPEG2000")
     out.seek(4)
-    assert out.read(2) != b"jP"
+    assert out.read(2) == b"jP"
+
+    out = BytesIO()
+    test_card.save(out, "JPEG2000", no_jp2=True)
+    out.seek(0)
+    assert out.read(2) == b"\xff\x4f"
+
+    out = BytesIO()
+    test_card.save(out, "JPEG2000", no_jp2=True)
+    out.seek(0)
+    assert out.read(2) == b"\xff\x4f"
+
+    out = BytesIO()
+    out.name = "foo.j2k"
+    test_card.save(out, "JPEG2000", no_jp2=True)
+    out.seek(0)
+    assert out.read(2) == b"\xff\x4f"
+
+    out = BytesIO()
+    out.name = "foo.jp2"
+    test_card.save(out, "JPEG2000", no_jp2=True)
+    out.seek(0)
+    assert out.read(2) == b"\xff\x4f"
+
+    # Use the filename extension to determine format
+    out = BytesIO()
+    out.name = "foo.j2k"
+    test_card.save(out, "JPEG2000", no_jp2=False)
+    out.seek(0)
+    assert out.read(2) == b"\xff\x4f"
+
+    out = BytesIO()
+    out.name = "foo.jp2"
+    test_card.save(out, "JPEG2000", no_jp2=False)
+    out.seek(4)
+    assert out.read(2) == b"jP"
+
+    # Default to JP2 if no filename
+    out = BytesIO()
+    test_card.save(out, "JPEG2000", no_jp2=False)
+    out.seek(4)
+    assert out.read(2) == b"jP"
+
+    out = BytesIO()
+    test_card.save(out, "JPEG2000", no_jp2=False)
+    out.seek(4)
+    assert out.read(2) == b"jP"
 
 
 def test_mct():
     # Three component
     for val in (0, 1):
         out = BytesIO()
-        test_card.save(out, "JPEG2000", mct=val, use_jp2=False)
+        test_card.save(out, "JPEG2000", mct=val, no_jp2=True)
         out.seek(0)
         with Image.open(out) as im:
             im.load()
             assert_image_similar(im, test_card, 1.0e-3)
             assert out.getvalue()[59] == val
 
-    # Single component
+    # Single component should have MCT disabled
     for val in (0, 1):
         out = BytesIO()
         with Image.open("Tests/images/16bit.cropped.jp2") as jp2:
-            jp2.save(out, "JPEG2000", mct=val, use_jp2=False)
+            jp2.save(out, "JPEG2000", mct=val, no_jp2=True)
 
         out.seek(0)
         with Image.open(out) as im:

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -215,6 +215,18 @@ def test_use_jp2():
     out.seek(0)
     assert out.read(2) == b"\xff\x4f"
 
+    out = BytesIO()
+    out.name = "foo.j2k"
+    test_card.save(out, "JPEG2000", use_jp2=False)
+    out.seek(0)
+    assert out.read(2) == b"\xff\x4f"
+
+    out = BytesIO()
+    out.name = "foo.jp2"
+    test_card.save(out, "JPEG2000", use_jp2=False)
+    out.seek(4)
+    assert out.read(2) != b"jP"
+
 
 def test_mct():
     # Three component

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -269,10 +269,10 @@ def test_mct():
     for val in (0, 1):
         out = BytesIO()
         test_card.save(out, "JPEG2000", mct=val, no_jp2=True)
-        out.seek(0)
+
+        assert out.getvalue()[59] == val
         with Image.open(out) as im:
             assert_image_similar(im, test_card, 1.0e-3)
-            assert out.getvalue()[59] == val
 
     # Single component should have MCT disabled
     for val in (0, 1):
@@ -280,10 +280,9 @@ def test_mct():
         with Image.open("Tests/images/16bit.cropped.jp2") as jp2:
             jp2.save(out, "JPEG2000", mct=val, no_jp2=True)
 
-        out.seek(0)
+        assert out.getvalue()[53] == 0
         with Image.open(out) as im:
             assert_image_similar(im, jp2, 1.0e-3)
-            assert out.getvalue()[53] == 0
 
 
 def test_rgba():

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -506,10 +506,10 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
     Defaults to ``False``, which uses the lossless DWT 5-3.
 
 **mct**
-    If ``0`` then don't use multiple component transformation when encoding,
-    otherwise use ``1`` to apply to components 0, 1 and 2. MCT works best
-    with a ``mode`` of ``RGB`` and is only available for 3 component image
-    data.
+    If ``1`` then apply multiple component transformation when encoding,
+    otherwise use ``0`` for no component transformation (default). MCT works
+    best with a ``mode`` of ``RGB`` and is only applied when the image data has
+    3 components.
 
 **progression**
     Controls the progression order; must be one of ``"LRCP"``, ``"RLCP"``,
@@ -529,9 +529,10 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
     for compliant 4K files, *at least one* of the dimensions must match
     4096 x 2160.
 
-**use_jp2**
-    If ``False`` then don't wrap the codestream in the JP2 file format when
-    saving. Defaults to ``True``.
+**no_jp2**
+    If ``True`` then don't wrap the raw codestream in the JP2 file format when
+    saving, otherwise the extension of the filename will be used to determine
+    the format (default).
 
 .. note::
 

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -506,10 +506,12 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
     Defaults to ``False``, which uses the lossless DWT 5-3.
 
 **mct**
-    If ``1`` then apply multiple component transformation when encoding,
-    otherwise use ``0`` for no component transformation (default). MCT works
-    best with a ``mode`` of ``RGB`` and is only applied when the image data has
-    3 components.
+    If ``1`` then enable multiple component transformation when encoding,
+    otherwise use ``0`` for no component transformation (default). If MCT is
+    enabled and ``irreversible`` is ``True`` then the Reversible Color
+    Transformation will be applied, otherwise encoding will use the
+    Irreversible Color Transformation. MCT works best with a ``mode`` of
+    ``RGB`` and is only applicable when the image data has 3 components.
 
 **progression**
     Controls the progression order; must be one of ``"LRCP"``, ``"RLCP"``,

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -502,9 +502,14 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
     and must be greater than the code-block size.
 
 **irreversible**
-    If ``True``, use the lossy Irreversible Color Transformation
-    followed by DWT 9-7.  Defaults to ``False``, which means to use the
-    Reversible Color Transformation with DWT 5-3.
+    If ``True``, use the lossy discrete waveform transformation DWT 9-7.
+    Defaults to ``False``, which uses the lossless DWT 5-3.
+
+**mct**
+    If ``0`` then don't use multiple component transformation when encoding,
+    otherwise use ``1`` to apply to components 0, 1 and 2. MCT works best
+    with a ``mode`` of ``RGB`` and is only available for 3 component image
+    data.
 
 **progression**
     Controls the progression order; must be one of ``"LRCP"``, ``"RLCP"``,
@@ -523,6 +528,10 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
     *at least one* of your image dimensions must match 2048 x 1080, while
     for compliant 4K files, *at least one* of the dimensions must match
     4096 x 2160.
+
+**use_jp2**
+    If ``False`` then don't wrap the codestream in the JP2 file format when
+    saving. Defaults to ``True``.
 
 .. note::
 

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -508,9 +508,9 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
 **mct**
     If ``1`` then enable multiple component transformation when encoding,
     otherwise use ``0`` for no component transformation (default). If MCT is
-    enabled and ``irreversible`` is ``True`` then the Reversible Color
+    enabled and ``irreversible`` is ``True`` then the Irreversible Color
     Transformation will be applied, otherwise encoding will use the
-    Irreversible Color Transformation. MCT works best with a ``mode`` of
+    Reversible Color Transformation. MCT works best with a ``mode`` of
     ``RGB`` and is only applicable when the image data has 3 components.
 
 **progression**

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -513,6 +513,8 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
     Reversible Color Transformation. MCT works best with a ``mode`` of
     ``RGB`` and is only applicable when the image data has 3 components.
 
+    .. versionadded:: 9.1.0
+
 **progression**
     Controls the progression order; must be one of ``"LRCP"``, ``"RLCP"``,
     ``"RPCL"``, ``"PCRL"``, ``"CPRL"``.  The letters stand for Component,
@@ -535,6 +537,8 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
     If ``True`` then don't wrap the raw codestream in the JP2 file format when
     saving, otherwise the extension of the filename will be used to determine
     the format (default).
+
+    .. versionadded:: 9.1.0
 
 .. note::
 

--- a/docs/releasenotes/9.1.0.rst
+++ b/docs/releasenotes/9.1.0.rst
@@ -146,12 +146,24 @@ At present, the information within each block is merely returned as a dictionary
 "data" entry. This will allow more useful information to be added in the future without
 breaking backwards compatibility.
 
-Added rawmode argument to Image.getpalette()
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Added mct and no_jp2 options for saving JPEG 2000
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default, :py:meth:`~PIL.Image.Image.getpalette` returns RGB data from the palette.
-A ``rawmode`` argument has been added, to allow the mode to be chosen instead. ``None``
-can be used to return data in the current mode of the palette.
+The :py:meth:`PIL.Image.Image.save` method now supports the following options for
+JPEG 2000:
+
+**mct**
+    If ``1`` then enable multiple component transformation when encoding,
+    otherwise use ``0`` for no component transformation (default). If MCT is
+    enabled and ``irreversible`` is ``True`` then the Irreversible Color
+    Transformation will be applied, otherwise encoding will use the
+    Reversible Color Transformation. MCT works best with a ``mode`` of
+    ``RGB`` and is only applicable when the image data has 3 components.
+
+**no_jp2**
+    If ``True`` then don't wrap the raw codestream in the JP2 file format when
+    saving, otherwise the extension of the filename will be used to determine
+    the format (default).
 
 Added PyEncoder
 ^^^^^^^^^^^^^^^

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -290,13 +290,13 @@ def _accept(prefix):
 
 
 def _save(im, fp, filename):
+    # Get the keyword arguments
+    info = im.encoderinfo
+
     if filename.endswith(".j2k"):
         kind = "j2k"
     else:
-        kind = "jp2"
-
-    # Get the keyword arguments
-    info = im.encoderinfo
+        kind = "jp2" if info.get("use_jp2", True) else "j2k"
 
     offset = info.get("offset", None)
     tile_offset = info.get("tile_offset", None)
@@ -321,9 +321,6 @@ def _save(im, fp, filename):
     progression = info.get("progression", "LRCP")
     cinema_mode = info.get("cinema_mode", "no")
     mct = info.get("mct", 0)
-
-    kind = "jp2" if info.get("use_jp2", True) else "j2k"
-
     fd = -1
 
     if hasattr(fp, "fileno"):

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -320,6 +320,10 @@ def _save(im, fp, filename):
     irreversible = info.get("irreversible", False)
     progression = info.get("progression", "LRCP")
     cinema_mode = info.get("cinema_mode", "no")
+    mct = info.get("mct", 0)
+
+    kind = "jp2" if info.get("use_jp2", True) else "j2k"
+
     fd = -1
 
     if hasattr(fp, "fileno"):
@@ -340,6 +344,7 @@ def _save(im, fp, filename):
         irreversible,
         progression,
         cinema_mode,
+        mct,
         fd,
     )
 

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -293,10 +293,10 @@ def _save(im, fp, filename):
     # Get the keyword arguments
     info = im.encoderinfo
 
-    if filename.endswith(".j2k"):
+    if filename.endswith(".j2k") or info.get("no_jp2", False):
         kind = "j2k"
     else:
-        kind = "jp2" if info.get("use_jp2", True) else "j2k"
+        kind = "jp2"
 
     offset = info.get("offset", None)
     tile_offset = info.get("tile_offset", None)

--- a/src/encode.c
+++ b/src/encode.c
@@ -1187,11 +1187,12 @@ PyImaging_Jpeg2KEncoderNew(PyObject *self, PyObject *args) {
     OPJ_PROG_ORDER prog_order;
     char *cinema_mode = "no";
     OPJ_CINEMA_MODE cine_mode;
+    char *mct = 0;
     Py_ssize_t fd = -1;
 
     if (!PyArg_ParseTuple(
             args,
-            "ss|OOOsOnOOOssn",
+            "ss|OOOsOnOOOssbn",
             &mode,
             &format,
             &offset,
@@ -1205,6 +1206,7 @@ PyImaging_Jpeg2KEncoderNew(PyObject *self, PyObject *args) {
             &irreversible,
             &progression,
             &cinema_mode,
+            &mct,
             &fd)) {
         return NULL;
     }
@@ -1302,6 +1304,7 @@ PyImaging_Jpeg2KEncoderNew(PyObject *self, PyObject *args) {
     context->irreversible = PyObject_IsTrue(irreversible);
     context->progression = prog_order;
     context->cinema_mode = cine_mode;
+    context->mct = mct;
 
     return (PyObject *)encoder;
 }

--- a/src/encode.c
+++ b/src/encode.c
@@ -1187,7 +1187,7 @@ PyImaging_Jpeg2KEncoderNew(PyObject *self, PyObject *args) {
     OPJ_PROG_ORDER prog_order;
     char *cinema_mode = "no";
     OPJ_CINEMA_MODE cine_mode;
-    char *mct = 0;
+    char mct;
     Py_ssize_t fd = -1;
 
     if (!PyArg_ParseTuple(

--- a/src/encode.c
+++ b/src/encode.c
@@ -1187,7 +1187,7 @@ PyImaging_Jpeg2KEncoderNew(PyObject *self, PyObject *args) {
     OPJ_PROG_ORDER prog_order;
     char *cinema_mode = "no";
     OPJ_CINEMA_MODE cine_mode;
-    char mct;
+    char mct = 0;
     Py_ssize_t fd = -1;
 
     if (!PyArg_ParseTuple(

--- a/src/libImaging/Jpeg2K.h
+++ b/src/libImaging/Jpeg2K.h
@@ -82,6 +82,9 @@ typedef struct {
     /* Compression style */
     int irreversible;
 
+    /* Set multiple component transformation */
+    char mct;
+
     /* Progression order (LRCP/RLCP/RPCL/PCRL/CPRL) */
     OPJ_PROG_ORDER progression;
 

--- a/src/libImaging/Jpeg2KEncode.c
+++ b/src/libImaging/Jpeg2KEncode.c
@@ -435,6 +435,9 @@ j2k_encode_entry(Imaging im, ImagingCodecState state) {
     }
 
     params.irreversible = context->irreversible;
+    if (components == 3) {
+        params.tcp_mct = context->mct;
+    }
 
     params.prog_order = context->progression;
 


### PR DESCRIPTION
Closes #5485

Changes proposed in this pull request:

 * Add `mct` option for JPEG2000 that allows the use of multiple component transformation when encoding
 * Add `no_jp2` option for JPEG2000 to allow specifying the format when not saving to file
 * Updates handbook with new options and revises `irreversible` entry

OpenJPEG's `tcp_mct` is defined [here](https://github.com/uclouvain/openjpeg/blob/b6b8d28b3a85b74ff5415565cff2c20c019ca3c5/src/lib/openjp2/openjpeg.h#L522)