### PR TITLE
Double quotes for old CPython on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,7 @@ import subprocess
 import sys
 import warnings
 
-from setuptools import Extension
-from setuptools import __version__ as setuptools_version
-from setuptools import setup
+from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
 
@@ -852,7 +850,6 @@ class pil_build_ext(build_ext):
             sys.platform == "win32"
             and sys.version_info < (3, 9)
             and not (PLATFORM_PYPY or PLATFORM_MINGW)
-            and int(setuptools_version.split(".")[0]) < 60
         ):
             defs.append(("PILLOW_VERSION", f'"\\"{PILLOW_VERSION}\\""'))
         else:


### PR DESCRIPTION
Fixes #6437.

@cgohlke found a failure with setuptools 65 on Python 3.7-3.8 but with `SETUPTOOLS_USE_DISTUTILS=stdlib`

Testing a CI matrix on Windows with:

```yml
        python-version: ["3.7", "3.8", "3.9"]
        architecture: ["x64"]
        SETUPTOOLS_USE_DISTUTILS: ["", "stdlib"]
        setuptools-max-version: ["60", "66"]
```

I [find](https://github.com/hugovk/Pillow/actions/runs/3344698796) that:

CPython | SETUPTOOLS_USE_DISTUTILS | setuptools | Quotes needed
-- | -- | -- | --
3.7 |   | <60 | double
3.7 |   | <66 | double
3.7 | stdlib | <60 | double
3.7 | stdlib | <66 | double
3.8 |   | <60 | double
3.8 |   | <66 | double
3.8 | stdlib | <60 | double
3.8 | stdlib | <66 | double
3.9 |   | <60 | single
3.9 |   | <66 | single
3.9 | stdlib | <60 | single
3.9 | stdlib | <66 | single


Testing this fix on the same matrix passes for all: 

* https://github.com/hugovk/Pillow/actions/runs/3344484651
