### PR TITLE
Helpful error message on encode/decode

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -400,7 +400,8 @@ def _getdecoder(mode, decoder_name, args, extra=()):
         # get decoder
         decoder = getattr(core, decoder_name + "_decoder")
     except AttributeError as e:
-        raise OSError(f"decoder {decoder_name} not available") from e
+        valid_decoders = ', '.join(DECODERS.keys())
+        raise OSError(f"decoder {decoder_name} not available. Valid decoders: {valid_decoders}") from e
     return decoder(mode, *args + extra)
 
 
@@ -423,7 +424,8 @@ def _getencoder(mode, encoder_name, args, extra=()):
         # get encoder
         encoder = getattr(core, encoder_name + "_encoder")
     except AttributeError as e:
-        raise OSError(f"encoder {encoder_name} not available") from e
+        valid_encoders = ', '.join(ENCODERS.keys())
+        raise OSError(f"encoder {encoder_name} not available. Valid encoders: {valid_encoders}") from e
     return encoder(mode, *args + extra)
 
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -400,8 +400,10 @@ def _getdecoder(mode, decoder_name, args, extra=()):
         # get decoder
         decoder = getattr(core, decoder_name + "_decoder")
     except AttributeError as e:
-        valid_decoders = ', '.join(DECODERS.keys())
-        raise OSError(f"decoder {decoder_name} not available. Valid decoders: {valid_decoders}") from e
+        valid_decoders = ", ".join(DECODERS.keys())
+        raise OSError(
+            f"decoder {decoder_name} not available. Valid decoders: {valid_decoders}"
+        ) from e
     return decoder(mode, *args + extra)
 
 
@@ -424,8 +426,10 @@ def _getencoder(mode, encoder_name, args, extra=()):
         # get encoder
         encoder = getattr(core, encoder_name + "_encoder")
     except AttributeError as e:
-        valid_encoders = ', '.join(ENCODERS.keys())
-        raise OSError(f"encoder {encoder_name} not available. Valid encoders: {valid_encoders}") from e
+        valid_encoders = ", ".join(ENCODERS.keys())
+        raise OSError(
+            f"encoder {encoder_name} not available. Valid encoders: {valid_encoders}"
+        ) from e
     return encoder(mode, *args + extra)
 
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * A nicer error message when encoding/decoding images. The code knows what encoders/decoders are available. It should just say what is valid so the user can fix their problem.
