### PR TITLE
Removed support for PyPy before Python 3.6

### DIFF
--- a/src/PIL/ImageTk.py
+++ b/src/PIL/ImageTk.py
@@ -68,18 +68,7 @@ def _pyimagingtkcall(command, photo, id):
         # may raise an error if it cannot attach to Tkinter
         from . import _imagingtk
 
-        if hasattr(tk, "interp"):
-            # Required for PyPy, which always has CFFI installed
-            from cffi import FFI
-
-            ffi = FFI()
-
-            # PyPy is using an FFI CDATA element
-            # (Pdb) self.tk.interp
-            #  <cdata 'Tcl_Interp *' 0x3061b50>
-            _imagingtk.tkinit(int(ffi.cast("uintptr_t", tk.interp)))
-        else:
-            _imagingtk.tkinit(tk.interpaddr())
+        _imagingtk.tkinit(tk.interpaddr())
         tk.call(command, photo, id)
 
 


### PR DESCRIPTION
Continuing from https://github.com/python-pillow/Pillow/pull/6549, this PR removes support for old PyPy.

The function `interpaddr` was added to PyPy over 4 years ago: https://foss.heptapod.net/pypy/pypy/-/commit/8f15f623274f84bae5a4c3be914abb96b604a254

From the tags on that commit, I can see it was included in `release-pypy3.6-v7.0.0`, the [first Python 3.6 PyPy release](https://doc.pypy.org/en/latest/release-v7.0.0.html).
Since Python 3.5 is no longer supported by Pillow, the old code can be removed without deprecation.