### PR TITLE
Updated tested Windows environment list

### DIFF
--- a/winbuild/README.md
+++ b/winbuild/README.md
@@ -11,8 +11,8 @@ For more extensive info, see the [Windows build instructions](build.rst).
 * Requires Microsoft Visual Studio 2017 or newer with C++ component.
 * Requires NASM for libjpeg-turbo, a required dependency when using this script.
 * Requires CMake 3.12 or newer (available as Visual Studio component).
-* Tested on Windows Server 2016 with Visual Studio 2017 Community (AppVeyor).
-* Tested on Windows Server 2019 with Visual Studio 2019 Enterprise (GitHub Actions).
+* Tested on Windows Server 2016 with Visual Studio 2017 Community, and Windows Server 2019 with Visual Studio 2022 Community (AppVeyor).
+* Tested on Windows Server 2022 with Visual Studio 2022 Enterprise (GitHub Actions).
 
 The following is a simplified version of the script used on AppVeyor:
 ```


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/d6e59bc750c0649ed26fc71a83e86e17ea862ec3/.appveyor.yml#L13-L18

https://www.appveyor.com/docs/windows-images-software/ lists Visual Studio 2017 as running on Windows Server 2016 and Visual Studio 2022 as running on Windows Server 2019.

As for GitHub Actions, it runs [Microsoft Windows Server 2022](https://github.com/python-pillow/Pillow/runs/8087262799?check_suite_focus=true#step:1:3) and uses [Visual Studio 2022.](https://github.com/python-pillow/Pillow/runs/8087262799?check_suite_focus=true#step:22:24)