### PR TITLE
GifImagePlugin seek-related optimizations

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -277,6 +277,7 @@ def test_seek():
                 img.seek(img.tell() + 1)
         except EOFError:
             assert frame_count == 5
+            assert img._n_frames == frame_count
 
 
 def test_seek_info():

--- a/docs/releasenotes/9.1.0.rst
+++ b/docs/releasenotes/9.1.0.rst
@@ -121,6 +121,34 @@ can be used to return data in the current mode of the palette.
 Other Changes
 =============
 
+GifImagePlugin seek-related optimizations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Optimized :py:meth:`~PIL.GifImagePlugin.seek()`,
+:py:property:`~PIL.GifImagePlugin.n_frames` and
+:py:property:`~PIL.GifImagePlugin.is_animated` when seeking back to the *current* frame
+before invoking the operation, after an ``EOFError`` is raised.
+
+These operations no longer have to seek back to **frame 0** before seeking forward,
+instead they seek back to the frame just before the *current* frame and then seek
+just one frame forward.
+
+Eliminated seek checks while computing :py:property:`~PIL.GifImagePlugin.n_frames`
+by using :py:meth:`PIL.GifImagePlugin._seek()` in place of
+:py:meth:`~PIL.GifImagePlugin.seek()` since the frame numbers cannot be invalid until
+the final one, which raises ``EOFError``.
+
+When an ``EOFError`` is raised within :py:meth:`~PIL.GifImagePlugin.seek()` i.e just
+seeked past the last frame, ``self._n_frames`` is updated if it hadn't been updated
+earlier, to prevent re-computation when :py:property:`~PIL.GifImagePlugin.n_frames` is
+later invoked.
+
+Added ``self.__prev_offset`` to always hold the offset of the frame just before the
+current frame.
+
+Replaced all internal calls to :py:meth:`~PIL.GifImagePlugin.tell()` with direct
+references to ``self.__frame``.
+
 ImageShow temporary files on Unix
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Added `self.__prev_offset` to always hold the offset of the frame just before the current frame.
- Optimized `GifImagePlugin.seek()`, `GifImagePlugin.n_frames` and `GifImagePlugin.is_animated` when seeking back to the current frame before invoking the operation, after an `EOFError` is raised.
- Seeking beyond the last frame automatically computes `GifImagePlugin.n_frames`.
- `GifImagePlugin.n_frames` now calls `GifImagePlugin._seek()` directly instead of  `GifImagePlugin.seek()`.
  - Skips unnecessary seek checks as all seeks will be valid, since the current frame is already valid and seeking starts from the next frame.
  - Skips the "current-frame-reset" step of `.seek()`
- Replaced all internal calls to `GifImagePlugin.tell()` with direct references to `self.__frame`.

## Extra Explanation
Concerning `.n_frames` for example, when a GIF (say 57 frames) is currently on the mid frame (say 28), invoking `.n_frames` for the first time would've resulted in the following chain of frame changes:

> 28 -> ... -> 56 -> 57 [(while performing seek checks for every step)... `EOFError` is caught in `seek()`, `seek()` tries to reset to 56]
> 57 -> 0 [Since 56 < 57]
> 0 -> ... -> 56 [`EOFError` is re-raised from `seek()`, caught in `n_frames` and tries to reset to 28]
> 56 -> 0 [Since 28 < 56]
> 0 -> 28 [`n_frames` finally sets and returns `_n_frames`]

Now, it goes thus:

> 28 -> ... -> 56 -> 57 [EOFError caught in `n_frames`, tries to reset to 28]
> 27 -> 28 [Causes the the file pointer to be directly seek-ed to the offset of frame 27 by setting `__offset`, which takes relatively "no" time. `n_frames` sets and returns `_n_frames`]

## Tests

The test image has 57 frames.

```python
def test_seek_1():
    img = Image.open("images/TIKTOK_LOGO_400.gif")
    try:
        img.seek(57)  # EOFError, then reset to frame 0
    except EOFError:
        pass

def test_seek_2():
    img = Image.open("images/TIKTOK_LOGO_400.gif")
    img.seek(56)  # Last frame
    try:
        img.seek(57)  # EOFError, then reset to frame 56
    except EOFError:
        pass

def test_seek_EOF_nframes():
    img = Image.open("images/TIKTOK_LOGO_400.gif")
    try:
        img.seek(57)  # EOFError
    except EOFError:
        pass
    img.n_frames  # Already computed in new version


def test_nframes_1():
    # 57 frames
    img = Image.open("images/TIKTOK_LOGO_400.gif")
    img.n_frames

def test_nframes_2():
    # 57 frames
    img = Image.open("images/TIKTOK_LOGO_400.gif")
    img.seek(28)  # Mid frame
    img.n_frames  # Seek to end and reset to frame 28

def test_nframes_3():
    # 57 frames
    img = Image.open("images/TIKTOK_LOGO_400.gif")
    img.seek(56)  # Last frame
    img.n_frames  # Seek to end and reset to frame 56


def test_is_animated_1():
    # 57 frames
    img = Image.open("images/TIKTOK_LOGO_400.gif")
    img.is_animated  # Seek to frame 1 and reset to frame 0

def test_is_animated_2():
    # 57 frames
    img = Image.open("images/TIKTOK_LOGO_400.gif")
    img.seek(56)  # Last frame
    img.is_animated  # Seek to frame 1 and reset to frame 56

```

## Results

Formerly:
```ipython
In [395]: %timeit test_seek_1()
76.1 ms ± 1.43 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [396]: %timeit test_seek_2()
155 ms ± 5.07 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [397]: %timeit test_seek_EOF_nframes()
220 ms ± 2.76 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)


In [399]: %timeit test_nframes_1()
152 ms ± 4.13 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [400]: %timeit test_nframes_2()
195 ms ± 6.24 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [401]: %timeit test_nframes_3()
153 ms ± 4.92 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)


In [402]: %timeit test_is_animated_1()
1.13 ms ± 21.9 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [403]: %timeit test_is_animated_2()
147 ms ± 2 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Now:
```
In [405]: %timeit test_seek_1()
74.5 ms ± 1.83 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [406]: %timeit test_seek_2()
73.5 ms ± 799 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [407]: %timeit test_seek_EOF_nframes()
73.7 ms ± 778 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)


In [408]: %timeit test_nframes_1()
75.1 ms ± 1.14 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [409]: %timeit test_nframes_2()
79.1 ms ± 1.82 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [410]: %timeit test_nframes_3()
80.1 ms ± 3.98 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)


In [411]: %timeit test_is_animated_1()
1.13 ms ± 44.8 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [412]: %timeit test_is_animated_2()
75.4 ms ± 1.8 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```