### PR TITLE
Issue warning if Raqm layout is requested, but Raqm is not available

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -1022,3 +1022,16 @@ def test_oom(test_file):
         font = ImageFont.truetype(BytesIO(f.read()))
         with pytest.raises(Image.DecompressionBombError):
             font.getmask("Test Text")
+
+
+def test_raqm_missing_warning(monkeypatch):
+    monkeypatch.setattr(ImageFont.core, "HAVE_RAQM", False)
+    with pytest.warns(UserWarning) as record:
+        font = ImageFont.truetype(
+            FONT_PATH, FONT_SIZE, layout_engine=ImageFont.LAYOUT_RAQM
+        )
+    assert font.layout_engine == ImageFont.LAYOUT_BASIC
+    assert str(record[-1].message) == (
+        "Raqm layout was requested, but Raqm is not available. "
+        "Falling back to basic layout."
+    )

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -169,6 +169,12 @@ class FreeTypeFont:
             if core.HAVE_RAQM:
                 layout_engine = LAYOUT_RAQM
         elif layout_engine == LAYOUT_RAQM and not core.HAVE_RAQM:
+            import warnings
+
+            warnings.warn(
+                "Raqm layout was requested, but Raqm is not available. "
+                "Falling back to basic layout."
+            )
             layout_engine = LAYOUT_BASIC
 
         self.layout_engine = layout_engine


### PR DESCRIPTION
Helps #6018 

If `layout_engine=ImageFont.LAYOUT_RAQM` is passed to `ImageFont.truetype` when `PIL.features.check_feature("raqm")` reports False, `ImageFont` currently silently falls back to basic layout. This PR adds a warning for this case.