### PR TITLE
Fix lcms2_static target for msbuild

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -236,7 +236,9 @@ deps = {
             cmd_rmdir("Lib"),
             cmd_rmdir(r"Projects\VC2017\Release"),
             cmd_msbuild(r"Projects\VC2017\lcms2.sln", "Release", "Clean"),
-            cmd_msbuild(r"Projects\VC2017\lcms2.sln", "Release", "lcms2_static"),
+            cmd_msbuild(
+                r"Projects\VC2017\lcms2.sln", "Release", "lcms2_static:Rebuild"
+            ),
             cmd_xcopy("include", "{inc_dir}"),
         ],
         "libs": [r"Lib\MS\*.lib"],


### PR DESCRIPTION
Fixes CI failures for Windows

For some unknown reason the "Build" target is indeed non-existant for the lcms2_static project, but VC2017 only (even when specified)! `msbuild Projects\VC2019\lcms2.sln /t:lcms2_static ` works :/