### PR TITLE
When saving RGBA to GIF, make use of first transparent palette entry

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -957,3 +957,13 @@ def test_missing_background():
     with Image.open("Tests/images/missing_background.gif") as im:
         im.seek(1)
         assert_image_equal_tofile(im, "Tests/images/missing_background_first_frame.png")
+
+
+def test_saving_rgba(tmp_path):
+    out = str(tmp_path / "temp.gif")
+    with Image.open("Tests/images/transparent.png") as im:
+        im.save(out)
+
+    with Image.open(out) as reloaded:
+        reloaded_rgba = reloaded.convert("RGBA")
+        assert reloaded_rgba.load()[0, 0][3] == 0

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -425,7 +425,13 @@ def _normalize_mode(im, initial_call=False):
             palette_size = 256
             if im.palette:
                 palette_size = len(im.palette.getdata()[1]) // 3
-            return im.convert("P", palette=Image.ADAPTIVE, colors=palette_size)
+            im = im.convert("P", palette=Image.ADAPTIVE, colors=palette_size)
+            if im.palette.mode == "RGBA":
+                for rgba in im.palette.colors.keys():
+                    if rgba[3] == 0:
+                        im.info["transparency"] = im.palette.colors[rgba]
+                        break
+            return im
         else:
             return im.convert("P")
     return im.convert("L")


### PR DESCRIPTION
Helps #4640

When saving an image as a GIF, the image passes through [`_normalize_mode`](https://github.com/python-pillow/Pillow/blob/bd00cd9214f986ceeef7d1707664f71231a5f643/src/PIL/GifImagePlugin.py#L349), to convert the image to 1, L or P.

When saving a single RGBA image as a GIF, the transparency is currently lost. This PR fixes that by setting the "transparency" key in the `info` dictionary to the first transparent palette entry (if you think that might not be very effective, since there could be many different transparent palette entries, remember #5282).