### PR TITLE
Changed quantize default dither to FLOYDSTEINBERG

### DIFF
--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -60,7 +60,7 @@ def test_quantize_no_dither():
     with Image.open("Tests/images/caption_6_33_22.png") as palette:
         palette = palette.convert("P")
 
-    converted = image.quantize(dither=0, palette=palette)
+    converted = image.quantize(dither=Image.Dither.NONE, palette=palette)
     assert converted.mode == "P"
     assert converted.palette.palette == palette.palette.palette
 
@@ -70,8 +70,8 @@ def test_quantize_dither_diff():
     with Image.open("Tests/images/caption_6_33_22.png") as palette:
         palette = palette.convert("P")
 
-    dither = image.quantize(dither=1, palette=palette)
-    nodither = image.quantize(dither=0, palette=palette)
+    dither = image.quantize(dither=Image.Dither.FLOYDSTEINBERG, palette=palette)
+    nodither = image.quantize(dither=Image.Dither.NONE, palette=palette)
 
     assert dither.tobytes() != nodither.tobytes()
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1123,7 +1123,14 @@ class Image:
                 new_im.info["transparency"] = trns
         return new_im
 
-    def quantize(self, colors=256, method=None, kmeans=0, palette=None, dither=1):
+    def quantize(
+        self,
+        colors=256,
+        method=None,
+        kmeans=0,
+        palette=None,
+        dither=Dither.FLOYDSTEINBERG,
+    ):
         """
         Convert the image to 'P' mode with the specified number
         of colors.
@@ -1148,7 +1155,6 @@ class Image:
            mode "RGB" to "P" or from "RGB" or "L" to "1".
            Available methods are :data:`Dither.NONE` or :data:`Dither.FLOYDSTEINBERG`
            (default).
-           Default: 1 (legacy setting)
         :returns: A new image
 
         """

--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -1447,7 +1447,7 @@ topalette(
 }
 
 static Imaging
-tobilevel(Imaging imOut, Imaging imIn, int dither) {
+tobilevel(Imaging imOut, Imaging imIn) {
     ImagingSectionCookie cookie;
     int x, y;
     int *errors;
@@ -1574,7 +1574,7 @@ convert(
     }
 
     if (dither && strcmp(mode, "1") == 0) {
-        return tobilevel(imOut, imIn, dither);
+        return tobilevel(imOut, imIn);
     }
 
     /* standard conversion machinery */


### PR DESCRIPTION
https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.quantize
> **dither** – Dithering method, used when converting from mode “RGB” to “P” or from “RGB” or “L” to “1”. Available methods are [NONE](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.NONE) or [FLOYDSTEINBERG](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.FLOYDSTEINBERG) (default). Default: 1 (legacy setting)

It's weird that the documentation specified twice what the default was, but I guess that the FLOYDSTEINBERG constant has a raw value of 1. Oh wait, no, it doesn't.

https://github.com/python-pillow/Pillow/blob/29b703063134c6845d3bee333c178d9bba2ddc25/src/PIL/Image.py#L168-L172

If you search for 'dither' in [Image.py](https://github.com/python-pillow/Pillow/blob/main/src/PIL/Image.py), [_imaging.c](https://github.com/python-pillow/Pillow/blob/main/src/_imaging.c) and [Convert.c](https://github.com/python-pillow/Pillow/blob/main/src/libImaging/Convert.c), it makes no difference in the code whether it is 1 or 3.

So this PR suggests changing the `quantize()` default dither to `FLOYDSTEINBERG`. It should have no effect on the behaviour of Pillow, but it will stop the docstring from being confusing.

While I'm here, I also stop passing `dither` to the C function `tobilevel`, since it is unused.