### PR TITLE
Fix WebP dealloc method definitions

### DIFF
--- a/src/_webp.c
+++ b/src/_webp.c
@@ -178,12 +178,11 @@ _anim_encoder_new(PyObject *self, PyObject *args) {
     return NULL;
 }
 
-PyObject *
+void
 _anim_encoder_dealloc(PyObject *self) {
     WebPAnimEncoderObject *encp = (WebPAnimEncoderObject *)self;
     WebPPictureFree(&(encp->frame));
     WebPAnimEncoderDelete(encp->enc);
-    Py_RETURN_NONE;
 }
 
 PyObject *
@@ -400,12 +399,11 @@ _anim_decoder_new(PyObject *self, PyObject *args) {
     return NULL;
 }
 
-PyObject *
+void
 _anim_decoder_dealloc(PyObject *self) {
     WebPAnimDecoderObject *decp = (WebPAnimDecoderObject *)self;
     WebPDataClear(&(decp->data));
     WebPAnimDecoderDelete(decp->dec);
-    Py_RETURN_NONE;
 }
 
 PyObject *


### PR DESCRIPTION
This fixes

```
  src/_webp.c:494:5: warning: cast between incompatible function types from ‘PyObject * (*)(PyObject *)’ {aka ‘struct _object * (*)(struct _object *)’} to ‘void (*)(PyObject *)’ {aka ‘void (*)(struct _object *)’} [-Wcast-function-type]
    494 |     (destructor)_anim_encoder_dealloc, /*tp_dealloc*/
        |     ^
```

Or to put that a bit more clearly, the function type of the destructor functions should be `void (*)(PyObject *)` not `PyObject * (*)(PyObject *)`.