### PR TITLE
Moved _info function into docstring

### DIFF
--- a/selftest.py
+++ b/selftest.py
@@ -14,17 +14,13 @@ except AttributeError:
     pass
 
 
-def _info(im):
-    im.load()
-    return im.format, im.mode, im.size
-
-
 def testimage():
     """
     PIL lets you create in-memory images with various pixel types:
 
     >>> from PIL import Image, ImageDraw, ImageFilter, ImageMath
     >>> im = Image.new("1", (128, 128)) # monochrome
+    >>> def _info(im): return (im.format, im.mode, im.size)
     >>> _info(im)
     (None, '1', (128, 128))
     >>> _info(Image.new("L", (128, 128))) # grayscale (luminance)


### PR DESCRIPTION
In selftest.py, the shell commands in the docstring refers a number of times to an earlier function, `_info`. This PR suggests merging that function into the docstring as a lambda instead.

This should help give users the impression that they can just be up-and-running from shell, rather than "Wait, I run these shell commands from the example... but they refer to an external function?"

I also removed the `load()` command from `_info`, as I found it wasn't necessary.