### PR TITLE
Allow remap_palette() to return an image with less than 256 palette entries

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -620,6 +620,7 @@ class TestImage:
 
         im_remapped = im.remap_palette([1, 0])
         assert im_remapped.info["transparency"] == 1
+        assert len(im_remapped.getpalette()) == 6
 
         # Test unused transparency
         im.info["transparency"] = 2

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1944,11 +1944,7 @@ class Image:
 
         m_im = m_im.convert("L")
 
-        # Internally, we require 256 palette entries.
-        new_palette_bytes = (
-            palette_bytes + ((256 * bands) - len(palette_bytes)) * b"\x00"
-        )
-        m_im.putpalette(new_palette_bytes, palette_mode)
+        m_im.putpalette(palette_bytes, palette_mode)
         m_im.palette = ImagePalette.ImagePalette(palette_mode, palette=palette_bytes)
 
         if "transparency" in self.info:


### PR DESCRIPTION
In `remap_palette()`, there is the following code.
https://github.com/python-pillow/Pillow/blob/ad7be550aa539dc4c79da928dad071cf0150b731/src/PIL/Image.py#L1947-L1950

Testing prior versions of Pillow, I can't find a time when the tests failed without this code, but the fact that #6060 contained a commit entitled "[Allow getpalette() to return less than 256 colors](https://github.com/python-pillow/Pillow/pull/6060/commits/948c064b282f80492f5b88d3f06a599b76516edf)" indicates to me that this requirement has been removed.