### PR TITLE
Updated GitHub Actions badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ As of 2019, Pillow development is
     <tr>
         <th>tests</th>
         <td>
-            <a href="https://github.com/python-pillow/Pillow/actions?query=workflow%3ALint"><img
+            <a href="https://github.com/python-pillow/Pillow/actions/workflows/lint.yml"><img
                 alt="GitHub Actions build status (Lint)"
                 src="https://github.com/python-pillow/Pillow/workflows/Lint/badge.svg"></a>
-            <a href="https://github.com/python-pillow/Pillow/actions?query=workflow%3ATest"><img
+            <a href="https://github.com/python-pillow/Pillow/actions/workflows/test.yml"><img
                 alt="GitHub Actions build status (Test Linux and macOS)"
                 src="https://github.com/python-pillow/Pillow/workflows/Test/badge.svg"></a>
-            <a href="https://github.com/python-pillow/Pillow/actions?query=workflow%3A%22Test+Windows%22"><img
+            <a href="https://github.com/python-pillow/Pillow/actions/workflows/test-windows.yml"><img
                 alt="GitHub Actions build status (Test Windows)"
                 src="https://github.com/python-pillow/Pillow/workflows/Test%20Windows/badge.svg"></a>
-            <a href="https://github.com/python-pillow/Pillow/actions?query=workflow%3A%22Test+Docker%22"><img
+            <a href="https://github.com/python-pillow/Pillow/actions/workflows/test-docker.yml"><img
                 alt="GitHub Actions build status (Test Docker)"
                 src="https://github.com/python-pillow/Pillow/workflows/Test%20Docker/badge.svg"></a>
             <a href="https://ci.appveyor.com/project/python-pillow/Pillow"><img

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ As of 2019, Pillow development is
             <a href="https://github.com/python-pillow/Pillow/actions/workflows/test-windows.yml"><img
                 alt="GitHub Actions build status (Test Windows)"
                 src="https://github.com/python-pillow/Pillow/workflows/Test%20Windows/badge.svg"></a>
+            <a href="https://github.com/python-pillow/Pillow/actions/workflows/test-mingw.yml"><img
+                alt="GitHub Actions build status (Test MinGW)"
+                src="https://github.com/python-pillow/Pillow/workflows/Test%20MinGW/badge.svg"></a>
             <a href="https://github.com/python-pillow/Pillow/actions/workflows/test-docker.yml"><img
                 alt="GitHub Actions build status (Test Docker)"
                 src="https://github.com/python-pillow/Pillow/workflows/Test%20Docker/badge.svg"></a>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,19 +10,19 @@ Pillow for enterprise is available via the Tidelift Subscription. `Learn more <h
    :alt: Documentation Status
 
 .. image:: https://github.com/python-pillow/Pillow/workflows/Lint/badge.svg
-   :target: https://github.com/python-pillow/Pillow/actions?query=workflow%3ALint
+   :target: https://github.com/python-pillow/Pillow/actions/workflows/lint.yml
    :alt: GitHub Actions build status (Lint)
 
 .. image:: https://github.com/python-pillow/Pillow/workflows/Test%20Docker/badge.svg
-   :target: https://github.com/python-pillow/Pillow/actions?query=workflow%3A%22Test+Docker%22
+   :target: https://github.com/python-pillow/Pillow/actions/workflows/test-docker.yml
    :alt: GitHub Actions build status (Test Docker)
 
 .. image:: https://github.com/python-pillow/Pillow/workflows/Test/badge.svg
-   :target: https://github.com/python-pillow/Pillow/actions?query=workflow%3ATest
+   :target: https://github.com/python-pillow/Pillow/actions/workflows/test.yml
    :alt: GitHub Actions build status (Test Linux and macOS)
 
 .. image:: https://github.com/python-pillow/Pillow/workflows/Test%20Windows/badge.svg
-   :target: https://github.com/python-pillow/Pillow/actions?query=workflow%3A%22Test+Windows%22
+   :target: https://github.com/python-pillow/Pillow/actions/workflows/test-windows.yml
    :alt: GitHub Actions build status (Test Windows)
 
 .. image:: https://img.shields.io/appveyor/build/python-pillow/Pillow/main.svg?label=Windows%20build

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,10 @@ Pillow for enterprise is available via the Tidelift Subscription. `Learn more <h
    :target: https://github.com/python-pillow/Pillow/actions/workflows/test-windows.yml
    :alt: GitHub Actions build status (Test Windows)
 
+.. image:: https://github.com/python-pillow/Pillow/workflows/Test%20MinGW/badge.svg
+   :target: https://github.com/python-pillow/Pillow/actions/workflows/test-mingw.yml
+   :alt: GitHub Actions build status (Test MinGW)
+
 .. image:: https://img.shields.io/appveyor/build/python-pillow/Pillow/main.svg?label=Windows%20build
    :target: https://ci.appveyor.com/project/python-pillow/Pillow
    :alt: AppVeyor CI build status (Windows)


### PR DESCRIPTION
Two changes in this PR.

1. https://github.com/python-pillow/Pillow/actions?query=workflow%3ALint shows GHA workflows with a search query for the "Lint" workflow. https://github.com/python-pillow/Pillow/actions/workflows/lint.yml links to the dedicated page for the "Lint" workflow. This seems neater to me.

2. Adds a MinGW badge, after #5709