### PR TITLE
Install libxcb-shape0

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -43,7 +43,7 @@ if [[ $(uname) != CYGWIN* ]]; then
 
     # PyQt6 doesn't support PyPy3
     if [[ $GHA_PYTHON_VERSION == 3.* ]]; then
-        sudo apt-get -qq install libegl1 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxkbcommon-x11-0
+        sudo apt-get -qq install libegl1 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxkbcommon-x11-0
         python3 -m pip install pyqt6
     fi
 


### PR DESCRIPTION
Tests/test_qt_image_qapplication.py has started aborting in ubuntu-latest on main - https://github.com/python-pillow/Pillow/runs/7337854934?check_suite_focus=true#step:8:2131

Starting [QApplication with `QT_DEBUG_PLUGINS` enabled](https://github.com/radarhere/Pillow/commit/a540fb9d2c42a994a4d91fdcaab661cba45e67b0), I find the message ["libxcb-shape.so.0: cannot open shared object file: No such file or directory"](https://github.com/radarhere/Pillow/runs/7339328878?check_suite_focus=true#step:4:258)

So this PR installs libxcb-shape0.

A similar thing has happened before, with #4662