### PR TITLE
Add CVE IDs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,13 +5,13 @@ Changelog (Pillow)
 9.0.0 (2022-01-02)
 ------------------
 
-- Restrict builtins for ImageMath.eval(). CVE TBD #5923
+- Restrict builtins for ImageMath.eval(). CVE-2022-22817 #5923
   [radarhere]
 
 - Ensure JpegImagePlugin stops at the end of a truncated file #5921
   [radarhere]
 
-- Fixed ImagePath.Path array handling. CVEs TBD #5920
+- Fixed ImagePath.Path array handling. CVE-2022-22815, CVE-2022-22816 #5920
   [radarhere]
 
 - Remove consecutive duplicate tiles that only differ by their offset #5919

--- a/docs/releasenotes/9.0.0.rst
+++ b/docs/releasenotes/9.0.0.rst
@@ -119,15 +119,16 @@ Google's `OSS-Fuzz`_ project for finding this issue.
 Restrict builtins available to ImageMath.eval
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To limit :py:class:`PIL.ImageMath` to working with images, Pillow will now restrict the
-builtins available to :py:meth:`PIL.ImageMath.eval`. This will help prevent problems
-arising if users evaluate arbitrary expressions, such as
-``ImageMath.eval("exec(exit())")``. CVE TBD
+:cve:`CVE-2022-22817`: To limit :py:class:`PIL.ImageMath` to working with images, Pillow
+will now restrict the builtins available to :py:meth:`PIL.ImageMath.eval`. This will
+help prevent problems arising if users evaluate arbitrary expressions, such as
+``ImageMath.eval("exec(exit())")``.
 
 Fixed ImagePath.Path array handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-CWE-126 and CWE-665 were found when initializing ``ImagePath.Path``. CVEs TBD
+:cve:`CVE-2022-22815` (CWE-126) and :cve:`CVE-2022-22816` (CWE-665) were found when
+initializing ``ImagePath.Path``.
 
 .. _OSS-Fuzz: https://github.com/google/oss-fuzz
 


### PR DESCRIPTION
CVEs received for:

* Restrict builtins for ImageMath.eval(). CVE-2022-22817 #5923
* Fixed ImagePath.Path array handling. CVE-2022-22815, CVE-2022-22816 #5920