### PR TITLE
Only set tile in ImageFile __setstate__

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -704,7 +704,6 @@ class Image:
 
     def __setstate__(self, state):
         Image.__init__(self)
-        self.tile = []
         info, mode, size, palette, data = state
         self.info = info
         self.mode = mode

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -137,6 +137,10 @@ class ImageFile(Image.Image):
         if self.format is not None:
             return Image.MIME.get(self.format.upper())
 
+    def __setstate__(self, state):
+        self.tile = []
+        super().__setstate__(state)
+
     def verify(self):
         """Check file integrity"""
 


### PR DESCRIPTION
`tile` is an ImageFile property, not an Image property.

https://github.com/python-pillow/Pillow/blob/0d6440d9f22286b14b31b368cdc586bf58cd4a8d/src/PIL/ImageFile.py#L84-L94

But it is currently set in `Image.__setstate__`

https://github.com/python-pillow/Pillow/blob/0d6440d9f22286b14b31b368cdc586bf58cd4a8d/src/PIL/Image.py#L705-L707

So this PR moves that line into ImageFile.