### PR TITLE
Keep IPython/Jupyter text/plain output stable

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -88,6 +88,17 @@ class TestImage:
         # with pytest.raises(MemoryError):
         #   Image.new("L", (1000000, 1000000))
 
+    def test_repr_pretty(self):
+        class Pretty:
+            def text(self, text):
+                self.pretty_output = text
+
+        im = Image.new("L", (100, 100))
+
+        p = Pretty()
+        im._repr_pretty_(p, None)
+        assert p.pretty_output == "<PIL.Image.Image image mode=L size=100x100>"
+
     def test_open_formats(self):
         PNGFILE = "Tests/images/hopper.png"
         JPGFILE = "Tests/images/hopper.jpg"

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -649,13 +649,16 @@ class Image:
 
         # Same as __repr__ but without unpredicatable id(self),
         # to keep Jupyter notebook `text/plain` output stable.
-        p.text("<%s.%s image mode=%s size=%dx%d>" % (
-            self.__class__.__module__,
-            self.__class__.__name__,
-            self.mode,
-            self.size[0],
-            self.size[1],
-        ))
+        p.text(
+            "<%s.%s image mode=%s size=%dx%d>"
+            % (
+                self.__class__.__module__,
+                self.__class__.__name__,
+                self.mode,
+                self.size[0],
+                self.size[1],
+            )
+        )
 
     def _repr_png_(self):
         """iPython display hook support

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -644,6 +644,19 @@ class Image:
             id(self),
         )
 
+    def _repr_pretty_(self, p, cycle):
+        """IPython plain text display support"""
+
+        # Same as __repr__ but without unpredicatable id(self),
+        # to keep Jupyter notebook `text/plain` output stable.
+        p.text("<%s.%s image mode=%s size=%dx%d>" % (
+            self.__class__.__module__,
+            self.__class__.__name__,
+            self.mode,
+            self.size[0],
+            self.size[1],
+        ))
+
     def _repr_png_(self):
         """iPython display hook support
 


### PR DESCRIPTION
Fixes #5890.

Introduce `Image._repr_pretty_` as an alternative to `__repr__` for Jupyter notebook environment.

After this change `text/plain` output in Jupyter notebook will stay the same after re-running the cell:

```diff
$ git diff test.ipynb
diff --git a/test.ipynb b/test.ipynb
index f769d4b..4f8ba79 100644
--- a/test.ipynb
+++ b/test.ipynb
@@ -9,7 +9,7 @@
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGUlEQVR4nGPc62fCQApgIkn1qIZRDUNKAwADRwFfBBwAnwAAAABJRU5ErkJggg==",
       "text/plain": [
-       "<PIL.Image.Image image mode=RGB size=16x16 at 0x1075D8370>"
+       "<PIL.Image.Image image mode=RGB size=16x16>"
       ]
      },
      "execution_count": 1,
```