### PR TITLE
Skip test_imagetk if tk raises a RuntimeError

### DIFF
--- a/Tests/test_imagetk.py
+++ b/Tests/test_imagetk.py
@@ -26,6 +26,8 @@ def setup_module():
         # setup tk
         tk.Frame()
         # root = tk.Tk()
+    except RuntimeError as v:
+        pytest.skip(f"RuntimeError: {v}")
     except tk.TclError as v:
         pytest.skip(f"TCL Error: {v}")
 


### PR DESCRIPTION
In main at the moment, [`tk.Frame` is failing for Python 3.7 on macOS.](https://github.com/python-pillow/Pillow/runs/6290406498?check_suite_focus=true#step:8:1230)


This PR skips test_imagetk.py if that error occurs, as it is not a problem with Pillow.
