### PR TITLE
Attach RGBA palettes from putpalette() when suitable

### DIFF
--- a/Tests/test_image_putpalette.py
+++ b/Tests/test_image_putpalette.py
@@ -62,3 +62,16 @@ def test_putpalette_with_alpha_values():
         im.putpalette(palette_with_alpha_values, "RGBA")
 
         assert_image_equal(im.convert("RGBA"), expected)
+
+
+@pytest.mark.parametrize(
+    "mode, palette",
+    (
+        ("RGBA", (1, 2, 3, 4)),
+        ("RGBAX", (1, 2, 3, 4, 0)),
+    ),
+)
+def test_rgba_palette(mode, palette):
+    im = Image.new("P", (1, 1))
+    im.putpalette(palette, mode)
+    assert im.palette.colors == {(1, 2, 3, 4): 0}

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -821,12 +821,6 @@ class Image:
         if self.im and self.palette and self.palette.dirty:
             # realize palette
             mode, arr = self.palette.getdata()
-            if mode == "RGBA":
-                mode = "RGB"
-                self.info["transparency"] = arr[3::4]
-                arr = bytes(
-                    value for (index, value) in enumerate(arr) if index % 4 != 3
-                )
             palette_length = self.im.putpalette(mode, arr)
             self.palette.dirty = 0
             self.palette.rawmode = None
@@ -837,8 +831,11 @@ class Image:
                     self.im.putpalettealphas(self.info["transparency"])
                 self.palette.mode = "RGBA"
             else:
-                self.palette.mode = "RGB"
-                self.palette.palette = self.im.getpalette()[: palette_length * 3]
+                palette_mode = "RGBA" if mode.startswith("RGBA") else "RGB"
+                self.palette.mode = palette_mode
+                self.palette.palette = self.im.getpalette(palette_mode, palette_mode)[
+                    : palette_length * len(palette_mode)
+                ]
 
         if self.im:
             if cffi and USE_CFFI_ACCESS:
@@ -1761,8 +1758,8 @@ class Image:
         Alternatively, an 8-bit string may be used instead of an integer sequence.
 
         :param data: A palette sequence (either a list or a string).
-        :param rawmode: The raw mode of the palette. Either "RGB", "RGBA", or a
-           mode that can be transformed to "RGB" (e.g. "R", "BGR;15", "RGBA;L").
+        :param rawmode: The raw mode of the palette. Either "RGB", "RGBA", or a mode
+           that can be transformed to "RGB" or "RGBA" (e.g. "R", "BGR;15", "RGBA;L").
         """
         from . import ImagePalette
 

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1641,7 +1641,7 @@ _putpalette(ImagingObject *self, PyObject *args) {
     ImagingShuffler unpack;
     int bits;
 
-    char *rawmode;
+    char *rawmode, *palette_mode;
     UINT8 *palette;
     Py_ssize_t palettesize;
     if (!PyArg_ParseTuple(args, "sy#", &rawmode, &palette, &palettesize)) {
@@ -1654,7 +1654,8 @@ _putpalette(ImagingObject *self, PyObject *args) {
         return NULL;
     }
 
-    unpack = ImagingFindUnpacker("RGB", rawmode, &bits);
+    palette_mode = strncmp("RGBA", rawmode, 4) == 0 ? "RGBA" : "RGB";
+    unpack = ImagingFindUnpacker(palette_mode, rawmode, &bits);
     if (!unpack) {
         PyErr_SetString(PyExc_ValueError, wrong_raw_mode);
         return NULL;
@@ -1669,7 +1670,7 @@ _putpalette(ImagingObject *self, PyObject *args) {
 
     strcpy(self->image->mode, strlen(self->image->mode) == 2 ? "PA" : "P");
 
-    self->image->palette = ImagingPaletteNew("RGB");
+    self->image->palette = ImagingPaletteNew(palette_mode);
 
     unpack(self->image->palette->palette, palette, palettesize * 8 / bits);
 


### PR DESCRIPTION
Resolves #6027

At the moment, `im.putpalette()` only results in RGB palettes, discarding alpha information. The exception to this is when [the mode is "RGBA", every 4th byte is extracted into `info`](https://github.com/python-pillow/Pillow/blob/cac305f8d2db5eca3ce18f8d334a9ff35f9c7fde/src/PIL/Image.py#L824-L829). However, that isn't a flexible way of retrieving alpha data, letting #6027 down when a user wants to retain alpha information from the more irregular "RGBA;15".

Instead, this PR changes `putpalette()` to create either RGB or RGBA palettes, moving the work of handling alpha data to Pillow's unpackers.