### PR TITLE
Added support for PPM arbitrary maxval

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -743,7 +743,7 @@ parameter must be set to ``True``. The following parameters can also be set:
 PPM
 ^^^
 
-Pillow reads and writes PBM, PGM, PPM and PNM files containing ``1``, ``L`` or
+Pillow reads and writes PBM, PGM, PPM and PNM files containing ``1``, ``L``, ``I`` or
 ``RGB`` data.
 
 SGI

--- a/src/PIL/PpmImagePlugin.py
+++ b/src/PIL/PpmImagePlugin.py
@@ -16,6 +16,9 @@
 
 
 from . import Image, ImageFile
+from ._binary import i16be as i16
+from ._binary import o8
+from ._binary import o32le as o32
 
 #
 # --------------------------------------------------------------------
@@ -102,6 +105,7 @@ class PpmImageFile(ImageFile.ImageFile):
         else:
             self.mode = rawmode = mode
 
+        decoder_name = "raw"
         for ix in range(3):
             token = int(self._read_token())
             if ix == 0:  # token is the x size
@@ -112,18 +116,44 @@ class PpmImageFile(ImageFile.ImageFile):
                     break
             elif ix == 2:  # token is maxval
                 maxval = token
-                if maxval > 255:
-                    if not mode == "L":
-                        raise ValueError(f"Too many colors for band: {token}")
-                    if maxval < 2**16:
-                        self.mode = "I"
-                        rawmode = "I;16B"
-                    else:
-                        self.mode = "I"
-                        rawmode = "I;32B"
+                if maxval > 255 and mode == "L":
+                    self.mode = "I"
+
+                # If maxval matches a bit depth,
+                # use the raw decoder directly
+                if maxval == 65535 and mode == "L":
+                    rawmode = "I;16B"
+                elif maxval != 255:
+                    decoder_name = "ppm"
+        args = (rawmode, 0, 1) if decoder_name == "raw" else (rawmode, maxval)
 
         self._size = xsize, ysize
-        self.tile = [("raw", (0, 0, xsize, ysize), self.fp.tell(), (rawmode, 0, 1))]
+        self.tile = [(decoder_name, (0, 0, xsize, ysize), self.fp.tell(), args)]
+
+
+class PpmDecoder(ImageFile.PyDecoder):
+    _pulls_fd = True
+
+    def decode(self, buffer):
+        data = bytearray()
+        maxval = min(self.args[-1], 65535)
+        in_byte_count = 1 if maxval < 256 else 2
+        out_byte_count = 4 if self.mode == "I" else 1
+        out_max = 65535 if self.mode == "I" else 255
+        bands = Image.getmodebands(self.mode)
+        while len(data) < self.state.xsize * self.state.ysize * bands * out_byte_count:
+            pixels = self.fd.read(in_byte_count * bands)
+            if len(pixels) < in_byte_count * bands:
+                # eof
+                break
+            for b in range(bands):
+                value = (
+                    pixels[b] if in_byte_count == 1 else i16(pixels, b * in_byte_count)
+                )
+                value = min(out_max, round(value / maxval * out_max))
+                data += o32(value) if self.mode == "I" else o8(value)
+        self.set_as_raw(bytes(data), (self.mode, 0, 1))
+        return -1, 0
 
 
 #
@@ -149,7 +179,7 @@ def _save(im, fp, filename):
     fp.write(head + ("\n%d %d\n" % im.size).encode("ascii"))
     if head == b"P6":
         fp.write(b"255\n")
-    if head == b"P5":
+    elif head == b"P5":
         if rawmode == "L":
             fp.write(b"255\n")
         elif rawmode == "I;16B":
@@ -168,6 +198,8 @@ def _save(im, fp, filename):
 
 Image.register_open(PpmImageFile.format, PpmImageFile, _accept)
 Image.register_save(PpmImageFile.format, _save)
+
+Image.register_decoder("ppm", PpmDecoder)
 
 Image.register_extensions(PpmImageFile.format, [".pbm", ".pgm", ".ppm", ".pnm"])
 


### PR DESCRIPTION
Resolves #5008
Resolves #5403

#5008 points out that the PPM [`maxval`](https://github.com/python-pillow/Pillow/blob/397a9409959bccd0130d0b51820f2a94e3bf153d/src/PIL/PpmImagePlugin.py#L114-L123) does not just indicate the bit depth of an image. It is an arbitrary number, that ["Must be less than 65536 and more than zero."](http://netpbm.sourceforge.net/doc/ppm.html)

The example from the issue has a `maxval` of 11 (not 2 ** 11, but just 11), and https://en.wikipedia.org/wiki/Netpbm#PGM_example shows an example where the `maxval` is 15. So when it is 15, the values range between 0 and 15, from black to white.

This PR 
- allows this value to be arbitrary for P5 (grayscale). That fixes the code example in #5008, and #5403, which features a P5 image at 10-bit depth, or 1023 maxval (2 ** 10 - 1).
- allows this value to be arbitrary for P6 (RGB). When the value is more than 255, that would require more than 16-bits of RGB data. As we do not have such a mode, this PR simply scales down the pixels to fit into 16-bit.