### PR TITLE
Added the _exclusive_fp check to Image.close()

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -570,12 +570,13 @@ class Image:
         more information.
         """
         try:
-            if getattr(self, "_fp", False):
-                if self._fp != self.fp:
-                    self._fp.close()
-                self._fp = DeferredError(ValueError("Operation on closed image"))
-            if self.fp:
-                self.fp.close()
+            if hasattr(self, "fp") and getattr(self, "_exclusive_fp", False):
+                if getattr(self, "_fp", False):
+                    if self._fp != self.fp:
+                        self._fp.close()
+                    self._fp = DeferredError(ValueError("Operation on closed image"))
+                if self.fp:
+                    self.fp.close()
             self.fp = None
         except Exception as msg:
             logger.debug("Error closing: %s", msg)


### PR DESCRIPTION
Fixes #5309

Changes proposed in this pull request:

 * Makes it so that when an image is opened using an exclusive file pointer, it will not close the original file pointer. This ensures that `Image.close()` is consistent with the functionality of `Image.__exit__()`

Changelog message:

Image.close() will no longer close an externally provided file pointer if one is provided.
