### PR TITLE
Raise an error when performing a negative crop

### DIFF
--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -86,21 +86,12 @@ class TestDecompressionCrop:
             pytest.warns(Image.DecompressionBombWarning, src.crop, box)
 
     def test_crop_decompression_checks(self):
-
         im = Image.new("RGB", (100, 100))
 
-        good_values = ((-9999, -9999, -9990, -9990), (-999, -999, -990, -990))
-
-        warning_values = ((-160, -160, 99, 99), (160, 160, -99, -99))
-
-        error_values = ((-99909, -99990, 99999, 99999), (99909, 99990, -99999, -99999))
-
-        for value in good_values:
+        for value in ((-9999, -9999, -9990, -9990), (-999, -999, -990, -990)):
             assert im.crop(value).size == (9, 9)
 
-        for value in warning_values:
-            pytest.warns(Image.DecompressionBombWarning, im.crop, value)
+        pytest.warns(Image.DecompressionBombWarning, im.crop, (-160, -160, 99, 99))
 
-        for value in error_values:
-            with pytest.raises(Image.DecompressionBombError):
-                im.crop(value)
+        with pytest.raises(Image.DecompressionBombError):
+            im.crop((-99909, -99990, 99999, 99999))

--- a/Tests/test_image_crop.py
+++ b/Tests/test_image_crop.py
@@ -47,16 +47,12 @@ def test_wide_crop():
     assert crop(-25, 75, 25, 125) == (1875, 625)
 
 
-def test_negative_crop():
-    # Check negative crop size (@PIL171)
+@pytest.mark.parametrize("box", ((8, 2, 2, 8), (2, 8, 8, 2), (8, 8, 2, 2)))
+def test_negative_crop(box):
+    im = Image.new("RGB", (10, 10))
 
-    im = Image.new("L", (512, 512))
-    im = im.crop((400, 400, 200, 200))
-
-    assert im.size == (0, 0)
-    assert len(im.getdata()) == 0
-    with pytest.raises(IndexError):
-        im.getdata()[0]
+    with pytest.raises(ValueError):
+        im.crop(box)
 
 
 def test_crop_float():

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1145,6 +1145,11 @@ class Image:
         if box is None:
             return self.copy()
 
+        if box[2] < box[0]:
+            raise ValueError("Region right less than region left")
+        elif box[3] < box[1]:
+            raise ValueError("Region lower less than region upper")
+
         self.load()
         return self._new(self._crop(self.im, box))
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1146,9 +1146,9 @@ class Image:
             return self.copy()
 
         if box[2] < box[0]:
-            raise ValueError("Region right less than region left")
+            raise ValueError("Coordinate 'right' is less than 'left'")
         elif box[3] < box[1]:
-            raise ValueError("Region lower less than region upper")
+            raise ValueError("Coordinate 'lower' is less than 'upper'")
 
         self.load()
         return self._new(self._crop(self.im, box))


### PR DESCRIPTION
Resolves #5957

At the moment, mixing up the order of the `box` values for `crop()`, so that a negative crop is performed, doesn't raise an error.
```python
from PIL import Image
im = Image.new("RGB", (10, 10))
im.crop((10, 10, 0, 0))
```
gives a (0, 0) image.

In the issue, this was done unintentionally by a user, and because no error was raised, they didn't realise their mistake.

This PR raises an error is the right of a crop region is less than the left, or if the bottom of the region is less than the top.

I am presuming that it is uncommon for users to want a negative crop, and more common for users to mix up the order of the values.