### PR TITLE
Add xfail mark to TestEmbeddable

### DIFF
--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -4,11 +4,10 @@ import sys
 import sysconfig
 
 import pytest
-from setuptools.command.build_ext import new_compiler
 
 from PIL import Image
 
-from .helper import assert_image_equal, hopper, is_win32, on_ci
+from .helper import assert_image_equal, hopper, is_win32
 
 # CFFI imports pycparser which doesn't support PYTHONOPTIMIZE=2
 # https://github.com/eliben/pycparser/pull/198#issuecomment-317001670
@@ -410,6 +409,7 @@ class TestEmbeddable:
     @pytest.mark.skipif(not is_win32(), reason="requires Windows")
     def test_embeddable(self):
         import ctypes
+        from setuptools.command.build_ext import new_compiler
 
         with open("embed_pil.c", "w", encoding="utf-8") as fh:
             fh.write(

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -406,11 +406,8 @@ class TestImagePutPixelError(AccessTest):
 
 
 class TestEmbeddable:
-    @pytest.mark.skipif(
-        not is_win32() or on_ci(),
-        reason="Failing on AppVeyor / GitHub Actions when run from subprocess, "
-        "not from shell",
-    )
+    @pytest.mark.xfail(reason="failing test")
+    @pytest.mark.skipif(not is_win32(), reason="requires Windows")
     def test_embeddable(self):
         import ctypes
 

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -409,6 +409,7 @@ class TestEmbeddable:
     @pytest.mark.skipif(not is_win32(), reason="requires Windows")
     def test_embeddable(self):
         import ctypes
+
         from setuptools.command.build_ext import new_compiler
 
         with open("embed_pil.c", "w", encoding="utf-8") as fh:


### PR DESCRIPTION
This test has been a constant annoyance: https://github.com/python-pillow/Pillow/issues/6679#issuecomment-1296068430, https://github.com/python-pillow/Pillow/pull/5811#issuecomment-965165151

This PR marks it as a "known failing test".