### PR TITLE
Enable heap verification without gflags

### DIFF
--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -45,6 +45,7 @@ jobs:
               ${{ matrix.package }}-python-pyqt6 \
               ${{ matrix.package }}-python3-setuptools \
               ${{ matrix.package }}-freetype \
+              ${{ matrix.package }}-gcc \
               ${{ matrix.package }}-ghostscript \
               ${{ matrix.package }}-lcms2 \
               ${{ matrix.package }}-libimagequant \

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -137,10 +137,11 @@ jobs:
         & $env:pythonLocation\python.exe selftest.py --installed
       shell: pwsh
 
-    # failing with PyPy3
+    # skip PyPy for speed
     - name: Enable heap verification
       if: "!contains(matrix.python-version, 'pypy')"
-      run: "& 'C:\\Program Files (x86)\\Windows Kits\\10\\Debuggers\\x86\\gflags.exe' /p /enable $env:pythonLocation\\python.exe"
+      run: |
+        & reg.exe add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\python.exe" /v "GlobalFlag" /t REG_SZ /d "0x02000000" /f
 
     - name: Test Pillow
       run: |


### PR DESCRIPTION
GitHub Actions have started [failing in main for Windows](https://github.com/python-pillow/Pillow/runs/5299567368) at the "Enable page verification" step.

https://github.com/python-pillow/Pillow/blob/4638c4fba651025851bf1f41a28583ae11d73c3a/.github/workflows/test-windows.yml#L140-L143

The error is
> The term 'C:\Program Files (x86)\Windows Kits\10\Debuggers\x86\gflags.exe' is not recognized as a name of a cmdlet, function, script file, or executable program.

The problem started at the same time that the jobs switched from windows-2019 to windows-2022. It looks like windows-2022 does not have gflags.exe.

Taking advice from "[How to enable PageHeap in Windows registry without having access to gflags.exe](https://klaus.hohenpoelz.de/how-to-enable-pageheap-in-windows-registry-without-having-access-to-gflags-exe.html)", this PR fixes the problem.

While this could now be used on PyPy, it takes an hour to do so, so I have continued to skip heap verification on PyPy.