### PR TITLE
Ensure TIFF RowsPerStrip is multiple of 8 for JPEG compression

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -968,10 +968,11 @@ class TestFileLibTiff(LibTiffTestCase):
             assert str(e.value) == "-9"
         TiffImagePlugin.READ_LIBTIFF = False
 
-    def test_save_multistrip(self, tmp_path):
+    @pytest.mark.parametrize("compression", ("tiff_adobe_deflate", "jpeg"))
+    def test_save_multistrip(self, compression, tmp_path):
         im = hopper("RGB").resize((256, 256))
         out = str(tmp_path / "temp.tif")
-        im.save(out, compression="tiff_adobe_deflate")
+        im.save(out, compression=compression)
 
         with Image.open(out) as im:
             # Assert that there are multiple strips

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1577,6 +1577,9 @@ def _save(im, fp, filename):
     # aim for 64 KB strips when using libtiff writer
     if libtiff:
         rows_per_strip = min((2 ** 16 + stride - 1) // stride, im.size[1])
+        # JPEG encoder expects multiple of 8 rows
+        if compression == "jpeg":
+            rows_per_strip = min(((rows_per_strip + 7) // 8) * 8, im.size[1])
     else:
         rows_per_strip = im.size[1]
     strip_byte_counts = stride * rows_per_strip


### PR DESCRIPTION
Fixes #5586