### PR TITLE
Improved GIF optimize condition

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -180,6 +180,21 @@ def test_optimize_full_l():
     assert im.mode == "L"
 
 
+def test_optimize_if_palette_can_be_reduced_by_half():
+    with Image.open("Tests/images/test.colors.gif") as im:
+        # Reduce because original is too big for _get_optimize()
+        im = im.resize((591, 443))
+        imrgb = im.convert("RGB")
+        out = BytesIO()
+        imrgb.save(out, "GIF", optimize=False)
+        with Image.open(out) as reloaded:
+            assert len(reloaded.palette.palette) // 3 == 256
+        out = BytesIO()
+        imrgb.save(out, "GIF", optimize=True)
+        with Image.open(out) as reloaded:
+            assert len(reloaded.palette.palette) // 3 == 8
+
+
 def test_roundtrip(tmp_path):
     out = str(tmp_path / "temp.gif")
     im = hopper()

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -824,9 +824,14 @@ def _get_optimize(im, info):
                 if count:
                     used_palette_colors.append(i)
 
+            num_palette_colors = len(im.palette.palette) // 4 if im.palette.mode == 'RGBA' else len(im.palette.palette) // 3
+            # Round up to power of 2 but at least 4
+            num_palette_colors = max(4, 1 << (num_palette_colors - 1).bit_length())
             if optimise or (
+
                 len(used_palette_colors) <= 128
-                and max(used_palette_colors) > len(used_palette_colors)
+                and max(used_palette_colors) >= len(used_palette_colors)
+                or len(used_palette_colors) <= num_palette_colors // 2
             ):
                 return used_palette_colors
 

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -824,11 +824,14 @@ def _get_optimize(im, info):
                 if count:
                     used_palette_colors.append(i)
 
-            num_palette_colors = len(im.palette.palette) // 4 if im.palette.mode == 'RGBA' else len(im.palette.palette) // 3
+            num_palette_colors = (
+                len(im.palette.palette) // 4
+                if im.palette.mode == "RGBA"
+                else len(im.palette.palette) // 3
+            )
             # Round up to power of 2 but at least 4
             num_palette_colors = max(4, 1 << (num_palette_colors - 1).bit_length())
             if optimise or (
-
                 len(used_palette_colors) <= 128
                 and max(used_palette_colors) >= len(used_palette_colors)
                 or len(used_palette_colors) <= num_palette_colors // 2


### PR DESCRIPTION
Palette can be optimized if number of colors can be reduced by half or more.

Fixes #6362 .

Changes proposed in this pull request:

 * Fix test for palette "hole" by changing comparison `max(used_palette_colors) > len(used_palette_colors)` to use `>=`
 * Also allow optimize if number of used colors is not more than half the number of current colors
 * Added a test for the latter that fails with current `_get_optimize()` but passes with this change.
 
I note that this change should obviate the condition `len(used_palette_colors) <= 128` but some tests fail if I remove it. I would rather leave it than try to update those tests in `test_file_gif.py`.
As noted in #6362, this assumes that im.palette.palette exists, is not None and is actually a byte string or array of RGB or RGBA colors. If this is possibly not the case please let me know!
