### PR TITLE
Add allowlist_externals=make to fix tox 4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
         args: ["--target-version", "py37"]
@@ -9,7 +9,7 @@ repos:
         types: []
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.11.1
     hooks:
       - id: isort
 
@@ -47,6 +47,11 @@ repos:
     rev: v0.6.7
     hooks:
       - id: sphinx-lint
+
+  - repo: https://github.com/tox-dev/tox-ini-fmt
+    rev: 0.5.2
+    hooks:
+      - id: tox-ini-fmt
 
 ci:
   autoupdate_schedule: monthly

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,13 @@
-# Tox (https://tox.readthedocs.io/en/latest/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it,
-# "python3 -m pip install tox" and then run "tox" from this directory.
-
 [tox]
 envlist =
     lint
-    py{37,38,39,310,311,py3}
+    py{py3, 311, 310, 39, 38, 37}
 minversion = 1.9
 
 [testenv]
+deps =
+    cffi
+    numpy
 extras =
     tests
 commands =
@@ -17,16 +15,14 @@ commands =
     {envpython} -m pip install --global-option="build_ext" --global-option="--inplace" .
     {envpython} selftest.py
     {envpython} -m pytest -W always {posargs}
-deps =
-    cffi
-    numpy
 
 [testenv:lint]
+passenv =
+    PRE_COMMIT_COLOR
+skip_install = true
+deps =
+    check-manifest
+    pre-commit
 commands =
     pre-commit run --all-files --show-diff-on-failure
     check-manifest
-deps =
-    pre-commit
-    check-manifest
-skip_install = true
-passenv = PRE_COMMIT_COLOR

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ commands =
     {envpython} -m pip install --global-option="build_ext" --global-option="--inplace" .
     {envpython} selftest.py
     {envpython} -m pytest -W always {posargs}
+allowlist_externals = make
 
 [testenv:lint]
 passenv =


### PR DESCRIPTION
Calling `make` (without `allowlist_externals = make` in `tox.ini`) gives a deprecation warning in tox 3 and an error in tox 4.

Add `allowlist_externals = make` to remove the warning and error.

Also format `tox.ini` with https://github.com/tox-dev/tox-ini-fmt

# Before

## tox 3.27.1

Warns about using `make` without `allowlist_externals`

```console
$ tox -e py311
GLOB sdist-make: /Users/hugo/github/Pillow/setup.py
py311 create: /Users/hugo/github/Pillow/.tox/py311
py311 installdeps: cffi, numpy
py311 inst: /Users/hugo/github/Pillow/.tox/.tmp/package/5/Pillow-9.4.0.dev0.zip
py311 installed: attrs==22.1.0,build==0.9.0,certifi==2022.12.7,cffi==1.15.1,charset-normalizer==2.1.1,check-manifest==0.49,coverage==6.5.0,defusedxml==0.7.1,docutils==0.19,idna==3.4,iniconfig==1.1.1,markdown2==2.4.6,numpy==1.23.5,olefile==0.46,packaging==22.0,pep517==0.13.0,Pillow @ file:///Users/hugo/github/Pillow/.tox/.tmp/package/5/Pillow-9.4.0.dev0.zip,pluggy==1.0.0,pycparser==2.21,Pygments==2.13.0,pyroma==4.1,pytest==7.2.0,pytest-cov==4.0.0,pytest-timeout==2.1.0,requests==2.28.1,trove-classifiers==2022.12.1,urllib3==1.26.13
py311 run-test-pre: PYTHONHASHSEED='3385010674'
py311 run-test: commands[0] | make clean
WARNING: test command found but not installed in testenv
  cmd: /usr/bin/make
  env: /Users/hugo/github/Pillow/.tox/py311
Maybe you forgot to specify a dependency? See also the allowlist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
python3 setup.py clean
...
```

## tox 4.0.8

As promised, fails when using `make` without `allowlist_externals`

```console
$ tox -e py311
.pkg: _optional_hooks> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_sdist> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: prepare_metadata_for_build_wheel> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_sdist> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py311: install_package> python -I -m pip install --force-reinstall --no-deps /Users/hugo/github/Pillow/.tox/.tmp/package/4/Pillow-9.4.0.dev0.tar.gz
py311: commands[0]> make clean
py311: failed with make is not allowed, use allowlist_externals to allow it
.pkg: _exit> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  py311: FAIL code 1 (24.65 seconds)
  evaluation failed :( (24.68 seconds)
```

# After

## tox 3.27.1

No warning

```console
$ ⌂10.76 [hugo:~/github/Pillow] fix-tox-4+* ± tox -e py311
GLOB sdist-make: /Users/hugo/github/Pillow/setup.py
py311 inst-nodeps: /Users/hugo/github/Pillow/.tox/.tmp/package/5/Pillow-9.4.0.dev0.zip
py311 installed: attrs==22.1.0,build==0.9.0,certifi==2022.12.7,cffi==1.15.1,charset-normalizer==2.1.1,check-manifest==0.49,coverage==6.5.0,defusedxml==0.7.1,docutils==0.19,idna==3.4,iniconfig==1.1.1,markdown2==2.4.6,numpy==1.23.5,olefile==0.46,packaging==22.0,pep517==0.13.0,Pillow @ file:///Users/hugo/github/Pillow/.tox/.tmp/package/5/Pillow-9.4.0.dev0.zip,pluggy==1.0.0,pycparser==2.21,Pygments==2.13.0,pyroma==4.1,pytest==7.2.0,pytest-cov==4.0.0,pytest-timeout==2.1.0,requests==2.28.1,trove-classifiers==2022.12.1,urllib3==1.26.13
py311 run-test-pre: PYTHONHASHSEED='1473613542'
py311 run-test: commands[0] | make clean
python3 setup.py clean
...
```

## tox 4.0.8

No error

```console
$ tox -e py311
py311: install_deps> python -I -m pip install cffi numpy
.pkg: _optional_hooks> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_sdist> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: prepare_metadata_for_build_wheel> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_sdist> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py311: install_package_deps> python -I -m pip install check-manifest coverage defusedxml markdown2 olefile packaging pyroma pytest pytest-cov pytest-timeout
py311: install_package> python -I -m pip install --force-reinstall --no-deps /Users/hugo/github/Pillow/.tox/.tmp/package/5/Pillow-9.4.0.dev0.tar.gz
py311: commands[0]> make clean
python3 setup.py clean
...
```
