### PR TITLE
Fixed writing int as BYTE tag

### DIFF
--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -201,6 +201,22 @@ def test_writing_bytes_to_ascii(tmp_path):
         assert reloaded.tag_v2[271] == "test"
 
 
+def test_writing_int_to_bytes(tmp_path):
+    im = hopper()
+    info = TiffImagePlugin.ImageFileDirectory_v2()
+
+    tag = TiffTags.TAGS_V2[700]
+    assert tag.type == TiffTags.BYTE
+
+    info[700] = 1
+
+    out = str(tmp_path / "temp.tiff")
+    im.save(out, tiffinfo=info)
+
+    with Image.open(out) as reloaded:
+        assert reloaded.tag_v2[700] == b"\x01"
+
+
 def test_undefined_zero(tmp_path):
     # Check that the tag has not been changed since this test was created
     tag = TiffTags.TAGS_V2[45059]

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -719,6 +719,8 @@ class ImageFileDirectory_v2(MutableMapping):
 
     @_register_writer(1)  # Basic type, except for the legacy API.
     def write_byte(self, data):
+        if isinstance(data, int):
+            data = bytes((data,))
         return data
 
     @_register_loader(2, 1)


### PR DESCRIPTION
Resolves #6737. Similar to #6493

The issue provides an image where the GPSAltitudeRef tag has type SHORT. https://www.awaresystems.be/imaging/tiff/tifftags/privateifd/gps/gpsaltituderef.html states that it should have type BYTE. The tag is loaded as an int then, not bytes as expected. This causes errors when Pillow tries to write the EXIF data.

This PR simply changes TiffImagePlugin to convert an int to bytes when writing a BYTE tag.