### PR TITLE
Remove ImagingAccessInit line() method

### DIFF
--- a/src/PIL/PyAccess.py
+++ b/src/PIL/PyAccess.py
@@ -13,8 +13,7 @@
 
 # Notes:
 #
-#  * Implements the pixel access object following Access.
-#  * Does not implement the line functions, as they don't appear to be used
+#  * Implements the pixel access object following Access.c
 #  * Taking only the tuple form, which is used from python.
 #    * Fill.c uses the integer form, but it's still going to use the old
 #      Access.c implementation.

--- a/src/libImaging/Access.c
+++ b/src/libImaging/Access.c
@@ -43,23 +43,6 @@ add_item(const char *mode) {
     return &access_table[i];
 }
 
-/* fetch pointer to pixel line */
-
-static void *
-line_8(Imaging im, int x, int y) {
-    return &im->image8[y][x];
-}
-
-static void *
-line_16(Imaging im, int x, int y) {
-    return &im->image8[y][x + x];
-}
-
-static void *
-line_32(Imaging im, int x, int y) {
-    return &im->image32[y][x];
-}
-
 /* fetch individual pixel */
 
 static void
@@ -187,36 +170,35 @@ put_pixel_32(Imaging im, int x, int y, const void *color) {
 
 void
 ImagingAccessInit() {
-#define ADD(mode_, line_, get_pixel_, put_pixel_) \
+#define ADD(mode_, get_pixel_, put_pixel_)        \
     {                                             \
         ImagingAccess access = add_item(mode_);   \
-        access->line = line_;                     \
         access->get_pixel = get_pixel_;           \
         access->put_pixel = put_pixel_;           \
     }
 
     /* populate access table */
-    ADD("1", line_8, get_pixel_8, put_pixel_8);
-    ADD("L", line_8, get_pixel_8, put_pixel_8);
-    ADD("LA", line_32, get_pixel, put_pixel);
-    ADD("La", line_32, get_pixel, put_pixel);
-    ADD("I", line_32, get_pixel_32, put_pixel_32);
-    ADD("I;16", line_16, get_pixel_16L, put_pixel_16L);
-    ADD("I;16L", line_16, get_pixel_16L, put_pixel_16L);
-    ADD("I;16B", line_16, get_pixel_16B, put_pixel_16B);
-    ADD("I;32L", line_32, get_pixel_32L, put_pixel_32L);
-    ADD("I;32B", line_32, get_pixel_32B, put_pixel_32B);
-    ADD("F", line_32, get_pixel_32, put_pixel_32);
-    ADD("P", line_8, get_pixel_8, put_pixel_8);
-    ADD("PA", line_32, get_pixel, put_pixel);
-    ADD("RGB", line_32, get_pixel_32, put_pixel_32);
-    ADD("RGBA", line_32, get_pixel_32, put_pixel_32);
-    ADD("RGBa", line_32, get_pixel_32, put_pixel_32);
-    ADD("RGBX", line_32, get_pixel_32, put_pixel_32);
-    ADD("CMYK", line_32, get_pixel_32, put_pixel_32);
-    ADD("YCbCr", line_32, get_pixel_32, put_pixel_32);
-    ADD("LAB", line_32, get_pixel_32, put_pixel_32);
-    ADD("HSV", line_32, get_pixel_32, put_pixel_32);
+    ADD("1", get_pixel_8, put_pixel_8);
+    ADD("L", get_pixel_8, put_pixel_8);
+    ADD("LA", get_pixel, put_pixel);
+    ADD("La", get_pixel, put_pixel);
+    ADD("I", get_pixel_32, put_pixel_32);
+    ADD("I;16", get_pixel_16L, put_pixel_16L);
+    ADD("I;16L", get_pixel_16L, put_pixel_16L);
+    ADD("I;16B", get_pixel_16B, put_pixel_16B);
+    ADD("I;32L", get_pixel_32L, put_pixel_32L);
+    ADD("I;32B", get_pixel_32B, put_pixel_32B);
+    ADD("F", get_pixel_32, put_pixel_32);
+    ADD("P", get_pixel_8, put_pixel_8);
+    ADD("PA", get_pixel, put_pixel);
+    ADD("RGB", get_pixel_32, put_pixel_32);
+    ADD("RGBA", get_pixel_32, put_pixel_32);
+    ADD("RGBa", get_pixel_32, put_pixel_32);
+    ADD("RGBX", get_pixel_32, put_pixel_32);
+    ADD("CMYK", get_pixel_32, put_pixel_32);
+    ADD("YCbCr", get_pixel_32, put_pixel_32);
+    ADD("LAB", get_pixel_32, put_pixel_32);
+    ADD("HSV", get_pixel_32, put_pixel_32);
 }
 
 ImagingAccess

--- a/src/libImaging/Imaging.h
+++ b/src/libImaging/Imaging.h
@@ -124,7 +124,6 @@ struct ImagingMemoryInstance {
 
 struct ImagingAccessInstance {
     const char *mode;
-    void *(*line)(Imaging im, int x, int y);
     void (*get_pixel)(Imaging im, int x, int y, void *pixel);
     void (*put_pixel)(Imaging im, int x, int y, const void *pixel);
 };


### PR DESCRIPTION
This method isn't used anywhere, and PyAccess doesn't implement it (because it's not used).