### PR TITLE
Restrict builtins within lambdas for ImageMath.eval

### DIFF
--- a/Tests/test_imagemath.py
+++ b/Tests/test_imagemath.py
@@ -52,9 +52,17 @@ def test_ops():
     assert pixel(ImageMath.eval("float(B)**33", images)) == "F 8589934592.0"
 
 
-def test_prevent_exec():
+@pytest.mark.parametrize(
+    "expression",
+    (
+        "exec('pass')",
+        "(lambda: exec('pass'))()",
+        "(lambda: (lambda: exec('pass'))())()",
+    ),
+)
+def test_prevent_exec(expression):
     with pytest.raises(ValueError):
-        ImageMath.eval("exec('pass')")
+        ImageMath.eval(expression)
 
 
 def test_logical():

--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -240,11 +240,18 @@ def eval(expression, _dict={}, **kw):
         if hasattr(v, "im"):
             args[k] = _Operand(v)
 
-    code = compile(expression, "<string>", "eval")
-    for name in code.co_names:
-        if name not in args and name != "abs":
-            raise ValueError(f"'{name}' not allowed")
+    compiled_code = compile(expression, "<string>", "eval")
 
+    def scan(code):
+        for const in code.co_consts:
+            if type(const) == type(compiled_code):
+                scan(const)
+
+        for name in code.co_names:
+            if name not in args and name != "abs":
+                raise ValueError(f"'{name}' not allowed")
+
+    scan(compiled_code)
     out = builtins.eval(expression, {"__builtins": {"abs": abs}}, args)
     try:
         return out.im


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/5923#issuecomment-1008715242 has pointed out that #5923 does not protect against lambdas wrapping unwanted code.
> ImageMath.eval("(lambda: exit())()")

I can also imagine a lambda wrapping a lambda.
```python
ImageMath.eval("(lambda: (lambda: exit())())()")
```

This PR protects against both.