### PR TITLE
Removed duplicate test

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -88,19 +88,6 @@ class TestImageFont:
 
         ImageFont.truetype(tempfile, FONT_SIZE)
 
-    def test_unavailable_layout_engine(self):
-        have_raqm = ImageFont.core.HAVE_RAQM
-        ImageFont.core.HAVE_RAQM = False
-
-        try:
-            ttf = ImageFont.truetype(
-                FONT_PATH, FONT_SIZE, layout_engine=ImageFont.Layout.RAQM
-            )
-        finally:
-            ImageFont.core.HAVE_RAQM = have_raqm
-
-        assert ttf.layout_engine == ImageFont.Layout.BASIC
-
     def _render(self, font):
         txt = "Hello World!"
         ttf = ImageFont.truetype(font, FONT_SIZE, layout_engine=self.LAYOUT_ENGINE)


### PR DESCRIPTION
#6035 added a test covering the situation when RAQM is requested but unavailable.

https://github.com/python-pillow/Pillow/blob/9e6537df5a7df1b96a69e7eb1da37053508ef979/Tests/test_imagefont.py#L1027-L1037

Turns out, we already had a test for this.

https://github.com/python-pillow/Pillow/blob/9e6537df5a7df1b96a69e7eb1da37053508ef979/Tests/test_imagefont.py#L91-L102

This PR removes the original. The new one appears better as it makes use of monkeypatching.