### PR TITLE
Use Sphinx Inline Tabs to organise installation per OS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,10 @@ indent_style = space
 
 trim_trailing_whitespace = true
 
+[*.rst]
+# Three-space indentation
+indent_size = 3
+
 [*.yml]
 # Two-space indentation
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,7 @@ trim_trailing_whitespace = true
 
 [*.rst]
 # Three-space indentation
-indent_size = 3
+indent_size = 4
 
 [*.yml]
 # Two-space indentation

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ indent_style = space
 trim_trailing_whitespace = true
 
 [*.rst]
-# Three-space indentation
+# Four-space indentation
 indent_size = 4
 
 [*.yml]

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,6 +20,8 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html       to make standalone HTML files"
+	@echo "  serve      to start a local server for viewing docs"
+	@echo "  livehtml   to start a local server for viewing docs and auto-reload on change"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
 	@echo "  pickle     to make pickle files"
@@ -38,6 +40,8 @@ help:
 	@echo "  changes    to make an overview of all changed/added/deprecated items"
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
+	@echo "  serve      to start a local server for viewing docs"
+	@echo "  livehtml   to start a local server for viewing docs and auto-reload on change"
 
 clean:
 	-rm -rf $(BUILDDIR)/*

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -90,7 +90,7 @@ htmlhelp:
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in $(BUILDDIR)/htmlhelp."
 
-.PHONY:  qthelp
+.PHONY: qthelp
 qthelp:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,8 +15,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
-
+.PHONY: help
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html       to make standalone HTML files"
@@ -40,45 +39,50 @@ help:
 	@echo "  changes    to make an overview of all changed/added/deprecated items"
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
-	@echo "  serve      to start a local server for viewing docs"
-	@echo "  livehtml   to start a local server for viewing docs and auto-reload on change"
 
+.PHONY: clean
 clean:
 	-rm -rf $(BUILDDIR)/*
 
 install-sphinx:
 	$(PYTHON) -m pip install --quiet furo olefile sphinx sphinx-copybutton sphinx-inline-tabs sphinx-issues sphinx-removed-in sphinxext-opengraph
 
+.PHONY: html
 html:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b html -W --keep-going $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
+.PHONY: dirhtml
 dirhtml:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
+.PHONY: singlehtml
 singlehtml:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
 
+.PHONY: pickle
 pickle:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files."
 
+.PHONY: json
 json:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
+.PHONY: htmlhelp
 htmlhelp:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
@@ -86,6 +90,7 @@ htmlhelp:
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in $(BUILDDIR)/htmlhelp."
 
+.PHONY:  qthelp
 qthelp:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
@@ -96,6 +101,7 @@ qthelp:
 	@echo "To view the help file:"
 	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/PillowPILfork.qhc"
 
+.PHONY: devhelp
 devhelp:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
@@ -106,12 +112,14 @@ devhelp:
 	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/PillowPILfork"
 	@echo "# devhelp"
 
+.PHONY: epub
 epub:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
 
+.PHONY: latex
 latex:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
@@ -120,6 +128,7 @@ latex:
 	@echo "Run \`make' in that directory to run these through (pdf)latex" \
 	      "(use \`make latexpdf' here to do that automatically)."
 
+.PHONY: latexpdf
 latexpdf:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
@@ -127,18 +136,21 @@ latexpdf:
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
+.PHONY: text
 text:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
 	@echo
 	@echo "Build finished. The text files are in $(BUILDDIR)/text."
 
+.PHONY: man
 man:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
 
+.PHONY: texinfo
 texinfo:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
@@ -147,6 +159,7 @@ texinfo:
 	@echo "Run \`make' in that directory to run these through makeinfo" \
 	      "(use \`make info' here to do that automatically)."
 
+.PHONY: info
 info:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
@@ -154,18 +167,21 @@ info:
 	make -C $(BUILDDIR)/texinfo info
 	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
 
+.PHONY: gettext
 gettext:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
 	@echo
 	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
 
+.PHONY: changes
 changes:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
 	@echo
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
+.PHONY: linkcheck
 linkcheck:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck -j auto
@@ -173,14 +189,17 @@ linkcheck:
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
 
+.PHONY: doctest
 doctest:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
+.PHONY: livehtml
 livehtml: html
 	livereload $(BUILDDIR)/html -p 33233
 
+.PHONY: serve
 serve:
 	cd $(BUILDDIR)/html; $(PYTHON) -m http.server

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -43,7 +43,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 install-sphinx:
-	$(PYTHON) -m pip install --quiet sphinx sphinx-copybutton sphinx-issues sphinx-removed-in sphinxext-opengraph furo olefile
+	$(PYTHON) -m pip install --quiet furo olefile sphinx sphinx-copybutton sphinx-inline-tabs sphinx-issues sphinx-removed-in sphinxext-opengraph
 
 html:
 	$(MAKE) install-sphinx

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,12 +27,13 @@ needs_sphinx = "2.4"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "sphinx_copybutton",
-    "sphinx_issues",
-    "sphinx_removed_in",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
+    "sphinx_copybutton",
+    "sphinx_inline_tabs",
+    "sphinx_issues",
+    "sphinx_removed_in",
     "sphinxext.opengraph",
 ]
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,9 +23,9 @@ Pillow supports these Python versions.
    :file: older-versions.csv
    :header-rows: 1
 
-.. _Windows Installation:
-.. _macOS Installation:
 .. _Linux Installation:
+.. _macOS Installation:
+.. _Windows Installation:
 .. _FreeBSD Installation:
 
 Basic Installation
@@ -43,29 +43,6 @@ Install Pillow with :command:`pip`::
     python3 -m pip install --upgrade Pillow
 
 
-.. tab:: Windows
-
-   We provide Pillow binaries for Windows compiled for the matrix of
-   supported Pythons in both 32 and 64-bit versions in the wheel format.
-   These binaries include support for all optional libraries except
-   libimagequant and libxcb. Raqm support requires
-   FriBiDi to be installed separately::
-
-       python3 -m pip install --upgrade pip
-       python3 -m pip install --upgrade Pillow
-
-   To install Pillow in MSYS2, see `Building on Windows using MSYS2/MinGW`_.
-
-.. tab:: macOS
-
-   We provide binaries for macOS for each of the supported Python
-   versions in the wheel format. These include support for all optional
-   libraries except libimagequant. Raqm support requires
-   FriBiDi to be installed separately::
-
-       python3 -m pip install --upgrade pip
-       python3 -m pip install --upgrade Pillow
-
 .. tab:: Linux
 
    We provide binaries for Linux for each of the supported Python
@@ -80,6 +57,29 @@ Install Pillow with :command:`pip`::
    also include Pillow in packages that previously contained PIL e.g.
    ``python-imaging``. Debian splits it into two packages, ``python3-pil``
    and ``python3-pil.imagetk``.
+
+.. tab:: macOS
+
+   We provide binaries for macOS for each of the supported Python
+   versions in the wheel format. These include support for all optional
+   libraries except libimagequant. Raqm support requires
+   FriBiDi to be installed separately::
+
+       python3 -m pip install --upgrade pip
+       python3 -m pip install --upgrade Pillow
+
+.. tab:: Windows
+
+   We provide Pillow binaries for Windows compiled for the matrix of
+   supported Pythons in both 32 and 64-bit versions in the wheel format.
+   These binaries include support for all optional libraries except
+   libimagequant and libxcb. Raqm support requires
+   FriBiDi to be installed separately::
+
+       python3 -m pip install --upgrade pip
+       python3 -m pip install --upgrade Pillow
+
+   To install Pillow in MSYS2, see `Building on Windows using MSYS2/MinGW`_.
 
 .. tab:: FreeBSD
 
@@ -100,11 +100,11 @@ Install Pillow with :command:`pip`::
        are tested by the ports team with all supported FreeBSD versions.
 
 
+.. _Building on Linux:
 .. _Building on macOS:
 .. _Building on Windows:
 .. _Building on Windows using MSYS2/MinGW:
 .. _Building on FreeBSD:
-.. _Building on Linux:
 .. _Building on Android:
 
 Building From Source
@@ -194,6 +194,53 @@ Many of Pillow's features require external libraries:
 
 * **libxcb** provides X11 screengrab support.
 
+.. tab:: Linux
+
+   If you didn't build Python from source, make sure you have Python's
+   development libraries installed.
+
+   In Debian or Ubuntu::
+
+       sudo apt-get install python3-dev python3-setuptools
+
+   In Fedora, the command is::
+
+       sudo dnf install python3-devel redhat-rpm-config
+
+   In Alpine, the command is::
+
+       sudo apk add python3-dev py3-setuptools
+
+   .. Note:: ``redhat-rpm-config`` is required on Fedora 23, but not earlier versions.
+
+   Prerequisites for **Ubuntu 16.04 LTS - 22.04 LTS** are installed with::
+
+       sudo apt-get install libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev \
+           libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \
+           libharfbuzz-dev libfribidi-dev libxcb1-dev
+
+   To install libraqm, ``sudo apt-get install meson`` and then see
+   ``depends/install_raqm.sh``.
+
+   Prerequisites are installed on recent **Red Hat**, **CentOS** or **Fedora** with::
+
+       sudo dnf install libtiff-devel libjpeg-devel openjpeg2-devel zlib-devel \
+           freetype-devel lcms2-devel libwebp-devel tcl-devel tk-devel \
+           harfbuzz-devel fribidi-devel libraqm-devel libimagequant-devel libxcb-devel
+
+   Note that the package manager may be yum or DNF, depending on the
+   exact distribution.
+
+   Prerequisites are installed for **Alpine** with::
+
+       sudo apk add tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev lcms2-dev \
+           libwebp-dev tcl-dev tk-dev harfbuzz-dev fribidi-dev libimagequant-dev \
+           libxcb-dev libpng-dev
+
+   See also the ``Dockerfile``\s in the Test Infrastructure repo
+   (https://github.com/python-pillow/docker-images) for a known working
+   install process for other tested distros.
+
 .. tab:: macOS
 
    The Xcode command line tools are required to compile portions of
@@ -266,53 +313,6 @@ Many of Pillow's features require external libraries:
        sudo pkg install jpeg-turbo tiff webp lcms2 freetype2 openjpeg harfbuzz fribidi libxcb
 
    Then see ``depends/install_raqm_cmake.sh`` to install libraqm.
-
-.. tab:: Linux
-
-   If you didn't build Python from source, make sure you have Python's
-   development libraries installed.
-
-   In Debian or Ubuntu::
-
-       sudo apt-get install python3-dev python3-setuptools
-
-   In Fedora, the command is::
-
-       sudo dnf install python3-devel redhat-rpm-config
-
-   In Alpine, the command is::
-
-       sudo apk add python3-dev py3-setuptools
-
-   .. Note:: ``redhat-rpm-config`` is required on Fedora 23, but not earlier versions.
-
-   Prerequisites for **Ubuntu 16.04 LTS - 22.04 LTS** are installed with::
-
-       sudo apt-get install libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev \
-           libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \
-           libharfbuzz-dev libfribidi-dev libxcb1-dev
-
-   To install libraqm, ``sudo apt-get install meson`` and then see
-   ``depends/install_raqm.sh``.
-
-   Prerequisites are installed on recent **Red Hat**, **CentOS** or **Fedora** with::
-
-       sudo dnf install libtiff-devel libjpeg-devel openjpeg2-devel zlib-devel \
-           freetype-devel lcms2-devel libwebp-devel tcl-devel tk-devel \
-           harfbuzz-devel fribidi-devel libraqm-devel libimagequant-devel libxcb-devel
-
-   Note that the package manager may be yum or DNF, depending on the
-   exact distribution.
-
-   Prerequisites are installed for **Alpine** with::
-
-       sudo apk add tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev lcms2-dev \
-           libwebp-dev tcl-dev tk-dev harfbuzz-dev fribidi-dev libimagequant-dev \
-           libxcb-dev libpng-dev
-
-   See also the ``Dockerfile``\s in the Test Infrastructure repo
-   (https://github.com/python-pillow/docker-images) for a known working
-   install process for other tested distros.
 
 .. tab:: Android
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,6 +23,11 @@ Pillow supports these Python versions.
    :file: older-versions.csv
    :header-rows: 1
 
+.. _Windows Installation:
+.. _macOS Installation:
+.. _Linux Installation:
+.. _FreeBSD Installation:
+
 Basic Installation
 ------------------
 
@@ -38,67 +43,69 @@ Install Pillow with :command:`pip`::
     python3 -m pip install --upgrade Pillow
 
 
-Windows Installation
-^^^^^^^^^^^^^^^^^^^^
+.. tab:: Windows
 
-We provide Pillow binaries for Windows compiled for the matrix of
-supported Pythons in both 32 and 64-bit versions in the wheel format.
-These binaries include support for all optional libraries except
-libimagequant and libxcb. Raqm support requires
-FriBiDi to be installed separately::
+   We provide Pillow binaries for Windows compiled for the matrix of
+   supported Pythons in both 32 and 64-bit versions in the wheel format.
+   These binaries include support for all optional libraries except
+   libimagequant and libxcb. Raqm support requires
+   FriBiDi to be installed separately::
 
-    python3 -m pip install --upgrade pip
-    python3 -m pip install --upgrade Pillow
+       python3 -m pip install --upgrade pip
+       python3 -m pip install --upgrade Pillow
 
-To install Pillow in MSYS2, see `Building on Windows using MSYS2/MinGW`_.
+   To install Pillow in MSYS2, see `Building on Windows using MSYS2/MinGW`_.
+
+.. tab:: macOS
+
+   We provide binaries for macOS for each of the supported Python
+   versions in the wheel format. These include support for all optional
+   libraries except libimagequant. Raqm support requires
+   FriBiDi to be installed separately::
+
+       python3 -m pip install --upgrade pip
+       python3 -m pip install --upgrade Pillow
+
+.. tab:: Linux
+
+   We provide binaries for Linux for each of the supported Python
+   versions in the manylinux wheel format. These include support for all
+   optional libraries except libimagequant. Raqm support requires
+   FriBiDi to be installed separately::
+
+       python3 -m pip install --upgrade pip
+       python3 -m pip install --upgrade Pillow
+
+   Most major Linux distributions, including Fedora, Ubuntu and ArchLinux
+   also include Pillow in packages that previously contained PIL e.g.
+   ``python-imaging``. Debian splits it into two packages, ``python3-pil``
+   and ``python3-pil.imagetk``.
+
+.. tab:: FreeBSD
+
+   Pillow can be installed on FreeBSD via the official Ports or Packages systems:
+
+   **Ports**::
+
+     cd /usr/ports/graphics/py-pillow && make install clean
+
+   **Packages**::
+
+     pkg install py38-pillow
+
+   .. note::
+
+       The `Pillow FreeBSD port
+       <https://www.freshports.org/graphics/py-pillow/>`_ and packages
+       are tested by the ports team with all supported FreeBSD versions.
 
 
-macOS Installation
-^^^^^^^^^^^^^^^^^^
-
-We provide binaries for macOS for each of the supported Python
-versions in the wheel format. These include support for all optional
-libraries except libimagequant. Raqm support requires
-FriBiDi to be installed separately::
-
-    python3 -m pip install --upgrade pip
-    python3 -m pip install --upgrade Pillow
-
-Linux Installation
-^^^^^^^^^^^^^^^^^^
-
-We provide binaries for Linux for each of the supported Python
-versions in the manylinux wheel format. These include support for all
-optional libraries except libimagequant. Raqm support requires
-FriBiDi to be installed separately::
-
-    python3 -m pip install --upgrade pip
-    python3 -m pip install --upgrade Pillow
-
-Most major Linux distributions, including Fedora, Ubuntu and ArchLinux
-also include Pillow in packages that previously contained PIL e.g.
-``python-imaging``. Debian splits it into two packages, ``python3-pil``
-and ``python3-pil.imagetk``.
-
-FreeBSD Installation
-^^^^^^^^^^^^^^^^^^^^
-
-Pillow can be installed on FreeBSD via the official Ports or Packages systems:
-
-**Ports**::
-
-  cd /usr/ports/graphics/py-pillow && make install clean
-
-**Packages**::
-
-  pkg install py38-pillow
-
-.. note::
-
-    The `Pillow FreeBSD port
-    <https://www.freshports.org/graphics/py-pillow/>`_ and packages
-    are tested by the ports team with all supported FreeBSD versions.
-
+.. _Building on macOS:
+.. _Building on Windows:
+.. _Building on Windows using MSYS2/MinGW:
+.. _Building on FreeBSD:
+.. _Building on Linux:
+.. _Building on Android:
 
 Building From Source
 --------------------
@@ -187,141 +194,135 @@ Many of Pillow's features require external libraries:
 
 * **libxcb** provides X11 screengrab support.
 
-Building on macOS
-"""""""""""""""""
+.. tab:: macOS
 
-The Xcode command line tools are required to compile portions of
-Pillow. The tools are installed by running ``xcode-select --install``
-from the command line. The command line tools are required even if you
-have the full Xcode package installed.  It may be necessary to run
-``sudo xcodebuild -license`` to accept the license prior to using the
-tools.
+   The Xcode command line tools are required to compile portions of
+   Pillow. The tools are installed by running ``xcode-select --install``
+   from the command line. The command line tools are required even if you
+   have the full Xcode package installed.  It may be necessary to run
+   ``sudo xcodebuild -license`` to accept the license prior to using the
+   tools.
 
-The easiest way to install external libraries is via `Homebrew
-<https://brew.sh/>`_. After you install Homebrew, run::
+   The easiest way to install external libraries is via `Homebrew
+   <https://brew.sh/>`_. After you install Homebrew, run::
 
-    brew install libjpeg libtiff little-cms2 openjpeg webp
+       brew install libjpeg libtiff little-cms2 openjpeg webp
 
-To install libraqm on macOS use Homebrew to install its dependencies::
+   To install libraqm on macOS use Homebrew to install its dependencies::
 
-    brew install freetype harfbuzz fribidi
+       brew install freetype harfbuzz fribidi
 
-Then see ``depends/install_raqm_cmake.sh`` to install libraqm.
+   Then see ``depends/install_raqm_cmake.sh`` to install libraqm.
 
-Building on Windows
-"""""""""""""""""""
+.. tab:: Windows
 
-We recommend you use prebuilt wheels from PyPI.
-If you wish to compile Pillow manually, you can use the build scripts
-in the ``winbuild`` directory used for CI testing and development.
-These scripts require Visual Studio 2017 or newer and NASM.
+   We recommend you use prebuilt wheels from PyPI.
+   If you wish to compile Pillow manually, you can use the build scripts
+   in the ``winbuild`` directory used for CI testing and development.
+   These scripts require Visual Studio 2017 or newer and NASM.
 
-The scripts also install Pillow from the local copy of the source code, so the
-`Installing`_ instructions will not be necessary afterwards.
+   The scripts also install Pillow from the local copy of the source code, so the
+   `Installing`_ instructions will not be necessary afterwards.
 
-Building on Windows using MSYS2/MinGW
-"""""""""""""""""""""""""""""""""""""
+.. tab:: Windows using MSYS2/MinGW
 
-To build Pillow using MSYS2, make sure you run the **MSYS2 MinGW 32-bit** or
-**MSYS2 MinGW 64-bit** console, *not* **MSYS2** directly.
+   To build Pillow using MSYS2, make sure you run the **MSYS2 MinGW 32-bit** or
+   **MSYS2 MinGW 64-bit** console, *not* **MSYS2** directly.
 
-The following instructions target the 64-bit build, for 32-bit
-replace all occurrences of ``mingw-w64-x86_64-`` with ``mingw-w64-i686-``.
+   The following instructions target the 64-bit build, for 32-bit
+   replace all occurrences of ``mingw-w64-x86_64-`` with ``mingw-w64-i686-``.
 
-Make sure you have Python and GCC installed::
+   Make sure you have Python and GCC installed::
 
-    pacman -S \
-        mingw-w64-x86_64-gcc \
-        mingw-w64-x86_64-python3 \
-        mingw-w64-x86_64-python3-pip \
-        mingw-w64-x86_64-python3-setuptools
+       pacman -S \
+           mingw-w64-x86_64-gcc \
+           mingw-w64-x86_64-python3 \
+           mingw-w64-x86_64-python3-pip \
+           mingw-w64-x86_64-python3-setuptools
 
-Prerequisites are installed on **MSYS2 MinGW 64-bit** with::
+   Prerequisites are installed on **MSYS2 MinGW 64-bit** with::
 
-    pacman -S \
-        mingw-w64-x86_64-libjpeg-turbo \
-        mingw-w64-x86_64-zlib \
-        mingw-w64-x86_64-libtiff \
-        mingw-w64-x86_64-freetype \
-        mingw-w64-x86_64-lcms2 \
-        mingw-w64-x86_64-libwebp \
-        mingw-w64-x86_64-openjpeg2 \
-        mingw-w64-x86_64-libimagequant \
-        mingw-w64-x86_64-libraqm
+       pacman -S \
+           mingw-w64-x86_64-libjpeg-turbo \
+           mingw-w64-x86_64-zlib \
+           mingw-w64-x86_64-libtiff \
+           mingw-w64-x86_64-freetype \
+           mingw-w64-x86_64-lcms2 \
+           mingw-w64-x86_64-libwebp \
+           mingw-w64-x86_64-openjpeg2 \
+           mingw-w64-x86_64-libimagequant \
+           mingw-w64-x86_64-libraqm
 
-Building on FreeBSD
-"""""""""""""""""""
+.. tab:: FreeBSD
 
-.. Note:: Only FreeBSD 10 and 11 tested
+   .. Note:: Only FreeBSD 10 and 11 tested
 
-Make sure you have Python's development libraries installed::
+   Make sure you have Python's development libraries installed::
 
-    sudo pkg install python3
+       sudo pkg install python3
 
-Prerequisites are installed on **FreeBSD 10 or 11** with::
+   Prerequisites are installed on **FreeBSD 10 or 11** with::
 
-    sudo pkg install jpeg-turbo tiff webp lcms2 freetype2 openjpeg harfbuzz fribidi libxcb
+       sudo pkg install jpeg-turbo tiff webp lcms2 freetype2 openjpeg harfbuzz fribidi libxcb
 
-Then see ``depends/install_raqm_cmake.sh`` to install libraqm.
+   Then see ``depends/install_raqm_cmake.sh`` to install libraqm.
 
-Building on Linux
-"""""""""""""""""
+.. tab:: Linux
 
-If you didn't build Python from source, make sure you have Python's
-development libraries installed.
+   If you didn't build Python from source, make sure you have Python's
+   development libraries installed.
 
-In Debian or Ubuntu::
+   In Debian or Ubuntu::
 
-    sudo apt-get install python3-dev python3-setuptools
+       sudo apt-get install python3-dev python3-setuptools
 
-In Fedora, the command is::
+   In Fedora, the command is::
 
-    sudo dnf install python3-devel redhat-rpm-config
+       sudo dnf install python3-devel redhat-rpm-config
 
-In Alpine, the command is::
+   In Alpine, the command is::
 
-    sudo apk add python3-dev py3-setuptools
+       sudo apk add python3-dev py3-setuptools
 
-.. Note:: ``redhat-rpm-config`` is required on Fedora 23, but not earlier versions.
+   .. Note:: ``redhat-rpm-config`` is required on Fedora 23, but not earlier versions.
 
-Prerequisites for **Ubuntu 16.04 LTS - 22.04 LTS** are installed with::
+   Prerequisites for **Ubuntu 16.04 LTS - 22.04 LTS** are installed with::
 
-    sudo apt-get install libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev \
-        libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \
-        libharfbuzz-dev libfribidi-dev libxcb1-dev
+       sudo apt-get install libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev \
+           libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \
+           libharfbuzz-dev libfribidi-dev libxcb1-dev
 
-To install libraqm, ``sudo apt-get install meson`` and then see
-``depends/install_raqm.sh``.
+   To install libraqm, ``sudo apt-get install meson`` and then see
+   ``depends/install_raqm.sh``.
 
-Prerequisites are installed on recent **Red Hat**, **CentOS** or **Fedora** with::
+   Prerequisites are installed on recent **Red Hat**, **CentOS** or **Fedora** with::
 
-    sudo dnf install libtiff-devel libjpeg-devel openjpeg2-devel zlib-devel \
-        freetype-devel lcms2-devel libwebp-devel tcl-devel tk-devel \
-        harfbuzz-devel fribidi-devel libraqm-devel libimagequant-devel libxcb-devel
+       sudo dnf install libtiff-devel libjpeg-devel openjpeg2-devel zlib-devel \
+           freetype-devel lcms2-devel libwebp-devel tcl-devel tk-devel \
+           harfbuzz-devel fribidi-devel libraqm-devel libimagequant-devel libxcb-devel
 
-Note that the package manager may be yum or DNF, depending on the
-exact distribution.
+   Note that the package manager may be yum or DNF, depending on the
+   exact distribution.
 
-Prerequisites are installed for **Alpine** with::
+   Prerequisites are installed for **Alpine** with::
 
-    sudo apk add tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev lcms2-dev \
-        libwebp-dev tcl-dev tk-dev harfbuzz-dev fribidi-dev libimagequant-dev \
-        libxcb-dev libpng-dev
+       sudo apk add tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev lcms2-dev \
+           libwebp-dev tcl-dev tk-dev harfbuzz-dev fribidi-dev libimagequant-dev \
+           libxcb-dev libpng-dev
 
-See also the ``Dockerfile``\s in the Test Infrastructure repo
-(https://github.com/python-pillow/docker-images) for a known working
-install process for other tested distros.
+   See also the ``Dockerfile``\s in the Test Infrastructure repo
+   (https://github.com/python-pillow/docker-images) for a known working
+   install process for other tested distros.
 
-Building on Android
-"""""""""""""""""""
+.. tab:: Android
 
-Basic Android support has been added for compilation within the Termux
-environment. The dependencies can be installed by::
+   Basic Android support has been added for compilation within the Termux
+   environment. The dependencies can be installed by::
 
-    pkg install -y python ndk-sysroot clang make \
-        libjpeg-turbo
+       pkg install -y python ndk-sysroot clang make \
+           libjpeg-turbo
 
-This has been tested within the Termux app on ChromeOS, on x86.
+   This has been tested within the Termux app on ChromeOS, on x86.
 
 Installing
 ^^^^^^^^^^

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -45,59 +45,59 @@ Install Pillow with :command:`pip`::
 
 .. tab:: Linux
 
-   We provide binaries for Linux for each of the supported Python
-   versions in the manylinux wheel format. These include support for all
-   optional libraries except libimagequant. Raqm support requires
-   FriBiDi to be installed separately::
+    We provide binaries for Linux for each of the supported Python
+    versions in the manylinux wheel format. These include support for all
+    optional libraries except libimagequant. Raqm support requires
+    FriBiDi to be installed separately::
 
-       python3 -m pip install --upgrade pip
-       python3 -m pip install --upgrade Pillow
+        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade Pillow
 
-   Most major Linux distributions, including Fedora, Ubuntu and ArchLinux
-   also include Pillow in packages that previously contained PIL e.g.
-   ``python-imaging``. Debian splits it into two packages, ``python3-pil``
-   and ``python3-pil.imagetk``.
+    Most major Linux distributions, including Fedora, Ubuntu and ArchLinux
+    also include Pillow in packages that previously contained PIL e.g.
+    ``python-imaging``. Debian splits it into two packages, ``python3-pil``
+    and ``python3-pil.imagetk``.
 
 .. tab:: macOS
 
-   We provide binaries for macOS for each of the supported Python
-   versions in the wheel format. These include support for all optional
-   libraries except libimagequant. Raqm support requires
-   FriBiDi to be installed separately::
+    We provide binaries for macOS for each of the supported Python
+    versions in the wheel format. These include support for all optional
+    libraries except libimagequant. Raqm support requires
+    FriBiDi to be installed separately::
 
-       python3 -m pip install --upgrade pip
-       python3 -m pip install --upgrade Pillow
+        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade Pillow
 
 .. tab:: Windows
 
-   We provide Pillow binaries for Windows compiled for the matrix of
-   supported Pythons in both 32 and 64-bit versions in the wheel format.
-   These binaries include support for all optional libraries except
-   libimagequant and libxcb. Raqm support requires
-   FriBiDi to be installed separately::
+    We provide Pillow binaries for Windows compiled for the matrix of
+    supported Pythons in both 32 and 64-bit versions in the wheel format.
+    These binaries include support for all optional libraries except
+    libimagequant and libxcb. Raqm support requires
+    FriBiDi to be installed separately::
 
-       python3 -m pip install --upgrade pip
-       python3 -m pip install --upgrade Pillow
+        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade Pillow
 
-   To install Pillow in MSYS2, see `Building on Windows using MSYS2/MinGW`_.
+    To install Pillow in MSYS2, see `Building on Windows using MSYS2/MinGW`_.
 
 .. tab:: FreeBSD
 
-   Pillow can be installed on FreeBSD via the official Ports or Packages systems:
+    Pillow can be installed on FreeBSD via the official Ports or Packages systems:
 
-   **Ports**::
+    **Ports**::
 
-     cd /usr/ports/graphics/py-pillow && make install clean
+        cd /usr/ports/graphics/py-pillow && make install clean
 
-   **Packages**::
+    **Packages**::
 
-     pkg install py38-pillow
+        pkg install py38-pillow
 
-   .. note::
+    .. note::
 
-       The `Pillow FreeBSD port
-       <https://www.freshports.org/graphics/py-pillow/>`_ and packages
-       are tested by the ports team with all supported FreeBSD versions.
+        The `Pillow FreeBSD port
+        <https://www.freshports.org/graphics/py-pillow/>`_ and packages
+        are tested by the ports team with all supported FreeBSD versions.
 
 
 .. _Building on Linux:
@@ -196,133 +196,133 @@ Many of Pillow's features require external libraries:
 
 .. tab:: Linux
 
-   If you didn't build Python from source, make sure you have Python's
-   development libraries installed.
+    If you didn't build Python from source, make sure you have Python's
+    development libraries installed.
 
-   In Debian or Ubuntu::
+    In Debian or Ubuntu::
 
-       sudo apt-get install python3-dev python3-setuptools
+        sudo apt-get install python3-dev python3-setuptools
 
-   In Fedora, the command is::
+    In Fedora, the command is::
 
        sudo dnf install python3-devel redhat-rpm-config
 
-   In Alpine, the command is::
+    In Alpine, the command is::
 
        sudo apk add python3-dev py3-setuptools
 
-   .. Note:: ``redhat-rpm-config`` is required on Fedora 23, but not earlier versions.
+    .. Note:: ``redhat-rpm-config`` is required on Fedora 23, but not earlier versions.
 
-   Prerequisites for **Ubuntu 16.04 LTS - 22.04 LTS** are installed with::
+    Prerequisites for **Ubuntu 16.04 LTS - 22.04 LTS** are installed with::
 
-       sudo apt-get install libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev \
-           libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \
-           libharfbuzz-dev libfribidi-dev libxcb1-dev
+        sudo apt-get install libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev \
+            libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \
+            libharfbuzz-dev libfribidi-dev libxcb1-dev
 
-   To install libraqm, ``sudo apt-get install meson`` and then see
-   ``depends/install_raqm.sh``.
+    To install libraqm, ``sudo apt-get install meson`` and then see
+    ``depends/install_raqm.sh``.
 
-   Prerequisites are installed on recent **Red Hat**, **CentOS** or **Fedora** with::
+    Prerequisites are installed on recent **Red Hat**, **CentOS** or **Fedora** with::
 
-       sudo dnf install libtiff-devel libjpeg-devel openjpeg2-devel zlib-devel \
-           freetype-devel lcms2-devel libwebp-devel tcl-devel tk-devel \
-           harfbuzz-devel fribidi-devel libraqm-devel libimagequant-devel libxcb-devel
+        sudo dnf install libtiff-devel libjpeg-devel openjpeg2-devel zlib-devel \
+            freetype-devel lcms2-devel libwebp-devel tcl-devel tk-devel \
+            harfbuzz-devel fribidi-devel libraqm-devel libimagequant-devel libxcb-devel
 
-   Note that the package manager may be yum or DNF, depending on the
-   exact distribution.
+    Note that the package manager may be yum or DNF, depending on the
+    exact distribution.
 
-   Prerequisites are installed for **Alpine** with::
+    Prerequisites are installed for **Alpine** with::
 
-       sudo apk add tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev lcms2-dev \
-           libwebp-dev tcl-dev tk-dev harfbuzz-dev fribidi-dev libimagequant-dev \
-           libxcb-dev libpng-dev
+        sudo apk add tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev lcms2-dev \
+            libwebp-dev tcl-dev tk-dev harfbuzz-dev fribidi-dev libimagequant-dev \
+            libxcb-dev libpng-dev
 
-   See also the ``Dockerfile``\s in the Test Infrastructure repo
-   (https://github.com/python-pillow/docker-images) for a known working
-   install process for other tested distros.
+    See also the ``Dockerfile``\s in the Test Infrastructure repo
+    (https://github.com/python-pillow/docker-images) for a known working
+    install process for other tested distros.
 
 .. tab:: macOS
 
-   The Xcode command line tools are required to compile portions of
-   Pillow. The tools are installed by running ``xcode-select --install``
-   from the command line. The command line tools are required even if you
-   have the full Xcode package installed.  It may be necessary to run
-   ``sudo xcodebuild -license`` to accept the license prior to using the
-   tools.
+    The Xcode command line tools are required to compile portions of
+    Pillow. The tools are installed by running ``xcode-select --install``
+    from the command line. The command line tools are required even if you
+    have the full Xcode package installed.  It may be necessary to run
+    ``sudo xcodebuild -license`` to accept the license prior to using the
+    tools.
 
-   The easiest way to install external libraries is via `Homebrew
-   <https://brew.sh/>`_. After you install Homebrew, run::
+    The easiest way to install external libraries is via `Homebrew
+    <https://brew.sh/>`_. After you install Homebrew, run::
 
-       brew install libjpeg libtiff little-cms2 openjpeg webp
+        brew install libjpeg libtiff little-cms2 openjpeg webp
 
-   To install libraqm on macOS use Homebrew to install its dependencies::
+    To install libraqm on macOS use Homebrew to install its dependencies::
 
-       brew install freetype harfbuzz fribidi
+        brew install freetype harfbuzz fribidi
 
-   Then see ``depends/install_raqm_cmake.sh`` to install libraqm.
+    Then see ``depends/install_raqm_cmake.sh`` to install libraqm.
 
 .. tab:: Windows
 
-   We recommend you use prebuilt wheels from PyPI.
-   If you wish to compile Pillow manually, you can use the build scripts
-   in the ``winbuild`` directory used for CI testing and development.
-   These scripts require Visual Studio 2017 or newer and NASM.
+    We recommend you use prebuilt wheels from PyPI.
+    If you wish to compile Pillow manually, you can use the build scripts
+    in the ``winbuild`` directory used for CI testing and development.
+    These scripts require Visual Studio 2017 or newer and NASM.
 
-   The scripts also install Pillow from the local copy of the source code, so the
-   `Installing`_ instructions will not be necessary afterwards.
+    The scripts also install Pillow from the local copy of the source code, so the
+    `Installing`_ instructions will not be necessary afterwards.
 
 .. tab:: Windows using MSYS2/MinGW
 
-   To build Pillow using MSYS2, make sure you run the **MSYS2 MinGW 32-bit** or
-   **MSYS2 MinGW 64-bit** console, *not* **MSYS2** directly.
+    To build Pillow using MSYS2, make sure you run the **MSYS2 MinGW 32-bit** or
+    **MSYS2 MinGW 64-bit** console, *not* **MSYS2** directly.
 
-   The following instructions target the 64-bit build, for 32-bit
-   replace all occurrences of ``mingw-w64-x86_64-`` with ``mingw-w64-i686-``.
+    The following instructions target the 64-bit build, for 32-bit
+    replace all occurrences of ``mingw-w64-x86_64-`` with ``mingw-w64-i686-``.
 
-   Make sure you have Python and GCC installed::
+    Make sure you have Python and GCC installed::
 
-       pacman -S \
-           mingw-w64-x86_64-gcc \
-           mingw-w64-x86_64-python3 \
-           mingw-w64-x86_64-python3-pip \
-           mingw-w64-x86_64-python3-setuptools
+        pacman -S \
+            mingw-w64-x86_64-gcc \
+            mingw-w64-x86_64-python3 \
+            mingw-w64-x86_64-python3-pip \
+            mingw-w64-x86_64-python3-setuptools
 
-   Prerequisites are installed on **MSYS2 MinGW 64-bit** with::
+    Prerequisites are installed on **MSYS2 MinGW 64-bit** with::
 
-       pacman -S \
-           mingw-w64-x86_64-libjpeg-turbo \
-           mingw-w64-x86_64-zlib \
-           mingw-w64-x86_64-libtiff \
-           mingw-w64-x86_64-freetype \
-           mingw-w64-x86_64-lcms2 \
-           mingw-w64-x86_64-libwebp \
-           mingw-w64-x86_64-openjpeg2 \
-           mingw-w64-x86_64-libimagequant \
-           mingw-w64-x86_64-libraqm
+        pacman -S \
+            mingw-w64-x86_64-libjpeg-turbo \
+            mingw-w64-x86_64-zlib \
+            mingw-w64-x86_64-libtiff \
+            mingw-w64-x86_64-freetype \
+            mingw-w64-x86_64-lcms2 \
+            mingw-w64-x86_64-libwebp \
+            mingw-w64-x86_64-openjpeg2 \
+            mingw-w64-x86_64-libimagequant \
+            mingw-w64-x86_64-libraqm
 
 .. tab:: FreeBSD
 
-   .. Note:: Only FreeBSD 10 and 11 tested
+    .. Note:: Only FreeBSD 10 and 11 tested
 
-   Make sure you have Python's development libraries installed::
+    Make sure you have Python's development libraries installed::
 
-       sudo pkg install python3
+        sudo pkg install python3
 
-   Prerequisites are installed on **FreeBSD 10 or 11** with::
+    Prerequisites are installed on **FreeBSD 10 or 11** with::
 
-       sudo pkg install jpeg-turbo tiff webp lcms2 freetype2 openjpeg harfbuzz fribidi libxcb
+        sudo pkg install jpeg-turbo tiff webp lcms2 freetype2 openjpeg harfbuzz fribidi libxcb
 
-   Then see ``depends/install_raqm_cmake.sh`` to install libraqm.
+    Then see ``depends/install_raqm_cmake.sh`` to install libraqm.
 
 .. tab:: Android
 
-   Basic Android support has been added for compilation within the Termux
-   environment. The dependencies can be installed by::
+    Basic Android support has been added for compilation within the Termux
+    environment. The dependencies can be installed by::
 
-       pkg install -y python ndk-sysroot clang make \
-           libjpeg-turbo
+        pkg install -y python ndk-sysroot clang make \
+            libjpeg-turbo
 
-   This has been tested within the Termux app on ChromeOS, on x86.
+    This has been tested within the Termux app on ChromeOS, on x86.
 
 Installing
 ^^^^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ docs =
     olefile
     sphinx>=2.4
     sphinx-copybutton
+    sphinx-inline-tabs
     sphinx-issues>=3.0.1
     sphinx-removed-in
     sphinxext-opengraph


### PR DESCRIPTION
Follow on from https://github.com/python-pillow/Pillow/issues/6755 / https://github.com/python-pillow/Pillow/pull/6756

Changes proposed in this pull request:

 * Use [Sphinx Inline Tabs](https://sphinx-inline-tabs.readthedocs.io/) to group the installation instructions by operating system
 * This helps hide irrelevant information on long, detailed page
 * If, for example, you click the macOS tab in the first tab group, it also opens the macOS tab in the second group
 * Because the subheaders are gone, I added in `.. _Linux Installation:` etc. to avoid linkrot
 * I re-ordered them to go: Linux, macOS, Windows, [Windows variant,] FreeBSD, [Android]
   * My thinking was to put the main three first, in order of "likelihood" to needs to follow these instructions, then the others afterwards, but happy to change it

![image](https://user-images.githubusercontent.com/1324225/204262341-3c7c0806-66de-4227-aeac-039eec7554f5.png)

![image](https://user-images.githubusercontent.com/1324225/204262377-b1397303-2abf-45e4-a3d1-c9cb48637290.png)

Plus some other cleanup:

* Like our top-level Makefile, inline the `.PHONY` targets to help avoid omissions in the docs `Makefile` (and `texinfo`, `info`, `livehtml` and `serve` were missing)
* Add `serve` and `livehtml` to `make -C docs help`
* EditorConfig: three-space indents for RST

# Demo

https://pillow--6764.org.readthedocs.build/en/6764/installation.html
