### PR TITLE
Skip tests unless libtiff is available

### DIFF
--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -12,6 +12,7 @@ from .helper import (
     assert_image_equal_tofile,
     assert_image_similar,
     hopper,
+    skip_unless_feature,
 )
 
 
@@ -264,6 +265,7 @@ class TestImageResize:
             with pytest.raises(ValueError):
                 im.resize((10, 10), "unknown")
 
+    @skip_unless_feature("libtiff")
     def test_load_first(self):
         # load() may change the size of the image
         # Test that resize() is calling it before getting the size

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -7,6 +7,7 @@ from .helper import (
     assert_image_similar,
     fromstring,
     hopper,
+    skip_unless_feature,
     tostring,
 )
 
@@ -88,6 +89,7 @@ def test_no_resize():
         assert im.size == (64, 64)
 
 
+@skip_unless_feature("libtiff")
 def test_load_first():
     # load() may change the size of the image
     # Test that thumbnail() is calling it before performing size calculations


### PR DESCRIPTION
#6138 has started failing on `Tests/test_image_resize.py::TestImageResize::test_load_first` with an error that `OSError: decoder libtiff not available`.

The fact that libtiff is not detected in #6138 is one problem. However, it should not cause the test suite to fail. So this PR skips the test from #6190, and also #6186, if libtiff is unavailable.