### PR TITLE
Remove readonly from Image.__eq__

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -627,7 +627,6 @@ class Image:
             and self.size == other.size
             and self.info == other.info
             and self._category == other._category
-            and self.readonly == other.readonly
             and self.getpalette() == other.getpalette()
             and self.tobytes() == other.tobytes()
         )


### PR DESCRIPTION
Fixes https://github.com/python-pillow/Pillow/issues/5926.

Changes proposed in this pull request:

 * The `readonly` flag causes issues with `Image` equality, and is not needed for recreating pickled images (added in https://github.com/python-pillow/Pillow/pull/638)
