### PR TITLE
Use screencapture arguments to crop on macOS

### DIFF
--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -30,14 +30,18 @@ def grab(bbox=None, include_layered_windows=False, all_screens=False, xdisplay=N
         if sys.platform == "darwin":
             fh, filepath = tempfile.mkstemp(".png")
             os.close(fh)
-            subprocess.call(["screencapture", "-x", filepath])
+            args = ["screencapture"]
+            if bbox:
+                left, top, right, bottom = bbox
+                args += ["-R", f"{left},{right},{right-left},{bottom-top}"]
+            subprocess.call(args + ["-x", filepath])
             im = Image.open(filepath)
             im.load()
             os.unlink(filepath)
             if bbox:
-                im_cropped = im.crop(bbox)
+                im_resized = im.resize((right - left, bottom - top))
                 im.close()
-                return im_cropped
+                return im_resized
             return im
         elif sys.platform == "win32":
             offset, size, data = Image.core.grabscreen_win32(


### PR DESCRIPTION
Resolves #6144

There are two ways of looking at this change.
1. Speed improvement. Rather than grabbing the complete screen on macOS, and then cropping the result to the `bbox` requested by the user, this PR tells `screencapture` the co-ordinates that we are interested in. The image does need to be resized afterwards, to avoid returning a image twice the size of the requested `bbox`, but presumably that is still faster than loading an image the size of the screen and cropping it.
2. Since `screencapture` without arguments returns an image at double resolution, cropping to the `bbox` can produce an unexpected offset. By passing the arguments to `screencapture`, Pillow can leave the problem of calculating which portion of the screen is desired to the system.