### PR TITLE
Reverted to __array_interface__ with the release of NumPy 1.23

### DIFF
--- a/Tests/test_image_array.py
+++ b/Tests/test_image_array.py
@@ -1,4 +1,5 @@
 import pytest
+from packaging.version import parse as parse_version
 
 from PIL import Image
 
@@ -34,9 +35,10 @@ def test_toarray():
     test_with_dtype(numpy.float64)
     test_with_dtype(numpy.uint8)
 
-    with Image.open("Tests/images/truncated_jpeg.jpg") as im_truncated:
-        with pytest.raises(OSError):
-            numpy.array(im_truncated)
+    if parse_version(numpy.__version__) >= parse_version("1.23"):
+        with Image.open("Tests/images/truncated_jpeg.jpg") as im_truncated:
+            with pytest.raises(OSError):
+                numpy.array(im_truncated)
 
 
 def test_fromarray():

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -671,14 +671,9 @@ class Image:
             raise ValueError("Could not save to PNG for display") from e
         return b.getvalue()
 
-    class _ArrayData:
-        def __init__(self, new):
-            self.__array_interface__ = new
-
-    def __array__(self, dtype=None):
+    @property
+    def __array_interface__(self):
         # numpy array interface support
-        import numpy as np
-
         new = {}
         shape, typestr = _conv_type_shape(self)
         new["shape"] = shape
@@ -690,8 +685,7 @@ class Image:
             new["data"] = self.tobytes("raw", "L")
         else:
             new["data"] = self.tobytes()
-
-        return np.array(self._ArrayData(new), dtype)
+        return new
 
     def __getstate__(self):
         return [self.info, self.mode, self.size, self.getpalette(), self.tobytes()]


### PR DESCRIPTION
Resolves #5815

#5379 was created to workaround a bug in NumPy. That bug has now been fixed in NumPy 1.23, so this PR reverts the src change from #5379.