### PR TITLE
Fixed ImageOps expand with tuple border on P image

### DIFF
--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -21,7 +21,7 @@ import functools
 import operator
 import re
 
-from . import Image, ImageDraw
+from . import Image
 
 #
 # helpers
@@ -395,15 +395,16 @@ def expand(image, border=0, fill=0):
     height = top + image.size[1] + bottom
     color = _color(fill, image.mode)
     if image.mode == "P" and image.palette:
-        out = Image.new(image.mode, (width, height))
-        out.putpalette(image.palette)
-        out.paste(image, (left, top))
-
-        draw = ImageDraw.Draw(out)
-        draw.rectangle((0, 0, width - 1, height - 1), outline=color, width=border)
+        image.load()
+        palette = image.palette.copy()
+        if isinstance(color, tuple):
+            color = palette.getcolor(color)
     else:
-        out = Image.new(image.mode, (width, height), color)
-        out.paste(image, (left, top))
+        palette = None
+    out = Image.new(image.mode, (width, height), color)
+    if palette:
+        out.putpalette(palette.palette)
+    out.paste(image, (left, top))
     return out
 
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/5552/commits/b6b362c80718eeee122e9d346758d18335d66b2a changed `expand()` so that for a P image in `ImageOps.expand()`, the border color is only filled after attaching the palette.

Instead, this PR create a copy of the palette (to avoid modifying the original), calculates the new palette index from that, and then sets the new palette index as the background of the image.

This brings the logic for P and non-P images in `ImageOps.expand()` closer together, and resolves #5614 in the process. In that issue, drawing a single rectangle wasn't able to accomodate a multiple border widths being passed in a tuple. This PR removes the rectangle drawing altogether, fixing that.