### PR TITLE
Updated links

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -827,11 +827,8 @@ the output format must be specified explicitly::
 
     im.save('newimage.spi', format='SPIDER')
 
-For more information about the SPIDER image processing package, see the
-`SPIDER homepage`_ at `Wadsworth Center`_.
-
-.. _SPIDER homepage: https://spider.wadsworth.org/spider_doc/spider/docs/spider.html
-.. _Wadsworth Center: https://www.wadsworth.org/
+For more information about the SPIDER image processing package, see
+https://github.com/spider-em/SPIDER
 
 TGA
 ^^^

--- a/docs/releasenotes/9.0.0.rst
+++ b/docs/releasenotes/9.0.0.rst
@@ -45,7 +45,7 @@ Support for FreeType 2.7 has been removed; FreeType 2.8 is the minimum supported
 We recommend upgrading to at least `FreeType`_ 2.10.4, which fixed a severe
 vulnerability introduced in FreeType 2.6 (:cve:`CVE-2020-15999`).
 
-.. _FreeType: https://www.freetype.org
+.. _FreeType: https://freetype.org/
 
 Image.show command parameter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/runs/7261653289?check_suite_focus=true#step:11:571
> (    deprecations: line  253) redirect  https://www.freetype.org/ - permanently to https://freetype.org/

So I've replaced that link with https://freetype.org/

https://github.com/python-pillow/Pillow/runs/7261653289?check_suite_focus=true#step:11:582
> (handbook/image-file-formats: line  830) broken    https://spider.wadsworth.org/spider_doc/spider/docs/spider.html - HTTPSConnectionPool(host='spider.wadsworth.org', port=443): Max retries exceeded with url: /spider_doc/spider/docs/spider.html (Caused by ConnectTimeoutError(<urllib3.connection.HTTPSConnection object at 0x7fb6f707da50>, 'Connection to spider.wadsworth.org timed out. (connect timeout=None)'))

We could replace the link using the Wayback machine - https://web.archive.org/web/20210122004053/https://spider.wadsworth.org/spider_doc/spider/docs/spider.html

But if it is just a link for ["more information about the SPIDER image processing package"](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#writing-files-in-spider-format), then it would seem better to link to https://github.com/spider-em/SPIDER instead. You can see a link to the GitHub project on the Wayback page.