### PR TITLE
Added specific error messages when ink has incorrect number of bands

### DIFF
--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -355,6 +355,24 @@ class TestImagePutPixelError(AccessTest):
             with pytest.raises(TypeError, match="color must be int or tuple"):
                 im.putpixel((0, 0), v)
 
+    @pytest.mark.parametrize(
+        ("mode", "band_numbers", "match"),
+        (
+            ("L", (0, 2), "color must be int or single-element tuple"),
+            ("LA", (0, 3), "color must be int, or tuple of one or two elements"),
+            (
+                "RGB",
+                (0, 2, 5),
+                "color must be int, or tuple of one, three or four elements",
+            ),
+        ),
+    )
+    def test_putpixel_invalid_number_of_bands(self, mode, band_numbers, match):
+        im = hopper(mode)
+        for band_number in band_numbers:
+            with pytest.raises(TypeError, match=match):
+                im.putpixel((0, 0), (0,) * band_number)
+
     @pytest.mark.parametrize("mode", IMAGE_MODES2)
     def test_putpixel_type_error2(self, mode):
         im = hopper(mode)

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -498,7 +498,7 @@ getink(PyObject *color, Imaging im, char *ink) {
        be cast to either UINT8 or INT32 */
 
     int rIsInt = 0;
-    if (PyTuple_Check(color) && PyTuple_Size(color) == 1) {
+    if (PyTuple_Check(color) && PyTuple_GET_SIZE(color) == 1) {
         color = PyTuple_GetItem(color, 0);
     }
     if (im->type == IMAGING_TYPE_UINT8 || im->type == IMAGING_TYPE_INT32 ||

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -527,7 +527,10 @@ getink(PyObject *color, Imaging im, char *ink) {
             if (im->bands == 1) {
                 /* unsigned integer, single layer */
                 if (rIsInt != 1) {
-                    if (!PyArg_ParseTuple(color, "L", &r)) {
+                    if (PyTuple_GET_SIZE(color) != 1) {
+                        PyErr_SetString(PyExc_TypeError, "color must be int or single-element tuple");
+                        return NULL;
+                    } else if (!PyArg_ParseTuple(color, "L", &r)) {
                         return NULL;
                     }
                 }
@@ -542,13 +545,20 @@ getink(PyObject *color, Imaging im, char *ink) {
                     g = (UINT8)(r >> 8);
                     r = (UINT8)r;
                 } else {
+                    int tupleSize = PyTuple_GET_SIZE(color);
                     if (im->bands == 2) {
-                        if (!PyArg_ParseTuple(color, "L|i", &r, &a)) {
+                        if (tupleSize != 1 && tupleSize != 2) {
+                            PyErr_SetString(PyExc_TypeError, "color must be int, or tuple of one or two elements");
+                            return NULL;
+                        } else if (!PyArg_ParseTuple(color, "L|i", &r, &a)) {
                             return NULL;
                         }
                         g = b = r;
                     } else {
-                        if (!PyArg_ParseTuple(color, "Lii|i", &r, &g, &b, &a)) {
+                        if (tupleSize != 3 && tupleSize != 4) {
+                            PyErr_SetString(PyExc_TypeError, "color must be int, or tuple of one, three or four elements");
+                            return NULL;
+                        } else if (!PyArg_ParseTuple(color, "Lii|i", &r, &g, &b, &a)) {
                             return NULL;
                         }
                     }


### PR DESCRIPTION
Resolves #5503

The issue requests that the error if `ink` has an incorrect number of bands be clearer than the default "TypeError: function takes exactly 1 argument (3 given)".

This PR adds error messages similar to https://github.com/python-pillow/Pillow/blob/16b9cadd419b0554c604bfc20a888cc55a78f12a/src/_imaging.c#L519
not just for 1 band images as mentioned in the issue, but also for other similar situations in the same C function.

While I'm here, I'm also replacing
https://github.com/python-pillow/Pillow/blob/16b9cadd419b0554c604bfc20a888cc55a78f12a/src/_imaging.c#L501
with `PyTuple_Check(color) && PyTuple_GET_SIZE(color) == 1`, since we have already performed the [error checking](https://docs.python.org/3/c-api/tuple.html#c.PyTuple_Size) with `PyTuple_Check`.