### PR TITLE
Updated declaration to match definition

### DIFF
--- a/src/libImaging/Imaging.h
+++ b/src/libImaging/Imaging.h
@@ -370,7 +370,7 @@ ImagingTransform(
     int y0,
     int x1,
     int y1,
-    double *a,
+    double a[8],
     int filter,
     int fill);
 extern Imaging


### PR DESCRIPTION
Pointed out in #5526. Currently, for `a`,

https://github.com/python-pillow/Pillow/blob/61b9065a25aaeefdca19940448b21b02f1e6766a/src/libImaging/Imaging.h#L364-L375

does not match

https://github.com/python-pillow/Pillow/blob/61b9065a25aaeefdca19940448b21b02f1e6766a/src/libImaging/Geometry.c#L1126-L1137

This PR fixes that, updating the declaration.