### PR TITLE
Do not expand GIF during n_frames

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -971,6 +971,11 @@ def test_lzw_bits():
 def test_extents():
     with Image.open("Tests/images/test_extents.gif") as im:
         assert im.size == (100, 100)
+
+        # Check that n_frames does not change the size
+        assert im.n_frames == 2
+        assert im.size == (100, 100)
+
         im.seek(1)
         assert im.size == (150, 150)
 

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -261,7 +261,7 @@ class GifImageFile(ImageFile.ImageFile):
                 # extent
                 x0, y0 = i16(s, 0), i16(s, 2)
                 x1, y1 = x0 + i16(s, 4), y0 + i16(s, 6)
-                if x1 > self.size[0] or y1 > self.size[1]:
+                if (x1 > self.size[0] or y1 > self.size[1]) and update_image:
                     self._size = max(x1, self.size[0]), max(y1, self.size[1])
                 self.dispose_extent = x0, y0, x1, y1
                 flags = s[8]


### PR DESCRIPTION
#3822 allowed GIFs to expand if a frame has extents outside of the image.

This PR stops that behaviour when the call to `_seek` are only to determine the number of frames.