### PR TITLE
Show all frames in ImageShow

### DIFF
--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -136,7 +136,7 @@ class WindowsViewer(Viewer):
     """The default viewer on Windows is the default system application for PNG files."""
 
     format = "PNG"
-    options = {"compress_level": 1}
+    options = {"compress_level": 1, "save_all": True}
 
     def get_command(self, file, **options):
         return (
@@ -154,7 +154,7 @@ class MacViewer(Viewer):
     """The default viewer on macOS using ``Preview.app``."""
 
     format = "PNG"
-    options = {"compress_level": 1}
+    options = {"compress_level": 1, "save_all": True}
 
     def get_command(self, file, **options):
         # on darwin open returns immediately resulting in the temp
@@ -197,7 +197,7 @@ if sys.platform == "darwin":
 
 class UnixViewer(Viewer):
     format = "PNG"
-    options = {"compress_level": 1}
+    options = {"compress_level": 1, "save_all": True}
 
     def get_command(self, file, **options):
         command = self.get_command_ex(file, **options)[0]


### PR DESCRIPTION
Helps #6608

The issue requests that multiple frames be displayed when using ImageShow. This PR adds the `save_all` argument.