### PR TITLE
Fixed PSDraw rectangle

### DIFF
--- a/src/PIL/PSDraw.py
+++ b/src/PIL/PSDraw.py
@@ -93,9 +93,9 @@ class PSDraw:
 
                     .. code-block:: python
 
-                        %d %d M %d %d 0 Vr\n
+                        %d %d M 0 %d %d Vr\n
         """
-        self.fp.write(b"%d %d M %d %d 0 Vr\n" % box)
+        self.fp.write(b"%d %d M 0 %d %d Vr\n" % box)
 
     def text(self, xy, text):
         """

--- a/src/PIL/PSDraw.py
+++ b/src/PIL/PSDraw.py
@@ -185,7 +185,7 @@ VDI_PS = b"""\
         exch dup 0 exch rlineto
         exch neg 0 rlineto
         0 exch neg rlineto
-        100 div setgray fill 0 setgray } bind def
+        setgray fill } bind def
 /Tm matrix def
 /Ve {   Tm currentmatrix pop
         translate scale newpath 0 0 .5 0 360 arc closepath

--- a/src/PIL/PSDraw.py
+++ b/src/PIL/PSDraw.py
@@ -86,14 +86,8 @@ class PSDraw:
         """
         Draws a rectangle.
 
-        :param box: A 4-tuple of integers whose order and function is currently
-                    undocumented.
-
-                    Hint: the tuple is passed into this format string:
-
-                    .. code-block:: python
-
-                        %d %d M 0 %d %d Vr\n
+        :param box: A tuple of four integers, specifying left, bottom, width and
+           height.
         """
         self.fp.write(b"%d %d M 0 %d %d Vr\n" % box)
 
@@ -188,9 +182,9 @@ VDI_PS = b"""\
 /Vl { moveto lineto stroke } bind def
 /Vc { newpath 0 360 arc closepath } bind def
 /Vr {   exch dup 0 rlineto
-        exch dup neg 0 exch rlineto
+        exch dup 0 exch rlineto
         exch neg 0 rlineto
-        0 exch rlineto
+        0 exch neg rlineto
         100 div setgray fill 0 setgray } bind def
 /Tm matrix def
 /Ve {   Tm currentmatrix pop


### PR DESCRIPTION
Resolves #6428

Uses the changes suggested in that issue. I can't see a way to add tests for this.

Moving the `neg` means that instead of going from `(0, 0)` to `(width, 0)`, `(width, -height)`, `(0, -height)` and `(0, 0)`,
it instead goes from `(0, 0)` to `(width, 0)`, `(width, height)`, `(0, height)` and `(0, 0)`,
so instead of drawing the rectangle below the starting point, it draws it above.