### PR TITLE
Do not close file pointer in SGI save handler

### DIFF
--- a/Tests/test_file_sgi.py
+++ b/Tests/test_file_sgi.py
@@ -73,6 +73,13 @@ def test_write(tmp_path):
         img.save(out, format="sgi")
         assert_image_equal_tofile(img, out)
 
+        out = str(tmp_path / "fp.sgi")
+        with open(out, "wb") as fp:
+            img.save(fp)
+            assert_image_equal_tofile(img, out)
+
+            assert not fp.closed
+
     for mode in ("L", "RGB", "RGBA"):
         roundtrip(hopper(mode))
 

--- a/src/PIL/SgiImagePlugin.py
+++ b/src/PIL/SgiImagePlugin.py
@@ -193,8 +193,6 @@ def _save(im, fp, filename):
     for channel in im.split():
         fp.write(channel.tobytes("raw", rawmode, 0, orientation))
 
-    fp.close()
-
 
 class SGI16Decoder(ImageFile.PyDecoder):
     _pulls_fd = True

--- a/src/PIL/SgiImagePlugin.py
+++ b/src/PIL/SgiImagePlugin.py
@@ -193,6 +193,9 @@ def _save(im, fp, filename):
     for channel in im.split():
         fp.write(channel.tobytes("raw", rawmode, 0, orientation))
 
+    if hasattr(fp, "flush"):
+        fp.flush()
+
 
 class SGI16Decoder(ImageFile.PyDecoder):
     _pulls_fd = True


### PR DESCRIPTION
Changes proposed in this pull request:

 * SGI save handler should not close output stream