### PR TITLE
Search for libfribidi.dylib in /usr/local/lib

### DIFF
--- a/src/thirdparty/fribidi-shim/fribidi.c
+++ b/src/thirdparty/fribidi-shim/fribidi.c
@@ -49,6 +49,9 @@ int load_fribidi(void) {
     if (!p_fribidi) {
         p_fribidi = dlopen("libfribidi.dylib", RTLD_LAZY);
     }
+    if (!p_fribidi) {
+        p_fribidi = dlopen("/usr/local/lib/libfribidi.dylib", RTLD_LAZY);
+    }
 #else
 #define LOAD_FUNCTION(func) \
     func = (t_##func)GetProcAddress(p_fribidi, #func); \


### PR DESCRIPTION
I recently created https://github.com/python-pillow/pillow-wheels/pull/281, to test fribidi on macOS. It became apparent that while /usr/local/lib/libfribidi.dylib was present on the system, it was not found by Pillow. My immediate solution to this was just to create a link to libfribidi.dylib in the current directory.

However, if the macOS environment being used for pillow-wheels is normal, then it is conceivable that this problem might occur for end users. For example, perhaps this is the solution to #6175? So I'm creating this PR to explicitly search /usr/local/lib.

If you would like some more information, [here](https://github.com/radarhere/pillow-wheels/actions/runs/2092961810) is a run of the pillow-wheels PR without the link, so that you can see Pillow fail to find libfribid, and [here](https://github.com/radarhere/pillow-wheels/actions/runs/2093139164) is a run of the PR without the link and with the changes from this PR, so you can see it work.