### PR TITLE
Updated location of make_hash script

### DIFF
--- a/src/libImaging/Access.c
+++ b/src/libImaging/Access.c
@@ -11,7 +11,7 @@
 
 #include "Imaging.h"
 
-/* use Tests/make_hash.py to calculate these values */
+/* use make_hash.py from the pillow-scripts repository to calculate these values */
 #define ACCESS_TABLE_SIZE 27
 #define ACCESS_TABLE_HASH 3078
 


### PR DESCRIPTION
Companion to https://github.com/python-pillow/pillow-scripts/pull/6