### PR TITLE
Add OpenSSF Best Practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ As of 2019, Pillow development is
             <a href="https://pypi.org/project/Pillow/"><img
                 alt="Number of PyPI downloads"
                 src="https://img.shields.io/pypi/dm/pillow.svg"></a>
+            <a href="https://bestpractices.coreinfrastructure.org/projects/6331"><img
+                alt="OpenSSF Best Practices"
+                src="https://bestpractices.coreinfrastructure.org/projects/6331/badge"></a>
         </td>
     </tr>
     <tr>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,10 @@ Pillow for enterprise is available via the Tidelift Subscription. `Learn more <h
    :target: https://pypi.org/project/Pillow/
    :alt: Number of PyPI downloads
 
+.. image:: https://bestpractices.coreinfrastructure.org/projects/6331/badge
+   :target: https://bestpractices.coreinfrastructure.org/projects/6331
+   :alt: OpenSSF Best Practices
+
 Overview
 ========
 


### PR DESCRIPTION
I started filling out the sections at https://bestpractices.coreinfrastructure.org/en/projects/6331 and we're currently at 76%:

![image](https://user-images.githubusercontent.com/1324225/190963369-428c2366-bed2-4024-bfaa-6227e9652ebf.png)

Still some more to check, but we can already add the badge:

![image](https://user-images.githubusercontent.com/1324225/190963328-44842e26-07e8-4c66-8796-0ea0813480b0.png)

# Preview

## README

![image](https://user-images.githubusercontent.com/1324225/190963560-61af15c3-dc79-4e1f-93f0-3496a28d813b.png)

https://github.com/hugovk/Pillow/tree/add-openssf-best-practices-badge

## Docs

![image](https://user-images.githubusercontent.com/1324225/190963528-3acead22-c174-4637-89ae-b46696511bbf.png)

https://pillow--6597.org.readthedocs.build/en/6597/