### PR TITLE
Added pytest-timeout to test dependencies

### DIFF
--- a/Tests/README.rst
+++ b/Tests/README.rst
@@ -8,7 +8,7 @@ Dependencies
 
 Install::
 
-    python3 -m pip install pytest pytest-cov
+    python3 -m pip install pytest pytest-cov pytest-timeout
 
 Execution
 ---------


### PR DESCRIPTION
In
https://github.com/python-pillow/Pillow/blob/638ba163f425fd586ded4780b8024536819922f8/.appveyor.yml#L46
and
https://github.com/python-pillow/Pillow/blob/638ba163f425fd586ded4780b8024536819922f8/.ci/install.sh#L34-L36

pytest-timeout is installed as a test dependency. However, it is not documented in Tests/README.rst. This PR fixes that.