### PR TITLE
Use cron schedule to fix Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,5 +13,5 @@
             "separateMajorMinor": "false"
         }
     ],
-    "schedule": ["on the 3rd day of the month"]
+    "schedule": ["0 12 3 * *"]
 }


### PR DESCRIPTION
In our [`renovate.json`](https://github.com/python-pillow/Pillow/blob/2f3561fe33df96cdb62d66f387009837ebf7254e/.github/renovate.json#L16) we have:

```json
    "schedule": ["on the 3rd day of the month"]
```

But Renovate PRs are being created immediately, for example:

* https://github.com/python-pillow/Pillow/pull/6776
* https://github.com/python-pillow/Pillow/pull/6806
* https://github.com/python-pillow/Pillow/pull/6813

I understand [Later.js](https://bunkat.github.io/later/) is used for scheduling, and if I run this code at https://npm.runkit.com/:

```js
var later = require('later');
var sched = later.parse.text('on the 3rd day of the month'),
      occurrences = later.schedule(sched).next(10);

for(var i = 0; i < 5; i++) {
  console.log(occurrences[i]);
}
```

I get the expected output for the third day of each month:

```
Tue Jan 03 2023 02:00:00 GMT+0200 (Eastern European Standard Time)
Fri Feb 03 2023 02:00:00 GMT+0200 (Eastern European Standard Time)
Fri Mar 03 2023 02:00:00 GMT+0200 (Eastern European Standard Time)
Mon Apr 03 2023 03:00:00 GMT+0300 (Eastern European Summer Time)
Wed May 03 2023 03:00:00 GMT+0300 (Eastern European Summer Time)
```

I asked about this at https://github.com/renovatebot/renovate/discussions/19513, one suggestion was to use cron scheduling instead. 

So let's try  [`0 12 3 * *`](https://crontab.guru/#0_12_3_*_*).
