### PR TITLE
Do not mark L mode JPEG as 1 bit in PDF

### DIFF
--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -127,7 +127,6 @@ def _save(im, fp, filename, save_all=False):
                 filter = "DCTDecode"
                 colorspace = PdfParser.PdfName("DeviceGray")
                 procset = "ImageB"  # grayscale
-                bits = 1
             elif im.mode == "L":
                 filter = "DCTDecode"
                 # params = f"<< /Predictor 15 /Columns {width-2} >>"


### PR DESCRIPTION
Resolves #6149

When saving a PDF, the `bits` setting is different for 1 and L mode images.
https://github.com/python-pillow/Pillow/blob/a6a843e5482345ffcd6cb45a534a11e839fcef43/src/PIL/PdfImagePlugin.py#L122-L135

Except that both images are encoded as JPEGs,
https://github.com/python-pillow/Pillow/blob/a6a843e5482345ffcd6cb45a534a11e839fcef43/src/PIL/PdfImagePlugin.py#L165-L166

which treats both 1 and L as L.
https://github.com/python-pillow/Pillow/blob/a6a843e5482345ffcd6cb45a534a11e839fcef43/src/PIL/JpegImagePlugin.py#L574-L578

So instructing the PDF that [`BitsPerComponent`](https://github.com/python-pillow/Pillow/blob/a6a843e5482345ffcd6cb45a534a11e839fcef43/src/PIL/PdfImagePlugin.py#L187) is different for these two images seems wrong. As a result, 1-bit PDFs from the current version of the code are read successfully by Chrome, but not by Firefox.

This PR fixes that by setting `bits` to 8 for 1-bit images as well.