### PR TITLE
Corrected memory allocation

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -57,7 +57,7 @@ alloc_array(Py_ssize_t count) {
     if ((unsigned long long)count > (SIZE_MAX / (2 * sizeof(double))) - 1) {
         return ImagingError_MemoryError();
     }
-    xy = calloc(2 * count * sizeof(double) + 1, sizeof(double));
+    xy = calloc(2 * count + 1, sizeof(double));
     if (!xy) {
         ImagingError_MemoryError();
     }


### PR DESCRIPTION
Addresses https://github.com/python-pillow/Pillow/commit/1e092419b6806495c683043ab3feb6ce264f3b9c#commitcomment-63846366

I failed to acknowledge that `malloc` allocates a block of "size", while `calloc` allocates "nitems" blocks of "size".