### PR TITLE
Run Bandit on CI via pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 22.12.0
     hooks:
       - id: black
-        args: ["--target-version", "py37"]
+        args: [--target-version=py37]
         # Only .py files, until https://github.com/psf/black/issues/402 resolved
         files: \.py$
         types: []
@@ -12,6 +12,13 @@ repos:
     rev: 5.11.1
     hooks:
       - id: isort
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.4
+    hooks:
+    - id: bandit
+      args: [--severity-level=high]
+      files: ^src/
 
   - repo: https://github.com/asottile/yesqa
     rev: v1.4.0

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -125,7 +125,7 @@ class Viewer:
                 path = options.pop("file")
             else:
                 raise TypeError("Missing required argument: 'path'")
-        os.system(self.get_command(path, **options))
+        os.system(self.get_command(path, **options))  # nosec
         return 1
 
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * Add[ Bandit](https://bandit.readthedocs.io) to the CI via pre-commit
 * Let's limit to high severity in the `src` directory
 * And mark the one existing finding as `nosec`
