### PR TITLE
Added specific error if ImagePath coordinate type is incorrect

### DIFF
--- a/Tests/test_imagepath.py
+++ b/Tests/test_imagepath.py
@@ -70,8 +70,10 @@ def test_invalid_coords():
     coords = ["a", "b"]
 
     # Act / Assert
-    with pytest.raises(SystemError):
+    with pytest.raises(ValueError) as e:
         ImagePath.Path(coords)
+
+    assert str(e.value) == "incorrect coordinate type"
 
 
 def test_path_odd_number_of_coordinates():

--- a/src/path.c
+++ b/src/path.c
@@ -162,42 +162,37 @@ PyPath_Flatten(PyObject *data, double **pxy) {
         return -1;
     }
 
+#define assign_item_to_array(op, decref) \
+if (PyFloat_Check(op)) { \
+    xy[j++] = PyFloat_AS_DOUBLE(op); \
+} else if (PyLong_Check(op)) { \
+    xy[j++] = (float)PyLong_AS_LONG(op); \
+} else if (PyNumber_Check(op)) { \
+    xy[j++] = PyFloat_AsDouble(op); \
+} else if (PyArg_ParseTuple(op, "dd", &x, &y)) { \
+    xy[j++] = x; \
+    xy[j++] = y; \
+} else { \
+    PyErr_SetString(PyExc_ValueError, "incorrect coordinate type"); \
+    if (decref) { \
+        Py_DECREF(op); \
+    } \
+    free(xy); \
+    return -1; \
+}
+
     /* Copy table to path array */
     if (PyList_Check(data)) {
         for (i = 0; i < n; i++) {
             double x, y;
             PyObject *op = PyList_GET_ITEM(data, i);
-            if (PyFloat_Check(op)) {
-                xy[j++] = PyFloat_AS_DOUBLE(op);
-            } else if (PyLong_Check(op)) {
-                xy[j++] = (float)PyLong_AS_LONG(op);
-            } else if (PyNumber_Check(op)) {
-                xy[j++] = PyFloat_AsDouble(op);
-            } else if (PyArg_ParseTuple(op, "dd", &x, &y)) {
-                xy[j++] = x;
-                xy[j++] = y;
-            } else {
-                free(xy);
-                return -1;
-            }
+            assign_item_to_array(op, 0);
         }
     } else if (PyTuple_Check(data)) {
         for (i = 0; i < n; i++) {
             double x, y;
             PyObject *op = PyTuple_GET_ITEM(data, i);
-            if (PyFloat_Check(op)) {
-                xy[j++] = PyFloat_AS_DOUBLE(op);
-            } else if (PyLong_Check(op)) {
-                xy[j++] = (float)PyLong_AS_LONG(op);
-            } else if (PyNumber_Check(op)) {
-                xy[j++] = PyFloat_AsDouble(op);
-            } else if (PyArg_ParseTuple(op, "dd", &x, &y)) {
-                xy[j++] = x;
-                xy[j++] = y;
-            } else {
-                free(xy);
-                return -1;
-            }
+            assign_item_to_array(op, 0);
         }
     } else {
         for (i = 0; i < n; i++) {
@@ -213,20 +208,7 @@ PyPath_Flatten(PyObject *data, double **pxy) {
                     return -1;
                 }
             }
-            if (PyFloat_Check(op)) {
-                xy[j++] = PyFloat_AS_DOUBLE(op);
-            } else if (PyLong_Check(op)) {
-                xy[j++] = (float)PyLong_AS_LONG(op);
-            } else if (PyNumber_Check(op)) {
-                xy[j++] = PyFloat_AsDouble(op);
-            } else if (PyArg_ParseTuple(op, "dd", &x, &y)) {
-                xy[j++] = x;
-                xy[j++] = y;
-            } else {
-                Py_DECREF(op);
-                free(xy);
-                return -1;
-            }
+            assign_item_to_array(op, 1);
             Py_DECREF(op);
         }
     }


### PR DESCRIPTION
Resolves #5939

When drawing a rectangle,
```python
from PIL import Image, ImageDraw
im = Image.new("RGB", (1, 1))
draw = ImageDraw.Draw(im)
draw.rectangle((0, 0, 1, 1))
```
if the wrong coordinate type is used,
```python
from PIL import Image, ImageDraw
im = Image.new("RGB", (1, 1))
draw = ImageDraw.Draw(im)
draw.rectangle(('0', '0', '1', '1'))
```
the error given is
```
Traceback (most recent call last):
  File "demo.py", line 4, in <module>
    draw.rectangle(('0', '0', '1', '1'))
  File "PIL/ImageDraw.py", line 259, in rectangle
    self.draw.draw_rectangle(xy, ink, 0, width)
SystemError: new style getargs format but argument is not a tuple
```
The issue points out that this is not terribly clear. Instead, this PR changes it to
```
Traceback (most recent call last):
  File "demo.py", line 4, in <module>
    draw.rectangle(('0', '0', '1', '1'))
  File "PIL/ImageDraw.py", line 279, in rectangle
ValueError: incorrect coordinate type
```

I also reduce some duplicate code at the same time.