### PR TITLE
Do not attempt normalization if mode is already normal

### DIFF
--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -38,6 +38,12 @@ def test_sanity():
             convert(im, output_mode)
 
 
+def test_unsupported_conversion():
+    im = hopper()
+    with pytest.raises(ValueError):
+        im.convert("INVALID")
+
+
 def test_default():
 
     im = hopper("P")

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1036,7 +1036,10 @@ class Image:
         except ValueError:
             try:
                 # normalize source image and try again
-                im = self.im.convert(getmodebase(self.mode))
+                modebase = getmodebase(self.mode)
+                if modebase == self.mode:
+                    raise
+                im = self.im.convert(modebase)
                 im = im.convert(mode, dither)
             except KeyError as e:
                 raise ValueError("illegal conversion") from e


### PR DESCRIPTION
While investigating #6643, I found that
```pycon
>>> from PIL import Image
>>> Image.new("RGB", (1, 1)).convert("XYZ")
Traceback (most recent call last):
  File "PIL/Image.py", line 1035, in convert
ValueError: conversion from RGB to XYZ not supported

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/Image.py", line 1040, in convert
ValueError: conversion from RGB to XYZ not supported
>>> 
```
It looks odd that "ValueError: conversion from RGB to XYZ not supported" is raised twice. One would expect the first time to be enough.

This is because of the following code. The intention is that if A -> B isn't supported, then maybe A -> C -> B will work, using the base mode as the intermediary.
https://github.com/python-pillow/Pillow/blob/243402e78e2bf2b7af478c6d891816e372b5c3f9/src/PIL/Image.py#L1034-L1040

But in this case, since `getmodebase(self.mode)` doesn't change the mode, it becomes A -> A -> B, and fails with the same error again.

This PR modifies that code so that if `getmodebase(self.mode)` doesn't change the mode, then this alternative conversion path is not attempted.