### PR TITLE
Clarify apply_transparency() docstring

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1482,7 +1482,8 @@ class Image:
     def apply_transparency(self):
         """
         If a P mode image has a "transparency" key in the info dictionary,
-        remove the key and apply the transparency to the palette instead.
+        remove the key and instead apply the transparency to the palette.
+        Otherwise, the image is unchanged.
         """
         if self.mode != "P" or "transparency" not in self.info:
             return


### PR DESCRIPTION
A user in https://github.com/python-pillow/Pillow/issues/6797#issuecomment-1345620052 thought that `apply_transparency()` did something for non-P mode images.

This clarifies that this is not the case.