### PR TITLE
Retain RGBA transparency when saving multiple GIF frames

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -842,6 +842,17 @@ def test_rgb_transparency(tmp_path):
         assert "transparency" not in reloaded.info
 
 
+def test_rgba_transparency(tmp_path):
+    out = str(tmp_path / "temp.gif")
+
+    im = hopper("P")
+    im.save(out, save_all=True, append_images=[Image.new("RGBA", im.size)])
+
+    with Image.open(out) as reloaded:
+        reloaded.seek(1)
+        assert_image_equal(hopper("P").convert("RGB"), reloaded)
+
+
 def test_bbox(tmp_path):
     out = str(tmp_path / "temp.gif")
 

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -432,10 +432,6 @@ def _normalize_mode(im):
     It may return the original image, or it may return an image converted to
     palette or 'L' mode.
 
-    UNDONE: What is the point of mucking with the initial call palette, for
-    an image that shouldn't have a palette, or it would be a mode 'P' and
-    get returned in the RAWMODE clause.
-
     :param im: Image object
     :returns: Image object
     """
@@ -443,10 +439,7 @@ def _normalize_mode(im):
         im.load()
         return im
     if Image.getmodebase(im.mode) == "RGB":
-        palette_size = 256
-        if im.palette:
-            palette_size = len(im.palette.getdata()[1]) // 3
-        im = im.convert("P", palette=Image.Palette.ADAPTIVE, colors=palette_size)
+        im = im.convert("P", palette=Image.Palette.ADAPTIVE)
         if im.palette.mode == "RGBA":
             for rgba in im.palette.colors.keys():
                 if rgba[3] == 0:


### PR DESCRIPTION
Resolves #6115

At the moment, RGBA transparency is only [retained](https://github.com/python-pillow/Pillow/blob/475b7233d6c6341f750829dbdd5123002bed57b7/src/PIL/GifImagePlugin.py#L447-L459) when saving a [single frame GIF](https://github.com/python-pillow/Pillow/blob/475b7233d6c6341f750829dbdd5123002bed57b7/src/PIL/GifImagePlugin.py#L517), not [multiple frames.](https://github.com/python-pillow/Pillow/blob/475b7233d6c6341f750829dbdd5123002bed57b7/src/PIL/GifImagePlugin.py#L548)

This PR removes the `initial_call` argument from `_normalize_mode`, allowing the transparency to be kept every time.