### PR TITLE
Only skip test if libimagequant is earlier than 4 on ppc64le

### DIFF
--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -1,8 +1,9 @@
 import pytest
+from packaging.version import parse as parse_version
 
-from PIL import Image
+from PIL import Image, features
 
-from .helper import assert_image_similar, hopper, is_ppc64le
+from .helper import assert_image_similar, hopper, is_ppc64le, skip_unless_feature
 
 
 def test_sanity():
@@ -17,16 +18,14 @@ def test_sanity():
     assert_image_similar(converted.convert("RGB"), image, 60)
 
 
-@pytest.mark.xfail(is_ppc64le(), reason="failing on ppc64le on GHA")
+@skip_unless_feature("libimagequant")
 def test_libimagequant_quantize():
     image = hopper()
-    try:
-        converted = image.quantize(100, Image.LIBIMAGEQUANT)
-    except ValueError as ex:  # pragma: no cover
-        if "dependency" in str(ex).lower():
-            pytest.skip("libimagequant support not available")
-        else:
-            raise
+    if is_ppc64le():
+        libimagequant = parse_version(features.version_feature("libimagequant"))
+        if libimagequant < parse_version("4"):
+            pytest.skip("Fails with libimagequant earlier than 4.0.0 on ppc64le")
+    converted = image.quantize(100, Image.LIBIMAGEQUANT)
     assert converted.mode == "P"
     assert_image_similar(converted.convert("RGB"), image, 15)
     assert len(converted.getcolors()) == 100


### PR DESCRIPTION
`test_libimagequant_quantize` is currently [skipped](https://github.com/python-pillow/Pillow/blob/cac305f8d2db5eca3ce18f8d334a9ff35f9c7fde/Tests/test_image_quantize.py#L20-L21) on ppc64le.

And for good reason, because if you [remove the skip](https://github.com/radarhere/Pillow/commit/12e2e97599209177550a8c382d64f6e03b910b29), it [fails](https://github.com/radarhere/Pillow/runs/5167378728).

Or rather, it did, because [that failure used libimagequant 2.12](https://github.com/radarhere/Pillow/runs/5167378728#step:6:82), and since https://github.com/python-pillow/docker-images/pull/138 effectively upgraded libimagequant on ppc64le to 4, it now passes, as seen in this PR.