### PR TITLE
Support saving JPEG comments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog (Pillow)
 9.4.0 (unreleased)
 ------------------
 
+- Added getxmp() to WebPImagePlugin #6758
+  [radarhere]
+
 - Added "exact" option when saving WebP #6747
   [ashafaei, radarhere]
 

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -98,6 +98,13 @@ class TestFileJpeg:
             with Image.open(out) as reloaded:
                 assert im.info["comment"] == reloaded.info["comment"]
 
+            # Ensure that a blank comment causes any existing comment to be removed
+            for comment in ("", b"", None):
+                out = BytesIO()
+                im.save(out, format="JPEG", comment=comment)
+                with Image.open(out) as reloaded:
+                    assert "comment" not in reloaded.info
+
             # Test that a comment argument overrides the default comment
             for comment in ("Test comment text", b"Text comment text"):
                 out = BytesIO()

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -87,6 +87,18 @@ class TestFileJpeg:
 
             assert im.info["comment"] == b"File written by Adobe Photoshop\xa8 4.0\x00"
 
+    def test_com_write(self):
+        dummy_text = "this is a test comment"
+        with Image.open(TEST_FILE) as im:
+            with BytesIO() as buf:
+                im.save(buf, format="JPEG")
+                with Image.open(buf) as im2:
+                    assert im.app['COM'] == im2.app['COM']
+            with BytesIO() as buf:
+                im.save(buf, format="JPEG", comment=dummy_text)
+                with Image.open(buf) as im2:
+                    assert im2.app['COM'].decode() == dummy_text
+
     def test_cmyk(self):
         # Test CMYK handling.  Thanks to Tim and Charlie for test data,
         # Michael for getting me to look one more time.

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -93,11 +93,11 @@ class TestFileJpeg:
             with BytesIO() as buf:
                 im.save(buf, format="JPEG")
                 with Image.open(buf) as im2:
-                    assert im.app['COM'] == im2.app['COM']
+                    assert im.app["COM"] == im2.app["COM"]
             with BytesIO() as buf:
                 im.save(buf, format="JPEG", comment=dummy_text)
                 with Image.open(buf) as im2:
-                    assert im2.app['COM'].decode() == dummy_text
+                    assert im2.app["COM"].decode() == dummy_text
 
     def test_cmyk(self):
         # Test CMYK handling.  Thanks to Tim and Charlie for test data,

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -44,6 +44,7 @@ import warnings
 from . import Image, ImageFile, TiffImagePlugin
 from ._binary import i16be as i16
 from ._binary import i32be as i32
+from ._binary import o16be as o16
 from ._binary import o8
 from ._deprecate import deprecate
 from .JpegPresets import presets
@@ -712,6 +713,15 @@ def _save(im, fp, filename):
     qtables = validate_qtables(qtables)
 
     extra = info.get("extra", b"")
+
+    comment = info.get("comment")
+    if comment is None and isinstance(im, JpegImageFile):
+        comment = im.app.get('COM')
+    if comment:
+        if isinstance(comment, str):
+            comment = comment.encode()
+        size = o16(2 + len(comment))
+        extra += b'\xFF\xFE%s%s' % (size, comment)
 
     icc_profile = info.get("icc_profile")
     if icc_profile:

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -736,9 +736,7 @@ def _save(im, fp, filename):
             )
             i += 1
 
-    comment = info.get("comment", im.info.get("comment")) or b""
-    if isinstance(comment, str):
-        comment = comment.encode()
+    comment = info.get("comment", im.info.get("comment"))
 
     # "progressive" is the official name, but older documentation
     # says "progression"

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -44,8 +44,8 @@ import warnings
 from . import Image, ImageFile, TiffImagePlugin
 from ._binary import i16be as i16
 from ._binary import i32be as i32
-from ._binary import o16be as o16
 from ._binary import o8
+from ._binary import o16be as o16
 from ._deprecate import deprecate
 from .JpegPresets import presets
 
@@ -716,12 +716,12 @@ def _save(im, fp, filename):
 
     comment = info.get("comment")
     if comment is None and isinstance(im, JpegImageFile):
-        comment = im.app.get('COM')
+        comment = im.app.get("COM")
     if comment:
         if isinstance(comment, str):
             comment = comment.encode()
         size = o16(2 + len(comment))
-        extra += b'\xFF\xFE%s%s' % (size, comment)
+        extra += b"\xFF\xFE%s%s" % (size, comment)
 
     icc_profile = info.get("icc_profile")
     if icc_profile:

--- a/src/encode.c
+++ b/src/encode.c
@@ -1057,7 +1057,7 @@ PyImaging_JpegEncoderNew(PyObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(
             args,
-            "ss|nnnnnnnnOy#y#y#",
+            "ss|nnnnnnnnOz#y#y#",
             &mode,
             &rawmode,
             &quality,

--- a/src/libImaging/JpegEncode.c
+++ b/src/libImaging/JpegEncode.c
@@ -278,7 +278,7 @@ ImagingJpegEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
 
         case 4:
 
-            if (context->comment_size > 0) {
+            if (context->comment) {
                 jpeg_write_marker(&context->cinfo, JPEG_COM, (unsigned char *)context->comment, context->comment_size);
             }
             state->state++;


### PR DESCRIPTION
Fixes #6773 

Changes proposed in this pull request:

 * a JPEG COM segment can now be written during `Image.save`
 * opening a JPEG file and saving to another file will now copy any existing comment across
 * user can now do `image.save(filename, format='JPEG', comment='comment to be written')` and the comment will be written to a COM segment
