### PR TITLE
Remove specific number of jobs from comment

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -141,7 +141,7 @@ jobs:
       if: steps.build-cache.outputs.cache-hit != 'true'
       run: "& winbuild\\build\\build_dep_fribidi.cmd"
 
-    # trim ~150MB x 9
+    # trim ~150MB for each job
     - name: Optimize build cache
       if: steps.build-cache.outputs.cache-hit != 'true'
       run: rmdir /S /Q winbuild\build\src


### PR DESCRIPTION
Most of the Windows builds have started failing in the main branch - https://github.com/python-pillow/Pillow/actions/runs/3600683266

> error C1047: The object or library file 'D:\a\Pillow\Pillow\winbuild\build\lib\lcms2_static.lib' was created by a different version of the compiler than other objects like 'build\temp.win32-3.7\Release\src\_imagingcms.obj'; rebuild all objects and libraries with the same compiler

This has occurred previously in #5051. The solution was to change the cache key for the Windows build. This PR does that by updating a comment.

In #4701, a comment was added
https://github.com/python-pillow/Pillow/blob/5bdf63e1d170e1db324c5f805c4e838e4d455e98/.github/workflows/test-windows.yml#L144

There were 9 jobs at the time, but there are now more than that.