### PR TITLE
Improved ImageShow documentation

### DIFF
--- a/docs/reference/ImageShow.rst
+++ b/docs/reference/ImageShow.rst
@@ -23,6 +23,9 @@ All default viewers convert the image to be shown to PNG format.
     .. autoclass:: PIL.ImageShow.EogViewer
     .. autoclass:: PIL.ImageShow.XVViewer
 
+    To provide maximum functionality on Unix-based systems, temporary files created
+    from images will not be automatically removed by Pillow.
+
 .. autofunction:: PIL.ImageShow.register
 .. autoclass:: PIL.ImageShow.Viewer
     :member-order: bysource

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -25,7 +25,12 @@ _viewers = []
 
 def register(viewer, order=1):
     """
-    The :py:func:`register` function is used to register additional viewers.
+    The :py:func:`register` function is used to register additional viewers::
+
+        from PIL import ImageShow
+        ImageShow.register(MyViewer())  # MyViewer will be used as a last resort
+        ImageShow.register(MySecondViewer(), 0)  # MySecondViewer will be prioritised
+        ImageShow.register(ImageShow.XVViewer(), 0)  # XVViewer will be prioritised
 
     :param viewer: The viewer to be registered.
     :param order:


### PR DESCRIPTION
Resolves #5976 by documenting that `ImageShow.register()` can be used to effectively change the priority of an existing viewer, and that as per #6045, temporary files are not removed on Unix.