### PR TITLE
Improve the fuzzer wrt. the current atheris version

### DIFF
--- a/Tests/oss-fuzz/fuzz_font.py
+++ b/Tests/oss-fuzz/fuzz_font.py
@@ -14,10 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 
-import atheris_no_libfuzzer as atheris
-import fuzzers
+import atheris
+with atheris.instrument_imports():
+    import sys
+    import fuzzers
 
 
 def TestOneInput(data):
@@ -26,13 +27,12 @@ def TestOneInput(data):
     except Exception:
         # We're catching all exceptions because Pillow's exceptions are
         # directly inheriting from Exception.
-        return
-    return
+        pass
 
 
 def main():
     fuzzers.enable_decompressionbomb_error()
-    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Setup(sys.argv, TestOneInput)
     atheris.Fuzz()
     fuzzers.disable_decompressionbomb_error()
 

--- a/Tests/oss-fuzz/fuzz_font.py
+++ b/Tests/oss-fuzz/fuzz_font.py
@@ -16,8 +16,10 @@
 
 
 import atheris
+
 with atheris.instrument_imports():
     import sys
+
     import fuzzers
 
 

--- a/Tests/oss-fuzz/fuzz_pillow.py
+++ b/Tests/oss-fuzz/fuzz_pillow.py
@@ -14,10 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 
-import atheris_no_libfuzzer as atheris
-import fuzzers
+import atheris
+with atheris.instrument_imports():
+    import sys
+    import fuzzers
 
 
 def TestOneInput(data):
@@ -26,13 +27,12 @@ def TestOneInput(data):
     except Exception:
         # We're catching all exceptions because Pillow's exceptions are
         # directly inheriting from Exception.
-        return
-    return
+        pass
 
 
 def main():
     fuzzers.enable_decompressionbomb_error()
-    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Setup(sys.argv, TestOneInput)
     atheris.Fuzz()
     fuzzers.disable_decompressionbomb_error()
 

--- a/Tests/oss-fuzz/fuzz_pillow.py
+++ b/Tests/oss-fuzz/fuzz_pillow.py
@@ -16,8 +16,10 @@
 
 
 import atheris
+
 with atheris.instrument_imports():
     import sys
+
     import fuzzers
 
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * Make use of the latest version of Atheris (the python fuzzer): atheris_no_libfuzzer is now aliased to atheris, so no need to use it
 * Use the new instrumentation syntax, with `with`
 * Use `pass` instead of multiple `return`
