### PR TITLE
Add inverse mappings for exif tags

### DIFF
--- a/docs/reference/ExifTags.rst
+++ b/docs/reference/ExifTags.rst
@@ -4,25 +4,45 @@
 :py:mod:`~PIL.ExifTags` Module
 ==============================
 
-The :py:mod:`~PIL.ExifTags` module exposes two dictionaries which
+The :py:mod:`~PIL.ExifTags` module exposes four dictionaries which
 provide constants and clear-text names for various well-known EXIF tags.
 
 .. py:data:: TAGS
     :type: dict
 
-    The TAG dictionary maps 16-bit integer EXIF tag enumerations to
-    descriptive string names.  For instance:
+    The TAGS dictionary maps 16-bit integer EXIF tag enumerations to
+    descriptive string names. For instance:
 
         >>> from PIL.ExifTags import TAGS
         >>> TAGS[0x010e]
         'ImageDescription'
+        
+.. py:data:: TAG_CODES
+    :type: dict
+
+    The TAG_CODES dictionary maps descriptive string names to 16-bit integer EXIF
+    tag enumerations. For instance:
+
+        >>> from PIL.ExifTags import TAG_CODES
+        >>> TAG_CODES['ImageDescription']
+        0x010e
 
 .. py:data:: GPSTAGS
     :type: dict
 
     The GPSTAGS dictionary maps 8-bit integer EXIF gps enumerations to
-    descriptive string names.  For instance:
+    descriptive string names. For instance:
 
         >>> from PIL.ExifTags import GPSTAGS
         >>> GPSTAGS[20]
         'GPSDestLatitude'
+        
+.. py:data:: GPS_CODES
+    :type: dict
+
+    The GPS_CODES dictionary maps descriptive string names to 8-bit integer EXIF
+    gps enumerations. For instance:
+
+        >>> from PIL.ExifTags import GPSTAGS
+        >>> GPS_CODES['GPSDestLatitude']
+        20

--- a/docs/reference/ExifTags.rst
+++ b/docs/reference/ExifTags.rst
@@ -16,7 +16,7 @@ provide constants and clear-text names for various well-known EXIF tags.
         >>> from PIL.ExifTags import TAGS
         >>> TAGS[0x010e]
         'ImageDescription'
-        
+
 .. py:data:: TAG_CODES
     :type: dict
 
@@ -36,7 +36,7 @@ provide constants and clear-text names for various well-known EXIF tags.
         >>> from PIL.ExifTags import GPSTAGS
         >>> GPSTAGS[20]
         'GPSDestLatitude'
-        
+
 .. py:data:: GPS_CODES
     :type: dict
 

--- a/src/PIL/ExifTags.py
+++ b/src/PIL/ExifTags.py
@@ -293,6 +293,11 @@ TAGS = {
 }
 """Maps EXIF tags to tag names."""
 
+TAG_CODES = {
+    # possibly incomplete
+    tag_name: tag_code for tag_code, tag_name in TAGS.items()
+}
+"""Maps tag names to EXIF tags."""
 
 GPSTAGS = {
     0: "GPSVersionID",
@@ -329,3 +334,6 @@ GPSTAGS = {
     31: "GPSHPositioningError",
 }
 """Maps EXIF GPS tags to tag names."""
+
+GPS_CODES = {gps_name: gps_code for gps_code, gps_name in GPSTAGS.items()}
+"""Maps tag names to EXIF GPS tags."""

--- a/src/PIL/ExifTags.py
+++ b/src/PIL/ExifTags.py
@@ -295,7 +295,8 @@ TAGS = {
 
 TAG_CODES = {
     # possibly incomplete
-    tag_name: tag_code for tag_code, tag_name in TAGS.items()
+    tag_name: tag_code
+    for tag_code, tag_name in TAGS.items()
 }
 """Maps tag names to EXIF tags."""
 


### PR DESCRIPTION
A nicer solution would be to switch to an enum with the right values, but this is the quick win.

Tested locally, ran through pycodestyle. To me it seems the code is trivial enough to not warrant adding a unit test.