### PR TITLE
Improved image lifecycle documentation

### DIFF
--- a/docs/reference/open_files.rst
+++ b/docs/reference/open_files.rst
@@ -61,12 +61,14 @@ Image Lifecycle
 * ``Image.Image.close()`` Closes the file and destroys the core image object.
 
   The Pillow context manager will also close the file, but will not destroy
-  the core image object. e.g.::
+  the core image object. e.g.:
 
-      with Image.open('test.jpg') as img:
+.. code-block:: python
+
+      with Image.open("test.jpg") as img:
          img.load()
       assert img.fp is None
-      img.save('test.png')
+      img.save("test.png")
 
 
 The lifecycle of a single-frame image is relatively simple. The file must


### PR DESCRIPTION
Resolves #5772 by improving the image lifecycle documentation.

- Copied images are not associated with the original file
- `__exit__` does not destroy the core image object
https://github.com/python-pillow/Pillow/blob/fa53b71afebe63fe5e0e9d80c84562246b42d2d3/src/PIL/Image.py#L579-L585