### PR TITLE
Don't reassign crc on ChunkStream close

### DIFF
--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -189,7 +189,7 @@ class ChunkStream:
         self.close()
 
     def close(self):
-        self.queue = self.crc = self.fp = None
+        self.queue = self.fp = None
 
     def push(self, cid, pos, length):
 

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -224,7 +224,7 @@ class ChunkStream:
             ) from e
 
     def crc_skip(self, cid, data):
-        """Read checksum.  Used if the C module is not present"""
+        """Read checksum"""
 
         self.fp.read(4)
 


### PR DESCRIPTION
Cherry-picking a commit from #2941

https://github.com/python-pillow/Pillow/blob/bdbf59d15178633b6b492c0cd27892894d0283ab/src/PIL/PngImagePlugin.py#L160-L164
https://github.com/python-pillow/Pillow/blob/bdbf59d15178633b6b492c0cd27892894d0283ab/src/PIL/PngImagePlugin.py#L191-L192

Ok, so when it is closing, it sets `fp` and `queue` to `None`, fair enough. What is `crc`?

https://github.com/python-pillow/Pillow/blob/bdbf59d15178633b6b492c0cd27892894d0283ab/src/PIL/PngImagePlugin.py#L204

...it's a method? I don't see why this should be set to `None`.

#2935 shows that it used to be sometimes set to `crc_skip`, but that still doesn't explain it to me.

Looking at that PR, I conclude that
https://github.com/python-pillow/Pillow/blob/bdbf59d15178633b6b492c0cd27892894d0283ab/src/PIL/PngImagePlugin.py#L226-L227
is no longer correct, so I've also removed the second sentence in that docstring.