### PR TITLE
Use stdlib for setuptools on Cygwin

### DIFF
--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 permissions:
   contents: read
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -76,7 +76,7 @@ jobs:
       - name: Build
         shell: bash.exe -eo pipefail -o igncr "{0}"
         run: |
-          .ci/build.sh
+          SETUPTOOLS_USE_DISTUTILS=stdlib .ci/build.sh
 
       - name: Test
         run: |


### PR DESCRIPTION
Alternative to #6759

[pyroma 4.1 was released yesterday](https://github.com/regebro/pyroma/tags). It now [requires setuptools >= 61](https://github.com/regebro/pyroma/blob/28387e8c6b3dd2fa588e78fb0bf6af348d04a532/setup.cfg#L41). This has started Cygwin failing in main - https://github.com/python-pillow/Pillow/actions/runs/3544062653

This PR uses `SETUPTOOLS_USE_DISTUTILS=stdlib`, [as suggested previously.](https://github.com/python-pillow/Pillow/issues/6216#issuecomment-1122340162)