### PR TITLE
Ensure palette string matches RGB mode

### DIFF
--- a/Tests/test_file_tga.py
+++ b/Tests/test_file_tga.py
@@ -65,9 +65,14 @@ def test_sanity(tmp_path):
                         roundtrip(original_im)
 
 
-def test_palette_depth_16():
+def test_palette_depth_16(tmp_path):
     with Image.open("Tests/images/p_16.tga") as im:
         assert_image_equal_tofile(im.convert("RGB"), "Tests/images/p_16.png")
+
+        out = str(tmp_path / "temp.png")
+        im.save(out)
+        with Image.open(out) as reloaded:
+            assert_image_equal_tofile(reloaded.convert("RGB"), "Tests/images/p_16.png")
 
 
 def test_id_field():

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -830,7 +830,7 @@ class Image:
                 arr = bytes(
                     value for (index, value) in enumerate(arr) if index % 4 != 3
                 )
-            self.im.putpalette(mode, arr)
+            palette_length = self.im.putpalette(mode, arr)
             self.palette.dirty = 0
             self.palette.rawmode = None
             if "transparency" in self.info:
@@ -841,7 +841,7 @@ class Image:
                 self.palette.mode = "RGBA"
             else:
                 self.palette.mode = "RGB"
-                self.palette.palette = self.im.getpalette()
+                self.palette.palette = self.im.getpalette()[: palette_length * 3]
 
         if self.im:
             if cffi and USE_CFFI_ACCESS:

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -841,6 +841,7 @@ class Image:
                 self.palette.mode = "RGBA"
             else:
                 self.palette.mode = "RGB"
+                self.palette.palette = self.im.getpalette()
 
         if self.im:
             if cffi and USE_CFFI_ACCESS:

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1663,8 +1663,7 @@ _putpalette(ImagingObject *self, PyObject *args) {
 
     unpack(self->image->palette->palette, palette, palettesize * 8 / bits);
 
-    Py_INCREF(Py_None);
-    return Py_None;
+    return PyLong_FromLong(palettesize * 8 / bits);
 }
 
 static PyObject *


### PR DESCRIPTION
Resolves #4830

The image from that issue has a [BGR;15 palette](https://github.com/python-pillow/Pillow/blob/384a4bf01ec8d631dcde2c3246bd08e37fa1b7cd/src/PIL/TgaImagePlugin.py#L115-L117). So when PngImagePlugin tries to calculate the number of colors to use when saving for `show()`,

https://github.com/python-pillow/Pillow/blob/384a4bf01ec8d631dcde2c3246bd08e37fa1b7cd/src/PIL/PngImagePlugin.py#L1195

the assumption, that it can divide by 3 because this is RGB, is false.

This PR adds a change to Image, so that when it sets the palette mode to RGB, there is actually RGB data in the palette string.