### PR TITLE
Various _accept changes

### DIFF
--- a/Tests/test_file_dds.py
+++ b/Tests/test_file_dds.py
@@ -196,6 +196,13 @@ def test__accept_false():
     assert not output
 
 
+def test_invalid_file():
+    invalid_file = "Tests/images/flower.jpg"
+
+    with pytest.raises(SyntaxError):
+        DdsImagePlugin.DdsImageFile(invalid_file)
+
+
 def test_short_header():
     """Check a short header"""
     with open(TEST_FILE_DXT5, "rb") as f:

--- a/Tests/test_file_ftex.py
+++ b/Tests/test_file_ftex.py
@@ -16,6 +16,13 @@ def test_load_dxt1():
             assert_image_similar(im, target.convert("RGBA"), 15)
 
 
+def test_invalid_file():
+    invalid_file = "Tests/images/flower.jpg"
+
+    with pytest.raises(SyntaxError):
+        FtexImagePlugin.FtexImageFile(invalid_file)
+
+
 def test_constants_deprecation():
     for enum, prefix in {
         FtexImagePlugin.Format: "FORMAT_",

--- a/Tests/test_file_xbm.py
+++ b/Tests/test_file_xbm.py
@@ -2,7 +2,7 @@ from io import BytesIO
 
 import pytest
 
-from PIL import Image
+from PIL import Image, XbmImagePlugin
 
 from .helper import hopper
 
@@ -61,6 +61,13 @@ def test_open_filename_with_underscore():
         # Assert
         assert im.mode == "1"
         assert im.size == (128, 128)
+
+
+def test_invalid_file():
+    invalid_file = "Tests/images/flower.jpg"
+
+    with pytest.raises(SyntaxError):
+        XbmImagePlugin.XbmImageFile(invalid_file)
 
 
 def test_save_wrong_mode(tmp_path):

--- a/docs/example/DdsImagePlugin.py
+++ b/docs/example/DdsImagePlugin.py
@@ -210,7 +210,9 @@ class DdsImageFile(ImageFile.ImageFile):
     format_description = "DirectDraw Surface"
 
     def _open(self):
-        magic, header_size = struct.unpack("<II", self.fp.read(8))
+        if not _accept(self.fp.read(4)):
+            raise SyntaxError("not a DDS file")
+        (header_size,) = struct.unpack("<I", self.fp.read(4))
         if header_size != 124:
             raise OSError(f"Unsupported header size {repr(header_size)}")
         header_bytes = self.fp.read(header_size - 4)

--- a/src/PIL/DdsImagePlugin.py
+++ b/src/PIL/DdsImagePlugin.py
@@ -111,7 +111,9 @@ class DdsImageFile(ImageFile.ImageFile):
     format_description = "DirectDraw Surface"
 
     def _open(self):
-        magic, header_size = struct.unpack("<II", self.fp.read(8))
+        if not _accept(self.fp.read(4)):
+            raise SyntaxError("not a DDS file")
+        (header_size,) = struct.unpack("<I", self.fp.read(4))
         if header_size != 124:
             raise OSError(f"Unsupported header size {repr(header_size)}")
         header_bytes = self.fp.read(header_size - 4)

--- a/src/PIL/FliImagePlugin.py
+++ b/src/PIL/FliImagePlugin.py
@@ -26,7 +26,11 @@ from ._binary import o8
 
 
 def _accept(prefix):
-    return len(prefix) >= 6 and i16(prefix, 4) in [0xAF11, 0xAF12]
+    return (
+        len(prefix) >= 6
+        and i16(prefix, 4) in [0xAF11, 0xAF12]
+        and i16(prefix, 14) in [0, 3]  # flags
+    )
 
 
 ##
@@ -44,11 +48,7 @@ class FliImageFile(ImageFile.ImageFile):
 
         # HEAD
         s = self.fp.read(128)
-        if not (
-            _accept(s)
-            and i16(s, 14) in [0, 3]  # flags
-            and s[20:22] == b"\x00\x00"  # reserved
-        ):
+        if not (_accept(s) and s[20:22] == b"\x00\x00"):
             raise SyntaxError("not an FLI/FLC file")
 
         # frames

--- a/src/PIL/FtexImagePlugin.py
+++ b/src/PIL/FtexImagePlugin.py
@@ -95,7 +95,7 @@ class FtexImageFile(ImageFile.ImageFile):
 
     def _open(self):
         if not _accept(self.fp.read(4)):
-            raise SyntaxError("not a FTEX file")
+            raise SyntaxError("not an FTEX file")
         struct.unpack("<i", self.fp.read(4))  # version
         self._size = struct.unpack("<2i", self.fp.read(8))
         mipmap_count, format_count = struct.unpack("<2i", self.fp.read(8))

--- a/src/PIL/FtexImagePlugin.py
+++ b/src/PIL/FtexImagePlugin.py
@@ -94,7 +94,8 @@ class FtexImageFile(ImageFile.ImageFile):
     format_description = "Texture File Format (IW2:EOC)"
 
     def _open(self):
-        struct.unpack("<I", self.fp.read(4))  # magic
+        if not _accept(self.fp.read(4)):
+            raise SyntaxError("not a FTEX file")
         struct.unpack("<i", self.fp.read(4))  # version
         self._size = struct.unpack("<2i", self.fp.read(8))
         mipmap_count, format_count = struct.unpack("<2i", self.fp.read(8))

--- a/src/PIL/GbrImagePlugin.py
+++ b/src/PIL/GbrImagePlugin.py
@@ -43,9 +43,9 @@ class GbrImageFile(ImageFile.ImageFile):
 
     def _open(self):
         header_size = i32(self.fp.read(4))
-        version = i32(self.fp.read(4))
         if header_size < 20:
             raise SyntaxError("not a GIMP brush")
+        version = i32(self.fp.read(4))
         if version not in (1, 2):
             raise SyntaxError(f"Unsupported GIMP brush version: {version}")
 

--- a/src/PIL/IcnsImagePlugin.py
+++ b/src/PIL/IcnsImagePlugin.py
@@ -167,7 +167,7 @@ class IcnsFile:
         self.dct = dct = {}
         self.fobj = fobj
         sig, filesize = nextheader(fobj)
-        if sig != MAGIC:
+        if not _accept(sig):
             raise SyntaxError("not an icns file")
         i = HEADERSIZE
         while i < filesize:

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -493,7 +493,7 @@ class ImageFileDirectory_v2(MutableMapping):
               endianness.
         :param prefix: Override the endianness of the file.
         """
-        if ifh[:4] not in PREFIXES:
+        if not _accept(ifh):
             raise SyntaxError(f"not a TIFF file (header {repr(ifh)} not valid)")
         self._prefix = prefix if prefix is not None else ifh[:2]
         if self._prefix == MM:

--- a/src/PIL/WmfImagePlugin.py
+++ b/src/PIL/WmfImagePlugin.py
@@ -21,7 +21,6 @@
 
 from . import Image, ImageFile
 from ._binary import i16le as word
-from ._binary import i32le as dword
 from ._binary import si16le as short
 from ._binary import si32le as _long
 
@@ -112,7 +111,7 @@ class WmfStubImageFile(ImageFile.StubImageFile):
             if s[22:26] != b"\x01\x00\t\x00":
                 raise SyntaxError("Unsupported WMF file format")
 
-        elif dword(s) == 1 and s[40:44] == b" EMF":
+        elif s[:4] == b"\x01\x00\x00\x00" and s[40:44] == b" EMF":
             # enhanced metafile
 
             # get bounding box

--- a/src/PIL/XbmImagePlugin.py
+++ b/src/PIL/XbmImagePlugin.py
@@ -52,18 +52,19 @@ class XbmImageFile(ImageFile.ImageFile):
 
         m = xbm_head.match(self.fp.read(512))
 
-        if m:
+        if not m:
+            raise SyntaxError("not a XBM file")
 
-            xsize = int(m.group("width"))
-            ysize = int(m.group("height"))
+        xsize = int(m.group("width"))
+        ysize = int(m.group("height"))
 
-            if m.group("hotspot"):
-                self.info["hotspot"] = (int(m.group("xhot")), int(m.group("yhot")))
+        if m.group("hotspot"):
+            self.info["hotspot"] = (int(m.group("xhot")), int(m.group("yhot")))
 
-            self.mode = "1"
-            self._size = xsize, ysize
+        self.mode = "1"
+        self._size = xsize, ysize
 
-            self.tile = [("xbm", (0, 0) + self.size, m.end(), None)]
+        self.tile = [("xbm", (0, 0) + self.size, m.end(), None)]
 
 
 def _save(im, fp, filename):


### PR DESCRIPTION
- Do not read data until necessary in GbrImagePlugin
- Raise SyntaxError if data is not as expected in XbmImagePlugin
- Moved FLI flags check into _accept
  - Since the [prefix is 16 characters](https://github.com/python-pillow/Pillow/blob/14b9b597ffa228ac56b91dc2782199f432defa14/src/PIL/Image.py#L3064), [this check on the 15th and 16th characters](https://github.com/python-pillow/Pillow/blob/14b9b597ffa228ac56b91dc2782199f432defa14/src/PIL/FliImagePlugin.py#L49) can be run earlier
- Make code clearer by matching _accept condition.
  - The `dword` condition here has the same purpose as the `prefix[:4]` check, so have them match for clarity.
    https://github.com/python-pillow/Pillow/blob/14b9b597ffa228ac56b91dc2782199f432defa14/src/PIL/WmfImagePlugin.py#L115
    https://github.com/python-pillow/Pillow/blob/14b9b597ffa228ac56b91dc2782199f432defa14/src/PIL/WmfImagePlugin.py#L68-L71
- Use `_accept` in `_open` for DDS and FLEX
- Simplify code by using `_accept`, instead of writing out the `_accept` condition a second time, in ICNS and TIFF