### PR TITLE
Corrected JPEG subsampling documentation

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -385,6 +385,8 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
     * ``1``: equivalent to ``4:2:2``
     * ``2``: equivalent to ``4:2:0``
 
+    If absent, the setting will be determined by libjpeg or libjpeg-turbo.
+
 **qtables**
     If present, sets the qtables for the encoder. This is listed as an
     advanced option for wizards in the JPEG documentation. Use with

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -381,7 +381,6 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
 
     * ``keep``: Only valid for JPEG files, will retain the original image setting.
     * ``4:4:4``, ``4:2:2``, ``4:2:0``: Specific sampling values
-    * ``-1``: equivalent to ``keep``
     * ``0``: equivalent to ``4:4:4``
     * ``1``: equivalent to ``4:2:2``
     * ``2``: equivalent to ``4:2:0``


### PR DESCRIPTION
Alternative to #4570

https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#jpeg
> **subsampling**
>    If present, sets the subsampling for the encoder.
>
>    * ``keep``: Only valid for JPEG files, will retain the original image setting.
>    * ``4:4:4``, ``4:2:2``, ``4:2:0``: Specific sampling values
>    * ``-1``: equivalent to ``keep``

Discussion in that PR revealed that `-1` is not always equivalent to `keep`. The PR suggested fixing that discrepancy by changing Pillow to make `-1` equivalent to `keep`.

This PR instead suggests to leave Pillow behaviour unchanged, and just correct the documentation.

In Python, [-1 is just the default value to pass to C](https://github.com/python-pillow/Pillow/blob/669247cbd758acccac131daf9a2804c99f82bbca/src/PIL/JpegImagePlugin.py#L640).
In C, [-1 is actually not a setting at all, it's just the default behaviour](https://github.com/python-pillow/Pillow/blob/df886ed38694197665c8cce50216c877b477a30c/src/libImaging/JpegEncode.c#L180-L217).
So I suggest removing `-1` from the documentation. If the user wants the default behaviour, they can just not specify the subsampling option. [`-1` is also the default for "quality"](https://github.com/python-pillow/Pillow/blob/669247cbd758acccac131daf9a2804c99f82bbca/src/PIL/JpegImagePlugin.py#L639), and [that isn't mentioned in the documentation](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#jpeg).

I'm also explicitly mentioning that if subsampling is not specified, then it will be determined by the JPEG dependency.