### PR TITLE
Always save TIFF with contiguous planar configuration

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -594,6 +594,17 @@ class TestFileTiff:
         with Image.open(infile) as im:
             assert_image_equal_tofile(im, "Tests/images/tiff_adobe_deflate.png")
 
+    def test_planar_configuration_save(self, tmp_path):
+        infile = "Tests/images/tiff_tiled_planar_raw.tif"
+        with Image.open(infile) as im:
+            assert im._planar_configuration == 2
+
+            outfile = str(tmp_path / "temp.tif")
+            im.save(outfile)
+
+            with Image.open(outfile) as reloaded:
+                assert_image_equal_tofile(reloaded, infile)
+
     def test_palette(self, tmp_path):
         def roundtrip(mode):
             outfile = str(tmp_path / "temp.tif")

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1528,7 +1528,7 @@ def _save(im, fp, filename):
     libtiff = WRITE_LIBTIFF or compression != "raw"
 
     # required for color libtiff images
-    ifd[PLANAR_CONFIGURATION] = getattr(im, "_planar_configuration", 1)
+    ifd[PLANAR_CONFIGURATION] = 1
 
     ifd[IMAGEWIDTH] = im.size[0]
     ifd[IMAGELENGTH] = im.size[1]


### PR DESCRIPTION
Resolves #3622

If a TIFF image is opened with "separate" [planar configuration](https://www.awaresystems.be/imaging/tiff/tifftags/planarconfiguration.html), it is successfully read.

However, if that same image is saved, Pillow tries to keep the "separate" planar configuration from the input file, and the output image is broken.

This PR simply changes Pillow to always save "contiguous", and the output image is fixed.