### PR TITLE
Pad COLORMAP to 768 items when saving TIFF

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -497,8 +497,8 @@ class TestFileLibTiff(LibTiffTestCase):
         im.save(out, compression="tiff_adobe_deflate")
         assert_image_equal_tofile(im, out)
 
-    def test_palette_save(self, tmp_path):
-        im = hopper("P")
+    @pytest.mark.parametrize("im", (hopper("P"), Image.new("P", (1, 1), "#000")))
+    def test_palette_save(self, im, tmp_path):
         out = str(tmp_path / "temp.tif")
 
         TiffImagePlugin.WRITE_LIBTIFF = True

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1676,7 +1676,12 @@ def _save(im, fp, filename):
 
     if im.mode in ["P", "PA"]:
         lut = im.im.getpalette("RGB", "RGB;L")
-        ifd[COLORMAP] = tuple(v * 256 for v in lut)
+        colormap = []
+        colors = len(lut) // 3
+        for i in range(3):
+            colormap += [v * 256 for v in lut[colors * i : colors * (i + 1)]]
+            colormap += [0] * (256 - colors)
+        ifd[COLORMAP] = colormap
     # data orientation
     stride = len(bits) * ((im.size[0] * bits[0] + 7) // 8)
     # aim for given strip size (64 KB by default) when using libtiff writer


### PR DESCRIPTION
Resolves #6230

#6060 contained a commit entitled "[Allow getpalette() to return less than 256 colors](https://github.com/python-pillow/Pillow/pull/6060/commits/948c064b282f80492f5b88d3f06a599b76516edf)"

That has that meant that there are less entries in COLORMAP.
https://github.com/python-pillow/Pillow/blob/c6637bc4de33a8b85ea02378ee25353a923e1898/src/PIL/TiffImagePlugin.py#L1677-L1679

Which then triggers the following error in the issue.
https://github.com/python-pillow/Pillow/blob/c6637bc4de33a8b85ea02378ee25353a923e1898/src/encode.c#L791-L792

This PR pads the COLORMAP entries until it reaches 768.