### PR TITLE
Update winbuild libimagequant to 2.16.0

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -257,10 +257,10 @@ deps = {
         "libs": [r"bin\*.lib"],
     },
     "libimagequant": {
-        # Merge master into msvc (matches 2.14.1 except for version bump)
-        "url": "https://github.com/ImageOptim/libimagequant/archive/16adaded22d1f90db5c9154a06d00a8b672ca09a.zip",  # noqa: E501
-        "filename": "libimagequant-16adaded22d1f90db5c9154a06d00a8b672ca09a.zip",
-        "dir": "libimagequant-16adaded22d1f90db5c9154a06d00a8b672ca09a",
+        # commit: Merge branch 'master' into msvc (matches 2.16.0 tag)
+        "url": "https://github.com/ImageOptim/libimagequant/archive/f41ee301ff3a407b16991af3dbe03910919bbdc3.zip",  # noqa: E501
+        "filename": "libimagequant-f41ee301ff3a407b16991af3dbe03910919bbdc3.zip",
+        "dir": "libimagequant-f41ee301ff3a407b16991af3dbe03910919bbdc3",
         "patch": {
             "CMakeLists.txt": {
                 "add_library": "add_compile_options(-openmp-)\r\nadd_library",

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -263,18 +263,19 @@ deps = {
         "dir": "libimagequant-f41ee301ff3a407b16991af3dbe03910919bbdc3",
         "patch": {
             "CMakeLists.txt": {
-                "add_library": "add_compile_options(-openmp-)\r\nadd_library",
-                " SHARED": " STATIC",
+                "if(OPENMP_FOUND)": "if(false)",
+                "install": "#install",
             }
         },
         "build": [
             # lint: do not inline
             cmd_cmake(),
             cmd_nmake(target="clean"),
-            cmd_nmake(),
+            cmd_nmake(target="imagequant_a"),
+            cmd_copy("imagequant_a.lib", "imagequant.lib"),
         ],
         "headers": [r"*.h"],
-        "libs": [r"*.lib"],
+        "libs": [r"imagequant.lib"],
     },
     "harfbuzz": {
         "url": "https://github.com/harfbuzz/harfbuzz/archive/3.0.0.zip",
@@ -437,6 +438,7 @@ def build_dep(name):
             assert patch_from in text
             text = text.replace(patch_from, patch_to)
         with open(patch_file, "w") as f:
+            print(f"Patching {patch_file}")
             f.write(text)
 
     banner = f"Building {name} ({dir})"


### PR DESCRIPTION
The commit is up to date with the latest tag, with minor changes needed for MSVC: https://github.com/ImageOptim/libimagequant/compare/f41ee301ff3a407b16991af3dbe03910919bbdc3...2.16.0

The patches need to be updated to fix an issue with the provided CMakeLists.txt.
