### PR TITLE
Update expected Pillow 10 release date: 2023-07-01

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -377,7 +377,7 @@ Changelog (Pillow)
 - Changed Image.open formats parameter to be case-insensitive #5250
   [Piolie, radarhere]
 
-- Deprecate Tk/Tcl 8.4, to be removed in Pillow 10 (2023-01-02) #5216
+- Deprecate Tk/Tcl 8.4, to be removed in Pillow 10 (2023-07-01) #5216
   [radarhere]
 
 - Added tk version to pilinfo #5226

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -30,7 +30,7 @@ Tk/Tcl 8.4
 
 .. deprecated:: 8.2.0
 
-Support for Tk/Tcl 8.4 is deprecated and will be removed in Pillow 10.0.0 (2023-01-02),
+Support for Tk/Tcl 8.4 is deprecated and will be removed in Pillow 10.0.0 (2023-07-01),
 when Tk/Tcl 8.5 will be the minimum supported.
 
 Categories
@@ -38,7 +38,7 @@ Categories
 
 .. deprecated:: 8.2.0
 
-``im.category`` is deprecated and will be removed in Pillow 10.0.0 (2023-01-02),
+``im.category`` is deprecated and will be removed in Pillow 10.0.0 (2023-07-01),
 along with the related ``Image.NORMAL``, ``Image.SEQUENCE`` and
 ``Image.CONTAINER`` attributes.
 
@@ -53,14 +53,14 @@ JpegImagePlugin.convert_dict_qtables
 JPEG ``quantization`` is now automatically converted, but still returned as a
 dictionary. The :py:attr:`~PIL.JpegImagePlugin.convert_dict_qtables` method no longer
 performs any operations on the data given to it, has been deprecated and will be
-removed in Pillow 10.0.0 (2023-01-02).
+removed in Pillow 10.0.0 (2023-07-01).
 
 ImagePalette size parameter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. deprecated:: 8.4.0
 
-The ``size`` parameter will be removed in Pillow 10.0.0 (2023-01-02).
+The ``size`` parameter will be removed in Pillow 10.0.0 (2023-07-01).
 
 Before Pillow 8.3.0, ``ImagePalette`` required palette data of particular lengths by
 default, and the size parameter could be used to override that. Pillow 8.3.0 removed

--- a/docs/releasenotes/8.2.0.rst
+++ b/docs/releasenotes/8.2.0.rst
@@ -7,7 +7,7 @@ Deprecations
 Categories
 ^^^^^^^^^^
 
-``im.category`` is deprecated and will be removed in Pillow 10.0.0 (2023-01-02),
+``im.category`` is deprecated and will be removed in Pillow 10.0.0 (2023-07-01),
 along with the related ``Image.NORMAL``, ``Image.SEQUENCE`` and
 ``Image.CONTAINER`` attributes.
 
@@ -17,7 +17,7 @@ To determine if an image has multiple frames or not,
 Tk/Tcl 8.4
 ^^^^^^^^^^
 
-Support for Tk/Tcl 8.4 is deprecated and will be removed in Pillow 10.0.0 (2023-01-02),
+Support for Tk/Tcl 8.4 is deprecated and will be removed in Pillow 10.0.0 (2023-07-01),
 when Tk/Tcl 8.5 will be the minimum supported.
 
 API Changes

--- a/docs/releasenotes/8.3.0.rst
+++ b/docs/releasenotes/8.3.0.rst
@@ -10,7 +10,7 @@ JpegImagePlugin.convert_dict_qtables
 JPEG ``quantization`` is now automatically converted, but still returned as a
 dictionary. The :py:attr:`~PIL.JpegImagePlugin.convert_dict_qtables` method no longer
 performs any operations on the data given to it, has been deprecated and will be
-removed in Pillow 10.0.0 (2023-01-02).
+removed in Pillow 10.0.0 (2023-07-01).
 
 API Changes
 ===========

--- a/docs/releasenotes/8.4.0.rst
+++ b/docs/releasenotes/8.4.0.rst
@@ -10,7 +10,7 @@ Deprecations
 ImagePalette size parameter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``size`` parameter will be removed in Pillow 10.0.0 (2023-01-02).
+The ``size`` parameter will be removed in Pillow 10.0.0 (2023-07-01).
 
 Before Pillow 8.3.0, ``ImagePalette`` required palette data of particular lengths by
 default, and the size parameter could be used to override that. Pillow 8.3.0 removed

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -58,7 +58,7 @@ if sys.version_info >= (3, 7):
         if name in categories:
             warnings.warn(
                 "Image categories are deprecated and will be removed in Pillow 10 "
-                "(2023-01-02). Use is_animated instead.",
+                "(2023-07-01). Use is_animated instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -521,7 +521,7 @@ class Image:
         if name == "category":
             warnings.warn(
                 "Image categories are deprecated and will be removed in Pillow 10 "
-                "(2023-01-02). Use is_animated instead.",
+                "(2023-07-01). Use is_animated instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/src/PIL/ImagePalette.py
+++ b/src/PIL/ImagePalette.py
@@ -44,7 +44,7 @@ class ImagePalette:
         if size != 0:
             warnings.warn(
                 "The size parameter is deprecated and will be removed in Pillow 10 "
-                "(2023-01-02).",
+                "(2023-07-01).",
                 DeprecationWarning,
             )
             if size != len(self.palette):

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -603,7 +603,7 @@ samplings = {
 def convert_dict_qtables(qtables):
     warnings.warn(
         "convert_dict_qtables is deprecated and will be removed in Pillow 10"
-        "(2023-01-02). Conversion is no longer needed.",
+        "(2023-07-01). Conversion is no longer needed.",
         DeprecationWarning,
     )
     return qtables

--- a/src/PIL/_tkinter_finder.py
+++ b/src/PIL/_tkinter_finder.py
@@ -14,7 +14,7 @@ tk_version = str(tkinter.TkVersion)
 if tk_version == "8.4":
     warnings.warn(
         "Support for Tk/Tcl 8.4 is deprecated and will be removed"
-        " in Pillow 10 (2023-01-02). Please upgrade to Tk/Tcl 8.5 "
+        " in Pillow 10 (2023-07-01). Please upgrade to Tk/Tcl 8.5 "
         "or newer.",
         DeprecationWarning,
     )


### PR DESCRIPTION
Python now has an annual release cadence in October, but the EOL dates haven't yet synced up: Python 3.7 will be the last (EOL: 2023-06-27) until they're also aligned to October.

| cycle | latest |  release   |    eol     |
|-------|--------|------------|------------|
| 3.10  | 3.10.0 | 2021-10-04 | 2026-10-04 |
| 3.9   | 3.9.7  | 2020-10-05 | 2025-10-05 |
| 3.8   | 3.8.12 | 2019-10-14 | 2024-10-14 |
| **3.7**   | 3.7.12 | 2018-06-27 | **2023-06-27** |
| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |

https://endoflife.date/python

That means if we tie the major bump Pillow 9->10 to the Python 3.7 drop (not guaranteed but most likely), then that will be in the 2023 _Q3_ release, not 2023 _Q1_.

And so we have until 2022-07-01 to deprecate new things, for them to have 12 months of deprecation before removal in Pillow 10.