### PR TITLE
Removed deprecations for Image constants, except for duplicate Resampling attributes

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -921,12 +921,7 @@ class TestImage:
         with pytest.warns(DeprecationWarning):
             assert Image.CONTAINER == 2
 
-    def test_constants_deprecation(self):
-        with pytest.warns(DeprecationWarning):
-            assert Image.NEAREST == 0
-        with pytest.warns(DeprecationWarning):
-            assert Image.NONE == 0
-
+    def test_constants(self):
         with pytest.warns(DeprecationWarning):
             assert Image.LINEAR == Image.Resampling.BILINEAR
         with pytest.warns(DeprecationWarning):
@@ -943,8 +938,7 @@ class TestImage:
             Image.Quantize,
         ):
             for name in enum.__members__:
-                with pytest.warns(DeprecationWarning):
-                    assert getattr(Image, name) == enum[name]
+                assert getattr(Image, name) == enum[name]
 
     @pytest.mark.parametrize(
         "path",

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -74,6 +74,11 @@ Constants
 A number of constants have been deprecated and will be removed in Pillow 10.0.0
 (2023-07-01). Instead, ``enum.IntEnum`` classes have been added.
 
+.. note::
+
+    Additional ``Image`` constants were deprecated in Pillow 9.1.0, but they
+    were later restored in Pillow 9.4.0. See  :ref:`restored-image-constants`
+
 =====================================================  ============================================================
 Deprecated                                             Use instead
 =====================================================  ============================================================

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -77,37 +77,9 @@ A number of constants have been deprecated and will be removed in Pillow 10.0.0
 =====================================================  ============================================================
 Deprecated                                             Use instead
 =====================================================  ============================================================
-``Image.NONE``                                         Either ``Image.Dither.NONE`` or ``Image.Resampling.NEAREST``
-``Image.NEAREST``                                      Either ``Image.Dither.NONE`` or ``Image.Resampling.NEAREST``
-``Image.ORDERED``                                      ``Image.Dither.ORDERED``
-``Image.RASTERIZE``                                    ``Image.Dither.RASTERIZE``
-``Image.FLOYDSTEINBERG``                               ``Image.Dither.FLOYDSTEINBERG``
-``Image.WEB``                                          ``Image.Palette.WEB``
-``Image.ADAPTIVE``                                     ``Image.Palette.ADAPTIVE``
-``Image.AFFINE``                                       ``Image.Transform.AFFINE``
-``Image.EXTENT``                                       ``Image.Transform.EXTENT``
-``Image.PERSPECTIVE``                                  ``Image.Transform.PERSPECTIVE``
-``Image.QUAD``                                         ``Image.Transform.QUAD``
-``Image.MESH``                                         ``Image.Transform.MESH``
-``Image.FLIP_LEFT_RIGHT``                              ``Image.Transpose.FLIP_LEFT_RIGHT``
-``Image.FLIP_TOP_BOTTOM``                              ``Image.Transpose.FLIP_TOP_BOTTOM``
-``Image.ROTATE_90``                                    ``Image.Transpose.ROTATE_90``
-``Image.ROTATE_180``                                   ``Image.Transpose.ROTATE_180``
-``Image.ROTATE_270``                                   ``Image.Transpose.ROTATE_270``
-``Image.TRANSPOSE``                                    ``Image.Transpose.TRANSPOSE``
-``Image.TRANSVERSE``                                   ``Image.Transpose.TRANSVERSE``
-``Image.BOX``                                          ``Image.Resampling.BOX``
-``Image.BILINEAR``                                     ``Image.Resampling.BILINEAR``
-``Image.LINEAR``                                       ``Image.Resampling.BILINEAR``
-``Image.HAMMING``                                      ``Image.Resampling.HAMMING``
-``Image.BICUBIC``                                      ``Image.Resampling.BICUBIC``
-``Image.CUBIC``                                        ``Image.Resampling.BICUBIC``
-``Image.LANCZOS``                                      ``Image.Resampling.LANCZOS``
-``Image.ANTIALIAS``                                    ``Image.Resampling.LANCZOS``
-``Image.MEDIANCUT``                                    ``Image.Quantize.MEDIANCUT``
-``Image.MAXCOVERAGE``                                  ``Image.Quantize.MAXCOVERAGE``
-``Image.FASTOCTREE``                                   ``Image.Quantize.FASTOCTREE``
-``Image.LIBIMAGEQUANT``                                ``Image.Quantize.LIBIMAGEQUANT``
+``Image.LINEAR``                                       ``Image.BILINEAR`` or ``Image.Resampling.BILINEAR``
+``Image.CUBIC``                                        ``Image.BICUBIC`` or ``Image.Resampling.BICUBIC``
+``Image.ANTIALIAS``                                    ``Image.LANCZOS`` or ``Image.Resampling.LANCZOS``
 ``ImageCms.INTENT_PERCEPTUAL``                         ``ImageCms.Intent.PERCEPTUAL``
 ``ImageCms.INTENT_RELATIVE_COLORMETRIC``               ``ImageCms.Intent.RELATIVE_COLORMETRIC``
 ``ImageCms.INTENT_SATURATION``                         ``ImageCms.Intent.SATURATION``

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -76,8 +76,9 @@ A number of constants have been deprecated and will be removed in Pillow 10.0.0
 
 .. note::
 
-    Additional ``Image`` constants were deprecated in Pillow 9.1.0, but they
-    were later restored in Pillow 9.4.0. See  :ref:`restored-image-constants`
+    Additional ``Image`` constants were deprecated in Pillow 9.1.0, but that
+    was reversed in Pillow 9.4.0 and those constants will now remain available.
+    See :ref:`restored-image-constants`
 
 =====================================================  ============================================================
 Deprecated                                             Use instead

--- a/docs/releasenotes/9.1.0.rst
+++ b/docs/releasenotes/9.1.0.rst
@@ -53,6 +53,11 @@ Constants
 A number of constants have been deprecated and will be removed in Pillow 10.0.0
 (2023-07-01). Instead, ``enum.IntEnum`` classes have been added.
 
+.. note::
+
+    Some of these deprecations were restored in Pillow 9.4.0. See
+    :ref:`restored-image-constants`
+
 =====================================================  ============================================================
 Deprecated                                             Use instead
 =====================================================  ============================================================

--- a/docs/releasenotes/9.4.0.rst
+++ b/docs/releasenotes/9.4.0.rst
@@ -103,3 +103,40 @@ Added support for DDS L and LA images
 
 Support has been added to read and write L and LA DDS images in the uncompressed
 format, known as "luminance" textures.
+
+.. _restored-image-constants:
+
+Constants
+^^^^^^^^^
+
+In Pillow 9.1.0, the following constants were deprecated. Those deprecations have now
+been restored.
+
+- ``Image.NONE``
+- ``Image.NEAREST``
+- ``Image.ORDERED``
+- ``Image.RASTERIZE``
+- ``Image.FLOYDSTEINBERG``
+- ``Image.WEB``
+- ``Image.ADAPTIVE``
+- ``Image.AFFINE``
+- ``Image.EXTENT``
+- ``Image.PERSPECTIVE``
+- ``Image.QUAD``
+- ``Image.MESH``
+- ``Image.FLIP_LEFT_RIGHT``
+- ``Image.FLIP_TOP_BOTTOM``
+- ``Image.ROTATE_90``
+- ``Image.ROTATE_180``
+- ``Image.ROTATE_270``
+- ``Image.TRANSPOSE``
+- ``Image.TRANSVERSE``
+- ``Image.BOX``
+- ``Image.BILINEAR``
+- ``Image.HAMMING``
+- ``Image.BICUBIC``
+- ``Image.LANCZOS``
+- ``Image.MEDIANCUT``
+- ``Image.MAXCOVERAGE``
+- ``Image.FASTOCTREE``
+- ``Image.LIBIMAGEQUANT``

--- a/docs/releasenotes/9.4.0.rst
+++ b/docs/releasenotes/9.4.0.rst
@@ -115,8 +115,8 @@ format, known as "luminance" textures.
 Constants
 ^^^^^^^^^
 
-In Pillow 9.1.0, the following constants were deprecated. Those deprecations have now
-been restored.
+In Pillow 9.1.0, the following constants were deprecated. That has been reversed and
+these constants will now remain available.
 
 - ``Image.NONE``
 - ``Image.NEAREST``

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -65,21 +65,16 @@ def __getattr__(name):
     if name in categories:
         deprecate("Image categories", 10, "is_animated", plural=True)
         return categories[name]
-    elif name in ("NEAREST", "NONE"):
-        deprecate(name, 10, "Resampling.NEAREST or Dither.NONE")
-        return 0
     old_resampling = {
         "LINEAR": "BILINEAR",
         "CUBIC": "BICUBIC",
         "ANTIALIAS": "LANCZOS",
     }
     if name in old_resampling:
-        deprecate(name, 10, f"Resampling.{old_resampling[name]}")
+        deprecate(
+            name, 10, f"{old_resampling[name]} or Resampling.{old_resampling[name]}"
+        )
         return Resampling[old_resampling[name]]
-    for enum in (Transpose, Transform, Resampling, Dither, Palette, Quantize):
-        if name in enum.__members__:
-            deprecate(name, 10, f"{enum.__name__}.{name}")
-            return enum[name]
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 
@@ -214,6 +209,12 @@ class Quantize(IntEnum):
     MAXCOVERAGE = 1
     FASTOCTREE = 2
     LIBIMAGEQUANT = 3
+
+
+module = sys.modules[__name__]
+for enum in (Transpose, Transform, Resampling, Dither, Palette, Quantize):
+    for item in enum:
+        setattr(module, item.name, item.value)
 
 
 if hasattr(core, "DEFAULT_STRATEGY"):


### PR DESCRIPTION
Resolves #6537

The user in the issue found a warning that `Image.BILINEAR` is deprecated, and questions whether it is necessary to deprecate this.

This PR removes the deprecation warnings for `Image.*` constants added in #5954 ([and released in Pillow 9.1.0](https://pillow.readthedocs.io/en/stable/releasenotes/9.1.0.html#constants)).
However, there are three exceptions - I've left `LINEAR`, `CUBIC` (which have been duplicates of other constants since PIL) and `ANTIALIAS` (which has been a duplicate since #1028) deprecated.

I'm also leaving the deprecations for ImageCms, ImageFont, BlpImagePlugin, FtexImagePlugin and PngImagePlugin in place.

See what you think of this.