### PR TITLE
Docs: No security updates in 8.4.0

### DIFF
--- a/docs/releasenotes/8.4.0.rst
+++ b/docs/releasenotes/8.4.0.rst
@@ -38,14 +38,6 @@ Added WalImageFile class
 :py:class:`PIL.Image.Image` instance. It now returns a dedicated
 :py:class:`PIL.WalImageFile.WalImageFile` class.
 
-Security
-========
-
-TODO
-^^^^
-
-TODO
-
 Other Changes
 =============
 


### PR DESCRIPTION
We didn't remove this placeholder from the release notes.

https://pillow.readthedocs.io/en/stable/releasenotes/8.4.0.html

For clarity: there were no security updates in Pillow 8.4.0.

