### PR TITLE
Pad IM palette to 768 bytes when saving

### DIFF
--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -86,6 +86,18 @@ def test_roundtrip(mode, tmp_path):
     assert_image_equal_tofile(im, out)
 
 
+def test_small_palette(tmp_path):
+    im = Image.new("P", (1, 1))
+    colors = [0, 1, 2]
+    im.putpalette(colors)
+
+    out = str(tmp_path / "temp.im")
+    im.save(out)
+
+    with Image.open(out) as reloaded:
+        assert reloaded.getpalette() == colors + [0] * 765
+
+
 def test_save_unsupported_mode(tmp_path):
     out = str(tmp_path / "temp.im")
     im = hopper("HSV")

--- a/src/PIL/ImImagePlugin.py
+++ b/src/PIL/ImImagePlugin.py
@@ -352,7 +352,13 @@ def _save(im, fp, filename):
         fp.write(b"Lut: 1\r\n")
     fp.write(b"\000" * (511 - fp.tell()) + b"\032")
     if im.mode in ["P", "PA"]:
-        fp.write(im.im.getpalette("RGB", "RGB;L"))  # 768 bytes
+        im_palette = im.im.getpalette("RGB", "RGB;L")
+        colors = len(im_palette) // 3
+        palette = b""
+        for i in range(3):
+            palette += im_palette[colors * i : colors * (i + 1)]
+            palette += b"\x00" * (256 - colors)
+        fp.write(palette)  # 768 bytes
     ImageFile._save(im, fp, [("raw", (0, 0) + im.size, 0, (rawmode, 0, -1))])
 
 


### PR DESCRIPTION
#6060 contained a commit entitled "[Allow getpalette() to return less than 256 colors](https://github.com/python-pillow/Pillow/pull/6060/commits/948c064b282f80492f5b88d3f06a599b76516edf)"

This meant that there were fewer bytes when saving in IM.
https://github.com/python-pillow/Pillow/blob/1d1a22bde37baaf162f4dd26e7b94cd96d3116a2/src/PIL/ImImagePlugin.py#L355

But IM still expected 768 bytes when reading.
https://github.com/python-pillow/Pillow/blob/1d1a22bde37baaf162f4dd26e7b94cd96d3116a2/src/PIL/ImImagePlugin.py#L220

So this PR pads the palette to 768 bytes when saving.