### PR TITLE
Added ImageShow support for xdg-open

### DIFF
--- a/docs/reference/ImageShow.rst
+++ b/docs/reference/ImageShow.rst
@@ -17,6 +17,7 @@ All default viewers convert the image to be shown to PNG format.
 
     The following viewers may be registered on Unix-based systems, if the given command is found:
 
+    .. autoclass:: PIL.ImageShow.XDGViewer
     .. autoclass:: PIL.ImageShow.DisplayViewer
     .. autoclass:: PIL.ImageShow.GmDisplayViewer
     .. autoclass:: PIL.ImageShow.EogViewer

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -186,6 +186,16 @@ class UnixViewer(Viewer):
         return 1
 
 
+class XDGViewer(UnixViewer):
+    """
+    The freedesktop.org ``xdg-open`` command.
+    """
+
+    def get_command_ex(self, file, **options):
+        command = executable = "xdg-open"
+        return command, executable
+
+
 class DisplayViewer(UnixViewer):
     """
     The ImageMagick ``display`` command.
@@ -233,6 +243,8 @@ class XVViewer(UnixViewer):
 
 
 if sys.platform not in ("win32", "darwin"):  # unixoids
+    if shutil.which("xdg-open"):
+        register(XDGViewer)
     if shutil.which("display"):
         register(DisplayViewer)
     if shutil.which("gm"):


### PR DESCRIPTION
`xdg-open` is reliable way to open image with preferred application.
It works on linux and BSD with any desktop environment.

Debugging process should be comfortable.