### PR TITLE
Improved example code

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -75,9 +75,9 @@ method with the following parameters to affect how Ghostscript renders the EPS
     relative position of the bounding box is maintained::
 
         im = Image.open(...)
-        im.size #(100,100)
+        im.size  # (100,100)
         im.load(scale=2)
-        im.size #(200,200)
+        im.size  # (200,200)
 
 **transparency**
     If true, generates an RGBA image with a transparent background, instead of
@@ -760,7 +760,7 @@ The :py:meth:`~PIL.Image.open` method sets the following attributes:
 A convenience method, :py:meth:`~PIL.SpiderImagePlugin.SpiderImageFile.convert2byte`,
 is provided for converting floating point data to byte data (mode ``L``)::
 
-    im = Image.open('image001.spi').convert2byte()
+    im = Image.open("image001.spi").convert2byte()
 
 Writing files in SPIDER format
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1201,6 +1201,7 @@ dpi. To load it at another resolution:
 .. code-block:: python
 
     from PIL import Image
+
     with Image.open("drawing.wmf") as im:
         im.load(dpi=144)
 
@@ -1212,14 +1213,18 @@ To add other read or write support, use
     from PIL import Image
     from PIL import WmfImagePlugin
 
+
     class WmfHandler:
         def open(self, im):
             ...
+
         def load(self, im):
             ...
             return image
+
         def save(self, im, fp, filename):
             ...
+
 
     wmf_handler = WmfHandler()
 

--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -176,12 +176,13 @@ Rolling an image
         xsize, ysize = image.size
 
         delta = delta % xsize
-        if delta == 0: return image
+        if delta == 0:
+            return image
 
         part1 = image.crop((0, 0, delta, ysize))
         part2 = image.crop((delta, 0, xsize, ysize))
-        image.paste(part1, (xsize-delta, 0, xsize, ysize))
-        image.paste(part2, (0, 0, xsize-delta, ysize))
+        image.paste(part1, (xsize - delta, 0, xsize, ysize))
+        image.paste(part2, (0, 0, xsize - delta, ysize))
 
         return image
 
@@ -264,6 +265,7 @@ Converting between modes
 ::
 
     from PIL import Image
+
     with Image.open("hopper.ppm") as im:
         im = im.convert("L")
 
@@ -382,14 +384,14 @@ Reading sequences
     from PIL import Image
 
     with Image.open("animation.gif") as im:
-        im.seek(1) # skip to the second frame
+        im.seek(1)  # skip to the second frame
 
         try:
             while 1:
-                im.seek(im.tell()+1)
+                im.seek(im.tell() + 1)
                 # do something to im
         except EOFError:
-            pass # end of sequence
+            pass  # end of sequence
 
 As seen in this example, you’ll get an :py:exc:`EOFError` exception when the
 sequence ends.
@@ -422,9 +424,9 @@ Drawing PostScript
 
     with Image.open("hopper.ppm") as im:
         title = "hopper"
-        box = (1*72, 2*72, 7*72, 10*72) # in points
+        box = (1 * 72, 2 * 72, 7 * 72, 10 * 72)  # in points
 
-        ps = PSDraw.PSDraw() # default is sys.stdout or sys.stdout.buffer
+        ps = PSDraw.PSDraw()  # default is sys.stdout or sys.stdout.buffer
         ps.begin_document(title)
 
         # draw the image (75 dpi)
@@ -433,7 +435,7 @@ Drawing PostScript
 
         # draw title
         ps.setfont("HelveticaNarrow-Bold", 36)
-        ps.text((3*72, 4*72), title)
+        ps.text((3 * 72, 4 * 72), title)
 
         ps.end_document()
 
@@ -462,6 +464,7 @@ Reading from an open file
 ::
 
     from PIL import Image
+
     with open("hopper.ppm", "rb") as fp:
         im = Image.open(fp)
 
@@ -475,6 +478,7 @@ Reading from binary data
 
     from PIL import Image
     import io
+
     im = Image.open(io.BytesIO(buffer))
 
 Note that the library rewinds the file (using ``seek(0)``) before reading the

--- a/docs/handbook/writing-your-own-file-decoder.rst
+++ b/docs/handbook/writing-your-own-file-decoder.rst
@@ -87,10 +87,13 @@ true color.
 
     Image.register_open(SpamImageFile.format, SpamImageFile, _accept)
 
-    Image.register_extensions(SpamImageFile.format, [
-        ".spam",
-        ".spa",  # DOS version
-    ])
+    Image.register_extensions(
+        SpamImageFile.format,
+        [
+            ".spam",
+            ".spa",  # DOS version
+        ],
+    )
 
 
 The format handler must always set the
@@ -111,6 +114,7 @@ Once the plugin has been imported, it can be used:
 
     from PIL import Image
     import SpamImagePlugin
+
     with Image.open("hopper.spam") as im:
         pass
 

--- a/docs/handbook/writing-your-own-file-decoder.rst
+++ b/docs/handbook/writing-your-own-file-decoder.rst
@@ -167,16 +167,16 @@ TIFF, and many others. To use the raw decoder with the
 
     image = Image.frombytes(
         mode, size, data, "raw",
-        raw mode, stride, orientation
+        raw_mode, stride, orientation
         )
 
 When used in a tile descriptor, the parameter field should look like::
 
-    (raw mode, stride, orientation)
+    (raw_mode, stride, orientation)
 
 The fields are used as follows:
 
-**raw mode**
+**raw_mode**
     The pixel layout used in the file, and is used to properly convert data to
     PIL’s internal layout. For a summary of the available formats, see the
     table below.

--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -81,11 +81,12 @@ Example: Draw Partial Opacity Text
 .. code-block:: python
 
     from PIL import Image, ImageDraw, ImageFont
+
     # get an image
     with Image.open("Pillow/Tests/images/hopper.png").convert("RGBA") as base:
 
         # make a blank image for the text, initialized to transparent text color
-        txt = Image.new("RGBA", base.size, (255,255,255,0))
+        txt = Image.new("RGBA", base.size, (255, 255, 255, 0))
 
         # get a font
         fnt = ImageFont.truetype("Pillow/Tests/fonts/FreeMono.ttf", 40)
@@ -93,9 +94,9 @@ Example: Draw Partial Opacity Text
         d = ImageDraw.Draw(txt)
 
         # draw text, half opacity
-        d.text((10,10), "Hello", font=fnt, fill=(255,255,255,128))
+        d.text((10, 10), "Hello", font=fnt, fill=(255, 255, 255, 128))
         # draw text, full opacity
-        d.text((10,60), "World", font=fnt, fill=(255,255,255,255))
+        d.text((10, 60), "World", font=fnt, fill=(255, 255, 255, 255))
 
         out = Image.alpha_composite(base, txt)
 
@@ -117,7 +118,7 @@ Example: Draw Multiline Text
     d = ImageDraw.Draw(out)
 
     # draw multiline text
-    d.multiline_text((10,10), "Hello\nWorld", font=fnt, fill=(0, 0, 0))
+    d.multiline_text((10, 10), "Hello\nWorld", font=fnt, fill=(0, 0, 0))
 
     out.show()
 
@@ -557,7 +558,9 @@ Methods
 
     .. code-block:: python
 
-        hello = draw.textlength("HelloW", font) - draw.textlength("W", font)  # adjusted for kerning
+        hello = draw.textlength("HelloW", font) - draw.textlength(
+            "W", font
+        )  # adjusted for kerning
         world = draw.textlength("World", font)
         hello_world = hello + world  # adjusted for kerning
         assert hello_world == draw.textlength("HelloWorld", font)  # True

--- a/docs/reference/PixelAccess.rst
+++ b/docs/reference/PixelAccess.rst
@@ -17,11 +17,12 @@ changes it.
 .. code-block:: python
 
     from PIL import Image
-    with Image.open('hopper.jpg') as im:
+
+    with Image.open("hopper.jpg") as im:
         px = im.load()
-    print (px[4,4])
-    px[4,4] = (0,0,0)
-    print (px[4,4])
+    print(px[4, 4])
+    px[4, 4] = (0, 0, 0)
+    print(px[4, 4])
 
 Results in the following::
 
@@ -32,8 +33,8 @@ Access using negative indexes is also possible.
 
 .. code-block:: python
 
-    px[-1,-1] = (0,0,0)
-    print (px[-1,-1])
+    px[-1, -1] = (0, 0, 0)
+    print(px[-1, -1])
 
 
 

--- a/docs/reference/PyAccess.rst
+++ b/docs/reference/PyAccess.rst
@@ -18,11 +18,12 @@ The following script loads an image, accesses one pixel from it, then changes it
 .. code-block:: python
 
     from PIL import Image
-    with Image.open('hopper.jpg') as im:
+
+    with Image.open("hopper.jpg") as im:
         px = im.load()
-    print (px[4,4])
-    px[4,4] = (0,0,0)
-    print (px[4,4])
+    print(px[4, 4])
+    px[4, 4] = (0, 0, 0)
+    print(px[4, 4])
 
 Results in the following::
 
@@ -33,8 +34,8 @@ Access using negative indexes is also possible.
 
 .. code-block:: python
 
-    px[-1,-1] = (0,0,0)
-    print (px[-1,-1])
+    px[-1, -1] = (0, 0, 0)
+    print(px[-1, -1])
 
 
 

--- a/docs/reference/c_extension_debugging.rst
+++ b/docs/reference/c_extension_debugging.rst
@@ -63,6 +63,7 @@ Take your test image, and make a really simple harness.
 ::
 
     from PIL import Image
+
     with Image.open(path) as im:
         im.load()
 

--- a/docs/reference/open_files.rst
+++ b/docs/reference/open_files.rst
@@ -14,17 +14,17 @@ The following are all equivalent::
     import io
     import pathlib
 
-    with Image.open('test.jpg') as im:
+    with Image.open("test.jpg") as im:
         ...
 
-    with Image.open(pathlib.Path('test.jpg')) as im2:
+    with Image.open(pathlib.Path("test.jpg")) as im2:
         ...
 
-    with open('test.jpg', 'rb') as f:
+    with open("test.jpg", "rb") as f:
         im3 = Image.open(f)
         ...
 
-    with open('test.jpg', 'rb') as f:
+    with open("test.jpg", "rb") as f:
         im4 = Image.open(io.BytesIO(f.read()))
         ...
 
@@ -65,10 +65,10 @@ Image Lifecycle
 
 .. code-block:: python
 
-      with Image.open("test.jpg") as img:
-         img.load()
-      assert img.fp is None
-      img.save("test.png")
+    with Image.open("test.jpg") as img:
+        img.load()
+    assert img.fp is None
+    img.save("test.png")
 
 
 The lifecycle of a single-frame image is relatively simple. The file must
@@ -90,13 +90,13 @@ Complications
 
 * After a file has been closed, operations that require file access will fail::
 
-    with open('test.jpg', 'rb') as f:
+    with open("test.jpg", "rb") as f:
         im5 = Image.open(f)
-    im5.load() # FAILS, closed file
+    im5.load()  # FAILS, closed file
 
-    with Image.open('test.jpg') as im6:
+    with Image.open("test.jpg") as im6:
         pass
-    im6.load() # FAILS, closed file
+    im6.load()  # FAILS, closed file
 
 
 Proposed File Handling


### PR DESCRIPTION
- Apply black formatting to various code examples
- At https://pillow.readthedocs.io/en/latest/handbook/writing-your-own-file-decoder.html#the-raw-decoder, "raw mode" is listed as two words. If this is Python code, it should be one word.