### PR TITLE
Return an empty bytestring from tobytes() for an empty image

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -786,6 +786,11 @@ class TestImage:
                 34665: 196,
             }
 
+    @pytest.mark.parametrize("size", ((1, 0), (0, 1), (0, 0)))
+    def test_zero_tobytes(self, size):
+        im = Image.new("RGB", size)
+        assert im.tobytes() == b""
+
     def test_categories_deprecation(self):
         with pytest.warns(DeprecationWarning):
             assert hopper().category == 0

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -716,6 +716,9 @@ class Image:
 
         self.load()
 
+        if self.width == 0 or self.height == 0:
+            return b""
+
         # unpack data
         e = _getencoder(self.mode, encoder_name, args)
         e.setimage(self.im)


### PR DESCRIPTION
Resolves #5931

```pycon
>>> from PIL import Image
>>> Image.new("RGB", (1, 2)).tobytes()
b'\x00\x00\x00\x00\x00\x00'
>>> Image.new("RGB", (1, 1)).tobytes()
b'\x00\x00\x00'
```
given this progression, you would expect
```pycon
>>> Image.new("RGB", (1, 0)).tobytes()
```
to give
```pycon
b''
```

However, instead it currently throws an error.
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/Image.py", line 748, in tobytes
    e.setimage(self.im)
SystemError: tile cannot extend outside image
```

This PR returns an empty bytestring instead.