### PR TITLE
DOC: the constants were deprecated in 9.1.0 not 9.2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: fc0be6eb1e2a96091e6f64009ee5e9081bf8b6c6  # frozen: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         args: ["--target-version", "py37"]
@@ -9,35 +9,35 @@ repos:
         types: []
 
   - repo: https://github.com/PyCQA/isort
-    rev: c5e8fa75dda5f764d20f66a215d71c21cfa198e1  # frozen: 5.10.1
+    rev: 5.10.1
     hooks:
       - id: isort
 
   - repo: https://github.com/asottile/yesqa
-    rev: 35cf7dc24fa922927caded7a21b2a8cb04bf8e10  # frozen: v1.3.0
+    rev: v1.3.0
     hooks:
       - id: yesqa
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: ca52c4245639abd55c970e6bbbca95cab3de22d8  # frozen: v1.1.13
+    rev: v1.1.13
     hooks:
       - id: remove-tabs
         exclude: (Makefile$|\.bat$|\.cmake$|\.eps$|\.fits$|\.opt$)
 
   - repo: https://github.com/PyCQA/flake8
-    rev: cbeb4c9c4137cff1568659fcc48e8b85cddd0c8d  # frozen: 4.0.1
+    rev: 4.0.1
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: 6f51a66bba59954917140ec2eeeaa4d5e630e6ce  # frozen: v1.9.0
+    rev: v1.9.0
     hooks:
       - id: python-check-blanket-noqa
       - id: rst-backticks
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 8fe62d14e0b4d7d845a7022c5c2c3ae41bdd3f26  # frozen: v4.1.0
+    rev: v4.1.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -69,7 +69,7 @@ In effect, ``viewer.show_file("test.jpg")`` will continue to work unchanged.
 Constants
 ~~~~~~~~~
 
-.. deprecated:: 9.2.0
+.. deprecated:: 9.1.0
 
 A number of constants have been deprecated and will be removed in Pillow 10.0.0
 (2023-07-01). Instead, ``enum.IntEnum`` classes have been added.


### PR DESCRIPTION
Changes proposed in this pull request:

 * Correct the deprecated note on  https://pillow.readthedocs.io/en/stable/deprecations.html#constants to match https://pillow.readthedocs.io/en/stable/releasenotes/9.1.0.html#constants
