### PR TITLE
Pass SAMPLEFORMAT to libtiff

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -9,7 +9,7 @@ from ctypes import c_float
 import pytest
 
 from PIL import Image, ImageFilter, TiffImagePlugin, TiffTags, features
-from PIL.TiffImagePlugin import STRIPOFFSETS, SUBIFD
+from PIL.TiffImagePlugin import SAMPLEFORMAT, STRIPOFFSETS, SUBIFD
 
 from .helper import (
     assert_image_equal,
@@ -824,6 +824,17 @@ class TestFileLibTiff(LibTiffTestCase):
             assert im.mode == "RGB"
 
             assert_image_equal_tofile(im, "Tests/images/copyleft.png", mode="RGB")
+
+    def test_sampleformat_write(self, tmp_path):
+        im = Image.new("F", (1, 1))
+        out = str(tmp_path / "temp.tif")
+        TiffImagePlugin.WRITE_LIBTIFF = True
+        im.save(out)
+        TiffImagePlugin.WRITE_LIBTIFF = False
+
+        with Image.open(out) as reloaded:
+            assert reloaded.mode == "F"
+            assert reloaded.getexif()[SAMPLEFORMAT] == 3
 
     def test_lzw(self):
         with Image.open("Tests/images/hopper_lzw.tif") as im:


### PR DESCRIPTION
Resolves #5843

`SAMPLEFORMAT` is currently in the `blocklist` when saving with libtiff.

https://github.com/python-pillow/Pillow/blob/ae7c2cb2e6a1d5bf3050cc0076d6155e56342c3c/src/PIL/TiffImagePlugin.py#L1687-L1689

The explanation is

https://github.com/python-pillow/Pillow/blob/ae7c2cb2e6a1d5bf3050cc0076d6155e56342c3c/src/PIL/TiffImagePlugin.py#L1679-L1680

But `SAMPLEFORMAT` doesn't only come from the user. It can also be set by TiffImagePlugin, according to the image format.

https://github.com/python-pillow/Pillow/blob/ae7c2cb2e6a1d5bf3050cc0076d6155e56342c3c/src/PIL/TiffImagePlugin.py#L1477-L1488

https://github.com/python-pillow/Pillow/blob/ae7c2cb2e6a1d5bf3050cc0076d6155e56342c3c/src/PIL/TiffImagePlugin.py#L1603-L1604

So this PR removes `SAMPLEFORMAT` from `blocklist`, allowing the value to be passed to libtiff by TiffImagePlugin's code - but also adding other code to still not allow the user to set it.