### PR TITLE
Updated URL

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -743,7 +743,7 @@ class TestFileJpeg:
 
             # Act / Assert
             # "When the image resolution is unknown, 72 [dpi] is designated."
-            # http://www.exiv2.org/tags.html
+            # https://exiv2.org/tags.html
             assert im.info.get("dpi") == (72, 72)
 
     def test_invalid_exif(self):

--- a/src/PIL/JpegPresets.py
+++ b/src/PIL/JpegPresets.py
@@ -37,7 +37,7 @@ You can get the subsampling of a JPEG with the
 :func:`.JpegImagePlugin.get_sampling` function.
 
 In JPEG compressed data a JPEG marker is used instead of an EXIF tag.
-(ref.: https://www.exiv2.org/tags.html)
+(ref.: https://exiv2.org/tags.html)
 
 
 Quantization tables


### PR DESCRIPTION
https://www.exiv2.org/tags.html does not work.
https://exiv2.org/tags.html does.