### PR TITLE
Removed unused constant

### DIFF
--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -19,8 +19,6 @@ import builtins
 
 from . import Image, _imagingmath
 
-VERBOSE = 0
-
 
 def _isconstant(v):
     return isinstance(v, (int, float))

--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -74,9 +74,7 @@ class _Operand:
                     im1 = im1.crop((0, 0) + size)
                 if im2.size != size:
                     im2 = im2.crop((0, 0) + size)
-                out = Image.new(mode or im1.mode, size, None)
-            else:
-                out = Image.new(mode or im1.mode, im1.size, None)
+            out = Image.new(mode or im1.mode, im1.size, None)
             im1.load()
             im2.load()
             try:

--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -67,8 +67,6 @@ class _Operand:
                     im1 = im1.convert("F")
                 if im2.mode != "F":
                     im2 = im2.convert("F")
-                if im1.mode != im2.mode:
-                    raise ValueError("mode mismatch")
             if im1.size != im2.size:
                 # crop both arguments to a common size
                 size = (min(im1.size[0], im2.size[0]), min(im1.size[1], im2.size[1]))


### PR DESCRIPTION
`ImageMath.VERBOSE` has been unused since PIL, so this PR removes it.

While I'm here, I've also included two cleanup changes.
- https://github.com/python-pillow/Pillow/blob/9a9afd36b41c3ff511ec2788ad657c0757e24b3e/src/PIL/ImageMath.py#L68-L73 The `ValueError` cannot be reached, so I've removed it.
- https://github.com/python-pillow/Pillow/blob/9a9afd36b41c3ff511ec2788ad657c0757e24b3e/src/PIL/ImageMath.py#L76-L83 `im1.size` will equal `size` at the end of this code, meaning that the last three lines can be simplified to a single line.