### PR TITLE
Image channel is used when converting PA with an RGBA palette

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -880,7 +880,7 @@ class Image:
         and the palette can be represented without a palette.
 
         The current version supports all possible conversions between
-        "L", "RGB" and "CMYK." The ``matrix`` argument only supports "L"
+        "L", "RGB" and "CMYK". The ``matrix`` argument only supports "L"
         and "RGB".
 
         When translating a color image to greyscale (mode "L"),
@@ -898,6 +898,9 @@ class Image:
         When converting from "RGBA" to "P" without a ``matrix`` argument,
         this passes the operation to :py:meth:`~PIL.Image.Image.quantize`,
         and ``dither`` and ``palette`` are ignored.
+
+        When converting from "PA", if an "RGBA" palette is present, the alpha
+        channel from the image will be used instead of the values from the palette.
 
         :param mode: The requested mode. See: :ref:`concept-modes`.
         :param matrix: An optional conversion matrix.  If given, this


### PR DESCRIPTION
Resolves #6658

This PR documents that when converting a PA image with an RGBA palette, the alpha values from the image are used, rather than the values from the palette.

```python
from PIL import Image, ImagePalette
im = Image.new("PA", (1, 2))
p = ImagePalette.ImagePalette("RGBA")
first = p.getcolor((1, 2, 3, 4))
second = p.getcolor((5, 6, 7, 8))
im.putpalette(p)
im.putpixel((0, 0), (first, 100))
im.putpixel((0, 1), (second, 200))

im_rgba = im.convert("RGBA")
print("(0, 0):", im_rgba.load()[0, 0])
print("(0, 1):", im_rgba.load()[0, 1])
```
gives
```
(0, 0): (1, 2, 3, 100)
(0, 1): (5, 6, 7, 200)
```