### PR TITLE
Improved consistency of returning an image access object from load()

### DIFF
--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -58,6 +58,15 @@ def test_sanity():
         assert image2_scale2.format == "EPS"
 
 
+@pytest.mark.skipif(not HAS_GHOSTSCRIPT, reason="Ghostscript not available")
+def test_load():
+    with Image.open(FILE1) as im:
+        assert im.load()[0, 0] == (255, 255, 255)
+
+        # Test again now that it has already been loaded once
+        assert im.load()[0, 0] == (255, 255, 255)
+
+
 def test_invalid_file():
     invalid_file = "Tests/images/flower.jpg"
 

--- a/Tests/test_file_gbr.py
+++ b/Tests/test_file_gbr.py
@@ -5,16 +5,17 @@ from PIL import GbrImagePlugin, Image
 from .helper import assert_image_equal_tofile
 
 
-def test_invalid_file():
-    invalid_file = "Tests/images/flower.jpg"
-
-    with pytest.raises(SyntaxError):
-        GbrImagePlugin.GbrImageFile(invalid_file)
-
-
 def test_gbr_file():
     with Image.open("Tests/images/gbr.gbr") as im:
         assert_image_equal_tofile(im, "Tests/images/gbr.png")
+
+
+def test_load():
+    with Image.open("Tests/images/gbr.gbr") as im:
+        assert im.load()[0, 0] == (0, 0, 0, 0)
+
+        # Test again now that it has already been loaded once
+        assert im.load()[0, 0] == (0, 0, 0, 0)
 
 
 def test_multiple_load_operations():
@@ -22,3 +23,10 @@ def test_multiple_load_operations():
         im.load()
         im.load()
         assert_image_equal_tofile(im, "Tests/images/gbr.png")
+
+
+def test_invalid_file():
+    invalid_file = "Tests/images/flower.jpg"
+
+    with pytest.raises(SyntaxError):
+        GbrImagePlugin.GbrImageFile(invalid_file)

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -28,6 +28,14 @@ def test_sanity():
         assert im.format == "ICNS"
 
 
+def test_load():
+    with Image.open(TEST_FILE) as im:
+        assert im.load()[0, 0] == (0, 0, 0, 0)
+
+        # Test again now that it has already been loaded once
+        assert im.load()[0, 0] == (0, 0, 0, 0)
+
+
 def test_save(tmp_path):
     temp_file = str(tmp_path / "temp.icns")
 

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -18,6 +18,11 @@ def test_sanity():
     assert im.get_format_mimetype() == "image/x-icon"
 
 
+def test_load():
+    with Image.open(TEST_ICO_FILE) as im:
+        assert im.load()[0, 0] == (1, 1, 9, 255)
+
+
 def test_mask():
     with Image.open("Tests/images/hopper_mask.ico") as im:
         assert_image_equal_tofile(im, "Tests/images/hopper_mask.png")

--- a/Tests/test_file_wal.py
+++ b/Tests/test_file_wal.py
@@ -2,15 +2,11 @@ from PIL import WalImageFile
 
 from .helper import assert_image_equal_tofile
 
+TEST_FILE = "Tests/images/hopper.wal"
+
 
 def test_open():
-    # Arrange
-    TEST_FILE = "Tests/images/hopper.wal"
-
-    # Act
     with WalImageFile.open(TEST_FILE) as im:
-
-        # Assert
         assert im.format == "WAL"
         assert im.format_description == "Quake2 Texture"
         assert im.mode == "P"
@@ -19,3 +15,11 @@ def test_open():
         assert isinstance(im, WalImageFile.WalImageFile)
 
         assert_image_equal_tofile(im, "Tests/images/hopper_wal.png")
+
+
+def test_load():
+    with WalImageFile.open(TEST_FILE) as im:
+        assert im.load()[0, 0] == 122
+
+        # Test again now that it has already been loaded once
+        assert im.load()[0, 0] == 122

--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -24,6 +24,12 @@ def test_load_raw():
             assert_image_similar_tofile(im, "Tests/images/drawing_wmf_ref.png", 2.0)
 
 
+def test_load():
+    with Image.open("Tests/images/drawing.emf") as im:
+        if hasattr(Image.core, "drawwmf"):
+            assert im.load()[0, 0] == (255, 255, 255)
+
+
 def test_register_handler(tmp_path):
     class TestHandler:
         methodCalled = False

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -329,12 +329,12 @@ class EpsImageFile(ImageFile.ImageFile):
 
     def load(self, scale=1, transparency=False):
         # Load EPS via Ghostscript
-        if not self.tile:
-            return
-        self.im = Ghostscript(self.tile, self.size, self.fp, scale, transparency)
-        self.mode = self.im.mode
-        self._size = self.im.size
-        self.tile = []
+        if self.tile:
+            self.im = Ghostscript(self.tile, self.size, self.fp, scale, transparency)
+            self.mode = self.im.mode
+            self._size = self.im.size
+            self.tile = []
+        return Image.Image.load(self)
 
     def load_seek(self, *args, **kwargs):
         # we can't incrementally load, so force ImageFile.parser to

--- a/src/PIL/GbrImagePlugin.py
+++ b/src/PIL/GbrImagePlugin.py
@@ -84,12 +84,10 @@ class GbrImageFile(ImageFile.ImageFile):
         self._data_size = width * height * color_depth
 
     def load(self):
-        if self.im:
-            # Already loaded
-            return
-
-        self.im = Image.core.new(self.mode, self.size)
-        self.frombytes(self.fp.read(self._data_size))
+        if not self.im:
+            self.im = Image.core.new(self.mode, self.size)
+            self.frombytes(self.fp.read(self._data_size))
+        return Image.Image.load(self)
 
 
 #

--- a/src/PIL/IcnsImagePlugin.py
+++ b/src/PIL/IcnsImagePlugin.py
@@ -286,21 +286,22 @@ class IcnsImageFile(ImageFile.ImageFile):
                 self.best_size[1] * self.best_size[2],
             )
 
-        Image.Image.load(self)
+        px = Image.Image.load(self)
         if self.im and self.im.size == self.size:
             # Already loaded
-            return
+            return px
         self.load_prepare()
         # This is likely NOT the best way to do it, but whatever.
         im = self.icns.getimage(self.best_size)
 
         # If this is a PNG or JPEG 2000, it won't be loaded yet
-        im.load()
+        px = im.load()
 
         self.im = im.im
         self.mode = im.mode
         self.size = im.size
-        self.load_end()
+
+        return px
 
 
 def _save(im, fp, filename):

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -306,7 +306,7 @@ class IcoImageFile(ImageFile.ImageFile):
     def load(self):
         if self.im and self.im.size == self.size:
             # Already loaded
-            return
+            return Image.Image.load(self)
         im = self.ico.getimage(self.size)
         # if tile is PNG, it won't really be loaded yet
         im.load()

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -328,6 +328,7 @@ class StubImageFile(ImageFile):
         # become the other object (!)
         self.__class__ = image.__class__
         self.__dict__ = image.__dict__
+        return image.load()
 
     def _load(self):
         """(Hook) Find actual image loader."""

--- a/src/PIL/WalImageFile.py
+++ b/src/PIL/WalImageFile.py
@@ -51,14 +51,11 @@ class WalImageFile(ImageFile.ImageFile):
             self.info["next_name"] = next_name
 
     def load(self):
-        if self.im:
-            # Already loaded
-            return
-
-        self.im = Image.core.new(self.mode, self.size)
-        self.frombytes(self.fp.read(self.size[0] * self.size[1]))
-        self.putpalette(quake2palette)
-        Image.Image.load(self)
+        if not self.im:
+            self.im = Image.core.new(self.mode, self.size)
+            self.frombytes(self.fp.read(self.size[0] * self.size[1]))
+            self.putpalette(quake2palette)
+        return Image.Image.load(self)
 
 
 def open(filename):

--- a/src/PIL/WmfImagePlugin.py
+++ b/src/PIL/WmfImagePlugin.py
@@ -158,7 +158,7 @@ class WmfStubImageFile(ImageFile.StubImageFile):
                 (x1 - x0) * self.info["dpi"] // self._inch,
                 (y1 - y0) * self.info["dpi"] // self._inch,
             )
-        super().load()
+        return super().load()
 
 
 def _save(im, fp, filename):


### PR DESCRIPTION
According to the documentation, the [`im.load()`](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.load) method
> **Returns:** An image access object.

Except in reality, `None` is sometimes returned instead. This PR improves the situation.