### PR TITLE
Fixed default numresolution for small JPEG2000 images

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -127,6 +127,16 @@ def test_prog_res_rt():
     assert_image_equal(im, test_card)
 
 
+def test_default_num_resolutions():
+    for num_resolutions in range(2, 6):
+        d = 1 << (num_resolutions - 1)
+        im = test_card.resize((d - 1, d - 1))
+        with pytest.raises(OSError):
+            roundtrip(im, num_resolutions=num_resolutions)
+        reloaded = roundtrip(im)
+        assert_image_equal(im, reloaded)
+
+
 def test_reduce():
     with Image.open("Tests/images/test-card-lossless.jp2") as im:
         assert callable(im.reduce)

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -248,4 +248,4 @@ class TestPyDecoder:
     def test_oserror(self):
         im = Image.new("RGB", (1, 1))
         with pytest.raises(OSError):
-            im.save(BytesIO(), "JPEG2000")
+            im.save(BytesIO(), "JPEG2000", num_resolutions=2)

--- a/src/libImaging/Jpeg2KEncode.c
+++ b/src/libImaging/Jpeg2KEncode.c
@@ -458,6 +458,12 @@ j2k_encode_entry(Imaging im, ImagingCodecState state) {
             break;
     }
 
+    if (!context->num_resolutions) {
+        while (tile_width < (1 << (params.numresolution - 1U)) || tile_height < (1 << (params.numresolution - 1U))) {
+            params.numresolution -= 1;
+        }
+    }
+
     if (context->cinema_mode != OPJ_OFF) {
         j2k_set_cinema_params(im, components, &params);
     }


### PR DESCRIPTION
Resolves #3161

A simple version of the problem in that issue is
```python
from PIL import Image
image = Image.new("RGB", (1, 1))
image.save("test.j2k")
```
At the moment, it gives "OSError: encoder error -2 when writing image file".

Debugging, OpenJPEG is trying to say that the ["Number of resolutions is too high in comparison to the size of tiles"](https://github.com/uclouvain/openjpeg/blob/cc1919b183f76d5ac79cc9927fb899b47700d925/src/lib/openjp2/j2k.c#L8648-L8653).

So this PR decreases the number of resolutions to work - unless the user explicitly set `num_resolutions` through a save argument.

If you're wondering where `numresolution` is set if Pillow's Python code isn't setting it, the default value for `numresolution` is [6 in OpenJPEG](https://github.com/uclouvain/openjpeg/blob/cc1919b183f76d5ac79cc9927fb899b47700d925/src/lib/openjp2/opj_common.h#L45) (or we might set the default to be [6 or 7](https://github.com/python-pillow/Pillow/blob/85d009c697bf96f3ed664e26ce17fc8625009b3e/src/libImaging/Jpeg2KEncode.c#L446-L457)).