### PR TITLE
Pad PCX palette to 768 bytes when saving

### DIFF
--- a/Tests/test_file_pcx.py
+++ b/Tests/test_file_pcx.py
@@ -20,6 +20,11 @@ def test_sanity(tmp_path):
     for mode in ("1", "L", "P", "RGB"):
         _roundtrip(tmp_path, hopper(mode))
 
+    # Test a palette with less than 256 colors
+    im = Image.new("P", (1, 1))
+    im.putpalette((255, 0, 0))
+    _roundtrip(tmp_path, im)
+
     # Test an unsupported mode
     f = str(tmp_path / "temp.pcx")
     im = hopper("RGBA")

--- a/src/PIL/PcxImagePlugin.py
+++ b/src/PIL/PcxImagePlugin.py
@@ -198,7 +198,9 @@ def _save(im, fp, filename):
     if im.mode == "P":
         # colour palette
         fp.write(o8(12))
-        fp.write(im.im.getpalette("RGB", "RGB"))  # 768 bytes
+        palette = im.im.getpalette("RGB", "RGB")
+        palette += b"\x00" * (768 - len(palette))
+        fp.write(palette)  # 768 bytes
     elif im.mode == "L":
         # greyscale palette
         fp.write(o8(12))


### PR DESCRIPTION
Fixes https://github.com/python-pillow/Pillow/discussions/6388#discussioncomment-2999295

This is a regression introduced by #6060