### PR TITLE
Fixed Python errors when saving a (0, 0) TIFF image

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -986,3 +986,10 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open(out) as im:
             # Assert that there are multiple strips
             assert len(im.tag_v2[STRIPOFFSETS]) > 1
+
+    @pytest.mark.parametrize("compression", ("tiff_adobe_deflate", None))
+    def test_save_zero(self, compression, tmp_path):
+        im = Image.new("RGB", (0, 0))
+        out = str(tmp_path / "temp.tif")
+        with pytest.raises(SystemError):
+            im.save(out, compression=compression)

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1619,13 +1619,17 @@ def _save(im, fp, filename):
     stride = len(bits) * ((im.size[0] * bits[0] + 7) // 8)
     # aim for 64 KB strips when using libtiff writer
     if libtiff:
-        rows_per_strip = min((2 ** 16 + stride - 1) // stride, im.size[1])
+        rows_per_strip = (
+            1 if stride == 0 else min((2 ** 16 + stride - 1) // stride, im.size[1])
+        )
         # JPEG encoder expects multiple of 8 rows
         if compression == "jpeg":
             rows_per_strip = min(((rows_per_strip + 7) // 8) * 8, im.size[1])
     else:
         rows_per_strip = im.size[1]
-    strip_byte_counts = stride * rows_per_strip
+    if rows_per_strip == 0:
+        rows_per_strip = 1
+    strip_byte_counts = 1 if stride == 0 else stride * rows_per_strip
     strips_per_image = (im.size[1] + rows_per_strip - 1) // rows_per_strip
     ifd[ROWSPERSTRIP] = rows_per_strip
     if strip_byte_counts >= 2 ** 16:


### PR DESCRIPTION
At the moment, saving a zero by zero image to TIFF gives a `ZeroDivisionError`.
```pycon
>>> from PIL import Image
>>> Image.new("RGB", (0, 0)).save("out.tiff")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/Image.py", line 2235, in save
    save_handler(self, fp, filename)
  File "PIL/TiffImagePlugin.py", line 1586, in _save
    strips_per_image = (im.size[1] + rows_per_strip - 1) // rows_per_strip
ZeroDivisionError: integer division or modulo by zero
```

This PR ensures that `rows_per_strip`, and then later `strip_byte_counts`, are not zero, allowing the code to progress forward to a `SystemError` instead.

```pycon
>>> Image.new("RGB", (0, 0)).save("out.tiff")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/Image.py", line 2240, in save
  File "PIL/TiffImagePlugin.py", line 1759, in _save
  File "PIL/ImageFile.py", line 531, in _save
SystemError: tile cannot extend outside image
```