### PR TITLE
Add support for unpacking 16-bit BGRA

### DIFF
--- a/Tests/test_lib_pack.py
+++ b/Tests/test_lib_pack.py
@@ -444,6 +444,8 @@ class TestLibUnpack:
         self.assert_unpack("RGBA", "RGBA;4B", 2, (17, 0, 34, 0), (51, 0, 68, 0))
         self.assert_unpack("RGBA", "RGBA;16L", 8, (2, 4, 6, 8), (10, 12, 14, 16))
         self.assert_unpack("RGBA", "RGBA;16B", 8, (1, 3, 5, 7), (9, 11, 13, 15))
+        self.assert_unpack("RGBA", "BGRA;16L", 8, (6, 4, 2, 8), (14, 12, 10, 16))
+        self.assert_unpack("RGBA", "BGRA;16B", 8, (5, 3, 1, 7), (13, 11, 9, 15))
         self.assert_unpack(
             "RGBA", "BGRA", 4, (3, 2, 1, 4), (7, 6, 5, 8), (11, 10, 9, 12)
         )

--- a/src/libImaging/Unpack.c
+++ b/src/libImaging/Unpack.c
@@ -1065,6 +1065,30 @@ unpackBGRA(UINT8 *_out, const UINT8 *in, int pixels) {
     }
 }
 
+static void
+unpackBGRA16L(UINT8 *_out, const UINT8 *in, int pixels) {
+    int i;
+    /* 16-bit RGBA, little-endian order, reversed words */
+    for (i = 0; i < pixels; i++) {
+        UINT32 iv = MAKE_UINT32(in[5], in[3], in[1], in[7]);
+        memcpy(_out, &iv, sizeof(iv));
+        in += 8;
+        _out += 4;
+    }
+}
+
+static void
+unpackBGRA16B(UINT8 *_out, const UINT8 *in, int pixels) {
+    int i;
+    /* 16-bit RGBA, big-endian order, reversed words */
+    for (i = 0; i < pixels; i++) {
+        UINT32 iv = MAKE_UINT32(in[4], in[2], in[0], in[6]);
+        memcpy(_out, &iv, sizeof(iv));
+        in += 8;
+        _out += 4;
+    }
+}
+
 /* Unpack to "CMYK" image */
 
 static void
@@ -1574,6 +1598,8 @@ static struct {
     {"RGBA", "RGBA;16L", 64, unpackRGBA16L},
     {"RGBA", "RGBA;16B", 64, unpackRGBA16B},
     {"RGBA", "BGRA", 32, unpackBGRA},
+    {"RGBA", "BGRA;16L", 64, unpackBGRA16L},
+    {"RGBA", "BGRA;16B", 64, unpackBGRA16B},
     {"RGBA", "ARGB", 32, unpackARGB},
     {"RGBA", "ABGR", 32, unpackABGR},
     {"RGBA", "YCCA;P", 32, ImagingUnpackYCCA},


### PR DESCRIPTION
Adds support for unpacking 16-bit BGRA format. This format is used by ImageMagick 6 for many platforms - the addition of this support enables converting directly from `Magick::PixelPacket*` into PIL images.

I have used this new functionality in an example image-processing library I wrote to accompany a talk on Python APIs for CUDA-accelerated applications (see e.g. https://github.com/gmarkall/numba-accelerated-udfs/blob/main/filigree/api.py#L47), but I think it is generally useful for other applications to be able to work directly with ImageMagick 6 data.