### PR TITLE
Raise ValueError when trying to access internal fp after close

### DIFF
--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -637,6 +637,15 @@ def test_apng_save_blend(tmp_path):
         assert im.getpixel((0, 0)) == (0, 255, 0, 255)
 
 
+def test_seek_after_close():
+    im = Image.open("Tests/images/apng/delay.png")
+    im.seek(1)
+    im.close()
+
+    with pytest.raises(ValueError):
+        im.seek(0)
+
+
 def test_constants_deprecation():
     for enum, prefix in {
         PngImagePlugin.Disposal: "APNG_DISPOSE_",

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -46,6 +46,15 @@ def test_closed_file():
         im.close()
 
 
+def test_seek_after_close():
+    im = Image.open(animated_test_file)
+    im.seek(1)
+    im.close()
+
+    with pytest.raises(ValueError):
+        im.seek(0)
+
+
 def test_context_manager():
     with warnings.catch_warnings():
         with Image.open(static_test_file) as im:

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -46,6 +46,19 @@ def test_closed_file():
         im.close()
 
 
+def test_seek_after_close():
+    im = Image.open("Tests/images/iss634.gif")
+    im.load()
+    im.close()
+
+    with pytest.raises(ValueError):
+        im.is_animated
+    with pytest.raises(ValueError):
+        im.n_frames
+    with pytest.raises(ValueError):
+        im.seek(1)
+
+
 def test_context_manager():
     with warnings.catch_warnings():
         with Image.open(TEST_GIF) as im:

--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -48,6 +48,14 @@ def test_closed_file():
         im.close()
 
 
+def test_seek_after_close():
+    im = Image.open(test_files[0])
+    im.close()
+
+    with pytest.raises(ValueError):
+        im.seek(1)
+
+
 def test_context_manager():
     with warnings.catch_warnings():
         with Image.open(test_files[0]) as im:

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -70,6 +70,15 @@ class TestFileTiff:
             im.load()
             im.close()
 
+    def test_seek_after_close(self):
+        im = Image.open("Tests/images/multipage.tiff")
+        im.close()
+
+        with pytest.raises(ValueError):
+            im.n_frames
+        with pytest.raises(ValueError):
+            im.seek(1)
+
     def test_context_manager(self):
         with warnings.catch_warnings():
             with Image.open("Tests/images/multipage.tiff") as im:

--- a/src/PIL/DcxImagePlugin.py
+++ b/src/PIL/DcxImagePlugin.py
@@ -57,7 +57,7 @@ class DcxImageFile(PcxImageFile):
                 break
             self._offset.append(offset)
 
-        self.__fp = self.fp
+        self._fp = self.fp
         self.frame = None
         self.n_frames = len(self._offset)
         self.is_animated = self.n_frames > 1
@@ -67,21 +67,21 @@ class DcxImageFile(PcxImageFile):
         if not self._seek_check(frame):
             return
         self.frame = frame
-        self.fp = self.__fp
+        self.fp = self._fp
         self.fp.seek(self._offset[frame])
         PcxImageFile._open(self)
 
     def tell(self):
         return self.frame
 
-    def _close__fp(self):
+    def _close_fp(self):
         try:
-            if self.__fp != self.fp:
-                self.__fp.close()
+            if self._fp != self.fp:
+                self._fp.close()
         except AttributeError:
             pass
         finally:
-            self.__fp = None
+            self._fp = None
 
 
 Image.register_open(DcxImageFile.format, DcxImageFile, _accept)

--- a/src/PIL/DcxImagePlugin.py
+++ b/src/PIL/DcxImagePlugin.py
@@ -74,15 +74,6 @@ class DcxImageFile(PcxImageFile):
     def tell(self):
         return self.frame
 
-    def _close_fp(self):
-        try:
-            if self._fp != self.fp:
-                self._fp.close()
-        except AttributeError:
-            pass
-        finally:
-            self._fp = None
-
 
 Image.register_open(DcxImageFile.format, DcxImageFile, _accept)
 

--- a/src/PIL/FliImagePlugin.py
+++ b/src/PIL/FliImagePlugin.py
@@ -91,7 +91,7 @@ class FliImageFile(ImageFile.ImageFile):
 
         # set things up to decode first frame
         self.__frame = -1
-        self.__fp = self.fp
+        self._fp = self.fp
         self.__rewind = self.fp.tell()
         self.seek(0)
 
@@ -125,7 +125,7 @@ class FliImageFile(ImageFile.ImageFile):
     def _seek(self, frame):
         if frame == 0:
             self.__frame = -1
-            self.__fp.seek(self.__rewind)
+            self._fp.seek(self.__rewind)
             self.__offset = 128
         else:
             # ensure that the previous frame was loaded
@@ -136,7 +136,7 @@ class FliImageFile(ImageFile.ImageFile):
         self.__frame = frame
 
         # move to next frame
-        self.fp = self.__fp
+        self.fp = self._fp
         self.fp.seek(self.__offset)
 
         s = self.fp.read(4)
@@ -153,14 +153,14 @@ class FliImageFile(ImageFile.ImageFile):
     def tell(self):
         return self.__frame
 
-    def _close__fp(self):
+    def _close_fp(self):
         try:
-            if self.__fp != self.fp:
-                self.__fp.close()
+            if self._fp != self.fp:
+                self._fp.close()
         except AttributeError:
             pass
         finally:
-            self.__fp = None
+            self._fp = None
 
 
 #

--- a/src/PIL/FliImagePlugin.py
+++ b/src/PIL/FliImagePlugin.py
@@ -153,15 +153,6 @@ class FliImageFile(ImageFile.ImageFile):
     def tell(self):
         return self.__frame
 
-    def _close_fp(self):
-        try:
-            if self._fp != self.fp:
-                self._fp.close()
-        except AttributeError:
-            pass
-        finally:
-            self._fp = None
-
 
 #
 # registry

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -102,7 +102,7 @@ class GifImageFile(ImageFile.ImageFile):
                 p = ImagePalette.raw("RGB", p)
                 self.global_palette = self.palette = p
 
-        self.__fp = self.fp  # FIXME: hack
+        self._fp = self.fp  # FIXME: hack
         self.__rewind = self.fp.tell()
         self._n_frames = None
         self._is_animated = None
@@ -161,7 +161,7 @@ class GifImageFile(ImageFile.ImageFile):
             self.__offset = 0
             self.dispose = None
             self.__frame = -1
-            self.__fp.seek(self.__rewind)
+            self._fp.seek(self.__rewind)
             self.disposal_method = 0
         else:
             # ensure that the previous frame was loaded
@@ -171,7 +171,7 @@ class GifImageFile(ImageFile.ImageFile):
         if frame != self.__frame + 1:
             raise ValueError(f"cannot seek to frame {frame}")
 
-        self.fp = self.__fp
+        self.fp = self._fp
         if self.__offset:
             # backup to last frame
             self.fp.seek(self.__offset)
@@ -281,7 +281,7 @@ class GifImageFile(ImageFile.ImageFile):
             s = None
 
         if interlace is None:
-            # self.__fp = None
+            # self._fp = None
             raise EOFError
         if not update_image:
             return
@@ -443,14 +443,14 @@ class GifImageFile(ImageFile.ImageFile):
     def tell(self):
         return self.__frame
 
-    def _close__fp(self):
+    def _close_fp(self):
         try:
-            if self.__fp != self.fp:
-                self.__fp.close()
+            if self._fp != self.fp:
+                self._fp.close()
         except AttributeError:
             pass
         finally:
-            self.__fp = None
+            self._fp = None
 
 
 # --------------------------------------------------------------------

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -443,15 +443,6 @@ class GifImageFile(ImageFile.ImageFile):
     def tell(self):
         return self.__frame
 
-    def _close_fp(self):
-        try:
-            if self._fp != self.fp:
-                self._fp.close()
-        except AttributeError:
-            pass
-        finally:
-            self._fp = None
-
 
 # --------------------------------------------------------------------
 # Write GIF files

--- a/src/PIL/ImImagePlugin.py
+++ b/src/PIL/ImImagePlugin.py
@@ -301,15 +301,6 @@ class ImImageFile(ImageFile.ImageFile):
     def tell(self):
         return self.frame
 
-    def _close_fp(self):
-        try:
-            if self._fp != self.fp:
-                self._fp.close()
-        except AttributeError:
-            pass
-        finally:
-            self._fp = None
-
 
 #
 # --------------------------------------------------------------------

--- a/src/PIL/ImImagePlugin.py
+++ b/src/PIL/ImImagePlugin.py
@@ -245,7 +245,7 @@ class ImImageFile(ImageFile.ImageFile):
 
         self.__offset = offs = self.fp.tell()
 
-        self.__fp = self.fp  # FIXME: hack
+        self._fp = self.fp  # FIXME: hack
 
         if self.rawmode[:2] == "F;":
 
@@ -294,21 +294,21 @@ class ImImageFile(ImageFile.ImageFile):
         size = ((self.size[0] * bits + 7) // 8) * self.size[1]
         offs = self.__offset + frame * size
 
-        self.fp = self.__fp
+        self.fp = self._fp
 
         self.tile = [("raw", (0, 0) + self.size, offs, (self.rawmode, 0, -1))]
 
     def tell(self):
         return self.frame
 
-    def _close__fp(self):
+    def _close_fp(self):
         try:
-            if self.__fp != self.fp:
-                self.__fp.close()
+            if self._fp != self.fp:
+                self._fp.close()
         except AttributeError:
             pass
         finally:
-            self.__fp = None
+            self._fp = None
 
 
 #

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -544,8 +544,10 @@ class Image:
 
     def __exit__(self, *args):
         if hasattr(self, "fp") and getattr(self, "_exclusive_fp", False):
-            if hasattr(self, "_close_fp"):
-                self._close_fp()
+            if getattr(self, "_fp", False):
+                if self._fp != self.fp:
+                    self._fp.close()
+                self._fp = None
             if self.fp:
                 self.fp.close()
         self.fp = None
@@ -563,8 +565,10 @@ class Image:
         more information.
         """
         try:
-            if hasattr(self, "_close_fp"):
-                self._close_fp()
+            if getattr(self, "_fp", False):
+                if self._fp != self.fp:
+                    self._fp.close()
+                self._fp = None
             if self.fp:
                 self.fp.close()
             self.fp = None

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -547,7 +547,7 @@ class Image:
             if getattr(self, "_fp", False):
                 if self._fp != self.fp:
                     self._fp.close()
-                self._fp = None
+                self._fp = DeferredError(ValueError("Operation on closed image"))
             if self.fp:
                 self.fp.close()
         self.fp = None
@@ -568,7 +568,7 @@ class Image:
             if getattr(self, "_fp", False):
                 if self._fp != self.fp:
                     self._fp.close()
-                self._fp = None
+                self._fp = DeferredError(ValueError("Operation on closed image"))
             if self.fp:
                 self.fp.close()
             self.fp = None

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -544,8 +544,8 @@ class Image:
 
     def __exit__(self, *args):
         if hasattr(self, "fp") and getattr(self, "_exclusive_fp", False):
-            if hasattr(self, "_close__fp"):
-                self._close__fp()
+            if hasattr(self, "_close_fp"):
+                self._close_fp()
             if self.fp:
                 self.fp.close()
         self.fp = None
@@ -563,8 +563,8 @@ class Image:
         more information.
         """
         try:
-            if hasattr(self, "_close__fp"):
-                self._close__fp()
+            if hasattr(self, "_close_fp"):
+                self._close_fp()
             if self.fp:
                 self.fp.close()
             self.fp = None

--- a/src/PIL/MicImagePlugin.py
+++ b/src/PIL/MicImagePlugin.py
@@ -62,7 +62,6 @@ class MicImageFile(TiffImagePlugin.TiffImageFile):
         if not self.images:
             raise SyntaxError("not an MIC file; no image entries")
 
-        self._fp = self.fp
         self.frame = None
         self._n_frames = len(self.images)
         self.is_animated = self._n_frames > 1

--- a/src/PIL/MicImagePlugin.py
+++ b/src/PIL/MicImagePlugin.py
@@ -89,15 +89,6 @@ class MicImageFile(TiffImagePlugin.TiffImageFile):
     def tell(self):
         return self.frame
 
-    def _close_fp(self):
-        try:
-            if self._fp != self.fp:
-                self._fp.close()
-        except AttributeError:
-            pass
-        finally:
-            self._fp = None
-
 
 #
 # --------------------------------------------------------------------

--- a/src/PIL/MicImagePlugin.py
+++ b/src/PIL/MicImagePlugin.py
@@ -62,7 +62,7 @@ class MicImageFile(TiffImagePlugin.TiffImageFile):
         if not self.images:
             raise SyntaxError("not an MIC file; no image entries")
 
-        self.__fp = self.fp
+        self._fp = self.fp
         self.frame = None
         self._n_frames = len(self.images)
         self.is_animated = self._n_frames > 1
@@ -89,14 +89,14 @@ class MicImageFile(TiffImagePlugin.TiffImageFile):
     def tell(self):
         return self.frame
 
-    def _close__fp(self):
+    def _close_fp(self):
         try:
-            if self.__fp != self.fp:
-                self.__fp.close()
+            if self._fp != self.fp:
+                self._fp.close()
         except AttributeError:
             pass
         finally:
-            self.__fp = None
+            self._fp = None
 
 
 #

--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -97,15 +97,6 @@ class MpoImageFile(JpegImagePlugin.JpegImageFile):
     def tell(self):
         return self.__frame
 
-    def _close_fp(self):
-        try:
-            if self._fp != self.fp:
-                self._fp.close()
-        except AttributeError:
-            pass
-        finally:
-            self._fp = None
-
     @staticmethod
     def adopt(jpeg_instance, mpheader=None):
         """

--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -58,20 +58,20 @@ class MpoImageFile(JpegImagePlugin.JpegImageFile):
         assert self.n_frames == len(self.__mpoffsets)
         del self.info["mpoffset"]  # no longer needed
         self.is_animated = self.n_frames > 1
-        self.__fp = self.fp  # FIXME: hack
-        self.__fp.seek(self.__mpoffsets[0])  # get ready to read first frame
+        self._fp = self.fp  # FIXME: hack
+        self._fp.seek(self.__mpoffsets[0])  # get ready to read first frame
         self.__frame = 0
         self.offset = 0
         # for now we can only handle reading and individual frame extraction
         self.readonly = 1
 
     def load_seek(self, pos):
-        self.__fp.seek(pos)
+        self._fp.seek(pos)
 
     def seek(self, frame):
         if not self._seek_check(frame):
             return
-        self.fp = self.__fp
+        self.fp = self._fp
         self.offset = self.__mpoffsets[frame]
 
         self.fp.seek(self.offset + 2)  # skip SOI marker
@@ -97,14 +97,14 @@ class MpoImageFile(JpegImagePlugin.JpegImageFile):
     def tell(self):
         return self.__frame
 
-    def _close__fp(self):
+    def _close_fp(self):
         try:
-            if self.__fp != self.fp:
-                self.__fp.close()
+            if self._fp != self.fp:
+                self._fp.close()
         except AttributeError:
             pass
         finally:
-            self.__fp = None
+            self._fp = None
 
     @staticmethod
     def adopt(jpeg_instance, mpheader=None):

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -689,7 +689,7 @@ class PngImageFile(ImageFile.ImageFile):
 
         if not _accept(self.fp.read(8)):
             raise SyntaxError("not a PNG file")
-        self.__fp = self.fp
+        self._fp = self.fp
         self.__frame = 0
 
         #
@@ -746,7 +746,7 @@ class PngImageFile(ImageFile.ImageFile):
             self._close_exclusive_fp_after_loading = False
             self.png.save_rewind()
             self.__rewind_idat = self.__prepare_idat
-            self.__rewind = self.__fp.tell()
+            self.__rewind = self._fp.tell()
             if self.default_image:
                 # IDAT chunk contains default image and not first animation frame
                 self.n_frames += 1
@@ -801,7 +801,7 @@ class PngImageFile(ImageFile.ImageFile):
     def _seek(self, frame, rewind=False):
         if frame == 0:
             if rewind:
-                self.__fp.seek(self.__rewind)
+                self._fp.seek(self.__rewind)
                 self.png.rewind()
                 self.__prepare_idat = self.__rewind_idat
                 self.im = None
@@ -809,7 +809,7 @@ class PngImageFile(ImageFile.ImageFile):
                     self.pyaccess = None
                 self.info = self.png.im_info
                 self.tile = self.png.im_tile
-                self.fp = self.__fp
+                self.fp = self._fp
             self._prev_im = None
             self.dispose = None
             self.default_image = self.info.get("default_image", False)
@@ -828,7 +828,7 @@ class PngImageFile(ImageFile.ImageFile):
                 self.im.paste(self.dispose, self.dispose_extent)
             self._prev_im = self.im.copy()
 
-            self.fp = self.__fp
+            self.fp = self._fp
 
             # advance to the next frame
             if self.__prepare_idat:
@@ -1006,14 +1006,14 @@ class PngImageFile(ImageFile.ImageFile):
             else {}
         )
 
-    def _close__fp(self):
+    def _close_fp(self):
         try:
-            if self.__fp != self.fp:
-                self.__fp.close()
+            if self._fp != self.fp:
+                self._fp.close()
         except AttributeError:
             pass
         finally:
-            self.__fp = None
+            self._fp = None
 
 
 # --------------------------------------------------------------------

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -1006,15 +1006,6 @@ class PngImageFile(ImageFile.ImageFile):
             else {}
         )
 
-    def _close_fp(self):
-        try:
-            if self._fp != self.fp:
-                self._fp.close()
-        except AttributeError:
-            pass
-        finally:
-            self._fp = None
-
 
 # --------------------------------------------------------------------
 # PNG writer

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -132,7 +132,7 @@ class PsdImageFile(ImageFile.ImageFile):
         self.tile = _maketile(self.fp, mode, (0, 0) + self.size, channels)
 
         # keep the file open
-        self.__fp = self.fp
+        self._fp = self.fp
         self.frame = 1
         self._min_frame = 1
 
@@ -146,7 +146,7 @@ class PsdImageFile(ImageFile.ImageFile):
             self.mode = mode
             self.tile = tile
             self.frame = layer
-            self.fp = self.__fp
+            self.fp = self._fp
             return name, bbox
         except IndexError as e:
             raise EOFError("no such layer") from e
@@ -155,14 +155,14 @@ class PsdImageFile(ImageFile.ImageFile):
         # return layer number (0=image, 1..max=layers)
         return self.frame
 
-    def _close__fp(self):
+    def _close_fp(self):
         try:
-            if self.__fp != self.fp:
-                self.__fp.close()
+            if self._fp != self.fp:
+                self._fp.close()
         except AttributeError:
             pass
         finally:
-            self.__fp = None
+            self._fp = None
 
 
 def _layerinfo(fp, ct_bytes):

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -155,15 +155,6 @@ class PsdImageFile(ImageFile.ImageFile):
         # return layer number (0=image, 1..max=layers)
         return self.frame
 
-    def _close_fp(self):
-        try:
-            if self._fp != self.fp:
-                self._fp.close()
-        except AttributeError:
-            pass
-        finally:
-            self._fp = None
-
 
 def _layerinfo(fp, ct_bytes):
     # read layerinfo block

--- a/src/PIL/SpiderImagePlugin.py
+++ b/src/PIL/SpiderImagePlugin.py
@@ -149,7 +149,7 @@ class SpiderImageFile(ImageFile.ImageFile):
         self.mode = "F"
 
         self.tile = [("raw", (0, 0) + self.size, offset, (self.rawmode, 0, 1))]
-        self.__fp = self.fp  # FIXME: hack
+        self._fp = self.fp  # FIXME: hack
 
     @property
     def n_frames(self):
@@ -172,7 +172,7 @@ class SpiderImageFile(ImageFile.ImageFile):
         if not self._seek_check(frame):
             return
         self.stkoffset = self.hdrlen + frame * (self.hdrlen + self.imgbytes)
-        self.fp = self.__fp
+        self.fp = self._fp
         self.fp.seek(self.stkoffset)
         self._open()
 
@@ -191,14 +191,14 @@ class SpiderImageFile(ImageFile.ImageFile):
 
         return ImageTk.PhotoImage(self.convert2byte(), palette=256)
 
-    def _close__fp(self):
+    def _close_fp(self):
         try:
-            if self.__fp != self.fp:
-                self.__fp.close()
+            if self._fp != self.fp:
+                self._fp.close()
         except AttributeError:
             pass
         finally:
-            self.__fp = None
+            self._fp = None
 
 
 # --------------------------------------------------------------------

--- a/src/PIL/SpiderImagePlugin.py
+++ b/src/PIL/SpiderImagePlugin.py
@@ -191,15 +191,6 @@ class SpiderImageFile(ImageFile.ImageFile):
 
         return ImageTk.PhotoImage(self.convert2byte(), palette=256)
 
-    def _close_fp(self):
-        try:
-            if self._fp != self.fp:
-                self._fp.close()
-        except AttributeError:
-            pass
-        finally:
-            self._fp = None
-
 
 # --------------------------------------------------------------------
 # Image series

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1515,15 +1515,6 @@ class TiffImageFile(ImageFile.ImageFile):
 
         self._tile_orientation = self.tag_v2.get(0x0112)
 
-    def _close_fp(self):
-        try:
-            if self._fp != self.fp:
-                self._fp.close()
-        except AttributeError:
-            pass
-        finally:
-            self._fp = None
-
 
 #
 # --------------------------------------------------------------------

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1073,7 +1073,7 @@ class TiffImageFile(ImageFile.ImageFile):
         # setup frame pointers
         self.__first = self.__next = self.tag_v2.next
         self.__frame = -1
-        self.__fp = self.fp
+        self._fp = self.fp
         self._frame_pos = []
         self._n_frames = None
 
@@ -1106,7 +1106,7 @@ class TiffImageFile(ImageFile.ImageFile):
         self.im = Image.core.new(self.mode, self.size)
 
     def _seek(self, frame):
-        self.fp = self.__fp
+        self.fp = self._fp
 
         # reset buffered io handle in case fp
         # was passed to libtiff, invalidating the buffer
@@ -1515,14 +1515,14 @@ class TiffImageFile(ImageFile.ImageFile):
 
         self._tile_orientation = self.tag_v2.get(0x0112)
 
-    def _close__fp(self):
+    def _close_fp(self):
         try:
-            if self.__fp != self.fp:
-                self.__fp.close()
+            if self._fp != self.fp:
+                self._fp.close()
         except AttributeError:
             pass
         finally:
-            self.__fp = None
+            self._fp = None
 
 
 #


### PR DESCRIPTION
Resolves #6205

The issue reported an unexpected error when calling `seek()` after an image had been closed, thrown when trying to use `__fp`.
This PR adds a `DeferredError` before trying to access the internal fp, like [`self.im` does after an image is closed.](https://github.com/python-pillow/Pillow/blob/0329b8fa1d7ad3ae39a171a903b328a56046003a/src/PIL/Image.py#L616)

Since this would be a further modification to `_close__fp` in multiple plugins, this PR also renames `__fp` to `_fp`, making it accessible from Image.py, and allowing `_close__fp` to be merged into Image.py