### PR TITLE
Accept methods cleanup

### DIFF
--- a/docs/example/DdsImagePlugin.py
+++ b/docs/example/DdsImagePlugin.py
@@ -269,9 +269,9 @@ Image.register_decoder("DXT1", DXT1Decoder)
 Image.register_decoder("DXT5", DXT5Decoder)
 
 
-def _validate(prefix):
+def _accept(prefix):
     return prefix[:4] == b"DDS "
 
 
-Image.register_open(DdsImageFile.format, DdsImageFile, _validate)
+Image.register_open(DdsImageFile.format, DdsImageFile, _accept)
 Image.register_extension(DdsImageFile.format, ".dds")

--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -22,8 +22,8 @@ from . import Image, ImageFile, JpegImagePlugin
 from ._binary import i16be as i16
 
 
-def _accept(prefix):
-    return JpegImagePlugin._accept(prefix)
+# def _accept(prefix):
+#     return JpegImagePlugin._accept(prefix)
 
 
 def _save(im, fp, filename):


### PR DESCRIPTION
Two changes.
- #5380 changed plugins to more consistently call a method called `_accept` as the last argument to `Image.register_open`. This PR also does that for our example plugin.
- MpoImagePlugin has its `Image.register_open` call commented out.
https://github.com/python-pillow/Pillow/blob/0a47b7306b0a602a7b362b0b1b6a9cc59edf42de/src/PIL/MpoImagePlugin.py#L130-L131
So this PR comments out the unused `_accept` method from MpoImagePlugin.