### PR TITLE
Fix multiline text drawing and height calculation

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -585,7 +585,7 @@ class TestImageFont:
         assert t.getsize_multiline("A") == (12, 16)
         assert t.getsize_multiline("AB") == (24, 16)
         assert t.getsize_multiline("a") == (12, 16)
-        assert t.getsize_multiline("ABC\n") == (36, 36)
+        assert t.getsize_multiline("ABC\n") == (36, 16)
         assert t.getsize_multiline("ABC\nA") == (36, 36)
         assert t.getsize_multiline("ABC\nAaaa") == (48, 36)
 

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -498,7 +498,7 @@ class ImageDraw:
                 line, font, direction=direction, features=features, language=language
             )
             widths.append(line_width)
-            heighs.append(line_height + spacing)
+            heighs.append(line_height + spacing if line_height != 0 else 0)
             max_width = max(max_width, line_width)
 
         top = xy[1]
@@ -689,7 +689,6 @@ class ImageDraw:
                 direction=direction,
                 features=features,
                 language=language,
-                embedded_color=embedded_color,
             )
             widths.append(line_width)
             heighs.append(line_height + spacing)

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -492,7 +492,7 @@ class FreeTypeFont:
                 line, direction, features, language, stroke_width
             )
             max_width = max(max_width, line_width)
-            all_height += line_height + spacing
+            all_height += line_height + spacing if line_height != 0 else 0
 
         return max_width, all_height - spacing
 


### PR DESCRIPTION
Fixes #1646  .

Changes proposed in this pull request:

 * Fixed size calculation and drawing of multiline text
 
 ### Example
 ```python
 from PIL import Image, ImageDraw, ImageFont

font = ImageFont.truetype("tnr.ttf", size=80, encoding="unic")
text = "{{{{\n}}}}"

size = font.getsize_multiline(text)
print(size) # (152, 132) / (152, 168)
image = Image.new("RGB", size, color="#FFF")
draw = ImageDraw.Draw(image)
draw.multiline_text((0, 0), text, "#000", font)
image.save("a.png")
```
### Then / Now
 
![a](https://user-images.githubusercontent.com/26704473/136648081-12aec3c2-f0ed-411a-a95a-842c6d347683.png) ![a](https://user-images.githubusercontent.com/26704473/136648108-17e50e27-945f-44c7-9269-be75b669a94e.png)


