### PR TITLE
Update Image.py docstring

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3327,7 +3327,7 @@ def effect_mandelbrot(size, extent, quality):
     :param size: The requested size in pixels, as a 2-tuple:
        (width, height).
     :param extent: The extent to cover, as a 4-tuple:
-       (x0, y0, x1, y2).
+       (x0, y0, x1, y1).
     :param quality: Quality.
     """
     return Image()._new(core.effect_mandelbrot(size, extent, quality))


### PR DESCRIPTION
Update Image.py file with  a typo in effect_mandelbrot method.
The Typo was in docstrings of the effect_mandelbrot method in Image module of PIL.

Fixes a docstring mistake in effect_mandelbrot method in Image module of PIL.

Changes proposed in this pull request:

 * Fixing Typo.
