### PR TITLE
Fix pushes_fd method signature

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -235,7 +235,7 @@ _setfd(ImagingDecoderObject *decoder, PyObject *args) {
 }
 
 static PyObject *
-_get_pulls_fd(ImagingDecoderObject *decoder) {
+_get_pulls_fd(ImagingDecoderObject *decoder, void *closure) {
     return PyBool_FromLong(decoder->pulls_fd);
 }
 

--- a/src/encode.c
+++ b/src/encode.c
@@ -299,7 +299,7 @@ _setfd(ImagingEncoderObject *encoder, PyObject *args) {
 }
 
 static PyObject *
-_get_pushes_fd(ImagingEncoderObject *encoder) {
+_get_pushes_fd(ImagingEncoderObject *encoder, void *closure) {
     return PyBool_FromLong(encoder->pushes_fd);
 }
 


### PR DESCRIPTION
Python getters are supposed to take a `void* closure` argument.

I am coming from Pyodide. Web assembly has no native support for function pointer casting -- a function declared with a certain signature must be called with the same signature, or it will fail with `RuntimeError: function signature mismatch`. Emscripten has support for emulating function pointer casts which we are currently using, but it imposes a significant performance and stack space cost and we are trying to remove the pointer cast emulation pyodide/pyodide#1677. To do this, we need to patch Python packages so that they have function signatures that match the calling conventions they declare.