### PR TITLE
Improved palette handling in ImageOps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog (Pillow)
 9.3.0 (unreleased)
 ------------------
 
+- Corrected BMP and TGA palette size when saving #6500
+  [radarhere]
+
 - Do not call load() before draft() in Image.thumbnail #6539
   [radarhere]
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -293,7 +293,7 @@ def pad(image, size, method=Image.Resampling.BICUBIC, color=None, centering=(0.5
         out = Image.new(image.mode, size, color)
         palette = image.palette.copy()
         if palette:
-            out.putpalette(palette.palette)
+            out.putpalette(palette)
         if resized.width != size[0]:
             x = int((size[0] - resized.width) * max(0, min(centering[0], 1)))
             out.paste(resized, (x, 0))

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -291,6 +291,9 @@ def pad(image, size, method=Image.Resampling.BICUBIC, color=None, centering=(0.5
         out = resized
     else:
         out = Image.new(image.mode, size, color)
+        palette = image.palette.copy()
+        if palette:
+            out.putpalette(palette.palette)
         if resized.width != size[0]:
             x = int((size[0] - resized.width) * max(0, min(centering[0], 1)))
             out.paste(resized, (x, 0))


### PR DESCRIPTION
Resolves #6595

This pull request fix `ImageOps.pad` method. In previous version of this method it doesn't copy the palette, and whats why it might change the image to full black image.

Changes proposed in this pull request:

 * Add copy origin image palette to pad image.
