### PR TITLE
Update image-file-formats.rst [ci skip]

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -101,7 +101,7 @@ GIF
 ^^^
 
 Pillow reads GIF87a and GIF89a versions of the GIF file format. The library
-writes run-length encoded files in GIF87a by default, unless GIF89a features
+writes LZW encoded files in GIF87a by default, unless GIF89a features
 are used or GIF89a is already in use.
 
 GIF files are initially read as grayscale (``L``) or palette mode (``P``)


### PR DESCRIPTION
Correct Handbook documentation about encoding of GIF files from run-length to LZW.

No issue associated with this pull request.

Changes proposed in this pull request:

 * Pillow writes GIF files with LZW encoding since 8.2.0, but the Handbook was not updated to reflect this. It still refers to run-length encoding (which was not quite correct before).

