### PR TITLE
Avoid race condition when displaying images with eog

### DIFF
--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -207,7 +207,8 @@ class EogViewer(UnixViewer):
     """The GNOME Image Viewer ``eog`` command."""
 
     def get_command_ex(self, file, **options):
-        command = executable = "eog"
+        executable = "eog"
+        command = "eog -n"
         return command, executable
 
 


### PR DESCRIPTION
First of all, thanks for maintaining Pillow all these years!

When Image.show() displays an image on Linux using eog, there's a race condition where the file can get deleted before eog opens it.

To reproduce this, you'll need a Linux system without imagemagick or graphicsmagick installed.  Then you can make it happen pretty reliably, just by calling Image.show() several times:

```python
from PIL import Image

im = Image.new('RGB', (400, 300), 'green')

for i in range(4):
    im.show()
```

With imagemagick installed, this correctly displays four green boxes.  But if you're using eog, usually several of the images will give error messages like "No images found in file:///tmp/tmprt8btbpr.PNG" instead.

This happens because Image.show() expects its display command to run synchronously, but in fact eog runs asynchronously if another eog instance is already running -- it just asks the other instance to open the file and then immediately exits.  The fix is to use eog -n instead, which forces it to always start a new instance.