### PR TITLE
Use --no-binary when installing from source

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -215,7 +215,7 @@ Many of Pillow's features require external libraries:
 Once you have installed the prerequisites, run::
 
     python3 -m pip install --upgrade pip
-    python3 -m pip install --upgrade Pillow
+    python3 -m pip install --upgrade Pillow --no-binary :all:
 
 If the prerequisites are installed in the standard library locations
 for your machine (e.g. :file:`/usr` or :file:`/usr/local`), no
@@ -225,7 +225,7 @@ those locations by editing :file:`setup.py` or
 :file:`setup.cfg`, or by adding environment variables on the command
 line::
 
-    CFLAGS="-I/usr/pkg/include" python3 -m pip install --upgrade Pillow
+    CFLAGS="-I/usr/pkg/include" python3 -m pip install --upgrade Pillow --no-binary :all:
 
 If Pillow has been previously built without the required
 prerequisites, it may be necessary to manually clear the pip cache or
@@ -302,7 +302,7 @@ Then see ``depends/install_raqm_cmake.sh`` to install libraqm.
 Now install Pillow with::
 
     python3 -m pip install --upgrade pip
-    python3 -m pip install --upgrade Pillow
+    python3 -m pip install --upgrade Pillow --no-binary :all:
 
 or from within the uncompressed source directory::
 
@@ -349,7 +349,7 @@ Prerequisites are installed on **MSYS2 MinGW 64-bit** with::
 Now install Pillow with::
 
     python3 -m pip install --upgrade pip
-    python3 -m pip install --upgrade Pillow
+    python3 -m pip install --upgrade Pillow --no-binary :all:
 
 
 Building on FreeBSD


### PR DESCRIPTION
When "Building From Source" as this section of the documentation is supposed to do, make sure that the user is not installing a wheel - use `--no-binary :all:`