### PR TITLE
Use actions/stale to close 'Awaiting OP Action' with no response

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: "Check issues"
-      uses: actions/stale@v4
+      uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         debug-only: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: Close stale issues
+
+on:
+  schedule:
+  - cron: "10 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    if: github.repository_owner == 'python-pillow'
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: "Check issues"
+      uses: actions/stale@v4
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        only-issue-labels: "Awaiting OP Action"
+        close-issue-message: "Closing this issue as no feedback has been received."
+        days-before-stale: -1
+        days-before-close: 7
+        labels-to-remove-when-unstale: "Awaiting OP Action"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,8 +19,9 @@ jobs:
       uses: actions/stale@v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+        debug-only: true
         only-issue-labels: "Awaiting OP Action"
         close-issue-message: "Closing this issue as no feedback has been received."
         days-before-stale: -1
-        days-before-close: 7
+        days-before-close: 1
         labels-to-remove-when-unstale: "Awaiting OP Action"


### PR DESCRIPTION
We often get issues where we ask the OP for more info but they never reply.

Most recently, no reply in a week after four comments from us: https://github.com/python-pillow/Pillow/issues/6181. Or already closed: https://github.com/python-pillow/Pillow/issues/6154, no reply after five comments from us.

We often label them ["Awaiting OP Action"](https://github.com/python-pillow/Pillow/issues?q=label%3A%22Awaiting+OP+Action%22+sort%3Aupdated-desc+) for our own convenience.

GitHub has an action to automatically close "stale" issues: https://github.com/actions/stale

There's a whole bunch of config. It can:

* add a "stale" label and/or a comment after some time, 
* and close the issue after more time.

For example, we could have this:

* We manually add the "Awaiting OP Action". 
* If no-one replies after, say, a week, it comments that it will be closed after another couple of days, and if still no action, just closes it.
* If someone does reply, the action removes "Awaiting OP Action".

Or, as in this PR, just keep it simple:

* We manually add the "Awaiting OP Action". 
* If no-one replies after, say, a week, the issue is closed with a comment.
* If someone does reply, the action removes "Awaiting OP Action".

And of course, we can always re-open issues.

---

The second commit here sets `debug-only: true` to do a dry run, so no issues will be closed, and also to set `days-before-close: 1`, so we can test it sooner and see the logs.

Let's keep https://github.com/python-pillow/Pillow/issues/6181 open for testing.
