### PR TITLE
Temporarily skip valgrind failure

### DIFF
--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -37,6 +37,7 @@ def helper_save_as_pdf(tmp_path, mode, **kwargs):
     return outfile
 
 
+@pytest.mark.valgrind_known_error(reason="Temporary skip")
 def test_monochrome(tmp_path):
     # Arrange
     mode = "1"


### PR DESCRIPTION
Temporarily skip the valgrind failure introduced by #6470, so that any new failing tests can be seen more clearly.

See https://github.com/radarhere/Pillow/runs/7962954391?check_suite_focus=true for a passing valgrind build with this change.