### PR TITLE
Do not return in ImageFile when saving to stdout

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -895,8 +895,8 @@ class TestFileJpeg:
 
         if buffer:
             mystdout = mystdout.buffer
-        reloaded = Image.open(mystdout)
-        assert_image_equal(reloaded, im_roundtrip)
+        with Image.open(mystdout) as reloaded:
+            assert_image_equal(reloaded, im_roundtrip)
 
 
 @pytest.mark.skipif(not is_win32(), reason="Windows only")

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -1,6 +1,5 @@
 import os
 import re
-import sys
 from io import BytesIO
 
 import pytest
@@ -870,33 +869,6 @@ class TestFileJpeg:
         if ElementTree is not None:
             with Image.open("Tests/images/hopper.jpg") as im:
                 assert im.getxmp() == {}
-
-    @pytest.mark.parametrize("buffer", (True, False))
-    def test_save_stdout(self, buffer):
-        old_stdout = sys.stdout
-
-        if buffer:
-
-            class MyStdOut:
-                buffer = BytesIO()
-
-            mystdout = MyStdOut()
-        else:
-            mystdout = BytesIO()
-
-        sys.stdout = mystdout
-
-        with Image.open(TEST_FILE) as im:
-            im.save(sys.stdout, "JPEG")
-            im_roundtrip = self.roundtrip(im)
-
-        # Reset stdout
-        sys.stdout = old_stdout
-
-        if buffer:
-            mystdout = mystdout.buffer
-        with Image.open(mystdout) as reloaded:
-            assert_image_equal(reloaded, im_roundtrip)
 
 
 @pytest.mark.skipif(not is_win32(), reason="Windows only")

--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -108,5 +108,5 @@ def test_save_stdout(buffer):
 
     if buffer:
         mystdout = mystdout.buffer
-    reloaded = Image.open(mystdout)
-    assert_image_equal_tofile(reloaded, TEST_FILE)
+    with Image.open(mystdout) as reloaded:
+        assert_image_equal_tofile(reloaded, TEST_FILE)

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -494,13 +494,6 @@ def _save(im, fp, tile, bufsize=0):
     # a tricky case.
     bufsize = max(MAXBLOCK, bufsize, im.size[0] * 4)  # see RawEncode.c
     try:
-        stdout = fp == sys.stdout or fp == sys.stdout.buffer
-    except (OSError, AttributeError):
-        stdout = False
-    if stdout:
-        fp.flush()
-        return
-    try:
         fh = fp.fileno()
         fp.flush()
     except (AttributeError, io.UnsupportedOperation) as exc:


### PR DESCRIPTION
Fixes #5657.

The removed block of code is bad for the following reasons:
1. The return statement makes the function write nothing when fp is stdout, which is obviously unwanted.
2. The fp.flush() statement is duplicate of the line below, and is therefore useless.