### PR TITLE
Release updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ release-test:
 	-rm dist/*.egg
 	-rmdir dist
 	python3 -m pytest -qq
-	python3 -m check-manifest
+	check-manifest
 	python3 -m pyroma .
 	$(MAKE) readme
 

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ release-test:
 	-rm dist/*.egg
 	-rmdir dist
 	python3 -m pytest -qq
-	check-manifest
+	python3 -m check_manifest
 	python3 -m pyroma .
 	$(MAKE) readme
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,13 +24,13 @@ Released quarterly on January 2nd, April 1st, July 1st and October 15th.
 * [ ] Create and check source distribution:
   ```bash
   make sdist
-  twine check dist/*
+  python3 -m twine check --strict dist/*
   ```
 * [ ] Create [binary distributions](https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#binary-distributions)
 * [ ] Check and upload all binaries and source distributions e.g.:
   ```bash
-  twine check dist/*
-  twine upload dist/Pillow-5.2.0*
+  python3 -m twine check --strict dist/*
+  python3 -m twine upload dist/Pillow-5.2.0*
   ```
 * [ ] Publish the [release on GitHub](https://github.com/python-pillow/Pillow/releases)
 * [ ] In compliance with [PEP 440](https://www.python.org/dev/peps/pep-0440/), increment and append `.dev0` to version identifier in `src/PIL/_version.py`
@@ -61,13 +61,13 @@ Released as needed for security, installation or critical bug fixes.
 * [ ] Create and check source distribution:
   ```bash
   make sdist
-  twine check dist/*
+  python3 -m twine check --strict dist/*
   ```
 * [ ] Create [binary distributions](https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#binary-distributions)
 * [ ] Check and upload all binaries and source distributions e.g.:
   ```bash
-  twine check dist/*
-  twine upload dist/Pillow-5.2.1*
+  python3 -m twine --strict check dist/*
+  python3 -m twine upload dist/Pillow-5.2.1*
   ```
 * [ ] Publish the [release on GitHub](https://github.com/python-pillow/Pillow/releases)
 
@@ -91,7 +91,7 @@ Released as needed privately to individual vendors for critical security-related
 * [ ] Create and check source distribution:
   ```bash
   make sdist
-  twine check dist/*
+  python3 -m twine check --strict dist/*
   ```
 * [ ] Create [binary distributions](https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#binary-distributions)
 * [ ] Publish the [release on GitHub](https://github.com/python-pillow/Pillow/releases)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -66,7 +66,7 @@ Released as needed for security, installation or critical bug fixes.
 * [ ] Create [binary distributions](https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#binary-distributions)
 * [ ] Check and upload all binaries and source distributions e.g.:
   ```bash
-  python3 -m twine --strict check dist/*
+  python3 -m twine check --strict dist/*
   python3 -m twine upload dist/Pillow-5.2.1*
   ```
 * [ ] Publish the [release on GitHub](https://github.com/python-pillow/Pillow/releases)


### PR DESCRIPTION
Some things noticed during https://github.com/python-pillow/Pillow/issues/6110.

# Fix

```console
$ # Nope
$ python3 -m check-manifest
/Library/Frameworks/Python.framework/Versions/3.10/bin/python3: No module named check-manifest
$ # Yep
$ check-manifest
$
```

# Improvement

And as an opposite, we can call twine via `python3 -m twine`, and for `twine check` include `--strict`:

```
  --strict    Fail on warnings
```
