### PR TITLE
Corrected BMP palette size when saving

### DIFF
--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -58,6 +58,18 @@ def test_save_to_bytes():
         assert reloaded.format == "BMP"
 
 
+def test_small_palette(tmp_path):
+    im = Image.new("P", (1, 1))
+    colors = [0, 0, 0, 125, 125, 125, 255, 255, 255]
+    im.putpalette(colors)
+
+    out = str(tmp_path / "temp.bmp")
+    im.save(out)
+
+    with Image.open(out) as reloaded:
+        assert reloaded.getpalette() == colors
+
+
 def test_save_too_large(tmp_path):
     outfile = str(tmp_path / "temp.bmp")
     with Image.new("RGB", (1, 1)) as im:

--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -375,6 +375,16 @@ def _save(im, fp, filename, bitmap_header=True):
     header = 40  # or 64 for OS/2 version 2
     image = stride * im.size[1]
 
+    if im.mode == "1":
+        palette = b"".join(o8(i) * 4 for i in (0, 255))
+    elif im.mode == "L":
+        palette = b"".join(o8(i) * 4 for i in range(256))
+    elif im.mode == "P":
+        palette = im.im.getpalette("RGB", "BGRX")
+        colors = len(palette) // 4
+    else:
+        palette = None
+
     # bitmap header
     if bitmap_header:
         offset = 14 + header + colors * 4
@@ -405,14 +415,8 @@ def _save(im, fp, filename, bitmap_header=True):
 
     fp.write(b"\0" * (header - 40))  # padding (for OS/2 format)
 
-    if im.mode == "1":
-        for i in (0, 255):
-            fp.write(o8(i) * 4)
-    elif im.mode == "L":
-        for i in range(256):
-            fp.write(o8(i) * 4)
-    elif im.mode == "P":
-        fp.write(im.im.getpalette("RGB", "BGRX"))
+    if palette:
+        fp.write(palette)
 
     ImageFile._save(im, fp, [("raw", (0, 0) + im.size, 0, (rawmode, stride, -1))])
 


### PR DESCRIPTION
Resolves #6572

#6060 contained a commit entitled "[Allow getpalette() to return less than 256 colors](https://github.com/python-pillow/Pillow/pull/6060/commits/948c064b282f80492f5b88d3f06a599b76516edf)"

That meant that when saving BMP images, the palette might be smaller than 256 colors. However, BmpImagePlugin always specifics the number of colors in the palette as 256 for P images.

This PR changes it to match the length of the palette.