### PR TITLE
Updated libimagequant to 4.0.0

### DIFF
--- a/depends/install_imagequant.sh
+++ b/depends/install_imagequant.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 # install libimagequant
 
-archive=libimagequant-2.17.0
+archive=libimagequant-4.0.0
 
 ./download-and-extract.sh $archive https://raw.githubusercontent.com/python-pillow/pillow-depends/main/$archive.tar.gz
 
-pushd $archive
+pushd $archive/imagequant-sys
 
-make shared
-sudo cp libimagequant.so* /usr/lib/
-sudo cp libimagequant.h /usr/include/
+cargo install cargo-c
+cargo cinstall --prefix=/usr --destdir=.
+sudo cp usr/lib/libimagequant.so* /usr/lib/
+sudo cp usr/include/libimagequant.h /usr/include/
 
 popd

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -187,7 +187,7 @@ Many of Pillow's features require external libraries:
 
 * **libimagequant** provides improved color quantization
 
-  * Pillow has been tested with libimagequant **2.6-2.17.0**
+  * Pillow has been tested with libimagequant **2.6-4.0**
   * Libimagequant is licensed GPLv3, which is more restrictive than
     the Pillow license, therefore we will not be distributing binaries
     with libimagequant support enabled.


### PR DESCRIPTION
With version 4.0, libimagequant has been [rewritten in Rust, and the Makefiles have been replaced with Cargo](https://github.com/ImageOptim/libimagequant/blob/main/CHANGELOG).

So this PR changes to the new build instructions - https://github.com/ImageOptim/libimagequant#building-with-cargo-c