### PR TITLE
Ubuntu dependencies also apply to Jammy

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -367,7 +367,7 @@ In Alpine, the command is::
 
 .. Note:: ``redhat-rpm-config`` is required on Fedora 23, but not earlier versions.
 
-Prerequisites for **Ubuntu 16.04 LTS - 20.04 LTS** are installed with::
+Prerequisites for **Ubuntu 16.04 LTS - 22.04 LTS** are installed with::
 
     sudo apt-get install libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev \
         libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \


### PR DESCRIPTION
https://pillow.readthedocs.io/en/stable/installation.html#building-on-linux
> Prerequisites for Ubuntu 16.04 LTS - 20.04 LTS are installed with:
> ```
> sudo apt-get install libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev \
>     libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \
>     libharfbuzz-dev libfribidi-dev libxcb1-dev
> ```

All of the packages listed are still used in [our docker install of Ubuntu 22.04](https://github.com/python-pillow/docker-images/blob/main/ubuntu-22.04-jammy-amd64/Dockerfile).

The only exception is libxcb1-dev, which isn't installed anywhere in our repositories. The package is [still available in Jammy though.](https://packages.ubuntu.com/jammy/libxcb1-dev).