### PR TITLE
Fixed broken URLs

### DIFF
--- a/docs/releasenotes/5.2.0.rst
+++ b/docs/releasenotes/5.2.0.rst
@@ -105,7 +105,7 @@ Resolve confusion getting PIL / Pillow version string
 Re: "version constants deprecated" listed above, as user gnbl notes in #3082:
 
 - it's confusing that PIL.VERSION returns the version string of the former PIL instead of Pillow's
-- there does not seem to be documentation on this version number (why this, will it ever change, ..) e.g. at https://pillow.readthedocs.io/en/5.1.x/about.html#why-a-fork
+- ReadTheDocs documentation is missing for some version branches (why is this, will it ever change, ...)
 - it's confusing that PIL.version is a module and does not return the version information directly or hints on how to get it
 - the package information header is essentially useless (placeholder, does not even mention Pillow, nor the version)
 - PIL._version module documentation comment could explain how to access the version information

--- a/docs/releasenotes/versioning.rst
+++ b/docs/releasenotes/versioning.rst
@@ -11,7 +11,7 @@ Pillow follows `Semantic Versioning <https://semver.org/>`_:
     2. MINOR version when you add functionality in a backwards compatible manner, and
     3. PATCH version when you make backwards compatible bug fixes.
 
-Quarterly releases ("`Main Release <https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#main-release>`_")
+Quarterly releases ("`Main Release <https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#user-content-main-release>`_")
 bump at least the MINOR version, as new functionality has likely been added in the
 prior three months.
 
@@ -21,8 +21,8 @@ these occur every 12-18 months, guided by
 `Python's EOL schedule <https://devguide.python.org/#status-of-python-branches>`_, and
 any APIs that have been deprecated for at least a year are removed at the same time.
 
-PATCH versions ("`Point Release <https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#point-release>`_"
-or "`Embargoed Release <https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#embargoed-release>`_")
+PATCH versions ("`Point Release <https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#user-content-point-release>`_"
+or "`Embargoed Release <https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#user-content-embargoed-release>`_")
 are for security, installation or critical bug fixes. These are less common as it is
 preferred to stick to quarterly releases.
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/3113355066/jobs/5047881943#step:11:560
> (releasenotes/5.2.0: line  108) broken    https://pillow.readthedocs.io/en/5.1.x/about.html#why-a-fork - 404 Client Error: Not Found for url: https://pillow.readthedocs.io/en/5.1.x/about.html

The link is shown at https://pillow.readthedocs.io/en/stable/releasenotes/5.2.0.html#resolve-confusion-getting-pil-pillow-version-string. It is a deliberate example of a broken URL, so I've reworded the sentence to avoid referring to it

https://github.com/python-pillow/Pillow/actions/runs/3113355066/jobs/5047881943#step:11:515
> (releasenotes/versioning: line   24) broken    https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#point-release - Anchor 'point-release' not found
> (releasenotes/versioning: line   24) broken    https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#embargoed-release - Anchor 'embargoed-release' not found

https://github.com/python-pillow/Pillow/actions/runs/3113355066/jobs/5047881943#step:11:518
> (releasenotes/versioning: line   14) broken    https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#main-release - Anchor 'main-release' not found

Inspecting the headings at https://github.com/python-pillow/Pillow/blob/main/RELEASING.md, I found that the anchors actually have a prefix of 'user-content-'.