### PR TITLE
Revert "Skip test_realloc_overflow unless libtiff 4.0.4 or higher"

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -18,7 +18,6 @@ from .helper import (
     hopper,
     mark_if_feature_version,
     skip_unless_feature,
-    skip_unless_feature_version,
 )
 
 
@@ -992,7 +991,6 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open(out) as im:
             im.load()
 
-    @skip_unless_feature_version("libtiff", "4.0.4")
     def test_realloc_overflow(self):
         TiffImagePlugin.READ_LIBTIFF = True
         with Image.open("Tests/images/tiff_overflow_rows_per_strip.tif") as im:


### PR DESCRIPTION
Reverts https://github.com/python-pillow/Pillow/commit/1a2866