### PR TITLE
Actually check the framesize in FliDecode.c

### DIFF
--- a/src/libImaging/FliDecode.c
+++ b/src/libImaging/FliDecode.c
@@ -46,7 +46,8 @@ ImagingFliDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t byt
     ptr = buf;
 
     framesize = I32(ptr);
-    if (framesize < I32(ptr)) {
+    // there can be one pad byte in the framesize
+    if (bytes + (bytes % 2) < framesize) {
         return 0;
     }
 


### PR DESCRIPTION
FliDecode.c had a check in the head of the frame where it was checking a variable against the value that was just set.

This updates the check to check the bytes in the buffer vs the framesize. 

Note that there are potentially single bytes of padding, such that all the sizes should be even.  This isn't necessarily reflected in the file size (e.g. `hopper.fli`) especially on the last chunk. 