### PR TITLE
Updated redirected URLs

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -253,7 +253,7 @@ Support for FreeType 2.7 has been removed.
 We recommend upgrading to at least `FreeType`_ 2.10.4, which fixed a severe
 vulnerability introduced in FreeType 2.6 (:cve:`CVE-2020-15999`).
 
-.. _FreeType: https://www.freetype.org
+.. _FreeType: https://freetype.org/
 
 im.offset
 ~~~~~~~~~

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -184,7 +184,7 @@ Many of Pillow's features require external libraries:
     loads libfribidi at runtime if it is installed.
     On Windows this requires compiling FriBiDi and installing ``fribidi.dll``
     into a directory listed in the `Dynamic-Link Library Search Order (Microsoft Docs)
-    <https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#search-order-for-desktop-applications>`_
+    <https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#search-order-for-desktop-applications>`_
     (``fribidi-0.dll`` or ``libfribidi-0.dll`` are also detected).
     See `Build Options`_ to see how to build this version.
   * Previous versions of Pillow (5.0.0 to 8.1.2) linked libraqm dynamically at runtime.

--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -731,4 +731,4 @@ Methods
         homogeneous, but similar, colors.
 
 .. _BCP 47 language code: https://www.w3.org/International/articles/language-tags/
-.. _OpenType docs: https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist
+.. _OpenType docs: https://learn.microsoft.com/en-us/typography/opentype/spec/featurelist

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -338,7 +338,7 @@ class FreeTypeFont:
                          example '-liga' to disable ligatures or '-kern'
                          to disable kerning.  To get all supported
                          features, see
-                         https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist
+                         https://learn.microsoft.com/en-us/typography/opentype/spec/featurelist
                          Requires libraqm.
 
         :param language: Language of the text. Different languages may use
@@ -391,7 +391,7 @@ class FreeTypeFont:
                          example '-liga' to disable ligatures or '-kern'
                          to disable kerning.  To get all supported
                          features, see
-                         https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist
+                         https://learn.microsoft.com/en-us/typography/opentype/spec/featurelist
                          Requires libraqm.
 
         :param language: Language of the text. Different languages may use
@@ -456,7 +456,7 @@ class FreeTypeFont:
                          example '-liga' to disable ligatures or '-kern'
                          to disable kerning.  To get all supported
                          features, see
-                         https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist
+                         https://learn.microsoft.com/en-us/typography/opentype/spec/featurelist
                          Requires libraqm.
 
                          .. versionadded:: 4.2.0
@@ -520,7 +520,7 @@ class FreeTypeFont:
                          example '-liga' to disable ligatures or '-kern'
                          to disable kerning.  To get all supported
                          features, see
-                         https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist
+                         https://learn.microsoft.com/en-us/typography/opentype/spec/featurelist
                          Requires libraqm.
 
         :param language: Language of the text. Different languages may use
@@ -610,7 +610,7 @@ class FreeTypeFont:
                          example '-liga' to disable ligatures or '-kern'
                          to disable kerning.  To get all supported
                          features, see
-                         https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist
+                         https://learn.microsoft.com/en-us/typography/opentype/spec/featurelist
                          Requires libraqm.
 
                          .. versionadded:: 4.2.0
@@ -702,7 +702,7 @@ class FreeTypeFont:
                          example '-liga' to disable ligatures or '-kern'
                          to disable kerning.  To get all supported
                          features, see
-                         https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist
+                         https://learn.microsoft.com/en-us/typography/opentype/spec/featurelist
                          Requires libraqm.
 
                          .. versionadded:: 4.2.0

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -24,7 +24,7 @@
  *
  * This cast is safe, as the top 32-bits of HFILE are guaranteed to be zero,
  * see
- * https://docs.microsoft.com/en-us/windows/win32/winprog64/interprocess-communication
+ * https://learn.microsoft.com/en-us/windows/win32/winprog64/interprocess-communication
  */
 #ifndef USE_WIN32_FILEIO
 #define fd_to_tiff_fd(fd) (fd)

--- a/src/thirdparty/raqm/README.md
+++ b/src/thirdparty/raqm/README.md
@@ -81,5 +81,5 @@ The following projects have patches to support complex text layout using Raqm:
 [1]: https://github.com/fribidi/fribidi
 [2]: https://github.com/Tehreer/SheenBidi
 [3]: https://github.com/harfbuzz/harfbuzz
-[4]: https://www.freetype.org
+[4]: https://freetype.org/
 [5]: https://www.gtk.org/gtk-doc


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/3110428498/jobs/5041604517#step:11:571
> (    deprecations: line  253) redirect  https://www.freetype.org/ - permanently to https://freetype.org/

https://github.com/python-pillow/Pillow/actions/runs/3110428498/jobs/5041604517#step:11:462
> (    installation: line  183) redirect  https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#search-order-for-desktop-applications - permanently to https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#search-order-for-desktop-applications
> (reference/ImageDraw: line  347) redirect  https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist - permanently to https://learn.microsoft.com/en-us/typography/opentype/spec/featurelist