### PR TITLE
Removed setuptools install from AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,6 @@ install:
         c:\pillow\winbuild\build\build_dep_all.cmd
         $host.SetShouldExit(0)
 - path C:\pillow\winbuild\build\bin;%PATH%
-- '%PYTHON%\%EXECUTABLE% -m pip install -U setuptools'
 
 build_script:
 - ps: |


### PR DESCRIPTION
#5014 added `- '%PYTHON%\%PIP_DIR%\pip.exe install -U "setuptools>=49.3.2"'`. See https://github.com/python-pillow/Pillow/pull/4784#issuecomment-668002511 for more context.

#5234 intended to revert this, but did not do so properly - `- '%PYTHON%\%EXECUTABLE% -m pip install -U setuptools'`

This PR removes the line altogether.