### PR TITLE
Added direct conversion from PA to P

### DIFF
--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -1027,6 +1027,14 @@ pa2l(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
+pa2p(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+    int x;
+    for (x = 0; x < xsize; x++, in += 4) {
+        *out++ = in[0];
+    }
+}
+
+static void
 p2pa(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
     int x;
     int rgb = strcmp(palette->mode, "RGB");
@@ -1209,6 +1217,8 @@ frompalette(Imaging imOut, Imaging imIn, const char *mode) {
         convert = alpha ? pa2l : p2l;
     } else if (strcmp(mode, "LA") == 0) {
         convert = alpha ? pa2la : p2la;
+    } else if (strcmp(mode, "P") == 0) {
+        convert = pa2p;
     } else if (strcmp(mode, "PA") == 0) {
         convert = p2pa;
     } else if (strcmp(mode, "I") == 0) {
@@ -1232,6 +1242,10 @@ frompalette(Imaging imOut, Imaging imIn, const char *mode) {
     imOut = ImagingNew2Dirty(mode, imOut, imIn);
     if (!imOut) {
         return NULL;
+    }
+    if (strcmp(mode, "P") == 0) {
+        ImagingPaletteDelete(imOut->palette);
+        imOut->palette = ImagingPaletteDuplicate(imIn->palette);
     }
 
     ImagingSectionEnter(&cookie);


### PR DESCRIPTION
#6506 asked how Pillow converted images from PA to P.

The answer was because PA to P conversion doesn't exist, Pillow instead [falls back](https://github.com/python-pillow/Pillow/blob/87ecd01fc042bb67b11bfcff3db99fc2b61e702d/src/PIL/Image.py#L1034-L1040) to converting from PA to RGB, and then RGB to P.

This PR adds direct conversion from PA to P. There should be no functional change, only an increase in efficiency.