### PR TITLE
Do not compare properties to themselves

### DIFF
--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -41,7 +41,7 @@ def test_sanity():
 def test_default():
 
     im = hopper("P")
-    assert_image(im, "P", im.size)
+    assert im.mode == "P"
     converted_im = im.convert()
     assert_image(converted_im, "RGB", im.size)
     converted_im = im.convert()

--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -2,18 +2,18 @@ import pytest
 
 from PIL import Image
 
-from .helper import assert_image, assert_image_similar, hopper, is_ppc64le
+from .helper import assert_image_similar, hopper, is_ppc64le
 
 
 def test_sanity():
     image = hopper()
     converted = image.quantize()
-    assert_image(converted, "P", converted.size)
+    assert converted.mode == "P"
     assert_image_similar(converted.convert("RGB"), image, 10)
 
     image = hopper()
     converted = image.quantize(palette=hopper("P"))
-    assert_image(converted, "P", converted.size)
+    assert converted.mode == "P"
     assert_image_similar(converted.convert("RGB"), image, 60)
 
 
@@ -27,7 +27,7 @@ def test_libimagequant_quantize():
             pytest.skip("libimagequant support not available")
         else:
             raise
-    assert_image(converted, "P", converted.size)
+    assert converted.mode == "P"
     assert_image_similar(converted.convert("RGB"), image, 15)
     assert len(converted.getcolors()) == 100
 
@@ -35,7 +35,7 @@ def test_libimagequant_quantize():
 def test_octree_quantize():
     image = hopper()
     converted = image.quantize(100, Image.FASTOCTREE)
-    assert_image(converted, "P", converted.size)
+    assert converted.mode == "P"
     assert_image_similar(converted.convert("RGB"), image, 20)
     assert len(converted.getcolors()) == 100
 
@@ -52,7 +52,7 @@ def test_quantize():
     with Image.open("Tests/images/caption_6_33_22.png") as image:
         image = image.convert("RGB")
     converted = image.quantize()
-    assert_image(converted, "P", converted.size)
+    assert converted.mode == "P"
     assert_image_similar(converted.convert("RGB"), image, 1)
 
 
@@ -62,7 +62,7 @@ def test_quantize_no_dither():
         palette = palette.convert("P")
 
     converted = image.quantize(dither=0, palette=palette)
-    assert_image(converted, "P", converted.size)
+    assert converted.mode == "P"
     assert converted.palette.palette == palette.palette.palette
 
 

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -6,7 +6,7 @@ import pytest
 
 from PIL import Image, ImageGrab
 
-from .helper import assert_image, assert_image_equal_tofile, skip_unless_feature
+from .helper import assert_image_equal_tofile, skip_unless_feature
 
 
 class TestImageGrab:
@@ -14,25 +14,20 @@ class TestImageGrab:
         sys.platform not in ("win32", "darwin"), reason="requires Windows or macOS"
     )
     def test_grab(self):
-        for im in [
-            ImageGrab.grab(),
-            ImageGrab.grab(include_layered_windows=True),
-            ImageGrab.grab(all_screens=True),
-        ]:
-            assert_image(im, im.mode, im.size)
+        ImageGrab.grab()
+        ImageGrab.grab(include_layered_windows=True)
+        ImageGrab.grab(all_screens=True)
 
         im = ImageGrab.grab(bbox=(10, 20, 50, 80))
-        assert_image(im, im.mode, (40, 60))
+        assert im.size == (40, 60)
 
     @skip_unless_feature("xcb")
     def test_grab_x11(self):
         try:
             if sys.platform not in ("win32", "darwin"):
-                im = ImageGrab.grab()
-                assert_image(im, im.mode, im.size)
+                ImageGrab.grab()
 
-            im2 = ImageGrab.grab(xdisplay="")
-            assert_image(im2, im2.mode, im2.size)
+            ImageGrab.grab(xdisplay="")
         except OSError as e:
             pytest.skip(str(e))
 
@@ -71,8 +66,7 @@ $bmp = New-Object Drawing.Bitmap 200, 200
             assert str(e.value) == "ImageGrab.grabclipboard() is macOS and Windows only"
             return
 
-        im = ImageGrab.grabclipboard()
-        assert_image(im, im.mode, im.size)
+        ImageGrab.grabclipboard()
 
     @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
     def test_grabclipboard_file(self):


### PR DESCRIPTION
The `assert_image` helper method is useful to assert an image's mode and size.

https://github.com/python-pillow/Pillow/blob/9d0703a8a82d00ec01303d8b7f7d408964e9fb9f/Tests/helper.py#L77-L86

However, I think that
```python
assert_image(im, "P", im.size)
```
could be more clearly expressed as
```python
assert im.mode == "P"
```
Similarly,
```python
assert_image(im, im.mode, (40, 60))
```
should be changed to
```python
assert im.size == (40, 60)
```
And
```python
assert_image(im, im.mode, im.size)
```
seems redundant.