### PR TITLE
Copy Python palette to new image in quantize()

### DIFF
--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -63,6 +63,7 @@ def test_quantize_no_dither():
 
     converted = image.quantize(dither=0, palette=palette)
     assert_image(converted, "P", converted.size)
+    assert converted.palette.palette == palette.palette.palette
 
 
 def test_quantize_dither_diff():

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1130,7 +1130,9 @@ class Image:
                     "only RGB or L mode images can be quantized to a palette"
                 )
             im = self.im.convert("P", dither, palette.im)
-            return self._new(im)
+            new_im = self._new(im)
+            new_im.palette = palette.palette.copy()
+            return new_im
 
         im = self._new(self.im.quantize(colors, method, kmeans))
 


### PR DESCRIPTION
Resolves #5695

[quantize()](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.quantize) accepts `palette` as an argument, but only applies the palette to the C layer.

https://github.com/python-pillow/Pillow/blob/d50052a75c4d0d17d3d37c24a4558c9e0736f0e8/src/PIL/Image.py#L1123-L1133

This PR copies the palette into the Python layer as well.