### PR TITLE
Removed print statement from tests

### DIFF
--- a/Tests/test_imagemath.py
+++ b/Tests/test_imagemath.py
@@ -6,10 +6,8 @@ from PIL import Image, ImageMath
 def pixel(im):
     if hasattr(im, "im"):
         return f"{im.mode} {repr(im.getpixel((0, 0)))}"
-    else:
-        if isinstance(im, int):
-            return int(im)  # hack to deal with booleans
-        print(im)
+    elif isinstance(im, int):
+        return int(im)  # hack to deal with booleans
 
 
 A = Image.new("L", (1, 1), 1)


### PR DESCRIPTION
The following test function
https://github.com/python-pillow/Pillow/blob/f63cc582b7d305780762f786cf61e602f7398b0d/Tests/test_imagemath.py#L6-L12
is used like so
https://github.com/python-pillow/Pillow/blob/f63cc582b7d305780762f786cf61e602f7398b0d/Tests/test_imagemath.py#L30

If the `print` statement is reached, then the assertion will fail anyway, so it is just debugging code. This PR removes it.