### PR TITLE
Added get_photoshop_blocks() to parse Photoshop TIFF tag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ Changelog (Pillow)
 - Ensure duplicated file pointer is closed #5946
   [radarhere]
 
-- Added specific error if ImagePath coordinate type is incorrect #5942
+- Added specific error if path coordinate type is incorrect #5942
   [radarhere]
 
 - Return an empty bytestring from tobytes() for an empty image #5938

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -685,6 +685,32 @@ class TestFileTiff:
                 assert description[0]["format"] == "image/tiff"
                 assert description[3]["BitsPerSample"]["Seq"]["li"] == ["8", "8", "8"]
 
+    def test_get_photoshop_blocks(self):
+        with Image.open("Tests/images/lab.tif") as im:
+            assert list(im.get_photoshop_blocks().keys()) == [
+                1061,
+                1002,
+                1005,
+                1062,
+                1037,
+                1049,
+                1011,
+                1034,
+                10000,
+                1013,
+                1016,
+                1032,
+                1054,
+                1050,
+                1064,
+                1041,
+                1044,
+                1036,
+                1057,
+                4000,
+                4001,
+            ]
+
     def test_close_on_load_exclusive(self, tmp_path):
         # similar to test_fd_leak, but runs on unixlike os
         tmpfile = str(tmp_path / "temp.tif")

--- a/docs/releasenotes/9.1.0.rst
+++ b/docs/releasenotes/9.1.0.rst
@@ -1,0 +1,16 @@
+9.1.0
+-----
+
+API Additions
+=============
+
+Added get_photoshop_blocks() to parse Photoshop TIFF tag
+--------------------------------------------------------
+
+:py:meth:`~PIL.TiffImagePlugin.TiffImageFile.get_photoshop_blocks` has been added, to
+allow users to determine what Photoshop "Image Resource Blocks" are contained within an
+image. The keys of the returned dictionary are the image resource IDs.
+
+At present, the information within each block is merely returned as a dictionary with a
+"data" entry. This will allow more useful information to be added in the future without
+breaking backwards compatibility.

--- a/docs/releasenotes/9.1.0.rst
+++ b/docs/releasenotes/9.1.0.rst
@@ -14,3 +14,13 @@ image. The keys of the returned dictionary are the image resource IDs.
 At present, the information within each block is merely returned as a dictionary with a
 "data" entry. This will allow more useful information to be added in the future without
 breaking backwards compatibility.
+
+Other Changes
+=============
+
+Image._repr_pretty_
+-------------------
+
+`im._repr_pretty_` has been added to provide a representation of an image without the
+identity of the object. This allows Jupyter to describe an image and have that
+description stay the same on subsequent executions of the same code.

--- a/docs/releasenotes/9.1.0.rst
+++ b/docs/releasenotes/9.1.0.rst
@@ -11,6 +11,13 @@ Performing a negative crop on an image previously just returned a `(0, 0)` image
 it will raise a `ValueError`, to help reduce confusion if a user has unintentionally
 provided the wrong arguments.
 
+Added specific error if path coordinate type is incorrect
+---------------------------------------------------------
+
+Rather than returning a `SystemError`, passing the incorrect types of coordinates into
+a path will now raise a more specific `ValueError`, with the message "incorrect
+coordinate type".
+
 API Additions
 =============
 

--- a/docs/releasenotes/9.1.0.rst
+++ b/docs/releasenotes/9.1.0.rst
@@ -1,6 +1,16 @@
 9.1.0
 -----
 
+API Changes
+===========
+
+Raise an error when performing a negative crop
+----------------------------------------------
+
+Performing a negative crop on an image previously just returned a `(0, 0)` image. Now
+it will raise a `ValueError`, to help reduce confusion if a user has unintentionally
+provided the wrong arguments.
+
 API Additions
 =============
 

--- a/docs/releasenotes/9.1.0.rst
+++ b/docs/releasenotes/9.1.0.rst
@@ -5,24 +5,37 @@ API Changes
 ===========
 
 Raise an error when performing a negative crop
-----------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Performing a negative crop on an image previously just returned a `(0, 0)` image. Now
-it will raise a `ValueError`, to help reduce confusion if a user has unintentionally
+Performing a negative crop on an image previously just returned a ``(0, 0)`` image. Now
+it will raise a ``ValueError``, to help reduce confusion if a user has unintentionally
 provided the wrong arguments.
 
 Added specific error if path coordinate type is incorrect
----------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Rather than returning a `SystemError`, passing the incorrect types of coordinates into
-a path will now raise a more specific `ValueError`, with the message "incorrect
+Rather than returning a ``SystemError``, passing the incorrect types of coordinates into
+a path will now raise a more specific ``ValueError``, with the message "incorrect
 coordinate type".
+
+Deprecations
+^^^^^^^^^^^^
+
+ImageShow.Viewer.show_file file argument
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``file`` argument in :py:meth:`~PIL.ImageShow.Viewer.show_file()` has been
+deprecated, replaced by ``path``.
+
+In effect, ``viewer.show_file("test.jpg")`` will continue to work unchanged.
+``viewer.show_file(file="test.jpg")`` will raise a deprecation warning, and suggest
+``viewer.show_file(path="test.jpg")`` instead.
 
 API Additions
 =============
 
 Added get_photoshop_blocks() to parse Photoshop TIFF tag
---------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :py:meth:`~PIL.TiffImagePlugin.TiffImageFile.get_photoshop_blocks` has been added, to
 allow users to determine what Photoshop "Image Resource Blocks" are contained within an
@@ -36,8 +49,8 @@ Other Changes
 =============
 
 Image._repr_pretty_
--------------------
+^^^^^^^^^^^^^^^^^^^
 
-`im._repr_pretty_` has been added to provide a representation of an image without the
+``im._repr_pretty_`` has been added to provide a representation of an image without the
 identity of the object. This allows Jupyter to describe an image and have that
 description stay the same on subsequent executions of the same code.

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -14,6 +14,7 @@ expected to be backported to earlier versions.
 .. toctree::
   :maxdepth: 2
 
+  9.1.0
   9.0.1
   9.0.0
   8.4.0

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -41,6 +41,7 @@
 import io
 import itertools
 import logging
+import math
 import os
 import struct
 import warnings
@@ -49,6 +50,8 @@ from fractions import Fraction
 from numbers import Number, Rational
 
 from . import Image, ImageFile, ImageOps, ImagePalette, TiffTags
+from ._binary import i16be as i16
+from ._binary import i32be as i32
 from ._binary import o8
 from .TiffTags import TYPES
 
@@ -1128,6 +1131,27 @@ class TiffImageFile(ImageFile.ImageFile):
         :returns: XMP tags in a dictionary.
         """
         return self._getxmp(self.tag_v2[700]) if 700 in self.tag_v2 else {}
+
+    def get_photoshop_blocks(self):
+        """
+        Returns a dictionary of Photoshop "Image Resource Blocks".
+        The keys are the image resource ID. For more information, see
+        https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577409_pgfId-1037727
+
+        :returns: Photoshop "Image Resource Blocks" in a dictionary.
+        """
+        blocks = {}
+        val = self.tag_v2.get(0x8649)
+        if val:
+            while val[:4] == b"8BIM":
+                id = i16(val[4:6])
+                n = math.ceil((val[6] + 1) / 2) * 2
+                size = i32(val[6 + n : 10 + n])
+                data = val[10 + n : 10 + n + size]
+                blocks[id] = {"data": data}
+
+                val = val[math.ceil((10 + n + size) / 2) * 2 :]
+        return blocks
 
     def load(self):
         if self.tile and self.use_load_libtiff:


### PR DESCRIPTION
Resolves #6025

TIFF tag 34377 is a ["Collection of Photoshop 'Image Resource Blocks'"](https://www.awaresystems.be/imaging/tiff/tifftags/photoshop.html). This PR adds a method, `getphotoshopblocks()`, to determine what blocks are present in an image. https://www.awaresystems.be/imaging/tiff/tifftags/docs/photoshopthumbnail.html was useful in writing this code.

This PR does not go so far as to format the information within each block. Instead, the bytes are simply deposited within a dictionary under a "data" key. This will allow us to add in more useful information in the future without breaking backwards compatibility. https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577409_pgfId-1037727 will be a good resource at that time.