### PR TITLE
Fixed Spider images for use with Bio-formats library

### DIFF
--- a/src/PIL/SpiderImagePlugin.py
+++ b/src/PIL/SpiderImagePlugin.py
@@ -238,13 +238,13 @@ def makeSpiderHeader(im):
     if 1024 % lenbyt != 0:
         labrec += 1
     labbyt = labrec * lenbyt
-    hdr = []
     nvalues = int(labbyt / 4)
+    if nvalues < 23:
+        return []
+
+    hdr = []
     for i in range(nvalues):
         hdr.append(0.0)
-
-    if len(hdr) < 23:
-        return []
 
     # NB these are Fortran indices
     hdr[1] = 1.0  # nslice (=1 for an image)
@@ -259,10 +259,7 @@ def makeSpiderHeader(im):
     hdr = hdr[1:]
     hdr.append(0.0)
     # pack binary data into a string
-    hdrstr = []
-    for v in hdr:
-        hdrstr.append(struct.pack("f", v))
-    return hdrstr
+    return [struct.pack("f", v) for v in hdr]
 
 
 def _save(im, fp, filename):

--- a/src/PIL/SpiderImagePlugin.py
+++ b/src/PIL/SpiderImagePlugin.py
@@ -249,6 +249,7 @@ def makeSpiderHeader(im):
     # NB these are Fortran indices
     hdr[1] = 1.0  # nslice (=1 for an image)
     hdr[2] = float(nrow)  # number of rows per slice
+    hdr[3] = float(nrow)  # number of records in the image
     hdr[5] = 1.0  # iform for 2D image
     hdr[12] = float(nsam)  # number of pixels per line
     hdr[13] = float(labrec)  # number of records in file header


### PR DESCRIPTION
Resolves #2518

The issue reports that Spider images saved with Pillow have a black line at the end when opened with Fiji.

Fiji [uses bioformats as a dependency](https://github.com/fiji/fiji/blob/3428cdbb8fd6eaa6483ce1e084cc93108f6c8ca5/pom.xml#L727-L732). So https://github.com/ome/bioformats/blob/develop/components/formats-gpl/src/loci/formats/in/SpiderReader.java would be the reader that Fiji is using.

Testing, I find that doubling the length of the header fixes the display of the image in Fiji. There is [code in bioformats that looks like it could double the header length](https://github.com/ome/bioformats/blob/7dd6a1ce3aeb6bdc9d3bb5d15071c9956e4f3f62/components/formats-gpl/src/loci/formats/in/SpiderReader.java#L104-L109). This code is apparently searching for a local header for each frame, not just the global header.

That code is triggered [based on the `irec` value.](https://github.com/ome/bioformats/blob/7dd6a1ce3aeb6bdc9d3bb5d15071c9956e4f3f62/components/formats-gpl/src/loci/formats/in/SpiderReader.java#L263-L264
) According to a specification, `irec` is the
> [Total number of records (including header records) in each image of a simple image or stacked image file.](https://web.archive.org/web/20201104112530/https://spider.wadsworth.org/spider_doc/spider/docs/image_doc.html)

So Bio-Formats is using the number of records to determine if we have included local headers.

We don't currently write an irec value - possibly because [one specification denotes it as unused.](http://svn.cgl.ucsf.edu/svn/chimera/trunk/libs/VolumeData/spider/spider_format.html).

This PR adds the number of records in an image as an `irec` value. I have tested this in Fiji and found it to work.