### PR TITLE
Added tag data for IFD groups

### DIFF
--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -376,3 +376,17 @@ def test_too_many_entries():
 
     # Should not raise ValueError.
     pytest.warns(UserWarning, lambda: ifd[277])
+
+
+def test_tag_group_data():
+    base_ifd = TiffImagePlugin.ImageFileDirectory_v2()
+    interop_ifd = TiffImagePlugin.ImageFileDirectory_v2(group=40965)
+    for ifd in (base_ifd, interop_ifd):
+        ifd[2] = "test"
+        ifd[256] = 10
+
+    assert base_ifd.tagtype[256] == 4
+    assert interop_ifd.tagtype[256] != base_ifd.tagtype[256]
+
+    assert interop_ifd.tagtype[2] == 7
+    assert base_ifd.tagtype[2] != interop_ifd.tagtype[256]


### PR DESCRIPTION
Resolves #5553

At the moment, our [list of tag data](https://github.com/python-pillow/Pillow/blob/70ef50cf72992ab6c9330412d6f1340c593e2d8f/src/PIL/TiffTags.py#L74) is 1 dimensional. It doesn't account for the fact that tags actually exist in different groups - see https://exiftool.org/TagNames/EXIF.html

This PR adds `TAGS_V2_GROUPS`, which is used when the tag in question is part of a group.

#5553 mentions that the wrong type is used for InteropVersion, part of the InteropIFD. The type information for that tag is added here.