### PR TITLE
Fixed errors when running tests in random order

### DIFF
--- a/Tests/oss-fuzz/fuzz_font.py
+++ b/Tests/oss-fuzz/fuzz_font.py
@@ -34,6 +34,7 @@ def main():
     fuzzers.enable_decompressionbomb_error()
     atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
     atheris.Fuzz()
+    fuzzers.disable_decompressionbomb_error()
 
 
 if __name__ == "__main__":

--- a/Tests/oss-fuzz/fuzz_pillow.py
+++ b/Tests/oss-fuzz/fuzz_pillow.py
@@ -34,6 +34,7 @@ def main():
     fuzzers.enable_decompressionbomb_error()
     atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
     atheris.Fuzz()
+    fuzzers.disable_decompressionbomb_error()
 
 
 if __name__ == "__main__":

--- a/Tests/oss-fuzz/fuzzers.py
+++ b/Tests/oss-fuzz/fuzzers.py
@@ -10,6 +10,11 @@ def enable_decompressionbomb_error():
     warnings.simplefilter("error", Image.DecompressionBombWarning)
 
 
+def disable_decompressionbomb_error():
+    ImageFile.LOAD_TRUNCATED_IMAGES = False
+    warnings.resetwarnings()
+
+
 def fuzz_image(data):
     # This will fail on some images in the corpus, as we have many
     # invalid images in the test suite.

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -44,6 +44,8 @@ def test_fuzz_images(path):
     ):
         # Known Image.* exceptions
         assert True
+    finally:
+        fuzzers.disable_decompressionbomb_error()
 
 
 @pytest.mark.parametrize(

--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -10,8 +10,7 @@ ORIGINAL_LIMIT = Image.MAX_IMAGE_PIXELS
 
 
 class TestDecompressionBomb:
-    @classmethod
-    def teardown_class(cls):
+    def teardown_method(self, method):
         Image.MAX_IMAGE_PIXELS = ORIGINAL_LIMIT
 
     def test_no_warning_small_file(self):


### PR DESCRIPTION
Helps #5526

With pytest-randomly installed, Tests/test_decompression_bomb.py can fail, because we are currently setting `Image.MAX_IMAGE_PIXELS` in three methods, and not resetting it until the tests in TestDecompressionBomb are done in `teardown_class`.

This PR instead resets it after each method.