### PR TITLE
Exclude carriage return in PDF regex to help prevent ReDoS

### DIFF
--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -313,8 +313,9 @@ def test_pdf_append_to_bytesio():
 
 
 @pytest.mark.timeout(1)
-def test_redos():
-    malicious = b" trailer<<>>" + b"\n" * 3456
+@pytest.mark.parametrize("newline", (b"\r", b"\n"))
+def test_redos(newline):
+    malicious = b" trailer<<>>" + newline * 3456
 
     # This particular exception isn't relevant here.
     # The important thing is it doesn't timeout, cause a ReDoS (CVE-2021-25292).

--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -582,7 +582,8 @@ class PdfParser:
     whitespace_or_hex = br"[\000\011\012\014\015\0400-9a-fA-F]"
     whitespace_optional = whitespace + b"*"
     whitespace_mandatory = whitespace + b"+"
-    whitespace_optional_no_nl = br"[\000\011\014\015\040]*"  # no "\012" aka "\n"
+    # No "\012" aka "\n" or "\015" aka "\r":
+    whitespace_optional_no_nl = br"[\000\011\014\040]*"
     newline_only = br"[\r\n]+"
     newline = whitespace_optional_no_nl + newline_only + whitespace_optional_no_nl
     re_trailer_end = re.compile(


### PR DESCRIPTION
Like https://github.com/python-pillow/Pillow/commit/3bce145966374dd39ce58a6fc0083f8d1890719c and #5393, except with `\r` instead of `\n`.