### PR TITLE
Fixed error saving APNG with duplicate frames and different duration times

### DIFF
--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -433,7 +433,9 @@ def test_apng_save_duration_loop(tmp_path):
 
     # test removal of duplicated frames
     frame = Image.new("RGBA", (128, 64), (255, 0, 0, 255))
-    frame.save(test_file, save_all=True, append_images=[frame], duration=[500, 250])
+    frame.save(
+        test_file, save_all=True, append_images=[frame, frame], duration=[500, 100, 150]
+    )
     with Image.open(test_file) as im:
         im.load()
         assert im.n_frames == 1

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -1117,12 +1117,12 @@ def _write_multiple_frames(im, fp, chunk, rawmode):
                     and prev_disposal == encoderinfo.get("disposal")
                     and prev_blend == encoderinfo.get("blend")
                 ):
-                    duration = encoderinfo.get("duration", 0)
-                    if duration:
+                    now_duration = encoderinfo.get("duration", 0)
+                    if now_duration:
                         if "duration" in previous["encoderinfo"]:
-                            previous["encoderinfo"]["duration"] += duration
+                            previous["encoderinfo"]["duration"] += now_duration
                         else:
-                            previous["encoderinfo"]["duration"] = duration
+                            previous["encoderinfo"]["duration"] = now_duration
                     continue
             else:
                 bbox = None

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -1117,12 +1117,12 @@ def _write_multiple_frames(im, fp, chunk, rawmode):
                     and prev_disposal == encoderinfo.get("disposal")
                     and prev_blend == encoderinfo.get("blend")
                 ):
-                    now_duration = encoderinfo.get("duration", 0)
-                    if now_duration:
+                    frame_duration = encoderinfo.get("duration", 0)
+                    if frame_duration:
                         if "duration" in previous["encoderinfo"]:
-                            previous["encoderinfo"]["duration"] += now_duration
+                            previous["encoderinfo"]["duration"] += frame_duration
                         else:
-                            previous["encoderinfo"]["duration"] = now_duration
+                            previous["encoderinfo"]["duration"] = frame_duration
                     continue
             else:
                 bbox = None


### PR DESCRIPTION
Resolves #5608 

This issue is caused by the 'duration' variable being overwritten.

https://github.com/python-pillow/Pillow/blob/83c05aaf8daa930086257eb38b254f06808d13e5/src/PIL/PngImagePlugin.py#L1120

After being overwritten, the duration variable is not updated.

https://github.com/python-pillow/Pillow/blob/83c05aaf8daa930086257eb38b254f06808d13e5/src/PIL/PngImagePlugin.py#L1083-L1084