### PR TITLE
libwebp 1.2.2 fixed endian bugs

### DIFF
--- a/Tests/test_file_webp_animated.py
+++ b/Tests/test_file_webp_animated.py
@@ -1,6 +1,7 @@
 import pytest
+from packaging.version import parse as parse_version
 
-from PIL import Image
+from PIL import Image, features
 
 from .helper import (
     assert_image_equal,
@@ -27,7 +28,6 @@ def test_n_frames():
         assert im.is_animated
 
 
-@pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
 def test_write_animation_L(tmp_path):
     """
     Convert an animated GIF to animated WebP, then compare the frame count, and first
@@ -46,6 +46,11 @@ def test_write_animation_L(tmp_path):
             orig.load()
             im.load()
             assert_image_similar(im, orig.convert("RGBA"), 32.9)
+
+            if is_big_endian():
+                webp = parse_version(features.version_module("webp"))
+                if webp < parse_version("1.2.2"):
+                    return
             orig.seek(orig.n_frames - 1)
             im.seek(im.n_frames - 1)
             orig.load()
@@ -53,7 +58,6 @@ def test_write_animation_L(tmp_path):
             assert_image_similar(im, orig.convert("RGBA"), 32.9)
 
 
-@pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
 def test_write_animation_RGB(tmp_path):
     """
     Write an animated WebP from RGB frames, and ensure the frames
@@ -69,6 +73,10 @@ def test_write_animation_RGB(tmp_path):
             assert_image_equal(im, frame1.convert("RGBA"))
 
             # Compare second frame to original
+            if is_big_endian():
+                webp = parse_version(features.version_module("webp"))
+                if webp < parse_version("1.2.2"):
+                    return
             im.seek(1)
             im.load()
             assert_image_equal(im, frame2.convert("RGBA"))

--- a/Tests/test_file_webp_animated.py
+++ b/Tests/test_file_webp_animated.py
@@ -50,7 +50,7 @@ def test_write_animation_L(tmp_path):
             if is_big_endian():
                 webp = parse_version(features.version_module("webp"))
                 if webp < parse_version("1.2.2"):
-                    return
+                    pytest.skip("Fails with libwebp earlier than 1.2.2")
             orig.seek(orig.n_frames - 1)
             im.seek(im.n_frames - 1)
             orig.load()
@@ -76,7 +76,7 @@ def test_write_animation_RGB(tmp_path):
             if is_big_endian():
                 webp = parse_version(features.version_module("webp"))
                 if webp < parse_version("1.2.2"):
-                    return
+                    pytest.skip("Fails with libwebp earlier than 1.2.2")
             im.seek(1)
             im.load()
             assert_image_equal(im, frame2.convert("RGBA"))


### PR DESCRIPTION
Resolves #3927
Resolves #4213

While investigating `TestFileWebpAnimation.test_write_animation_L` and `TestFileWebpAnimation.test_write_animation_RGB` failures on big-endian, I came to the conclusion that it was not a problem in our code, but in libwebp itself. I [reported](https://bugs.chromium.org/p/webp/issues/detail?id=548) this to them, it was accepted, and then fixed in libwebp 1.2.2.

This PR removes the xfails on those tests for big endian, runs the first half of them that passes before libwebp 1.2.2, and then skips the second half if libwebp 1.2.2 or greater is not available.

https://github.com/python-pillow/docker-images/pull/128 and #5982 made libwebp 1.2.2 available to the CI job.