### PR TITLE
Support more affine expression forms in im.point()

### DIFF
--- a/Tests/test_image_point.py
+++ b/Tests/test_image_point.py
@@ -18,10 +18,18 @@ def test_sanity():
     im.point(lambda x: x * 1)
     im.point(lambda x: x + 1)
     im.point(lambda x: x * 1 + 1)
+    im.point(lambda x: 0.1 + 0.2 * x)
+    im.point(lambda x: -x)
+    im.point(lambda x: x - 0.5)
+    im.point(lambda x: 1 - x / 2)
+    im.point(lambda x: (2 + x) / 3)
+    im.point(lambda x: 0.5)
     with pytest.raises(TypeError):
-        im.point(lambda x: x - 1)
+        im.point(lambda x: x * x)
     with pytest.raises(TypeError):
-        im.point(lambda x: x / 1)
+        im.point(lambda x: 1 / x)
+    with pytest.raises(TypeError):
+        im.point(lambda x: x // 2)
 
 
 def test_16bit_lut():

--- a/Tests/test_image_point.py
+++ b/Tests/test_image_point.py
@@ -1,5 +1,7 @@
 import pytest
 
+from PIL import Image
+
 from .helper import assert_image_equal, hopper
 
 
@@ -17,6 +19,7 @@ def test_sanity():
         im.point(list(range(256)))
     im.point(lambda x: x * 1)
     im.point(lambda x: x + 1)
+    im.point(lambda x: x - 1)
     im.point(lambda x: x * 1 + 1)
     im.point(lambda x: 0.1 + 0.2 * x)
     im.point(lambda x: -x)
@@ -24,6 +27,7 @@ def test_sanity():
     im.point(lambda x: 1 - x / 2)
     im.point(lambda x: (2 + x) / 3)
     im.point(lambda x: 0.5)
+    im.point(lambda x: x / 1)
     with pytest.raises(TypeError):
         im.point(lambda x: x * x)
     with pytest.raises(TypeError):
@@ -55,3 +59,8 @@ def test_f_mode():
     im = hopper("F")
     with pytest.raises(ValueError):
         im.point(None)
+
+
+def test_coerce_e_deprecation():
+    with pytest.warns(DeprecationWarning):
+        assert Image.coerce_e(2).data == 2

--- a/Tests/test_image_point.py
+++ b/Tests/test_image_point.py
@@ -28,8 +28,11 @@ def test_sanity():
     im.point(lambda x: (2 + x) / 3)
     im.point(lambda x: 0.5)
     im.point(lambda x: x / 1)
+    im.point(lambda x: x + x)
     with pytest.raises(TypeError):
         im.point(lambda x: x * x)
+    with pytest.raises(TypeError):
+        im.point(lambda x: x / x)
     with pytest.raises(TypeError):
         im.point(lambda x: 1 / x)
     with pytest.raises(TypeError):

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -170,6 +170,14 @@ in Pillow 10 (2023-07-01). Upgrade to
 `PyQt6 <https://www.riverbankcomputing.com/static/Docs/PyQt6/>`_ or
 `PySide6 <https://doc.qt.io/qtforpython/>`_ instead.
 
+Image.coerce_e
+~~~~~~~~~~~~~~
+
+.. deprecated:: 9.2.0
+
+This undocumented method has been deprecated and will be removed in Pillow 10
+(2023-07-01).
+
 Removed features
 ----------------
 

--- a/docs/releasenotes/9.2.0.rst
+++ b/docs/releasenotes/9.2.0.rst
@@ -31,6 +31,14 @@ FreeTypeFont.getmask2 fill parameter
 The undocumented ``fill`` parameter of :py:meth:`.FreeTypeFont.getmask2`
 has been deprecated and will be removed in Pillow 10 (2023-07-01).
 
+Image.coerce_e
+~~~~~~~~~~~~~~
+
+.. deprecated:: 9.2.0
+
+This undocumented method has been deprecated and will be removed in Pillow 10
+(2023-07-01).
+
 API Changes
 ===========
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -29,7 +29,6 @@ import builtins
 import io
 import logging
 import math
-import numbers
 import os
 import re
 import struct
@@ -431,19 +430,23 @@ def _getencoder(mode, encoder_name, args, extra=()):
 # Simple expression analyzer
 
 
-# _Affine(m, b) represents the polynomial m x + b
-class _Affine:
-    def __init__(self, m, b):
-        self.m = m
-        self.b = b
+def coerce_e(value):
+    deprecate("coerce_e", 10)
+    return value if isinstance(value, _E) else _E(1, value)
+
+
+class _E:
+    def __init__(self, scale, data):
+        self.scale = scale
+        self.data = data
 
     def __neg__(self):
-        return _Affine(-self.m, -self.b)
+        return _E(-self.scale, -self.data)
 
     def __add__(self, other):
-        if isinstance(other, _Affine):
-            return _Affine(self.m + other.m, self.b + other.b)
-        return _Affine(self.m, self.b + other)
+        if isinstance(other, _E):
+            return _E(self.scale + other.scale, self.data + other.data)
+        return _E(self.scale, self.data + other)
 
     __radd__ = __add__
 
@@ -454,21 +457,21 @@ class _Affine:
         return other + -self
 
     def __mul__(self, other):
-        if isinstance(other, _Affine):
+        if isinstance(other, _E):
             return NotImplemented
-        return _Affine(self.m * other, self.b * other)
+        return _E(self.scale * other, self.data * other)
 
     __rmul__ = __mul__
 
     def __truediv__(self, other):
-        if isinstance(other, _Affine):
+        if isinstance(other, _E):
             return NotImplemented
-        return _Affine(self.m / other, self.b / other)
+        return _E(self.scale / other, self.data / other)
 
 
 def _getscaleoffset(expr):
-    a = expr(_Affine(1.0, 0.0))
-    return (a.m, a.b) if isinstance(a, _Affine) else (0.0, a)
+    a = expr(_E(1, 0))
+    return (a.scale, a.data) if isinstance(a, _E) else (0, a)
 
 
 # --------------------------------------------------------------------

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -435,6 +435,9 @@ def coerce_e(value):
     return value if isinstance(value, _E) else _E(1, value)
 
 
+# _E(scale, offset) represents the affine transformation scale * x + offset.
+# The "data" field is named for compatibility with the old implementation,
+# and should be renamed once coerce_e is removed.
 class _E:
     def __init__(self, scale, data):
         self.scale = scale


### PR DESCRIPTION
In modes I and F, Image.point only supported affine expressions of the forms (lambda x:) x * a, x + a, and x * a + b. Expressions like 1 - x had to be written x * -1 + 1.

This rewrite, though still limited to affine transformations, supports far more expression forms, including 1 - x, (2 * x + 1) / 3, etc.
