### PR TITLE
Round lut values where necessary

### DIFF
--- a/Tests/test_image_point.py
+++ b/Tests/test_image_point.py
@@ -10,6 +10,7 @@ def test_sanity():
         im.point(list(range(256)))
     im.point(list(range(256)) * 3)
     im.point(lambda x: x)
+    im.point(lambda x: x * 1.2)
 
     im = im.convert("I")
     with pytest.raises(ValueError):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1720,6 +1720,8 @@ class Image:
             # FIXME: _imaging returns a confusing error message for this case
             raise ValueError("point operation not supported for this mode")
 
+        if mode != "F":
+            lut = [round(i) for i in lut]
         return self._new(self.im.point(lut, mode))
 
     def putalpha(self, alpha):


### PR DESCRIPTION
Resolves #6187

The issue reports that float `lut` values raise an error in Python 3.10 for `im.point()`.

This would be because `_point` calls `getlist()`,
https://github.com/python-pillow/Pillow/blob/4996f84fb3fb80dc1d4e8288ff45ef11f8b162cc/src/_imaging.c#L1428

which then calls `PyLong_AsLong`.
https://github.com/python-pillow/Pillow/blob/4996f84fb3fb80dc1d4e8288ff45ef11f8b162cc/src/_imaging.c#L379-L380

https://docs.python.org/3/c-api/long.html#c.PyLong_AsLong
> Changed in version 3.10: This function will no longer use `__int__()`.

So this PR casts `lut` values to `int` first, except for the [case where `_point` uses float values instead.](https://github.com/python-pillow/Pillow/blob/4996f84fb3fb80dc1d4e8288ff45ef11f8b162cc/src/_imaging.c#L1393) 