### PR TITLE
Fixed GIF remapping to palette with duplicate entries

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1087,6 +1087,19 @@ def test_palette_save_P(tmp_path):
         assert_image_equal(reloaded, im)
 
 
+def test_palette_save_duplicate_entries(tmp_path):
+    im = Image.new("P", (1, 2))
+    im.putpixel((0, 1), 1)
+
+    im.putpalette((0, 0, 0, 0, 0, 0))
+
+    out = str(tmp_path / "temp.gif")
+    im.save(out, palette=[0, 0, 0, 0, 0, 0, 1, 1, 1])
+
+    with Image.open(out) as reloaded:
+        assert reloaded.convert("RGB").getpixel((0, 1)) == (0, 0, 0)
+
+
 def test_palette_save_all_P(tmp_path):
     frames = []
     colors = ((255, 0, 0), (0, 255, 0))

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -523,6 +523,8 @@ def _normalize_palette(im, palette, info):
                 index = im.palette.colors[source_color]
             except KeyError:
                 index = None
+            if index in used_palette_colors:
+                index = None
             used_palette_colors.append(index)
         for i, index in enumerate(used_palette_colors):
             if index is None:

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -519,10 +519,7 @@ def _normalize_palette(im, palette, info):
         used_palette_colors = []
         for i in range(0, len(source_palette), 3):
             source_color = tuple(source_palette[i : i + 3])
-            try:
-                index = im.palette.colors[source_color]
-            except KeyError:
-                index = None
+            index = im.palette.colors.get(source_color)
             if index in used_palette_colors:
                 index = None
             used_palette_colors.append(index)


### PR DESCRIPTION
Addresses #6389

`remap_palette` cannot map multiple palette indexes to the same output index, by its very definition. It accepts a list of palette indexes that it transforms to the position in the list. There cannot be more than one palette index at a given position in the list.

If a palette is supplied when saving a GIF image, `im.save("out.gif", palette=...)`, and that palette has duplicate entries, then the following GifImagePlugin code will try to prepare a list that maps the first of the duplicated entries to multiple locations, leaving the rest of the duplicate entries to be not strictly defined in the behaviour of `remap_palette`.
https://github.com/python-pillow/Pillow/blob/ad7be550aa539dc4c79da928dad071cf0150b731/src/PIL/GifImagePlugin.py#L519-L526

This PR fixes that, by leaving the duplicated indexes as they are - setting `index` to `None`, the next loop in GifImagePlugin
https://github.com/python-pillow/Pillow/blob/ad7be550aa539dc4c79da928dad071cf0150b731/src/PIL/GifImagePlugin.py#L527-L532

will tell `remap_palette` to map the index to itself, leaving it untouched.

