### PR TITLE
Remove backup implementation of Round for Windows platforms

### DIFF
--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -43,13 +43,6 @@
 #define L(rgb) ((INT32)(rgb)[0] * 299 + (INT32)(rgb)[1] * 587 + (INT32)(rgb)[2] * 114)
 #define L24(rgb) ((rgb)[0] * 19595 + (rgb)[1] * 38470 + (rgb)[2] * 7471 + 0x8000)
 
-#ifndef round
-double
-round(double x) {
-    return floor(x + 0.5);
-}
-#endif
-
 /* ------------------- */
 /* 1 (bit) conversions */
 /* ------------------- */


### PR DESCRIPTION
Fixes link error on Visual Studio 2019 14.29.30133 with Windows 10 SDK 10.0.19041.0:
```
ucrt.lib(api-ms-win-crt-math-l1-1-0.dll) : error LNK2005: round already defined in Convert.obj
   Creating library build\temp.win-amd64-3.10\Release\src\_imaging.cp310-win_amd64.lib and object build\temp.win-amd64-3.10\Release\src\_imaging.cp310-win_amd64.exp
build\lib.win-amd64-3.10\PIL\_imaging.cp310-win_amd64.pyd : fatal error LNK1169: one or more multiply defined symbols found
error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX86\\x64\\link.exe' failed with exit code 1169
```