### PR TITLE
GHA: Use macos-10.15 to fix build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-          "macOS-latest",
+          "macos-10.15",
           "ubuntu-latest",
         ]
         python-version: [
@@ -29,7 +29,7 @@ jobs:
         # Include new variables for Codecov
         - os: ubuntu-latest
           codecov-flag: GHA_Ubuntu
-        - os: macOS-latest
+        - os: macos-10.15
           codecov-flag: GHA_macOS
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Changes proposed in this pull request:

 * This repo has switched from `macos-10.15` to `macos-11` for `macos-latest`, but it's failing the build
 * The quick fix to get the CI back to green is to explicitly use `macos-10.15`

---

 For reference, here's logs from the last pass and first fail:

   * [last pass](https://github.com/python-pillow/Pillow/runs/4497134031?check_suite_focus=true): [logs_16004.zip](https://github.com/python-pillow/Pillow/files/7712892/logs_16004.zip)
   * [first fail](https://github.com/python-pillow/Pillow/runs/4518959612?check_suite_focus=true): [logs_16005.zip](https://github.com/python-pillow/Pillow/files/7712893/logs_16005.zip)

Last pass:

```
2021-12-12T09:46:43.0437590Z Processing dependencies for Pillow==9.0.0.dev0
2021-12-12T09:46:43.0460460Z Finished processing dependencies for Pillow==9.0.0.dev0
```

First fail:

```
2021-12-13T22:19:37.7945510Z Processing dependencies for Pillow==9.0.0.dev0
2021-12-13T22:19:37.7949620Z Searching for Pillow==9.0.0.dev0
2021-12-13T22:19:37.7951660Z Reading https://pypi.org/simple/Pillow/
2021-12-13T22:19:40.9891760Z No local packages or working download links found for Pillow==9.0.0.dev0
2021-12-13T22:19:40.9903990Z error: Could not find suitable distribution for Requirement.parse('Pillow==9.0.0.dev0')
2021-12-13T22:19:40.9974850Z make: *** [install-coverage] Error 1
2021-12-13T22:19:40.9991600Z ##[error]Process completed with exit code 2.
```