### PR TITLE
Unix Viewers - 2nd attempt 

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -27,8 +27,7 @@ if os.environ.get("SHOW_ERRORS", None):
     class test_image_results:
         @staticmethod
         def upload(a, b):
-            a.show()
-            b.show()
+            return None
 
 elif "GITHUB_ACTIONS" in os.environ:
     HAS_UPLOADER = True
@@ -314,6 +313,10 @@ def is_ppc64le():
 
 def is_win32():
     return sys.platform.startswith("win32")
+
+
+def is_macos():
+    return sys.platform.startswith("darwin")
 
 
 def is_pypy():

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -44,7 +44,6 @@ def test_viewer_show(order):
 @pytest.mark.skip(
     reason="""Current implementation of some viewers requires manual closing of an image,
         because of that the tests calling show() method will hang infinitely.
-        Please also note that this test duplicates test_viewer_show() test.
     """
 )
 def test_show():

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -54,7 +54,7 @@ def test_show():
 def test_viewer():
     viewer = ImageShow.Viewer()
 
-    assert viewer.get_format(None) is None
+    assert viewer.get_format(None) == "PNG"
 
     with pytest.raises(NotImplementedError):
         viewer.get_command(None)

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -240,11 +240,13 @@ class UnixViewer(Viewer):
         command = self.get_command(path, **options)
 
         kwargs = {
+            "shell": True,
             "stdout": subprocess.PIPE,
+            "stderr": subprocess.PIPE
         }
 
         th = threading.Thread(
-            target=subprocess.run, args=(command.split(),), kwargs=kwargs, name=path
+            target=subprocess.run, args=(command, ), kwargs=kwargs, name=path
         )
         self.opened_images.append(th.name)
         th.start()

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -61,6 +61,11 @@ def show(image, title=None, **options):
 class Viewer:
     """Base class for viewers."""
 
+    format = "PNG"
+    """The format to convert the image into."""
+    options = {"compress_level": 1}
+    """Additional options used to convert the image."""
+
     # main api
 
     def show(self, image, **options):
@@ -80,11 +85,6 @@ class Viewer:
         return self.show_image(image, **options)
 
     # hook methods
-
-    format = None
-    """The format to convert the image into."""
-    options = {}
-    """Additional options used to convert the image."""
 
     def get_format(self, image):
         """Return format name, or ``None`` to save as PGM/PPM."""
@@ -143,9 +143,6 @@ class Viewer:
 class WindowsViewer(Viewer):
     """The default viewer on Windows is the default system application for PNG files."""
 
-    format = "PNG"
-    options = {"compress_level": 1}
-
     def get_command(self, file, **options):
         return (
             f'start "Pillow" /WAIT "{file}" '
@@ -160,9 +157,6 @@ if sys.platform == "win32":
 
 class MacViewer(Viewer):
     """The default viewer on macOS using ``Preview.app``."""
-
-    format = "PNG"
-    options = {"compress_level": 1}
 
     def get_command(self, file, **options):
         # on darwin open returns immediately resulting in the temp
@@ -199,9 +193,6 @@ if sys.platform == "darwin":
 
 
 class UnixViewer(Viewer):
-    format = "PNG"
-    options = {"compress_level": 1}
-
     def get_command(self, file, **options):
         command = self.get_command_ex(file, **options)[0]
         return f"({command} {quote(file)}; rm -f {quote(file)})&"
@@ -394,6 +385,9 @@ if sys.platform not in ("win32", "darwin"):  # unixoids
 
 class IPythonViewer(Viewer):
     """The viewer for IPython frontends."""
+
+    format = None
+    options = {}
 
     def show_image(self, image, **options):
         ipython_display(image)

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -239,14 +239,10 @@ class UnixViewer(Viewer):
         path = quote(path)
         command = self.get_command(path, **options)
 
-        kwargs = {
-            "shell": True,
-            "stdout": subprocess.PIPE,
-            "stderr": subprocess.PIPE
-        }
+        kwargs = {"shell": True, "stdout": subprocess.PIPE, "stderr": subprocess.PIPE}
 
         th = threading.Thread(
-            target=subprocess.run, args=(command, ), kwargs=kwargs, name=path
+            target=subprocess.run, args=(command,), kwargs=kwargs, name=path
         )
         self.opened_images.append(th.name)
         th.start()


### PR DESCRIPTION
Fixes #5945, #5976

Changes proposed in this pull request:

 *  Viewer class properties **format** and **options** have been moved to the parent Viewer class, those properties were removed from the Viewer child classed. **format** is set to **"PNG"** and **options** are set to **{"compress_level": 1}** The exception is IPythonViewer class, for this class **format** was set to **None** and options are set to **{}**.
* Python threads were used to control opening/closing of images by external Linux/Unix viewers.
* Within current setup, when working with Linux viewers the Python program remains opened till the user closes the image in the viewer.
* Implementation description: there are viewer thread and monitoring thread. Viewer thread is responsible for opening an image in a viewer; the monitoring thread is responsible for removal of temporary images after user closed the image in the viewer.
* Corresponding documentation is updated.
* Affected tests are updated: Tests/test_imageshow.py, Tests/helper.py
