### PR TITLE
Add example to read image from URL

### DIFF
--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -511,7 +511,7 @@ Reading from URL
 
     from PIL import Image
     from urllib.request import urlopen
-    url = "https://raw.githubusercontent.com/python-pillow/pillow-logo/main/pillow-logo-248x250.png"
+    url = "https://python-pillow.org/images/pillow-logo.png"
     img = Image.open(urlopen(url))
 
 

--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -504,6 +504,17 @@ image header. In addition, seek will also be used when the image data is read
 tar file, you can use the :py:class:`~PIL.ContainerIO` or
 :py:class:`~PIL.TarIO` modules to access it.
 
+Reading from URL
+^^^^^^^^^^^^^^^^
+
+::
+
+    from PIL import Image
+    from urllib.request import urlopen
+    url = "https://raw.githubusercontent.com/python-pillow/pillow-logo/main/pillow-logo-248x250.png"
+    img = Image.open(urlopen(url))
+
+
 Reading from a tar archive
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Reading images from URL is only documented at https://pillow.readthedocs.io/en/stable/releasenotes/2.8.0.html#open-http-response-objects-with-image-open (which uses urllib2, which is not available in Python 3).
Now, a Python3 compatible example will also appear in the PIL Tutorial section.
EDIT: Here is the link: https://pillow--6215.org.readthedocs.build/en/6215/handbook/tutorial.html#reading-from-url