### PR TITLE
Clip I;16 to be unsigned, not signed

### DIFF
--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -70,6 +70,11 @@ def test_16bit():
     with Image.open("Tests/images/16bit.cropped.tif") as im:
         _test_float_conversion(im)
 
+    for color in (65535, 65536):
+        im = Image.new("I", (1, 1), color)
+        im_i16 = im.convert("I;16")
+        assert im_i16.getpixel((0, 0)) == 65535
+
 
 def test_16bit_workaround():
     with Image.open("Tests/images/16bit.cropped.tif") as im:

--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -37,7 +37,7 @@
 #define MAX(a, b) (a) > (b) ? (a) : (b)
 #define MIN(a, b) (a) < (b) ? (a) : (b)
 
-#define CLIP16(v) ((v) <= -32768 ? -32768 : (v) >= 32767 ? 32767 : (v))
+#define CLIP16(v) ((v) <= 0 ? 0 : (v) >= 65535 ? 65535 : (v))
 
 /* ITU-R Recommendation 601-2 (assuming nonlinear RGB) */
 #define L(rgb) ((INT32)(rgb)[0] * 299 + (INT32)(rgb)[1] * 587 + (INT32)(rgb)[2] * 114)


### PR DESCRIPTION
Resolves #5967

```pycon
>>> from PIL import Image
>>> Image.new("I;16", (1, 1), 65535).load()[0, 0]
65535
>>> Image.new("I;16", (1, 1), 65536).load()[0, 0]
0
```
So we can agree that the maximum for "I;16" is 65535, a.k.a 2**16 - 1, as expected.

When converting from "I" to "I;16", there is [clipping](https://github.com/python-pillow/Pillow/blob/38f4660d9ecfab74af8bad292d31e080072b25b3/src/libImaging/Convert.c#L767-L789). So you would expect that clipping to limit the values of "I", the 32-bit mode, to the maximum value of "I;16", the 16-bit mode.

Except it doesn't.
```pycon
>>> im = Image.new("I", (1, 1), 65535)
>>> im.convert("I;16").load()[0, 0]
32767
```
The following line incorrectly imagines that we need to clip to an signed range, not an unsigned range.
https://github.com/python-pillow/Pillow/blob/38f4660d9ecfab74af8bad292d31e080072b25b3/src/libImaging/Convert.c#L40

This PR corrects it.