### PR TITLE
Populate Python palette in fromarray()

### DIFF
--- a/Tests/test_image_array.py
+++ b/Tests/test_image_array.py
@@ -80,3 +80,15 @@ def test_fromarray():
     with pytest.raises(TypeError):
         wrapped = Wrapper(test("L"), {"shape": (100, 128)})
         Image.fromarray(wrapped)
+
+
+def test_fromarray_palette():
+    # Arrange
+    i = im.convert("L")
+    a = numpy.array(i)
+
+    # Act
+    out = Image.fromarray(a, "P")
+
+    # Assert that the Python and C palettes match
+    assert len(out.palette.colors) == len(out.im.getpalette()) / 3

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2838,6 +2838,10 @@ def frombuffer(mode, size, data, decoder_name="raw", *args):
         if args[0] in _MAPMODES:
             im = new(mode, (1, 1))
             im = im._new(core.map_buffer(data, size, decoder_name, 0, args))
+            if mode == "P":
+                from . import ImagePalette
+
+                im.palette = ImagePalette.ImagePalette("RGB", im.im.getpalette("RGB"))
             im.readonly = 1
             return im
 


### PR DESCRIPTION
Resolves #6210

In `fromarray`, or more specifically `frombuffer`, this PR populates the Python palette from the C palette.

This is equivalent to populating the Python palette from the C palette in `convert` (see [here](https://github.com/python-pillow/Pillow/blob/134023796e935ef79d5feb6879e9270327cfb8a2/src/PIL/Image.py#L1007) and [here](https://github.com/python-pillow/Pillow/blob/134023796e935ef79d5feb6879e9270327cfb8a2/src/PIL/Image.py#L1040)).