### PR TITLE
Docs: Allow setting Python interpreter via command line

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,8 +2,9 @@
 #
 
 # You can set these variables from the command line.
+PYTHON        = python3
 SPHINXOPTS    =
-SPHINXBUILD   = python3 -m sphinx.cmd.build
+SPHINXBUILD   = $(PYTHON) -m sphinx.cmd.build
 PAPER         =
 BUILDDIR      = _build
 
@@ -42,8 +43,8 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 install-sphinx:
-	python3 -c "import sphinx" > /dev/null 2>&1 || python3 -m pip install sphinx
-	python3 -c "import furo" > /dev/null 2>&1 || python3 -m pip install furo
+	$(PYTHON) -c "import sphinx" > /dev/null 2>&1 || $(PYTHON) -m pip install sphinx
+	$(PYTHON) -c "import furo" > /dev/null 2>&1 || $(PYTHON) -m pip install furo
 
 html:
 	$(MAKE) install-sphinx
@@ -179,4 +180,4 @@ livehtml: html
 	livereload $(BUILDDIR)/html -p 33233
 
 serve:
-	cd $(BUILDDIR)/html; python3 -m http.server
+	cd $(BUILDDIR)/html; $(PYTHON) -m http.server


### PR DESCRIPTION
Changes proposed in this pull request:

 * Allow setting the Python interpreter on the command line when building docs.
 * For example: `make doc PYTHON=python3.11`


(I wanted to check 3.11 and they build fine; I have `3.11-dev` installed via pyenv and needed to do [this](https://stackoverflow.com/a/60469203/724176) first to make sure it built Python with Tk.)
