### PR TITLE
Added merging images example

### DIFF
--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -171,20 +171,37 @@ Rolling an image
 
 ::
 
-    def roll(image, delta):
+    def roll(im, delta):
         """Roll an image sideways."""
-        xsize, ysize = image.size
+        xsize, ysize = im.size
 
         delta = delta % xsize
         if delta == 0:
-            return image
+            return im
 
-        part1 = image.crop((0, 0, delta, ysize))
-        part2 = image.crop((delta, 0, xsize, ysize))
-        image.paste(part1, (xsize - delta, 0, xsize, ysize))
-        image.paste(part2, (0, 0, xsize - delta, ysize))
+        part1 = im.crop((0, 0, delta, ysize))
+        part2 = im.crop((delta, 0, xsize, ysize))
+        im.paste(part1, (xsize - delta, 0, xsize, ysize))
+        im.paste(part2, (0, 0, xsize - delta, ysize))
 
-        return image
+        return im
+
+Or if you would like to merge two images into a wider image:
+
+Merging images
+^^^^^^^^^^^^^^
+
+::
+
+    def merge(im1, im2):
+        w = im1.size[0] + im2.size[0]
+        h = max(im1.size[1], im2.size[1])
+        im = Image.new("RGBA", (w, h))
+
+        im.paste(im1)
+        im.paste(im2, (im1.size[0], 0))
+
+        return im
 
 For more advanced tricks, the paste method can also take a transparency mask as
 an optional argument. In this mask, the value 255 indicates that the pasted


### PR DESCRIPTION
Alternative to #6064

Added example code to the tutorial that merges two images into a single wider image.