### PR TITLE
Fix loading FriBiDi on Alpine

### DIFF
--- a/src/thirdparty/fribidi-shim/fribidi.c
+++ b/src/thirdparty/fribidi-shim/fribidi.c
@@ -7,7 +7,6 @@
 #endif
 
 #define FRIBIDI_SHIM_IMPLEMENTATION
-
 #include "fribidi.h"
 
 
@@ -86,7 +85,7 @@ int load_fribidi(void) {
 
 #ifndef _WIN32
     fribidi_version_info = *(const char**)dlsym(p_fribidi, "fribidi_version_info");
-    if (dlerror() || error || (fribidi_version_info == 0)) {
+    if (error || (fribidi_version_info == 0)) {
         dlclose(p_fribidi);
         p_fribidi = 0;
         return 2;


### PR DESCRIPTION
Testing https://github.com/python-pillow/pillow-wheels/pull/271, I find the tests pass, but Raqm is not enabled even when I install FriBiDi.

On Alpine, fribidi is at `/usr/lib/libfribidi.so.0`, and I can see the second `dlopen` call succeeds when using `strace`. However, the shim is still rejecting the SO. This is because the `dlerror` call returns the error for the first `dlopen` call.

This could be fixed by calling `dlerror` before retrying to clear the error, but since all `dlsym` return values are checked to be non-null, there is actually no need to check `dlerror` at all.

See PR adding tests in https://github.com/python-pillow/pillow-wheels/pull/274