### PR TITLE
Decode bytes before passing to f-string

### DIFF
--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -123,7 +123,7 @@ def test_token_too_long(tmp_path):
         with Image.open(path):
             pass
 
-    assert str(e.value) == "Token too long in file header: b'01234567890'"
+    assert str(e.value) == "Token too long in file header: 01234567890"
 
 
 def test_truncated_file(tmp_path):

--- a/src/PIL/PpmImagePlugin.py
+++ b/src/PIL/PpmImagePlugin.py
@@ -83,7 +83,7 @@ class PpmImageFile(ImageFile.ImageFile):
             # Token was not even 1 byte
             raise ValueError("Reached EOF while reading header")
         elif len(token) > 10:
-            raise ValueError(f"Token too long in file header: {token}")
+            raise ValueError(f"Token too long in file header: {token.decode()}")
         return token
 
     def _open(self):


### PR DESCRIPTION
Fixes a warning occurring on main.

https://github.com/python-pillow/Pillow/runs/6134877188?check_suite_focus=true#step:8:3147
```
Tests/test_file_ppm.py::test_token_too_long
  /opt/hostedtoolcache/Python/3.9.12/x64/lib/python3.9/site-packages/PIL/PpmImagePlugin.py:86: BytesWarning: str() on a bytes instance
    raise ValueError(f"Token too long in file header: {token}")
```