### PR TITLE
Only try to connect discontiguous corners at the end of edges

### DIFF
--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -1452,3 +1452,9 @@ def test_discontiguous_corners_polygon():
     )
     expected = os.path.join(IMAGES_PATH, "discontiguous_corners_polygon.png")
     assert_image_similar_tofile(img, expected, 1)
+
+    im = Image.new("RGB", (W, H))
+    draw = ImageDraw.Draw(im)
+    draw.polygon([(18, 30), (19, 31), (18, 30), (85, 30), (60, 72)], "red")
+    expected = "Tests/images/imagedraw_outline_polygon_RGB.png"
+    assert_image_similar_tofile(im, expected, 1)

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -1453,6 +1453,8 @@ def test_discontiguous_corners_polygon():
     expected = os.path.join(IMAGES_PATH, "discontiguous_corners_polygon.png")
     assert_image_similar_tofile(img, expected, 1)
 
+
+def test_polygon():
     im = Image.new("RGB", (W, H))
     draw = ImageDraw.Draw(im)
     draw.polygon([(18, 30), (19, 31), (18, 30), (85, 30), (60, 72)], "red")

--- a/src/libImaging/Draw.c
+++ b/src/libImaging/Draw.c
@@ -513,7 +513,9 @@ polygon_generic(Imaging im, int n, Edge *e, int ink, int eofill, hline_handler h
                             continue;
                         }
                         // Check if the two edges join to make a corner
-                        if (xx[j-1] == (ymin - other_edge->y0) * other_edge->dx + other_edge->x0) {
+                        if (((ymin == current->ymin && ymin == other_edge->ymin) ||
+                             (ymin == current->ymax && ymin == other_edge->ymax)) &&
+                            xx[j-1] == (ymin - other_edge->y0) * other_edge->dx + other_edge->x0) {
                             // Determine points from the edges on the next row
                             // Or if this is the last row, check the previous row
                             int offset = ymin == ymax ? -1 : 1;


### PR DESCRIPTION
Resolves #6290

During drawing, #5980 moves a point to join discontiguous corners to the rest of the shape. However, this has been applied too thoroughly, and in #6290, the attempt to join pixels together has ended up dragging pixels from the left hand side of the polygon all the way to the right, creating a gap instead.

Adding a condition to only try and join discontiguous corners at the end of edges fixes the problem.