### PR TITLE
Ensure JpegImagePlugin stops at the end of a truncated file

### DIFF
--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -401,9 +401,10 @@ class JpegImageFile(ImageFile.ImageFile):
         """
         s = self.fp.read(read_bytes)
 
-        if not s and ImageFile.LOAD_TRUNCATED_IMAGES:
+        if not s and ImageFile.LOAD_TRUNCATED_IMAGES and not hasattr(self, "_ended"):
             # Premature EOF.
             # Pretend file is finished adding EOI marker
+            self._ended = True
             return b"\xFF\xD9"
 
         return s


### PR DESCRIPTION
``JpegImagePlugin`` may append an EOF marker to the end of a truncated file, so that the last segment of the data will still be processed by the decoder.

If the EOF marker is not detected as such however, this could lead to an infinite loop where ``JpegImagePlugin`` keeps trying to end the file.