### PR TITLE
Fixed freeing pointer in ImageDraw.Outline.transform

### DIFF
--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -467,6 +467,23 @@ def test_shape2():
     assert_image_equal_tofile(im, "Tests/images/imagedraw_shape2.png")
 
 
+def test_transform():
+    # Arrange
+    im = Image.new("RGB", (100, 100), "white")
+    expected = im.copy()
+    draw = ImageDraw.Draw(im)
+
+    # Act
+    s = ImageDraw.Outline()
+    s.line(0, 0)
+    s.transform((0, 0, 0, 0, 0, 0))
+
+    draw.shape(s, fill=1)
+
+    # Assert
+    assert_image_equal(im, expected)
+
+
 def helper_pieslice(bbox, start, end):
     # Arrange
     im = Image.new("RGB", (W, H))

--- a/src/libImaging/Draw.c
+++ b/src/libImaging/Draw.c
@@ -1854,14 +1854,8 @@ ImagingOutlineTransform(ImagingOutline outline, double a[6]) {
     eIn = outline->edges;
     n = outline->count;
 
-    /* FIXME: ugly! */
-    outline->edges = NULL;
-    outline->count = outline->size = 0;
-
     eOut = allocate(outline, n);
     if (!eOut) {
-        outline->edges = eIn;
-        outline->count = outline->size = n;
         ImagingError_MemoryError();
         return -1;
     }
@@ -1897,7 +1891,11 @@ ImagingOutlineTransform(ImagingOutline outline, double a[6]) {
         eOut++;
     }
 
-    free(eIn);
+    free(outline->edges);
+
+    /* FIXME: ugly! */
+    outline->edges = NULL;
+    outline->count = outline->size = 0;
 
     return 0;
 }


### PR DESCRIPTION
The following code will crash when trying to free a pointer.

```python
>>> from PIL import ImageDraw
>>> o = ImageDraw.Outline()
>>> o.line(0, 0)
>>> o.transform((0, 0, 0, 0, 0, 0))
```

This PR fixes it.