### PR TITLE
Added MP Format Version when saving MPO

### DIFF
--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -268,6 +268,7 @@ def test_save_all():
     im_reloaded = roundtrip(im, save_all=True, append_images=[im2])
 
     assert_image_equal(im, im_reloaded)
+    assert im_reloaded.mpinfo[45056] == b"0100"
 
     im_reloaded.seek(1)
     assert_image_similar(im2, im_reloaded, 1)

--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -51,7 +51,7 @@ def _save_all(im, fp, filename):
             if not offsets:
                 # APP2 marker
                 im.encoderinfo["extra"] = (
-                    b"\xFF\xE2" + struct.pack(">H", 6 + 70) + b"MPF\0" + b" " * 70
+                    b"\xFF\xE2" + struct.pack(">H", 6 + 82) + b"MPF\0" + b" " * 82
                 )
                 JpegImagePlugin._save(im_frame, fp, filename)
                 offsets.append(fp.tell())
@@ -60,6 +60,7 @@ def _save_all(im, fp, filename):
                 offsets.append(fp.tell() - offsets[-1])
 
     ifd = TiffImagePlugin.ImageFileDirectory_v2()
+    ifd[0xB000] = b"0100"
     ifd[0xB001] = len(offsets)
 
     mpentries = b""


### PR DESCRIPTION
As noted in https://github.com/python-pillow/Pillow/issues/6720#issuecomment-1308617053, https://web.archive.org/web/20190227081740/http://www.cipa.jp/std/documents/e/DC-007_E.pdf states that
> 5.2.3.1. MP Format Version
> This tag specifies the version of the MP Extensions. An MP File that complies with this specification shall specify a 4 byte ASCII value of “0100.”

This PR adds "MP Format Version" when saving MPO images.