### PR TITLE
Copies of an image do not retain the format

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -13,6 +13,14 @@ contents, not their names, but the :py:meth:`~PIL.Image.Image.save` method
 looks at the name to determine which format to use, unless the format is given
 explicitly.
 
+When an image is opened from a file, only that instance of the image is considered to
+have the format. Copies of the image will contain data loaded from the file, but not
+the file itself, meaning that it can no longer be considered to be in the original
+format. So if :py:meth:`~PIL.Image.Image.copy` is called on an image, or another method
+internally creates a copy of the image, the ``fp`` (file pointer), along with any
+methods and attributes specific to a format. The :py:attr:`~PIL.Image.Image.format`
+attribute will be `None`.
+
 Fully supported formats
 -----------------------
 

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -19,7 +19,7 @@ the file itself, meaning that it can no longer be considered to be in the origin
 format. So if :py:meth:`~PIL.Image.Image.copy` is called on an image, or another method
 internally creates a copy of the image, the ``fp`` (file pointer), along with any
 methods and attributes specific to a format. The :py:attr:`~PIL.Image.Image.format`
-attribute will be `None`.
+attribute will be ``None``.
 
 Fully supported formats
 -----------------------


### PR DESCRIPTION
Resolves #5527

The issue is from a user expecting a copy of an image instance to retain the format of the original - as has happened before in #4571. This PR documents that this is not the case.