### PR TITLE
Keep transparency when converting from P to LA or PA

### DIFF
--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -100,18 +100,22 @@ def test_trns_p(tmp_path):
 # ref https://github.com/python-pillow/Pillow/issues/664
 
 
-def test_trns_p_rgba():
+@pytest.mark.parametrize("mode", ("LA", "PA", "RGBA"))
+def test_trns_p_transparency(mode):
     # Arrange
     im = hopper("P")
     im.info["transparency"] = 128
 
     # Act
-    im_rgba = im.convert("RGBA")
+    converted_im = im.convert(mode)
 
     # Assert
-    assert "transparency" not in im_rgba.info
-    # https://github.com/python-pillow/Pillow/issues/2702
-    assert im_rgba.palette is None
+    assert "transparency" not in converted_im.info
+    if mode == "PA":
+        assert converted_im.palette is not None
+    else:
+        # https://github.com/python-pillow/Pillow/issues/2702
+        assert converted_im.palette is None
 
 
 def test_trns_l(tmp_path):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1005,7 +1005,7 @@ class Image:
                             trns_im = trns_im.convert("RGB")
                         trns = trns_im.getpixel((0, 0))
 
-            elif self.mode == "P" and mode == "RGBA":
+            elif self.mode == "P" and mode in ("LA", "PA", "RGBA"):
                 t = self.info["transparency"]
                 delete_trns = True
 


### PR DESCRIPTION
Resolves #5593, fixing the second problem in that issue.

At the moment, there is code in `convert()` to keep transparency when going from P to RGBA.

https://github.com/python-pillow/Pillow/blob/be30792714bbea84d21335350f4cd71146491532/src/PIL/Image.py#L1008-L1017

This PR expands the condition to do the same if going from P to LA or PA as well.