### PR TITLE
Initialize unsigned char variables

### DIFF
--- a/src/libImaging/Quant.c
+++ b/src/libImaging/Quant.c
@@ -1717,7 +1717,7 @@ ImagingQuantize(Imaging im, int colors, int mode, int kmeans) {
 
         withAlpha = !strcmp(im->mode, "RGBA");
         int transparency = 0;
-        unsigned char r, g, b;
+        unsigned char r = 0, g = 0, b = 0;
         for (i = y = 0; y < im->ysize; y++) {
             for (x = 0; x < im->xsize; x++, i++) {
                 p[i].v = im->image32[y][x];


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/3752682144/jobs/6375115871#step:7:141
>   src/libImaging/Quant.c: In function ‘ImagingQuantize’:
>   src/libImaging/Quant.c:1720:29: warning: ‘b’ may be used uninitialized in this function [-Wmaybe-uninitialized]
>    1720 |         unsigned char r, g, b;
>         |                             ^
>   src/libImaging/Quant.c:1720:26: warning: ‘g’ may be used uninitialized in this function [-Wmaybe-uninitialized]
>    1720 |         unsigned char r, g, b;
>         |                          ^
>   src/libImaging/Quant.c:1720:23: warning: ‘r’ may be used uninitialized in this function [-Wmaybe-uninitialized]
>    1720 |         unsigned char r, g, b;
>         |                       ^