### PR TITLE
Add missing ImageModes

### DIFF
--- a/src/PIL/ImageMode.py
+++ b/src/PIL/ImageMode.py
@@ -52,6 +52,11 @@ def getmode(mode):
             "HSV": ("RGB", "L", ("H", "S", "V")),
             # extra experimental modes
             "RGBa": ("RGB", "L", ("R", "G", "B", "a")),
+            "BGR": ("BGR", "L", ("B", "G", "R")),
+            "BGR;15": ("RGB", "L", ("B", "G", "R")),
+            "BGR;16": ("RGB", "L", ("B", "G", "R")),
+            "BGR;24": ("RGB", "L", ("B", "G", "R")),
+            "BGR;32": ("RGB", "L", ("B", "G", "R")),
             "LA": ("L", "L", ("L", "A")),
             "La": ("L", "L", ("L", "a")),
             "PA": ("RGB", "L", ("P", "A")),

--- a/src/PIL/ImageMode.py
+++ b/src/PIL/ImageMode.py
@@ -52,7 +52,6 @@ def getmode(mode):
             "HSV": ("RGB", "L", ("H", "S", "V")),
             # extra experimental modes
             "RGBa": ("RGB", "L", ("R", "G", "B", "a")),
-            "BGR": ("BGR", "L", ("B", "G", "R")),
             "BGR;15": ("RGB", "L", ("B", "G", "R")),
             "BGR;16": ("RGB", "L", ("B", "G", "R")),
             "BGR;24": ("RGB", "L", ("B", "G", "R")),


### PR DESCRIPTION
Fixes #5933

This PR adds the modes mentioned in the docs to ImageMode. It also adds the mode `BGR` to be used as a basetype for the missing modes.

---

Sidenote: To get pillow 9.1.0.dev0 to build on Windows I had to do some modifications to the script in `winbuild\README.md`, e.g., because the script/snippet builds for python3.8, but calls python3.7 to prepare - which I don't have. I will leave my modified script here, since I don't know where else to put it, but if there is interest in a dedicated DOC PR for this, I can do that, too:

```cmd
set PYTHON=C:\Users\<username>\AppData\Local\Programs\Python\Python38
set PILLOW_REPO=<git-clone-location>\Pillow

cd /D %PILLOW_REPO%\winbuild
%PYTHON%\python.exe build_prepare.py -v --depends=%PILLOW_REPO%\depends
build\build_dep_all.cmd
build\build_pillow.cmd install

path %PILLOW_REPO%\winbuild\build\bin;%PATH%
%PYTHON%\python.exe -m pip install -U -e .
%PYTHON%\python.exe selftest.py
%PYTHON%\python.exe -m pytest -vx --cov PIL --cov Tests --cov-report term --cov-report xml Tests
%PILLOW_REPO%\winbuild\build\build_pillow.cmd bdist_wheel
```

Sidenote2: I didn't manage to get the full test suite to pass after building pillow. One test (`Tests/test_image_access.py::TestEmbeddable::test_embeddable`) keeps failing. However, I think this is because the test can't find `python38.lib` on my system rather than something related to the PR.