### PR TITLE
Corrected pathlib.Path detection when saving

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -149,10 +149,11 @@ class TestImage:
             assert im.mode == "RGB"
             assert im.size == (128, 128)
 
-            temp_file = str(tmp_path / "temp.jpg")
-            if os.path.exists(temp_file):
-                os.remove(temp_file)
-            im.save(Path(temp_file))
+            for ext in (".jpg", ".jp2"):
+                temp_file = str(tmp_path / ("temp." + ext))
+                if os.path.exists(temp_file):
+                    os.remove(temp_file)
+                im.save(Path(temp_file))
 
     def test_fp_name(self, tmp_path):
         temp_file = str(tmp_path / "temp.jpg")

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2180,11 +2180,11 @@ class Image:
 
         filename = ""
         open_fp = False
-        if isPath(fp):
-            filename = fp
-            open_fp = True
-        elif isinstance(fp, Path):
+        if isinstance(fp, Path):
             filename = str(fp)
+            open_fp = True
+        elif isPath(fp):
+            filename = fp
             open_fp = True
         elif fp == sys.stdout:
             try:


### PR DESCRIPTION
Resolves #5632

As #3825 did for `open()`, this fixes detecting pathlib.Path in `save()`.

https://github.com/python-pillow/Pillow/blob/68c5f2dce11768e5334a97d17feb2a85a0fd0590/src/PIL/Image.py#L2183-L2188

The above code will never execute the second block, because `isPath` returns true for `Path` instances.

https://github.com/python-pillow/Pillow/blob/68c5f2dce11768e5334a97d17feb2a85a0fd0590/src/PIL/_util.py#L5-L6

So this PR swaps the order.