### PR TITLE
Fixed BUFR, GRIB and HDF5 stub saving

### DIFF
--- a/Tests/test_file_bufrstub.py
+++ b/Tests/test_file_bufrstub.py
@@ -45,3 +45,35 @@ def test_save(tmp_path):
     # Act / Assert: stub cannot save without an implemented handler
     with pytest.raises(OSError):
         im.save(tmpfile)
+
+
+def test_handler(tmp_path):
+    class TestHandler:
+        opened = False
+        loaded = False
+        saved = False
+
+        def open(self, im):
+            self.opened = True
+
+        def load(self, im):
+            self.loaded = True
+            return Image.new("RGB", (1, 1))
+
+        def save(self, im, fp, filename):
+            self.saved = True
+
+    handler = TestHandler()
+    BufrStubImagePlugin.register_handler(handler)
+    with Image.open(TEST_FILE) as im:
+        assert handler.opened
+        assert not handler.loaded
+
+        im.load()
+        assert handler.loaded
+
+        temp_file = str(tmp_path / "temp.bufr")
+        im.save(temp_file)
+        assert handler.saved
+
+    BufrStubImagePlugin._handler = None

--- a/Tests/test_file_gribstub.py
+++ b/Tests/test_file_gribstub.py
@@ -45,3 +45,35 @@ def test_save(tmp_path):
     # Act / Assert: stub cannot save without an implemented handler
     with pytest.raises(OSError):
         im.save(tmpfile)
+
+
+def test_handler(tmp_path):
+    class TestHandler:
+        opened = False
+        loaded = False
+        saved = False
+
+        def open(self, im):
+            self.opened = True
+
+        def load(self, im):
+            self.loaded = True
+            return Image.new("RGB", (1, 1))
+
+        def save(self, im, fp, filename):
+            self.saved = True
+
+    handler = TestHandler()
+    GribStubImagePlugin.register_handler(handler)
+    with Image.open(TEST_FILE) as im:
+        assert handler.opened
+        assert not handler.loaded
+
+        im.load()
+        assert handler.loaded
+
+        temp_file = str(tmp_path / "temp.grib")
+        im.save(temp_file)
+        assert handler.saved
+
+    GribStubImagePlugin._handler = None

--- a/src/PIL/BufrStubImagePlugin.py
+++ b/src/PIL/BufrStubImagePlugin.py
@@ -59,7 +59,7 @@ class BufrStubImageFile(ImageFile.StubImageFile):
 
 
 def _save(im, fp, filename):
-    if _handler is None or not hasattr("_handler", "save"):
+    if _handler is None or not hasattr(_handler, "save"):
         raise OSError("BUFR save handler not installed")
     _handler.save(im, fp, filename)
 

--- a/src/PIL/GribStubImagePlugin.py
+++ b/src/PIL/GribStubImagePlugin.py
@@ -59,7 +59,7 @@ class GribStubImageFile(ImageFile.StubImageFile):
 
 
 def _save(im, fp, filename):
-    if _handler is None or not hasattr("_handler", "save"):
+    if _handler is None or not hasattr(_handler, "save"):
         raise OSError("GRIB save handler not installed")
     _handler.save(im, fp, filename)
 

--- a/src/PIL/Hdf5StubImagePlugin.py
+++ b/src/PIL/Hdf5StubImagePlugin.py
@@ -59,7 +59,7 @@ class HDF5StubImageFile(ImageFile.StubImageFile):
 
 
 def _save(im, fp, filename):
-    if _handler is None or not hasattr("_handler", "save"):
+    if _handler is None or not hasattr(_handler, "save"):
         raise OSError("HDF5 save handler not installed")
     _handler.save(im, fp, filename)
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/af345358e321bf3b9acc08f4f38c37d24152e470/src/PIL/BufrStubImagePlugin.py#L62-L63

`hasattr("_handler", "save")` is incorrect. We are not interested if the string `"handler"` has a `save` attribute, we are interested if the variable `_handler` has a save attribute.

This was fixed for WmfStubImageFile in https://github.com/python-pillow/Pillow/commit/751a6d1c2d13144e240ac2, but the fix wasn't applied to other stub formats.

I have not applied this fix to FITS, as the stub form of that plugin is being deprecated in #6056