### PR TITLE
macOS: 'brew install openjpeg' for JPEG2000 support

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -291,7 +291,7 @@ tools.
 The easiest way to install external libraries is via `Homebrew
 <https://brew.sh/>`_. After you install Homebrew, run::
 
-    brew install libtiff libjpeg webp little-cms2
+    brew install libjpeg libtiff little-cms2 openjpeg webp
 
 To install libraqm on macOS use Homebrew to install its dependencies::
 


### PR DESCRIPTION
Shall we include JPEG2000 as well?

---

Whilst we're here, a line or two down we tell the user to pip install Pillow from PyPI, or instead build from source:


```rst
Now install Pillow with::

    python3 -m pip install --upgrade pip
    python3 -m pip install --upgrade Pillow

or from within the uncompressed source directory::

    python3 -m pip install .
```

But this is the section on [Building from source](https://pillow.readthedocs.io/en/stable/installation.html#building-on-macos), we already had the [Basic installation](https://pillow.readthedocs.io/en/stable/installation.html#basic-installation) near the top of the page.

Shall we change it to this?

```rst
Now install from within the uncompressed source directory::::

    python3 -m pip install --upgrade pip
    python3 -m pip install .
```
