### PR TITLE
GHA: Use actions/setup-python's pip cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,14 +12,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: pip cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: lint-pip-${{ hashFiles('**/setup.py') }}
-        restore-keys: |
-          lint-pip-
-
     - name: pre-commit cache
       uses: actions/cache@v2
       with:
@@ -31,7 +23,9 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.10"
+        cache: pip
+        cache-dependency-path: "setup.py"
 
     - name: Build system information
       run: python3 .github/workflows/system-info.py
@@ -45,4 +39,3 @@ jobs:
       run: tox -e lint
       env:
         PRE_COMMIT_COLOR: always
-

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -31,22 +31,14 @@ jobs:
         repository: python-pillow/pillow-depends
         path: winbuild\depends
 
-    - name: Cache pip
-      uses: actions/cache@v2
-      with:
-        path: ~\AppData\Local\pip\Cache
-        key:
-          ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.architecture }}-${{ hashFiles('**/.github/workflows/test-windows.yml') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.architecture }}-
-          ${{ runner.os }}-${{ matrix.python-version }}-
-
     # sets env: pythonLocation
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}
+        cache: pip
+        cache-dependency-path: ".github/workflows/test-windows.yml"
 
     - name: Print build system information
       run: python .github/workflows/system-info.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
-        cache-dependency-path: "**/.ci/*.sh"
+        cache-dependency-path: ".ci/*.sh"
 
     - name: Build system information
       run: python3 .github/workflows/system-info.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,20 +42,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "::set-output name=dir::$(python3 -m pip cache dir)"
-
-    - name: pip cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key:
-          ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/.ci/*.sh') }}
-        restore-keys: |
-          ${{ matrix.os }}-${{ matrix.python-version }}-
+        cache: pip
+        cache-dependency-path: "**/.ci/*.sh"
 
     - name: Build system information
       run: python3 .github/workflows/system-info.py


### PR DESCRIPTION
The https://github.com/actions/setup-python action can now take care of the pip cache, meaning we can remove a bunch of `actions/cache` config.

Re: https://github.com/actions/setup-python/releases/tag/v2.3.0
