### PR TITLE
Removed EXIF prefix when saving WebP

### DIFF
--- a/Tests/test_file_webp_metadata.py
+++ b/Tests/test_file_webp_metadata.py
@@ -55,9 +55,7 @@ def test_write_exif_metadata():
     test_buffer.seek(0)
     with Image.open(test_buffer) as webp_image:
         webp_exif = webp_image.info.get("exif", None)
-    assert webp_exif
-    if webp_exif:
-        assert webp_exif == expected_exif, "WebP EXIF didn't match"
+    assert webp_exif == expected_exif[6:], "WebP EXIF didn't match"
 
 
 def test_read_icc_profile():

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -311,9 +311,11 @@ def _save(im, fp, filename):
     lossless = im.encoderinfo.get("lossless", False)
     quality = im.encoderinfo.get("quality", 80)
     icc_profile = im.encoderinfo.get("icc_profile") or ""
-    exif = im.encoderinfo.get("exif", "")
+    exif = im.encoderinfo.get("exif", b"")
     if isinstance(exif, Image.Exif):
         exif = exif.tobytes()
+    if exif.startswith(b"Exif\x00\x00"):
+        exif = exif[6:]
     xmp = im.encoderinfo.get("xmp", "")
     method = im.encoderinfo.get("method", 4)
 


### PR DESCRIPTION
Resolves #6580

As seen before in #4677, WebP images do not require the `b"Exif\x00\x00"` prefix in their EXIF data.

This PR removes it when saving, for the sake of creating smaller files.