### PR TITLE
Do not automatically remove temporary ImageShow files on Unix

### DIFF
--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -51,6 +51,16 @@ def test_show():
         assert ImageShow.show(im)
 
 
+def test_show_without_viewers():
+    viewers = ImageShow._viewers
+    ImageShow._viewers = []
+
+    im = hopper()
+    assert not ImageShow.show(im)
+
+    ImageShow._viewers = viewers
+
+
 def test_viewer():
     viewer = ImageShow.Viewer()
 

--- a/docs/releasenotes/9.1.0.rst
+++ b/docs/releasenotes/9.1.0.rst
@@ -48,6 +48,13 @@ breaking backwards compatibility.
 Other Changes
 =============
 
+ImageShow temporary files on Unix
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When calling :py:meth:`~PIL.Image.Image.show` or using :py:mod:`~PIL.ImageShow`,
+a temporary file is created from the image. On Unix, Pillow will no longer delete these
+files, and instead leave it to the operating system to do so.
+
 Image._repr_pretty_
 ^^^^^^^^^^^^^^^^^^^
 

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -126,16 +126,6 @@ class Viewer:
         os.system(self.get_command(path, **options))
         return 1
 
-    def _remove_path_after_delay(self, path):
-        subprocess.Popen(
-            [
-                sys.executable,
-                "-c",
-                "import os, sys, time; time.sleep(20); os.remove(sys.argv[1])",
-                path,
-            ]
-        )
-
 
 # --------------------------------------------------------------------
 
@@ -190,7 +180,14 @@ class MacViewer(Viewer):
             else:
                 raise TypeError("Missing required argument: 'path'")
         subprocess.call(["open", "-a", "Preview.app", path])
-        self._remove_path_after_delay(path)
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import os, sys, time; time.sleep(20); os.remove(sys.argv[1])",
+                path,
+            ]
+        )
         return 1
 
 
@@ -235,7 +232,6 @@ class XDGViewer(UnixViewer):
             else:
                 raise TypeError("Missing required argument: 'path'")
         subprocess.Popen(["xdg-open", path])
-        self._remove_path_after_delay(path)
         return 1
 
 
@@ -274,7 +270,6 @@ class DisplayViewer(UnixViewer):
         args.append(path)
 
         subprocess.Popen(args)
-        os.remove(path)
         return 1
 
 
@@ -304,7 +299,6 @@ class GmDisplayViewer(UnixViewer):
             else:
                 raise TypeError("Missing required argument: 'path'")
         subprocess.Popen(["gm", "display", path])
-        os.remove(path)
         return 1
 
 
@@ -334,7 +328,6 @@ class EogViewer(UnixViewer):
             else:
                 raise TypeError("Missing required argument: 'path'")
         subprocess.Popen(["eog", "-n", path])
-        os.remove(path)
         return 1
 
 
@@ -375,7 +368,6 @@ class XVViewer(UnixViewer):
         args.append(path)
 
         subprocess.Popen(args)
-        os.remove(path)
         return 1
 
 

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -54,8 +54,8 @@ def show(image, title=None, **options):
     """
     for viewer in _viewers:
         if viewer.show(image, title=title, **options):
-            return 1
-    return 0
+            return True
+    return False
 
 
 class Viewer:

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -248,7 +248,7 @@ class DisplayViewer(UnixViewer):
     def get_command_ex(self, file, title=None, **options):
         command = executable = "display"
         if title:
-            command += f" -name {quote(title)}"
+            command += f" -title {quote(title)}"
         return command, executable
 
     def show_file(self, path=None, **options):
@@ -270,7 +270,7 @@ class DisplayViewer(UnixViewer):
                 raise TypeError("Missing required argument: 'path'")
         args = ["display"]
         if "title" in options:
-            args += ["-name", options["title"]]
+            args += ["-title", options["title"]]
         args.append(path)
 
         subprocess.Popen(args)

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -201,7 +201,7 @@ class UnixViewer(Viewer):
 
     def get_command(self, file, **options):
         command = self.get_command_ex(file, **options)[0]
-        return f"({command} {quote(file)}; rm -f {quote(file)})&"
+        return f"({command} {quote(file)}"
 
 
 class XDGViewer(UnixViewer):


### PR DESCRIPTION
Helps #5945 and #5976. Alternative to #6021

Three changes here.
1. As pointed out in #6021, `ImageShow.show()` does not return `True` and `False` like the docstring states, it returns 0 and 1. This PR updates the return values to match the docstring.
2. As suggested out in https://github.com/python-pillow/Pillow/pull/6005#discussion_r796396077, `display -title` looks preferable to `display -name`.

![Screen Shot 2022-02-09 at 4 17 44 pm](https://user-images.githubusercontent.com/3112309/153131306-a69b567c-c67b-460a-af35-053570e2c5b2.png)
![Screen Shot 2022-02-09 at 4 18 04 pm](https://user-images.githubusercontent.com/3112309/153131309-367fc5b9-31f2-421a-8e3d-dd018c59bd93.png)

3. Given that there have been [requests](https://github.com/python-pillow/Pillow/issues/5945#issuecomment-1028760062) for [multiple images to be shown at once](https://github.com/python-pillow/Pillow/issues/5976#issuecomment-1017214685) and [to be viewed after 20s](https://github.com/python-pillow/Pillow/issues/5976#issuecomment-1018444936), a possible solution to these requests is to not manually remove the temporary ImageShow files on Unix.