### PR TITLE
3.11: Add Trove classifier and to tox.ini and update setup.py version check

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Multimedia :: Graphics

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ TIFF_ROOT = None
 ZLIB_ROOT = None
 FUZZING_BUILD = "LIB_FUZZING_ENGINE" in os.environ
 
-if sys.platform == "win32" and sys.version_info >= (3, 11):
+if sys.platform == "win32" and sys.version_info >= (3, 12):
     import atexit
 
     atexit.register(

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 envlist =
     lint
-    py{37,38,39,310,py3}
+    py{37,38,39,310,311,py3}
 minversion = 1.9
 
 [testenv]


### PR DESCRIPTION
Changes proposed in this pull request:

 * The next quarterly release (Pillow 9.3.0) will officially support Python 3.11
 * This PR is like https://github.com/python-pillow/Pillow/pull/5570 but for 3.11
 * https://github.com/python-pillow/Pillow/pull/6433 has the support table update

