### PR TITLE
ImageOps.contain function finding new size

### DIFF
--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -255,11 +255,11 @@ def contain(image, size, method=Image.Resampling.BICUBIC):
 
     if im_ratio != dest_ratio:
         if im_ratio > dest_ratio:
-            new_height = int(image.height / image.width * size[0])
+            new_height = round(image.height / image.width * size[0])
             if new_height != size[1]:
                 size = (size[0], new_height)
         else:
-            new_width = int(image.width / image.height * size[1])
+            new_width = round(image.width / image.height * size[1])
             if new_width != size[0]:
                 size = (new_width, size[1])
     return image.resize(size, resample=method)


### PR DESCRIPTION
Fixes ImageOps.contain function

Changes proposed in this pull request:

I tried to use ImageOps.pad on an image of size (4307, 6030) and I needed to resize it to (50,70). The image was resized but it had extended only on the right side. But actually, these two sizes don't need any expansion since both sizes are proportional.

So I checked the pillow code and found that ImageOps.pad is using ImageOps.contain and in contain function there is a code for calculating new height or new width based on the size.
 `new_height = int(image.height / image.width * size[0])`
or
`new_width = int(image.width / image.height * size[1])`

But the problem here is when I ran that function with (50,70), it gave output (49,70).
code explanation:
```python
size = (4307,6030)
new_width = int(image.width / image.height * size[1])
new_width = int(4307 / 6030 * 70)
new_width = 49
```
Expected output : 
```python
new_width = 50
```
But the new width should have been 50. So I changed " int " method with "round"