### PR TITLE
Image.NONE is only used for resampling and dithers

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -138,8 +138,6 @@ def isImageType(t):
 #
 # Constants
 
-NONE = 0
-
 # transpose
 FLIP_LEFT_RIGHT = 0
 FLIP_TOP_BOTTOM = 1


### PR DESCRIPTION
In Image.py, we have
https://github.com/python-pillow/Pillow/blob/11c536b6d49b6d354157329643d1a58c7e1bf74d/src/PIL/Image.py#L159-L160

https://github.com/python-pillow/Pillow/blob/11c536b6d49b6d354157329643d1a58c7e1bf74d/src/PIL/Image.py#L170-L171

and

https://github.com/python-pillow/Pillow/blob/11c536b6d49b6d354157329643d1a58c7e1bf74d/src/PIL/Image.py#L139-L141

I can't see any use for the last one, so this PR suggests removing it. This does not change any functionality, since the other two code blocks still define `Image.NONE`.