### PR TITLE
Corrected dictionary name

### DIFF
--- a/docs/reference/ExifTags.rst
+++ b/docs/reference/ExifTags.rst
@@ -10,7 +10,7 @@ provide constants and clear-text names for various well-known EXIF tags.
 .. py:data:: TAGS
     :type: dict
 
-    The TAG dictionary maps 16-bit integer EXIF tag enumerations to
+    The TAGS dictionary maps 16-bit integer EXIF tag enumerations to
     descriptive string names.  For instance:
 
         >>> from PIL.ExifTags import TAGS


### PR DESCRIPTION
I think #6586 is a topic for debate, so this PR copies a straightforward correction from it so that it can be merged at least.

There is no `TAG` dictionary in ExifTags.py. Only `TAGS`.
https://github.com/python-pillow/Pillow/blob/b8d96246f71753cbd8aaafc6dc633cad3aad0317/src/PIL/ExifTags.py#L18