### PR TITLE
Replaced xml.etree.ElementTree

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -24,6 +24,7 @@ sudo apt-get -qq install libfreetype6-dev liblcms2-dev python3-tk\
 python3 -m pip install --upgrade pip
 PYTHONOPTIMIZE=0 python3 -m pip install cffi
 python3 -m pip install coverage
+python3 -m pip install defusedxml
 python3 -m pip install olefile
 python3 -m pip install -U pytest
 python3 -m pip install -U pytest-cov

--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -6,6 +6,7 @@ brew install libtiff libjpeg openjpeg libimagequant webp little-cms2 freetype op
 
 PYTHONOPTIMIZE=0 python3 -m pip install cffi
 python3 -m pip install coverage
+python3 -m pip install defusedxml
 python3 -m pip install olefile
 python3 -m pip install -U pytest
 python3 -m pip install -U pytest-cov

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -51,8 +51,8 @@ jobs:
     - name: Print build system information
       run: python .github/workflows/system-info.py
 
-    - name: python -m pip install wheel pytest pytest-cov pytest-timeout
-      run: python -m pip install wheel pytest pytest-cov pytest-timeout
+    - name: python -m pip install wheel pytest pytest-cov pytest-timeout defusedxml
+      run: python -m pip install wheel pytest pytest-cov pytest-timeout defusedxml
 
     - name: Install dependencies
       id: install

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -831,7 +831,8 @@ class TestFileJpeg:
     def test_getxmp(self):
         with Image.open("Tests/images/xmp_test.jpg") as im:
             if ElementTree is None:
-                assert xmp == {}
+                with pytest.warns(UserWarning):
+                    assert im.getxmp() == {}
             else:
                 xmp = im.getxmp()
 

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -19,6 +19,11 @@ from .helper import (
     skip_unless_feature,
 )
 
+try:
+    import defusedxml.ElementTree as ElementTree
+except ImportError:
+    ElementTree = None
+
 # sample png stream
 
 TEST_PNG_FILE = "Tests/images/hopper.png"
@@ -651,15 +656,16 @@ class TestFilePng:
         with Image.open(out) as reloaded:
             assert len(reloaded.png.im_palette[1]) == 3
 
-    def test_xmp(self):
+    def test_getxmp(self):
         with Image.open("Tests/images/color_snakes.png") as im:
-            xmp = im.getxmp()
+            if ElementTree is None:
+                assert im.getxmp() == {}
+            else:
+                xmp = im.getxmp()
 
-            assert isinstance(xmp, dict)
-
-            description = xmp["xmpmeta"]["RDF"]["Description"]
-            assert description["PixelXDimension"] == "10"
-            assert description["subject"]["Seq"] is None
+                description = xmp["xmpmeta"]["RDF"]["Description"]
+                assert description["PixelXDimension"] == "10"
+                assert description["subject"]["Seq"] is None
 
     def test_exif(self):
         # With an EXIF chunk

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -659,7 +659,8 @@ class TestFilePng:
     def test_getxmp(self):
         with Image.open("Tests/images/color_snakes.png") as im:
             if ElementTree is None:
-                assert im.getxmp() == {}
+                with pytest.warns(UserWarning):
+                    assert im.getxmp() == {}
             else:
                 xmp = im.getxmp()
 

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -16,6 +16,11 @@ from .helper import (
     is_win32,
 )
 
+try:
+    import defusedxml.ElementTree as ElementTree
+except ImportError:
+    ElementTree = None
+
 
 class TestFileTiff:
     def test_sanity(self, tmp_path):
@@ -643,15 +648,16 @@ class TestFileTiff:
         with Image.open(outfile) as reloaded:
             assert "icc_profile" not in reloaded.info
 
-    def test_xmp(self):
+    def test_getxmp(self):
         with Image.open("Tests/images/lab.tif") as im:
-            xmp = im.getxmp()
+            if ElementTree is None:
+                assert im.getxmp() == {}
+            else:
+                xmp = im.getxmp()
 
-            assert isinstance(xmp, dict)
-
-            description = xmp["xmpmeta"]["RDF"]["Description"]
-            assert description[0]["format"] == "image/tiff"
-            assert description[3]["BitsPerSample"]["Seq"]["li"] == ["8", "8", "8"]
+                description = xmp["xmpmeta"]["RDF"]["Description"]
+                assert description[0]["format"] == "image/tiff"
+                assert description[3]["BitsPerSample"]["Seq"]["li"] == ["8", "8", "8"]
 
     def test_close_on_load_exclusive(self, tmp_path):
         # similar to test_fd_leak, but runs on unixlike os

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -651,7 +651,8 @@ class TestFileTiff:
     def test_getxmp(self):
         with Image.open("Tests/images/lab.tif") as im:
             if ElementTree is None:
-                assert im.getxmp() == {}
+                with pytest.warns(UserWarning):
+                    assert im.getxmp() == {}
             else:
                 xmp = im.getxmp()
 

--- a/docs/releasenotes/8.3.0.rst
+++ b/docs/releasenotes/8.3.0.rst
@@ -61,7 +61,17 @@ format, through the new ``bitmap_format`` argument::
 Security
 ========
 
-TODO
+Parsing XML
+^^^^^^^^^^^
+
+Pillow previously parsed XMP data using Python's ``xml`` module. However, this module
+is not secure.
+
+- :py:meth:`~PIL.Image.Image.getexif` has used ``xml`` to potentially retrieve
+  orientation data since Pillow 7.2.0. It has been refactored to use ``re`` instead.
+- :py:meth:`~PIL.JpegImagePlugin.JpegImageFile.getxmp` was added in Pillow 8.2.0. It
+  will now use ``defusedxml`` instead. If the dependency is not present, an empty
+  dictionary will be returned and a warning raised.
 
 Other Changes
 =============

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 black
 check-manifest
 coverage
+defusedxml
 markdown2
 olefile
 packaging

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -31,6 +31,7 @@ import logging
 import math
 import numbers
 import os
+import re
 import struct
 import sys
 import tempfile
@@ -1381,15 +1382,9 @@ class Image:
         if 0x0112 not in self._exif:
             xmp_tags = self.info.get("XML:com.adobe.xmp")
             if xmp_tags:
-                xmp = self._getxmp(xmp_tags)
-                if (
-                    "xmpmeta" in xmp
-                    and "RDF" in xmp["xmpmeta"]
-                    and "Description" in xmp["xmpmeta"]["RDF"]
-                ):
-                    description = xmp["xmpmeta"]["RDF"]["Description"]
-                    if "Orientation" in description:
-                        self._exif[0x0112] = int(description["Orientation"])
+                match = re.search(r'tiff:Orientation="([0-9])"', xmp_tags)
+                if match:
+                    self._exif[0x0112] = int(match[1])
 
         return self._exif
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1364,6 +1364,7 @@ class Image:
             return value
 
         if ElementTree is None:
+            warnings.warn("XMP data cannot be read without defusedxml dependency")
             return {}
         else:
             root = ElementTree.fromstring(xmp_tags)

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -36,9 +36,13 @@ import struct
 import sys
 import tempfile
 import warnings
-import xml.etree.ElementTree
 from collections.abc import Callable, MutableMapping
 from pathlib import Path
+
+try:
+    import defusedxml.ElementTree as ElementTree
+except ImportError:
+    ElementTree = None
 
 # VERSION was removed in Pillow 6.0.0.
 # PILLOW_VERSION is deprecated and will be removed in a future release.
@@ -1359,8 +1363,11 @@ class Image:
                 return element.text
             return value
 
-        root = xml.etree.ElementTree.fromstring(xmp_tags)
-        return {get_name(root.tag): get_value(root)}
+        if ElementTree is None:
+            return {}
+        else:
+            root = ElementTree.fromstring(xmp_tags)
+            return {get_name(root.tag): get_value(root)}
 
     def getexif(self):
         if self._exif is None:

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -480,6 +480,7 @@ class JpegImageFile(ImageFile.ImageFile):
     def getxmp(self):
         """
         Returns a dictionary containing the XMP tags.
+        Requires defusedxml to be installed.
         :returns: XMP tags in a dictionary.
         """
 

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -981,6 +981,7 @@ class PngImageFile(ImageFile.ImageFile):
     def getxmp(self):
         """
         Returns a dictionary containing the XMP tags.
+        Requires defusedxml to be installed.
         :returns: XMP tags in a dictionary.
         """
         return (

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1112,6 +1112,7 @@ class TiffImageFile(ImageFile.ImageFile):
     def getxmp(self):
         """
         Returns a dictionary containing the XMP tags.
+        Requires defusedxml to be installed.
         :returns: XMP tags in a dictionary.
         """
         return self._getxmp(self.tag_v2[700]) if 700 in self.tag_v2 else {}


### PR DESCRIPTION
https://docs.python.org/3/library/xml.etree.elementtree.html
> Warning The xml.etree.ElementTree module is not secure against maliciously constructed data. If you need to parse untrusted or unauthenticated data see XML vulnerabilities.

`xml.etree.ElementTree` is in use in `getexif()` and now `getxmp()`. So the earliest Pillow version affected is 7.2.0

The Python docs later recommend defusedxml.
> **The defusedxml Package**
> defusedxml is a pure Python package with modified subclasses of all stdlib XML parsers that prevent any potentially malicious operation. Use of this package is recommended for any server code that parses untrusted XML data.

So this PR replaces `xml.etree.ElementTree` in `getxmp()` with `defusedxml.ElementTree`. If it is not installed, an empty dictionary is returned instead and a warning is raised.

The use in `getexif()` is simpler, so I have just used `re` there instead.