### PR TITLE
Copy palette when converting from P to PA

### DIFF
--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -236,6 +236,12 @@ def test_p2pa_alpha():
             assert im_a.getpixel((x, y)) == alpha
 
 
+def test_p2pa_palette():
+    with Image.open("Tests/images/tiny.png") as im:
+        im_pa = im.convert("PA")
+    assert im_pa.getpalette() == im.getpalette()
+
+
 def test_matrix_illegal_conversion():
     # Arrange
     im = hopper("CMYK")

--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -1243,7 +1243,7 @@ frompalette(Imaging imOut, Imaging imIn, const char *mode) {
     if (!imOut) {
         return NULL;
     }
-    if (strcmp(mode, "P") == 0) {
+    if (strcmp(mode, "P") == 0 || strcmp(mode, "PA") == 0) {
         ImagingPaletteDelete(imOut->palette);
         imOut->palette = ImagingPaletteDuplicate(imIn->palette);
     }


### PR DESCRIPTION
Resolves #6496

At the moment. when converting from P to PA, the palette isn't copied to the new image.