### PR TITLE
Fixed BytesWarnings

### DIFF
--- a/src/PIL/PpmImagePlugin.py
+++ b/src/PIL/PpmImagePlugin.py
@@ -208,7 +208,9 @@ class PpmPlainDecoder(ImageFile.PyDecoder):
             tokens = b"".join(block.split())
             for token in tokens:
                 if token not in (48, 49):
-                    raise ValueError(f"Invalid token for this mode: {bytes([token])}")
+                    raise ValueError(
+                        b"Invalid token for this mode: %s" % bytes([token])
+                    )
             data = (data + tokens)[:total_bytes]
         invert = bytes.maketrans(b"01", b"\xFF\x00")
         return data.translate(invert)
@@ -242,13 +244,13 @@ class PpmPlainDecoder(ImageFile.PyDecoder):
                 half_token = tokens.pop()  # save half token for later
                 if len(half_token) > max_len:  # prevent buildup of half_token
                     raise ValueError(
-                        f"Token too long found in data: {half_token[:max_len + 1]}"
+                        b"Token too long found in data: %s" % half_token[: max_len + 1]
                     )
 
             for token in tokens:
                 if len(token) > max_len:
                     raise ValueError(
-                        f"Token too long found in data: {token[:max_len + 1]}"
+                        b"Token too long found in data: %s" % token[: max_len + 1]
                     )
                 value = int(token)
                 if value > maxval:


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/3745012260/jobs/6358985335#step:8:4128

> Tests/test_file_ppm.py::test_plain_invalid_data[P1\n128 128\n1009]
>   /opt/hostedtoolcache/Python/3.11.1/x64/lib/python3.11/site-packages/PIL/PpmImagePlugin.py:211: BytesWarning: str() on a bytes instance
>     raise ValueError(f"Invalid token for this mode: {bytes([token])}")
> 
> Tests/test_file_ppm.py::test_plain_ppm_token_too_long[P3\n128 128\n255\n012345678910]
>   /opt/hostedtoolcache/Python/3.11.1/x64/lib/python3.11/site-packages/PIL/PpmImagePlugin.py:245: BytesWarning: str() on a bytes instance
>     f"Token too long found in data: {half_token[:max_len + 1]}"
> 
> Tests/test_file_ppm.py::test_plain_ppm_token_too_long[P3\n128 128\n255\n012345678910 0]
>   /opt/hostedtoolcache/Python/3.11.1/x64/lib/python3.11/site-packages/PIL/PpmImagePlugin.py:251: BytesWarning: str() on a bytes instance
>     f"Token too long found in data: {token[:max_len + 1]}"

This PR fixes these BytesWarnings by changing the entire error messages to bytes.