### PR TITLE
Added WebP encoding with exact config

### DIFF
--- a/Tests/test_file_webp_alpha.py
+++ b/Tests/test_file_webp_alpha.py
@@ -96,6 +96,40 @@ def test_write_rgba(tmp_path):
         else:
             assert_image_similar(image, pil_image, 1.0)
 
+def test_write_rgba_keep_transparent(tmp_path):
+    """
+    Can we write a RGBA mode file to WebP while preserving
+    the transparent RGB without error.
+    Does it have the bits we expect?
+    """
+
+    temp_output_file = str(tmp_path / "temp.webp")
+
+    input_image = hopper("RGB")
+    # make a copy of the image
+    output_image = input_image.copy()
+    # make a single channel image with the same size as input_image
+    new_alpha = Image.new("L", input_image.size, 255)
+    # make the left half transparent
+    new_alpha.paste((0,), (0, 0, new_alpha.size[0]//2, new_alpha.size[1]))
+    # putalpha on output_image
+    output_image.putalpha(new_alpha)
+
+    # now save with transparent area preserved.
+    output_image.save(temp_output_file, "WEBP", exact=True, lossless=True)
+    # even though it is lossless, if we don't put exact=True, the transparent
+    # area will be filled with black (or something more conducive to compression)
+
+    with Image.open(temp_output_file) as image:
+        image.load()
+
+        assert image.mode == "RGBA"
+        assert image.format == "WEBP"
+        image.load()
+        image = image.convert("RGB")
+        assert_image_similar(image, input_image, 1.0)
+
+
 
 def test_write_unsupported_mode_PA(tmp_path):
     """

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1127,7 +1127,7 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
 **exact**
     If true, preserve the transparent RGB values. Otherwise, discard
     invisible RGB values for better compression. Defaults to false.
-    Requires LibWebP 0.5.0 or later.
+    Requires libwebp 0.5.0 or later.
 
 **icc_profile**
     The ICC Profile to include in the saved file. Only supported if

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1124,6 +1124,10 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
 **method**
     Quality/speed trade-off (0=fast, 6=slower-better). Defaults to 4.
 
+**exact**
+    If true, preserve the transparent RGB values. Otherwise, discard
+    invisible RGB values for better compression. Defaults to false.
+
 **icc_profile**
     The ICC Profile to include in the saved file. Only supported if
     the system WebP library was built with webpmux support.

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1127,6 +1127,7 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
 **exact**
     If true, preserve the transparent RGB values. Otherwise, discard
     invisible RGB values for better compression. Defaults to false.
+    Requires LibWebP 0.5.0 or later.
 
 **icc_profile**
     The ICC Profile to include in the saved file. Only supported if

--- a/docs/releasenotes/9.4.0.rst
+++ b/docs/releasenotes/9.4.0.rst
@@ -41,8 +41,9 @@ Added the ``exact`` encoding option for WebP
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``exact`` encoding option for WebP is now supported. The WebP encoder
-removes the hidden RGB values for better compression by default. By setting
-this option to ``True``, the encoder will keep the hidden RGB values.
+removes the hidden RGB values for better compression by default in libwebp 0.5
+or later. By setting this option to ``True``, the encoder will keep the hidden
+RGB values.
 
 Security
 ========

--- a/docs/releasenotes/9.4.0.rst
+++ b/docs/releasenotes/9.4.0.rst
@@ -41,7 +41,7 @@ Added the ``exact`` encoding option for WebP
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``exact`` encoding option for WebP is now supported. The WebP encoder
-removes the hidden RGB values for better compression by default. By setting 
+removes the hidden RGB values for better compression by default. By setting
 this option to ``True``, the encoder will keep the hidden RGB values.
 
 Security

--- a/docs/releasenotes/9.4.0.rst
+++ b/docs/releasenotes/9.4.0.rst
@@ -37,6 +37,13 @@ support a ``start`` argument. This tuple of horizontal and vertical offset
 will be used internally by :py:meth:`.ImageDraw.text` to more accurately place
 text at the ``xy`` coordinates.
 
+Added the ``exact`` encoding option for WebP
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``exact`` encoding option for WebP is now supported. The WebP encoder
+removes the hidden RGB values for better compression by default. By setting 
+this option to ``True``, the encoder will keep the hidden RGB values.
+
 Security
 ========
 

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -318,6 +318,7 @@ def _save(im, fp, filename):
         exif = exif[6:]
     xmp = im.encoderinfo.get("xmp", "")
     method = im.encoderinfo.get("method", 4)
+    exact = im.encoderinfo.get("exact", False)
 
     if im.mode not in _VALID_WEBP_LEGACY_MODES:
         alpha = (
@@ -336,6 +337,7 @@ def _save(im, fp, filename):
         im.mode,
         icc_profile,
         method,
+        1 if exact else 0,
         exif,
         xmp,
     )

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -576,6 +576,7 @@ WebPEncode_wrapper(PyObject *self, PyObject *args) {
     int lossless;
     float quality_factor;
     int method;
+    int exact;
     uint8_t *rgb;
     uint8_t *icc_bytes;
     uint8_t *exif_bytes;
@@ -597,7 +598,7 @@ WebPEncode_wrapper(PyObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(
             args,
-            "y#iiifss#is#s#",
+            "y#iiifss#iis#s#",
             (char **)&rgb,
             &size,
             &width,
@@ -608,6 +609,7 @@ WebPEncode_wrapper(PyObject *self, PyObject *args) {
             &icc_bytes,
             &icc_size,
             &method,
+            &exact,
             &exif_bytes,
             &exif_size,
             &xmp_bytes,
@@ -633,6 +635,7 @@ WebPEncode_wrapper(PyObject *self, PyObject *args) {
     config.lossless = lossless;
     config.quality = quality_factor;
     config.method = method;
+    config.exact = exact;
 
     // Validate the config
     if (!WebPValidateConfig(&config)) {

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -635,7 +635,10 @@ WebPEncode_wrapper(PyObject *self, PyObject *args) {
     config.lossless = lossless;
     config.quality = quality_factor;
     config.method = method;
+#if WEBP_ENCODER_ABI_VERSION >= 0x0209
+    // the exact flag is only available in libwebp 0.5.0 and later
     config.exact = exact;
+#endif
 
     // Validate the config
     if (!WebPValidateConfig(&config)) {

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -636,7 +636,7 @@ WebPEncode_wrapper(PyObject *self, PyObject *args) {
     config.quality = quality_factor;
     config.method = method;
 #if WEBP_ENCODER_ABI_VERSION >= 0x0209
-    // the exact flag is only available in libwebp 0.5.0 and later
+    // the "exact" flag is only available in libwebp 0.5.0 and later
     config.exact = exact;
 #endif
 


### PR DESCRIPTION
When encoding a transparent image with WebP, even if specified to be lossless, it'll drop the information that is not visible. This is normally fine, except for applications where you need to undo the mask or make additional changes later.

There's an option in the `WebPConfig` data structure named `exact`:

```C++
     int exact;           // if non-zero, preserve the exact RGB values under
                          // transparent area. Otherwise, discard this invisible
                          // RGB information for better compression. The default
                          // value is 0.
```

This option is not exposed to the users. In this pull request, I make this option available.

The parameter `exact` is True/False at the python level but translated to `0 or 1 (int)` to match that of `WebPConfig`.

Changes proposed in this pull request:

 * Updated the binding at `src/_webp.c`.
 * Updated the Python encoder at `src/PIL/WebPImagePlugin.py`.
 * Added documentation for the new flag `docs/handbook/image-file-formats.rst`.
 * Added the unit-test `Tests/test_file_webp_alpha.py`.

I tried to follow the guidelines as much as possible. Let me know if I'm missing anything.
Thanks.
