### PR TITLE
Do not modify EXIF of original image instance in exif_transpose()

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -302,6 +302,7 @@ def test_exif_transpose():
                     else:
                         assert transposed_im.info["exif"] != original_exif
 
+                        assert 0x0112 in im.getexif()
                         assert 0x0112 not in transposed_im.getexif()
 
                     # Repeat the operation to test that it does not keep transposing

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -578,7 +578,8 @@ def exif_transpose(image):
     }.get(orientation)
     if method is not None:
         transposed_image = image.transpose(method)
-        del exif[0x0112]
-        transposed_image.info["exif"] = exif.tobytes()
+        transposed_exif = transposed_image.getexif()
+        del transposed_exif[0x0112]
+        transposed_image.info["exif"] = transposed_exif.tobytes()
         return transposed_image
     return image.copy()


### PR DESCRIPTION
Resolves #5546

The instance points out that in [`exif_transpose()`](https://github.com/python-pillow/Pillow/blob/384a4bf01ec8d631dcde2c3246bd08e37fa1b7cd/src/PIL/ImageOps.py#L560-L584),
```python
exif = image.getexif()
...
del exif[0x0112]
transposed_image.info["exif"] = exif.tobytes()
```
we're deleting the orientation data from the original image's EXIF object (and then, as intended, saving it to the new image instance).

Instead, this PR changes it to
```python
exif = image.getexif()
...
transposed_exif = transposed_image.getexif()
del transposed_exif[0x0112]
transposed_image.info["exif"] = transposed_exif.tobytes()
```
so that we are deleting the orientation data from the new image's EXIF object only, leaving the original image unaffected.