### PR TITLE
Use durations from each frame by default when saving GIFs

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -3,7 +3,7 @@ from io import BytesIO
 
 import pytest
 
-from PIL import GifImagePlugin, Image, ImageDraw, ImagePalette, features
+from PIL import GifImagePlugin, Image, ImageDraw, ImagePalette, ImageSequence, features
 
 from .helper import (
     assert_image_equal,
@@ -689,6 +689,23 @@ def test_multiple_duration(tmp_path):
                 reread.seek(reread.tell() + 1)
             except EOFError:
                 pass
+
+
+def test_roundtrip_info_duration(tmp_path):
+    duration_list = [100, 500, 500]
+
+    out = str(tmp_path / "temp.gif")
+    with Image.open("Tests/images/transparent_dispose.gif") as im:
+        assert [
+            frame.info["duration"] for frame in ImageSequence.Iterator(im)
+        ] == duration_list
+
+        im.save(out, save_all=True)
+
+    with Image.open(out) as reloaded:
+        assert [
+            frame.info["duration"] for frame in ImageSequence.Iterator(reloaded)
+        ] == duration_list
 
 
 def test_identical_frames(tmp_path):

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -561,7 +561,7 @@ def _write_single_frame(im, fp, palette):
 
 def _write_multiple_frames(im, fp, palette):
 
-    duration = im.encoderinfo.get("duration", im.info.get("duration"))
+    duration = im.encoderinfo.get("duration")
     disposal = im.encoderinfo.get("disposal", im.info.get("disposal"))
 
     im_frames = []
@@ -579,6 +579,8 @@ def _write_multiple_frames(im, fp, palette):
             encoderinfo = im.encoderinfo.copy()
             if isinstance(duration, (list, tuple)):
                 encoderinfo["duration"] = duration[frame_count]
+            elif duration is None and "duration" in im_frame.info:
+                encoderinfo["duration"] = im_frame.info["duration"]
             if isinstance(disposal, (list, tuple)):
                 encoderinfo["disposal"] = disposal[frame_count]
             frame_count += 1


### PR DESCRIPTION
Resolves #6259

If duration isn't passed in as a keyword argument when saving GIFs, default to the duration from each frame, rather than just using the duration from the first frame.