### PR TITLE
Modified docstring for GaussianBlur

### DIFF
--- a/src/PIL/ImageFilter.py
+++ b/src/PIL/ImageFilter.py
@@ -149,9 +149,10 @@ class ModeFilter(Filter):
 
 
 class GaussianBlur(MultibandFilter):
-    """Gaussian blur filter.
+    """Blurs the image with an extended box filter, which approximates a
+    Gaussian kernel.
 
-    :param radius: Blur radius.
+    :param radius: Standard deviation of the Gaussian kernel.
     """
 
     name = "GaussianBlur"

--- a/src/PIL/ImageFilter.py
+++ b/src/PIL/ImageFilter.py
@@ -149,8 +149,9 @@ class ModeFilter(Filter):
 
 
 class GaussianBlur(MultibandFilter):
-    """Blurs the image with an extended box filter, which approximates a
-    Gaussian kernel.
+    """Blurs the image with a sequence of extended box filters, which
+    approximates a Gaussian kernel. For details on accuracy see
+    <https://www.mia.uni-saarland.de/Publications/gwosdek-ssvm11.pdf>
 
     :param radius: Standard deviation of the Gaussian kernel.
     """


### PR DESCRIPTION
Changes proposed in this pull request:

 * The argument for `GaussianBlur` is `radius`. The canonical name for the parameter is standard deviation. The value for the standard normal distribution at a given radius is a function of standard deviation.
 * `GaussianBlur` doesn't convolve the image with a Gaussian kernel. It uses a kernel that when applied iteratively approximates a Gaussian kernel.

The changes improve the precision of the documentation.