### PR TITLE
Limit TIFF strip size when saving with libtiff

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -9,7 +9,7 @@ from ctypes import c_float
 import pytest
 
 from PIL import Image, ImageFilter, TiffImagePlugin, TiffTags, features
-from PIL.TiffImagePlugin import SUBIFD
+from PIL.TiffImagePlugin import STRIPOFFSETS, SUBIFD
 
 from .helper import (
     assert_image_equal,
@@ -967,3 +967,12 @@ class TestFileLibTiff(LibTiffTestCase):
             # Assert that the error code is IMAGING_CODEC_MEMORY
             assert str(e.value) == "-9"
         TiffImagePlugin.READ_LIBTIFF = False
+
+    def test_save_multistrip(self, tmp_path):
+        im = hopper("RGB").resize((256, 256))
+        out = str(tmp_path / "temp.tif")
+        im.save(out, compression="tiff_adobe_deflate")
+
+        with Image.open(out) as im:
+            # Assert that there are multiple strips
+            assert len(im.tag_v2[STRIPOFFSETS]) > 1

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1568,8 +1568,12 @@ def _save(im, fp, filename):
     ifd[ROWSPERSTRIP] = rows_per_strip
     if strip_byte_counts >= 2 ** 16:
         ifd.tagtype[STRIPBYTECOUNTS] = TiffTags.LONG
-    ifd[STRIPBYTECOUNTS] = (strip_byte_counts,) * (strips_per_image - 1) + (stride * im.size[1] - strip_byte_counts * (strips_per_image - 1),)
-    ifd[STRIPOFFSETS] = tuple(range(0, strip_byte_counts * strips_per_image, strip_byte_counts))  # this is adjusted by IFD writer
+    ifd[STRIPBYTECOUNTS] = (strip_byte_counts,) * (strips_per_image - 1) + (
+        stride * im.size[1] - strip_byte_counts * (strips_per_image - 1),
+    )
+    ifd[STRIPOFFSETS] = tuple(
+        range(0, strip_byte_counts * strips_per_image, strip_byte_counts)
+    )  # this is adjusted by IFD writer
     # no compression by default:
     ifd[COMPRESSION] = COMPRESSION_INFO_REV.get(compression, 1)
 

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1558,12 +1558,12 @@ def _save(im, fp, filename):
         ifd[COLORMAP] = tuple(v * 256 for v in lut)
     # data orientation
     stride = len(bits) * ((im.size[0] * bits[0] + 7) // 8)
-    rows_per_strip = im.size[1]
-    strip_byte_counts = stride * im.size[1]
     # aim for 64 KB strips when using libtiff writer
-    while libtiff and strip_byte_counts > 2 ** 16 and rows_per_strip > 1:
-        rows_per_strip = (rows_per_strip + 1) // 2
-        strip_byte_counts = stride * rows_per_strip
+    if libtiff:
+        rows_per_strip = (2 ** 16 + stride - 1) // stride
+    else:
+        rows_per_strip = im.size[1]
+    strip_byte_counts = stride * rows_per_strip
     strips_per_image = (im.size[1] + rows_per_strip - 1) // rows_per_strip
     ifd[ROWSPERSTRIP] = rows_per_strip
     if strip_byte_counts >= 2 ** 16:

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1560,7 +1560,7 @@ def _save(im, fp, filename):
     stride = len(bits) * ((im.size[0] * bits[0] + 7) // 8)
     # aim for 64 KB strips when using libtiff writer
     if libtiff:
-        rows_per_strip = (2 ** 16 + stride - 1) // stride
+        rows_per_strip = min((2 ** 16 + stride - 1) // stride, im.size[1])
     else:
         rows_per_strip = im.size[1]
     strip_byte_counts = stride * rows_per_strip

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1558,12 +1558,18 @@ def _save(im, fp, filename):
         ifd[COLORMAP] = tuple(v * 256 for v in lut)
     # data orientation
     stride = len(bits) * ((im.size[0] * bits[0] + 7) // 8)
-    ifd[ROWSPERSTRIP] = im.size[1]
+    rows_per_strip = im.size[1]
     strip_byte_counts = stride * im.size[1]
+    # aim for 64 KB strips when using libtiff writer
+    while libtiff and strip_byte_counts > 2 ** 16 and rows_per_strip > 1:
+        rows_per_strip = (rows_per_strip + 1) // 2
+        strip_byte_counts = stride * rows_per_strip
+    strips_per_image = (im.size[1] + rows_per_strip - 1) // rows_per_strip
+    ifd[ROWSPERSTRIP] = rows_per_strip
     if strip_byte_counts >= 2 ** 16:
         ifd.tagtype[STRIPBYTECOUNTS] = TiffTags.LONG
-    ifd[STRIPBYTECOUNTS] = strip_byte_counts
-    ifd[STRIPOFFSETS] = 0  # this is adjusted by IFD writer
+    ifd[STRIPBYTECOUNTS] = (strip_byte_counts,) * (strips_per_image - 1) + (stride * im.size[1] - strip_byte_counts * (strips_per_image - 1),)
+    ifd[STRIPOFFSETS] = tuple(range(0, strip_byte_counts * strips_per_image, strip_byte_counts))  # this is adjusted by IFD writer
     # no compression by default:
     ifd[COMPRESSION] = COMPRESSION_INFO_REV.get(compression, 1)
 


### PR DESCRIPTION
Adresses #5370 partly.

Doesn't really "fix" the loading of any existing >2GB single strip images (would need to handle specially by buffered read in decoder), but reduces their incidence as recommended by the TIFF spec.