### PR TITLE
Hide FriBiDi shim symbols to avoid conflict with real FriBiDi library

### DIFF
--- a/src/thirdparty/fribidi-shim/fribidi.c
+++ b/src/thirdparty/fribidi-shim/fribidi.c
@@ -12,7 +12,7 @@
 
 
 /* FriBiDi>=1.0.0 adds bracket_types param, ignore and call legacy function */
-FriBidiLevel fribidi_get_par_embedding_levels_ex_compat(
+static FriBidiLevel fribidi_get_par_embedding_levels_ex_compat(
     const FriBidiCharType *bidi_types,
     const FriBidiBracketType *bracket_types,
     const FriBidiStrIndex len,
@@ -24,7 +24,7 @@ FriBidiLevel fribidi_get_par_embedding_levels_ex_compat(
 }
 
 /* FriBiDi>=1.0.0 gets bracket types here, ignore */
-void fribidi_get_bracket_types_compat(
+static void fribidi_get_bracket_types_compat(
     const FriBidiChar *str,
     const FriBidiStrIndex len,
     const FriBidiCharType *types,

--- a/src/thirdparty/fribidi-shim/fribidi.h
+++ b/src/thirdparty/fribidi-shim/fribidi.h
@@ -63,7 +63,11 @@ typedef uint32_t FriBidiParType;
 /* functions */
 
 #ifdef FRIBIDI_SHIM_IMPLEMENTATION
+#ifdef _MSC_VER
 #define FRIBIDI_ENTRY
+#else
+#define FRIBIDI_ENTRY __attribute__((visibility ("hidden")))
+#endif
 #else
 #define FRIBIDI_ENTRY extern
 #endif


### PR DESCRIPTION
Fixes #5637

In #5637, when Gtk is imported, the FriBiDi library gets loaded which replaces the shim symbols due to dynamic linking. Trying to load `_imagingft` then calls `load_fribidi` which attempts to overwrite its symbols and segfaults. Hiding the symbols prevents them from being replaced by the real library and segfaulting. Hiding is the default with MSVC.