### PR TITLE
Adjust Exif behaviour of Jpeg, WebP and Tiff to Png Exif Behaviour

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -442,6 +442,17 @@ class TestFileJpeg:
             info = im._getexif()
             assert info[305] == "Adobe Photoshop CS Macintosh"
 
+    def test_exif_keep(self, tmp_path):
+        with Image.open("Tests/images/pil_sample_rgb.jpg") as im:
+            f = str(tmp_path / "temp.jpg")
+            im.save(f)
+
+        with Image.open(f) as new_im:
+            orig_info = im._getexif()
+            new_info = new_im._getexif()
+
+        assert orig_info == new_info
+
     def test_get_child_images(self):
         with Image.open("Tests/images/flower.jpg") as im:
             ims = im.get_child_images()

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -530,6 +530,18 @@ class TestFileTiff:
             exif = im.getexif()
             assert exif[256] == 100
 
+    def test_exif_keep(self, tmp_path):
+        with Image.open("Tests/images/ifd_tag_type.tiff") as orig_im:
+            orig_exif = orig_im.getexif()
+            assert orig_exif[271] == "FLIR"
+
+            f = str(tmp_path / "temp.tif")
+            orig_im.save(f)
+
+        with Image.open(f) as new_im:
+            new_exif = new_im.getexif()
+            assert orig_exif[271] == new_exif[271]
+
     def test_reload_exif_after_seek(self):
         with Image.open("Tests/images/multipage.tiff") as im:
             exif = im.getexif()

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -119,6 +119,18 @@ class TestFileWebp:
             reloaded.seek(1)
             assert_image_similar(im2, reloaded, 1)
 
+    def test_exif_keep(self, tmp_path):
+        with Image.open("Tests/images/flower.webp") as orig_im:
+            orig_exif = orig_im.getexif()
+            f = str(tmp_path / "exif_img.webp")
+            orig_im.save(f)
+
+        with Image.open(f) as new_im:
+            new_exif = new_im.getexif()
+
+        assert orig_exif[271] == "Canon"
+        assert orig_exif[271] == new_exif[271]
+
     def test_icc_profile(self, tmp_path):
         self._roundtrip(tmp_path, self.rgb_mode, 12.5, {"icc_profile": None})
         if _webp.HAVE_WEBPANIM:

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -746,7 +746,7 @@ def _save(im, fp, filename):
 
     optimize = info.get("optimize", False)
 
-    exif = info.get("exif", b"")
+    exif = info.get("exif", im.info.get("exif", b""))
     if isinstance(exif, Image.Exif):
         exif = exif.tobytes()
 

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1602,7 +1602,7 @@ def _save(im, fp, filename):
     if "tiffinfo" in encoderinfo:
         info = encoderinfo["tiffinfo"]
     else:
-        info = encoderinfo.get("exif", im.info.get("exif", b""))
+        info = encoderinfo.get("exif", im.info.get("exif", im.getexif()))
         if isinstance(info, bytes):
             exif = Image.Exif()
             exif.load(info)

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1601,14 +1601,13 @@ def _save(im, fp, filename):
     # write any arbitrary tags passed in as an ImageFileDirectory
     if "tiffinfo" in encoderinfo:
         info = encoderinfo["tiffinfo"]
-    elif "exif" in encoderinfo:
-        info = encoderinfo["exif"]
+    else:
+        info = encoderinfo.get("exif", im.info.get("exif", b""))
         if isinstance(info, bytes):
             exif = Image.Exif()
             exif.load(info)
             info = exif
-    else:
-        info = {}
+
     logger.debug("Tiffinfo Keys: %s" % list(info))
     if isinstance(info, ImageFileDirectory_v1):
         info = info.to_v2()

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -320,7 +320,7 @@ def _save(im, fp, filename):
     lossless = im.encoderinfo.get("lossless", False)
     quality = im.encoderinfo.get("quality", 80)
     icc_profile = im.encoderinfo.get("icc_profile") or ""
-    exif = im.encoderinfo.get("exif", b"")
+    exif = im.encoderinfo.get("exif", im.info.get("exif", b""))
     if isinstance(exif, Image.Exif):
         exif = exif.tobytes()
     if exif.startswith(b"Exif\x00\x00"):


### PR DESCRIPTION
Fixes #6804 

Changes proposed in this pull request:
 * Change behaviour of Plugins to keep exif information when saving image for the following formats:
   * Jpeg
   * Tiff
   * WebP

These plugins now behave the save way as the Png Plugin.
