### PR TITLE
Raise ValueError when trying to save empty JPEG

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -68,6 +68,13 @@ class TestFileJpeg:
             assert im.format == "JPEG"
             assert im.get_format_mimetype() == "image/jpeg"
 
+    @pytest.mark.parametrize("size", ((1, 0), (0, 1), (0, 0)))
+    def test_zero(self, size, tmp_path):
+        f = str(tmp_path / "temp.jpg")
+        im = Image.new("RGB", size)
+        with pytest.raises(ValueError):
+            im.save(f)
+
     def test_app(self):
         # Test APP/COM reader (@PIL135)
         with Image.open(TEST_FILE) as im:

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -656,7 +656,7 @@ class TestImage:
         temp_file = str(tmp_path / "temp.jpg")
 
         im = Image.new("RGB", (0, 0))
-        with pytest.raises(SystemError):
+        with pytest.raises(ValueError):
             im.save(temp_file)
 
         assert not os.path.exists(temp_file)

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -626,6 +626,8 @@ def get_sampling(im):
 
 
 def _save(im, fp, filename):
+    if im.width == 0 or im.height == 0:
+        raise ValueError("cannot write empty image as JPEG")
 
     try:
         rawmode = RAWMODE[im.mode]


### PR DESCRIPTION
Suggested in https://github.com/python-pillow/Pillow/issues/5944#issuecomment-1079934111

The JPEG format [does not support saving an image with zero width or height](https://github.com/python-pillow/Pillow/issues/5931#issuecomment-1007142950). This PR raises a ValueError for the situation, rather than the SystemError that is currently raised.