### PR TITLE
Defer parsing of palette into colors

### DIFF
--- a/src/PIL/ImagePalette.py
+++ b/src/PIL/ImagePalette.py
@@ -50,15 +50,24 @@ class ImagePalette:
 
     @palette.setter
     def palette(self, palette):
+        self._colors = None
         self._palette = palette
 
-        mode_len = len(self.mode)
-        self.colors = {}
-        for i in range(0, len(self.palette), mode_len):
-            color = tuple(self.palette[i : i + mode_len])
-            if color in self.colors:
-                continue
-            self.colors[color] = i // mode_len
+    @property
+    def colors(self):
+        if self._colors is None:
+            mode_len = len(self.mode)
+            self._colors = {}
+            for i in range(0, len(self.palette), mode_len):
+                color = tuple(self.palette[i : i + mode_len])
+                if color in self._colors:
+                    continue
+                self._colors[color] = i // mode_len
+        return self._colors
+
+    @colors.setter
+    def colors(self, colors):
+        self._colors = colors
 
     def copy(self):
         new = ImagePalette()


### PR DESCRIPTION
Addresses #6561

The discussion points out that `Image.fromarray(a, "P")` is slower than `Image.fromarray(a, "L")`. The difference is that when [`fromarray` calls `frombuffer`](https://github.com/python-pillow/Pillow/blob/d843759ca9e0295032c5123508798cfdc9aaf6ce/src/PIL/Image.py#L2974), for P mode [an ImagePalette instance is created](https://github.com/python-pillow/Pillow/blob/d843759ca9e0295032c5123508798cfdc9aaf6ce/src/PIL/Image.py#L2894-L2897). Once ImagePalette [assigns the initial palette](https://github.com/python-pillow/Pillow/blob/d843759ca9e0295032c5123508798cfdc9aaf6ce/src/PIL/ImagePalette.py#L40), it [parses the palette into a `colors` dictionary.](https://github.com/python-pillow/Pillow/blob/d843759ca9e0295032c5123508798cfdc9aaf6ce/src/PIL/ImagePalette.py#L56-L61) This parsing is the main difference in speed.

I'm not convinced that `Image.fromarray(a, "P")` is a common enough to warrant speed optimization. However, the parsing of the initial ImagePalette palette string would be an operation shared through all P mode images, and depending on the series of operations from the user, `colors` is not necessarily used afterwards.

This PR defers the parsing of the palette into colors until the `colors` attribute is accessed.