### PR TITLE
Use constants in TiffImagePlugin

### DIFF
--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1153,7 +1153,7 @@ class TiffImageFile(ImageFile.ImageFile):
 
         :returns: XMP tags in a dictionary.
         """
-        return self._getxmp(self.tag_v2[700]) if 700 in self.tag_v2 else {}
+        return self._getxmp(self.tag_v2[XMP]) if XMP in self.tag_v2 else {}
 
     def get_photoshop_blocks(self):
         """
@@ -1328,7 +1328,7 @@ class TiffImageFile(ImageFile.ImageFile):
         logger.debug(f"- photometric_interpretation: {photo}")
         logger.debug(f"- planar_configuration: {self._planar_configuration}")
         logger.debug(f"- fill_order: {fillorder}")
-        logger.debug(f"- YCbCr subsampling: {self.tag.get(530)}")
+        logger.debug(f"- YCbCr subsampling: {self.tag.get(YCBCRSUBSAMPLING)}")
 
         # size
         xsize = int(self.tag_v2.get(IMAGEWIDTH))
@@ -1469,8 +1469,8 @@ class TiffImageFile(ImageFile.ImageFile):
             else:
                 # tiled image
                 offsets = self.tag_v2[TILEOFFSETS]
-                w = self.tag_v2.get(322)
-                h = self.tag_v2.get(323)
+                w = self.tag_v2.get(TILEWIDTH)
+                h = self.tag_v2.get(TILELENGTH)
 
             for offset in offsets:
                 if x + w > xsize:


### PR DESCRIPTION
Make further use of the constants at the beginning of TiffImagePlugin
https://github.com/python-pillow/Pillow/blob/196210bc804a4575b6cc0b1cb6c9b7b1f09e4ff9/src/PIL/TiffImagePlugin.py#L95-L110