### PR TITLE
Fixed saving EXIF data to MPO

### DIFF
--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -80,7 +80,10 @@ def test_app(test_file):
 
 @pytest.mark.parametrize("test_file", test_files)
 def test_exif(test_file):
-    with Image.open(test_file) as im:
+    with Image.open(test_file) as im_original:
+        im_reloaded = roundtrip(im_original, save_all=True, exif=im_original.getexif())
+
+    for im in (im_original, im_reloaded):
         info = im._getexif()
         assert info[272] == "Nintendo 3DS"
         assert info[296] == 2


### PR DESCRIPTION
MpoImagePlugin initially writes blank MPF data, and then returns to write out the offsets once the length of the JPEG data is known.

However, the offset for the MPF data didn't consider that EXIF data might be part of the header. This PR fixes that.