### PR TITLE
putpalette() rawmode may be modes that can be unpacked to RGB

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1751,14 +1751,19 @@ class Image:
         Attaches a palette to this image.  The image must be a "P", "PA", "L"
         or "LA" image.
 
-        The palette sequence must contain at most 768 integer values, or 1024
-        integer values if alpha is included. Each group of values represents
-        the red, green, blue (and alpha if included) values for the
-        corresponding pixel index. Instead of an integer sequence, you can use
-        an 8-bit string.
+        The palette sequence must contain at most 256 colors, made up of one
+        integer value for each channel in the raw mode.
+        For example, if the raw mode is "RGB", then it can contain at most 768
+        values, made up of red, green and blue values for the corresponding pixel
+        index in the 256 colors.
+        If the raw mode is "RGBA", then it can contain at most 1024 values,
+        containing red, green, blue and alpha values.
+
+        Alternatively, an 8-bit string may be used instead of an integer sequence.
 
         :param data: A palette sequence (either a list or a string).
-        :param rawmode: The raw mode of the palette.
+        :param rawmode: The raw mode of the palette. Either "RGB", "RGBA", or a
+           mode that can be transformed to "RGB" (e.g. "R", "BGR;15", "RGBA;L").
         """
         from . import ImagePalette
 


### PR DESCRIPTION
Resolves #1280 by better documenting the range of raw modes that `im.putpalette()` can accept. It does not only accept RGB or RGBA, but also [any raw mode that can be unpacked to RGB](https://github.com/python-pillow/Pillow/blob/68c5f2dce11768e5334a97d17feb2a85a0fd0590/src/libImaging/Unpack.c#L1516-L1544).

This means that the limit for the length of `data` is not just 768 or 1024. Since the limit is the number of channels multiplied by 256, for "R", it is 256.

```python
>>> from PIL import Image
>>> im = Image.new("L", (1, 1))
>>> im.putpalette((1,)*256, "R")
>>> im.putpalette((1,)*257, "R")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/Image.py", line 1776, in putpalette
    self.load()  # install new palette
  File "PIL/Image.py", line 838, in load
    palette_length = self.im.putpalette(mode, arr)
ValueError: invalid palette size
```