### PR TITLE
Document where to find other codecs

### DIFF
--- a/docs/handbook/writing-your-own-image-plugin.rst
+++ b/docs/handbook/writing-your-own-image-plugin.rst
@@ -141,6 +141,10 @@ The fields are used as follows:
     uncompressed data, in a variety of pixel formats. For more information on
     this decoder, see the description below.
 
+    A list of C decoders can be seen under codecs section of the function array
+    in :file:`_imaging.c`. Python decoders are registered within the relevant
+    plugins.
+
 **region**
     A 4-tuple specifying where to store data in the image.
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -715,6 +715,11 @@ class Image:
 
         :param encoder_name: What encoder to use.  The default is to
                              use the standard "raw" encoder.
+
+                             A list of C encoders can be seen under
+                             codecs section of the function array in
+                             :file:`_imaging.c`. Python encoders are
+                             registered within the relevant plugins.
         :param args: Extra arguments to the encoder.
         :returns: A :py:class:`bytes` object.
         """


### PR DESCRIPTION
In https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.tobytes and in https://pillow.readthedocs.io/en/stable/handbook/writing-your-own-image-plugin.html#the-tile-attribute, the "raw" codec is mentioned, without immediate information on how to find other codecs.

This PR adds text pointing to either `_imaging.c` or Python plugins. It is intended to help address the concerns of #6310