### PR TITLE
Updated winbuild libimagequant to 2.17.0

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -257,10 +257,10 @@ deps = {
         "libs": [r"bin\*.lib"],
     },
     "libimagequant": {
-        # commit: Merge branch 'master' into msvc (matches 2.16.0 tag)
-        "url": "https://github.com/ImageOptim/libimagequant/archive/f41ee301ff3a407b16991af3dbe03910919bbdc3.zip",  # noqa: E501
-        "filename": "libimagequant-f41ee301ff3a407b16991af3dbe03910919bbdc3.zip",
-        "dir": "libimagequant-f41ee301ff3a407b16991af3dbe03910919bbdc3",
+        # commit: Merge branch 'master' into msvc (matches 2.17.0 tag)
+        "url": "https://github.com/ImageOptim/libimagequant/archive/e4c1334be0eff290af5e2b4155057c2953a313ab.zip",  # noqa: E501
+        "filename": "libimagequant-e4c1334be0eff290af5e2b4155057c2953a313ab.zip",
+        "dir": "libimagequant-e4c1334be0eff290af5e2b4155057c2953a313ab",
         "patch": {
             "CMakeLists.txt": {
                 "if(OPENMP_FOUND)": "if(false)",


### PR DESCRIPTION
Just for context, suggested in https://github.com/python-pillow/Pillow/pull/5811#discussion_r776074823

This updates libimagequant to the latest commit in the [msvc branch](https://github.com/ImageOptim/libimagequant/tree/msvc), after merging in master at [the 2.17.0 tag.](https://github.com/ImageOptim/libimagequant/tree/2.17.0)