### PR TITLE
Restored __array__ for libraries that do not support __array_interface__

### DIFF
--- a/Tests/test_image_array.py
+++ b/Tests/test_image_array.py
@@ -94,3 +94,10 @@ def test_fromarray_palette():
 
     # Assert that the Python and C palettes match
     assert len(out.palette.colors) == len(out.im.getpalette()) / 3
+
+
+def test_array():
+    i = im.convert("L")
+    a = numpy.array(i)
+
+    assert (a == i.__array__()).all()

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -671,6 +671,11 @@ class Image:
             raise ValueError("Could not save to PNG for display") from e
         return b.getvalue()
 
+    def __array__(self, dtype=None):
+        import numpy as np
+
+        return np.array(self, dtype)
+
     @property
     def __array_interface__(self):
         # numpy array interface support


### PR DESCRIPTION
Resolves #6422

The issue has discovered that tensorflow supports converting Pillow images using `__array__`, but not `__array_interface__`. One solution would be to say that tensorflow should support `__array_interface__`, and an issue has been opened for that - https://github.com/tensorflow/tensorflow/issues/56723

This PR is an alternative, where we add `__array__`, to provide support from our end. Conceivably, there may be other libraries that support `__array__`, but not `__array_interface__`. Testing, I find that NumPy prefers `__array_interface__` over `__array__`, so this should not affect NumPy use.