### PR TITLE
Do not install test-image-results on GitHub Actions

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -35,7 +35,6 @@ python3 -m pip install -U pytest
 python3 -m pip install -U pytest-cov
 python3 -m pip install -U pytest-timeout
 python3 -m pip install pyroma
-python3 -m pip install test-image-results
 
 if [[ $(uname) != CYGWIN* ]]; then
     # TODO Remove condition when NumPy supports 3.11

--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -12,7 +12,6 @@ python3 -m pip install -U pytest
 python3 -m pip install -U pytest-cov
 python3 -m pip install -U pytest-timeout
 python3 -m pip install pyroma
-python3 -m pip install test-image-results
 
 echo -e "[openblas]\nlibraries = openblas\nlibrary_dirs = /usr/local/opt/openblas/lib" >> ~/.numpy-site.cfg
 # TODO Remove condition when NumPy supports 3.11


### PR DESCRIPTION
With #4135, artifacts are preferred over test-image-results on GitHub Actions.

So test-image-results does not need to be installed.