### PR TITLE
Updated isort to 5.11.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         types: []
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.1
+    rev: 5.11.4
     hooks:
       - id: isort
 


### PR DESCRIPTION
isort 5.11.4 has been released - https://github.com/PyCQA/isort/releases

I've triggered #6604, but it didn't detect this for some reason.