### PR TITLE
Updated deprecated NumPy alias

### DIFF
--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -34,7 +34,7 @@ def test_numpy_to_image():
 
     # Check supported 1-bit integer formats
     assert_image(to_image(bool, 1, 1), "1", TEST_IMAGE_SIZE)
-    assert_image(to_image(numpy.bool8, 1, 1), "1", TEST_IMAGE_SIZE)
+    assert_image(to_image(numpy.bool_, 1, 1), "1", TEST_IMAGE_SIZE)
 
     # Check supported 8-bit integer formats
     assert_image(to_image(numpy.uint8), "L", TEST_IMAGE_SIZE)
@@ -193,7 +193,7 @@ def test_putdata():
     "dtype",
     (
         bool,
-        numpy.bool8,
+        numpy.bool_,
         numpy.int8,
         numpy.int16,
         numpy.int32,


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/3730334148/jobs/6327268745#step:8:4081
> /home/runner/work/Pillow/Pillow/Tests/test_numpy.py:196: DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)

See also the NumPy release notes

https://numpy.org/devdocs/release/1.24.0-notes.html#np-str0-and-similar-are-now-deprecated
> The scalar type aliases ending in a 0 bit size: np.object0, np.str0, np.bytes0, np.void0, np.int0, np.uint0 as well as np.bool8 are now deprecated and will eventually be removed.

