### PR TITLE
Docs: Remove docutils pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,6 @@ black
 check-manifest
 coverage
 defusedxml
-# Remove docutils once https://github.com/readthedocs/sphinx_rtd_theme/issues/1115 released
-docutils==0.16
 markdown2
 olefile
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ sphinx>=2.4
 sphinx-copybutton
 sphinx-issues
 sphinx-removed-in
-sphinx-rtd-theme
+sphinx-rtd-theme>=1.0
 sphinxext-opengraph


### PR DESCRIPTION
This reverts commit 9509a73ed9080640d8d6b95f514b77329d123fa1.

Changes proposed in this pull request:

 * Undo PR https://github.com/python-pillow/Pillow/pull/5704 now Sphinx 1.0.0 has been released
 * https://github.com/readthedocs/sphinx_rtd_theme/releases/tag/1.0.0
 * https://github.com/readthedocs/sphinx_rtd_theme/tags

