### PR TITLE
Updated checks that no warnings were raised

### DIFF
--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -1,6 +1,5 @@
 import os
-
-import pytest
+import warnings
 
 from PIL import Image
 
@@ -20,15 +19,13 @@ def test_bad():
     either"""
     for f in get_files("b"):
 
-        with pytest.warns(None) as record:
+        # Assert that there is no unclosed file warning
+        with warnings.catch_warnings():
             try:
                 with Image.open(f) as im:
                     im.load()
             except Exception:  # as msg:
                 pass
-
-        # Assert that there is no unclosed file warning
-        assert not record
 
 
 def test_questionable():

--- a/Tests/test_file_dcx.py
+++ b/Tests/test_file_dcx.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 from PIL import DcxImagePlugin, Image
@@ -31,20 +33,16 @@ def test_unclosed_file():
 
 
 def test_closed_file():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         im = Image.open(TEST_FILE)
         im.load()
         im.close()
 
-    assert not record
-
 
 def test_context_manager():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         with Image.open(TEST_FILE) as im:
             im.load()
-
-    assert not record
 
 
 def test_invalid_file():

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 from PIL import FliImagePlugin, Image
@@ -38,20 +40,16 @@ def test_unclosed_file():
 
 
 def test_closed_file():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         im = Image.open(static_test_file)
         im.load()
         im.close()
 
-    assert not record
-
 
 def test_context_manager():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         with Image.open(static_test_file) as im:
             im.load()
-
-    assert not record
 
 
 def test_tell():

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1,3 +1,4 @@
+import warnings
 from io import BytesIO
 
 import pytest
@@ -39,20 +40,16 @@ def test_unclosed_file():
 
 
 def test_closed_file():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         im = Image.open(TEST_GIF)
         im.load()
         im.close()
 
-    assert not record
-
 
 def test_context_manager():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         with Image.open(TEST_GIF) as im:
             im.load()
-
-    assert not record
 
 
 def test_invalid_file():

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -1,5 +1,6 @@
 import io
 import os
+import warnings
 
 import pytest
 
@@ -19,9 +20,8 @@ def test_sanity():
     with Image.open(TEST_FILE) as im:
 
         # Assert that there is no unclosed file warning
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
             im.load()
-        assert not record
 
         assert im.mode == "RGBA"
         assert im.size == (1024, 1024)

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -1,4 +1,5 @@
 import filecmp
+import warnings
 
 import pytest
 
@@ -35,20 +36,16 @@ def test_unclosed_file():
 
 
 def test_closed_file():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         im = Image.open(TEST_IM)
         im.load()
         im.close()
 
-    assert not record
-
 
 def test_context_manager():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         with Image.open(TEST_IM) as im:
             im.load()
-
-    assert not record
 
 
 def test_tell():

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -1,5 +1,6 @@
 import os
 import re
+import warnings
 from io import BytesIO
 
 import pytest
@@ -756,9 +757,8 @@ class TestFileJpeg:
             assert exif[282] == 180
 
             out = str(tmp_path / "out.jpg")
-            with pytest.warns(None) as record:
+            with warnings.catch_warnings():
                 im.save(out, exif=exif)
-            assert not record
 
         with Image.open(out) as reloaded:
             assert reloaded.getexif()[282] == 180

--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -1,3 +1,4 @@
+import warnings
 from io import BytesIO
 
 import pytest
@@ -41,20 +42,16 @@ def test_unclosed_file():
 
 
 def test_closed_file():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         im = Image.open(test_files[0])
         im.load()
         im.close()
 
-    assert not record
-
 
 def test_context_manager():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         with Image.open(test_files[0]) as im:
             im.load()
-
-    assert not record
 
 
 def test_app():

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -1,5 +1,6 @@
 import re
 import sys
+import warnings
 import zlib
 from io import BytesIO
 
@@ -331,9 +332,8 @@ class TestFilePng:
 
         with Image.open(TEST_PNG_FILE) as im:
             # Assert that there is no unclosed file warning
-            with pytest.warns(None) as record:
+            with warnings.catch_warnings():
                 im.verify()
-            assert not record
 
         with Image.open(TEST_PNG_FILE) as im:
             im.load()

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 from PIL import Image, PsdImagePlugin
@@ -29,20 +31,16 @@ def test_unclosed_file():
 
 
 def test_closed_file():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         im = Image.open(test_file)
         im.load()
         im.close()
 
-    assert not record
-
 
 def test_context_manager():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         with Image.open(test_file) as im:
             im.load()
-
-    assert not record
 
 
 def test_invalid_file():

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -1,4 +1,5 @@
 import tempfile
+import warnings
 from io import BytesIO
 
 import pytest
@@ -28,20 +29,16 @@ def test_unclosed_file():
 
 
 def test_closed_file():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         im = Image.open(TEST_FILE)
         im.load()
         im.close()
 
-    assert not record
-
 
 def test_context_manager():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         with Image.open(TEST_FILE) as im:
             im.load()
-
-    assert not record
 
 
 def test_save(tmp_path):

--- a/Tests/test_file_tar.py
+++ b/Tests/test_file_tar.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 from PIL import Image, TarIO, features
@@ -31,16 +33,12 @@ def test_unclosed_file():
 
 
 def test_close():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         tar = TarIO.TarIO(TEST_TAR_FILE, "hopper.jpg")
         tar.close()
 
-    assert not record
-
 
 def test_contextmanager():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         with TarIO.TarIO(TEST_TAR_FILE, "hopper.jpg"):
             pass
-
-    assert not record

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from io import BytesIO
 
 import pytest
@@ -64,19 +65,15 @@ class TestFileTiff:
         pytest.warns(ResourceWarning, open)
 
     def test_closed_file(self):
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
             im = Image.open("Tests/images/multipage.tiff")
             im.load()
             im.close()
 
-        assert not record
-
     def test_context_manager(self):
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
             with Image.open("Tests/images/multipage.tiff") as im:
                 im.load()
-
-        assert not record
 
     def test_mac_tiff(self):
         # Read RGBa images from macOS [@PIL136]

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -1,6 +1,7 @@
 import io
 import re
 import sys
+import warnings
 
 import pytest
 
@@ -161,9 +162,8 @@ class TestFileWebp:
         file_path = "Tests/images/hopper.webp"
         with Image.open(file_path) as image:
             temp_file = str(tmp_path / "temp.webp")
-            with pytest.warns(None) as record:
+            with warnings.catch_warnings():
                 image.save(temp_file)
-            assert not record
 
     def test_file_pointer_could_be_reused(self):
         file_path = "Tests/images/hopper.webp"

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import sys
 import tempfile
+import warnings
 
 import pytest
 
@@ -648,9 +649,8 @@ class TestImage:
 
         # Act/Assert
         with Image.open(test_file) as im:
-            with pytest.warns(None) as record:
+            with warnings.catch_warnings():
                 im.save(temp_file)
-            assert not record
 
     def test_load_on_nonexclusive_multiframe(self):
         with open("Tests/images/frozenpond.mpo", "rb") as fp:

--- a/Tests/test_imageqt.py
+++ b/Tests/test_imageqt.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 from PIL import ImageQt
@@ -56,7 +58,5 @@ def test_image():
 
 
 def test_closed_file():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         ImageQt.ImageQt("Tests/images/hopper.gif")
-
-    assert not record

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 from PIL import Image
@@ -237,6 +239,5 @@ def test_no_resource_warning_for_numpy_array():
     with Image.open(test_file) as im:
 
         # Act/Assert
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
             array(im)
-        assert not record


### PR DESCRIPTION
A warning has started appearing.

https://github.com/python-pillow/Pillow/runs/5266944375#step:8:3064
> PytestRemovedIn8Warning: Passing None has been deprecated.
>  See https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests for alternatives in common use cases.

It is complaining about our method for checking that no warnings were raised during a test.
```python
with pytest.warns(None) as record:
    ...
assert not record
```

Instead, https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests suggests
```python
with warnings.catch_warnings():
    warnings.simplefilter("error")
    ...
```
I have implemented that here, albeit without the `simplefilter`, since I presume we would also like to know if any errors are raised.
