### PR TITLE
Document ImageDraw attributes

### DIFF
--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -139,17 +139,50 @@ Functions
         must be the same as the image mode.  If omitted, the mode
         defaults to the mode of the image.
 
+Attributes
+----------
+
+.. py:attribute:: ImageDraw.fill
+    :type: bool
+    :value: False
+
+    Selects whether :py:attr:`ImageDraw.ink` should be used as a fill or outline color.
+
+.. py:attribute:: ImageDraw.font
+
+    The current default font.
+
+    Can be set per instance::
+
+        from PIL import ImageDraw, ImageFont
+        draw = ImageDraw.Draw(image)
+        draw.font = ImageFont.truetype("Tests/fonts/FreeMono.ttf")
+
+    Or globally for all future ImageDraw instances::
+
+        from PIL import ImageDraw, ImageFont
+        ImageDraw.ImageDraw.font = ImageFont.truetype("Tests/fonts/FreeMono.ttf")
+
+.. py:attribute:: ImageDraw.fontmode
+
+    The current font drawing mode.
+
+    Set to ``"1"`` to disable antialiasing or ``"L"`` to enable it.
+
+.. py:attribute:: ImageDraw.ink
+    :type: int
+
+    The internal representation of the current default color.
+
 Methods
 -------
 
 .. py:method:: ImageDraw.getfont()
 
-    Get the current default font.
+    Get the current default font, :py:attr:`ImageDraw.font`.
 
-    To set the default font for all future ImageDraw instances::
-
-        from PIL import ImageDraw, ImageFont
-        ImageDraw.ImageDraw.font = ImageFont.truetype("Tests/fonts/FreeMono.ttf")
+    If the current default font is ``None``,
+    it is initialized with :py:func:`.ImageFont.load_default`.
 
     :returns: An image font.
 

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -87,16 +87,24 @@ class ImageDraw:
             self.fontmode = "1"
         else:
             self.fontmode = "L"  # aliasing is okay for other modes
-        self.fill = 0
+        self.fill = False
 
     def getfont(self):
         """
         Get the current default font.
 
+        To set the default font for this ImageDraw instance::
+
+            from PIL import ImageDraw, ImageFont
+            draw.font = ImageFont.truetype("Tests/fonts/FreeMono.ttf")
+
         To set the default font for all future ImageDraw instances::
 
             from PIL import ImageDraw, ImageFont
             ImageDraw.ImageDraw.font = ImageFont.truetype("Tests/fonts/FreeMono.ttf")
+
+        If the current default font is ``None``,
+        it is initialized with ``ImageFont.load_default()``.
 
         :returns: An image font."""
         if not self.font:


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/6480#issuecomment-1208658621

Changes proposed in this pull request:

 * Document `ImageDraw` attributes `font`, `fontmode`, `ink`, `fill`.
 * Change `self.fill = 0` to `self.fill = False` to match its use as a bool.
