### PR TITLE
Raise an error if ImageDraw.textbbox is used without a TrueType font

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -719,6 +719,13 @@ class TestImageFont:
         font.set_variation_by_axes([100])
         self._check_text(font, "Tests/images/variation_tiny_axes.png", 32.5)
 
+    def test_textbbox_non_freetypefont(self):
+        im = Image.new("RGB", (200, 200))
+        d = ImageDraw.Draw(im)
+        default_font = ImageFont.load_default()
+        with pytest.raises(ValueError):
+            d.textbbox((0, 0), "test", font=default_font)
+
     @pytest.mark.parametrize(
         "anchor, left, left_old, top",
         (

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -33,7 +33,7 @@
 import math
 import numbers
 
-from . import Image, ImageColor
+from . import Image, ImageColor, ImageFont
 
 """
 A simple 2D drawing interface for PIL images.
@@ -646,6 +646,8 @@ class ImageDraw:
 
         if font is None:
             font = self.getfont()
+        if not isinstance(font, ImageFont.FreeTypeFont):
+            raise ValueError("Only supported for TrueType fonts")
         mode = "RGBA" if embedded_color else self.fontmode
         bbox = font.getbbox(
             text, mode, direction, features, language, stroke_width, anchor


### PR DESCRIPTION
Resolves #5506 by raising a specific error if `textbbox()` is used without a TrueType font.