### PR TITLE
Switched from deprecated "setup.py install" to "pip install ."

### DIFF
--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -60,7 +60,7 @@ jobs:
           pushd depends && ./install_extra_test_images.sh && popd
 
       - name: Build Pillow
-        run: CFLAGS="-coverage" python3 setup.py build_ext install
+        run: CFLAGS="-coverage" python3 -m pip install --global-option="build_ext" .
 
       - name: Test Pillow
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,17 +31,6 @@ jobs:
           codecov-flag: GHA_Ubuntu
         - os: macos-latest
           codecov-flag: GHA_macOS
-        - os: macos-10.15
-          codecov-flag: GHA_macOS
-          python-version: pypy-3.8
-        - os: macos-10.15
-          codecov-flag: GHA_macOS
-          python-version: pypy-3.7
-        exclude:
-        - os: macos-latest
-          python-version: pypy-3.8
-        - os: macos-latest
-          python-version: pypy-3.7
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/Makefile
+++ b/Makefile
@@ -54,12 +54,12 @@ inplace: clean
 
 .PHONY: install
 install:
-	python3 setup.py install
+	python3 -m pip install .
 	python3 selftest.py
 
 .PHONY: install-coverage
 install-coverage:
-	CFLAGS="-coverage -Werror=implicit-function-declaration" python3 setup.py build_ext install
+	CFLAGS="-coverage -Werror=implicit-function-declaration" python3 -m pip install --global-option="build_ext" .
 	python3 selftest.py
 
 .PHONY: debug
@@ -68,7 +68,7 @@ debug:
 # for our stuff, kills optimization, and redirects to dev null so we
 # see any build failures.
 	make clean > /dev/null
-	CFLAGS='-g -O0' python3 setup.py build_ext install > /dev/null
+	CFLAGS='-g -O0' python3 -m pip install --global-option="build_ext" . > /dev/null
 
 .PHONY: install-req
 install-req:
@@ -86,7 +86,7 @@ release-test:
 	python3 setup.py develop
 	python3 selftest.py
 	python3 -m pytest Tests
-	python3 setup.py install
+	python3 -m pip install .
 	-rm dist/*.egg
 	-rmdir dist
 	python3 -m pytest -qq

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ help:
 
 .PHONY: inplace
 inplace: clean
-	python3 setup.py develop build_ext --inplace
+	python3 -m pip install -e --global-option="build_ext" --global-option="--inplace" .
 
 .PHONY: install
 install:
@@ -83,7 +83,7 @@ install-venv:
 .PHONY: release-test
 release-test:
 	$(MAKE) install-req
-	python3 setup.py develop
+	python3 -m pip install -e .
 	python3 selftest.py
 	python3 -m pytest Tests
 	python3 -m pip install .

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -275,10 +275,6 @@ Build Options
 
 Sample usage::
 
-    MAX_CONCURRENCY=1 python3 setup.py build_ext --enable-[feature] install
-
-or using pip::
-
     python3 -m pip install --upgrade Pillow --global-option="build_ext" --global-option="--enable-[feature]"
 
 
@@ -310,7 +306,7 @@ Now install Pillow with::
 
 or from within the uncompressed source directory::
 
-    python3 setup.py install
+    python3 -m pip install .
 
 Building on Windows
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Replaces `setup.py install` with `pip install .`, as per https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html

As worked out by https://github.com/pypa/setuptools/issues/2929, this also fixes the problem found in #5886. So this PR reverts #5886 and #5888.