### PR TITLE
Release Python GIL when converting images using matrix operations

### DIFF
--- a/src/libImaging/Matrix.c
+++ b/src/libImaging/Matrix.c
@@ -21,6 +21,7 @@ Imaging
 ImagingConvertMatrix(Imaging im, const char *mode, float m[]) {
     Imaging imOut;
     int x, y;
+    ImagingSectionCookie cookie;
 
     /* Assume there's enough data in the buffer */
     if (!im) {
@@ -33,6 +34,7 @@ ImagingConvertMatrix(Imaging im, const char *mode, float m[]) {
             return NULL;
         }
 
+        ImagingSectionEnter(&cookie);
         for (y = 0; y < im->ysize; y++) {
             UINT8 *in = (UINT8 *)im->image[y];
             UINT8 *out = (UINT8 *)imOut->image[y];
@@ -43,6 +45,7 @@ ImagingConvertMatrix(Imaging im, const char *mode, float m[]) {
                 in += 4;
             }
         }
+        ImagingSectionLeave(&cookie);
 
     } else if (strlen(mode) == 3 && im->bands == 3) {
         imOut = ImagingNewDirty(mode, im->xsize, im->ysize);
@@ -54,6 +57,7 @@ ImagingConvertMatrix(Imaging im, const char *mode, float m[]) {
             UINT8 *in = (UINT8 *)im->image[y];
             UINT8 *out = (UINT8 *)imOut->image[y];
 
+            ImagingSectionEnter(&cookie);
             for (x = 0; x < im->xsize; x++) {
                 float v0 = m[0] * in[0] + m[1] * in[1] + m[2] * in[2] + m[3] + 0.5;
                 float v1 = m[4] * in[0] + m[5] * in[1] + m[6] * in[2] + m[7] + 0.5;
@@ -64,6 +68,7 @@ ImagingConvertMatrix(Imaging im, const char *mode, float m[]) {
                 in += 4;
                 out += 4;
             }
+            ImagingSectionLeave(&cookie);
         }
     } else {
         return (Imaging)ImagingError_ModeError();


### PR DESCRIPTION
Resolves #6520

Related to 
* https://github.com/python-pillow/Pillow/issues/2635
* https://github.com/python-pillow/Pillow/issues/2664#issuecomment-328666279

Changes proposed in this pull request:

 * Release python GIL when converting images using matrix operations

Thank you for reviewing!
