### PR TITLE
Ignore non-opaque WebP background when saving as GIF

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -859,13 +859,22 @@ def test_background(tmp_path):
     im.info["background"] = 1
     im.save(out)
     with Image.open(out) as reread:
-
         assert reread.info["background"] == im.info["background"]
 
+
+def test_webp_background(tmp_path):
+    out = str(tmp_path / "temp.gif")
+
+    # Test opaque WebP background
     if features.check("webp") and features.check("webp_anim"):
         with Image.open("Tests/images/hopper.webp") as im:
-            assert isinstance(im.info["background"], tuple)
+            assert im.info["background"] == (255, 255, 255, 255)
             im.save(out)
+
+    # Test non-opaque WebP background
+    im = Image.new("L", (100, 100), "#000")
+    im.info["background"] = (0, 0, 0, 0)
+    im.save(out)
 
 
 def test_comment(tmp_path):

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -886,20 +886,23 @@ def _get_palette_bytes(im):
 def _get_background(im, info_background):
     background = 0
     if info_background:
-        background = info_background
-        if isinstance(background, tuple):
+        if isinstance(info_background, tuple):
             # WebPImagePlugin stores an RGBA value in info["background"]
             # So it must be converted to the same format as GifImagePlugin's
             # info["background"] - a global color table index
             try:
-                background = im.palette.getcolor(background, im)
+                background = im.palette.getcolor(info_background, im)
             except ValueError as e:
-                if str(e) == "cannot allocate more than 256 colors":
+                if str(e) not in (
                     # If all 256 colors are in use,
                     # then there is no need for the background color
-                    return 0
-                else:
+                    "cannot allocate more than 256 colors",
+                    # Ignore non-opaque WebP background
+                    "cannot add non-opaque RGBA color to RGB palette",
+                ):
                     raise
+        else:
+            background = info_background
     return background
 
 


### PR DESCRIPTION
Resolves #6791

The user found a WebP image with `info["background"]` of `(255, 255, 255, 0)`. When the user attempts to save this as a GIF, an error is thrown, because GifImagePlugin can't add this transparent color to the RGB palette of the GIF.

This PR solves this by simply ignoring transparent or translucent background colors when saving as GIF.