### PR TITLE
Added support for I;16 modes in putdata()

### DIFF
--- a/Tests/test_image_putdata.py
+++ b/Tests/test_image_putdata.py
@@ -55,10 +55,11 @@ def test_mode_with_L_with_float():
     assert im.getpixel((0, 0)) == 2
 
 
-def test_mode_i():
+@pytest.mark.parametrize("mode", ("I", "I;16", "I;16L", "I;16B"))
+def test_mode_i(mode):
     src = hopper("L")
     data = list(src.getdata())
-    im = Image.new("I", src.size, 0)
+    im = Image.new(mode, src.size, 0)
     im.putdata(data, 2, 256)
 
     target = [2 * elt + 256 for elt in data]

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1531,25 +1531,21 @@ if (PySequence_Check(op)) { \
                 PyErr_SetString(PyExc_TypeError, must_be_sequence);
                 return NULL;
             }
+            int endian = strncmp(image->mode, "I;16", 4) == 0 ? (strcmp(image->mode, "I;16B") == 0 ? 2 : 1) : 0;
             double value;
-            if (scale == 1.0 && offset == 0.0) {
-                /* Clipped data */
-                for (i = x = y = 0; i < n; i++) {
-                    set_value_to_item(seq, i);
-                    image->image8[y][x] = (UINT8)CLIP8(value);
-                    if (++x >= (int)image->xsize) {
-                        x = 0, y++;
-                    }
+            for (i = x = y = 0; i < n; i++) {
+                set_value_to_item(seq, i);
+                if (scale != 1.0 || offset != 0.0) {
+                    value = value * scale + offset;
                 }
-
-            } else {
-                /* Scaled and clipped data */
-                for (i = x = y = 0; i < n; i++) {
-                    set_value_to_item(seq, i);
-                    image->image8[y][x] = CLIP8(value * scale + offset);
-                    if (++x >= (int)image->xsize) {
-                        x = 0, y++;
-                    }
+                if (endian == 0) {
+                    image->image8[y][x] = (UINT8)CLIP8(value);
+                } else {
+                    image->image8[y][x * 2 + (endian == 2 ? 1 : 0)] = CLIP8((int)value % 256);
+                    image->image8[y][x * 2 + (endian == 2 ? 0 : 1)] = CLIP8((int)value >> 8);
+                }
+                if (++x >= (int)image->xsize) {
+                    x = 0, y++;
                 }
             }
             PyErr_Clear(); /* Avoid weird exceptions */


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/issues/6769#issuecomment-1364769723 by adding support for "I;16", "I;16L" and "I;16B" in `putdata()`.

The C code did not previously consider that the values had a `pixelsize` of 2.