### PR TITLE
Dedicate the next release to Fredrik Lundh

### DIFF
--- a/docs/releasenotes/9.0.0.rst
+++ b/docs/releasenotes/9.0.0.rst
@@ -1,6 +1,29 @@
 9.0.0
 -----
 
+Fredrik Lundh
+=============
+
+This release is dedicated to the memory of Fredrik Lundh, aka Effbot, who died in
+November 2021. Fredrik created PIL in 1995 and he was instrumental in the early
+success of Python.
+
+`Guido wrote <https://mail.python.org/archives/list/python-dev@python.org/thread/36Q5QBILL3QIFIA3KHNGFBNJQKXKN7SD/>`_:
+
+    Fredrik was an early Python contributor (e.g. Elementtree and the 're'
+    module) and his enthusiasm for the language and community were inspiring
+    for all who encountered him or his work. He spent countless hours on
+    comp.lang.python answering questions from newbies and advanced users alike.
+
+    He also co-founded an early Python startup, Secret Labs AB, which among
+    other software released an IDE named PythonWorks. Fredrik also created the
+    Python Imaging Library (PIL) which is still THE way to interact with images
+    in Python, now most often through its Pillow fork. His effbot.org site was
+    a valuable resource for generations of Python users, especially its Tkinter
+    documentation.
+
+Thank you, Fredrik.
+
 Backwards Incompatible Changes
 ==============================
 


### PR DESCRIPTION
I thought it would be a nice gesture to dedicate the next release to Fredrik's memory. Guido said it was okay to quote part of his post.

@python-pillow/pillow-team

Preview:

* https://pillow--5885.org.readthedocs.build/en/5885/releasenotes/9.0.0.html