### PR TITLE
Reset size when seeking away from "Large Thumbnail" MPO frame

### DIFF
--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -85,6 +85,9 @@ def test_frame_size():
         im.seek(1)
         assert im.size == (680, 480)
 
+        im.seek(0)
+        assert im.size == (640, 480)
+
 
 def test_ignore_frame_size():
     # Ignore the different size of the second frame

--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -46,6 +46,7 @@ class MpoImageFile(JpegImagePlugin.JpegImageFile):
         self._after_jpeg_open()
 
     def _after_jpeg_open(self, mpheader=None):
+        self._initial_size = self.size
         self.mpinfo = mpheader if mpheader is not None else self._getmp()
         self.n_frames = self.mpinfo[0xB001]
         self.__mpoffsets = [
@@ -77,6 +78,7 @@ class MpoImageFile(JpegImagePlugin.JpegImageFile):
         segment = self.fp.read(2)
         if not segment:
             raise ValueError("No data found for frame")
+        self._size = self._initial_size
         if i16(segment) == 0xFFE1:  # APP1
             n = i16(self.fp.read(2)) - 2
             self.info["exif"] = ImageFile._safe_read(self.fp, n)


### PR DESCRIPTION
Resolves #6100

#5168 introduced a rule that MPO image size can only change for "Large Thumbnail" frames.

However, it forgot to reset the size back to the initial value when seeking to another frame after that.