### PR TITLE
WebP: Fix memory leak during decoding on failure

### DIFF
--- a/src/_webp.c
+++ b/src/_webp.c
@@ -392,6 +392,7 @@ _anim_decoder_new(PyObject *self, PyObject *args) {
                     return (PyObject *)decp;
                 }
             }
+            WebPDataClear(&(decp->data));
         }
         PyObject_Del(decp);
     }


### PR DESCRIPTION
When creating the `WebPAnimDecoder` object, we create a `WebPAnimDecoderObject` and populate its data using `WebPDataCopy()`.

Subsequently, if either `WebPAnimDecoderNew()` or `WebPAnimDecoderGetInfo()` fails, data is not currently deallocated, which may cause memory leaks.

This PR clears the decoder object's data in that situation.