### PR TITLE
Do not call load() before draft() in Image.thumbnail

### DIFF
--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -97,6 +97,28 @@ def test_load_first():
         im.thumbnail((64, 64))
         assert im.size == (64, 10)
 
+    # Test thumbnail(), without draft(),
+    # on an image that is large enough once load() has changed the size
+    with Image.open("Tests/images/g4_orientation_5.tif") as im:
+        im.thumbnail((590, 88), reducing_gap=None)
+        assert im.size == (590, 88)
+
+
+def test_load_first_unless_jpeg():
+    # Test that thumbnail() still uses draft() for JPEG
+    with Image.open("Tests/images/hopper.jpg") as im:
+        draft = im.draft
+
+        def im_draft(mode, size):
+            result = draft(mode, size)
+            assert result is not None
+
+            return result
+
+        im.draft = im_draft
+
+        im.thumbnail((64, 64))
+
 
 # valgrind test is failing with memory allocated in libjpeg
 @pytest.mark.valgrind_known_error(reason="Known Failing")


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/issues/6528#issuecomment-1228203478 has pointed out that by calling `load()` at the beginning of `thumbnail()`, the JPEG `draft()` method wouldn't perform any operations.
> `thumbnail` starts by calling the `load` function. Doesn't this defeat the purpose of the `draft` method ?

https://github.com/python-pillow/Pillow/blob/ba98fe782941bdc65601b65994bce6b013630e37/src/PIL/Image.py#L2476

#6186 added the line because `load()` may change the size of the image, and so change `thumbnail()` size calculations.

This PR rearranges the code to suit both scenarios, so that `load()` is called before size calculations **unless** `draft()` returns a result.