### PR TITLE
Add Twitter to PyPI project URLs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -992,6 +992,7 @@ try:
             "index.html",
             "Changelog": "https://github.com/python-pillow/Pillow/blob/master/"
             "CHANGES.rst",
+            "Twitter": "https://twitter.com/PythonPillow",
         },
         classifiers=[
             "Development Status :: 6 - Mature",


### PR DESCRIPTION
Will show it in the sidebar at https://pypi.org/project/Pillow/:

![image](https://user-images.githubusercontent.com/1324225/123800411-f12e6680-d8f1-11eb-9ea4-f1b5ec28feb2.png)
