### PR TITLE
Initialize libtiff buffer when saving

### DIFF
--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -42,7 +42,6 @@ def test_save(tmp_path, mode):
     helper_save_as_pdf(tmp_path, mode)
 
 
-@pytest.mark.valgrind_known_error(reason="Temporary skip")
 def test_monochrome(tmp_path):
     # Arrange
     mode = "1"

--- a/docs/releasenotes/9.3.0.rst
+++ b/docs/releasenotes/9.3.0.rst
@@ -40,6 +40,12 @@ classes: :py:data:`~PIL.ExifTags.Base` and :py:data:`~PIL.ExifTags.GPS`.
 Security
 ========
 
+Initialize libtiff buffer when saving
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When saving a TIFF image to a file object using libtiff, the buffer was not
+initialized. This behaviour introduced in Pillow 2.0.0, and has now been fixed.
+
 Decode JPEG compressed BLP1 data in original mode
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -771,11 +771,11 @@ ImagingLibTiffEncodeInit(ImagingCodecState state, char *filename, int fp) {
         TRACE(("Opening using fd: %d for writing \n", clientstate->fp));
         clientstate->tiff = TIFFFdOpen(fd_to_tiff_fd(clientstate->fp), filename, mode);
     } else {
-        // malloc a buffer to write the tif, we're going to need to realloc or something
+        // calloc a buffer to write the tif, we're going to need to realloc or something
         // if we need bigger.
         TRACE(("Opening a buffer for writing \n"));
-        /* malloc check ok, small constant allocation */
-        clientstate->data = malloc(bufsize);
+        /* calloc check ok, small constant allocation */
+        clientstate->data = calloc(bufsize, 1);
         clientstate->size = bufsize;
         clientstate->flrealloc = 1;
 


### PR DESCRIPTION
When saving a TIFF image to a file object using libtiff, the buffer was not initialized. This behaviour introduced in Pillow 2.0.0, and has now been fixed.