### PR TITLE
If available, use wl-paste or xclip for grabclipboard() on Linux

### DIFF
--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -64,9 +64,13 @@ $bmp = New-Object Drawing.Bitmap 200, 200
             )
             p.communicate()
         else:
-            with pytest.raises(NotImplementedError) as e:
-                ImageGrab.grabclipboard()
-            assert str(e.value) == "ImageGrab.grabclipboard() is macOS and Windows only"
+            if not shutil.which("wl-paste"):
+                with pytest.raises(NotImplementedError) as e:
+                    ImageGrab.grabclipboard()
+                assert (
+                    str(e.value)
+                    == "wl-paste is required for ImageGrab.grabclipboard() on Linux"
+                )
             return
 
         ImageGrab.grabclipboard()

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -68,8 +68,8 @@ $bmp = New-Object Drawing.Bitmap 200, 200
                 with pytest.raises(NotImplementedError) as e:
                     ImageGrab.grabclipboard()
                 assert (
-                    str(e.value)
-                    == "wl-paste is required for ImageGrab.grabclipboard() on Linux"
+                    str(e.value) == "wl-paste or xclip is required"
+                    " for ImageGrab.grabclipboard() on Linux"
                 )
             return
 

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -65,12 +65,12 @@ $bmp = New-Object Drawing.Bitmap 200, 200
             p.communicate()
         else:
             if not shutil.which("wl-paste"):
-                with pytest.raises(NotImplementedError) as e:
+                with pytest.raises(
+                    NotImplementedError,
+                    match="wl-paste or xclip is required for"
+                    r" ImageGrab.grabclipboard\(\) on Linux",
+                ):
                     ImageGrab.grabclipboard()
-                assert (
-                    str(e.value) == "wl-paste or xclip is required"
-                    " for ImageGrab.grabclipboard() on Linux"
-                )
             return
 
         ImageGrab.grabclipboard()

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -132,4 +132,14 @@ def grabclipboard():
                 return BmpImagePlugin.DibImageFile(data)
         return None
     else:
-        raise NotImplementedError("ImageGrab.grabclipboard() is macOS and Windows only")
+        if not shutil.which("wl-paste"):
+            raise NotImplementedError(
+                "wl-paste is required for ImageGrab.grabclipboard() on Linux"
+            )
+        fh, filepath = tempfile.mkstemp()
+        subprocess.call(["wl-paste"], stdout=fh)
+        os.close(fh)
+        im = Image.open(filepath)
+        im.load()
+        os.unlink(filepath)
+        return im

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -132,12 +132,16 @@ def grabclipboard():
                 return BmpImagePlugin.DibImageFile(data)
         return None
     else:
-        if not shutil.which("wl-paste"):
+        if shutil.which("wl-paste"):
+            args = ["wl-paste"]
+        elif shutil.which("xclip"):
+            args = ["xclip", "-selection", "clipboard", "-t", "image/png", "-o"]
+        else:
             raise NotImplementedError(
-                "wl-paste is required for ImageGrab.grabclipboard() on Linux"
+                "wl-paste or xclip is required for ImageGrab.grabclipboard() on Linux"
             )
         fh, filepath = tempfile.mkstemp()
-        subprocess.call(["wl-paste"], stdout=fh)
+        subprocess.call(args, stdout=fh)
         os.close(fh)
         im = Image.open(filepath)
         im.load()


### PR DESCRIPTION
Resolves #6751, by using [`wl-paste`](https://github.com/bugaevc/wl-clipboard) or [`xclip`](https://github.com/astrand/xclip) for `ImageGrab.grabclipboard()` on Linux.