### PR TITLE
Do not use CCITTFaxDecode filter if libtiff is not available

### DIFF
--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -6,7 +6,7 @@ import time
 
 import pytest
 
-from PIL import Image, PdfParser
+from PIL import Image, PdfParser, features
 
 from .helper import hopper, mark_if_feature_version
 
@@ -43,7 +43,7 @@ def test_monochrome(tmp_path):
 
     # Act / Assert
     outfile = helper_save_as_pdf(tmp_path, mode)
-    assert os.path.getsize(outfile) < 5000
+    assert os.path.getsize(outfile) < (5000 if features.check("libtiff") else 15000)
 
 
 def test_greyscale(tmp_path):

--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -25,7 +25,7 @@ import math
 import os
 import time
 
-from . import Image, ImageFile, ImageSequence, PdfParser, __version__
+from . import Image, ImageFile, ImageSequence, PdfParser, __version__, features
 
 #
 # --------------------------------------------------------------------
@@ -130,20 +130,23 @@ def _save(im, fp, filename, save_all=False):
             width, height = im.size
 
             if im.mode == "1":
-                filter = "CCITTFaxDecode"
-                bits = 1
-                params = PdfParser.PdfArray(
-                    [
-                        PdfParser.PdfDict(
-                            {
-                                "K": -1,
-                                "BlackIs1": True,
-                                "Columns": width,
-                                "Rows": height,
-                            }
-                        )
-                    ]
-                )
+                if features.check("libtiff"):
+                    filter = "CCITTFaxDecode"
+                    bits = 1
+                    params = PdfParser.PdfArray(
+                        [
+                            PdfParser.PdfDict(
+                                {
+                                    "K": -1,
+                                    "BlackIs1": True,
+                                    "Columns": width,
+                                    "Rows": height,
+                                }
+                            )
+                        ]
+                    )
+                else:
+                    filter = "DCTDecode"
                 colorspace = PdfParser.PdfName("DeviceGray")
                 procset = "ImageB"  # grayscale
             elif im.mode == "L":


### PR DESCRIPTION
Since libtiff is an optional dependency, it should be optional where possible.

This PR reverts the change from #6470 if libtiff is missing.