### PR TITLE
If first GIF frame has transparency for RGB_ALWAYS loading strategy, use RGBA mode

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -84,17 +84,24 @@ def test_l_mode_transparency():
 
 
 def test_strategy():
+    with Image.open("Tests/images/iss634.gif") as im:
+        expected_rgb_always = im.convert("RGB")
+
     with Image.open("Tests/images/chi.gif") as im:
-        expected_zero = im.convert("RGB")
+        expected_rgb_always_rgba = im.convert("RGBA")
 
         im.seek(1)
-        expected_one = im.convert("RGB")
+        expected_different = im.convert("RGB")
 
     try:
         GifImagePlugin.LOADING_STRATEGY = GifImagePlugin.LoadingStrategy.RGB_ALWAYS
-        with Image.open("Tests/images/chi.gif") as im:
+        with Image.open("Tests/images/iss634.gif") as im:
             assert im.mode == "RGB"
-            assert_image_equal(im, expected_zero)
+            assert_image_equal(im, expected_rgb_always)
+
+        with Image.open("Tests/images/chi.gif") as im:
+            assert im.mode == "RGBA"
+            assert_image_equal(im, expected_rgb_always_rgba)
 
         GifImagePlugin.LOADING_STRATEGY = (
             GifImagePlugin.LoadingStrategy.RGB_AFTER_DIFFERENT_PALETTE_ONLY
@@ -105,7 +112,7 @@ def test_strategy():
 
             im.seek(1)
             assert im.mode == "P"
-            assert_image_equal(im.convert("RGB"), expected_one)
+            assert_image_equal(im.convert("RGB"), expected_different)
 
         # Change to RGB mode when a frame has an individual palette
         with Image.open("Tests/images/iss634.gif") as im:

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -299,11 +299,13 @@ class GifImageFile(ImageFile.ImageFile):
             self.im.paste(self.dispose, self.dispose_extent)
 
         self._frame_palette = palette or self.global_palette
+        self._frame_transparency = frame_transparency
         if frame == 0:
             if self._frame_palette:
-                self.mode = (
-                    "RGB" if LOADING_STRATEGY == LoadingStrategy.RGB_ALWAYS else "P"
-                )
+                if LOADING_STRATEGY == LoadingStrategy.RGB_ALWAYS:
+                    self.mode = "RGBA" if frame_transparency is not None else "RGB"
+                else:
+                    self.mode = "P"
             else:
                 self.mode = "L"
 
@@ -313,7 +315,6 @@ class GifImageFile(ImageFile.ImageFile):
                 palette = copy(self.global_palette)
             self.palette = palette
         else:
-            self._frame_transparency = frame_transparency
             if self.mode == "P":
                 if (
                     LOADING_STRATEGY != LoadingStrategy.RGB_AFTER_DIFFERENT_PALETTE_ONLY
@@ -386,7 +387,8 @@ class GifImageFile(ImageFile.ImageFile):
             transparency = -1
             if frame_transparency is not None:
                 if frame == 0:
-                    self.info["transparency"] = frame_transparency
+                    if LOADING_STRATEGY != LoadingStrategy.RGB_ALWAYS:
+                        self.info["transparency"] = frame_transparency
                 elif self.mode not in ("RGB", "RGBA"):
                     transparency = frame_transparency
             self.tile = [
@@ -410,9 +412,9 @@ class GifImageFile(ImageFile.ImageFile):
         temp_mode = "P" if self._frame_palette else "L"
         self._prev_im = None
         if self.__frame == 0:
-            if "transparency" in self.info:
+            if self._frame_transparency is not None:
                 self.im = Image.core.fill(
-                    temp_mode, self.size, self.info["transparency"]
+                    temp_mode, self.size, self._frame_transparency
                 )
         elif self.mode in ("RGB", "RGBA"):
             self._prev_im = self.im
@@ -429,8 +431,12 @@ class GifImageFile(ImageFile.ImageFile):
     def load_end(self):
         if self.__frame == 0:
             if self.mode == "P" and LOADING_STRATEGY == LoadingStrategy.RGB_ALWAYS:
-                self.mode = "RGB"
-                self.im = self.im.convert("RGB", Image.Dither.FLOYDSTEINBERG)
+                if self._frame_transparency is not None:
+                    self.im.putpalettealpha(self._frame_transparency, 0)
+                    self.mode = "RGBA"
+                else:
+                    self.mode = "RGB"
+                self.im = self.im.convert(self.mode, Image.Dither.FLOYDSTEINBERG)
             return
         if self.mode == "P" and self._prev_im:
             if self._frame_transparency is not None:


### PR DESCRIPTION
Resolves #6590 

At the moment, the first frame of a GIF is never RGBA.
https://github.com/python-pillow/Pillow/blob/b8d96246f71753cbd8aaafc6dc633cad3aad0317/src/PIL/GifImagePlugin.py#L302-L308

This PR changes it to be RGBA if there is transparency and `LoadingStrategy.RGB_ALWAYS` is used. In that situation, `transparency` should not be set in the `info` dictionary, because the transparency is a palette index, and the image is in RGBA mode.