### PR TITLE
Remove patch for Raqm<0.9.0

### DIFF
--- a/src/thirdparty/raqm/raqm.c
+++ b/src/thirdparty/raqm/raqm.c
@@ -42,21 +42,6 @@
 #include <hb.h>
 #include <hb-ft.h>
 
-#if FREETYPE_MAJOR > 2 || \
-    FREETYPE_MAJOR == 2 && FREETYPE_MINOR >= 11
-#define HAVE_FT_GET_TRANSFORM
-#endif
-
-#if HB_VERSION_ATLEAST(2, 0, 0)
-#define HAVE_HB_BUFFER_SET_INVISIBLE_GLYPH
-#endif
-
-#if HB_VERSION_ATLEAST(1, 8, 0)
-#define HAVE_DECL_HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES 1
-#else
-#define HAVE_DECL_HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES 0
-#endif
-
 #include "raqm.h"
 
 /**


### PR DESCRIPTION
This reverts commit 6565d13275cead21dc6f369204f0dc3d0b43bc18.

This change is no longer needed with Raqm 0.9.0 (updated in #6000) due to https://github.com/HOST-Oman/libraqm/compare/v0.8.0...v0.9.0#diff-f28598af2e23aa5d2bc7c72e022ae2c56a33802eb970afffaeca1e40607f97fe