### PR TITLE
Added file to list of partially supported BMPs

### DIFF
--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -35,6 +35,7 @@ def test_questionable():
         "pal8os2v2.bmp",
         "rgb24prof.bmp",
         "pal1p1.bmp",
+        "pal4rletrns.bmp",
         "pal8offs.bmp",
         "rgb24lprof.bmp",
         "rgb32fakealpha.bmp",


### PR DESCRIPTION
Since #6674, Tests/test_bmp_reference.py has started [printing](https://github.com/python-pillow/Pillow/blob/86b4cb6d14553d93b65ca6fbd76c433ae515aeeb/Tests/test_bmp_reference.py#L51)
> Please add Tests/images/bmp/q/pal4rletrns.bmp to the partially supported bmp specs.