### PR TITLE
Hide stderr from --keep-system-libs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -255,14 +255,16 @@ def _pkg_config(name):
         try:
             command_libs = [command, "--libs-only-L", name]
             command_cflags = [command, "--cflags-only-I", name]
+            stderr = None
             if keep_system:
                 command_libs.append("--keep-system-libs")
                 command_cflags.append("--keep-system-cflags")
+                stderr = subprocess.DEVNULL
             if not DEBUG:
                 command_libs.append("--silence-errors")
                 command_cflags.append("--silence-errors")
             libs = (
-                subprocess.check_output(command_libs)
+                subprocess.check_output(command_libs, stderr=stderr)
                 .decode("utf8")
                 .strip()
                 .replace("-L", "")


### PR DESCRIPTION
After merging #6138, I now notice that when I install Pillow, I see `Unknown option --keep-system-libs` in the output.

This in itself it not unexpected. #6138 is seeing if pkg-config is actually pkgconf, and the error results if it is not.

However, we should not bother the user with this. This PR hides `stderr` on the first call.