### PR TITLE
Orientation data is removed by exif_transpose()

### DIFF
--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -572,9 +572,9 @@ def solarize(image, threshold=128):
 
 def exif_transpose(image):
     """
-    If an image has an EXIF Orientation tag return a new image that is
-    transposed accordingly. The new image will have the orientation data
-    removed.
+    If an image has an EXIF Orientation tag, other than 1, return a new image
+    that is transposed accordingly. The new image will have the orientation
+    data removed.
 
     Otherwise, return a copy of the image.
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -572,8 +572,11 @@ def solarize(image, threshold=128):
 
 def exif_transpose(image):
     """
-    If an image has an EXIF Orientation tag, return a new image that is
-    transposed accordingly. Otherwise, return a copy of the image.
+    If an image has an EXIF Orientation tag return a new image that is
+    transposed accordingly. The new image will have the orientation data
+    removed.
+
+    Otherwise, return a copy of the image.
 
     :param image: The image to transpose.
     :return: An image.


### PR DESCRIPTION
Mention in the `exif_transpose()` docstring that orientation data is removed by the operation.

Also mention that this does not happen if the orientation is 1. Requested in https://github.com/python-pillow/Pillow/issues/4124#issuecomment-1204627944