### PR TITLE
Copy palette to new images in ImageOps expand

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -156,6 +156,12 @@ def test_scale():
     assert newimg.size == (25, 25)
 
 
+def test_expand_palette():
+    im = Image.open("Tests/images/hopper.gif")
+    im_expanded = ImageOps.expand(im)
+    assert_image_equal(im_expanded.convert("RGB"), im.convert("RGB"))
+
+
 def test_colorize_2color():
     # Test the colorizing function with 2-color functionality
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -393,6 +393,8 @@ def expand(image, border=0, fill=0):
     width = left + image.size[0] + right
     height = top + image.size[1] + bottom
     out = Image.new(image.mode, (width, height), _color(fill, image.mode))
+    if image.mode == "P" and image.palette:
+        out.putpalette(image.palette)
     out.paste(image, (left, top))
     return out
 


### PR DESCRIPTION
Helps #5375

`ImageOps.expand()` returns a new image instance, to allow for the larger size.

However, it doesn't copy the palette, causing the image to become grayscale.

This PR fixes that.