### PR TITLE
Ignore compression value from BMP info dictionary when saving as TIFF

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -690,6 +690,13 @@ class TestFileTiff:
         with Image.open(outfile) as reloaded:
             assert reloaded.info["icc_profile"] == icc_profile
 
+    def test_save_bmp_compression(self, tmp_path):
+        with Image.open("Tests/images/hopper.bmp") as im:
+            assert im.info["compression"] == 0
+
+            outfile = str(tmp_path / "temp.tif")
+            im.save(outfile)
+
     def test_discard_icc_profile(self, tmp_path):
         outfile = str(tmp_path / "temp.tif")
 

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1568,7 +1568,13 @@ def _save(im, fp, filename):
 
     encoderinfo = im.encoderinfo
     encoderconfig = im.encoderconfig
-    compression = encoderinfo.get("compression", im.info.get("compression"))
+    try:
+        compression = encoderinfo["compression"]
+    except KeyError:
+        compression = im.info.get("compression")
+        if isinstance(compression, int):
+            # compression value may be from BMP. Ignore it
+            compression = None
     if compression is None:
         compression = "raw"
     elif compression == "tiff_jpeg":


### PR DESCRIPTION
Helps #6230 

BmpImagePlugin sets the info dictionary "compression" to an integer.

https://github.com/python-pillow/Pillow/blob/c6637bc4de33a8b85ea02378ee25353a923e1898/src/PIL/BmpImagePlugin.py#L70-L72
https://github.com/python-pillow/Pillow/blob/c6637bc4de33a8b85ea02378ee25353a923e1898/src/PIL/BmpImagePlugin.py#L95
https://github.com/python-pillow/Pillow/blob/c6637bc4de33a8b85ea02378ee25353a923e1898/src/PIL/BmpImagePlugin.py#L252

However, when TiffImagePlugin is saving, it expects a string.

https://github.com/python-pillow/Pillow/blob/c6637bc4de33a8b85ea02378ee25353a923e1898/src/PIL/TiffImagePlugin.py#L1571-L1578

This leads to an error. This PR instead ignores integer compression values from the info dictionary when saving as a TIFF.