### PR TITLE
ImageViewer that allows users to provide commands

### DIFF
--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -78,7 +78,7 @@ def test_commandviewer():
         basecmd = "rm -f {file}"
     viewer = ImageShow.CommandViewer()
     im = hopper()
-    viewer.get_command(im, command=basecmd)
+    viewer.get_command(viewer.save_image(im), command=basecmd)
 
 
 def test_ipythonviewer():

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -78,7 +78,8 @@ def test_commandviewer():
         basecmd = "rm -f {file}"
     viewer = ImageShow.CommandViewer()
     im = hopper()
-    assert viewer.show(im, command=basecmd) == 1
+    try:
+        viewer.get_command(im, command=basecmd)
 
 
 def test_ipythonviewer():

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -78,8 +78,7 @@ def test_commandviewer():
         basecmd = "rm -f {file}"
     viewer = ImageShow.CommandViewer()
     im = hopper()
-    try:
-        viewer.get_command(im, command=basecmd)
+    viewer.get_command(im, command=basecmd)
 
 
 def test_ipythonviewer():

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -67,6 +67,18 @@ def test_viewers():
         except NotImplementedError:
             pass
 
+def test_commandviewer():
+    if is_win32():
+        basecmd = 
+        'start "Pillow" /WAIT "{file}" '             
+        "&& ping -n 2 127.0.0.1 >NUL "
+        '&& del /f "{file}"'
+	else:
+		# Not guessing command, just deleting
+        basecmd = "rm -f {file}"
+	viewer = ImageShow.CommandViewer()
+	im = hopper()
+	assert viewer.show(im, command=basecmd) == 1
 
 def test_ipythonviewer():
     pytest.importorskip("IPython", reason="IPython not installed")

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -78,6 +78,10 @@ def test_commandviewer():
         basecmd = "rm -f {file}"
     viewer = ImageShow.CommandViewer()
     im = hopper()
+    with pytest.raises(TypeError):
+		viewer.get_command(viewer.save_image(im))
+    with pytest.raises(TypeError):
+		viewer.get_command(viewer.save_image(im), command=5)
     viewer.get_command(viewer.save_image(im), command=basecmd)
 
 

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -69,7 +69,7 @@ def test_viewers():
 
 def test_commandviewer():
     if is_win32():
-        basecmd = 
+        basecmd = \
         'start "Pillow" /WAIT "{file}" '             
         "&& ping -n 2 127.0.0.1 >NUL "
         '&& del /f "{file}"'

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -73,12 +73,12 @@ def test_commandviewer():
         'start "Pillow" /WAIT "{file}" '             
         "&& ping -n 2 127.0.0.1 >NUL "
         '&& del /f "{file}"'
-	else:
-		# Not guessing command, just deleting
+    else:
+        # Not guessing command, just deleting
         basecmd = "rm -f {file}"
-	viewer = ImageShow.CommandViewer()
-	im = hopper()
-	assert viewer.show(im, command=basecmd) == 1
+    viewer = ImageShow.CommandViewer()
+    im = hopper()
+    assert viewer.show(im, command=basecmd) == 1
 
 def test_ipythonviewer():
     pytest.importorskip("IPython", reason="IPython not installed")

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -79,9 +79,9 @@ def test_commandviewer():
     viewer = ImageShow.CommandViewer()
     im = hopper()
     with pytest.raises(TypeError):
-		viewer.get_command(viewer.save_image(im))
+        viewer.get_command(viewer.save_image(im))
     with pytest.raises(TypeError):
-		viewer.get_command(viewer.save_image(im), command=5)
+        viewer.get_command(viewer.save_image(im), command=5)
     viewer.get_command(viewer.save_image(im), command=basecmd)
 
 

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -67,10 +67,10 @@ def test_viewers():
         except NotImplementedError:
             pass
 
+
 def test_commandviewer():
     if is_win32():
-        basecmd = \
-        'start "Pillow" /WAIT "{file}" '             
+        basecmd = 'start "Pillow" /WAIT "{file}" '
         "&& ping -n 2 127.0.0.1 >NUL "
         '&& del /f "{file}"'
     else:
@@ -79,6 +79,7 @@ def test_commandviewer():
     viewer = ImageShow.CommandViewer()
     im = hopper()
     assert viewer.show(im, command=basecmd) == 1
+
 
 def test_ipythonviewer():
     pytest.importorskip("IPython", reason="IPython not installed")

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -278,7 +278,7 @@ class CommandViewer(Viewer):
         command = options["command"]
         if not isinstance(command, str):
             raise TypeError(f"'command' must be 'str' not '{type(command)}'")
-        values = {"file": file, **options}
+        values = {"file": quote(file), **options}
         return command.format(values)
 
 

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -271,10 +271,8 @@ class CommandViewer(Viewer):
         :param options: kwargs that should have 'command' in it
         """
 
-        if not "command" in options:
-            raise TypeError(
-                "CommandViewer missing required keyword-only argument 'command'"
-            )
+        if "command" not in options:
+            raise TypeError("CommandViewer missing required keyword-only argument 'command'")
         command = options["command"]
         if not isinstance(command, str):
             raise TypeError(f"'command' must be 'str' not '{type(command)}'")

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -258,6 +258,7 @@ except ImportError:
 else:
     register(IPythonViewer)
 
+
 class CommandViewer(Viewer):
     """
     The viewer that use commands.
@@ -271,11 +272,13 @@ class CommandViewer(Viewer):
         """
 
         if not "command" in options:
-            raise TypeError("CommandViewer missing required keyword-only argument 'command'")
+            raise TypeError(
+                "CommandViewer missing required keyword-only argument 'command'"
+            )
         command = options["command"]
         if not isinstance(command, str):
             raise TypeError(f"'command' must be 'str' not '{type(command)}'")
-        values = {'file': file, **options}
+        values = {"file": file, **options}
         return command.format(values)
 
 

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -272,7 +272,9 @@ class CommandViewer(Viewer):
         """
 
         if "command" not in options:
-            raise TypeError("CommandViewer missing required keyword-only argument 'command'")
+            raise TypeError(
+                "CommandViewer missing required keyword-only argument 'command'"
+            )
         command = options["command"]
         if not isinstance(command, str):
             raise TypeError(f"'command' must be 'str' not '{type(command)}'")

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -258,6 +258,26 @@ except ImportError:
 else:
     register(IPythonViewer)
 
+class CommandViewer(Viewer):
+    """
+    The viewer that use commands.
+    Should be suitable for any OS
+    """
+
+    def get_command(self, file, **options):
+        """
+        Substitute ``{}`` specifiers in ``command``
+        :param options: kwargs that should have 'command' in it
+        """
+
+        if not "command" in options:
+            raise TypeError("CommandViewer missing required keyword-only argument 'command'")
+        command = options["command"]
+        if not isinstance(command, str):
+            raise TypeError(f"'command' must be 'str' not '{type(command)}'")
+        values = {'file': file, **options}
+        return command.format(values)
+
 
 if __name__ == "__main__":
 

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -279,7 +279,7 @@ class CommandViewer(Viewer):
         if not isinstance(command, str):
             raise TypeError(f"'command' must be 'str' not '{type(command)}'")
         values = {"file": quote(file), **options}
-        return command.format(values)
+        return command.format(**values)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently all viewers ignores `command` parameter.
But sometimes it useful to be able to provide specific command.
Especially on unix, where PIL can't guess "which viewer user prefer?"
Writing own viewer for every project where you need custom command is weird, So i think, it should be in PIL by default

Changes proposed in this pull request:
 * Add Viewer that rely on provided command.
   This viewer should not be registered now, since Image.show() is throwing `DeprecationWarning` on `command` parameter
   Should warning be removed?
