### PR TITLE
Removed load_prepare nearly identical to ImageFile load_prepare

### DIFF
--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -155,14 +155,6 @@ class PsdImageFile(ImageFile.ImageFile):
         # return layer number (0=image, 1..max=layers)
         return self.frame
 
-    def load_prepare(self):
-        # create image memory if necessary
-        if not self.im or self.im.mode != self.mode or self.im.size != self.size:
-            self.im = Image.core.fill(self.mode, self.size, 0)
-        # create palette (optional)
-        if self.mode == "P":
-            Image.Image.load(self)
-
     def _close__fp(self):
         try:
             if self.__fp != self.fp:


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/397a9409959bccd0130d0b51820f2a94e3bf153d/src/PIL/PsdImagePlugin.py#L158-L164
is nearly identical to its super method
https://github.com/python-pillow/Pillow/blob/397a9409959bccd0130d0b51820f2a94e3bf153d/src/PIL/ImageFile.py#L280-L286

And the differences don't lead to any changes.

```pycon
>>> from PIL import Image
>>> im = Image.core.fill("RGB", (1, 1), 0)
>>> Image.Image()._new(im).load()[0, 0]
(0, 0, 0)
>>> im = Image.core.new("RGB", (1, 1))
>>> Image.Image()._new(im).load()[0, 0]
(0, 0, 0)
```