### PR TITLE
Fixed PyAccess after changing ICO size

### DIFF
--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -71,6 +71,19 @@ def test_save_to_bytes():
         )
 
 
+def test_getpixel(tmp_path):
+    temp_file = str(tmp_path / "temp.ico")
+
+    im = hopper()
+    im.save(temp_file, "ico", sizes=[(32, 32), (64, 64)])
+
+    with Image.open(temp_file) as reloaded:
+        reloaded.load()
+        reloaded.size = (32, 32)
+
+        assert reloaded.getpixel((0, 0)) == (18, 20, 62)
+
+
 def test_no_duplicates(tmp_path):
     temp_file = str(tmp_path / "temp.ico")
     temp_file2 = str(tmp_path / "temp2.ico")

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -327,6 +327,7 @@ class IcoImageFile(ImageFile.ImageFile):
         # if tile is PNG, it won't really be loaded yet
         im.load()
         self.im = im.im
+        self.pyaccess = None
         self.mode = im.mode
         if im.size != self.size:
             warnings.warn("Image was not the expected size")


### PR DESCRIPTION
As with GifImagePlugin
https://github.com/python-pillow/Pillow/blob/edcfe09f12d6113aaca3a4b3f9bad343c0ddbdb9/src/PIL/GifImagePlugin.py#L325-L333
and PngImagePlugin
https://github.com/python-pillow/Pillow/blob/edcfe09f12d6113aaca3a4b3f9bad343c0ddbdb9/src/PIL/PngImagePlugin.py#L1004-L1006
after replacing `self.im`, `self.pyaccess` should be cleared.