### PR TITLE
Replace 'setup.py sdist' with '-m build --sdist'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,8 @@ release-test:
 
 .PHONY: sdist
 sdist:
-	python3 setup.py sdist --format=gztar
+	python3 -m build --help > /dev/null 2>&1 || python3 -m pip install build
+	python3 -m build --sdist
 
 .PHONY: test
 test:


### PR DESCRIPTION
Direct invocation of `setup.py` has been deprecated by `setuptools`, and there's a multi-year effort ongoing to replace its commands with other tools.

The long version:

* https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html

Direct calling isn't going away any time soon, but we should start to replace those that we can. Here's one of the simpler replacements.

I compared the generated `Pillow-9.0.0.dev0.tar.gz` with the old and new commands, and the contents were identical (except for this change to the `Makefile`).


---

We currently use these:

```sh
setup.py --long-description | markdown2 > .long-description.html && open .long-description.html
setup.py build --build-base=/tmp/build install
setup.py build_ext --enable-[feature] install
setup.py build_ext --inplace
setup.py build_ext --vendor-raqm --vendor-fribidi %*
setup.py build_ext install
setup.py clean
setup.py develop
setup.py develop build_ext --inplace
setup.py install
setup.py sdist --format=gztar
```