### PR TITLE
chore: enabled syntax highlighting

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -95,7 +95,7 @@ method with the following parameters to affect how Ghostscript renders the EPS
     Affects the scale of the resultant rasterized image. If the EPS suggests
     that the image be rendered at 100px x 100px, setting this parameter to
     2 will make the Ghostscript render a 200px x 200px image instead. The
-    relative position of the bounding box is maintained.
+    relative position of the bounding box is maintained
     
 .. code-block:: python
 

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -95,7 +95,7 @@ method with the following parameters to affect how Ghostscript renders the EPS
     Affects the scale of the resultant rasterized image. If the EPS suggests
     that the image be rendered at 100px x 100px, setting this parameter to
     2 will make the Ghostscript render a 200px x 200px image instead. The
-    relative position of the bounding box is maintained
+    relative position of the bounding box is maintained:
     
 .. code-block:: python
 
@@ -127,7 +127,7 @@ colors. Instead, the image is converted to ``RGB`` handle this.
 
 If you would prefer the first ``P`` image frame to be ``RGB`` as well, so that
 every ``P`` frame is converted to ``RGB`` or ``RGBA`` mode, there is a setting
-available
+available:
 
 .. code-block:: python
 
@@ -137,7 +137,7 @@ available
 GIF frames do not always contain individual palettes however. If there is only
 a global palette, then all of the colors can fit within ``P`` mode. If you would
 prefer the frames to be kept as ``P`` in that case, there is also a setting
-available
+available:
 
 .. code-block:: python
 
@@ -145,7 +145,7 @@ available
     GifImagePlugin.LOADING_STRATEGY = GifImagePlugin.LoadingStrategy.RGB_AFTER_DIFFERENT_PALETTE_ONLY
 
 To restore the default behavior, where ``P`` mode images are only converted to
-``RGB`` or ``RGBA`` after the first frame
+``RGB`` or ``RGBA`` after the first frame:
 
 .. code-block:: python
 

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -271,7 +271,7 @@ Reading local images
 
 The GIF loader creates an image memory the same size as the GIF file’s *logical
 screen size*, and pastes the actual pixel data (the *local image*) into this
-image. If you only want the actual pixel rectangle, you can crop the image
+image. If you only want the actual pixel rectangle, you can crop the image:
 
 .. code-block:: python
 
@@ -454,7 +454,9 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
 **icc_profile**
     If present and true, the image is stored with the provided ICC profile.
     If this parameter is not provided, the image will be saved with no profile
-    attached. To preserve the existing profile::
+    attached. To preserve the existing profile:
+    
+.. code-block:: python
 
         im.save(filename, 'jpeg', icc_profile=im.info.get('icc_profile'))
 

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -200,7 +200,9 @@ Saving
 ~~~~~~
 
 When calling :py:meth:`~PIL.Image.Image.save` to write a GIF file, the
-following options are available::
+following options are available:
+
+.. code-block:: python
 
     im.save(out, save_all=True, append_images=[im1, im2, ...])
 
@@ -883,7 +885,9 @@ The :py:meth:`~PIL.Image.open` method sets the following attributes:
     Set to the number of images in the stack.
 
 A convenience method, :py:meth:`~PIL.SpiderImagePlugin.SpiderImageFile.convert2byte`,
-is provided for converting floating point data to byte data (mode ``L``)::
+is provided for converting floating point data to byte data (mode ``L``):
+
+.. code-block:: python
 
     im = Image.open("image001.spi").convert2byte()
 
@@ -893,7 +897,9 @@ Saving
 ~~~~~~
 
 The extension of SPIDER files may be any 3 alphanumeric characters. Therefore
-the output format must be specified explicitly::
+the output format must be specified explicitly:
+
+.. code-block:: python
 
     im.save('newimage.spi', format='SPIDER')
 

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -95,7 +95,9 @@ method with the following parameters to affect how Ghostscript renders the EPS
     Affects the scale of the resultant rasterized image. If the EPS suggests
     that the image be rendered at 100px x 100px, setting this parameter to
     2 will make the Ghostscript render a 200px x 200px image instead. The
-    relative position of the bounding box is maintained::
+    relative position of the bounding box is maintained.
+    
+.. code-block:: python
 
         im = Image.open(...)
         im.size  # (100,100)
@@ -125,7 +127,9 @@ colors. Instead, the image is converted to ``RGB`` handle this.
 
 If you would prefer the first ``P`` image frame to be ``RGB`` as well, so that
 every ``P`` frame is converted to ``RGB`` or ``RGBA`` mode, there is a setting
-available::
+available
+
+.. code-block:: python
 
     from PIL import GifImagePlugin
     GifImagePlugin.LOADING_STRATEGY = GifImagePlugin.LoadingStrategy.RGB_ALWAYS
@@ -133,13 +137,17 @@ available::
 GIF frames do not always contain individual palettes however. If there is only
 a global palette, then all of the colors can fit within ``P`` mode. If you would
 prefer the frames to be kept as ``P`` in that case, there is also a setting
-available::
+available
+
+.. code-block:: python
 
     from PIL import GifImagePlugin
     GifImagePlugin.LOADING_STRATEGY = GifImagePlugin.LoadingStrategy.RGB_AFTER_DIFFERENT_PALETTE_ONLY
 
 To restore the default behavior, where ``P`` mode images are only converted to
-``RGB`` or ``RGBA`` after the first frame::
+``RGB`` or ``RGBA`` after the first frame
+
+.. code-block:: python
 
     from PIL import GifImagePlugin
     GifImagePlugin.LOADING_STRATEGY = GifImagePlugin.LoadingStrategy.RGB_AFTER_FIRST
@@ -263,7 +271,9 @@ Reading local images
 
 The GIF loader creates an image memory the same size as the GIF file’s *logical
 screen size*, and pastes the actual pixel data (the *local image*) into this
-image. If you only want the actual pixel rectangle, you can crop the image::
+image. If you only want the actual pixel rectangle, you can crop the image
+
+.. code-block:: python
 
     im = Image.open(...)
 


### PR DESCRIPTION
I enabled the syntax highlighting feature in the `image-file-formats.rst`