### PR TITLE
Upgrade Raqm to 0.7.2

### DIFF
--- a/src/thirdparty/raqm/NEWS
+++ b/src/thirdparty/raqm/NEWS
@@ -1,4 +1,18 @@
 Overview of changes leading to 0.7.1
+Monday, September 27, 2021
+====================================
+
+Fix test failure with newer HarfBuzz versions.
+
+Apply FT_Face transformation matrix when built against FreeType 2.11 or later.
+
+Add meson build system. Autotools build system will be dropped in next release.
+
+Improve MSVC support.
+
+Build and documentation fixes.
+
+Overview of changes leading to 0.7.1
 Sunday, November 22, 2020
 ====================================
 

--- a/src/thirdparty/raqm/README.md
+++ b/src/thirdparty/raqm/README.md
@@ -1,8 +1,7 @@
 Raqm
 ====
 
-[![Linux & macOS build](https://travis-ci.org/HOST-Oman/libraqm.svg?branch=master)](https://travis-ci.org/HOST-Oman/libraqm)
-[![Windows build](https://img.shields.io/appveyor/ci/HOSTOman/libraqm/master.svg)](https://ci.appveyor.com/project/HOSTOman/libraqm)
+[![Build](https://github.com/HOST-Oman/libraqm/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/HOST-Oman/libraqm/actions)
 
 Raqm is a small library that encapsulates the logic for complex text layout and
 provides a convenient API.
@@ -15,7 +14,7 @@ The documentation can be accessed on the web at:
 > http://host-oman.github.io/libraqm/
 
 Raqm (Arabic: رَقْم) is writing, also number or digit and the Arabic word for
-digital (رَقَمِيّ) shares the same root, so it is a play on “digital writing”.
+digital (رَقَمِيّ) shares the same root, so it is a play on “digital writing”.
 
 Building
 --------
@@ -30,31 +29,30 @@ To build the documentation you will also need:
 
 To install dependencies on Fedora:
 
-    sudo dnf install freetype-devel harfbuzz-devel fribidi-devel gtk-doc
+    sudo dnf install freetype-devel harfbuzz-devel fribidi-devel meson gtk-doc
 
 To install dependencies on Ubuntu:
 
-    sudo apt-get install libfreetype6-dev libharfbuzz-dev libfribidi-dev \
-                         gtk-doc-tools
+    sudo apt-get install libfreetype6-dev libharfbuzz-dev libfribidi-dev meson gtk-doc-tools
 
 On Mac OS X you can use Homebrew:
 
-    brew install freetype harfbuzz fribidi gtk-doc
+    brew install freetype harfbuzz fribidi meson gtk-doc
     export XML_CATALOG_FILES="/usr/local/etc/xml/catalog" # for the docs
 
 Once you have the source code and the dependencies, you can proceed to build.
 To do that, run the customary sequence of commands in the source code
 directory:
 
-    $ ./configure
-    $ make
-    $ make install
+    $ meson build
+    $ ninja -C build
+    $ ninja -C build install
 
-To build the documentation, pass `--enable-gtk-doc` to the `configure` script.
+To build the documentation, pass `-Ddocs=enable` to the `meson`.
 
 To run the tests:
 
-    $ make check
+    $ ninja -C test
 
 Contributing
 ------------

--- a/src/thirdparty/raqm/raqm-version.h
+++ b/src/thirdparty/raqm/raqm-version.h
@@ -33,9 +33,9 @@
 
 #define RAQM_VERSION_MAJOR 0
 #define RAQM_VERSION_MINOR 7
-#define RAQM_VERSION_MICRO 1
+#define RAQM_VERSION_MICRO 2
 
-#define RAQM_VERSION_STRING "0.7.1"
+#define RAQM_VERSION_STRING "0.7.2"
 
 #define RAQM_VERSION_ATLEAST(major,minor,micro) \
     ((major)*10000+(minor)*100+(micro) <= \

--- a/src/thirdparty/raqm/raqm.c
+++ b/src/thirdparty/raqm/raqm.c
@@ -39,6 +39,21 @@
 #include <hb.h>
 #include <hb-ft.h>
 
+#if FREETYPE_MAJOR > 2 || \
+    FREETYPE_MAJOR == 2 && FREETYPE_MINOR >= 11
+#define HAVE_FT_GET_TRANSFORM
+#endif
+
+#if HB_VERSION_ATLEAST(2, 0, 0)
+#define HAVE_HB_BUFFER_SET_INVISIBLE_GLYPH
+#endif
+
+#if HB_VERSION_ATLEAST(1, 8, 0)
+#define HAVE_DECL_HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES 1
+#else
+#define HAVE_DECL_HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES 0
+#endif
+
 #include "raqm.h"
 
 #if FRIBIDI_MAJOR_VERSION >= 1

--- a/src/thirdparty/raqm/raqm.c
+++ b/src/thirdparty/raqm/raqm.c
@@ -455,8 +455,6 @@ raqm_set_text_utf8 (raqm_t         *rq,
     return true;
   }
 
-  RAQM_TEST ("Text is: %s\n", text);
-
   rq->flags |= RAQM_FLAG_UTF8;
 
   rq->text_utf8 = malloc (sizeof (char) * len);
@@ -1556,6 +1554,21 @@ _raqm_resolve_scripts (raqm_t *rq)
   return true;
 }
 
+static void
+_raqm_ft_transform (int      *x,
+                    int      *y,
+                    FT_Matrix matrix)
+{
+  FT_Vector vector;
+  vector.x = *x;
+  vector.y = *y;
+
+  FT_Vector_Transform (&vector, &matrix);
+
+  *x = vector.x;
+  *y = vector.y;
+}
+
 static bool
 _raqm_shape (raqm_t *rq)
 {
@@ -1585,6 +1598,22 @@ _raqm_shape (raqm_t *rq)
 
     hb_shape_full (run->font, run->buffer, rq->features, rq->features_len,
                    NULL);
+
+#ifdef HAVE_FT_GET_TRANSFORM
+    {
+      FT_Matrix matrix;
+      hb_glyph_position_t *pos;
+      unsigned int len;
+
+      FT_Get_Transform (hb_ft_font_get_face (run->font), &matrix, NULL);
+      pos = hb_buffer_get_glyph_positions (run->buffer, &len);
+      for (unsigned int i = 0; i < len; i++)
+      {
+        _raqm_ft_transform (&pos[i].x_advance, &pos[i].y_advance, matrix);
+        _raqm_ft_transform (&pos[i].x_offset, &pos[i].y_offset, matrix);
+      }
+    }
+#endif
   }
 
   return true;

--- a/src/thirdparty/raqm/raqm.h
+++ b/src/thirdparty/raqm/raqm.h
@@ -30,6 +30,10 @@
 #include "config.h"
 #endif
 
+#ifndef RAQM_API
+#define RAQM_API
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <ft2build.h>
@@ -93,86 +97,86 @@ typedef struct raqm_glyph_t {
     FT_Face ftface;
 } raqm_glyph_t;
 
-raqm_t *
+RAQM_API raqm_t *
 raqm_create (void);
 
-raqm_t *
+RAQM_API raqm_t *
 raqm_reference (raqm_t *rq);
 
-void
+RAQM_API void
 raqm_destroy (raqm_t *rq);
 
-bool
+RAQM_API bool
 raqm_set_text (raqm_t         *rq,
                const uint32_t *text,
                size_t          len);
 
-bool
+RAQM_API bool
 raqm_set_text_utf8 (raqm_t     *rq,
                     const char *text,
                     size_t      len);
 
-bool
+RAQM_API bool
 raqm_set_par_direction (raqm_t          *rq,
                         raqm_direction_t dir);
 
-bool
+RAQM_API bool
 raqm_set_language (raqm_t       *rq,
                    const char   *lang,
                    size_t        start,
                    size_t        len);
 
-bool
+RAQM_API bool
 raqm_add_font_feature  (raqm_t     *rq,
                         const char *feature,
                         int         len);
 
-bool
+RAQM_API bool
 raqm_set_freetype_face (raqm_t *rq,
                         FT_Face face);
 
-bool
+RAQM_API bool
 raqm_set_freetype_face_range (raqm_t *rq,
                               FT_Face face,
                               size_t  start,
                               size_t  len);
 
-bool
+RAQM_API bool
 raqm_set_freetype_load_flags (raqm_t *rq,
                               int flags);
 
-bool
+RAQM_API bool
 raqm_set_invisible_glyph (raqm_t *rq,
                           int gid);
 
-bool
+RAQM_API bool
 raqm_layout (raqm_t *rq);
 
-raqm_glyph_t *
+RAQM_API raqm_glyph_t *
 raqm_get_glyphs (raqm_t *rq,
                  size_t *length);
 
-bool
+RAQM_API bool
 raqm_index_to_position (raqm_t *rq,
                         size_t *index,
                         int *x,
                         int *y);
 
-bool
+RAQM_API bool
 raqm_position_to_index (raqm_t *rq,
                         int x,
                         int y,
                         size_t *index);
 
-void
+RAQM_API void
 raqm_version (unsigned int *major,
               unsigned int *minor,
               unsigned int *micro);
 
-const char *
+RAQM_API const char *
 raqm_version_string (void);
 
-bool
+RAQM_API bool
 raqm_version_atleast (unsigned int major,
                       unsigned int minor,
                       unsigned int micro);


### PR DESCRIPTION
See https://github.com/HOST-Oman/libraqm/compare/v0.7.1...v0.7.2#diff-59a61630d549b166bf2c219870932583b13aa83bca0580d410e06057ae525c15R99

Also add preprocessor definitions for supported FreeType and HarfBuzz features based on version.