### PR TITLE
Deprecate ImagePalette size parameter

### DIFF
--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -10,8 +10,9 @@ def test_sanity():
     palette = ImagePalette.ImagePalette("RGB", list(range(256)) * 3)
     assert len(palette.colors) == 256
 
-    with pytest.raises(ValueError):
-        ImagePalette.ImagePalette("RGB", list(range(256)) * 3, 10)
+    with pytest.warns(DeprecationWarning):
+        with pytest.raises(ValueError):
+            ImagePalette.ImagePalette("RGB", list(range(256)) * 3, 10)
 
 
 def test_reload():

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -92,6 +92,17 @@ dictionary. The :py:attr:`~PIL.JpegImagePlugin.convert_dict_qtables` method no l
 performs any operations on the data given to it, has been deprecated and will be
 removed in Pillow 10.0.0 (2023-01-02).
 
+ImagePalette size parameter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 8.4.0
+
+The ``size`` parameter will be removed in Pillow 10.0.0 (2023-01-02).
+
+Before Pillow 8.3.0, ImagePalette required palette data of particular lengths by
+default, and the size parameter could be used to override that. Pillow 8.3.0 removed
+the default required length, also removing the need for the size parameter.
+
 Removed features
 ----------------
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -99,7 +99,7 @@ ImagePalette size parameter
 
 The ``size`` parameter will be removed in Pillow 10.0.0 (2023-01-02).
 
-Before Pillow 8.3.0, ImagePalette required palette data of particular lengths by
+Before Pillow 8.3.0, ``ImagePalette`` required palette data of particular lengths by
 default, and the size parameter could be used to override that. Pillow 8.3.0 removed
 the default required length, also removing the need for the size parameter.
 

--- a/src/PIL/ImagePalette.py
+++ b/src/PIL/ImagePalette.py
@@ -17,6 +17,7 @@
 #
 
 import array
+import warnings
 
 from . import GimpGradientFile, GimpPaletteFile, ImageColor, PaletteFile
 
@@ -40,8 +41,14 @@ class ImagePalette:
         self.rawmode = None  # if set, palette contains raw data
         self.palette = palette or bytearray()
         self.dirty = None
-        if size != 0 and size != len(self.palette):
-            raise ValueError("wrong palette size")
+        if size != 0:
+            warnings.warn(
+                "The size parameter is deprecated and will be removed in Pillow 10 "
+                "(2023-01-02).",
+                DeprecationWarning,
+            )
+            if size != len(self.palette):
+                raise ValueError("wrong palette size")
 
     @property
     def palette(self):


### PR DESCRIPTION
Resolves #5636

The `size` parameter was originally added in #537. Before #5552, it was there to override a default length check.

https://github.com/python-pillow/Pillow/blob/10615a7da7a5254de9696f4f3f14d229098b67cc/src/PIL/ImagePalette.py#L45-L48

Afterwards though, the default length check was gone, so `size` is now just adding an arbitrary constraint on the user - if provided, it throws an error if `palette` parameter is not the length of the `size` parmeter.

https://github.com/python-pillow/Pillow/blob/3462b5fd74e5e86539e7fa639adf4a52d53bf57c/src/PIL/ImagePalette.py#L43-L44