### PR TITLE
Support 16-bit grayscale ImageQt conversion

### DIFF
--- a/Tests/test_imageqt.py
+++ b/Tests/test_imageqt.py
@@ -2,7 +2,7 @@ import pytest
 
 from PIL import ImageQt
 
-from .helper import hopper
+from .helper import assert_image_similar, hopper
 
 pytestmark = pytest.mark.skipif(
     not ImageQt.qt_is_installed, reason="Qt bindings are not installed"
@@ -42,11 +42,17 @@ def test_rgb():
 
 
 def test_image():
-    for mode in ("1", "RGB", "RGBA", "L", "P"):
-        ImageQt.ImageQt(hopper(mode))
+    modes = ["1", "RGB", "RGBA", "L", "P"]
     qt_format = ImageQt.QImage.Format if ImageQt.qt_version == "6" else ImageQt.QImage
     if hasattr(qt_format, "Format_Grayscale16"):  # Qt 5.13+
-        ImageQt.ImageQt(hopper("I;16"))
+        modes.append("I;16")
+
+    for mode in modes:
+        im = hopper(mode)
+        roundtripped_im = ImageQt.fromqimage(ImageQt.ImageQt(im))
+        if mode not in ("RGB", "RGBA"):
+            im = im.convert("RGB")
+        assert_image_similar(roundtripped_im, im, 1)
 
 
 def test_closed_file():

--- a/Tests/test_imageqt.py
+++ b/Tests/test_imageqt.py
@@ -42,7 +42,7 @@ def test_rgb():
 
 
 def test_image():
-    for mode in ("1", "RGB", "RGBA", "L", "P"):
+    for mode in ("1", "RGB", "RGBA", "L", "P", "I;16"):
         ImageQt.ImageQt(hopper(mode))
 
 

--- a/Tests/test_imageqt.py
+++ b/Tests/test_imageqt.py
@@ -42,8 +42,11 @@ def test_rgb():
 
 
 def test_image():
-    for mode in ("1", "RGB", "RGBA", "L", "P", "I;16"):
+    for mode in ("1", "RGB", "RGBA", "L", "P"):
         ImageQt.ImageQt(hopper(mode))
+    qt_format = ImageQt.QImage.Format if ImageQt.qt_version == "6" else ImageQt.QImage
+    if hasattr(qt_format, "Format_Grayscale16"):  # Qt 5.13+
+        ImageQt.ImageQt(hopper("I;16"))
 
 
 def test_closed_file():

--- a/src/PIL/ImageQt.py
+++ b/src/PIL/ImageQt.py
@@ -168,6 +168,8 @@ def _toqclass_helper(im):
         data = im.tobytes("raw", "BGRA")
         format = qt_format.Format_ARGB32
     elif im.mode == "I;16" and hasattr(qt_format, "Format_Grayscale16"):  # Qt 5.13+
+        im = im.point(lambda i: i * 256)
+
         format = qt_format.Format_Grayscale16
     else:
         if exclusive_fp:

--- a/src/PIL/ImageQt.py
+++ b/src/PIL/ImageQt.py
@@ -167,7 +167,7 @@ def _toqclass_helper(im):
     elif im.mode == "RGBA":
         data = im.tobytes("raw", "BGRA")
         format = qt_format.Format_ARGB32
-    elif im.mode == "I;16":
+    elif im.mode == "I;16" and hasattr(qt_format, "Format_Grayscale16"):  # Qt 5.13+
         format = qt_format.Format_Grayscale16
     else:
         if exclusive_fp:

--- a/src/PIL/ImageQt.py
+++ b/src/PIL/ImageQt.py
@@ -108,7 +108,7 @@ def align8to32(bytes, width, mode):
     converts each scanline of data from 8 bit to 32 bit aligned
     """
 
-    bits_per_pixel = {"1": 1, "L": 8, "P": 8}[mode]
+    bits_per_pixel = {"1": 1, "L": 8, "P": 8, "I;16": 16}[mode]
 
     # calculate bytes per line and the extra padding if needed
     bits_per_line = bits_per_pixel * width
@@ -167,6 +167,8 @@ def _toqclass_helper(im):
     elif im.mode == "RGBA":
         data = im.tobytes("raw", "BGRA")
         format = qt_format.Format_ARGB32
+    elif im.mode == "I;16":
+        format = qt_format.Format_Grayscale16
     else:
         if exclusive_fp:
             im.close()


### PR DESCRIPTION
Steps to reproduce:

```python
from PIL import Image, ImageQt

image = Image.open("test.tif")  # test.tif is a 16-bit grayscale image
imageqt = ImageQt.ImageQt(image)
```

Expected behavior: A valid QImage is created.

Behavior without this code change: `ValueError: unsupported image mode 'I;16'`

I verified that a valid QImage is created with this change. Sorry I cannot share the test image I am using.