### PR TITLE
unnecessary values

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1111,7 +1111,8 @@ class Image:
         from . import ImagePalette
 
         mode = im.im.getpalettemode()
-        im.palette = ImagePalette.ImagePalette(mode, im.im.getpalette(mode, mode))
+        palette = im.im.getpalette(mode, mode)[: colors * len(mode)]
+        im.palette = ImagePalette.ImagePalette(mode, palette)
 
         return im
 


### PR DESCRIPTION
Fixes #5877 .

Changes proposed in this pull request:
Pillow is saving all 256 colors in palette even if only 2 colors are defined thus increasing the size of the pngs significantly.
We use paletted pngs to save space and bandwidth but we have to manually remove palette from all pngs saved by Pillow. (In old version we would simply remove img.palette.palette altogether and png would be saved properly. In new versions it's no longer possible so we have to cut it to correct size)
Python code provided should show exact way how palettes are being increased in size by this issue.
 * 
 * 
 * 
