### PR TITLE
Only prefer command line tools SDK on macOS over the default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -532,16 +532,24 @@ class pil_build_ext(build_ext):
                 _add_directory(include_dirs, "/usr/X11/include")
 
             # SDK install path
-            sdk_path = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
-            if not os.path.exists(sdk_path):
-                try:
-                    sdk_path = (
-                        subprocess.check_output(["xcrun", "--show-sdk-path"])
-                        .strip()
-                        .decode("latin1")
-                    )
-                except Exception:
-                    sdk_path = None
+            try:
+                sdk_path = (
+                    subprocess.check_output(["xcrun", "--show-sdk-path"])
+                    .strip()
+                    .decode("latin1")
+                )
+            except Exception:
+                sdk_path = None
+            if (
+                not sdk_path
+                or sdk_path == "/Applications/Xcode.app/Contents/Developer"
+                "/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+            ):
+                commandlinetools_sdk_path = (
+                    "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+                )
+                if os.path.exists(commandlinetools_sdk_path):
+                    sdk_path = commandlinetools_sdk_path
             if sdk_path:
                 _add_directory(library_dirs, os.path.join(sdk_path, "usr", "lib"))
                 _add_directory(include_dirs, os.path.join(sdk_path, "usr", "include"))

--- a/setup.py
+++ b/setup.py
@@ -404,6 +404,27 @@ class pil_build_ext(build_ext):
                 self.extensions.remove(extension)
                 break
 
+    def get_macos_sdk_path(self):
+        try:
+            sdk_path = (
+                subprocess.check_output(["xcrun", "--show-sdk-path"])
+                .strip()
+                .decode("latin1")
+            )
+        except Exception:
+            sdk_path = None
+        if (
+            not sdk_path
+            or sdk_path == "/Applications/Xcode.app/Contents/Developer"
+            "/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+        ):
+            commandlinetools_sdk_path = (
+                "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+            )
+            if os.path.exists(commandlinetools_sdk_path):
+                sdk_path = commandlinetools_sdk_path
+        return sdk_path
+
     def build_extensions(self):
 
         library_dirs = []
@@ -531,25 +552,7 @@ class pil_build_ext(build_ext):
                 _add_directory(library_dirs, "/usr/X11/lib")
                 _add_directory(include_dirs, "/usr/X11/include")
 
-            # SDK install path
-            try:
-                sdk_path = (
-                    subprocess.check_output(["xcrun", "--show-sdk-path"])
-                    .strip()
-                    .decode("latin1")
-                )
-            except Exception:
-                sdk_path = None
-            if (
-                not sdk_path
-                or sdk_path == "/Applications/Xcode.app/Contents/Developer"
-                "/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
-            ):
-                commandlinetools_sdk_path = (
-                    "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
-                )
-                if os.path.exists(commandlinetools_sdk_path):
-                    sdk_path = commandlinetools_sdk_path
+            sdk_path = self.get_macos_sdk_path()
             if sdk_path:
                 _add_directory(library_dirs, os.path.join(sdk_path, "usr", "lib"))
                 _add_directory(include_dirs, os.path.join(sdk_path, "usr", "include"))


### PR DESCRIPTION
Resolves #5827

#5624 changed setup.py on macOS to prefer the command line tools SDK over `xcrun --show-sdk-path`. Apparently that was too far however, as conda-forge would like to specify the SDK path.

So instead, this PR scales back #5624 to only use the command line tools SDK when `xcrun --show-sdk-path` returns the default path of `/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk`