### PR TITLE
Use the Windows method to get TCL functions on Cygwin

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -193,6 +193,10 @@ class TestImage:
         assert not im.readonly
 
     @pytest.mark.skipif(is_win32(), reason="Test requires opening tempfile twice")
+    @pytest.mark.skipif(
+        sys.platform == "cygwin",
+        reason="Test requires opening an mmaped file for writing",
+    )
     def test_readonly_save(self, tmp_path):
         temp_file = str(tmp_path / "temp.bmp")
         shutil.copy("Tests/images/rgb32bf-rgba.bmp", temp_file)

--- a/setup.py
+++ b/setup.py
@@ -887,9 +887,7 @@ class pil_build_ext(build_ext):
         else:
             self._remove_extension("PIL._webp")
 
-        tk_libs = (
-            ["psapi"] if (sys.platform == "win32" or sys.platform == "cygwin") else []
-        )
+        tk_libs = ["psapi"] if sys.platform in ("win32", "cygwin") else []
         self._update_extension("PIL._imagingtk", tk_libs)
 
         build_ext.build_extensions(self)

--- a/setup.py
+++ b/setup.py
@@ -887,7 +887,7 @@ class pil_build_ext(build_ext):
         else:
             self._remove_extension("PIL._webp")
 
-        tk_libs = ["psapi"] if sys.platform == "win32" else []
+        tk_libs = ["psapi"] if (sys.platform == "win32" or sys.platform == "cygwin") else []
         self._update_extension("PIL._imagingtk", tk_libs)
 
         build_ext.build_extensions(self)

--- a/setup.py
+++ b/setup.py
@@ -887,7 +887,9 @@ class pil_build_ext(build_ext):
         else:
             self._remove_extension("PIL._webp")
 
-        tk_libs = ["psapi"] if (sys.platform == "win32" or sys.platform == "cygwin") else []
+        tk_libs = (
+            ["psapi"] if (sys.platform == "win32" or sys.platform == "cygwin") else []
+        )
         self._update_extension("PIL._imagingtk", tk_libs)
 
         build_ext.build_extensions(self)

--- a/src/Tk/tkImaging.c
+++ b/src/Tk/tkImaging.c
@@ -219,7 +219,7 @@ TkImaging_Init(Tcl_Interp *interp) {
 
 #define TKINTER_FINDER "PIL._tkinter_finder"
 
-#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(__CYGWIN__)
 
 /*
  * On Windows, we can't load the tkinter module to get the Tcl or Tk symbols,

--- a/src/libImaging/ImPlatform.h
+++ b/src/libImaging/ImPlatform.h
@@ -31,10 +31,17 @@
 #endif
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
+
+#ifdef __CYGWIN__
+#undef _WIN64
+#undef _WIN32
+#undef __WIN32__
+#undef WIN32
+#endif
 
 #else
 /* For System that are not Windows, we'll need to define these. */


### PR DESCRIPTION
This is related to linking semantics, so Cygwin should follow the Windows codepath.

Fixes #5795 (and the bug that prompted that issue).

Changes proposed in this pull request:

 * Use the Windows method to get TCL functions on Cygwin, instead of the Linux method (the Linux method might also work on BSD, I haven't tested there)
