### PR TITLE
GHA: Add workflow_dispatch to enable manually triggering builds

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,4 +1,5 @@
 name: CIFuzz
+
 on:
   push:
     paths:
@@ -8,6 +9,7 @@ on:
     paths:
       - "**.c"
       - "**.h"
+  workflow_dispatch:
 
 jobs:
   Fuzzing:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,7 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   update_release_draft:

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -1,6 +1,6 @@
 name: Test Docker
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -1,6 +1,6 @@
 name: Test MinGW
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/test-valgrind.yml
+++ b/.github/workflows/test-valgrind.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - "**.c"
       - "**.h"
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -132,7 +132,7 @@ jobs:
     - name: Build Pillow
       run: |
         $FLAGS=""
-        if ('${{ github.event_name }}' -eq 'push') { $FLAGS="--disable-imagequant" }
+        if ('${{ github.event_name }}' -ne 'pull_request') { $FLAGS="--disable-imagequant" }
         & winbuild\build\build_pillow.cmd $FLAGS install
         & $env:pythonLocation\python.exe selftest.py --installed
       shell: pwsh
@@ -175,14 +175,14 @@ jobs:
 
     - name: Build wheel
       id: wheel
-      if: "github.event_name == 'push'"
+      if: "github.event_name != 'pull_request'"
       run: |
         for /f "tokens=3 delims=/" %%a in ("${{ github.ref }}") do echo ::set-output name=dist::dist-%%a
         winbuild\\build\\build_pillow.cmd --disable-imagequant bdist_wheel
       shell: cmd
 
     - uses: actions/upload-artifact@v2
-      if: "github.event_name == 'push'"
+      if: "github.event_name != 'pull_request'"
       with:
         name: ${{ steps.wheel.outputs.dist }}
         path: dist\*.whl

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,6 +1,6 @@
 name: Test Windows
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
Changes proposed in this pull request:

 * This will add a button to allow us to manually trigger a new build for a (whole) workflow, similar to Travis CI
 * https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#manual-events

