### PR TITLE
Handle EXIF data truncated to just the header

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -666,6 +666,19 @@ class TestImage:
 
             assert not fp.closed
 
+    def test_empty_exif(self):
+        with Image.open("Tests/images/exif.png") as im:
+            exif = im.getexif()
+        assert dict(exif) != {}
+
+        # Test that exif data is cleared after another load
+        exif.load(None)
+        assert dict(exif) == {}
+
+        # Test loading just the EXIF header
+        exif.load(b"Exif\x00\x00")
+        assert dict(exif) == {}
+
     @mark_if_feature_version(
         pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
     )

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3478,12 +3478,12 @@ class Exif(MutableMapping):
         self._loaded_exif = data
         self._data.clear()
         self._ifds.clear()
+        if data and data.startswith(b"Exif\x00\x00"):
+            data = data[6:]
         if not data:
             self._info = None
             return
 
-        if data.startswith(b"Exif\x00\x00"):
-            data = data[6:]
         self.fp = io.BytesIO(data)
         self.head = self.fp.read(8)
         # process dictionary


### PR DESCRIPTION
Resolves #6123

A malformed image from that issue has Exif data that stops after the header. This is the second report of this however, so this PR handles the data instead of throwing an error.