### PR TITLE
decode() should return -1 when finished

### DIFF
--- a/src/PIL/BlpImagePlugin.py
+++ b/src/PIL/BlpImagePlugin.py
@@ -306,7 +306,7 @@ class _BLPBaseDecoder(ImageFile.PyDecoder):
             self._load()
         except struct.error as e:
             raise OSError("Truncated BLP file") from e
-        return 0, 0
+        return -1, 0
 
     def _read_blp_header(self):
         self.fd.seek(4)

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -664,7 +664,7 @@ class PyDecoder(PyCodec):
 
         :param buffer: A bytes object with the data to be decoded.
         :returns: A tuple of ``(bytes consumed, errcode)``.
-            If finished with decoding return 0 for the bytes consumed.
+            If finished with decoding return -1 for the bytes consumed.
             Err codes are from :data:`.ImageFile.ERRORS`.
         """
         raise NotImplementedError()

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -231,7 +231,7 @@ class ImageFile(Image.Image):
                     decoder.setimage(self.im, extents)
                     if decoder.pulls_fd:
                         decoder.setfd(self.fp)
-                        status, err_code = decoder.decode(b"")
+                        err_code = decoder.decode(b"")[1]
                     else:
                         b = prefix
                         while True:

--- a/src/PIL/MspImagePlugin.py
+++ b/src/PIL/MspImagePlugin.py
@@ -148,7 +148,7 @@ class MspDecoder(ImageFile.PyDecoder):
 
         self.set_as_raw(img.getvalue(), ("1", 0, 1))
 
-        return 0, 0
+        return -1, 0
 
 
 Image.register_decoder("MSP", MspDecoder)


### PR DESCRIPTION
I made a mistake in #6069, when I wrote that for `PyDecoder`, when `decode()` is finished, it should ["return 0 for the bytes consumed."](https://github.com/python-pillow/Pillow/pull/6069/files#diff-4668a28f508bbcb68e61f9b257415dc814c22e8bb24850629fe7788ae5b7475cR674) It should be a negative number instead.

This can be seen from the ImageFile code
https://github.com/python-pillow/Pillow/blob/397a9409959bccd0130d0b51820f2a94e3bf153d/src/PIL/ImageFile.py#L257-L259
and also from Tests/test_imagefile.py
https://github.com/python-pillow/Pillow/blob/397a9409959bccd0130d0b51820f2a94e3bf153d/Tests/test_imagefile.py#L193-L196
which causes the test suite to fail if the return value is changed to `0, 0` instead.