### PR TITLE
Do not modify previous frame when calculating delta in PNG

### DIFF
--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -553,18 +553,20 @@ def test_apng_save_disposal(tmp_path):
 def test_apng_save_disposal_previous(tmp_path):
     test_file = str(tmp_path / "temp.png")
     size = (128, 64)
-    transparent = Image.new("RGBA", size, (0, 0, 0, 0))
+    blue = Image.new("RGBA", size, (0, 0, 255, 255))
     red = Image.new("RGBA", size, (255, 0, 0, 255))
     green = Image.new("RGBA", size, (0, 255, 0, 255))
 
     # test OP_NONE
-    transparent.save(
+    blue.save(
         test_file,
         save_all=True,
         append_images=[red, green],
         disposal=PngImagePlugin.Disposal.OP_PREVIOUS,
     )
     with Image.open(test_file) as im:
+        assert im.getpixel((0, 0)) == (0, 0, 255, 255)
+
         im.seek(2)
         assert im.getpixel((0, 0)) == (0, 255, 0, 255)
         assert im.getpixel((64, 32)) == (0, 255, 0, 255)

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -1128,7 +1128,7 @@ def _write_multiple_frames(im, fp, chunk, rawmode, default_image, append_images)
                     prev_disposal = Disposal.OP_BACKGROUND
 
                 if prev_disposal == Disposal.OP_BACKGROUND:
-                    base_im = previous["im"]
+                    base_im = previous["im"].copy()
                     dispose = Image.core.fill("RGBA", im.size, (0, 0, 0, 0))
                     bbox = previous["bbox"]
                     if bbox:


### PR DESCRIPTION
Helps the original code in #6672

When iterating through frames to save a PNG, the following code
https://github.com/python-pillow/Pillow/blob/c924fd84a39f3ee9aa9b96d8dec58ec50fdca9d6/src/PIL/PngImagePlugin.py#L1130-L1138
actually changing the previous frame with the `paste` operation.

This PR fixes that by making `base_im` a `copy()` instead.