### PR TITLE
Raise ValueError if PNG chunks are truncated

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -635,6 +635,17 @@ class TestFilePng:
 
             assert_image_equal_tofile(im, "Tests/images/bw_gradient.png")
 
+    @pytest.mark.parametrize("cid", (b"IHDR", b"pHYs", b"acTL", b"fcTL", b"fdAT"))
+    def test_truncated_chunks(self, cid):
+        fp = BytesIO()
+        with PngImagePlugin.PngStream(fp) as png:
+            with pytest.raises(ValueError):
+                png.call(cid, 0, 0)
+
+            ImageFile.LOAD_TRUNCATED_IMAGES = True
+            png.call(cid, 0, 0)
+            ImageFile.LOAD_TRUNCATED_IMAGES = False
+
     def test_specify_bits(self, tmp_path):
         im = hopper("P")
 


### PR DESCRIPTION
Resolves #6252

Some PNG chunks expect a certain amount of data.
If the chunk doesn't state that it is long enough to contain that data, then errors can occur, as reported in the issue.

Instead, this PR raises a ValueError. As with other operations in PngImagePlugin, `ImageFile.LOAD_TRUNCATED_IMAGES = True` can be used to silence these errors.