### PR TITLE
Return from ImagingFill early if image has a zero dimension

### DIFF
--- a/.github/workflows/test-valgrind.yml
+++ b/.github/workflows/test-valgrind.yml
@@ -48,5 +48,5 @@ jobs:
       run: |
         # The Pillow user in the docker container is UID 1000
         sudo chown -R 1000 $GITHUB_WORKSPACE
-        docker run --name pillow_container  -v $GITHUB_WORKSPACE:/Pillow pythonpillow/${{ matrix.docker }}:${{ matrix.dockerTag }}
+        docker run --name pillow_container -e "PILLOW_VALGRIND_TEST=true" -v $GITHUB_WORKSPACE:/Pillow pythonpillow/${{ matrix.docker }}:${{ matrix.dockerTag }}
         sudo chown -R runner $GITHUB_WORKSPACE

--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -286,6 +286,7 @@ def test_pdf_append_to_bytesio():
 
 
 @pytest.mark.timeout(1)
+@pytest.mark.skipif("PILLOW_VALGRIND_TEST" in os.environ, reason="Valgrind is slower")
 @pytest.mark.parametrize("newline", (b"\r", b"\n"))
 def test_redos(newline):
     malicious = b" trailer<<>>" + newline * 3456

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -512,8 +512,11 @@ class TestImage:
         i = Image.new("RGB", [1, 1])
         assert isinstance(i.size, tuple)
 
+    @pytest.mark.timeout(0.75)
+    @pytest.mark.skipif(
+        "PILLOW_VALGRIND_TEST" in os.environ, reason="Valgrind is slower"
+    )
     @pytest.mark.parametrize("size", ((0, 100000000), (100000000, 0)))
-    @pytest.mark.timeout(0.5)
     def test_empty_image(self, size):
         Image.new("RGB", size)
 

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -512,6 +512,11 @@ class TestImage:
         i = Image.new("RGB", [1, 1])
         assert isinstance(i.size, tuple)
 
+    @pytest.mark.parametrize("size", ((0, 100000000), (100000000, 0)))
+    @pytest.mark.timeout(0.5)
+    def test_empty_image(self, size):
+        Image.new("RGB", size)
+
     def test_storage_neg(self):
         # Storage.c accepted negative values for xsize, ysize.  Was
         # test_neg_ppm, but the core function for that has been

--- a/src/libImaging/Fill.c
+++ b/src/libImaging/Fill.c
@@ -24,6 +24,11 @@ ImagingFill(Imaging im, const void *colour) {
     int x, y;
     ImagingSectionCookie cookie;
 
+    /* 0-width or 0-height image. No need to do anything */
+    if (!im->linesize || !im->ysize) {
+        return im;
+    }
+
     if (im->type == IMAGING_TYPE_SPECIAL) {
         /* use generic API */
         ImagingAccess access = ImagingAccessNew(im);


### PR DESCRIPTION
`ImagingAllocateArray` [returns early](https://github.com/python-pillow/Pillow/blob/8bd5fbf450f9f5a03a32c7efcfb488bfc2a40d1c/src/libImaging/Storage.c#L393-L396) when the image has zero width or height.

This PR applies that to `ImagingFill` as well.