### PR TITLE
CI: Split MINGW to own workflow, remove redundant job

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,6 +7,7 @@ pull_request_rules:
       - status-success=Test Successful
       - status-success=Docker Test Successful
       - status-success=Windows Test Successful
+      - status-success=MinGW Test Successful
       - status-success=continuous-integration/appveyor/pr
     actions:
       merge:

--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -3,7 +3,7 @@ name: Test MinGW
 on: [push, pull_request]
 
 jobs:
-  msys:
+  build:
     runs-on: windows-2019
     strategy:
       fail-fast: false
@@ -76,7 +76,7 @@ jobs:
           CODECOV_NAME: ${{ matrix.name }}
 
   success:
-    needs: msys
+    needs: build
     runs-on: ubuntu-latest
     name: MinGW Test Successful
     steps:

--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -1,0 +1,84 @@
+name: Test MinGW
+
+on: [push, pull_request]
+
+jobs:
+  msys:
+    runs-on: windows-2019
+    strategy:
+      fail-fast: false
+      matrix:
+        mingw: ["MINGW32", "MINGW64"]
+        include:
+          - mingw: "MINGW32"
+            name: "MSYS2 MinGW 32-bit"
+            package: "mingw-w64-i686"
+          - mingw: "MINGW64"
+            name: "MSYS2 MinGW 64-bit"
+            package: "mingw-w64-x86_64"
+
+    defaults:
+      run:
+        shell: bash.exe --login -eo pipefail "{0}"
+    env:
+      MSYSTEM: ${{ matrix.mingw }}
+      CHERE_INVOKING: 1
+
+    timeout-minutes: 30
+    name: ${{ matrix.name }}
+
+    steps:
+      - name: Checkout Pillow
+        uses: actions/checkout@v2
+
+      - name: Set up shell
+        run: echo "C:\msys64\usr\bin\" >> $env:GITHUB_PATH
+        shell: pwsh
+
+      - name: Install dependencies
+        run: |
+          pacman -S --noconfirm \
+              ${{ matrix.package }}-python3-cffi \
+              ${{ matrix.package }}-python3-numpy \
+              ${{ matrix.package }}-python3-olefile \
+              ${{ matrix.package }}-python3-pip \
+              ${{ matrix.package }}-python3-pyqt5 \
+              ${{ matrix.package }}-python3-setuptools \
+              ${{ matrix.package }}-freetype \
+              ${{ matrix.package }}-ghostscript \
+              ${{ matrix.package }}-lcms2 \
+              ${{ matrix.package }}-libimagequant \
+              ${{ matrix.package }}-libjpeg-turbo \
+              ${{ matrix.package }}-libraqm \
+              ${{ matrix.package }}-libtiff \
+              ${{ matrix.package }}-libwebp \
+              ${{ matrix.package }}-openjpeg2 \
+              subversion
+
+          python3 -m pip install pyroma pytest pytest-cov
+
+          pushd depends && ./install_extra_test_images.sh && popd
+
+      - name: Build Pillow
+        run: CFLAGS="-coverage" python3 setup.py build_ext install
+
+      - name: Test Pillow
+        run: |
+          python3 selftest.py --installed
+          python3 -c "from PIL import Image"
+          python3 -m pytest -vx --cov PIL --cov Tests --cov-report term --cov-report xml Tests
+
+      - name: Upload coverage
+        run: |
+          python3 -m pip install codecov
+          bash <(curl -s https://codecov.io/bash) -F GHA_Windows
+        env:
+          CODECOV_NAME: ${{ matrix.name }}
+
+  success:
+    needs: msys
+    runs-on: ubuntu-latest
+    name: MinGW Test Successful
+    steps:
+      - name: Success
+        run: echo MinGW Test Successful

--- a/.github/workflows/test-valgrind.yml
+++ b/.github/workflows/test-valgrind.yml
@@ -42,11 +42,3 @@ jobs:
         sudo chown -R 1000 $GITHUB_WORKSPACE
         docker run --name pillow_container  -v $GITHUB_WORKSPACE:/Pillow pythonpillow/${{ matrix.docker }}:${{ matrix.dockerTag }}
         sudo chown -R runner $GITHUB_WORKSPACE
-
-  success:
-    needs: build
-    runs-on: ubuntu-latest
-    name: Valgrind Test Successful
-    steps:
-      - name: Success
-        run: echo Valgrind Test Successful

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -17,6 +17,7 @@ jobs:
           # PyPy 7.3.4+ only ships 64-bit binaries for Windows
           - python-version: "pypy-3.7"
             architecture: "x64"
+
     timeout-minutes: 30
 
     name: Python ${{ matrix.python-version }} ${{ matrix.architecture }}
@@ -195,80 +196,8 @@ jobs:
         name: ${{ steps.wheel.outputs.dist }}
         path: dist\*.whl
 
-  msys:
-    runs-on: windows-2019
-
-    strategy:
-      fail-fast: false
-      matrix:
-        mingw: ["MINGW32", "MINGW64"]
-        include:
-          - mingw: "MINGW32"
-            name: "MSYS2 MinGW 32-bit"
-            package: "mingw-w64-i686"
-          - mingw: "MINGW64"
-            name: "MSYS2 MinGW 64-bit"
-            package: "mingw-w64-x86_64"
-
-    defaults:
-      run:
-        shell: bash.exe --login -eo pipefail "{0}"
-    env:
-      MSYSTEM: ${{ matrix.mingw }}
-      CHERE_INVOKING: 1
-
-    timeout-minutes: 30
-    name: ${{ matrix.name }}
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up shell
-        run: echo "C:\msys64\usr\bin\" >> $env:GITHUB_PATH
-        shell: pwsh
-
-      - name: Install Dependencies
-        run: |
-          pacman -S --noconfirm \
-              ${{ matrix.package }}-python3-cffi \
-              ${{ matrix.package }}-python3-numpy \
-              ${{ matrix.package }}-python3-olefile \
-              ${{ matrix.package }}-python3-pip \
-              ${{ matrix.package }}-python3-pyqt5 \
-              ${{ matrix.package }}-python3-setuptools \
-              ${{ matrix.package }}-freetype \
-              ${{ matrix.package }}-ghostscript \
-              ${{ matrix.package }}-lcms2 \
-              ${{ matrix.package }}-libimagequant \
-              ${{ matrix.package }}-libjpeg-turbo \
-              ${{ matrix.package }}-libraqm \
-              ${{ matrix.package }}-libtiff \
-              ${{ matrix.package }}-libwebp \
-              ${{ matrix.package }}-openjpeg2 \
-              subversion
-
-          python3 -m pip install pyroma pytest pytest-cov
-
-          pushd depends && ./install_extra_test_images.sh && popd
-
-      - name: Build Pillow
-        run: CFLAGS="-coverage" python3 setup.py build_ext install
-
-      - name: Test Pillow
-        run: |
-          python3 selftest.py --installed
-          python3 -c "from PIL import Image"
-          python3 -m pytest -vx --cov PIL --cov Tests --cov-report term --cov-report xml Tests
-
-      - name: Upload coverage
-        run: |
-          python3 -m pip install codecov
-          bash <(curl -s https://codecov.io/bash) -F GHA_Windows
-        env:
-          CODECOV_NAME: ${{ matrix.name }}
-
   success:
-    needs: [build, msys]
+    needs: build
     runs-on: ubuntu-latest
     name: Windows Test Successful
     steps:


### PR DESCRIPTION
A couple of minor improvements spotted during last release cycle.

Changes proposed in this pull request:

 * Split MINGW out from `test-windows.yml` into its own workflow
   * makes each yml file shorter
   * there's not much overlap/re-use, and it's now easier to diff the files to compare
   * I happened to hit some network timeouts during the release, GHA still only allows re-starting the _whole workflow_ (not a single job), so this allows wasting less time/electricity/resources

 * Remove the final "Valgrind Test Successful" job from `test-valgrind.yml`
   * redundant: not used by Mergify
   * avoids the CI waiting and running a job for this, however quick
   * workflow reports success sooner

cc @nulano about the MINGW stuff.