### PR TITLE
CI: Install pytest-timeout for MinGW CI

### DIFF
--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -55,7 +55,7 @@ jobs:
               ${{ matrix.package }}-openjpeg2 \
               subversion
 
-          python3 -m pip install pyroma pytest pytest-cov
+          python3 -m pip install pyroma pytest pytest-cov pytest-timeout
 
           pushd depends && ./install_extra_test_images.sh && popd
 


### PR DESCRIPTION
# Before

```
Tests/test_util.py::test_is_not_directory PASSED                         [ 99%]
Tests/test_util.py::test_deferred_error PASSED                           [ 99%]
Tests/test_webp_leaks.py::TestWebPLeaks::test_leak_load SKIPPED (Req...) [100%]

============================== warnings summary ===============================
Tests/test_file_eps.py:283
  D:/a/Pillow/Pillow/Tests/test_file_eps.py:283: PytestUnknownMarkWarning: Unknown pytest.mark.timeout - is this a typo?  You can register custom marks to avoid this warning - for details, see docs.pytest.org/en/stable/mark.html
    @pytest.mark.timeout(timeout=5)

Tests/test_file_fli.py:135
  D:/a/Pillow/Pillow/Tests/test_file_fli.py:135: PytestUnknownMarkWarning: Unknown pytest.mark.timeout - is this a typo?  You can register custom marks to avoid this warning - for details, see docs.pytest.org/en/stable/mark.html
    @pytest.mark.timeout(timeout=3)

Tests/test_file_pdf.py:315
  D:/a/Pillow/Pillow/Tests/test_file_pdf.py:315: PytestUnknownMarkWarning: Unknown pytest.mark.timeout - is this a typo?  You can register custom marks to avoid this warning - for details, see docs.pytest.org/en/stable/mark.html
    @pytest.mark.timeout(1)

-- Docs: docs.pytest.org/en/stable/warnings.html

----------- coverage: platform win32, python 3.9.7-final-0 -----------
```

https://github.com/python-pillow/Pillow/runs/3924866011?check_suite_focus=true#step:6:1976

# After

```
Tests/test_util.py::test_is_not_directory PASSED                         [ 99%]
Tests/test_util.py::test_deferred_error PASSED                           [ 99%]
Tests/test_webp_leaks.py::TestWebPLeaks::test_leak_load SKIPPED (Req...) [100%]

----------- coverage: platform win32, python 3.9.7-final-0 -----------
```

https://github.com/hugovk/Pillow/runs/3926912601?check_suite_focus=true#step:6:1976
