### PR TITLE
Fix/filter/avoid test warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ docs/_build/
 Tests/images/README.md
 Tests/images/crash_1.tif
 Tests/images/crash_2.tif
+Tests/images/crash-81154a65438ba5aaeca73fd502fa4850fbde60f8.tif
 Tests/images/string_dimension.tiff
 Tests/images/jpeg2000
 Tests/images/msp

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -698,6 +698,8 @@ class TestFileTiff:
     # Ignore this UserWarning which triggers for four tags:
     # "Possibly corrupt EXIF data.  Expecting to read 50404352 bytes but..."
     @pytest.mark.filterwarnings("ignore:Possibly corrupt EXIF data")
+    # Ignore this UserWarning:
+    @pytest.mark.filterwarnings("ignore:Truncated File Read")
     @pytest.mark.skipif(
         not os.path.exists("Tests/images/string_dimension.tiff"),
         reason="Extra image files not installed",

--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -16,10 +16,10 @@ def test_sanity():
 
 
 def test_reload():
-    im = Image.open("Tests/images/hopper.gif")
-    original = im.copy()
-    im.palette.dirty = 1
-    assert_image_equal(im.convert("RGB"), original.convert("RGB"))
+    with Image.open("Tests/images/hopper.gif") as im:
+        original = im.copy()
+        im.palette.dirty = 1
+        assert_image_equal(im.convert("RGB"), original.convert("RGB"))
 
 
 def test_getcolor():

--- a/Tests/test_map.py
+++ b/Tests/test_map.py
@@ -24,10 +24,16 @@ def test_overflow():
 
 
 def test_tobytes():
+    # Note that this image triggers the decompression bomb warning:
+    max_pixels = Image.MAX_IMAGE_PIXELS
+    Image.MAX_IMAGE_PIXELS = None
+
     # Previously raised an access violation on Windows
     with Image.open("Tests/images/l2rgb_read.bmp") as im:
         with pytest.raises((ValueError, MemoryError, OSError)):
             im.tobytes()
+
+    Image.MAX_IMAGE_PIXELS = max_pixels
 
 
 @pytest.mark.skipif(sys.maxsize <= 2 ** 32, reason="Requires 64-bit system")

--- a/Tests/test_tiff_crashes.py
+++ b/Tests/test_tiff_crashes.py
@@ -40,6 +40,7 @@ from .helper import on_ci
 )
 @pytest.mark.filterwarnings("ignore:Possibly corrupt EXIF data")
 @pytest.mark.filterwarnings("ignore:Metadata warning")
+@pytest.mark.filterwarnings("ignore:Truncated File Read")
 def test_tiff_crashes(test_file):
     try:
         with Image.open(test_file) as im:


### PR DESCRIPTION
Running plain `pytest` warns:

```
======================================================== warnings summary ========================================================
Tests/test_file_tiff.py: 1 warning
Tests/test_tiff_crashes.py: 13 warnings
  /Users/hugo/github/Pillow/src/PIL/TiffImagePlugin.py:812: UserWarning: Truncated File Read
    warnings.warn(str(msg))

Tests/test_map.py::test_tobytes
  /Users/hugo/github/Pillow/src/PIL/Image.py:2916: DecompressionBombWarning: Image size (151587072 pixels) exceeds limit of 89478485 pixels, could be decompression bomb DOS attack.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```

Runing `pytest -Wall` with all warnings enabled adds some more:

```
======================================================== warnings summary ========================================================
Tests/test_file_tiff.py: 2 warnings
Tests/test_tiff_crashes.py: 26 warnings
  /Users/hugo/github/Pillow/src/PIL/TiffImagePlugin.py:812: UserWarning: Truncated File Read
    warnings.warn(str(msg))

Tests/test_imagepalette.py::test_reload
  /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/_pytest/python.py:183: ResourceWarning: unclosed file <_io.BufferedReader name='Tests/images/hopper.gif'>
    result = testfunction(**testargs)

Tests/test_map.py::test_tobytes
  /Users/hugo/github/Pillow/src/PIL/Image.py:2916: DecompressionBombWarning: Image size (151587072 pixels) exceeds limit of 89478485 pixels, could be decompression bomb DOS attack.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```
