### PR TITLE
Updated AppVeyor to Python 3.11

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ environment:
   TEST_OPTIONS:
   DEPLOY: YES
   matrix:
-  - PYTHON: C:/Python310
+  - PYTHON: C:/Python311
     ARCHITECTURE: x86
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
   - PYTHON: C:/Python37-x64


### PR DESCRIPTION
Helps #6575

Python 3.11.0 has been deployed to AppVeyor - https://www.appveyor.com/updates/2022/11/07/