### PR TITLE
Note to Windows users that FreeType will keep the font file open

### DIFF
--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -911,6 +911,7 @@ def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):
     limits the number of files that can be open in C at once to 512, so if many
     fonts are opened simultaneously and that limit is approached, an
     ``OSError`` may be thrown, reporting that FreeType "cannot open resource".
+    A workaround would be to copy the file(s) into memory, and open that instead.
 
     This function requires the _imagingft service.
 

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -906,9 +906,10 @@ def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):
     This function loads a font object from the given file or file-like
     object, and creates a font object for a font of the given size.
 
-    Pillow uses FreeType to open font files. If you are opening many fonts
-    simultaneously on Windows, be aware that Windows limits the number of files
-    that can be open in C at once to 512. If you approach that limit, an
+    Pillow uses FreeType to open font files. On Windows, be aware that FreeType
+    will keep the file open as long as the FreeTypeFont object exists. Windows
+    limits the number of files that can be open in C at once to 512, so if many
+    fonts are opened simultaneously and that limit is approached, an
     ``OSError`` may be thrown, reporting that FreeType "cannot open resource".
 
     This function requires the _imagingft service.


### PR DESCRIPTION
Resolves #6324

It has been [requested](https://github.com/python-pillow/Pillow/issues/6324#issuecomment-1135153357) we document that on Windows, FreeType keeps the font file open while Pillow is using it.

Testing [this](https://github.com/radarhere/Pillow/commit/84438b738d993bb8e26b24f3f80ea94cf8e13b39),
```python
import shutil
shutil.copy("Tests/fonts/FreeMono.ttf", "out.ttf")
font = ImageFont.truetype("out.ttf")
os.remove("out.ttf")
```
on Windows, I see a [PermissionError.](https://github.com/radarhere/Pillow/runs/7704792192?check_suite_focus=true#step:24:1634) On [macOS and Linux, there is no problem.](https://github.com/radarhere/Pillow/actions/runs/2808890136)

The error [disappears on CPython](https://github.com/radarhere/Pillow/actions/runs/2808891207) if you [insert `del font` before `os.remove`](https://github.com/radarhere/Pillow/commit/d8bba1513799d1879fe1565a5f5b07c0438982fc).