### PR TITLE
Update to Python 3.11 in GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.11"
+        python-version: "3.x"
         cache: pip
         cache-dependency-path: "setup.py"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 permissions:
   contents: read
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
         cache: pip
         cache-dependency-path: "setup.py"
 

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -226,7 +226,7 @@ jobs:
         path: dist\*.whl
 
     - name: Upload fribidi.dll
-      if: "github.event_name != 'pull_request' && matrix.python-version == 3.10"
+      if: "github.event_name != 'pull_request' && matrix.python-version == 3.11"
       uses: actions/upload-artifact@v3
       with:
         name: fribidi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 permissions:
   contents: read
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -96,7 +96,7 @@ jobs:
         path: Tests/errors
 
     - name: Docs
-      if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == 3.10
+      if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == 3.11
       run: |
         make doccheck
 


### PR DESCRIPTION
Use Python 3.11 instead of 3.10 in GitHub Actions when
- running lint
- uploading Fribidi
- checking the documentation