### PR TITLE
CVE-2007-4559 patch in winbuild

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -474,7 +474,26 @@ def extract_dep(url, filename):
             zf.extractall(sources_dir)
     elif filename.endswith(".tar.gz") or filename.endswith(".tgz"):
         with tarfile.open(file, "r:gz") as tgz:
-            tgz.extractall(sources_dir)
+            def is_within_directory(directory, target):
+
+                abs_directory = os.path.abspath(directory)
+                abs_target = os.path.abspath(target)
+
+                prefix = os.path.commonprefix([abs_directory, abs_target])
+
+                return prefix == abs_directory
+
+            def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+
+                for member in tar.getmembers():
+                    member_path = os.path.join(path, member.name)
+                    if not is_within_directory(path, member_path):
+                        raise Exception("Attempted Path Traversal in Tar File")
+
+                tar.extractall(path, members, numeric_owner=numeric_owner)
+
+
+            safe_extract(tgz, sources_dir)
     else:
         raise RuntimeError("Unknown archive type: " + filename)
 

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -469,31 +469,23 @@ def extract_dep(url, filename):
             raise RuntimeError(ex)
 
     print("Extracting " + filename)
+    sources_dir_abs = os.path.abspath(sources_dir)
     if filename.endswith(".zip"):
         with zipfile.ZipFile(file) as zf:
+            for member in zf.namelist():
+                member_abspath = os.path.abspath(os.path.join(sources_dir, member))
+                member_prefix = os.path.commonprefix([sources_dir_abs, member_abspath])
+                if sources_dir_abs != member_prefix:
+                    raise RuntimeError("Attempted Path Traversal in Zip File")
             zf.extractall(sources_dir)
     elif filename.endswith(".tar.gz") or filename.endswith(".tgz"):
         with tarfile.open(file, "r:gz") as tgz:
-            def is_within_directory(directory, target):
-
-                abs_directory = os.path.abspath(directory)
-                abs_target = os.path.abspath(target)
-
-                prefix = os.path.commonprefix([abs_directory, abs_target])
-
-                return prefix == abs_directory
-
-            def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
-
-                for member in tar.getmembers():
-                    member_path = os.path.join(path, member.name)
-                    if not is_within_directory(path, member_path):
-                        raise Exception("Attempted Path Traversal in Tar File")
-
-                tar.extractall(path, members, numeric_owner=numeric_owner)
-
-
-            safe_extract(tgz, sources_dir)
+            for member in tgz.getmembers():
+                member_abspath = os.path.abspath(os.path.join(sources_dir, member.name))
+                member_prefix = os.path.commonprefix([sources_dir_abs, member_abspath])
+                if sources_dir_abs != member_prefix:
+                    raise RuntimeError("Attempted Path Traversal in Tar File")
+            tgz.extractall(sources_dir)
     else:
         raise RuntimeError("Unknown archive type: " + filename)
 

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -474,7 +474,7 @@ def extract_dep(url, filename):
         with zipfile.ZipFile(file) as zf:
             for member in zf.namelist():
                 member_abspath = os.path.abspath(os.path.join(sources_dir, member))
-                member_prefix = os.path.commonprefix([sources_dir_abs, member_abspath])
+                member_prefix = os.path.commonpath([sources_dir_abs, member_abspath])
                 if sources_dir_abs != member_prefix:
                     raise RuntimeError("Attempted Path Traversal in Zip File")
             zf.extractall(sources_dir)
@@ -482,7 +482,7 @@ def extract_dep(url, filename):
         with tarfile.open(file, "r:gz") as tgz:
             for member in tgz.getmembers():
                 member_abspath = os.path.abspath(os.path.join(sources_dir, member.name))
-                member_prefix = os.path.commonprefix([sources_dir_abs, member_abspath])
+                member_prefix = os.path.commonpath([sources_dir_abs, member_abspath])
                 if sources_dir_abs != member_prefix:
                     raise RuntimeError("Attempted Path Traversal in Tar File")
             tgz.extractall(sources_dir)

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -480,8 +480,8 @@ def extract_dep(url, filename):
             zf.extractall(sources_dir)
     elif filename.endswith(".tar.gz") or filename.endswith(".tgz"):
         with tarfile.open(file, "r:gz") as tgz:
-            for member in tgz.getmembers():
-                member_abspath = os.path.abspath(os.path.join(sources_dir, member.name))
+            for member in tgz.getnames():
+                member_abspath = os.path.abspath(os.path.join(sources_dir, member))
                 member_prefix = os.path.commonpath([sources_dir_abs, member_abspath])
                 if sources_dir_abs != member_prefix:
                     raise RuntimeError("Attempted Path Traversal in Tar File")


### PR DESCRIPTION
Originally submitted in https://github.com/nulano/pypy_ext/pull/2 by @TrellixVulnTeam:

> # Patching [CVE-2007-4559](https://github.com/advisories/GHSA-gw9q-c7gh-j9vm)
> Hi, we are security researchers from the Advanced Research Center at [Trellix](https://www.trellix.com). We have began a campaign to patch a widespread bug named [CVE-2007-4559](https://github.com/advisories/GHSA-gw9q-c7gh-j9vm). [CVE-2007-4559](https://github.com/advisories/GHSA-gw9q-c7gh-j9vm) is a 15 year old bug in the Python tarfile package. By using extract() or extractall() on a tarfile object without sanitizing input, a maliciously crafted .tar file could perform a directory path traversal attack. We found at least one unsantized extractall() in your codebase and are providing a patch for you via pull request. The patch essentially checks to see if all tarfile members will be extracted safely and throws an exception otherwise. We encourage you to use this patch or your own solution to secure against [CVE-2007-4559](https://github.com/advisories/GHSA-gw9q-c7gh-j9vm). Further technical information about the vulnerability can be found in this [blog](https://www.trellix.com/en-us/about/newsroom/stories/research/tarfile-exploiting-the-world.html).
> 
> If you have further questions you may contact us through this projects lead researcher [Kasimir Schulz](mailto:kasimir.schulz@trellix.com).

I've simplified the changes and applied them to zip files also.

I'm not sure how important this is here, but it probably can't hurt to add.