### PR TITLE
Docs: Temporarily pin docutils to fix bullets in sphinx_rtd_theme

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ black
 check-manifest
 coverage
 defusedxml
+# Remove docutils once https://github.com/readthedocs/sphinx_rtd_theme/issues/1115 released
+docutils==0.16
 markdown2
 olefile
 packaging


### PR DESCRIPTION
Bullet points are missing at https://pillow.readthedocs.io/en/stable/releasenotes/8.3.2.html and on other pages.

This is due to sphinx_rtd_theme not working properly with latest docutils 0.17.

sphinx_rtd_theme issue and fix:
* https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
* https://github.com/readthedocs/sphinx_rtd_theme/pull/1185

Build with 0.16:

![image](https://user-images.githubusercontent.com/1324225/132358419-def37143-1d08-4aa2-ab35-8989beb71057.png)


Build with 0.17:

![image](https://user-images.githubusercontent.com/1324225/132358459-e18c2885-f3d9-4a10-86ee-60e484d52928.png)

Let's pin to docutils 0.16 until the sphinx_rtd_theme fix is out.
