### PR TITLE
Docs: remove redundant search page from table of contents

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -94,4 +94,3 @@ Indices and tables
 
 * :ref:`genindex`
 * :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
Fixes #6398

Changes proposed in this pull request:

 * Remove the search page from the TOC
