### PR TITLE
Moved tile encoding into separate function

### DIFF
--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -499,9 +499,14 @@ def _save(im, fp, tile, bufsize=0):
     try:
         fh = fp.fileno()
         fp.flush()
-        exc = None
-    except (AttributeError, io.UnsupportedOperation) as e:
-        exc = e
+        _encode_tile(im, fp, tile, bufsize, fh)
+    except (AttributeError, io.UnsupportedOperation) as exc:
+        _encode_tile(im, fp, tile, bufsize, None, exc)
+    if hasattr(fp, "flush"):
+        fp.flush()
+
+
+def _encode_tile(im, fp, tile, bufsize, fh, exc=None):
     for e, b, o, a in tile:
         if o > 0:
             fp.seek(o)
@@ -526,8 +531,6 @@ def _save(im, fp, tile, bufsize=0):
                 raise OSError(f"encoder error {s} when writing image file") from exc
         finally:
             encoder.cleanup()
-    if hasattr(fp, "flush"):
-        fp.flush()
 
 
 def _safe_read(fp, size):


### PR DESCRIPTION
Resolves #6448

The issue reports an increase in memory usage. Testing, I find that it started with https://github.com/python-pillow/Pillow/pull/6096/commits/bb9338e34d705501b87876ebe6a8212b88b96acb. It would appear that the exception value is being held onto.

This PR moves the code into a separate function, which stops the memory problem.