### PR TITLE
Added WebP default duration of zero when saving

### DIFF
--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -192,7 +192,7 @@ def _save_all(im, fp, filename):
                 r, g, b = palette[background * 3 : (background + 1) * 3]
                 background = (r, g, b, 0)
 
-    duration = im.encoderinfo.get("duration", im.info.get("duration"))
+    duration = im.encoderinfo.get("duration", im.info.get("duration", 0))
     loop = im.encoderinfo.get("loop", 0)
     minimize_size = im.encoderinfo.get("minimize_size", False)
     kmin = im.encoderinfo.get("kmin", None)


### PR DESCRIPTION
Resolves #6139

When saving multiple frames to a WebP image, there is currently no default duration.
https://github.com/python-pillow/Pillow/blob/0cf072db39bf1868575c625fc4403f388e5d47d4/src/PIL/WebPImagePlugin.py#L195

But duration is added together when iterating over each frame.
https://github.com/python-pillow/Pillow/blob/0cf072db39bf1868575c625fc4403f388e5d47d4/src/PIL/WebPImagePlugin.py#L249
https://github.com/python-pillow/Pillow/blob/0cf072db39bf1868575c625fc4403f388e5d47d4/src/PIL/WebPImagePlugin.py#L289-L292

That can lead to an error, because `None` cannot be added to `0`.

This PR adds a default duration of zero.