### PR TITLE
Ensure Tkinter hook is activated for getimage()

### DIFF
--- a/Tests/test_imagetk.py
+++ b/Tests/test_imagetk.py
@@ -75,8 +75,9 @@ def test_photoimage_blank():
         assert im_tk.width() == 100
         assert im_tk.height() == 100
 
-        # reloaded = ImageTk.getimage(im_tk)
-        # assert_image_equal(reloaded, im)
+        im = Image.new(mode, (100, 100))
+        reloaded = ImageTk.getimage(im_tk)
+        assert_image_equal(reloaded.convert(mode), im)
 
 
 def test_bitmapimage():

--- a/src/PIL/ImageTk.py
+++ b/src/PIL/ImageTk.py
@@ -64,27 +64,25 @@ def _pyimagingtkcall(command, photo, id):
         tk.call(command, photo, id)
     except tkinter.TclError:
         # activate Tkinter hook
+        # may raise an error if it cannot attach to Tkinter
+        from . import _imagingtk
+
         try:
-            from . import _imagingtk
+            if hasattr(tk, "interp"):
+                # Required for PyPy, which always has CFFI installed
+                from cffi import FFI
 
-            try:
-                if hasattr(tk, "interp"):
-                    # Required for PyPy, which always has CFFI installed
-                    from cffi import FFI
+                ffi = FFI()
 
-                    ffi = FFI()
-
-                    # PyPy is using an FFI CDATA element
-                    # (Pdb) self.tk.interp
-                    #  <cdata 'Tcl_Interp *' 0x3061b50>
-                    _imagingtk.tkinit(int(ffi.cast("uintptr_t", tk.interp)), 1)
-                else:
-                    _imagingtk.tkinit(tk.interpaddr(), 1)
-            except AttributeError:
-                _imagingtk.tkinit(id(tk), 0)
-            tk.call(command, photo, id)
-        except (ImportError, AttributeError, tkinter.TclError):
-            raise  # configuration problem; cannot attach to Tkinter
+                # PyPy is using an FFI CDATA element
+                # (Pdb) self.tk.interp
+                #  <cdata 'Tcl_Interp *' 0x3061b50>
+                _imagingtk.tkinit(int(ffi.cast("uintptr_t", tk.interp)), 1)
+            else:
+                _imagingtk.tkinit(tk.interpaddr(), 1)
+        except AttributeError:
+            _imagingtk.tkinit(id(tk), 0)
+        tk.call(command, photo, id)
 
 
 # --------------------------------------------------------------------

--- a/src/PIL/ImageTk.py
+++ b/src/PIL/ImageTk.py
@@ -58,6 +58,35 @@ def _get_image_from_kw(kw):
         return Image.open(source)
 
 
+def _pyimagingtkcall(command, photo, id):
+    tk = photo.tk
+    try:
+        tk.call(command, photo, id)
+    except tkinter.TclError:
+        # activate Tkinter hook
+        try:
+            from . import _imagingtk
+
+            try:
+                if hasattr(tk, "interp"):
+                    # Required for PyPy, which always has CFFI installed
+                    from cffi import FFI
+
+                    ffi = FFI()
+
+                    # PyPy is using an FFI CDATA element
+                    # (Pdb) self.tk.interp
+                    #  <cdata 'Tcl_Interp *' 0x3061b50>
+                    _imagingtk.tkinit(int(ffi.cast("uintptr_t", tk.interp)), 1)
+                else:
+                    _imagingtk.tkinit(tk.interpaddr(), 1)
+            except AttributeError:
+                _imagingtk.tkinit(id(tk), 0)
+            tk.call(command, photo, id)
+        except (ImportError, AttributeError, tkinter.TclError):
+            raise  # configuration problem; cannot attach to Tkinter
+
+
 # --------------------------------------------------------------------
 # PhotoImage
 
@@ -170,33 +199,7 @@ class PhotoImage:
             block = image.new_block(self.__mode, im.size)
             image.convert2(block, image)  # convert directly between buffers
 
-        tk = self.__photo.tk
-
-        try:
-            tk.call("PyImagingPhoto", self.__photo, block.id)
-        except tkinter.TclError:
-            # activate Tkinter hook
-            try:
-                from . import _imagingtk
-
-                try:
-                    if hasattr(tk, "interp"):
-                        # Required for PyPy, which always has CFFI installed
-                        from cffi import FFI
-
-                        ffi = FFI()
-
-                        # PyPy is using an FFI CDATA element
-                        # (Pdb) self.tk.interp
-                        #  <cdata 'Tcl_Interp *' 0x3061b50>
-                        _imagingtk.tkinit(int(ffi.cast("uintptr_t", tk.interp)), 1)
-                    else:
-                        _imagingtk.tkinit(tk.interpaddr(), 1)
-                except AttributeError:
-                    _imagingtk.tkinit(id(tk), 0)
-                tk.call("PyImagingPhoto", self.__photo, block.id)
-            except (ImportError, AttributeError, tkinter.TclError):
-                raise  # configuration problem; cannot attach to Tkinter
+        _pyimagingtkcall("PyImagingPhoto", self.__photo, block.id)
 
 
 # --------------------------------------------------------------------
@@ -276,7 +279,7 @@ def getimage(photo):
     im = Image.new("RGBA", (photo.width(), photo.height()))
     block = im.im
 
-    photo.tk.call("PyImagingPhotoGet", photo, block.id)
+    _pyimagingtkcall("PyImagingPhotoGet", photo, block.id)
 
     return im
 


### PR DESCRIPTION
Resolves #6020

When [`PhotoImage.paste` calls "PyImagingPhoto"](https://github.com/python-pillow/Pillow/blob/ab8125fa6b8dff98b9de1a148308d40744583cca/src/PIL/ImageTk.py#L175-L199), it catches a TclError in case the tkinter hooks have not been activated yet. If they haven't, then it calls `_imagingtk.tkinit`, which [calls `TkImaging_Init`](https://github.com/python-pillow/Pillow/blob/ab8125fa6b8dff98b9de1a148308d40744583cca/src/_imagingtk.c#L55), which [creates the "PyImaging" Tcl commands.](https://github.com/python-pillow/Pillow/blob/ab8125fa6b8dff98b9de1a148308d40744583cca/src/Tk/tkImaging.c#L200-L214)

`ImageTk.getimage` does not handle the situation where the tkinter hooks have not been activated yet.
https://github.com/python-pillow/Pillow/blob/ab8125fa6b8dff98b9de1a148308d40744583cca/src/PIL/ImageTk.py#L274-L281
So the user from the issue has reported a TclError being raised. This was missed in #3814.

As for testing this, although [`test_photoimage()`](https://github.com/python-pillow/Pillow/blob/ab8125fa6b8dff98b9de1a148308d40744583cca/Tests/test_imagetk.py#L55-L67) looks like it is only testing `getimage()`, when `PhotoImage` is called with an image as the first argument, [it calls `paste` immediately](https://github.com/python-pillow/Pillow/blob/ab8125fa6b8dff98b9de1a148308d40744583cca/src/PIL/ImageTk.py#L114-L115). In contrast, the test that I've modified just calls `getimage()`, and so when the test suite is run in [reverse](https://github.com/python-pillow/Pillow/blob/ab8125fa6b8dff98b9de1a148308d40744583cca/.github/workflows/test.yml#L24-L26), this will be called first.