### PR TITLE
Use title for display in ImageShow

### DIFF
--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -189,8 +189,10 @@ class UnixViewer(Viewer):
 class DisplayViewer(UnixViewer):
     """The ImageMagick ``display`` command."""
 
-    def get_command_ex(self, file, **options):
+    def get_command_ex(self, file, title=None, **options):
         command = executable = "display"
+        if title:
+            command += f" -name {quote(title)}"
         return command, executable
 
 


### PR DESCRIPTION
Adds support for the `title` argument to DisplayViewer in ImageShow.

Suggested at https://github.com/python-pillow/Pillow/issues/5739#issuecomment-949488387

Also documented at https://linux.die.net/man/1/display
> In addition to those listed above, you can specify these standard X resources as command line options: -background, -bordercolor, -borderwidth, -font, -foreground, -iconGeometry, -iconic, -mattecolor, -name, -shared-memory, -usePixmap, or -title.