### PR TITLE
Fixed typo

### DIFF
--- a/src/_webp.c
+++ b/src/_webp.c
@@ -486,7 +486,7 @@ static struct PyMethodDef _anim_encoder_methods[] = {
     {NULL, NULL} /* sentinel */
 };
 
-// WebPAnimDecoder type definition
+// WebPAnimEncoder type definition
 static PyTypeObject WebPAnimEncoder_Type = {
     PyVarObject_HEAD_INIT(NULL, 0) "WebPAnimEncoder", /*tp_name */
     sizeof(WebPAnimEncoderObject),                    /*tp_size */


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/591e79e01e16ef9580257e741944e22aac657526/src/_webp.c#L489-L490

This is not the WebPAnim**Decoder** type definition.

Presumably it was just copy-and-pasted from the WebPAnimDecoder type definition.

https://github.com/python-pillow/Pillow/blob/591e79e01e16ef9580257e741944e22aac657526/src/_webp.c#L532-L533