### PR TITLE
XCB will not be used by default on Linux if gnome-screenshot is present

### DIFF
--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import sys
 
@@ -33,7 +34,9 @@ class TestImageGrab:
 
     @pytest.mark.skipif(Image.core.HAVE_XCB, reason="tests missing XCB")
     def test_grab_no_xcb(self):
-        if sys.platform not in ("win32", "darwin"):
+        if sys.platform not in ("win32", "darwin") and not shutil.which(
+            "gnome-screenshot"
+        ):
             with pytest.raises(OSError) as e:
                 ImageGrab.grab()
             assert str(e.value).startswith("Pillow was built without XCB support")


### PR DESCRIPTION
Resolves #6710

#6361 added support for `gnome-screenshot` in ImageGrab on Linux, but didn't update `test_grab_no_xcb` in light of the fact that something else might be used instead of XCB on Linux.