### PR TITLE
Fixed writing int as ASCII tag

### DIFF
--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -185,20 +185,21 @@ def test_iptc(tmp_path):
         im.save(out)
 
 
-def test_writing_bytes_to_ascii(tmp_path):
+def test_writing_other_types_to_ascii(tmp_path):
     im = hopper()
     info = TiffImagePlugin.ImageFileDirectory_v2()
 
     tag = TiffTags.TAGS_V2[271]
     assert tag.type == TiffTags.ASCII
 
-    info[271] = b"test"
-
     out = str(tmp_path / "temp.tiff")
-    im.save(out, tiffinfo=info)
+    for (value, expected) in {b"test": "test", 1: "1"}.items():
+        info[271] = value
 
-    with Image.open(out) as reloaded:
-        assert reloaded.tag_v2[271] == "test"
+        im.save(out, tiffinfo=info)
+
+        with Image.open(out) as reloaded:
+            assert reloaded.tag_v2[271] == expected
 
 
 def test_writing_int_to_bytes(tmp_path):

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -185,21 +185,21 @@ def test_iptc(tmp_path):
         im.save(out)
 
 
-def test_writing_other_types_to_ascii(tmp_path):
-    im = hopper()
+@pytest.mark.parametrize("value, expected", ((b"test", "test"), (1, "1")))
+def test_writing_other_types_to_ascii(value, expected, tmp_path):
     info = TiffImagePlugin.ImageFileDirectory_v2()
 
     tag = TiffTags.TAGS_V2[271]
     assert tag.type == TiffTags.ASCII
 
+    info[271] = value
+
+    im = hopper()
     out = str(tmp_path / "temp.tiff")
-    for (value, expected) in {b"test": "test", 1: "1"}.items():
-        info[271] = value
+    im.save(out, tiffinfo=info)
 
-        im.save(out, tiffinfo=info)
-
-        with Image.open(out) as reloaded:
-            assert reloaded.tag_v2[271] == expected
+    with Image.open(out) as reloaded:
+        assert reloaded.tag_v2[271] == expected
 
 
 def test_writing_int_to_bytes(tmp_path):

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -732,6 +732,8 @@ class ImageFileDirectory_v2(MutableMapping):
     @_register_writer(2)
     def write_string(self, value):
         # remerge of https://github.com/python-pillow/Pillow/pull/1416
+        if isinstance(value, int):
+            value = str(value)
         if not isinstance(value, bytes):
             value = value.encode("ascii", "replace")
         return value + b"\0"


### PR DESCRIPTION
Resolves #6799

The image from the issue has a GPSLongitudeRef tag that [should be ASCII](https://www.awaresystems.be/imaging/tiff/tifftags/privateifd/gps/gpslongituderef.html), but is instead SHORT.

The tag is loaded as an int then, not a string as expected, and when Pillow tries to save it as a string, it fails.

This PR simply changes TiffImagePlugin to convert the variable to a string.