### PR TITLE
Raise ValueError if PNG sRGB chunk is truncated

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -635,7 +635,9 @@ class TestFilePng:
 
             assert_image_equal_tofile(im, "Tests/images/bw_gradient.png")
 
-    @pytest.mark.parametrize("cid", (b"IHDR", b"pHYs", b"acTL", b"fcTL", b"fdAT"))
+    @pytest.mark.parametrize(
+        "cid", (b"IHDR", b"sRGB", b"pHYs", b"acTL", b"fcTL", b"fdAT")
+    )
     def test_truncated_chunks(self, cid):
         fp = BytesIO()
         with PngImagePlugin.PngStream(fp) as png:

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -509,6 +509,10 @@ class PngStream(ChunkStream):
         # 3 absolute colorimetric
 
         s = ImageFile._safe_read(self.fp, length)
+        if length < 1:
+            if ImageFile.LOAD_TRUNCATED_IMAGES:
+                return s
+            raise ValueError("Truncated sRGB chunk")
         self.im_info["srgb"] = s[0]
         return s
 


### PR DESCRIPTION
Resolves #6430.

This is like #6253, only for a different PNG chunk.