### PR TITLE
Do not attempt to read IFD1 if absent

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3687,7 +3687,7 @@ class Exif(MutableMapping):
     def get_ifd(self, tag):
         if tag not in self._ifds:
             if tag == ExifTags.IFD.IFD1:
-                if self._info is not None:
+                if self._info is not None and self._info.next != 0:
                     self._ifds[tag] = self._get_ifd_dict(self._info.next)
             elif tag in [ExifTags.IFD.Exif, ExifTags.IFD.GPSInfo]:
                 offset = self._hidden_data.get(tag, self.get(tag))


### PR DESCRIPTION
#6748 added reading of IFD1 in `Image.Exif`.

However, I didn't consider that zero is a special value for the offset to the next IFD.

https://www.media.mit.edu/pia/Research/deepview/exif.html
> If its value is '0x00000000', it means this is the last IFD and there is no linked IFD.

So if that is the case, don't attempt to read IFD1.

This fixes some warnings that are shown at the moment - https://github.com/python-pillow/Pillow/actions/runs/3799772426/jobs/6462615701#step:8:4148
> Tests/test_file_tiff.py::TestFileTiff::test_get_child_images[Tests/images/hopper.tif-sizes0]
> Tests/test_file_tiff.py::TestFileTiff::test_get_child_images[Tests/images/child_ifd.tiff-sizes1]
> Tests/test_file_tiff.py::TestFileTiff::test_get_child_images[Tests/images/child_ifd_jpeg.tiff-sizes2]
>   /opt/hostedtoolcache/Python/3.11.1/x64/lib/python3.11/site-packages/PIL/TiffImagePlugin.py:852: UserWarning: Truncated File Read
>     warnings.warn(str(msg))