### PR TITLE
Use declarative package configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,41 @@
+[metadata]
+name = Pillow
+description = Python Imaging Library (Fork)
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://python-pillow.org
+author = Alex Clark (PIL Fork Author)
+author_email = aclark@python-pillow.org
+license = HPND
+classifiers =
+    Development Status :: 6 - Mature
+    License :: OSI Approved :: Historical Permission Notice and Disclaimer (HPND)
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+    Topic :: Multimedia :: Graphics
+    Topic :: Multimedia :: Graphics :: Capture :: Digital Camera
+    Topic :: Multimedia :: Graphics :: Capture :: Screen Capture
+    Topic :: Multimedia :: Graphics :: Graphics Conversion
+    Topic :: Multimedia :: Graphics :: Viewers
+keywords = Imaging
+project_urls =
+    Documentation=https://pillow.readthedocs.io
+    Source=https://github.com/python-pillow/Pillow
+    Funding=https://tidelift.com/subscription/pkg/pypi-pillow?utm_source=pypi-pillow&utm_medium=pypi
+    Release notes=https://pillow.readthedocs.io/en/stable/releasenotes/index.html
+    Changelog=https://github.com/python-pillow/Pillow/blob/main/CHANGES.rst
+    Twitter=https://twitter.com/PythonPillow
+
+[options]
+python_requires = >=3.6
+
 [flake8]
 extend-ignore = E203
 max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ def get_version():
     return locals()["__version__"]
 
 
-NAME = "Pillow"
 PILLOW_VERSION = get_version()
 FREETYPE_ROOT = None
 HARFBUZZ_ROOT = None
@@ -971,56 +970,14 @@ ext_modules = [
     Extension("PIL._imagingmorph", ["src/_imagingmorph.c"]),
 ]
 
-with open("README.md") as f:
-    long_description = f.read()
-
 try:
     setup(
-        name=NAME,
         version=PILLOW_VERSION,
-        description="Python Imaging Library (Fork)",
-        long_description=long_description,
-        long_description_content_type="text/markdown",
-        license="HPND",
-        author="Alex Clark (PIL Fork Author)",
-        author_email="aclark@python-pillow.org",
-        url="https://python-pillow.org",
-        project_urls={
-            "Documentation": "https://pillow.readthedocs.io",
-            "Source": "https://github.com/python-pillow/Pillow",
-            "Funding": "https://tidelift.com/subscription/pkg/pypi-pillow?"
-            "utm_source=pypi-pillow&utm_medium=pypi",
-            "Release notes": "https://pillow.readthedocs.io/en/stable/releasenotes/"
-            "index.html",
-            "Changelog": "https://github.com/python-pillow/Pillow/blob/main/"
-            "CHANGES.rst",
-            "Twitter": "https://twitter.com/PythonPillow",
-        },
-        classifiers=[
-            "Development Status :: 6 - Mature",
-            "License :: OSI Approved :: Historical Permission Notice and Disclaimer (HPND)",  # noqa: E501
-            "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.6",
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "Programming Language :: Python :: 3 :: Only",
-            "Programming Language :: Python :: Implementation :: CPython",
-            "Programming Language :: Python :: Implementation :: PyPy",
-            "Topic :: Multimedia :: Graphics",
-            "Topic :: Multimedia :: Graphics :: Capture :: Digital Camera",
-            "Topic :: Multimedia :: Graphics :: Capture :: Screen Capture",
-            "Topic :: Multimedia :: Graphics :: Graphics Conversion",
-            "Topic :: Multimedia :: Graphics :: Viewers",
-        ],
-        python_requires=">=3.6",
         cmdclass={"build_ext": pil_build_ext},
         ext_modules=ext_modules,
         include_package_data=True,
         packages=["PIL"],
         package_dir={"": "src"},
-        keywords=["Imaging"],
         zip_safe=not (debug_build() or PLATFORM_MINGW),
     )
 except RequiredDependencyException as err:


### PR DESCRIPTION
We can move much of the static packaging metadata from `setup.py` to a declarative package configuration file, `setup.cfg`.

This is happening in many Python projects (and pure Python projects can have a minimal or no `setup.py`).

A benefit for us is we can get to this metadata without scrolling to the end of 1,000 lines of logic, making it more visible and easier to edit. If it doesn't need any logic, it's cleaner to move it out. 