### PR TITLE
Support Python distributions where _tkinter is compiled in

### DIFF
--- a/src/PIL/_tkinter_finder.py
+++ b/src/PIL/_tkinter_finder.py
@@ -5,10 +5,15 @@ import tkinter
 import warnings
 from tkinter import _tkinter as tk
 
-if hasattr(sys, "pypy_find_executable"):
-    TKINTER_LIB = tk.tklib_cffi.__file__
-else:
-    TKINTER_LIB = tk.__file__
+try:
+    if hasattr(sys, "pypy_find_executable"):
+        TKINTER_LIB = tk.tklib_cffi.__file__
+    else:
+        TKINTER_LIB = tk.__file__
+except AttributeError:
+    # _tkinter may be compiled directly into Python, in which case __file__ is
+    # not available. load_tkinter_funcs will check the binary first in any case.
+    TKINTER_LIB = None
 
 tk_version = str(tkinter.TkVersion)
 if tk_version == "8.4":


### PR DESCRIPTION
In some cases, the Tk library may have been directly compiled in or bundled into the main executable by the time Pillow runs, in which case `__file__` isn't available (nor would it make sense to use, anyway).

If `__file__` is missing, then set the library path to None and rely on our Tk loader being able to find the function pointers within the main binary - we know we probably have it because we've managed to import it already.