### PR TITLE
Only import ImageFont in ImageDraw when necessary

### DIFF
--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -33,7 +33,7 @@
 import math
 import numbers
 
-from . import Image, ImageColor, ImageFont
+from . import Image, ImageColor
 
 """
 A simple 2D drawing interface for PIL images.
@@ -667,6 +667,8 @@ class ImageDraw:
 
         if font is None:
             font = self.getfont()
+        from . import ImageFont
+
         if not isinstance(font, ImageFont.FreeTypeFont):
             raise ValueError("Only supported for TrueType fonts")
         mode = "RGBA" if embedded_color else self.fontmode


### PR DESCRIPTION
#5510 added an ImageFont to the top of ImageDraw, not noticing that ImageDraw already imports ImageFont later on.

https://github.com/python-pillow/Pillow/blob/753da81757752457ef9faca83997be87974a1cb0/src/PIL/ImageDraw.py#L96-L98

This PR changes the import from #5510 to only run when necessary, following the original pattern.