### PR TITLE
Allow saving 1 and L mode TIFF with PhotometricInterpretation 0

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -447,9 +447,10 @@ class TestFileTiff:
             im.seek(1)
             assert im.getexif()[273] == (1408, 1907)
 
-    def test_photometric(self, tmp_path):
+    @pytest.mark.parametrize("mode", ("1", "L"))
+    def test_photometric(self, mode, tmp_path):
         filename = str(tmp_path / "temp.tif")
-        im = hopper("1")
+        im = hopper(mode)
         im.save(filename, tiffinfo={262: 0})
         with Image.open(filename) as reloaded:
             assert reloaded.tag_v2[262] == 0

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -447,6 +447,14 @@ class TestFileTiff:
             im.seek(1)
             assert im.getexif()[273] == (1408, 1907)
 
+    def test_photometric(self, tmp_path):
+        filename = str(tmp_path / "temp.tif")
+        im = hopper("1")
+        im.save(filename, tiffinfo={262: 0})
+        with Image.open(filename) as reloaded:
+            assert reloaded.tag_v2[262] == 0
+            assert_image_equal(im, reloaded)
+
     def test_seek(self):
         filename = "Tests/images/pil136.tiff"
         with Image.open(filename) as im:


### PR DESCRIPTION
Resolves #4804

TIFF tag 262 is [PhotometricInterpretation](https://www.awaresystems.be/imaging/tiff/tifftags/photometricinterpretation.html). Pillow currently does not allow this value to be set when saving. Changing the value for mode 1 images means that white becomes black and vice versa, so to keep the output the same, we need to invert the pixel values.

This PR allows for that specific scenario, inverting the values when saving.