### PR TITLE
Allow default ImageDraw font to be set

### DIFF
--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -1314,6 +1314,23 @@ def test_stroke_multiline():
     assert_image_similar_tofile(im, "Tests/images/imagedraw_stroke_multiline.png", 3.3)
 
 
+def test_setting_default_font():
+    # Arrange
+    im = Image.new("RGB", (100, 250))
+    draw = ImageDraw.Draw(im)
+    font = ImageFont.truetype("Tests/fonts/FreeMono.ttf", 120)
+
+    # Act
+    ImageDraw.ImageDraw.font = font
+
+    # Assert
+    try:
+        assert draw.getfont() == font
+    finally:
+        ImageDraw.ImageDraw.font = None
+        assert isinstance(draw.getfont(), ImageFont.ImageFont)
+
+
 def test_same_color_outline():
     # Prepare shape
     x0, y0 = 5, 5

--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -64,7 +64,7 @@ Fonts
 
 PIL can use bitmap fonts or OpenType/TrueType fonts.
 
-Bitmap fonts are stored in PIL’s own format, where each font typically consists
+Bitmap fonts are stored in PIL's own format, where each font typically consists
 of two files, one named .pil and the other usually named .pbm. The former
 contains font metrics, the latter raster data.
 
@@ -145,6 +145,11 @@ Methods
 .. py:method:: ImageDraw.getfont()
 
     Get the current default font.
+
+    To set the default font for all future ImageDraw instances::
+
+        from PIL import ImageDraw, ImageFont
+        ImageDraw.ImageDraw.font = ImageFont.truetype("Tests/fonts/FreeMono.ttf")
 
     :returns: An image font.
 

--- a/docs/releasenotes/9.3.0.rst
+++ b/docs/releasenotes/9.3.0.rst
@@ -31,7 +31,7 @@ Allow default ImageDraw font to be set
 
 Rather than specifying a font when calling text-related ImageDraw methods, or
 setting a font on each ImageDraw instance, the default font can now be set for
-all future ImageDraw operations.
+all future ImageDraw operations::
 
     from PIL import ImageDraw, ImageFont
     ImageDraw.ImageDraw.font = ImageFont.truetype("Tests/fonts/FreeMono.ttf")

--- a/docs/releasenotes/9.3.0.rst
+++ b/docs/releasenotes/9.3.0.rst
@@ -26,6 +26,16 @@ TODO
 API Additions
 =============
 
+Allow default ImageDraw font to be set
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Rather than specifying a font when calling text-related ImageDraw methods, or
+setting a font on each ImageDraw instance, the default font can now be set for
+all future ImageDraw operations.
+
+    from PIL import ImageDraw, ImageFont
+    ImageDraw.ImageDraw.font = ImageFont.truetype("Tests/fonts/FreeMono.ttf")
+
 Saving multiple MPO frames
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -93,6 +93,11 @@ class ImageDraw:
         """
         Get the current default font.
 
+        To set the default font for all future ImageDraw instances::
+
+            from PIL import ImageDraw, ImageFont
+            ImageDraw.ImageDraw.font = ImageFont.truetype("Tests/fonts/FreeMono.ttf")
+
         :returns: An image font."""
         if not self.font:
             # FIXME: should add a font repository

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -46,6 +46,8 @@ directly.
 
 
 class ImageDraw:
+    font = None
+
     def __init__(self, im, mode=None):
         """
         Create a drawing instance.
@@ -86,7 +88,6 @@ class ImageDraw:
         else:
             self.fontmode = "L"  # aliasing is okay for other modes
         self.fill = 0
-        self.font = None
 
     def getfont(self):
         """


### PR DESCRIPTION
Resolves #6480

By raising `ImageDraw.ImageDraw.font` from an instance variable to a class variable, a default ImageDraw font can be set by the user.

```python
from PIL import ImageDraw, ImageFont
ImageDraw.ImageDraw.font = ImageFont.truetype("Tests/fonts/FreeMono.ttf", 120)
```

From then on, ImageDraw operations would use that font as the default, instead of the `ImageFont.load_default()` font.