### PR TITLE
Fix compiler error: accessing 64 bytes in a region of size 48

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1829,7 +1829,7 @@ _resize(ImagingObject *self, PyObject *args) {
         box[1] - (int)box[1] == 0 && box[3] - box[1] == ysize) {
         imOut = ImagingCrop(imIn, box[0], box[1], box[2], box[3]);
     } else if (filter == IMAGING_TRANSFORM_NEAREST) {
-        double a[6];
+        double a[8];
 
         memset(a, 0, sizeof a);
         a[0] = (double)(box[2] - box[0]) / xsize;


### PR DESCRIPTION
      src/_imaging.c:1842:17: warning: ‘ImagingTransform’ accessing 64 bytes in a region of size 48 [-Wstringop-overflow=]
       1842 |         imOut = ImagingTransform(
            |                 ^~~~~~~~~~~~~~~~~
       1843 |             imOut, imIn, IMAGING_TRANSFORM_AFFINE, 0, 0, xsize, ysize, a, filter, 1);
            |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      src/_imaging.c:1842:17: note: referencing argument 8 of type ‘double *’

