### PR TITLE
Added apply_transparency()

### DIFF
--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -123,6 +123,7 @@ methods. Unless otherwise stated, all methods return a new instance of the
 
 
 .. automethod:: PIL.Image.Image.alpha_composite
+.. automethod:: PIL.Image.Image.apply_transparency
 .. automethod:: PIL.Image.Image.convert
 
 The following example converts an RGB image (linearly calibrated according to

--- a/docs/releasenotes/9.2.0.rst
+++ b/docs/releasenotes/9.2.0.rst
@@ -57,10 +57,13 @@ TODO
 API Additions
 =============
 
-TODO
-^^^^
+Image.apply_transparency
+^^^^^^^^^^^^^^^^^^^^^^^^
 
-TODO
+Added :py:meth:`~PIL.Image.Image.apply_transparency`, a method to take a P mode image
+with "transparency" in ``im.info``, and apply the transparency to the palette instead.
+The image's palette mode will become "RGBA", and "transparency" will be removed from
+``im.info``.
 
 Security
 ========

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1449,6 +1449,28 @@ class Image:
             rawmode = mode
         return list(self.im.getpalette(mode, rawmode))
 
+    def apply_transparency(self):
+        """
+        If a P mode image has a "transparency" key in the info dictionary,
+        remove the key and apply the transparency to the palette instead.
+        """
+        if self.mode != "P" or "transparency" not in self.info:
+            return
+
+        from . import ImagePalette
+
+        palette = self.getpalette("RGBA")
+        transparency = self.info["transparency"]
+        if isinstance(transparency, bytes):
+            for i, alpha in enumerate(transparency):
+                palette[i * 4 + 3] = alpha
+        else:
+            palette[transparency * 4 + 3] = 0
+        self.palette = ImagePalette.ImagePalette("RGBA", bytes(palette))
+        self.palette.dirty = 1
+
+        del self.info["transparency"]
+
     def getpixel(self, xy):
         """
         Returns the pixel value at a given position.


### PR DESCRIPTION
Resolves #6348

Adds `apply_transparency()`, a method to take a P mode image with a "transparency" key in the `im.info` dictionary, remove the "transparency" key and apply the transparency to the palette instead.