### PR TITLE
Disable __CxxFrameHandler4 when compiling HarfBuzz

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -360,6 +360,7 @@ deps = {
         "dir": "harfbuzz-5.3.1",
         "license": "COPYING",
         "build": [
+            cmd_set("CXXFLAGS", "-d2FH4-"),
             cmd_cmake("-DHB_HAVE_FREETYPE:BOOL=TRUE"),
             cmd_nmake(target="clean"),
             cmd_nmake(target="harfbuzz"),


### PR DESCRIPTION
Likely fix for #6701.

This is automatically enabled when compiling C++ with modern Visual Studio to [reduce the binary size of try/catch blocks](https://devblogs.microsoft.com/cppblog/making-cpp-exception-handling-smaller-x64/).
It uses `VCRUNTIME140_1.dll`, which is not available out-of-the-box, and needs to be included in the wheels.

However, I find there is almost no difference to the size of `_imagingft.{...}.pyd` when disabling it (disabling it actually saves 3KB), and it removes the need to include `VCRUNTIME140_1.dll` in the wheels.
