### PR TITLE
Do not use EXIF from info when saving PNG images

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -706,9 +706,17 @@ class TestFilePng:
         assert exif[274] == 3
 
     def test_exif_save(self, tmp_path):
+        # Test exif is not saved from info
+        test_file = str(tmp_path / "temp.png")
         with Image.open("Tests/images/exif.png") as im:
-            test_file = str(tmp_path / "temp.png")
             im.save(test_file)
+
+        with Image.open(test_file) as reloaded:
+            assert reloaded._getexif() is None
+
+        # Test passing in exif
+        with Image.open("Tests/images/exif.png") as im:
+            im.save(test_file, exif=im.getexif())
 
         with Image.open(test_file) as reloaded:
             exif = reloaded._getexif()
@@ -720,7 +728,7 @@ class TestFilePng:
     def test_exif_from_jpg(self, tmp_path):
         with Image.open("Tests/images/pil_sample_rgb.jpg") as im:
             test_file = str(tmp_path / "temp.png")
-            im.save(test_file)
+            im.save(test_file, exif=im.getexif())
 
         with Image.open(test_file) as reloaded:
             exif = reloaded._getexif()

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -1383,7 +1383,7 @@ def _save(im, fp, filename, chunk=putchunk, save_all=False):
                 chunks.remove(cid)
                 chunk(fp, cid, data)
 
-    exif = im.encoderinfo.get("exif", im.info.get("exif"))
+    exif = im.encoderinfo.get("exif")
     if exif:
         if isinstance(exif, Image.Exif):
             exif = exif.tobytes(8)


### PR DESCRIPTION
Resolves #6804

Do not use `im.info["exif"]` when saving PNG files, to be consistent with other formats - [JPEG](https://github.com/python-pillow/Pillow/blob/edcfe09f12d6113aaca3a4b3f9bad343c0ddbdb9/src/PIL/JpegImagePlugin.py#L749), [TIFF](https://github.com/python-pillow/Pillow/blob/edcfe09f12d6113aaca3a4b3f9bad343c0ddbdb9/src/PIL/TiffImagePlugin.py#L1605) and [WebP](https://github.com/python-pillow/Pillow/blob/edcfe09f12d6113aaca3a4b3f9bad343c0ddbdb9/src/PIL/WebPImagePlugin.py#L323)