### PR TITLE
Removed support for Python versions before interpaddr()

### DIFF
--- a/src/PIL/ImageTk.py
+++ b/src/PIL/ImageTk.py
@@ -68,21 +68,18 @@ def _pyimagingtkcall(command, photo, id):
         # may raise an error if it cannot attach to Tkinter
         from . import _imagingtk
 
-        try:
-            if hasattr(tk, "interp"):
-                # Required for PyPy, which always has CFFI installed
-                from cffi import FFI
+        if hasattr(tk, "interp"):
+            # Required for PyPy, which always has CFFI installed
+            from cffi import FFI
 
-                ffi = FFI()
+            ffi = FFI()
 
-                # PyPy is using an FFI CDATA element
-                # (Pdb) self.tk.interp
-                #  <cdata 'Tcl_Interp *' 0x3061b50>
-                _imagingtk.tkinit(int(ffi.cast("uintptr_t", tk.interp)), 1)
-            else:
-                _imagingtk.tkinit(tk.interpaddr(), 1)
-        except AttributeError:
-            _imagingtk.tkinit(id(tk), 0)
+            # PyPy is using an FFI CDATA element
+            # (Pdb) self.tk.interp
+            #  <cdata 'Tcl_Interp *' 0x3061b50>
+            _imagingtk.tkinit(int(ffi.cast("uintptr_t", tk.interp)))
+        else:
+            _imagingtk.tkinit(tk.interpaddr())
         tk.call(command, photo, id)
 
 

--- a/src/_imagingtk.c
+++ b/src/_imagingtk.c
@@ -23,33 +23,16 @@ TkImaging_Init(Tcl_Interp *interp);
 extern int
 load_tkinter_funcs(void);
 
-/* copied from _tkinter.c (this isn't as bad as it may seem: for new
-   versions, we use _tkinter's interpaddr hook instead, and all older
-   versions use this structure layout) */
-
-typedef struct {
-    PyObject_HEAD Tcl_Interp *interp;
-} TkappObject;
-
 static PyObject *
 _tkinit(PyObject *self, PyObject *args) {
     Tcl_Interp *interp;
 
     PyObject *arg;
-    int is_interp;
-    if (!PyArg_ParseTuple(args, "Oi", &arg, &is_interp)) {
+    if (!PyArg_ParseTuple(args, "O", &arg)) {
         return NULL;
     }
 
-    if (is_interp) {
-        interp = (Tcl_Interp *)PyLong_AsVoidPtr(arg);
-    } else {
-        TkappObject *app;
-        /* Do it the hard way.  This will break if the TkappObject
-        layout changes */
-        app = (TkappObject *)PyLong_AsVoidPtr(arg);
-        interp = app->interp;
-    }
+    interp = (Tcl_Interp *)PyLong_AsVoidPtr(arg);
 
     /* This will bomb if interp is invalid... */
     TkImaging_Init(interp);


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/ad7be550aa539dc4c79da928dad071cf0150b731/src/_imagingtk.c#L26-L28

I saw "for new versions", and wondered how long this message has been there. It turns out, it has been there since the fork from PIL.

The code is used when ImageTk catches an AttributeError, which has also been present since the fork.

https://github.com/python-pillow/Pillow/blob/ad7be550aa539dc4c79da928dad071cf0150b731/src/PIL/ImageTk.py#L71-L85

`interpaddr()` added in Python 1.5.2. The last version of PIL supported Python 1.5.2, so it seems likely that the AttributeError catch was there for Python versions < 1.5.2.

We no longer support such early versions of Python, so this code can be removed.