### PR TITLE
Added conversion from RGBa to RGB

### DIFF
--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -104,6 +104,13 @@ def test_rgba_p():
     assert_image_similar(im, comparable, 20)
 
 
+def test_rgba():
+    with Image.open("Tests/images/transparent.png") as im:
+        assert im.mode == "RGBA"
+
+        assert_image_similar(im.convert("RGBa").convert("RGB"), im.convert("RGB"), 1.5)
+
+
 def test_trns_p(tmp_path):
     im = hopper("P")
     im.info["transparency"] = 0

--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -479,6 +479,25 @@ rgba2rgbA(UINT8 *out, const UINT8 *in, int xsize) {
     }
 }
 
+static void
+rgba2rgb_(UINT8 *out, const UINT8 *in, int xsize) {
+    int x;
+    unsigned int alpha;
+    for (x = 0; x < xsize; x++, in += 4) {
+        alpha = in[3];
+        if (alpha == 255 || alpha == 0) {
+            *out++ = in[0];
+            *out++ = in[1];
+            *out++ = in[2];
+        } else {
+            *out++ = CLIP8((255 * in[0]) / alpha);
+            *out++ = CLIP8((255 * in[1]) / alpha);
+            *out++ = CLIP8((255 * in[2]) / alpha);
+        }
+        *out++ = 255;
+    }
+}
+
 /*
  * Conversion of RGB + single transparent color to RGBA,
  * where any pixel that matches the color will have the
@@ -934,6 +953,7 @@ static struct {
     {"RGBA", "HSV", rgb2hsv},
 
     {"RGBa", "RGBA", rgba2rgbA},
+    {"RGBa", "RGB", rgba2rgb_},
 
     {"RGBX", "1", rgb2bit},
     {"RGBX", "L", rgb2l},


### PR DESCRIPTION
Resolves #6706. Alternative to #6707

The new conversion function is just a copy of
https://github.com/python-pillow/Pillow/blob/a4ec9f331c11cd8ad05137bc78dff8197e8af2e3/src/libImaging/Convert.c#L463-L480
except with the last channel set to 255, as happens in other conversions to RGB.
https://github.com/python-pillow/Pillow/blob/a4ec9f331c11cd8ad05137bc78dff8197e8af2e3/src/libImaging/Convert.c#L436-L446