### PR TITLE
Add support for pickling TrueType fonts

### DIFF
--- a/docs/releasenotes/9.0.0.rst
+++ b/docs/releasenotes/9.0.0.rst
@@ -72,6 +72,21 @@ Support has been added for the "title" argument in
 argument will also now be supported, e.g. ``im.show(title="My Image")`` and
 ``ImageShow.show(im, title="My Image")``.
 
+Added support for pickling TrueType fonts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+TrueType fonts may now be pickled and unpickled. For example:
+
+.. code-block:: python
+
+    from PIL import Image, ImageDraw, ImageFont
+
+    font = ImageFont.truetype("arial.ttf", size=30)
+    pickled_font = pickle.dumps(font1, protocol=pickle.HIGHEST_PROTOCOL)
+
+    # Later...
+    unpickled_font = pickle.loads(pickled_font)
+
 Security
 ========
 

--- a/docs/releasenotes/9.0.0.rst
+++ b/docs/releasenotes/9.0.0.rst
@@ -79,10 +79,11 @@ TrueType fonts may now be pickled and unpickled. For example:
 
 .. code-block:: python
 
-    from PIL import Image, ImageDraw, ImageFont
+    import pickle
+    from PIL import ImageFont
 
     font = ImageFont.truetype("arial.ttf", size=30)
-    pickled_font = pickle.dumps(font1, protocol=pickle.HIGHEST_PROTOCOL)
+    pickled_font = pickle.dumps(font, protocol=pickle.HIGHEST_PROTOCOL)
 
     # Later...
     unpickled_font = pickle.loads(pickled_font)

--- a/docs/releasenotes/9.0.0.rst
+++ b/docs/releasenotes/9.0.0.rst
@@ -72,6 +72,17 @@ Support has been added for the "title" argument in
 argument will also now be supported, e.g. ``im.show(title="My Image")`` and
 ``ImageShow.show(im, title="My Image")``.
 
+Security
+========
+
+TODO
+^^^^
+
+TODO
+
+Other Changes
+=============
+
 Added support for pickling TrueType fonts
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -87,19 +98,3 @@ TrueType fonts may now be pickled and unpickled. For example:
 
     # Later...
     unpickled_font = pickle.loads(pickled_font)
-
-Security
-========
-
-TODO
-^^^^
-
-TODO
-
-Other Changes
-=============
-
-TODO
-^^^^
-
-TODO

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -196,6 +196,13 @@ class FreeTypeFont:
         else:
             load_from_bytes(font)
 
+    def __getstate__(self):
+        return [self.path, self.size, self.index, self.encoding, self.layout_engine]
+
+    def __setstate__(self, state):
+        path, size, index, encoding, layout_engine = state
+        self.__init__(path, size, index, encoding, layout_engine)
+
     def _multiline_split(self, text):
         split_character = "\n" if isinstance(text, str) else b"\n"
         return text.split(split_character)


### PR DESCRIPTION
Fixes https://github.com/python-pillow/Pillow/issues/5825.

Changes proposed in this pull request:

 * TrueType fonts can now be pickled and unpickled
