### PR TITLE
Fix return in docs

### DIFF
--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -482,6 +482,7 @@ class JpegImageFile(ImageFile.ImageFile):
         """
         Returns a dictionary containing the XMP tags.
         Requires defusedxml to be installed.
+
         :returns: XMP tags in a dictionary.
         """
 

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -982,6 +982,7 @@ class PngImageFile(ImageFile.ImageFile):
         """
         Returns a dictionary containing the XMP tags.
         Requires defusedxml to be installed.
+
         :returns: XMP tags in a dictionary.
         """
         return (

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1124,6 +1124,7 @@ class TiffImageFile(ImageFile.ImageFile):
         """
         Returns a dictionary containing the XMP tags.
         Requires defusedxml to be installed.
+
         :returns: XMP tags in a dictionary.
         """
         return self._getxmp(self.tag_v2[700]) if 700 in self.tag_v2 else {}


### PR DESCRIPTION
Changes proposed in this pull request:

 * Need a newline for the `getxmp` return to render

# Before

![image](https://user-images.githubusercontent.com/1324225/153201618-76c0286e-159c-48b7-aa4d-002b1f7ced2a.png)

https://pillow.readthedocs.io/en/stable/reference/plugins.html#PIL.JpegImagePlugin.JpegImageFile.getxmp

# After

![image](https://user-images.githubusercontent.com/1324225/153201587-a29bcd3e-dac3-4c94-af76-3f4f829fa340.png)

