### PR TITLE
Improved codec documentation

### DIFF
--- a/docs/handbook/writing-your-own-image-plugin.rst
+++ b/docs/handbook/writing-your-own-image-plugin.rst
@@ -432,4 +432,7 @@ Python-based file codec:
    a buffer of data to be interpreted, or the ``encode`` method is repeatedly
    called with the size of data to be output.
 
+   In ``decode``, once the data has been interpreted, ``set_as_raw`` can be
+   used to populate the image.
+
 3. Cleanup: The instance's ``cleanup`` method is called.

--- a/docs/handbook/writing-your-own-image-plugin.rst
+++ b/docs/handbook/writing-your-own-image-plugin.rst
@@ -441,4 +441,9 @@ Python-based file codec:
    In ``decode``, once the data has been interpreted, ``set_as_raw`` can be
    used to populate the image.
 
-3. Cleanup: The instance's ``cleanup`` method is called.
+3. Cleanup: The instance's ``cleanup`` method is called once the transformation
+   is complete. This can be used to clean up any resources used by the codec.
+
+   If you set ``_pulls_fd`` or ``_pushes_fd`` to ``True`` however, then you
+   probably chose to perform any cleanup tasks  at the end of ``decode`` or
+   ``encode``.

--- a/docs/handbook/writing-your-own-image-plugin.rst
+++ b/docs/handbook/writing-your-own-image-plugin.rst
@@ -447,3 +447,9 @@ Python-based file codec:
    If you set ``_pulls_fd`` or ``_pushes_fd`` to ``True`` however, then you
    probably chose to perform any cleanup tasks  at the end of ``decode`` or
    ``encode``.
+
+For an example :py:class:`PIL.ImageFile.PyDecoder`, see `DdsImagePlugin
+<https://github.com/python-pillow/Pillow/blob/main/docs/example/DdsImagePlugin.py>`_.
+For a plugin that uses both :py:class:`PIL.ImageFile.PyDecoder` and
+:py:class:`PIL.ImageFile.PyEncoder`, see `BlpImagePlugin
+<https://github.com/python-pillow/Pillow/blob/main/src/PIL/BlpImagePlugin.py>`_

--- a/docs/handbook/writing-your-own-image-plugin.rst
+++ b/docs/handbook/writing-your-own-image-plugin.rst
@@ -395,7 +395,9 @@ from the file like object.
 
 Alternatively, if ``pulls_fd`` is set, then the decode function is
 called once, with an empty buffer. It is the decoder's responsibility
-to decode the entire tile in that one call.
+to decode the entire tile in that one call.  Using this will provide a
+codec with more freedom, but that freedom may mean increased memory usage
+if entire tile is held in memory at once by the codec.
 
 If an error occurs, set ``state->errcode`` and return -1.
 
@@ -428,6 +430,13 @@ Python-based file codec:
 2. Transforming: The instance's ``decode`` method is repeatedly called with
    a buffer of data to be interpreted, or the ``encode`` method is repeatedly
    called with the size of data to be output.
+
+   Alternatively, if the decoder's ``_pulls_fd`` property (or the encoder's
+   ``_pushes_fd`` property) is set to ``True``, then ``decode`` and ``encode``
+   will only be called once. In the decoder, ``self.fd`` can be used to access
+   the file-like object. Using this will provide a codec with more freedom, but
+   that freedom may mean increased memory usage if entire file is held in
+   memory at once by the codec.
 
    In ``decode``, once the data has been interpreted, ``set_as_raw`` can be
    used to populate the image.

--- a/docs/handbook/writing-your-own-image-plugin.rst
+++ b/docs/handbook/writing-your-own-image-plugin.rst
@@ -123,8 +123,12 @@ The ``tile`` attribute
 To be able to read the file as well as just identifying it, the ``tile``
 attribute must also be set. This attribute consists of a list of tile
 descriptors, where each descriptor specifies how data should be loaded to a
-given region in the image. In most cases, only a single descriptor is used,
-covering the full image.
+given region in the image.
+
+In most cases, only a single descriptor is used, covering the full image.
+:py:class:`.PsdImagePlugin.PsdImageFile` uses multiple tiles to combine
+channels within a single layer, given that the channels are stored separately,
+one after the other.
 
 The tile descriptor is a 4-tuple with the following contents::
 

--- a/docs/handbook/writing-your-own-image-plugin.rst
+++ b/docs/handbook/writing-your-own-image-plugin.rst
@@ -373,12 +373,10 @@ interest in this object are:
   any format specific state or options.
 
 **pulls_fd**
-  **EXPERIMENTAL** -- **WARNING**, interface may change. If set to 1,
-  ``state->fd`` will be a pointer to the Python file like object.  The
-  decoder may use the functions in ``codec_fd.c`` to read directly
-  from the file like object rather than have the data pushed through a
-  buffer.  Note that this implementation may be refactored until this
-  warning is removed.
+  If set to 1, ``state->fd`` will be a pointer to the Python file like
+  object. The decoder may use the functions in ``codec_fd.c`` to read
+  directly from the file like object rather than have the data pushed
+  through a buffer.
 
   .. versionadded:: 3.3.0
 
@@ -389,16 +387,15 @@ Decoding
 The decode function is called with the target (core) image, the
 decoder state structure, and a buffer of data to be decoded.
 
-**Experimental** -- If ``pulls_fd`` is set, then the decode function
-is called once, with an empty buffer. It is the decoder's
-responsibility to decode the entire tile in that one call.  The rest of
-this section only applies if ``pulls_fd`` is not set.
-
 It is the decoder's responsibility to pull as much data as possible
 out of the buffer and return the number of bytes consumed. The next
 call to the decoder will include the previous unconsumed tail. The
 decoder function will be called multiple times as the data is read
 from the file like object.
+
+Alternatively, if ``pulls_fd`` is set, then the decode function is
+called once, with an empty buffer. It is the decoder's responsibility
+to decode the entire tile in that one call.
 
 If an error occurs, set ``state->errcode`` and return -1.
 

--- a/docs/handbook/writing-your-own-image-plugin.rst
+++ b/docs/handbook/writing-your-own-image-plugin.rst
@@ -354,7 +354,7 @@ Setup
 The current conventions are that the codec setup function is named
 ``PyImaging_[codecname]DecoderNew`` or ``PyImaging_[codecname]EncoderNew``
 and defined in ``decode.c`` or ``encode.c``. The Python binding for it is
-named ``[codecname]_decoder`` or ``[codecname]_encoder`` and is setup from
+named ``[codecname]_decoder`` or ``[codecname]_encoder`` and is set up from
 within the ``_imaging.c`` file in the codecs section of the function array.
 
 The setup function needs to call ``PyImaging_DecoderNew`` or
@@ -400,7 +400,7 @@ Alternatively, if ``pulls_fd`` or ``pushes_fd`` is set, then the decode or
 encode function is called once, with an empty buffer. It is the codec's
 responsibility to transform the entire tile in that one call.  Using this will
 provide a codec with more freedom, but that freedom may mean increased memory
-usage if entire tile is held in memory at once by the codec.
+usage if the entire tile is held in memory at once by the codec.
 
 If an error occurs, set ``state->errcode`` and return -1.
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2779,9 +2779,9 @@ def frombytes(mode, size, data, decoder_name="raw", *args):
     In its simplest form, this function takes three arguments
     (mode, size, and unpacked pixel data).
 
-    You can also use any pixel decoder supported by PIL.  For more
+    You can also use any pixel decoder supported by PIL. For more
     information on available decoders, see the section
-    :ref:`Writing Your Own File Decoder <file-decoders>`.
+    :ref:`Writing Your Own File Codec <file-codecs>`.
 
     Note that this function decodes pixel data only, not entire images.
     If you have an entire image in a string, wrap it in a

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -725,6 +725,9 @@ class PyEncoder(PyCodec):
 
     def encode_to_pyfd(self):
         """
+        If ``pushes_fd`` is ``True``, then this method will be used,
+        and ``encode()`` will only be called once.
+
         :returns: A tuple of ``(bytes consumed, errcode)``.
             Err codes are from :data:`.ImageFile.ERRORS`.
         """


### PR DESCRIPTION
Helps #4818, by
- mentioning [`set_as_raw()`](https://github.com/python-pillow/Pillow/blob/6b9b392ccca040bf889e31d76d5c59e5c12164af/src/PIL/ImageFile.py#L673) in the Python decoder documentation
- removing the "Experimental" label from ``pulls_fd``. It was added in Pillow 3.3.0, and the next release is Pillow 9.1.0.
- noting that ``pulls_fd`` and ``pushes_fd`` allow more freedom, by abandoning Pillow's process of handling the file in blocks, but may lead to increase memory usage, if the codec is written to hold the everything in memory at once.
- re-iterating that ``cleanup()`` is for... cleanup tasks, but also clarifying that if ``_pulls_fd`` or ``_pushes_fd`` was used, then  the codec author probably doesn't need this, as they would have instinctively cleaned up their resources at the end of ``decode()`` or ``encode()``.
- linking to the BlpImagePlugin and the example DdsImagePlugin as demonstrations of ``PyDecoder`` and ``PyEncoder``.
- linking to PsdImagePlugin, as a plugin that uses multiple tiles
- documenting writing your own encoder in C