### PR TITLE
Do not write new images to disk until they have successfully completed

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -641,6 +641,15 @@ class TestImage:
                 im.save(temp_file)
             assert not record
 
+    def test_no_new_file_on_error(self, tmp_path):
+        temp_file = str(tmp_path / "temp.jpg")
+
+        im = Image.new("RGB", (0, 0))
+        with pytest.raises(SystemError):
+            im.save(temp_file)
+
+        assert not os.path.exists(temp_file)
+
     def test_load_on_nonexclusive_multiframe(self):
         with open("Tests/images/frozenpond.mpo", "rb") as fp:
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2202,16 +2202,23 @@ class Image:
         else:
             save_handler = SAVE[format.upper()]
 
+        new_file = False
         if open_fp:
             if params.get("append", False):
                 # Open also for reading ("+"), because TIFF save_all
                 # writer needs to go back and edit the written data.
                 fp = builtins.open(filename, "r+b")
+            elif not os.path.exists(filename):
+                new_file = True
+                fp = io.BytesIO()
             else:
                 fp = builtins.open(filename, "w+b")
 
         try:
             save_handler(self, fp, filename)
+            if new_file:
+                with builtins.open(filename, "w+b") as new_file_fp:
+                    new_file_fp.write(fp.getvalue())
         finally:
             # do what we can to clean up
             if open_fp:


### PR DESCRIPTION
Resolves #5944

Wait until an image has successfully finished saving before writing it to disk, rather than leaving behind a potentially corrupt image after an error.