### PR TITLE
Moved xdg-open to lowest priority

### DIFF
--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -243,8 +243,6 @@ class XVViewer(UnixViewer):
 
 
 if sys.platform not in ("win32", "darwin"):  # unixoids
-    if shutil.which("xdg-open"):
-        register(XDGViewer)
     if shutil.which("display"):
         register(DisplayViewer)
     if shutil.which("gm"):
@@ -253,6 +251,8 @@ if sys.platform not in ("win32", "darwin"):  # unixoids
         register(EogViewer)
     if shutil.which("xv"):
         register(XVViewer)
+    if shutil.which("xdg-open"):
+        register(XDGViewer)
 
 
 class IPythonViewer(Viewer):


### PR DESCRIPTION
Resolves #5945

In the issue, two users find that ImageShow no longer successfully passes images to `eog`. It would seem that #5897 calling `xdg-open` has introduced some delay that means that images are removed before the viewing application is finished with them.

We could add in a `sleep` to try and solve this, but I would think it is preferable to minimise the race condition.

This PR instead moves `xdg-open` to the lowest priority, so that `eog` can run directly.