### PR TITLE
Changed contain function

### DIFF
--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -18,9 +18,10 @@
 #
 
 import functools
+import math
 import operator
 import re
-import math
+
 from . import Image
 
 #

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -20,7 +20,7 @@
 import functools
 import operator
 import re
-
+import math
 from . import Image
 
 #
@@ -255,11 +255,11 @@ def contain(image, size, method=Image.Resampling.BICUBIC):
 
     if im_ratio != dest_ratio:
         if im_ratio > dest_ratio:
-            new_height = int(image.height / image.width * size[0])
+            new_height = math.ceil(image.height / image.width * size[0])
             if new_height != size[1]:
                 size = (size[0], new_height)
         else:
-            new_width = int(image.width / image.height * size[1])
+            new_width = math.ceil(image.width / image.height * size[1])
             if new_width != size[0]:
                 size = (new_width, size[1])
     return image.resize(size, resample=method)


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:

 * I was using ImageOps.pad for resizing an image by keeping the aspect ratio. But when I used pad function for an image with size (4307, 6030) to resize it to (50,70), it extended right side only. When I manually resized it, that image didn't need any extension or padding to keep the aspect ratio because both sizes are proportional.
 * So I checked the function in pillow repo, and found that pad function is using contain function and in contain function, finding new height or width for keeping aspect ratio was using this code : 
 `new_height = int(image.height / image.width * size[0])`
`new_width = int(image.width / image.height * size[1])`
 * I think this code has a problem, actually instead of "int", it should use math.ceil so that the next highest number will be used as size(width or height)
 * In my image by running contain function by running ImageOps.contain, it gave an output image with size (49,70), not (50,70).
