### PR TITLE
Ensure cleanup() is called for PyEncoders

### DIFF
--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -200,6 +200,9 @@ class MockPyEncoder(ImageFile.PyEncoder):
     def encode(self, buffer):
         return 1, 1, b""
 
+    def cleanup(self):
+        self.cleanup_called = True
+
 
 xoff, yoff, xsize, ysize = 10, 20, 100, 100
 
@@ -327,10 +330,12 @@ class TestPyEncoder(CodecsTest):
         im = MockImageFile(buf)
 
         fp = BytesIO()
+        self.encoder.cleanup_called = False
         with pytest.raises(ValueError):
             ImageFile._save(
                 im, fp, [("MOCK", (xoff, yoff, -10, yoff + ysize), 0, "RGB")]
             )
+        assert self.encoder.cleanup_called
 
         with pytest.raises(ValueError):
             ImageFile._save(

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -223,11 +223,11 @@ class ImageFile(Image.Image):
                 )
             ]
             for decoder_name, extents, offset, args in self.tile:
+                seek(offset)
                 decoder = Image._getdecoder(
                     self.mode, decoder_name, args, self.decoderconfig
                 )
                 try:
-                    seek(offset)
                     decoder.setimage(self.im, extents)
                     if decoder.pulls_fd:
                         decoder.setfd(self.fp)
@@ -502,10 +502,10 @@ def _save(im, fp, tile, bufsize=0):
     except (AttributeError, io.UnsupportedOperation) as exc:
         # compress to Python file-compatible object
         for e, b, o, a in tile:
+            if o > 0:
+                fp.seek(o)
             e = Image._getencoder(im.mode, e, a, im.encoderconfig)
             try:
-                if o > 0:
-                    fp.seek(o)
                 e.setimage(im.im, b)
                 if e.pushes_fd:
                     e.setfd(fp)
@@ -523,10 +523,10 @@ def _save(im, fp, tile, bufsize=0):
     else:
         # slight speedup: compress to real file object
         for e, b, o, a in tile:
+            if o > 0:
+                fp.seek(o)
             e = Image._getencoder(im.mode, e, a, im.encoderconfig)
             try:
-                if o > 0:
-                    fp.seek(o)
                 e.setimage(im.im, b)
                 if e.pushes_fd:
                     e.setfd(fp)


### PR DESCRIPTION
In ImageFile, the encoder `cleanup()` method is not called from Python if there is an error.
https://github.com/python-pillow/Pillow/blob/2f2b48dc2c6f8907968c9deea4fb3a4be57c3c09/src/PIL/ImageFile.py#L505-L520

However, `cleanup()` would still be called from `_dealloc` in C.
https://github.com/python-pillow/Pillow/blob/2f2b48dc2c6f8907968c9deea4fb3a4be57c3c09/src/encode.c#L94-L98

Except that doesn't help a PyEncoder. So this PR ensures `cleanup()` is called from ImageFile.