### PR TITLE
Fixed calling DisplayViewer or XVViewer without a title

### DIFF
--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -270,8 +270,9 @@ class DisplayViewer(UnixViewer):
             else:
                 raise TypeError("Missing required argument: 'path'")
         args = ["display"]
-        if "title" in options:
-            args += ["-title", options["title"]]
+        title = options.get("title")
+        if title:
+            args += ["-title", title]
         args.append(path)
 
         subprocess.Popen(args)
@@ -368,8 +369,9 @@ class XVViewer(UnixViewer):
             else:
                 raise TypeError("Missing required argument: 'path'")
         args = ["xv"]
-        if "title" in options:
-            args += ["-name", options["title"]]
+        title = options.get("title")
+        if title:
+            args += ["-name", title]
         args.append(path)
 
         subprocess.Popen(args)


### PR DESCRIPTION
Requested in https://github.com/python-pillow/Pillow/commit/8da80130dbc747f3954b4904247d26289fe722f9#r68650261
Resolves #6146

That comment points out that https://github.com/python-pillow/Pillow/blob/6faebd3ff321e7b2dd780950858301e1b2d76db8/src/PIL/ImageShow.py#L51-L61 can set `title` to `None`, which is then passed (through [`Viewer.show`](https://github.com/python-pillow/Pillow/blob/6faebd3ff321e7b2dd780950858301e1b2d76db8/src/PIL/ImageShow.py#L71-L85) and [`show_image`](https://github.com/python-pillow/Pillow/blob/6faebd3ff321e7b2dd780950858301e1b2d76db8/src/PIL/ImageShow.py#L109-L111)) to `DisplayViewer` and `XVViewer` as `None` for one of the values passed to `subprocess.Popen`.

This problem was introduced in #6010.