### PR TITLE
Add support for PyPy3.9, drop PyPy3.7

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -19,9 +19,9 @@ jobs:
         architecture: ["x86", "x64"]
         include:
           # PyPy 7.3.4+ only ships 64-bit binaries for Windows
-          - python-version: "pypy-3.7"
+          - python-version: "pypy3.8"
             architecture: "x64"
-          - python-version: "pypy-3.8"
+          - python-version: "pypy3.9"
             architecture: "x64"
 
     timeout-minutes: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
           "ubuntu-latest",
         ]
         python-version: [
-          "pypy-3.8",
-          "pypy-3.7",
+          "pypy3.9",
+          "pypy3.8",
           "3.11",
           "3.10",
           "3.9",


### PR DESCRIPTION
Changes proposed in this pull request:

 * PyPy v7.3.10 has been released
   * https://www.pypy.org/posts/2022/12/pypy-v7310-release.html
 * Includes PyPy3.9 as a non-beta release:
   * "We have gained confidence in the stability of this version, and are removing the "beta" label."
 * Drops PyPy3.7

Currently https://github.com/actions/setup-python is still pointing to v7.3.9 but should bump up in a day or two.