### PR TITLE
Use latin1 encoding to decode bytes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ def _find_library_dirs_ldconfig():
         return []
     [data, _] = p.communicate()
     if isinstance(data, bytes):
-        data = data.decode()
+        data = data.decode("latin1")
 
     dirs = []
     for dll in re.findall(expr, data):


### PR DESCRIPTION
Resolves #5865

That issue reports an error decoding bytes. A self-contained example of that error is
```pycon
>>> bytes(list(range(46))+[231, 1]).decode()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe7 in position 46: invalid continuation byte
```
It can be fixed by using "latin1"
```pycon
>>> bytes(list(range(46))+[231, 1]).decode("latin1")
'\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !"#$%&\'()*+,-ç\x01'
```

"latin1" is already used in two other places in setup.py - https://github.com/python-pillow/Pillow/blob/c5d9223a8b5e9295d15b5a9b1ef1dae44c8499f3/setup.py#L412 and https://github.com/python-pillow/Pillow/blob/c5d9223a8b5e9295d15b5a9b1ef1dae44c8499f3/setup.py#L528