### PR TITLE
libjpeg-turbo may result in different pixels

### DIFF
--- a/docs/releasenotes/9.0.0.rst
+++ b/docs/releasenotes/9.0.0.rst
@@ -149,6 +149,9 @@ Switched to libjpeg-turbo in macOS and Linux wheels
 The Pillow wheels from PyPI for macOS and Linux have switched from libjpeg to
 libjpeg-turbo. It is a fork of libjpeg, popular for its speed.
 
+Because different JPEG decoders load images differently, JPEG pixels may be
+altered slightly with this change.
+
 Added support for pickling TrueType fonts
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Resolves #6262

The issue requests the the Pillow 9.0 release notes be updated to note that switching to libjpeg-turbo in the macOS and Linux wheels may result in different pixel values.

This was also a problem in #6113.