### PR TITLE
Support arbitrary number of loaded modules on Windows

### DIFF
--- a/src/Tk/tkImaging.c
+++ b/src/Tk/tkImaging.c
@@ -363,7 +363,7 @@ load_tkinter_funcs(void) {
     }
 
     free(hMods);
-    if (found_tcl != 1) {
+    if (found_tcl == 0) {
         PyErr_SetString(PyExc_RuntimeError, "Could not find Tcl routines");
     } else if (found_tk == 0) {
         PyErr_SetString(PyExc_RuntimeError, "Could not find Tk routines");

--- a/src/Tk/tkImaging.c
+++ b/src/Tk/tkImaging.c
@@ -332,7 +332,7 @@ load_tkinter_funcs(void) {
         PyErr_SetFromWindowsErr(0);
         return 1;
     }
-    if (!(hMods = static_cast<HMODULE*>(malloc(cbNeeded)))) {
+    if (!(hMods = (HMODULE*) malloc(cbNeeded))) {
         PyErr_NoMemory();
         return 1;
     }

--- a/src/Tk/tkImaging.c
+++ b/src/Tk/tkImaging.c
@@ -365,7 +365,7 @@ load_tkinter_funcs(void) {
     free(hMods);
     if (found_tcl != 1) {
         PyErr_SetString(PyExc_RuntimeError, "Could not find Tcl routines");
-    } else if (found_tk != 1) {
+    } else if (found_tk == 0) {
         PyErr_SetString(PyExc_RuntimeError, "Could not find Tk routines");
     }
     return (int) ((found_tcl != 1) || (found_tk != 1));

--- a/src/Tk/tkImaging.c
+++ b/src/Tk/tkImaging.c
@@ -365,7 +365,7 @@ exit:
     } else if (found_tk != 1) {
         PyErr_SetString(PyExc_RuntimeError, "Could not find Tk routines");
     }
-    return int((found_tcl != 1) && (found_tk != 1));
+    return (int) ((found_tcl != 1) && (found_tk != 1));
 }
 
 #else /* not Windows */

--- a/src/Tk/tkImaging.c
+++ b/src/Tk/tkImaging.c
@@ -329,7 +329,11 @@ load_tkinter_funcs(void) {
 
     /* Allocate module handlers array */
     if (!EnumProcessModules(hProcess, NULL, 0, &cbNeeded)) {
+#if defined(__CYGWIN__)
+        PyErr_SetString(PyExc_OSError, "Call to EnumProcessModules failed");
+#else
         PyErr_SetFromWindowsErr(0);
+#endif
         return 1;
     }
     if (!(hMods = (HMODULE*) malloc(cbNeeded))) {

--- a/src/Tk/tkImaging.c
+++ b/src/Tk/tkImaging.c
@@ -368,7 +368,7 @@ load_tkinter_funcs(void) {
     } else if (found_tk != 1) {
         PyErr_SetString(PyExc_RuntimeError, "Could not find Tk routines");
     }
-    return (int) ((found_tcl != 1) && (found_tk != 1));
+    return (int) ((found_tcl != 1) || (found_tk != 1));
 }
 
 #else /* not Windows */


### PR DESCRIPTION
Changed the TKinter module loading function for Windows to support the rare (but possible) case of having more than 1024 modules loaded. This is an adaptation of the same fix that was added to Matplotlib in [PR #22445](https://github.com/matplotlib/matplotlib/pull/22445) to solve their [issue #22378](https://github.com/matplotlib/matplotlib/issues/22378). The same issue happens with Pillow under similar circumstances (error `RuntimeError: Could not find Tcl routines` with `PIL.ImageTk` module is loaded).