### PR TITLE
Check if self.im is not None

### DIFF
--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -154,14 +154,17 @@ class TestImageGetPixel(AccessTest):
 
         # Check 0
         im = Image.new(mode, (0, 0), None)
-        with pytest.raises(IndexError):
+        assert im.load() is not None
+
+        error = ValueError if self._need_cffi_access else IndexError
+        with pytest.raises(error):
             im.putpixel((0, 0), c)
-        with pytest.raises(IndexError):
+        with pytest.raises(error):
             im.getpixel((0, 0))
         # Check 0 negative index
-        with pytest.raises(IndexError):
+        with pytest.raises(error):
             im.putpixel((-1, -1), c)
-        with pytest.raises(IndexError):
+        with pytest.raises(error):
             im.getpixel((-1, -1))
 
         # check initial color
@@ -176,10 +179,10 @@ class TestImageGetPixel(AccessTest):
 
         # Check 0
         im = Image.new(mode, (0, 0), c)
-        with pytest.raises(IndexError):
+        with pytest.raises(error):
             im.getpixel((0, 0))
         # Check 0 negative index
-        with pytest.raises(IndexError):
+        with pytest.raises(error):
             im.getpixel((-1, -1))
 
     def test_basic(self):

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -298,7 +298,7 @@ class GifImageFile(ImageFile.ImageFile):
                 self.dispose = Image.core.fill(dispose_mode, dispose_size, color)
             else:
                 # replace with previous contents
-                if self.im:
+                if self.im is not None:
                     # only dispose the extent in this frame
                     self.dispose = self._crop(self.im, self.dispose_extent)
                 elif frame_transparency is not None:

--- a/src/PIL/IcnsImagePlugin.py
+++ b/src/PIL/IcnsImagePlugin.py
@@ -287,7 +287,7 @@ class IcnsImageFile(ImageFile.ImageFile):
             )
 
         px = Image.Image.load(self)
-        if self.im and self.im.size == self.size:
+        if self.im is not None and self.im.size == self.size:
             # Already loaded
             return px
         self.load_prepare()

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -304,7 +304,7 @@ class IcoImageFile(ImageFile.ImageFile):
         self._size = value
 
     def load(self):
-        if self.im and self.im.size == self.size:
+        if self.im is not None and self.im.size == self.size:
             # Already loaded
             return Image.Image.load(self)
         im = self.ico.getimage(self.size)

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -847,7 +847,7 @@ class Image:
         :returns: An image access object.
         :rtype: :ref:`PixelAccess` or :py:class:`PIL.PyAccess`
         """
-        if self.im and self.palette and self.palette.dirty:
+        if self.im is not None and self.palette and self.palette.dirty:
             # realize palette
             mode, arr = self.palette.getdata()
             self.im.putpalette(mode, arr)
@@ -864,7 +864,7 @@ class Image:
                 self.palette.mode = palette_mode
                 self.palette.palette = self.im.getpalette(palette_mode, palette_mode)
 
-        if self.im:
+        if self.im is not None:
             if cffi and USE_CFFI_ACCESS:
                 if self.pyaccess:
                     return self.pyaccess


### PR DESCRIPTION
For a (0, 0) image, `im.load()` currently returns `None`.
```pycon
>>> from PIL import Image
>>> im = Image.new("RGB", (1, 1))
>>> im.load()
<PixelAccess object at 0x103b865f0>
>>> im = Image.new("RGB", (0, 0))
>>> im.load()
>>> 
```

This is because `load()` tests if `self.im` is truthy.

https://github.com/python-pillow/Pillow/blob/92c26a77ca53a2bfbd8804f009c6c8755d0e5a43/src/PIL/Image.py#L867-L876

And the image size is what is used to determine the boolean value.
```pycon
>>> from PIL import Image
>>> im = Image.new("RGB", (10, 10))
>>> len(im.im)
100
>>> bool(im.im)
True
>>> im = Image.new("RGB", (0, 0))
>>> len(im.im)
0
>>> bool(im.im)
False
```

So this PR instead changes the Python code to check `self.im is not None`, there and in other locations. I've added a check to `assert im.load() is not None` for a (0, 0) image.

This then required existing checks in Tests/test_image_access.py on (0, 0) images to be updated. Why? Because once the (0, 0) image started returning an access object from `load()`, it is revealed that PixelAccess and PyAccess return different errors when the index is out of range.
https://github.com/python-pillow/Pillow/blob/92c26a77ca53a2bfbd8804f009c6c8755d0e5a43/src/_imaging.c#L449
https://github.com/python-pillow/Pillow/blob/92c26a77ca53a2bfbd8804f009c6c8755d0e5a43/src/PIL/PyAccess.py#L126