### PR TITLE
Simplified enum references

### DIFF
--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -53,9 +53,9 @@ Functions
         To protect against potential DOS attacks caused by "`decompression bombs`_" (i.e. malicious files
         which decompress into a huge amount of data and are designed to crash or cause disruption by using up
         a lot of memory), Pillow will issue a ``DecompressionBombWarning`` if the number of pixels in an
-        image is over a certain limit, :py:data:`PIL.Image.MAX_IMAGE_PIXELS`.
+        image is over a certain limit, :py:data:`MAX_IMAGE_PIXELS`.
 
-        This threshold can be changed by setting :py:data:`PIL.Image.MAX_IMAGE_PIXELS`. It can be disabled
+        This threshold can be changed by setting :py:data:`MAX_IMAGE_PIXELS`. It can be disabled
         by setting ``Image.MAX_IMAGE_PIXELS = None``.
 
         If desired, the warning can be turned into an error with
@@ -63,7 +63,7 @@ Functions
         ``warnings.simplefilter('ignore', Image.DecompressionBombWarning)``. See also
         `the logging documentation`_ to have warnings output to the logging facility instead of stderr.
 
-        If the number of pixels is greater than twice :py:data:`PIL.Image.MAX_IMAGE_PIXELS`, then a
+        If the number of pixels is greater than twice :py:data:`MAX_IMAGE_PIXELS`, then a
         ``DecompressionBombError`` will be raised instead.
 
     .. _decompression bombs: https://en.wikipedia.org/wiki/Zip_bomb
@@ -255,7 +255,7 @@ This rotates the input image by ``theta`` degrees counter clockwise:
 .. automethod:: PIL.Image.Image.transform
 .. automethod:: PIL.Image.Image.transpose
 
-This flips the input image by using the :data:`PIL.Image.Transpose.FLIP_LEFT_RIGHT`
+This flips the input image by using the :data:`Transpose.FLIP_LEFT_RIGHT`
 method.
 
 .. code-block:: python

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1989,18 +1989,14 @@ class Image:
         :param size: The requested size in pixels, as a 2-tuple:
            (width, height).
         :param resample: An optional resampling filter.  This can be
-           one of :py:data:`PIL.Image.Resampling.NEAREST`,
-           :py:data:`PIL.Image.Resampling.BOX`,
-           :py:data:`PIL.Image.Resampling.BILINEAR`,
-           :py:data:`PIL.Image.Resampling.HAMMING`,
-           :py:data:`PIL.Image.Resampling.BICUBIC` or
-           :py:data:`PIL.Image.Resampling.LANCZOS`.
+           one of :py:data:`Resampling.NEAREST`, :py:data:`Resampling.BOX`,
+           :py:data:`Resampling.BILINEAR`, :py:data:`Resampling.HAMMING`,
+           :py:data:`Resampling.BICUBIC` or :py:data:`Resampling.LANCZOS`.
            If the image has mode "1" or "P", it is always set to
-           :py:data:`PIL.Image.Resampling.NEAREST`.
-           If the image mode specifies a number of bits, such as "I;16", then the
-           default filter is :py:data:`PIL.Image.Resampling.NEAREST`.
-           Otherwise, the default filter is
-           :py:data:`PIL.Image.Resampling.BICUBIC`. See: :ref:`concept-filters`.
+           :py:data:`Resampling.NEAREST`. If the image mode specifies a number
+           of bits, such as "I;16", then the default filter is
+           :py:data:`Resampling.NEAREST`. Otherwise, the default filter is
+           :py:data:`Resampling.BICUBIC`. See: :ref:`concept-filters`.
         :param box: An optional 4-tuple of floats providing
            the source image region to be scaled.
            The values must be within (0, 0, width, height) rectangle.
@@ -2140,12 +2136,12 @@ class Image:
 
         :param angle: In degrees counter clockwise.
         :param resample: An optional resampling filter.  This can be
-           one of :py:data:`PIL.Image.Resampling.NEAREST` (use nearest neighbour),
-           :py:data:`PIL.Image.BILINEAR` (linear interpolation in a 2x2
-           environment), or :py:data:`PIL.Image.Resampling.BICUBIC`
-           (cubic spline interpolation in a 4x4 environment).
-           If omitted, or if the image has mode "1" or "P", it is
-           set to :py:data:`PIL.Image.Resampling.NEAREST`. See :ref:`concept-filters`.
+           one of :py:data:`Resampling.NEAREST` (use nearest neighbour),
+           :py:data:`Resampling.BILINEAR` (linear interpolation in a 2x2
+           environment), or :py:data:`Resampling.BICUBIC` (cubic spline
+           interpolation in a 4x4 environment). If omitted, or if the image has
+           mode "1" or "P", it is set to :py:data:`Resampling.NEAREST`.
+           See :ref:`concept-filters`.
         :param expand: Optional expansion flag.  If true, expands the output
            image to make it large enough to hold the entire rotated image.
            If false or omitted, make the output image the same size as the
@@ -2452,14 +2448,11 @@ class Image:
 
         :param size: Requested size.
         :param resample: Optional resampling filter.  This can be one
-           of :py:data:`PIL.Image.Resampling.NEAREST`,
-           :py:data:`PIL.Image.Resampling.BOX`,
-           :py:data:`PIL.Image.Resampling.BILINEAR`,
-           :py:data:`PIL.Image.Resampling.HAMMING`,
-           :py:data:`PIL.Image.Resampling.BICUBIC` or
-           :py:data:`PIL.Image.Resampling.LANCZOS`.
-           If omitted, it defaults to :py:data:`PIL.Image.Resampling.BICUBIC`.
-           (was :py:data:`PIL.Image.Resampling.NEAREST` prior to version 2.5.0).
+           of :py:data:`Resampling.NEAREST`, :py:data:`Resampling.BOX`,
+           :py:data:`Resampling.BILINEAR`, :py:data:`Resampling.HAMMING`,
+           :py:data:`Resampling.BICUBIC` or :py:data:`Resampling.LANCZOS`.
+           If omitted, it defaults to :py:data:`Resampling.BICUBIC`.
+           (was :py:data:`Resampling.NEAREST` prior to version 2.5.0).
            See: :ref:`concept-filters`.
         :param reducing_gap: Apply optimization by resizing the image
            in two steps. First, reducing the image by integer times
@@ -2530,11 +2523,11 @@ class Image:
 
         :param size: The output size.
         :param method: The transformation method.  This is one of
-          :py:data:`PIL.Image.Transform.EXTENT` (cut out a rectangular subregion),
-          :py:data:`PIL.Image.Transform.AFFINE` (affine transform),
-          :py:data:`PIL.Image.Transform.PERSPECTIVE` (perspective transform),
-          :py:data:`PIL.Image.Transform.QUAD` (map a quadrilateral to a rectangle), or
-          :py:data:`PIL.Image.Transform.MESH` (map a number of source quadrilaterals
+          :py:data:`Transform.EXTENT` (cut out a rectangular subregion),
+          :py:data:`Transform.AFFINE` (affine transform),
+          :py:data:`Transform.PERSPECTIVE` (perspective transform),
+          :py:data:`Transform.QUAD` (map a quadrilateral to a rectangle), or
+          :py:data:`Transform.MESH` (map a number of source quadrilaterals
           in one operation).
 
           It may also be an :py:class:`~PIL.Image.ImageTransformHandler`
@@ -2554,11 +2547,11 @@ class Image:
                     return method, data
         :param data: Extra data to the transformation method.
         :param resample: Optional resampling filter.  It can be one of
-           :py:data:`PIL.Image.Resampling.NEAREST` (use nearest neighbour),
-           :py:data:`PIL.Image.Resampling.BILINEAR` (linear interpolation in a 2x2
-           environment), or :py:data:`PIL.Image.BICUBIC` (cubic spline
+           :py:data:`Resampling.NEAREST` (use nearest neighbour),
+           :py:data:`Resampling.BILINEAR` (linear interpolation in a 2x2
+           environment), or :py:data:`Resampling.BICUBIC` (cubic spline
            interpolation in a 4x4 environment). If omitted, or if the image
-           has mode "1" or "P", it is set to :py:data:`PIL.Image.Resampling.NEAREST`.
+           has mode "1" or "P", it is set to :py:data:`Resampling.NEAREST`.
            See: :ref:`concept-filters`.
         :param fill: If ``method`` is an
           :py:class:`~PIL.Image.ImageTransformHandler` object, this is one of
@@ -2685,13 +2678,10 @@ class Image:
         """
         Transpose image (flip or rotate in 90 degree steps)
 
-        :param method: One of :py:data:`PIL.Image.Transpose.FLIP_LEFT_RIGHT`,
-          :py:data:`PIL.Image.Transpose.FLIP_TOP_BOTTOM`,
-          :py:data:`PIL.Image.Transpose.ROTATE_90`,
-          :py:data:`PIL.Image.Transpose.ROTATE_180`,
-          :py:data:`PIL.Image.Transpose.ROTATE_270`,
-          :py:data:`PIL.Image.Transpose.TRANSPOSE` or
-          :py:data:`PIL.Image.Transpose.TRANSVERSE`.
+        :param method: One of :py:data:`Transpose.FLIP_LEFT_RIGHT`,
+          :py:data:`Transpose.FLIP_TOP_BOTTOM`, :py:data:`Transpose.ROTATE_90`,
+          :py:data:`Transpose.ROTATE_180`, :py:data:`Transpose.ROTATE_270`,
+          :py:data:`Transpose.TRANSPOSE` or :py:data:`Transpose.TRANSVERSE`.
         :returns: Returns a flipped or rotated copy of this image.
         """
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/6491#issuecomment-1211674455 points out that https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.convert refers to `Dither.NONE`, while https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.resize refers to `PIL.Image.Resampling.BOX`.

To be consistent, this PR removes the `PIL.Image.` prefix. This is the opposite of #6491, which adds the prefix.