### PR TITLE
Move some static config to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,11 @@ project_urls =
     Twitter=https://twitter.com/PythonPillow
 
 [options]
+packages = PIL
 python_requires = >=3.7
+include_package_data = True
+package_dir =
+    = src
 
 [options.extras_require]
 docs =

--- a/setup.py
+++ b/setup.py
@@ -999,9 +999,6 @@ try:
         version=PILLOW_VERSION,
         cmdclass={"build_ext": pil_build_ext},
         ext_modules=ext_modules,
-        include_package_data=True,
-        packages=["PIL"],
-        package_dir={"": "src"},
         zip_safe=not (debug_build() or PLATFORM_MINGW),
     )
 except RequiredDependencyException as err:


### PR DESCRIPTION
Follow on from https://github.com/python-pillow/Pillow/pull/5784 to use declarative package configuration.

Changes proposed in this pull request:

 * Converted with https://github.com/gvalkov/setuptools-py2cfg
 * Formatted with https://github.com/asottile/setup-cfg-fmt
