### PR TITLE
Deprecated PhotoImage.paste() box parameter

### DIFF
--- a/Tests/test_imagetk.py
+++ b/Tests/test_imagetk.py
@@ -80,6 +80,13 @@ def test_photoimage_blank():
         assert_image_equal(reloaded.convert(mode), im)
 
 
+def test_box_deprecation():
+    im = hopper()
+    im_tk = ImageTk.PhotoImage(im)
+    with pytest.warns(DeprecationWarning):
+        im_tk.paste(im, (0, 0, 128, 128))
+
+
 def test_bitmapimage():
     im = hopper("1")
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -142,6 +142,13 @@ The stub image plugin ``FitsStubImagePlugin`` has been deprecated and will be re
 Pillow 10.0.0 (2023-07-01). FITS images can be read without a handler through
 :mod:`~PIL.FitsImagePlugin` instead.
 
+PhotoImage.paste box parameter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 9.2.0
+
+The ``box`` parameter is unused. It will be removed in Pillow 10.0.0 (2023-07-01).
+
 Removed features
 ----------------
 

--- a/src/PIL/ImageTk.py
+++ b/src/PIL/ImageTk.py
@@ -26,6 +26,7 @@
 #
 
 import tkinter
+import warnings
 from io import BytesIO
 
 from . import Image
@@ -183,10 +184,14 @@ class PhotoImage:
         :param im: A PIL image. The size must match the target region.  If the
                    mode does not match, the image is converted to the mode of
                    the bitmap image.
-        :param box: A 4-tuple defining the left, upper, right, and lower pixel
-                    coordinate. See :ref:`coordinate-system`. If None is given
-                    instead of a tuple, all of the image is assumed.
         """
+
+        if box is not None:
+            warnings.warn(
+                "The box parameter is deprecated and will be removed in Pillow 10 "
+                "(2023-07-01).",
+                DeprecationWarning,
+            )
 
         # convert to blittable
         im.load()


### PR DESCRIPTION
Resolves #6163

In [PhotoImage.paste()](https://github.com/python-pillow/Pillow/blob/a575ec33d2f0a04de6cde880a4163de61106b343/src/PIL/ImageTk.py#L178), the `box` parameter is unused.

This PR deprecates it.