### PR TITLE
Ensure dependencies are installed when building docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,6 @@ jobs:
     - name: Docs
       if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == 3.10
       run: |
-        python3 -m pip install furo sphinx-copybutton sphinx-issues sphinx-removed-in sphinxext-opengraph
         make doccheck
 
     - name: After success

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ coverage:
 .PHONY: doc
 doc:
 	python3 -c "import PIL" > /dev/null 2>&1 || python3 -m pip install .
-	python3 -c "import olefile" > /dev/null 2>&1 || python3 -m pip install olefile
 	$(MAKE) -C docs html
 
 .PHONY: doccheck

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,13 @@ coverage:
 
 .PHONY: doc
 doc:
+	python3 -c "import PIL" > /dev/null 2>&1 || python3 -m pip install .
+	python3 -c "import olefile" > /dev/null 2>&1 || python3 -m pip install olefile
 	$(MAKE) -C docs html
 
 .PHONY: doccheck
 doccheck:
-	$(MAKE) -C docs html
+	$(MAKE) doc
 # Don't make our tests rely on the links in the docs being up every single build.
 # We don't control them.  But do check, and update them to the target of their redirects.
 	$(MAKE) -C docs linkcheck || true

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -44,6 +44,10 @@ clean:
 
 install-sphinx:
 	$(PYTHON) -c "import sphinx" > /dev/null 2>&1 || $(PYTHON) -m pip install sphinx
+	$(PYTHON) -c "import sphinx_copybutton" > /dev/null 2>&1 || $(PYTHON) -m pip install sphinx-copybutton
+	$(PYTHON) -c "import sphinx_issues" > /dev/null 2>&1 || $(PYTHON) -m pip install sphinx-issues
+	$(PYTHON) -c "import sphinx_removed_in" > /dev/null 2>&1 || $(PYTHON) -m pip install sphinx-removed-in
+	$(PYTHON) -c "import sphinxext_opengraph" > /dev/null 2>&1 || $(PYTHON) -m pip install sphinxext-opengraph
 	$(PYTHON) -c "import furo" > /dev/null 2>&1 || $(PYTHON) -m pip install furo
 
 html:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -43,7 +43,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 install-sphinx:
-	$(PYTHON) -m pip install --quiet sphinx sphinx-copybutton sphinx-issues sphinx-removed-in sphinxext-opengraph furo
+	$(PYTHON) -m pip install --quiet sphinx sphinx-copybutton sphinx-issues sphinx-removed-in sphinxext-opengraph furo olefile
 
 html:
 	$(MAKE) install-sphinx

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -43,12 +43,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 install-sphinx:
-	$(PYTHON) -c "import sphinx" > /dev/null 2>&1 || $(PYTHON) -m pip install sphinx
-	$(PYTHON) -c "import sphinx_copybutton" > /dev/null 2>&1 || $(PYTHON) -m pip install sphinx-copybutton
-	$(PYTHON) -c "import sphinx_issues" > /dev/null 2>&1 || $(PYTHON) -m pip install sphinx-issues
-	$(PYTHON) -c "import sphinx_removed_in" > /dev/null 2>&1 || $(PYTHON) -m pip install sphinx-removed-in
-	$(PYTHON) -c "import sphinxext_opengraph" > /dev/null 2>&1 || $(PYTHON) -m pip install sphinxext-opengraph
-	$(PYTHON) -c "import furo" > /dev/null 2>&1 || $(PYTHON) -m pip install furo
+	$(PYTHON) -m pip install --quiet sphinx sphinx-copybutton sphinx-issues sphinx-removed-in sphinxext-opengraph furo
 
 html:
 	$(MAKE) install-sphinx


### PR DESCRIPTION
Moves the sphinx requirements from https://github.com/python-pillow/Pillow/blob/af8260ee5505642ff7d97ff7d53660ca9a609cab/.github/workflows/test.yml#L102 to https://github.com/python-pillow/Pillow/blob/af8260ee5505642ff7d97ff7d53660ca9a609cab/docs/Makefile#L45-L47 so that `make doc` can ensure that all of the dependencies are installed.

Also ensures that Pillow and olefile are installed, two more requirements for building the docs.