### PR TITLE
If font is file-like object, do not re-read from object to get variant

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -65,9 +65,12 @@ class TestImageFont:
         return font_bytes
 
     def test_font_with_filelike(self):
-        ImageFont.truetype(
+        ttf = ImageFont.truetype(
             self._font_as_bytes(), FONT_SIZE, layout_engine=self.LAYOUT_ENGINE
         )
+        ttf_copy = ttf.font_variant()
+        assert ttf_copy.font_bytes == ttf.font_bytes
+
         self._render(self._font_as_bytes())
         # Usage note:  making two fonts from the same buffer fails.
         # shared_bytes = self._font_as_bytes()

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -711,8 +711,13 @@ class FreeTypeFont:
 
         :return: A FreeTypeFont object.
         """
+        if font is None:
+            try:
+                font = BytesIO(self.font_bytes)
+            except AttributeError:
+                font = self.path
         return FreeTypeFont(
-            font=self.path if font is None else font,
+            font=font,
             size=self.size if size is None else size,
             index=self.index if index is None else index,
             encoding=self.encoding if encoding is None else encoding,


### PR DESCRIPTION
Resolves #6209

In the issue, a user opens a font from a file-like object, and the font contents are read from that object.
Then the user tries to open a `font_variant()` and the font contents are read from the same object again, without seeking, which means that there is nothing left to read.

This PR changes `font_variant()` to just use the originally read bytes in that situation.