### PR TITLE
Fixed comparison warnings

### DIFF
--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -551,7 +551,7 @@ ImagingLibTiffDecode(
     uint16_t planarconfig = 0;
     int planes = 1;
     ImagingShuffler unpackers[4];
-    UINT32 img_width, img_height;
+    INT32 img_width, img_height;
 
     memset(unpackers, 0, sizeof(ImagingShuffler) * 4);
 


### PR DESCRIPTION
Running `pip install -v .` on my macOS machine, I see

```
  src/libImaging/TiffDecode.c:654:51: warning: comparison of integers of different signs: 'int' and 'unsigned int' [-Wsign-compare]
      if (state->xsize != img_width || state->ysize != img_height) {
                                       ~~~~~~~~~~~~ ^  ~~~~~~~~~~
  src/libImaging/TiffDecode.c:654:22: warning: comparison of integers of different signs: 'int' and 'unsigned int' [-Wsign-compare]
      if (state->xsize != img_width || state->ysize != img_height) {
          ~~~~~~~~~~~~ ^  ~~~~~~~~~
  2 warnings generated.
```

This PR fixes those warnings.