### PR TITLE
Updated FreeBSD package install command to Python 3.8

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -111,7 +111,7 @@ Pillow can be installed on FreeBSD via the official Ports or Packages systems:
 
 **Packages**::
 
-  pkg install py36-pillow
+  pkg install py38-pillow
 
 .. note::
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/master/docs/installation.rst#freebsd-installation
> pkg install py36-pillow

The way that I read https://www.freshports.org/graphics/py-pillow/, py36-Pillow only has Pillow 5.0, and py37-Pillow only has Pillow 7.0. py38-Pillow is the most up-to-date, with Pillow 8.2.

This PR updates our documentation to list py38-Pillow as the FreeBSD package. Also helpful as we're planning to drop Python 3.6 support at the end of the year.