### PR TITLE
Fix differing background colors in right sidebar in dark mode docs

### DIFF
--- a/docs/resources/css/dark.css
+++ b/docs/resources/css/dark.css
@@ -1275,7 +1275,7 @@
 
     .wy-body-for-nav {
         background-image: initial;
-        background-color: rgb(26, 28, 29);
+        background-color: rgb(24, 26, 27);
     }
 
     .wy-nav-side {
@@ -1335,7 +1335,7 @@
 
     .wy-body-for-nav {
         background-image: initial;
-        background-color: rgb(26, 28, 29);
+        background-color: rgb(24, 26, 27);
     }
 
     @media screen and (min-width: 1100px) {


### PR DESCRIPTION
Fixes differently colored blocks in the right sidebar in the dark mode docs.

For comparison, see the following two images:
Before fix (current situation):
![before_fix](https://user-images.githubusercontent.com/50588793/119912142-247c7f00-bf5b-11eb-830f-ce86670d4f6a.png)
After fix:
![after_fix](https://user-images.githubusercontent.com/50588793/119912153-29d9c980-bf5b-11eb-8a59-3c72ae5df6a3.png)



Change proposed in this pull request:

 * Make the `background-color` of the top part of the right sidebar in the docs darker when in dark mode to match the rest of the right sidebar
