### PR TITLE
Added rounding when converting P and PA

### DIFF
--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -93,7 +93,7 @@ def test_trns_p(tmp_path):
     f = str(tmp_path / "temp.png")
 
     im_l = im.convert("L")
-    assert im_l.info["transparency"] == 0  # undone
+    assert im_l.info["transparency"] == 1  # undone
     im_l.save(f)
 
     im_rgb = im.convert("RGB")
@@ -168,6 +168,20 @@ def test_trns_RGB(tmp_path):
     im_p = im.convert("P", palette=Image.ADAPTIVE)
     assert im_p.info["transparency"] == im_p.getpixel((0, 0))
     im_p.save(f)
+
+
+@pytest.mark.parametrize("convert_mode", ("L", "LA", "I"))
+def test_l_macro_rounding(convert_mode):
+    for mode in ("P", "PA"):
+        im = Image.new(mode, (1, 1))
+        im.palette.getcolor((0, 1, 2))
+
+        converted_im = im.convert(convert_mode)
+        px = converted_im.load()
+        converted_color = px[0, 0]
+        if convert_mode == "LA":
+            converted_color = converted_color[0]
+        assert converted_color == 1
 
 
 def test_gif_with_rgba_palette_to_p():

--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -1013,7 +1013,7 @@ p2l(UINT8 *out, const UINT8 *in, int xsize, const UINT8 *palette) {
     int x;
     /* FIXME: precalculate greyscale palette? */
     for (x = 0; x < xsize; x++) {
-        *out++ = L(&palette[in[x] * 4]) / 1000;
+        *out++ = L24(&palette[in[x] * 4]) >> 16;
     }
 }
 
@@ -1022,7 +1022,7 @@ pa2l(UINT8 *out, const UINT8 *in, int xsize, const UINT8 *palette) {
     int x;
     /* FIXME: precalculate greyscale palette? */
     for (x = 0; x < xsize; x++, in += 4) {
-        *out++ = L(&palette[in[0] * 4]) / 1000;
+        *out++ = L24(&palette[in[0] * 4]) >> 16;
     }
 }
 
@@ -1044,7 +1044,7 @@ p2la(UINT8 *out, const UINT8 *in, int xsize, const UINT8 *palette) {
     /* FIXME: precalculate greyscale palette? */
     for (x = 0; x < xsize; x++, out += 4) {
         const UINT8 *rgba = &palette[*in++ * 4];
-        out[0] = out[1] = out[2] = L(rgba) / 1000;
+        out[0] = out[1] = out[2] = L24(rgba) >> 16;
         out[3] = rgba[3];
     }
 }
@@ -1054,7 +1054,7 @@ pa2la(UINT8 *out, const UINT8 *in, int xsize, const UINT8 *palette) {
     int x;
     /* FIXME: precalculate greyscale palette? */
     for (x = 0; x < xsize; x++, in += 4, out += 4) {
-        out[0] = out[1] = out[2] = L(&palette[in[0] * 4]) / 1000;
+        out[0] = out[1] = out[2] = L24(&palette[in[0] * 4]) >> 16;
         out[3] = in[3];
     }
 }
@@ -1063,7 +1063,7 @@ static void
 p2i(UINT8 *out_, const UINT8 *in, int xsize, const UINT8 *palette) {
     int x;
     for (x = 0; x < xsize; x++, out_ += 4) {
-        INT32 v = L(&palette[in[x] * 4]) / 1000;
+        INT32 v = L24(&palette[in[x] * 4]) >> 16;
         memcpy(out_, &v, sizeof(v));
     }
 }
@@ -1073,7 +1073,7 @@ pa2i(UINT8 *out_, const UINT8 *in, int xsize, const UINT8 *palette) {
     int x;
     INT32 *out = (INT32 *)out_;
     for (x = 0; x < xsize; x++, in += 4) {
-        *out++ = L(&palette[in[0] * 4]) / 1000;
+        *out++ = L24(&palette[in[0] * 4]) >> 16;
     }
 }
 


### PR DESCRIPTION
Resolves #5728 

The issue discusses a pixel in an image with the palette value `(177, 175, 175)`, and asks why converting from P to L doesn't convert it to 176. That conversion uses the L macro -

https://github.com/python-pillow/Pillow/blob/a3d1e2f85db890c6a1623e3902711863f55cc54e/src/libImaging/Convert.c#L1012-L1016

https://github.com/python-pillow/Pillow/blob/a3d1e2f85db890c6a1623e3902711863f55cc54e/src/libImaging/Convert.c#L43

Applying the L macro,

`(177*299 + 175*587 + 175*114) / 1000` = 175.598

Except the `p2l` code above rounds it down. This PR applies proper rounding to bring it to 176.