### PR TITLE
Add Sphinx Lint to pre-commit and fix RST bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,5 +42,10 @@ repos:
       - id: check-merge-conflict
       - id: check-yaml
 
+  - repo: https://github.com/sphinx-contrib/sphinx-lint
+    rev: v0.6
+    hooks:
+      - id: sphinx-lint
+
 ci:
   autoupdate_schedule: monthly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,4 +43,4 @@ repos:
       - id: check-yaml
 
 ci:
-  autoupdate_schedule: quarterly
+  autoupdate_schedule: monthly

--- a/winbuild/build.rst
+++ b/winbuild/build.rst
@@ -42,7 +42,7 @@ behaviour of ``build_prepare.py``:
   If ``PYTHON`` is unset, the version of Python used to run
   ``build_prepare.py`` will be used. If only ``PYTHON`` is set,
   ``EXECUTABLE`` defaults to ``python.exe``.
-* ``ARCHITECTURE`` is used to select a ``x86``, ``x64`` or ``ARM64``build.
+* ``ARCHITECTURE`` is used to select a ``x86``, ``x64`` or ``ARM64`` build.
   By default, uses same architecture as the version of Python used to run ``build_prepare.py``.
   is used.
 * ``PILLOW_BUILD`` can be used to override the ``winbuild\build`` directory

--- a/winbuild/build.rst
+++ b/winbuild/build.rst
@@ -44,7 +44,6 @@ behaviour of ``build_prepare.py``:
   ``EXECUTABLE`` defaults to ``python.exe``.
 * ``ARCHITECTURE`` is used to select a ``x86``, ``x64`` or ``ARM64`` build.
   By default, uses same architecture as the version of Python used to run ``build_prepare.py``.
-  is used.
 * ``PILLOW_BUILD`` can be used to override the ``winbuild\build`` directory
   path, used to store generated build scripts and compiled libraries.
   **Warning:** This directory is wiped when ``build_prepare.py`` is run.


### PR DESCRIPTION
[Sphinx Lint](https://github.com/sphinx-contrib/sphinx-lint) is an RST linter that has been spun out from a CPython tool.

It finds this bug in https://github.com/python-pillow/Pillow/blob/a50addb8e212e57dfe703b3d792691b3e18b2587/winbuild/build.rst#build-configuration

```
inline literal missing (escaped) space after literal: '``ARM64``b' (missing-space-after-literal)
```

<img width="1041" alt="image" src="https://user-images.githubusercontent.com/1324225/170880087-7cd6b7c6-da62-4d80-8a10-037a94818120.png">

So let's fix that, and also remove an orphaned sentence fragment.

---

And as follow on from https://github.com/python-pillow/Pillow/pull/6223, let's switch to monthly autoupdate if quarterly is too seldom.
