### PR TITLE
Revert "Install NumPy with OpenBLAS"

### DIFF
--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-brew install libtiff libjpeg openjpeg libimagequant webp little-cms2 freetype openblas libraqm
+brew install libtiff libjpeg openjpeg libimagequant webp little-cms2 freetype libraqm
 
 PYTHONOPTIMIZE=0 python3 -m pip install cffi
 python3 -m pip install coverage
@@ -13,7 +13,6 @@ python3 -m pip install -U pytest-cov
 python3 -m pip install -U pytest-timeout
 python3 -m pip install pyroma
 
-echo -e "[openblas]\nlibraries = openblas\nlibrary_dirs = /usr/local/opt/openblas/lib" >> ~/.numpy-site.cfg
 python3 -m pip install numpy
 
 # extra test images


### PR DESCRIPTION
Reverts #4711, as I find that macOS PyPy no longer fails without it.

This is likely because [NumPy 1.21 enabled Accelerate](https://numpy.org/doc/stable/release/1.21.0-notes.html#enable-accelerate-framework). This was the [motivation](https://github.com/python-pillow/Pillow/pull/4710#issuecomment-647081765) for switching to OpenBLAS, as there were [problems with it.](https://github.com/numpy/numpy/issues/15947)