### PR TITLE
Install furo if it is not available

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -43,6 +43,7 @@ clean:
 
 install-sphinx:
 	python3 -c "import sphinx" > /dev/null 2>&1 || python3 -m pip install sphinx
+	python3 -c "import furo" > /dev/null 2>&1 || python3 -m pip install furo
 
 html:
 	$(MAKE) install-sphinx


### PR DESCRIPTION
Running `make doccheck` without furo installed leads to
```
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C docs html
/Applications/Xcode.app/Contents/Developer/usr/bin/make install-sphinx
python3 -c "import sphinx" > /dev/null 2>&1 || python3 -m pip install sphinx
python3 -m sphinx.cmd.build -b html -W --keep-going -d _build/doctrees   . _build/html
Running Sphinx v4.4.0
loading translations [en]... done
loading pickled environment... done

Theme error:
no theme named 'furo' found (missing theme.conf?)
make[1]: *** [html] Error 2
make: *** [doccheck] Error 2
```

This PR installs furo as part of `install-sphinx`.