### PR TITLE
(Discussion) Use setuptools / importlib entry points to load installed decoders

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -44,6 +44,12 @@ try:
 except ImportError:
     ElementTree = None
 
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    # NB: potentially try to load entry_points from backported importlib_metadata?
+    entry_points = None
+
 # VERSION was removed in Pillow 6.0.0.
 # PILLOW_VERSION was removed in Pillow 9.0.0.
 # Use __version__ instead.
@@ -373,6 +379,12 @@ def init():
             __import__(f"PIL.{plugin}", globals(), locals(), [])
         except ImportError as e:
             logger.debug("Image: failed to import %s: %s", plugin, e)
+
+    if entry_points:
+        for decoder in entry_points(group='PIL.Image.decoder'):
+            # or, alternatively, register a decoder directly from here:
+            # DECODERS[decoder.name] = decoder.load()
+            decoder.load()
 
     if OPEN or SAVE:
         _initialized = 2

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -403,6 +403,9 @@ def _getdecoder(mode, decoder_name, args, extra=()):
     elif not isinstance(args, tuple):
         args = (args,)
 
+    if _initialized < 2:
+        init()
+
     try:
         decoder = DECODERS[decoder_name]
     except KeyError:

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -381,7 +381,7 @@ def init():
             logger.debug("Image: failed to import %s: %s", plugin, e)
 
     if entry_points:
-        for decoder in entry_points(group='PIL.Image.decoder'):
+        for decoder in entry_points(group="PIL.Image.decoder"):
             # or, alternatively, register a decoder directly from here:
             # DECODERS[decoder.name] = decoder.load()
             decoder.load()


### PR DESCRIPTION
*Note that this pull request is currently a proof of concept to aid in the discussion on whether this type of feature would suit Pillow.*

Changes proposed in this pull request:

* Define a `PIL.Image.decoder` entry point group;
* Load / import decoders defined in this way on init.

This proof of concept was tested locally in Python 3.10 with the following addition to @K0lb3's [implementation of an ASTC-decoder for Pillow](https://github.com/K0lb3/astc_decomp/):

```ini
[options.entry_points]
PIL.Image.decoder =
     astc = astc_decomp:ASTCDecoder
```

The addition is purely packaging metadata, that can be discovered by `importlib.metadata.entry_points` as shown in the diff. Older versions of Python could be supported through the `importlib_metadata` backport, not currently implemented in the PR. Note that this definition contains the exact same information as it would normally register to `DECODERS`: a name and a type reference.

This PoC primarily poses the question **"does using packaging metadata entry points suit Pillow?"**. This was driven by my own surprise at having to import a module like `astc_decomp` without using that module for anything to allow it to register itself into `PIL.Image.DECODERS`. Considering that many Python projects use some kind of plugin system and setuptools / importlib expose a stdlib system for this, why could Pillow not do something similar?

There's more than just the primary question here that might need some discussion and / or fiddling to smoothly support something like this:

- Should it work in Python < 3.10 (throught the importlib backport)?
- Is importing a declared module (expecting that module to register itself, as they'd be doing right now) enough, or should the registration be explicit as per the entry point declaration (see diff)?
- At what point in time should this listing be done?
    - At the module level in `Image.py` won't work, this would halt execution of the module while 'plugins' would want to import things from that module;
    - Is this something for `preinit()` or for `init()`?
    - `init()` is not always called early enough it seems, my code would call `Image.frombytes(..., 'astc', ...)`, at which point `init()` was not (being) called yet, causing it to complain that the decoder was not available (or am I doing something wrong?);
    - An `EntryPoint` need not be loaded at `init()`, it could be 'wrapped' with a lazy loader that registers it, but only actually loads it when it's first used;
- Is `PIL.Image.decoder` the right entry point group (too specific maybe)?

I'm willing to put in work to implement more of this idea and add tests and documentation if needed, but I'm currently mostly interested in other people's thoughts on this; is this a good or a bad idea? :)