### PR TITLE
Added sys import

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1,6 +1,7 @@
 import io
 import os
 import shutil
+import sys
 import tempfile
 
 import pytest


### PR DESCRIPTION
`import sys` was removed from Tests/test_image.py in #5768.

This was fine, until #5807 was merged and it was needed again - leading to main failing at the moment.