### PR TITLE
Fix when `sys.executable` is empty or null

### DIFF
--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -178,10 +178,11 @@ class MacViewer(Viewer):
             else:
                 raise TypeError("Missing required argument: 'path'")
         subprocess.call(["open", "-a", "Preview.app", path])
-        if sys.executable:
+        exectable = sys.executable or shutil.which("python3")
+        if executable:
             subprocess.Popen(
                 [
-                    sys.executable,
+                    executable,
                     "-c",
                     "import os, sys, time; time.sleep(20); os.remove(sys.argv[1])",
                     path,

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -178,7 +178,7 @@ class MacViewer(Viewer):
             else:
                 raise TypeError("Missing required argument: 'path'")
         subprocess.call(["open", "-a", "Preview.app", path])
-        exectable = sys.executable or shutil.which("python3")
+        executable = sys.executable or shutil.which("python3")
         if executable:
             subprocess.Popen(
                 [

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -178,14 +178,15 @@ class MacViewer(Viewer):
             else:
                 raise TypeError("Missing required argument: 'path'")
         subprocess.call(["open", "-a", "Preview.app", path])
-        subprocess.Popen(
-            [
-                sys.executable,
-                "-c",
-                "import os, sys, time; time.sleep(20); os.remove(sys.argv[1])",
-                path,
-            ]
-        )
+        if sys.executable:
+            subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    "import os, sys, time; time.sleep(20); os.remove(sys.argv[1])",
+                    path,
+                ]
+            )
         return 1
 
 


### PR DESCRIPTION
There are exceptional cases in which `sys.executable` is empty or null (see [the docs](https://docs.python.org/3/library/sys.html#sys.executable)). I think it's better to just not delete the image in these cases, instead of crashing.