### PR TITLE
If default conversion from P is RGB with transparency, convert to RGBA

### DIFF
--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -42,10 +42,14 @@ def test_default():
 
     im = hopper("P")
     assert_image(im, "P", im.size)
-    im = im.convert()
-    assert_image(im, "RGB", im.size)
-    im = im.convert()
-    assert_image(im, "RGB", im.size)
+    converted_im = im.convert()
+    assert_image(converted_im, "RGB", im.size)
+    converted_im = im.convert()
+    assert_image(converted_im, "RGB", im.size)
+
+    im.info["transparency"] = 0
+    converted_im = im.convert()
+    assert_image(converted_im, "RGBA", im.size)
 
 
 # ref https://github.com/python-pillow/Pillow/issues/274

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -914,16 +914,18 @@ class Image:
 
         self.load()
 
+        has_transparency = self.info.get("transparency") is not None
         if not mode and self.mode == "P":
             # determine default mode
             if self.palette:
                 mode = self.palette.mode
             else:
                 mode = "RGB"
+            if mode == "RGB" and has_transparency:
+                mode = "RGBA"
         if not mode or (mode == self.mode and not matrix):
             return self.copy()
 
-        has_transparency = self.info.get("transparency") is not None
         if matrix:
             # matrix conversion
             if mode not in ("L", "RGB"):


### PR DESCRIPTION
Helps #5593, fixing the first problem in that issue.

If calling `convert()` without specifying the mode on a P image, the mode chosen is [either the palette mode or RGB.](https://github.com/python-pillow/Pillow/blob/5fe583598fd7a96514abec669b1bf5f7676aeb57/src/PIL/Image.py#L917-L922)

This PR detects if the image has `info["transparency"]`, and if it does, chooses RGBA instead.