### PR TITLE
Removed redundant part of condition

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -812,7 +812,7 @@ class Image:
             palette_length = self.im.putpalette(mode, arr)
             self.palette.dirty = 0
             self.palette.rawmode = None
-            if "transparency" in self.info and mode in ("RGBA", "LA", "PA"):
+            if "transparency" in self.info and mode in ("LA", "PA"):
                 if isinstance(self.info["transparency"], int):
                     self.im.putpalettealpha(self.info["transparency"], 0)
                 else:


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/aa287bc9349ae298c68f875a9b9164c5bb85a1f2/src/PIL/Image.py#L806-L815

#5914 points out that `mode` will never be RGBA in the last line.
> Unless I'm reading this incorrectly, the addition of the check on mode means that this won't ever evaluate to True, because mode is set back to RGB a few lines above?

Setting RGBA modes to RGB was introduced in #5089.

This PR just removes the check for RGBA in the last line, since it is not needed.