### PR TITLE
Corrected border position for P mode in ImageOps.expand()

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -161,7 +161,13 @@ def test_expand_palette():
     im_expanded = ImageOps.expand(im, 10, (255, 0, 0))
 
     px = im_expanded.convert("RGB").load()
-    assert px[0, 0] == (255, 0, 0)
+    for b in range(10):
+        for x in range(im_expanded.width):
+            assert px[x, b] == (255, 0, 0)
+            assert px[x, im_expanded.height - 1 - b] == (255, 0, 0)
+        for y in range(im_expanded.height):
+            assert px[b, x] == (255, 0, 0)
+            assert px[b, im_expanded.width - 1 - b] == (255, 0, 0)
 
     im_cropped = im_expanded.crop(
         (10, 10, im_expanded.width - 10, im_expanded.height - 10)

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -399,7 +399,7 @@ def expand(image, border=0, fill=0):
         out.paste(image, (left, top))
 
         draw = ImageDraw.Draw(out)
-        draw.rectangle((0, 0, width, height), outline=color, width=border)
+        draw.rectangle((0, 0, width - 1, height - 1), outline=color, width=border)
     else:
         out = Image.new(image.mode, (width, height), color)
         out.paste(image, (left, top))


### PR DESCRIPTION
Resolves #5375

After #5552, running the code from that issue, there is a unintended line on the right and bottom of the image.

![test](https://user-images.githubusercontent.com/3112309/123789846-f1922600-d920-11eb-8ce3-d58d4dd993a0.png)

https://github.com/python-pillow/Pillow/blob/28330c2f9db518f8c8eccd394cc2990e3ffec2e3/src/PIL/ImageOps.py#L402

I would have just forgotten that

https://pillow.readthedocs.io/en/stable/reference/ImageDraw.html#PIL.ImageDraw.ImageDraw.rectangle
> The second point is just outside the drawn rectangle.

Fixing that, I get

![test](https://user-images.githubusercontent.com/3112309/123790283-78df9980-d921-11eb-98ae-fab8dd87afb4.png)