### PR TITLE
When reading BLP, do not trust JPEG decoder to determine image is CMYK

### DIFF
--- a/src/PIL/BlpImagePlugin.py
+++ b/src/PIL/BlpImagePlugin.py
@@ -373,6 +373,9 @@ class BLP1Decoder(_BLPBaseDecoder):
         data = BytesIO(data)
         image = JpegImageFile(data)
         Image._decompression_bomb_check(image.size)
+        if image.mode == "CMYK":
+            decoder_name, extents, offset, args = image.tile[0]
+            image.tile = [(decoder_name, extents, offset, (args[0], "CMYK"))]
         r, g, b = image.convert("RGB").split()
         image = Image.merge("RGB", (b, g, r))
         self.set_as_raw(image.tobytes())


### PR DESCRIPTION
Resolves #6741

libjpeg 9e has decided to no longer detect the JPEG embedded within Tests/images/blp/blp1_jpeg.blp as being CMYK.

To allow our tests to still pass, if the BLP JPEG is in CMYK mode, this PR passes a value for [`jpegmode`](https://github.com/python-pillow/Pillow/blob/0ec32a30120cb22b533fd8563749d44bd5d3f78f/src/decode.c#L824-L833), so that [JpegDecode.c will override what libjpeg has detected.](https://github.com/python-pillow/Pillow/blob/0ec32a30120cb22b533fd8563749d44bd5d3f78f/src/libImaging/JpegDecode.c#L183-L195)

Testing in libjpeg 9d and 9e in my fork of pillow-wheels, the BLP tests [fail without this](https://github.com/radarhere/pillow-wheels/actions/runs/3579890161), and [pass with it.](https://github.com/radarhere/pillow-wheels/actions/runs/3579892207)