### PR TITLE
Document when BLP1 JPEG data started being loaded incorrectly

### DIFF
--- a/docs/releasenotes/9.3.0.rst
+++ b/docs/releasenotes/9.3.0.rst
@@ -43,7 +43,7 @@ Within the BLP image format, BLP1 data may use JPEG compression. Instead of
 telling the JPEG library that this data is in BGRX mode, Pillow will now
 decode the data in its natural CMYK mode, then convert it to RGB and rearrange
 the channels afterwards. Trying to load the data in an incorrect mode could
-result in a segmentation fault.
+result in a segmentation fault. This issue was introduced in Pillow 9.1.0.
 
 Other Changes
 =============


### PR DESCRIPTION
Sequel to #6680

The security issue was introduced with #4685 in Pillow 9.1.0.