### PR TITLE
Corrected MPO marker order

### DIFF
--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -82,6 +82,7 @@ def test_app(test_file):
 def test_exif(test_file):
     with Image.open(test_file) as im_original:
         im_reloaded = roundtrip(im_original, save_all=True, exif=im_original.getexif())
+        assert tuple(app[0] for app in im_reloaded.applist[:2]) == ("APP1", "APP2")
 
     for im in (im_original, im_reloaded):
         info = im._getexif()
@@ -258,6 +259,7 @@ def test_save_all():
     for test_file in test_files:
         with Image.open(test_file) as im:
             im_reloaded = roundtrip(im, save_all=True)
+            assert im_reloaded.applist[0][0] == "APP2"
 
             im.seek(0)
             assert_image_similar(im, im_reloaded, 30)

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -713,7 +713,7 @@ def _save(im, fp, filename):
         qtables = getattr(im, "quantization", None)
     qtables = validate_qtables(qtables)
 
-    extra = info.get("extra", b"")
+    extra = b""
 
     icc_profile = info.get("icc_profile")
     if icc_profile:


### PR DESCRIPTION
Helps #6720

In "5.1. Basic MP File Structure" of the [specification](https://web.archive.org/web/20190227081740/http://www.cipa.jp/std/documents/e/DC-007_E.pdf), the order of the markers is SOI, APP1 and then APP2.

Testing Pillow at the moment, JPEG's APP0 marker comes immediately after SOI.

This PR stops passing `encoderinfo["extra"]` data to JpegImagePlugin, and instead has MpoImagePlugin write out the markers by itself, so that SOI is first, then the optional APP1 EXIF marker, then APP2, and then the data created by JpegImagePlugin.
I've also given up on the idea of writing data to file and then rewinding to populate the offsets to each frame later, and am instead using `io.BytesIO` to store the JPEG data until the offsets have been calculated, and then write to file.