### PR TITLE
Document that histogram() uses 256 bins per channel

### DIFF
--- a/docs/reference/ImageStat.rst
+++ b/docs/reference/ImageStat.rst
@@ -14,6 +14,16 @@ for a region of an image.
     statistics. You can also pass in a previously calculated histogram.
 
     :param image: A PIL image, or a precalculated histogram.
+
+        .. note::
+
+            For a PIL image, calculations rely on the
+            :py:meth:`~PIL.Image.Image.histogram` method. The pixel counts are
+            grouped into 256 bins, even if the image has more than 8 bits per
+            channel. So ``I`` and ``F`` mode images have a maximum ``mean``,
+            ``median`` and ``rms`` of 255, and cannot have an ``extrema`` maximum
+            of more than 255.
+
     :param mask: An optional mask.
 
     .. py:attribute:: extrema

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1492,11 +1492,12 @@ class Image:
 
     def histogram(self, mask=None, extrema=None):
         """
-        Returns a histogram for the image. The histogram is returned as
-        a list of pixel counts, one for each pixel value in the source
-        image. If the image has more than one band, the histograms for
-        all bands are concatenated (for example, the histogram for an
-        "RGB" image contains 768 values).
+        Returns a histogram for the image. The histogram is returned as a
+        list of pixel counts, one for each pixel value in the source
+        image. Counts are grouped into 256 bins for each band, even if
+        the image has more than 8 bits per band. If the image has more
+        than one band, the histograms for all bands are concatenated (for
+        example, the histogram for an "RGB" image contains 768 values).
 
         A bilevel image (mode "1") is treated as a greyscale ("L") image
         by this method.


### PR DESCRIPTION
Resolves #3958

`im.histogram()` groups pixel counts into 256 bins per channel, even for `I` and `F` mode images (which have pixel values of 0 to 65535, meaning that you could have 65536 bins in theory).
```python
from PIL import Image
for mode in ("1", "L", "I", "F"):
    im = Image.new(mode, (1, 1))
    assert len(im.histogram()) == 256
```

The ImageStat module performs operations on that histogram. This means that for `I` and `F` mode images, ImageStat can only report what it has been given.

```python
from PIL import Image, ImageStat
im = Image.new("I", (100, 1))
px = im.load()
for i in range(99):
    px[i, 0] = 65535 - i
stat = ImageStat.Stat(im)
print(stat.mean[0])  # 251.47
```
So I've added a note that `mean`, `median`,`rms` and the maximum `extrema` can't be more than 255.