### PR TITLE
Increase wait time of temporary file deletion on Windows

### DIFF
--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -141,7 +141,7 @@ class WindowsViewer(Viewer):
     def get_command(self, file, **options):
         return (
             f'start "Pillow" /WAIT "{file}" '
-            "&& ping -n 2 127.0.0.1 >NUL "
+            "&& ping -n 4 127.0.0.1 >NUL "
             f'&& del /f "{file}"'
         )
 


### PR DESCRIPTION
Increase wait time to 4 seconds from 2 seconds for the deletion of the temporary file made from .show(). The Windows default image viewer at times can take longer than 2 seconds to open and display an image causing the image to never display for the user.

Fixes # Line 144, Increase wait time

Changes proposed in this pull request:

 * Increase wait time to 4 seconds from 2 seconds for deletion of temporary image file