### PR TITLE
Fixed raising OSError in _safe_read when size is greater than SAFEBLOCK

### DIFF
--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -545,12 +545,13 @@ def _safe_read(fp, size):
             raise OSError("Truncated File Read")
         return data
     data = []
-    while size > 0:
-        block = fp.read(min(size, SAFEBLOCK))
+    remaining_size = size
+    while remaining_size > 0:
+        block = fp.read(min(remaining_size, SAFEBLOCK))
         if not block:
             break
         data.append(block)
-        size -= len(block)
+        remaining_size -= len(block)
     if sum(len(d) for d in data) < size:
         raise OSError("Truncated File Read")
     return b"".join(data)


### PR DESCRIPTION
Resolves #5871

I have contrived a test so that BmpImagePlugin will try to call `ImageFile._safe_read` with a `size` greater than `ImageFile.SAFEBLOCK` on a truncated file.

Without this PR, a truncation error is not raised [as advertised.](https://github.com/python-pillow/Pillow/blob/c5d9223a8b5e9295d15b5a9b1ef1dae44c8499f3/src/PIL/ImageFile.py#L537)

With this PR, it is.