### PR TITLE
Consider transparency from each frame when saving GIF

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -619,7 +619,7 @@ def test_dispose2_background(tmp_path):
         assert im.getpixel((0, 0)) == (255, 0, 0)
 
 
-def test_transparency_in_second_frame():
+def test_transparency_in_second_frame(tmp_path):
     with Image.open("Tests/images/different_transparency.gif") as im:
         assert im.info["transparency"] == 0
 
@@ -628,6 +628,15 @@ def test_transparency_in_second_frame():
         assert "transparency" not in im.info
 
         assert_image_equal_tofile(im, "Tests/images/different_transparency_merged.png")
+
+        out = str(tmp_path / "temp.gif")
+        im.save(out, save_all=True)
+
+        with Image.open(out) as reread:
+            reread.seek(reread.tell() + 1)
+            assert_image_equal_tofile(
+                reread, "Tests/images/different_transparency_merged.png"
+            )
 
 
 def test_no_transparency_in_second_frame():

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -573,10 +573,14 @@ def _write_multiple_frames(im, fp, palette):
             im_frame = _normalize_mode(im_frame.copy())
             if frame_count == 0:
                 for k, v in im_frame.info.items():
+                    if k == "transparency":
+                        continue
                     im.encoderinfo.setdefault(k, v)
-            im_frame = _normalize_palette(im_frame, palette, im.encoderinfo)
 
             encoderinfo = im.encoderinfo.copy()
+            if "transparency" in im_frame.info:
+                encoderinfo.setdefault("transparency", im_frame.info["transparency"])
+            im_frame = _normalize_palette(im_frame, palette, encoderinfo)
             if isinstance(duration, (list, tuple)):
                 encoderinfo["duration"] = duration[frame_count]
             if isinstance(disposal, (list, tuple)):


### PR DESCRIPTION
Resolves #6162

When saving a GIF, `_normalize_mode` may set `info["transparency"]` for a frame.
https://github.com/python-pillow/Pillow/blob/a575ec33d2f0a04de6cde880a4163de61106b343/src/PIL/GifImagePlugin.py#L482

When the code comes back to `_write_multiple_frames`, the transparency is used, if the user hasn't overridden it from `encoderinfo`... but it is only copied from the first frame.
https://github.com/python-pillow/Pillow/blob/a575ec33d2f0a04de6cde880a4163de61106b343/src/PIL/GifImagePlugin.py#L573-L576

This PR allows each frame to have a different transparency from `_normalize_mode`.