### PR TITLE
Autolink CWE numbers with sphinx-issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Docs
       if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == 3.9
       run: |
-        python3 -m pip install sphinx-copybutton sphinx-issues sphinx-removed-in sphinx-rtd-theme sphinxext-opengraph
+        python3 -m pip install sphinx-copybutton sphinx-issues>=3.0.1 sphinx-removed-in sphinx-rtd-theme sphinxext-opengraph
         make doccheck
 
     - name: After success

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Docs
       if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == 3.9
       run: |
-        python3 -m pip install sphinx-copybutton sphinx-issues>=3.0.1 sphinx-removed-in sphinx-rtd-theme sphinxext-opengraph
+        python3 -m pip install sphinx-copybutton sphinx-issues sphinx-removed-in sphinx-rtd-theme sphinxext-opengraph
         make doccheck
 
     - name: After success

--- a/docs/releasenotes/9.0.0.rst
+++ b/docs/releasenotes/9.0.0.rst
@@ -127,8 +127,8 @@ help prevent problems arising if users evaluate arbitrary expressions, such as
 Fixed ImagePath.Path array handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:cve:`CVE-2022-22815` (CWE-126) and :cve:`CVE-2022-22816` (CWE-665) were found when
-initializing ``ImagePath.Path``.
+:cve:`CVE-2022-22815` (:cwe:`CWE-126`) and :cve:`CVE-2022-22816` (:cwe:`CWE-665`) were
+found when initializing ``ImagePath.Path``.
 
 .. _OSS-Fuzz: https://github.com/google/oss-fuzz
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pytest-cov
 pytest-timeout
 sphinx>=2.4
 sphinx-copybutton
-sphinx-issues
+sphinx-issues>=3.0.1
 sphinx-removed-in
 sphinx-rtd-theme>=1.0
 sphinxext-opengraph


### PR DESCRIPTION
Changes proposed in this pull request:

 * sphinx-issues 3.0.0 now has a CWE role for linking to https://cwe.mitre.org/
 * https://github.com/sloria/sphinx-issues#usage-inside-the-documentation
 * sphinx-issues 3.0.1 fixes the docs build problem in 3.0.0 (noted at https://github.com/python-pillow/Pillow/pull/5953#issuecomment-1009953021)

# Demo

https://pillow--5955.org.readthedocs.build/en/5955/releasenotes/9.0.0.html#security