### PR TITLE
CI: Install PyQt5 on Python 3.10

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -35,8 +35,7 @@ python3 -m pip install test-image-results
 if ! [ "$GHA_PYTHON_VERSION" == "3.10-dev" ]; then python3 -m pip install numpy ; fi
 
 # PyQt5 doesn't support PyPy3
-# Wheel doesn't yet support 3.10
-if [[ $GHA_PYTHON_VERSION == 3.* && $GHA_PYTHON_VERSION != "3.10-dev" ]]; then
+if [[ $GHA_PYTHON_VERSION == 3.* ]]; then
   # arm64, ppc64le, s390x CPUs:
   # "ERROR: Could not find a version that satisfies the requirement pyqt5"
     sudo apt-get -qq install libxcb-xinerama0 pyqt5-dev-tools

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -22,6 +22,7 @@ sudo apt-get -qq install libfreetype6-dev liblcms2-dev python3-tk\
                          cmake imagemagick libharfbuzz-dev libfribidi-dev
 
 python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade wheel
 PYTHONOPTIMIZE=0 python3 -m pip install cffi
 python3 -m pip install coverage
 python3 -m pip install defusedxml

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ Changelog (Pillow)
 8.4.0 (unreleased)
 ------------------
 
+- Added "transparency" argument to EpsImagePlugin load() #5620
+  [radarhere]
+
+- Corrected pathlib.Path detection when saving #5633
+  [radarhere]
+
 - Added WalImageFile class #5618
   [radarhere]
 


### PR DESCRIPTION
Wheel now works on Python 3.10 so we can install PyQt5 there.

We can also install `wheel` early on in the CI. This avoids legacy 'setup.py install' for packages that only have sdists and no wheels, and then stores the wheel in the cache for the next run.

```
Using legacy 'setup.py install' for cffi, since package 'wheel' is not installed.
...
Using legacy 'setup.py install' for olefile, since package 'wheel' is not installed.
```

The cache isn't there for new branches, but will help `master` and updates to feature branches.

---

NumPy is also buildable for 3.10 now, so we _could_ remove this:

```sh
# TODO Remove condition when numpy supports 3.10
if ! [ "$GHA_PYTHON_VERSION" == "3.10-dev" ]; then python3 -m pip install numpy ; fi
```

But it takes about 5-6 minutes to build from sdist (3.10 only, others have wheels). It will be stored in the wheel cache for subsequent builds. 

As we're now also aiming at getting 3.10 RC wheels out (https://github.com/python-pillow/Pillow/issues/5569), shall we take the hit and also test NumPy on 3.10? It's possible we won't notice it given the large build matrix with many runners.

If not, hopefully there'll be NumPy wheels for 3.10 soon: https://github.com/numpy/numpy/issues/19630
