### PR TITLE
In show_file, use os.remove to remove temporary images

### DIFF
--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -85,11 +85,13 @@ def test_ipythonviewer():
     not on_ci() or is_win32(),
     reason="Only run on CIs; hangs on Windows CIs",
 )
-def test_file_deprecated():
+def test_file_deprecated(tmp_path):
+    f = str(tmp_path / "temp.jpg")
     for viewer in ImageShow._viewers:
+        hopper().save(f)
         with pytest.warns(DeprecationWarning):
             try:
-                viewer.show_file(file="test.jpg")
+                viewer.show_file(file=f)
             except NotImplementedError:
                 pass
         with pytest.raises(TypeError):

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -126,6 +126,16 @@ class Viewer:
         os.system(self.get_command(path, **options))
         return 1
 
+    def _remove_path_after_delay(self, path):
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import os, sys, time; time.sleep(20); os.remove(sys.argv[1])",
+                path,
+            ]
+        )
+
 
 # --------------------------------------------------------------------
 
@@ -180,14 +190,7 @@ class MacViewer(Viewer):
             else:
                 raise TypeError("Missing required argument: 'path'")
         subprocess.call(["open", "-a", "Preview.app", path])
-        subprocess.Popen(
-            [
-                sys.executable,
-                "-c",
-                "import os, sys, time; time.sleep(20); os.remove(sys.argv[1])",
-                path,
-            ]
-        )
+        self._remove_path_after_delay(path)
         return 1
 
 
@@ -232,7 +235,7 @@ class XDGViewer(UnixViewer):
             else:
                 raise TypeError("Missing required argument: 'path'")
         subprocess.Popen(["xdg-open", path])
-        os.remove(path)
+        self._remove_path_after_delay(path)
         return 1
 
 

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -184,7 +184,7 @@ class MacViewer(Viewer):
             [
                 sys.executable,
                 "-c",
-                "import os, sys, time;time.sleep(20);os.remove(sys.argv[1])",
+                "import os, sys, time; time.sleep(20); os.remove(sys.argv[1])",
                 path,
             ]
         )


### PR DESCRIPTION
Rather than using `rm` inside a `subprocess` shell command, this PR switches to using `subprocess` without shell to open the image and then `os.remove`. This should resolve any path problems.

But there is a twist on macOS - Pillow sleeps before removing the image, and we presumably don't want to make our Python script hang for 20 seconds. Instead, this PR uses `subprocess` to start a Python process that sleeps and removes the file afterwards.

And since that makes `sleep`ing before removing the file nicer, this PR adds `sleep` for `xdg-open`,  instead of https://github.com/python-pillow/Pillow/pull/5950, to help https://github.com/python-pillow/Pillow/issues/5945 and https://github.com/python-pillow/Pillow/issues/5968