### PR TITLE
Fixed undefined variable in logging

### DIFF
--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -376,3 +376,16 @@ def test_too_many_entries():
 
     # Should not raise ValueError.
     pytest.warns(UserWarning, lambda: ifd[277])
+
+
+def test_empty_subifd(tmp_path):
+    out = str(tmp_path / "temp.jpg")
+
+    im = hopper()
+    exif = im.getexif()
+    exif[TiffImagePlugin.EXIFIFD] = {}
+    im.save(out, exif=exif)
+
+    with Image.open(out) as reloaded:
+        exif = reloaded.getexif()
+        assert exif.get_ifd(TiffImagePlugin.EXIFIFD) == {}

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -826,7 +826,8 @@ class ImageFileDirectory_v2(MutableMapping):
                 else:
                     ifh = b"MM\x00\x2A\x00\x00\x00\x08"
                 ifd = ImageFileDirectory_v2(ifh)
-                for ifd_tag, ifd_value in self._tags_v2[tag].items():
+                values = self._tags_v2[tag]
+                for ifd_tag, ifd_value in values.items():
                     ifd[ifd_tag] = ifd_value
                 data = ifd.tobytes(offset)
             else:


### PR DESCRIPTION
Resolves #5555

In [TiffImagePlugin](https://github.com/python-pillow/Pillow/blob/70ef50cf72992ab6c9330412d6f1340c593e2d8f/src/PIL/TiffImagePlugin.py#L823), `values` might not be defined when it is comes to be used in logging.
```python
if is_ifd:
    ...
else:
    values = value if isinstance(value, tuple) else (value,)
    ...

...
msg += " - value: " + (
    "<table: %d bytes>" % len(data) if len(data) >= 16 else str(values)
)
```

This PR fixes it by ensuring that `values` is always defined.