### PR TITLE
Switched from windows-2019 to windows-latest in GitHub Actions

### DIFF
--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
In test.yml, we have

https://github.com/python-pillow/Pillow/blob/5fdf29f13b30b763b5b9f399ec227d76fb51f291/.github/workflows/test.yml#L12-L13

but in test-windows.yml and test-mingw.yml, we have

https://github.com/python-pillow/Pillow/blob/5fdf29f13b30b763b5b9f399ec227d76fb51f291/.github/workflows/test-windows.yml#L7
https://github.com/python-pillow/Pillow/blob/5fdf29f13b30b763b5b9f399ec227d76fb51f291/.github/workflows/test-mingw.yml#L7

This PR switches from windows-2019 to windows-latest, to ensure that we are always running the latest version, and don't have to upgrade it.

See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners for more information about this topic.