### PR TITLE
Corrected screencapture argument in ImageGrab.grab()

### DIFF
--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -33,7 +33,7 @@ def grab(bbox=None, include_layered_windows=False, all_screens=False, xdisplay=N
             args = ["screencapture"]
             if bbox:
                 left, top, right, bottom = bbox
-                args += ["-R", f"{left},{right},{right-left},{bottom-top}"]
+                args += ["-R", f"{left},{top},{right-left},{bottom-top}"]
             subprocess.call(args + ["-x", filepath])
             im = Image.open(filepath)
             im.load()


### PR DESCRIPTION
I have found a bug in ImageGrab.grab().

File "src/PIL/ImageGrab.py", line 36,
`args += ["-R", f"{left},{right},{right-left},{bottom-top}"]`
seems to be a mistake and ImageGrab.grab() does not return expected results.

As ImageGrab.grab() is implemented with "screencapture" subprocess which takes an option -R "x,y,width,height" to capture a rectangle area, it must be `args += ["-R", f"{left},{top},{right-left},{bottom-top}"]`.