### PR TITLE
Test invalid WebP background colors

### DIFF
--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -185,6 +185,17 @@ class TestFileWebp:
             Image.open(blob).load()
             Image.open(blob).load()
 
+    @pytest.mark.parametrize(
+        "background",
+        (0, (0,), (-1, 0, 1, 2), (253, 254, 255, 256)),
+    )
+    @skip_unless_feature("webp_anim")
+    def test_invalid_background(self, background, tmp_path):
+        temp_file = str(tmp_path / "temp.webp")
+        im = hopper()
+        with pytest.raises(OSError):
+            im.save(temp_file, save_all=True, append_images=[im], background=background)
+
     @skip_unless_feature("webp_anim")
     def test_background_from_gif(self, tmp_path):
         # Save L mode GIF with background


### PR DESCRIPTION
Adds a test for https://github.com/python-pillow/Pillow/blob/bcded33ceead2ae69dad602ce95d8f892ffb46df/src/PIL/WebPImagePlugin.py#L221-L229