### PR TITLE
Wait until executable has finished to remove file on Unix

### DIFF
--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -50,12 +50,12 @@ def show(image, title=None, **options):
     :param image: An image object.
     :param title: Optional title. Not all viewers can display the title.
     :param \**options: Additional viewer options.
-    :returns: ``1`` if a suitable viewer was found, ``0`` otherwise.
+    :returns: ``True`` if a suitable viewer was found, ``False`` otherwise.
     """
     for viewer in _viewers:
         if viewer.show(image, title=title, **options):
-            return 1
-    return 0
+            return True
+    return False
 
 
 class Viewer:

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -50,7 +50,7 @@ def show(image, title=None, **options):
     :param image: An image object.
     :param title: Optional title. Not all viewers can display the title.
     :param \**options: Additional viewer options.
-    :returns: ``True`` if a suitable viewer was found, ``False`` otherwise.
+    :returns: ``1`` if a suitable viewer was found, ``0`` otherwise.
     """
     for viewer in _viewers:
         if viewer.show(image, title=title, **options):

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -248,7 +248,7 @@ class DisplayViewer(UnixViewer):
     def get_command_ex(self, file, title=None, **options):
         command = executable = "display"
         if title:
-            command += f" -name {quote(title)}"
+            command += f" -title {quote(title)}"
         return command, executable
 
     def show_file(self, path=None, **options):
@@ -270,7 +270,7 @@ class DisplayViewer(UnixViewer):
                 raise TypeError("Missing required argument: 'path'")
         args = ["display"]
         if "title" in options:
-            args += ["-name", options["title"]]
+            args += ["-title", options["title"]]
         args.append(path)
 
         subprocess.Popen(args)


### PR DESCRIPTION
Helps #5945 and #5976. Alternative to #6021

Three changes here.
1. As pointed out in #6021, `ImageShow.show()` does not return `True` and `False` like the docstring states, it returns 0 and 1. So this PR updates the docstring.
2. As suggested out in https://github.com/python-pillow/Pillow/pull/6005#discussion_r796396077, `display -title` looks preferable to `display -name`.

![Screen Shot 2022-02-09 at 4 17 44 pm](https://user-images.githubusercontent.com/3112309/153131306-a69b567c-c67b-460a-af35-053570e2c5b2.png)
![Screen Shot 2022-02-09 at 4 18 04 pm](https://user-images.githubusercontent.com/3112309/153131309-367fc5b9-31f2-421a-8e3d-dd018c59bd93.png)

3. Rather than waiting an arbitrary 20 seconds on Unix, wait until the application has finished showing the file to remove it. #6021 also does this, but in that version, Python script hangs until the application is closed. This version does not.
Since `xdg-open` does not wait until the application is closed, this PR instead uses `xdg-mime` to determine what application would be selected by `xdg-open`, and executes it directly.
For the record - I'm also not opposed to the [suggested alternative](https://github.com/python-pillow/Pillow/issues/5945#issuecomment-1028845574) of just abandoning the idea of manually deleting temporary files and leaving it up to the operating system.