### PR TITLE
Raise ValueError for invalid PPM maxval

### DIFF
--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -145,6 +145,19 @@ def test_truncated_file(tmp_path):
             im.load()
 
 
+@pytest.mark.parametrize("maxval", (0, 65536))
+def test_invalid_maxval(maxval, tmp_path):
+    path = str(tmp_path / "temp.ppm")
+    with open(path, "w") as f:
+        f.write("P6\n3 1 " + str(maxval))
+
+    with pytest.raises(ValueError) as e:
+        with Image.open(path):
+            pass
+
+    assert str(e.value) == "maxval must be greater than 0 and less than 65536"
+
+
 def test_neg_ppm():
     # Storage.c accepted negative values for xsize, ysize.  the
     # internal open_ppm function didn't check for sanity but it

--- a/src/PIL/PpmImagePlugin.py
+++ b/src/PIL/PpmImagePlugin.py
@@ -116,6 +116,10 @@ class PpmImageFile(ImageFile.ImageFile):
                     break
             elif ix == 2:  # token is maxval
                 maxval = token
+                if not 0 < maxval < 65536:
+                    raise ValueError(
+                        "maxval must be greater than 0 and less than 65536"
+                    )
                 if maxval > 255 and mode == "L":
                     self.mode = "I"
 


### PR DESCRIPTION
Resolves #6240

http://netpbm.sourceforge.net/doc/ppm.html states that maxval "Must be less than 65536 and more than zero". The issue found that a maxval of zero raised a ZeroDivisionError instead.

Instead, if `maxval` is outside of the valid range, this PR raises a ValueError, "Invalid maxval".