### PR TITLE
Merged _MODE_CONV typ into ImageMode as typestr

### DIFF
--- a/Tests/test_image_mode.py
+++ b/Tests/test_image_mode.py
@@ -21,6 +21,7 @@ def test_sanity():
     assert m.bands == ("1",)
     assert m.basemode == "L"
     assert m.basetype == "L"
+    assert m.typestr == "|b1"
 
     for mode in (
         "I;16",
@@ -45,6 +46,7 @@ def test_sanity():
     assert m.bands == ("R", "G", "B")
     assert m.basemode == "RGB"
     assert m.basetype == "L"
+    assert m.typestr == "|u1"
 
 
 def test_properties():

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -203,10 +203,7 @@ ENCODERS = {}
 # --------------------------------------------------------------------
 # Modes
 
-if sys.byteorder == "little":
-    _ENDIAN = "<"
-else:
-    _ENDIAN = ">"
+_ENDIAN = "<" if sys.byteorder == "little" else ">"
 
 
 def _conv_type_shape(im):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -208,7 +208,7 @@ _ENDIAN = "<" if sys.byteorder == "little" else ">"
 
 def _conv_type_shape(im):
     m = ImageMode.getmode(im.mode)
-    shape = (im.size[1], im.size[0])
+    shape = (im.height, im.width)
     extra = len(m.bands)
     if extra != 1:
         shape += (extra,)

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -208,44 +208,14 @@ if sys.byteorder == "little":
 else:
     _ENDIAN = ">"
 
-_MODE_CONV = {
-    # official modes
-    "1": "|b1",  # Bits need to be extended to bytes
-    "L": "|u1",
-    "LA": "|u1",
-    "I": _ENDIAN + "i4",
-    "F": _ENDIAN + "f4",
-    "P": "|u1",
-    "RGB": "|u1",
-    "RGBX": "|u1",
-    "RGBA": "|u1",
-    "CMYK": "|u1",
-    "YCbCr": "|u1",
-    "LAB": "|u1",  # UNDONE - unsigned |u1i1i1
-    "HSV": "|u1",
-    # I;16 == I;16L, and I;32 == I;32L
-    "I;16": "<u2",
-    "I;16B": ">u2",
-    "I;16L": "<u2",
-    "I;16S": "<i2",
-    "I;16BS": ">i2",
-    "I;16LS": "<i2",
-    "I;32": "<u4",
-    "I;32B": ">u4",
-    "I;32L": "<u4",
-    "I;32S": "<i4",
-    "I;32BS": ">i4",
-    "I;32LS": "<i4",
-}
-
 
 def _conv_type_shape(im):
-    typ = _MODE_CONV[im.mode]
-    extra = len(im.getbands())
-    if extra == 1:
-        return (im.size[1], im.size[0]), typ
-    else:
-        return (im.size[1], im.size[0], extra), typ
+    m = ImageMode.getmode(im.mode)
+    shape = (im.size[1], im.size[0])
+    extra = len(m.bands)
+    if extra != 1:
+        shape += (extra,)
+    return shape, m.typestr
 
 
 MODES = ["1", "CMYK", "F", "HSV", "I", "L", "LAB", "P", "RGB", "RGBA", "RGBX", "YCbCr"]

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -210,38 +210,39 @@ else:
 
 _MODE_CONV = {
     # official modes
-    "1": ("|b1", None),  # Bits need to be extended to bytes
-    "L": ("|u1", None),
-    "LA": ("|u1", 2),
-    "I": (_ENDIAN + "i4", None),
-    "F": (_ENDIAN + "f4", None),
-    "P": ("|u1", None),
-    "RGB": ("|u1", 3),
-    "RGBX": ("|u1", 4),
-    "RGBA": ("|u1", 4),
-    "CMYK": ("|u1", 4),
-    "YCbCr": ("|u1", 3),
-    "LAB": ("|u1", 3),  # UNDONE - unsigned |u1i1i1
-    "HSV": ("|u1", 3),
+    "1": "|b1",  # Bits need to be extended to bytes
+    "L": "|u1",
+    "LA": "|u1",
+    "I": _ENDIAN + "i4",
+    "F": _ENDIAN + "f4",
+    "P": "|u1",
+    "RGB": "|u1",
+    "RGBX": "|u1",
+    "RGBA": "|u1",
+    "CMYK": "|u1",
+    "YCbCr": "|u1",
+    "LAB": "|u1",  # UNDONE - unsigned |u1i1i1
+    "HSV": "|u1",
     # I;16 == I;16L, and I;32 == I;32L
-    "I;16": ("<u2", None),
-    "I;16B": (">u2", None),
-    "I;16L": ("<u2", None),
-    "I;16S": ("<i2", None),
-    "I;16BS": (">i2", None),
-    "I;16LS": ("<i2", None),
-    "I;32": ("<u4", None),
-    "I;32B": (">u4", None),
-    "I;32L": ("<u4", None),
-    "I;32S": ("<i4", None),
-    "I;32BS": (">i4", None),
-    "I;32LS": ("<i4", None),
+    "I;16": "<u2",
+    "I;16B": ">u2",
+    "I;16L": "<u2",
+    "I;16S": "<i2",
+    "I;16BS": ">i2",
+    "I;16LS": "<i2",
+    "I;32": "<u4",
+    "I;32B": ">u4",
+    "I;32L": "<u4",
+    "I;32S": "<i4",
+    "I;32BS": ">i4",
+    "I;32LS": "<i4",
 }
 
 
 def _conv_type_shape(im):
-    typ, extra = _MODE_CONV[im.mode]
-    if extra is None:
+    typ = _MODE_CONV[im.mode]
+    extra = len(im.getbands())
+    if extra == 1:
         return (im.size[1], im.size[0]), typ
     else:
         return (im.size[1], im.size[0], extra), typ

--- a/src/PIL/ImageMode.py
+++ b/src/PIL/ImageMode.py
@@ -13,7 +13,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-from PIL import Image
+import sys
 
 # mode descriptor cache
 _modes = None
@@ -39,13 +39,14 @@ def getmode(mode):
     if not _modes:
         # initialize mode cache
         modes = {}
+        endian = "<" if sys.byteorder == "little" else ">"
         for m, (basemode, basetype, bands, typestr) in {
             # core modes
             # Bits need to be extended to bytes
             "1": ("L", "L", ("1",), "|b1"),
             "L": ("L", "L", ("L",), "|u1"),
-            "I": ("L", "I", ("I",), Image._ENDIAN + "i4"),
-            "F": ("L", "F", ("F",), Image._ENDIAN + "f4"),
+            "I": ("L", "I", ("I",), endian + "i4"),
+            "F": ("L", "F", ("F",), endian + "f4"),
             "P": ("P", "L", ("P",), "|u1"),
             "RGB": ("RGB", "L", ("R", "G", "B"), "|u1"),
             "RGBX": ("RGB", "L", ("R", "G", "B", "X"), "|u1"),
@@ -75,8 +76,8 @@ def getmode(mode):
             "I;16LS": "<i2",
             "I;16B": ">u2",
             "I;16BS": ">i2",
-            "I;16N": Image._ENDIAN + "u2",
-            "I;16NS": Image._ENDIAN + "i2",
+            "I;16N": endian + "u2",
+            "I;16NS": endian + "i2",
             "I;32": "<u4",
             "I;32B": ">u4",
             "I;32L": "<u4",

--- a/src/PIL/ImageMode.py
+++ b/src/PIL/ImageMode.py
@@ -13,6 +13,8 @@
 # See the README file for information on usage and redistribution.
 #
 
+from PIL import Image
+
 # mode descriptor cache
 _modes = None
 
@@ -20,11 +22,12 @@ _modes = None
 class ModeDescriptor:
     """Wrapper for mode strings."""
 
-    def __init__(self, mode, bands, basemode, basetype):
+    def __init__(self, mode, bands, basemode, basetype, typestr):
         self.mode = mode
         self.bands = bands
         self.basemode = basemode
         self.basetype = basetype
+        self.typestr = typestr
 
     def __str__(self):
         return self.mode
@@ -36,43 +39,52 @@ def getmode(mode):
     if not _modes:
         # initialize mode cache
         modes = {}
-        for m, (basemode, basetype, bands) in {
+        for m, (basemode, basetype, bands, typestr) in {
             # core modes
-            "1": ("L", "L", ("1",)),
-            "L": ("L", "L", ("L",)),
-            "I": ("L", "I", ("I",)),
-            "F": ("L", "F", ("F",)),
-            "P": ("P", "L", ("P",)),
-            "RGB": ("RGB", "L", ("R", "G", "B")),
-            "RGBX": ("RGB", "L", ("R", "G", "B", "X")),
-            "RGBA": ("RGB", "L", ("R", "G", "B", "A")),
-            "CMYK": ("RGB", "L", ("C", "M", "Y", "K")),
-            "YCbCr": ("RGB", "L", ("Y", "Cb", "Cr")),
-            "LAB": ("RGB", "L", ("L", "A", "B")),
-            "HSV": ("RGB", "L", ("H", "S", "V")),
+            # Bits need to be extended to bytes
+            "1": ("L", "L", ("1",), "|b1"),
+            "L": ("L", "L", ("L",), "|u1"),
+            "I": ("L", "I", ("I",), Image._ENDIAN + "i4"),
+            "F": ("L", "F", ("F",), Image._ENDIAN + "f4"),
+            "P": ("P", "L", ("P",), "|u1"),
+            "RGB": ("RGB", "L", ("R", "G", "B"), "|u1"),
+            "RGBX": ("RGB", "L", ("R", "G", "B", "X"), "|u1"),
+            "RGBA": ("RGB", "L", ("R", "G", "B", "A"), "|u1"),
+            "CMYK": ("RGB", "L", ("C", "M", "Y", "K"), "|u1"),
+            "YCbCr": ("RGB", "L", ("Y", "Cb", "Cr"), "|u1"),
+            # UNDONE - unsigned |u1i1i1
+            "LAB": ("RGB", "L", ("L", "A", "B"), "|u1"),
+            "HSV": ("RGB", "L", ("H", "S", "V"), "|u1"),
             # extra experimental modes
-            "RGBa": ("RGB", "L", ("R", "G", "B", "a")),
-            "BGR;15": ("RGB", "L", ("B", "G", "R")),
-            "BGR;16": ("RGB", "L", ("B", "G", "R")),
-            "BGR;24": ("RGB", "L", ("B", "G", "R")),
-            "BGR;32": ("RGB", "L", ("B", "G", "R")),
-            "LA": ("L", "L", ("L", "A")),
-            "La": ("L", "L", ("L", "a")),
-            "PA": ("RGB", "L", ("P", "A")),
+            "RGBa": ("RGB", "L", ("R", "G", "B", "a"), None),
+            "BGR;15": ("RGB", "L", ("B", "G", "R"), None),
+            "BGR;16": ("RGB", "L", ("B", "G", "R"), None),
+            "BGR;24": ("RGB", "L", ("B", "G", "R"), None),
+            "BGR;32": ("RGB", "L", ("B", "G", "R"), None),
+            "LA": ("L", "L", ("L", "A"), "|u1"),
+            "La": ("L", "L", ("L", "a"), None),
+            "PA": ("RGB", "L", ("P", "A"), "|u1"),
         }.items():
-            modes[m] = ModeDescriptor(m, bands, basemode, basetype)
+            modes[m] = ModeDescriptor(m, bands, basemode, basetype, typestr)
         # mapping modes
-        for i16mode in (
-            "I;16",
-            "I;16S",
-            "I;16L",
-            "I;16LS",
-            "I;16B",
-            "I;16BS",
-            "I;16N",
-            "I;16NS",
-        ):
-            modes[i16mode] = ModeDescriptor(i16mode, ("I",), "L", "L")
+        for i16mode, typestr in {
+            # I;16 == I;16L, and I;32 == I;32L
+            "I;16": "<u2",
+            "I;16S": "<i2",
+            "I;16L": "<u2",
+            "I;16LS": "<i2",
+            "I;16B": ">u2",
+            "I;16BS": ">i2",
+            "I;16N": Image._ENDIAN + "u2",
+            "I;16NS": Image._ENDIAN + "i2",
+            "I;32": "<u4",
+            "I;32B": ">u4",
+            "I;32L": "<u4",
+            "I;32S": "<i4",
+            "I;32BS": ">i4",
+            "I;32LS": "<i4",
+        }.items():
+            modes[i16mode] = ModeDescriptor(i16mode, ("I",), "L", "L", typestr)
         # set global mode cache atomically
         _modes = modes
     return _modes[mode]

--- a/src/PIL/ImageMode.py
+++ b/src/PIL/ImageMode.py
@@ -57,13 +57,13 @@ def getmode(mode):
             "LAB": ("RGB", "L", ("L", "A", "B"), "|u1"),
             "HSV": ("RGB", "L", ("H", "S", "V"), "|u1"),
             # extra experimental modes
-            "RGBa": ("RGB", "L", ("R", "G", "B", "a"), None),
-            "BGR;15": ("RGB", "L", ("B", "G", "R"), None),
-            "BGR;16": ("RGB", "L", ("B", "G", "R"), None),
-            "BGR;24": ("RGB", "L", ("B", "G", "R"), None),
-            "BGR;32": ("RGB", "L", ("B", "G", "R"), None),
+            "RGBa": ("RGB", "L", ("R", "G", "B", "a"), "|u1"),
+            "BGR;15": ("RGB", "L", ("B", "G", "R"), endian + "u2"),
+            "BGR;16": ("RGB", "L", ("B", "G", "R"), endian + "u2"),
+            "BGR;24": ("RGB", "L", ("B", "G", "R"), endian + "u3"),
+            "BGR;32": ("RGB", "L", ("B", "G", "R"), endian + "u4"),
             "LA": ("L", "L", ("L", "A"), "|u1"),
-            "La": ("L", "L", ("L", "a"), None),
+            "La": ("L", "L", ("L", "a"), "|u1"),
             "PA": ("RGB", "L", ("P", "A"), "|u1"),
         }.items():
             modes[m] = ModeDescriptor(m, bands, basemode, basetype, typestr)


### PR DESCRIPTION
Resolves #5990

https://github.com/python-pillow/Pillow/issues/5990#issuecomment-1039873428 pointed out that the second value in [`_MODE_CONV`](https://github.com/python-pillow/Pillow/blob/7b3f28047fe008d70bda1938e3178da388ecaa64/src/PIL/Image.py#L211-L239), [`extra`](https://github.com/python-pillow/Pillow/blob/7b3f28047fe008d70bda1938e3178da388ecaa64/src/PIL/Image.py#L243), is the number of bands in the mode. Rather than writing those out in `_MODE_CONV`, this could instead be derived from ImageMode.

The user in the issue would also like the NumPy typestr from `_MODE_CONV` available through a public API, and suggested ImageMode. From an organisational point of view for Pillow's code, that seems like a more logical location for that information, and it would be neater, since it then means that `_MODE_CONV` can be removed. The NumPy typestr could then be accessed by a user through `ImageMode.getmode(mode).typestr`.