### PR TITLE
Apply transparency to P images in ImageTk.PhotoImage

### DIFF
--- a/Tests/test_imagetk.py
+++ b/Tests/test_imagetk.py
@@ -69,6 +69,13 @@ def test_photoimage():
         assert_image_equal(reloaded, im.convert("RGBA"))
 
 
+def test_photoimage_apply_transparency():
+    with Image.open("Tests/images/pil123p.png") as im:
+        im_tk = ImageTk.PhotoImage(im)
+        reloaded = ImageTk.getimage(im_tk)
+        assert_image_equal(reloaded, im.convert("RGBA"))
+
+
 def test_photoimage_blank():
     # test a image using mode/size:
     for mode in TK_MODES:

--- a/src/PIL/ImageTk.py
+++ b/src/PIL/ImageTk.py
@@ -107,6 +107,7 @@ class PhotoImage:
             mode = image.mode
             if mode == "P":
                 # palette mapped data
+                image.apply_transparency()
                 image.load()
                 try:
                     mode = image.palette.mode


### PR DESCRIPTION
Resolves #6558

Runs [`apply_transparency()`](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.apply_transparency) on P mode images when passing them to `tkinter.PhotoImage`. This will move the transparency from `info` into the palette in a P mode image, so that tkinter can understand the transparency information.