### PR TITLE
Ensure that furthest v is set in quantize2

### DIFF
--- a/src/libImaging/Quant.c
+++ b/src/libImaging/Quant.c
@@ -1577,6 +1577,7 @@ quantize2(
     data.new.c.b = (int)(.5 + (double)mean[2] / (double)nPixels);
     for (i = 0; i < nQuantPixels; i++) {
         data.furthestDistance = 0;
+        data.furthestV = pixelData[0].v;
         data.secondPixel = (i == 1) ? 1 : 0;
         hashtable_foreach_update(h, compute_distances, &data);
         p[i].v = data.furthestV;

--- a/src/libImaging/Quant.c
+++ b/src/libImaging/Quant.c
@@ -1519,7 +1519,7 @@ error_0:
 
 typedef struct {
     Pixel new;
-    Pixel furthest;
+    uint32_t furthestV;
     uint32_t furthestDistance;
     int secondPixel;
 } DistanceData;
@@ -1536,7 +1536,7 @@ compute_distances(const HashTable *h, const Pixel pixel, uint32_t *dist, void *u
     }
     if (oldDist > data->furthestDistance) {
         data->furthestDistance = oldDist;
-        data->furthest.v = pixel.v;
+        data->furthestV = pixel.v;
     }
 }
 
@@ -1579,8 +1579,8 @@ quantize2(
         data.furthestDistance = 0;
         data.secondPixel = (i == 1) ? 1 : 0;
         hashtable_foreach_update(h, compute_distances, &data);
-        p[i].v = data.furthest.v;
-        data.new.v = data.furthest.v;
+        p[i].v = data.furthestV;
+        data.new.v = data.furthestV;
     }
     hashtable_free(h);
 


### PR DESCRIPTION
First, in `quantize2`, the variable `Pixel furthest` is only used for its `v` property. So the `Pixel` can be simplified to just that [`uint32_t`.](https://github.com/python-pillow/Pillow/blob/31800a0213422aca9a83d31a4b925fd4dac8e941/src/libImaging/QuantTypes.h#L22-L30)

Second, `quantize2` sets `furthestDistance` to zero,
https://github.com/python-pillow/Pillow/blob/31800a0213422aca9a83d31a4b925fd4dac8e941/src/libImaging/Quant.c#L1579-L1583
and then runs `compute_distances`, assigning `furthest`,
https://github.com/python-pillow/Pillow/blob/31800a0213422aca9a83d31a4b925fd4dac8e941/src/libImaging/Quant.c#L1528-L1541
before it returns to `quantize2` and `p[i].v` and `data.new.v` are set to `data.furthest.v`.

What if `oldDist` was never greater than zero though? Then `furthest.v` would never be assigned.
This causes a problem in https://github.com/python-pillow/docker-images/pull/148 - https://github.com/python-pillow/docker-images/runs/6247349541?check_suite_focus=true.
So instead, this PR sets it to the first `v` of `pixelData`.