### PR TITLE
If an error occurs after creating a file, remove the file

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -652,6 +652,15 @@ class TestImage:
             with warnings.catch_warnings():
                 im.save(temp_file)
 
+    def test_no_new_file_on_error(self, tmp_path):
+        temp_file = str(tmp_path / "temp.jpg")
+
+        im = Image.new("RGB", (0, 0))
+        with pytest.raises(SystemError):
+            im.save(temp_file)
+
+        assert not os.path.exists(temp_file)
+
     def test_load_on_nonexclusive_multiframe(self):
         with open("Tests/images/frozenpond.mpo", "rb") as fp:
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2286,7 +2286,9 @@ class Image:
         else:
             save_handler = SAVE[format.upper()]
 
+        created = False
         if open_fp:
+            created = not os.path.exists(filename)
             if params.get("append", False):
                 # Open also for reading ("+"), because TIFF save_all
                 # writer needs to go back and edit the written data.
@@ -2296,10 +2298,17 @@ class Image:
 
         try:
             save_handler(self, fp, filename)
-        finally:
-            # do what we can to clean up
+        except Exception:
             if open_fp:
                 fp.close()
+            if created:
+                try:
+                    os.remove(filename)
+                except PermissionError:
+                    pass
+            raise
+        if open_fp:
+            fp.close()
 
     def seek(self, frame):
         """


### PR DESCRIPTION
Helps #5944. Alternative to #5947

If an error occurs after creating a file, remove the file, rather than leaving a potentially corrupt image on disk.