### PR TITLE
Do not always require ctypes in tests

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -4,7 +4,6 @@ import itertools
 import os
 import re
 from collections import namedtuple
-from ctypes import c_float
 
 import pytest
 
@@ -168,14 +167,11 @@ class TestFileLibTiff(LibTiffTestCase):
                     val = original[tag]
                     if tag.endswith("Resolution"):
                         if legacy_api:
-                            assert (
-                                c_float(val[0][0] / val[0][1]).value
-                                == c_float(value[0][0] / value[0][1]).value
+                            assert val[0][0] / val[0][1] == (
+                                4294967295 / 113653537
                             ), f"{tag} didn't roundtrip"
                         else:
-                            assert (
-                                c_float(val).value == c_float(value).value
-                            ), f"{tag} didn't roundtrip"
+                            assert val == 37.79000115940079, f"{tag} didn't roundtrip"
                     else:
                         assert val == value, f"{tag} didn't roundtrip"
 

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -1,4 +1,3 @@
-import ctypes
 import os
 import subprocess
 import sys
@@ -404,6 +403,8 @@ class TestEmbeddable:
         "not from shell",
     )
     def test_embeddable(self):
+        import ctypes
+
         with open("embed_pil.c", "w") as fh:
             fh.write(
                 """

--- a/Tests/test_imagewin_pointers.py
+++ b/Tests/test_imagewin_pointers.py
@@ -1,4 +1,3 @@
-import ctypes
 from io import BytesIO
 
 from PIL import Image, ImageWin
@@ -8,6 +7,7 @@ from .helper import hopper, is_win32
 # see https://github.com/python-pillow/Pillow/pull/1431#issuecomment-144692652
 
 if is_win32():
+    import ctypes
     import ctypes.wintypes
 
     class BITMAPFILEHEADER(ctypes.Structure):


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/f3a3b20c51035969e585583e7340c80bf28caef3/Tests/test_image_access.py#L8

This import at the top level of test_image_access.py, but is only used on [non-CI Windows](https://github.com/python-pillow/Pillow/blob/f3a3b20c51035969e585583e7340c80bf28caef3/Tests/test_image_access.py#L402). This PR moves the import so that if a user doesn't have setuptools installed, that doesn't stop them from running our test suite.

test_image_access.py and test_imagewin_pointers.py similarly always import ctypes for tests that only run on Windows. I have moved those imports as well.

test_file_libtiff.py imports ctypes to calculate libtiff will transform a specific value into. I've just run that calculation now, recorded the value and removed the import.