### PR TITLE
Run Tidelift Align on Pipfile changes

### DIFF
--- a/.github/workflows/tidelift.yml
+++ b/.github/workflows/tidelift.yml
@@ -4,9 +4,11 @@ on:
     - cron: "30 2 * * *"  # daily at 02:30 UTC
   push:
     paths:
+      - "Pipfile*"
       - ".github/workflows/tidelift.yml"
   pull_request:
     paths:
+      - "Pipfile*"
       - ".github/workflows/tidelift.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
Same as and closes https://github.com/python-pillow/Pillow/pull/6221 but from a branch in this repo, instead of from a personal fork.

That one failed because it can't find the API key, likely a GitHub security precaution to prevents forks accessing secrets.
