### PR TITLE
Forbid Lambda expressions in ImageMath.eval()

### DIFF
--- a/Tests/test_imagemath.py
+++ b/Tests/test_imagemath.py
@@ -52,9 +52,10 @@ def test_ops():
     assert pixel(ImageMath.eval("float(B)**33", images)) == "F 8589934592.0"
 
 
-def test_prevent_exec():
+@pytest.mark.parametrize("expression", ("exec('pass')", "(lambda: None)()"))
+def test_prevent_exec(expression):
     with pytest.raises(ValueError):
-        ImageMath.eval("exec('pass')")
+        ImageMath.eval(expression)
 
 
 def test_logical():

--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -244,6 +244,9 @@ def eval(expression, _dict={}, **kw):
     for name in code.co_names:
         if name not in args and name != "abs":
             raise ValueError(f"'{name}' not allowed")
+    for const in code.co_consts:
+        if getattr(const, "co_name", None) == "<lambda>":
+            raise ValueError("Lambda expressions are not allowed")
 
     out = builtins.eval(expression, {"__builtins": {"abs": abs}}, args)
     try:


### PR DESCRIPTION
## Description
This is an additional fix for CVE-2022-22817 (addressed in https://github.com/python-pillow/Pillow/pull/5923). As [commented](https://github.com/python-pillow/Pillow/pull/5923#issuecomment-1008715242) in the original PR, it's still possible to execute arbitrary code via lambda expressions - e.g.: `ImageMath.eval("(lambda: exit())()")`.

### Original Fix
The original fix checks all `co_names` in the compiled `expression` passed to `ImageMath.eval()` against builtins names. However, lambda expressions generates anonymous functions and they're not listed in the `co_names` structure. 

## Changes in this PR
This PR forbids Lambda expressions being passed to `ImageMath.eval()` by verifying all functions names in the literals section of the bytecode (`co_consts`). 

## Trade-offs 
Lambda expressions will no longer be supported in `ImageMath.eval()`. If such support is desired, all code objects inside `co_consts` can be verified in the same way as the original fix does (iterating through `co_names` and verifying against builtins names). Please let me know in the comments I can rewrite this fix. 