### PR TITLE
Do not import PIL.Image

### DIFF
--- a/Tests/test_000_sanity.py
+++ b/Tests/test_000_sanity.py
@@ -1,19 +1,18 @@
-import PIL
-import PIL.Image
+from PIL import Image
 
 
 def test_sanity():
     # Make sure we have the binary extension
-    PIL.Image.core.new("L", (100, 100))
+    Image.core.new("L", (100, 100))
 
     # Create an image and do stuff with it.
-    im = PIL.Image.new("1", (100, 100))
+    im = Image.new("1", (100, 100))
     assert (im.mode, im.size) == ("1", (100, 100))
     assert len(im.tobytes()) == 1300
 
     # Create images in all remaining major modes.
-    PIL.Image.new("L", (100, 100))
-    PIL.Image.new("P", (100, 100))
-    PIL.Image.new("RGB", (100, 100))
-    PIL.Image.new("I", (100, 100))
-    PIL.Image.new("F", (100, 100))
+    Image.new("L", (100, 100))
+    Image.new("P", (100, 100))
+    Image.new("RGB", (100, 100))
+    Image.new("I", (100, 100))
+    Image.new("F", (100, 100))


### PR DESCRIPTION
Since we're [considering](https://github.com/python-pillow/Pillow/issues/6614#issuecomment-1256599460) deprecating `import PIL.Image`, this PR removes a use of that from the test suite.