### PR TITLE
Added ExifTags enums

### DIFF
--- a/docs/reference/ExifTags.rst
+++ b/docs/reference/ExifTags.rst
@@ -11,7 +11,7 @@ provide constants and clear-text names for various well-known EXIF tags.
     :type: dict
 
     The TAGS dictionary maps 16-bit integer EXIF tag enumerations to
-    descriptive string names.  For instance:
+    descriptive string names. For instance:
 
         >>> from PIL.ExifTags import TAGS
         >>> TAGS[0x010e]
@@ -20,9 +20,28 @@ provide constants and clear-text names for various well-known EXIF tags.
 .. py:data:: GPSTAGS
     :type: dict
 
-    The GPSTAGS dictionary maps 8-bit integer EXIF gps enumerations to
-    descriptive string names.  For instance:
+    The GPSTAGS dictionary maps 8-bit integer EXIF GPS enumerations to
+    descriptive string names. For instance:
 
         >>> from PIL.ExifTags import GPSTAGS
         >>> GPSTAGS[20]
         'GPSDestLatitude'
+
+
+These values are also exposed as ``enum.IntEnum`` classes.
+
+.. py:data:: Base
+
+    >>> from PIL.ExifTags import Base
+    >>> Base.ImageDescription.value
+    270
+    >>> Base(270).name
+    'ImageDescription'
+
+.. py:data:: GPS
+
+    >>> from PIL.ExifTags import GPS
+    >>> GPS.GPSDestLatitude.value
+    20
+    >>> GPS(20).name
+    'GPSDestLatitude'

--- a/src/PIL/ExifTags.py
+++ b/src/PIL/ExifTags.py
@@ -14,318 +14,327 @@ This module provides constants and clear-text names for various
 well-known EXIF tags.
 """
 
+from enum import IntEnum
 
-TAGS = {
+
+class Base(IntEnum):
     # possibly incomplete
-    0x0001: "InteropIndex",
-    0x000B: "ProcessingSoftware",
-    0x00FE: "NewSubfileType",
-    0x00FF: "SubfileType",
-    0x0100: "ImageWidth",
-    0x0101: "ImageLength",
-    0x0102: "BitsPerSample",
-    0x0103: "Compression",
-    0x0106: "PhotometricInterpretation",
-    0x0107: "Thresholding",
-    0x0108: "CellWidth",
-    0x0109: "CellLength",
-    0x010A: "FillOrder",
-    0x010D: "DocumentName",
-    0x010E: "ImageDescription",
-    0x010F: "Make",
-    0x0110: "Model",
-    0x0111: "StripOffsets",
-    0x0112: "Orientation",
-    0x0115: "SamplesPerPixel",
-    0x0116: "RowsPerStrip",
-    0x0117: "StripByteCounts",
-    0x0118: "MinSampleValue",
-    0x0119: "MaxSampleValue",
-    0x011A: "XResolution",
-    0x011B: "YResolution",
-    0x011C: "PlanarConfiguration",
-    0x011D: "PageName",
-    0x0120: "FreeOffsets",
-    0x0121: "FreeByteCounts",
-    0x0122: "GrayResponseUnit",
-    0x0123: "GrayResponseCurve",
-    0x0124: "T4Options",
-    0x0125: "T6Options",
-    0x0128: "ResolutionUnit",
-    0x0129: "PageNumber",
-    0x012D: "TransferFunction",
-    0x0131: "Software",
-    0x0132: "DateTime",
-    0x013B: "Artist",
-    0x013C: "HostComputer",
-    0x013D: "Predictor",
-    0x013E: "WhitePoint",
-    0x013F: "PrimaryChromaticities",
-    0x0140: "ColorMap",
-    0x0141: "HalftoneHints",
-    0x0142: "TileWidth",
-    0x0143: "TileLength",
-    0x0144: "TileOffsets",
-    0x0145: "TileByteCounts",
-    0x014A: "SubIFDs",
-    0x014C: "InkSet",
-    0x014D: "InkNames",
-    0x014E: "NumberOfInks",
-    0x0150: "DotRange",
-    0x0151: "TargetPrinter",
-    0x0152: "ExtraSamples",
-    0x0153: "SampleFormat",
-    0x0154: "SMinSampleValue",
-    0x0155: "SMaxSampleValue",
-    0x0156: "TransferRange",
-    0x0157: "ClipPath",
-    0x0158: "XClipPathUnits",
-    0x0159: "YClipPathUnits",
-    0x015A: "Indexed",
-    0x015B: "JPEGTables",
-    0x015F: "OPIProxy",
-    0x0200: "JPEGProc",
-    0x0201: "JpegIFOffset",
-    0x0202: "JpegIFByteCount",
-    0x0203: "JpegRestartInterval",
-    0x0205: "JpegLosslessPredictors",
-    0x0206: "JpegPointTransforms",
-    0x0207: "JpegQTables",
-    0x0208: "JpegDCTables",
-    0x0209: "JpegACTables",
-    0x0211: "YCbCrCoefficients",
-    0x0212: "YCbCrSubSampling",
-    0x0213: "YCbCrPositioning",
-    0x0214: "ReferenceBlackWhite",
-    0x02BC: "XMLPacket",
-    0x1000: "RelatedImageFileFormat",
-    0x1001: "RelatedImageWidth",
-    0x1002: "RelatedImageLength",
-    0x4746: "Rating",
-    0x4749: "RatingPercent",
-    0x800D: "ImageID",
-    0x828D: "CFARepeatPatternDim",
-    0x828E: "CFAPattern",
-    0x828F: "BatteryLevel",
-    0x8298: "Copyright",
-    0x829A: "ExposureTime",
-    0x829D: "FNumber",
-    0x83BB: "IPTCNAA",
-    0x8649: "ImageResources",
-    0x8769: "ExifOffset",
-    0x8773: "InterColorProfile",
-    0x8822: "ExposureProgram",
-    0x8824: "SpectralSensitivity",
-    0x8825: "GPSInfo",
-    0x8827: "ISOSpeedRatings",
-    0x8828: "OECF",
-    0x8829: "Interlace",
-    0x882A: "TimeZoneOffset",
-    0x882B: "SelfTimerMode",
-    0x8830: "SensitivityType",
-    0x8831: "StandardOutputSensitivity",
-    0x8832: "RecommendedExposureIndex",
-    0x8833: "ISOSpeed",
-    0x8834: "ISOSpeedLatitudeyyy",
-    0x8835: "ISOSpeedLatitudezzz",
-    0x9000: "ExifVersion",
-    0x9003: "DateTimeOriginal",
-    0x9004: "DateTimeDigitized",
-    0x9010: "OffsetTime",
-    0x9011: "OffsetTimeOriginal",
-    0x9012: "OffsetTimeDigitized",
-    0x9101: "ComponentsConfiguration",
-    0x9102: "CompressedBitsPerPixel",
-    0x9201: "ShutterSpeedValue",
-    0x9202: "ApertureValue",
-    0x9203: "BrightnessValue",
-    0x9204: "ExposureBiasValue",
-    0x9205: "MaxApertureValue",
-    0x9206: "SubjectDistance",
-    0x9207: "MeteringMode",
-    0x9208: "LightSource",
-    0x9209: "Flash",
-    0x920A: "FocalLength",
-    0x920B: "FlashEnergy",
+    InteropIndex = 0x0001
+    ProcessingSoftware = 0x000B
+    NewSubfileType = 0x00FE
+    SubfileType = 0x00FF
+    ImageWidth = 0x0100
+    ImageLength = 0x0101
+    BitsPerSample = 0x0102
+    Compression = 0x0103
+    PhotometricInterpretation = 0x0106
+    Thresholding = 0x0107
+    CellWidth = 0x0108
+    CellLength = 0x0109
+    FillOrder = 0x010A
+    DocumentName = 0x010D
+    ImageDescription = 0x010E
+    Make = 0x010F
+    Model = 0x0110
+    StripOffsets = 0x0111
+    Orientation = 0x0112
+    SamplesPerPixel = 0x0115
+    RowsPerStrip = 0x0116
+    StripByteCounts = 0x0117
+    MinSampleValue = 0x0118
+    MaxSampleValue = 0x0119
+    XResolution = 0x011A
+    YResolution = 0x011B
+    PlanarConfiguration = 0x011C
+    PageName = 0x011D
+    FreeOffsets = 0x0120
+    FreeByteCounts = 0x0121
+    GrayResponseUnit = 0x0122
+    GrayResponseCurve = 0x0123
+    T4Options = 0x0124
+    T6Options = 0x0125
+    ResolutionUnit = 0x0128
+    PageNumber = 0x0129
+    TransferFunction = 0x012D
+    Software = 0x0131
+    DateTime = 0x0132
+    Artist = 0x013B
+    HostComputer = 0x013C
+    Predictor = 0x013D
+    WhitePoint = 0x013E
+    PrimaryChromaticities = 0x013F
+    ColorMap = 0x0140
+    HalftoneHints = 0x0141
+    TileWidth = 0x0142
+    TileLength = 0x0143
+    TileOffsets = 0x0144
+    TileByteCounts = 0x0145
+    SubIFDs = 0x014A
+    InkSet = 0x014C
+    InkNames = 0x014D
+    NumberOfInks = 0x014E
+    DotRange = 0x0150
+    TargetPrinter = 0x0151
+    ExtraSamples = 0x0152
+    SampleFormat = 0x0153
+    SMinSampleValue = 0x0154
+    SMaxSampleValue = 0x0155
+    TransferRange = 0x0156
+    ClipPath = 0x0157
+    XClipPathUnits = 0x0158
+    YClipPathUnits = 0x0159
+    Indexed = 0x015A
+    JPEGTables = 0x015B
+    OPIProxy = 0x015F
+    JPEGProc = 0x0200
+    JpegIFOffset = 0x0201
+    JpegIFByteCount = 0x0202
+    JpegRestartInterval = 0x0203
+    JpegLosslessPredictors = 0x0205
+    JpegPointTransforms = 0x0206
+    JpegQTables = 0x0207
+    JpegDCTables = 0x0208
+    JpegACTables = 0x0209
+    YCbCrCoefficients = 0x0211
+    YCbCrSubSampling = 0x0212
+    YCbCrPositioning = 0x0213
+    ReferenceBlackWhite = 0x0214
+    XMLPacket = 0x02BC
+    RelatedImageFileFormat = 0x1000
+    RelatedImageWidth = 0x1001
+    RelatedImageLength = 0x1002
+    Rating = 0x4746
+    RatingPercent = 0x4749
+    ImageID = 0x800D
+    CFARepeatPatternDim = 0x828D
+    BatteryLevel = 0x828F
+    Copyright = 0x8298
+    ExposureTime = 0x829A
+    FNumber = 0x829D
+    IPTCNAA = 0x83BB
+    ImageResources = 0x8649
+    ExifOffset = 0x8769
+    InterColorProfile = 0x8773
+    ExposureProgram = 0x8822
+    SpectralSensitivity = 0x8824
+    GPSInfo = 0x8825
+    ISOSpeedRatings = 0x8827
+    OECF = 0x8828
+    Interlace = 0x8829
+    TimeZoneOffset = 0x882A
+    SelfTimerMode = 0x882B
+    SensitivityType = 0x8830
+    StandardOutputSensitivity = 0x8831
+    RecommendedExposureIndex = 0x8832
+    ISOSpeed = 0x8833
+    ISOSpeedLatitudeyyy = 0x8834
+    ISOSpeedLatitudezzz = 0x8835
+    ExifVersion = 0x9000
+    DateTimeOriginal = 0x9003
+    DateTimeDigitized = 0x9004
+    OffsetTime = 0x9010
+    OffsetTimeOriginal = 0x9011
+    OffsetTimeDigitized = 0x9012
+    ComponentsConfiguration = 0x9101
+    CompressedBitsPerPixel = 0x9102
+    ShutterSpeedValue = 0x9201
+    ApertureValue = 0x9202
+    BrightnessValue = 0x9203
+    ExposureBiasValue = 0x9204
+    MaxApertureValue = 0x9205
+    SubjectDistance = 0x9206
+    MeteringMode = 0x9207
+    LightSource = 0x9208
+    Flash = 0x9209
+    FocalLength = 0x920A
+    Noise = 0x920D
+    ImageNumber = 0x9211
+    SecurityClassification = 0x9212
+    ImageHistory = 0x9213
+    TIFFEPStandardID = 0x9216
+    MakerNote = 0x927C
+    UserComment = 0x9286
+    SubsecTime = 0x9290
+    SubsecTimeOriginal = 0x9291
+    SubsecTimeDigitized = 0x9292
+    AmbientTemperature = 0x9400
+    Humidity = 0x9401
+    Pressure = 0x9402
+    WaterDepth = 0x9403
+    Acceleration = 0x9404
+    CameraElevationAngle = 0x9405
+    XPTitle = 0x9C9B
+    XPComment = 0x9C9C
+    XPAuthor = 0x9C9D
+    XPKeywords = 0x9C9E
+    XPSubject = 0x9C9F
+    FlashPixVersion = 0xA000
+    ColorSpace = 0xA001
+    ExifImageWidth = 0xA002
+    ExifImageHeight = 0xA003
+    RelatedSoundFile = 0xA004
+    ExifInteroperabilityOffset = 0xA005
+    FlashEnergy = 0xA20B
+    SpatialFrequencyResponse = 0xA20C
+    FocalPlaneXResolution = 0xA20E
+    FocalPlaneYResolution = 0xA20F
+    FocalPlaneResolutionUnit = 0xA210
+    SubjectLocation = 0xA214
+    ExposureIndex = 0xA215
+    SensingMethod = 0xA217
+    FileSource = 0xA300
+    SceneType = 0xA301
+    CFAPattern = 0xA302
+    CustomRendered = 0xA401
+    ExposureMode = 0xA402
+    WhiteBalance = 0xA403
+    DigitalZoomRatio = 0xA404
+    FocalLengthIn35mmFilm = 0xA405
+    SceneCaptureType = 0xA406
+    GainControl = 0xA407
+    Contrast = 0xA408
+    Saturation = 0xA409
+    Sharpness = 0xA40A
+    DeviceSettingDescription = 0xA40B
+    SubjectDistanceRange = 0xA40C
+    ImageUniqueID = 0xA420
+    CameraOwnerName = 0xA430
+    BodySerialNumber = 0xA431
+    LensSpecification = 0xA432
+    LensMake = 0xA433
+    LensModel = 0xA434
+    LensSerialNumber = 0xA435
+    CompositeImage = 0xA460
+    CompositeImageCount = 0xA461
+    CompositeImageExposureTimes = 0xA462
+    Gamma = 0xA500
+    PrintImageMatching = 0xC4A5
+    DNGVersion = 0xC612
+    DNGBackwardVersion = 0xC613
+    UniqueCameraModel = 0xC614
+    LocalizedCameraModel = 0xC615
+    CFAPlaneColor = 0xC616
+    CFALayout = 0xC617
+    LinearizationTable = 0xC618
+    BlackLevelRepeatDim = 0xC619
+    BlackLevel = 0xC61A
+    BlackLevelDeltaH = 0xC61B
+    BlackLevelDeltaV = 0xC61C
+    WhiteLevel = 0xC61D
+    DefaultScale = 0xC61E
+    DefaultCropOrigin = 0xC61F
+    DefaultCropSize = 0xC620
+    ColorMatrix1 = 0xC621
+    ColorMatrix2 = 0xC622
+    CameraCalibration1 = 0xC623
+    CameraCalibration2 = 0xC624
+    ReductionMatrix1 = 0xC625
+    ReductionMatrix2 = 0xC626
+    AnalogBalance = 0xC627
+    AsShotNeutral = 0xC628
+    AsShotWhiteXY = 0xC629
+    BaselineExposure = 0xC62A
+    BaselineNoise = 0xC62B
+    BaselineSharpness = 0xC62C
+    BayerGreenSplit = 0xC62D
+    LinearResponseLimit = 0xC62E
+    CameraSerialNumber = 0xC62F
+    LensInfo = 0xC630
+    ChromaBlurRadius = 0xC631
+    AntiAliasStrength = 0xC632
+    ShadowScale = 0xC633
+    DNGPrivateData = 0xC634
+    MakerNoteSafety = 0xC635
+    CalibrationIlluminant1 = 0xC65A
+    CalibrationIlluminant2 = 0xC65B
+    BestQualityScale = 0xC65C
+    RawDataUniqueID = 0xC65D
+    OriginalRawFileName = 0xC68B
+    OriginalRawFileData = 0xC68C
+    ActiveArea = 0xC68D
+    MaskedAreas = 0xC68E
+    AsShotICCProfile = 0xC68F
+    AsShotPreProfileMatrix = 0xC690
+    CurrentICCProfile = 0xC691
+    CurrentPreProfileMatrix = 0xC692
+    ColorimetricReference = 0xC6BF
+    CameraCalibrationSignature = 0xC6F3
+    ProfileCalibrationSignature = 0xC6F4
+    AsShotProfileName = 0xC6F6
+    NoiseReductionApplied = 0xC6F7
+    ProfileName = 0xC6F8
+    ProfileHueSatMapDims = 0xC6F9
+    ProfileHueSatMapData1 = 0xC6FA
+    ProfileHueSatMapData2 = 0xC6FB
+    ProfileToneCurve = 0xC6FC
+    ProfileEmbedPolicy = 0xC6FD
+    ProfileCopyright = 0xC6FE
+    ForwardMatrix1 = 0xC714
+    ForwardMatrix2 = 0xC715
+    PreviewApplicationName = 0xC716
+    PreviewApplicationVersion = 0xC717
+    PreviewSettingsName = 0xC718
+    PreviewSettingsDigest = 0xC719
+    PreviewColorSpace = 0xC71A
+    PreviewDateTime = 0xC71B
+    RawImageDigest = 0xC71C
+    OriginalRawFileDigest = 0xC71D
+    SubTileBlockSize = 0xC71E
+    RowInterleaveFactor = 0xC71F
+    ProfileLookTableDims = 0xC725
+    ProfileLookTableData = 0xC726
+    OpcodeList1 = 0xC740
+    OpcodeList2 = 0xC741
+    OpcodeList3 = 0xC74E
+    NoiseProfile = 0xC761
+
+
+"""Maps EXIF tags to tag names."""
+TAGS = {
+    **{i.value: i.name for i in Base},
     0x920C: "SpatialFrequencyResponse",
-    0x920D: "Noise",
-    0x9211: "ImageNumber",
-    0x9212: "SecurityClassification",
-    0x9213: "ImageHistory",
     0x9214: "SubjectLocation",
     0x9215: "ExposureIndex",
+    0x828E: "CFAPattern",
+    0x920B: "FlashEnergy",
     0x9216: "TIFF/EPStandardID",
-    0x927C: "MakerNote",
-    0x9286: "UserComment",
-    0x9290: "SubsecTime",
-    0x9291: "SubsecTimeOriginal",
-    0x9292: "SubsecTimeDigitized",
-    0x9400: "AmbientTemperature",
-    0x9401: "Humidity",
-    0x9402: "Pressure",
-    0x9403: "WaterDepth",
-    0x9404: "Acceleration",
-    0x9405: "CameraElevationAngle",
-    0x9C9B: "XPTitle",
-    0x9C9C: "XPComment",
-    0x9C9D: "XPAuthor",
-    0x9C9E: "XPKeywords",
-    0x9C9F: "XPSubject",
-    0xA000: "FlashPixVersion",
-    0xA001: "ColorSpace",
-    0xA002: "ExifImageWidth",
-    0xA003: "ExifImageHeight",
-    0xA004: "RelatedSoundFile",
-    0xA005: "ExifInteroperabilityOffset",
-    0xA20B: "FlashEnergy",
-    0xA20C: "SpatialFrequencyResponse",
-    0xA20E: "FocalPlaneXResolution",
-    0xA20F: "FocalPlaneYResolution",
-    0xA210: "FocalPlaneResolutionUnit",
-    0xA214: "SubjectLocation",
-    0xA215: "ExposureIndex",
-    0xA217: "SensingMethod",
-    0xA300: "FileSource",
-    0xA301: "SceneType",
-    0xA302: "CFAPattern",
-    0xA401: "CustomRendered",
-    0xA402: "ExposureMode",
-    0xA403: "WhiteBalance",
-    0xA404: "DigitalZoomRatio",
-    0xA405: "FocalLengthIn35mmFilm",
-    0xA406: "SceneCaptureType",
-    0xA407: "GainControl",
-    0xA408: "Contrast",
-    0xA409: "Saturation",
-    0xA40A: "Sharpness",
-    0xA40B: "DeviceSettingDescription",
-    0xA40C: "SubjectDistanceRange",
-    0xA420: "ImageUniqueID",
-    0xA430: "CameraOwnerName",
-    0xA431: "BodySerialNumber",
-    0xA432: "LensSpecification",
-    0xA433: "LensMake",
-    0xA434: "LensModel",
-    0xA435: "LensSerialNumber",
-    0xA460: "CompositeImage",
-    0xA461: "CompositeImageCount",
-    0xA462: "CompositeImageExposureTimes",
-    0xA500: "Gamma",
-    0xC4A5: "PrintImageMatching",
-    0xC612: "DNGVersion",
-    0xC613: "DNGBackwardVersion",
-    0xC614: "UniqueCameraModel",
-    0xC615: "LocalizedCameraModel",
-    0xC616: "CFAPlaneColor",
-    0xC617: "CFALayout",
-    0xC618: "LinearizationTable",
-    0xC619: "BlackLevelRepeatDim",
-    0xC61A: "BlackLevel",
-    0xC61B: "BlackLevelDeltaH",
-    0xC61C: "BlackLevelDeltaV",
-    0xC61D: "WhiteLevel",
-    0xC61E: "DefaultScale",
-    0xC61F: "DefaultCropOrigin",
-    0xC620: "DefaultCropSize",
-    0xC621: "ColorMatrix1",
-    0xC622: "ColorMatrix2",
-    0xC623: "CameraCalibration1",
-    0xC624: "CameraCalibration2",
-    0xC625: "ReductionMatrix1",
-    0xC626: "ReductionMatrix2",
-    0xC627: "AnalogBalance",
-    0xC628: "AsShotNeutral",
-    0xC629: "AsShotWhiteXY",
-    0xC62A: "BaselineExposure",
-    0xC62B: "BaselineNoise",
-    0xC62C: "BaselineSharpness",
-    0xC62D: "BayerGreenSplit",
-    0xC62E: "LinearResponseLimit",
-    0xC62F: "CameraSerialNumber",
-    0xC630: "LensInfo",
-    0xC631: "ChromaBlurRadius",
-    0xC632: "AntiAliasStrength",
-    0xC633: "ShadowScale",
-    0xC634: "DNGPrivateData",
-    0xC635: "MakerNoteSafety",
-    0xC65A: "CalibrationIlluminant1",
-    0xC65B: "CalibrationIlluminant2",
-    0xC65C: "BestQualityScale",
-    0xC65D: "RawDataUniqueID",
-    0xC68B: "OriginalRawFileName",
-    0xC68C: "OriginalRawFileData",
-    0xC68D: "ActiveArea",
-    0xC68E: "MaskedAreas",
-    0xC68F: "AsShotICCProfile",
-    0xC690: "AsShotPreProfileMatrix",
-    0xC691: "CurrentICCProfile",
-    0xC692: "CurrentPreProfileMatrix",
-    0xC6BF: "ColorimetricReference",
-    0xC6F3: "CameraCalibrationSignature",
-    0xC6F4: "ProfileCalibrationSignature",
-    0xC6F6: "AsShotProfileName",
-    0xC6F7: "NoiseReductionApplied",
-    0xC6F8: "ProfileName",
-    0xC6F9: "ProfileHueSatMapDims",
-    0xC6FA: "ProfileHueSatMapData1",
-    0xC6FB: "ProfileHueSatMapData2",
-    0xC6FC: "ProfileToneCurve",
-    0xC6FD: "ProfileEmbedPolicy",
-    0xC6FE: "ProfileCopyright",
-    0xC714: "ForwardMatrix1",
-    0xC715: "ForwardMatrix2",
-    0xC716: "PreviewApplicationName",
-    0xC717: "PreviewApplicationVersion",
-    0xC718: "PreviewSettingsName",
-    0xC719: "PreviewSettingsDigest",
-    0xC71A: "PreviewColorSpace",
-    0xC71B: "PreviewDateTime",
-    0xC71C: "RawImageDigest",
-    0xC71D: "OriginalRawFileDigest",
-    0xC71E: "SubTileBlockSize",
-    0xC71F: "RowInterleaveFactor",
-    0xC725: "ProfileLookTableDims",
-    0xC726: "ProfileLookTableData",
-    0xC740: "OpcodeList1",
-    0xC741: "OpcodeList2",
-    0xC74E: "OpcodeList3",
-    0xC761: "NoiseProfile",
 }
-"""Maps EXIF tags to tag names."""
 
 
-GPSTAGS = {
-    0: "GPSVersionID",
-    1: "GPSLatitudeRef",
-    2: "GPSLatitude",
-    3: "GPSLongitudeRef",
-    4: "GPSLongitude",
-    5: "GPSAltitudeRef",
-    6: "GPSAltitude",
-    7: "GPSTimeStamp",
-    8: "GPSSatellites",
-    9: "GPSStatus",
-    10: "GPSMeasureMode",
-    11: "GPSDOP",
-    12: "GPSSpeedRef",
-    13: "GPSSpeed",
-    14: "GPSTrackRef",
-    15: "GPSTrack",
-    16: "GPSImgDirectionRef",
-    17: "GPSImgDirection",
-    18: "GPSMapDatum",
-    19: "GPSDestLatitudeRef",
-    20: "GPSDestLatitude",
-    21: "GPSDestLongitudeRef",
-    22: "GPSDestLongitude",
-    23: "GPSDestBearingRef",
-    24: "GPSDestBearing",
-    25: "GPSDestDistanceRef",
-    26: "GPSDestDistance",
-    27: "GPSProcessingMethod",
-    28: "GPSAreaInformation",
-    29: "GPSDateStamp",
-    30: "GPSDifferential",
-    31: "GPSHPositioningError",
-}
+class GPS(IntEnum):
+    GPSVersionID = 0
+    GPSLatitudeRef = 1
+    GPSLatitude = 2
+    GPSLongitudeRef = 3
+    GPSLongitude = 4
+    GPSAltitudeRef = 5
+    GPSAltitude = 6
+    GPSTimeStamp = 7
+    GPSSatellites = 8
+    GPSStatus = 9
+    GPSMeasureMode = 10
+    GPSDOP = 11
+    GPSSpeedRef = 12
+    GPSSpeed = 13
+    GPSTrackRef = 14
+    GPSTrack = 15
+    GPSImgDirectionRef = 16
+    GPSImgDirection = 17
+    GPSMapDatum = 18
+    GPSDestLatitudeRef = 19
+    GPSDestLatitude = 20
+    GPSDestLongitudeRef = 21
+    GPSDestLongitude = 22
+    GPSDestBearingRef = 23
+    GPSDestBearing = 24
+    GPSDestDistanceRef = 25
+    GPSDestDistance = 26
+    GPSProcessingMethod = 27
+    GPSAreaInformation = 28
+    GPSDateStamp = 29
+    GPSDifferential = 30
+    GPSHPositioningError = 31
+
+
 """Maps EXIF GPS tags to tag names."""
+GPSTAGS = {i.value: i.name for i in GPS}


### PR DESCRIPTION
Alternative to #6586

This PR effectively copies the data from `ExifTags.TAGS` and `ExifTags.GPSTAGS` into two new `IntEnum` classes, `ExifTags.Base` and `ExifTags.GPS`.

The advantage of this is ease of mapping a tag name to a tag number. Rather than
```pycon
>>> from PIL.ExifTags import TAGS
>>> for value, name in TAGS.items():
...   if name == "ImageDescription":
...     print(value)
... 
270
```
users could
```pycon
>>> from PIL.ExifTags import Base
>>> Base.ImageDescription.value
270
```