### PR TITLE
Updated libtiff to 4.5.0

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -143,7 +143,7 @@ Many of Pillow's features require external libraries:
 
 * **libtiff** provides compressed TIFF functionality
 
-  * Pillow has been tested with libtiff versions **3.x** and **4.0-4.4**
+  * Pillow has been tested with libtiff versions **3.x** and **4.0-4.5**
 
 * **libfreetype** provides type related services
 

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -200,15 +200,11 @@ deps = {
         "libs": [r"output\release-static\{architecture}\lib\*.lib"],
     },
     "libtiff": {
-        "url": "https://download.osgeo.org/libtiff/tiff-4.4.0.tar.gz",
-        "filename": "tiff-4.4.0.tar.gz",
-        "dir": "tiff-4.4.0",
-        "license": "COPYRIGHT",
+        "url": "https://download.osgeo.org/libtiff/tiff-4.5.0.tar.gz",
+        "filename": "tiff-4.5.0.tar.gz",
+        "dir": "tiff-4.5.0",
+        "license": "LICENSE.md",
         "patch": {
-            r"cmake\LZMACodec.cmake": {
-                # fix typo
-                "${{LZMA_FOUND}}": "${{LIBLZMA_FOUND}}",
-            },
             r"libtiff\tif_lzma.c": {
                 # link against liblzma.lib
                 "#ifdef LZMA_SUPPORT": '#ifdef LZMA_SUPPORT\n#pragma comment(lib, "liblzma.lib")',  # noqa: E501


### PR DESCRIPTION
libtiff 4.5.0 has been released - http://www.simplesystems.org/libtiff/

The first patch
https://github.com/python-pillow/Pillow/blob/8bd5fbf450f9f5a03a32c7efcfb488bfc2a40d1c/winbuild/build_prepare.py#L207-L211
is now a part of libtiff, thanks to https://gitlab.com/libtiff/libtiff/-/commit/58ad3b5635896a143ad4ed9f4494a5c834098ace