### PR TITLE
Block tile TIFF tags when saving

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -920,6 +920,23 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open("Tests/images/tiff_strip_planar_16bit_RGBa.tiff") as im:
             assert_image_equal_tofile(im, "Tests/images/tiff_16bit_RGBa_target.png")
 
+    @pytest.mark.parametrize("compression", (None, "jpeg"))
+    def test_block_tile_tags(self, compression, tmp_path):
+        im = hopper()
+        out = str(tmp_path / "temp.tif")
+
+        tags = {
+            TiffImagePlugin.TILEWIDTH: 256,
+            TiffImagePlugin.TILELENGTH: 256,
+            TiffImagePlugin.TILEOFFSETS: 256,
+            TiffImagePlugin.TILEBYTECOUNTS: 256,
+        }
+        im.save(out, exif=tags, compression=compression)
+
+        with Image.open(out) as reloaded:
+            for tag in tags.keys():
+                assert tag not in reloaded.getexif()
+
     def test_old_style_jpeg(self):
         with Image.open("Tests/images/old-style-jpeg-compression.tif") as im:
             assert_image_equal_tofile(im, "Tests/images/old-style-jpeg-compression.png")

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -89,7 +89,10 @@ DATE_TIME = 306
 ARTIST = 315
 PREDICTOR = 317
 COLORMAP = 320
+TILEWIDTH = 322
+TILELENGTH = 323
 TILEOFFSETS = 324
+TILEBYTECOUNTS = 325
 SUBIFD = 330
 EXTRASAMPLES = 338
 SAMPLEFORMAT = 339
@@ -1649,6 +1652,7 @@ def _save(im, fp, filename):
         }.items():
             ifd.setdefault(tag, value)
 
+    blocklist = [TILEWIDTH, TILELENGTH, TILEOFFSETS, TILEBYTECOUNTS]
     if libtiff:
         if "quality" in encoderinfo:
             quality = encoderinfo["quality"]
@@ -1680,7 +1684,7 @@ def _save(im, fp, filename):
         # BITSPERSAMPLE, etc), passing arrays with a different length will result in
         # segfaults. Block these tags until we add extra validation.
         # SUBIFD may also cause a segfault.
-        blocklist = [
+        blocklist += [
             REFERENCEBLACKWHITE,
             SAMPLEFORMAT,
             STRIPBYTECOUNTS,
@@ -1753,6 +1757,8 @@ def _save(im, fp, filename):
             raise OSError(f"encoder error {s} when writing image file")
 
     else:
+        for tag in blocklist:
+            del ifd[tag]
         offset = ifd.save(fp)
 
         ImageFile._save(


### PR DESCRIPTION
Resolves #5838

It is [suggested in that issue](https://github.com/python-pillow/Pillow/issues/5838#issuecomment-972714494) that Pillow should automatically remove tile TIFF tags - rather than having [both tile and strip tags saved to the same image](https://github.com/python-pillow/Pillow/issues/5838#issuecomment-972699979).

So this PR removes TILEWIDTH, TILELENGTH, TILEOFFSETS and TILEBYTECOUNTS.