### PR TITLE
Ensure duplicated file pointer is closed

### DIFF
--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1234,6 +1234,12 @@ class TiffImageFile(ImageFile.ImageFile):
             # UNDONE -- so much for that buffer size thing.
             n, err = decoder.decode(self.fp.read())
 
+        if fp:
+            try:
+                os.close(fp)
+            except OSError:
+                pass
+
         self.tile = []
         self.readonly = 0
 


### PR DESCRIPTION
Resolves #5936. Ensures that the file pointer duplicated in TiffImagePlugin is closed, rather than counting on libtiff to do it.

https://github.com/python-pillow/Pillow/blob/eff6c34bd13df9cba034c54fd0c270bebfb8a270/src/PIL/TiffImagePlugin.py#L1186-L1188

I haven't added a test for this, since the issue involves hitting the limit on the number of open files.