### PR TITLE
Fix Sphinx 5 warning by setting docs language

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ release = PIL.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
New in Sphinx 5:

> [#10062](https://github.com/sphinx-doc/sphinx/issues/10062): Change the default language to 'en' if any language is not set in conf.py

https://www.sphinx-doc.org/en/master/changes.html

# Before

```
Running Sphinx v5.0.1
WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid langauge code. Falling back to 'en' (English).
making output directory... done
...
```

https://readthedocs.org/projects/pillow/builds/17091425/

# After

```
Running Sphinx v5.0.1
making output directory... done
...
```

https://readthedocs.org/projects/pillow-hugovk/builds/17091435/