### PR TITLE
Replaced further direct invocations of setup.py

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ minversion = 1.9
 
 [testenv]
 commands =
-    {envpython} setup.py clean
-    {envpython} setup.py build_ext --inplace
+    make clean
+    {envpython} -m pip install --global-option="build_ext" --global-option="--inplace" .
     {envpython} selftest.py
     {envpython} -m pytest -W always {posargs}
 deps =


### PR DESCRIPTION
Continuing the work started with #5896, since [invoking setup.py directly is deprecated.](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html)