### PR TITLE
Allow 1 mode images to be inverted

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -63,6 +63,7 @@ def test_sanity():
     ImageOps.grayscale(hopper("L"))
     ImageOps.grayscale(hopper("RGB"))
 
+    ImageOps.invert(hopper("1"))
     ImageOps.invert(hopper("L"))
     ImageOps.invert(hopper("RGB"))
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -523,7 +523,7 @@ def invert(image):
     lut = []
     for i in range(256):
         lut.append(255 - i)
-    return _lut(image, lut)
+    return image.point(lut) if image.mode == "1" else _lut(image, lut)
 
 
 def mirror(image):


### PR DESCRIPTION
Allows `autocontrast`, `equalize`, `invert`, `posterize` and `solarize` to support 1 mode images.

Alternative to #6033