### PR TITLE
Check available features in Windows wheels

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -221,16 +221,8 @@ jobs:
     - name: Test Wheel
       if: "github.event_name != 'pull_request' && !contains(matrix.python-version, 'pypy')"
       run: |
-        cd C:\pillow
-        python -m pip install pytest pytest-timeout
-        for %%f in (dist\*.whl) do python -m pip install %%f
-        reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\python.exe" /v "GlobalFlag" /t REG_SZ /d "0x02000000" /f
-        path C:\pillow\winbuild\build\bin\;%PATH%
-        set CI=
-        python -m pytest -vx Tests\check_wheel.py Tests
-      shell: cmd /c copy {0} docker.bat && docker run --rm -v %GITHUB_WORKSPACE%:C:\pillow %DOCKER_IMAGE% C:\pillow\docker.bat
-      env:
-        DOCKER_IMAGE: winamd64/python:${{ matrix.python-version }}-windowsservercore
+        docker run --rm -v ${env:GITHUB_WORKSPACE}:C:\pillow mcr.microsoft.com/windows/servercore:ltsc2022 powershell C:\pillow\winbuild\test_docker.ps1 ${{ matrix.python-version }}.0 ${{ matrix.architecture }}
+      shell: pwsh
 
     - name: Upload wheel
       uses: actions/upload-artifact@v3

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -218,6 +218,20 @@ jobs:
         winbuild\\build\\build_pillow.cmd --disable-imagequant bdist_wheel
       shell: cmd
 
+    - name: Test Wheel
+      if: "github.event_name != 'pull_request' && !contains(matrix.python-version, 'pypy')"
+      run: |
+        cd C:\pillow
+        python -m pip install pytest pytest-timeout
+        for %%f in (dist\*.whl) do python -m pip install %%f
+        reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\python.exe" /v "GlobalFlag" /t REG_SZ /d "0x02000000" /f
+        path C:\pillow\winbuild\build\bin\;%PATH%
+        set CI=
+        python -m pytest -vx Tests\check_wheel.py Tests
+      shell: cmd /c copy {0} docker.bat && docker run --rm -v %GITHUB_WORKSPACE%:C:\pillow %DOCKER_IMAGE% C:\pillow\docker.bat
+      env:
+        DOCKER_IMAGE: winamd64/python:${{ matrix.python-version }}-windowsservercore
+
     - name: Upload wheel
       uses: actions/upload-artifact@v3
       if: "github.event_name != 'pull_request'"

--- a/Tests/check_wheel.py
+++ b/Tests/check_wheel.py
@@ -1,0 +1,24 @@
+import sys
+
+import pytest
+
+from PIL import features
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires Windows")
+def test_windows_wheel_features():
+    expected_modules = ["pil", "tkinter", "freetype2", "littlecms2", "webp"]
+    expected_codecs = ["jpg", "jpg_2000", "zlib", "libtiff"]
+    expected_features = [
+        "webp_anim",
+        "webp_mux",
+        "transp_webp",
+        "raqm",
+        "fribidi",
+        "harfbuzz",
+        "libjpeg_turbo",
+    ]
+
+    assert features.get_supported_modules() == expected_modules
+    assert features.get_supported_codecs() == expected_codecs
+    assert features.get_supported_features() == expected_features

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -15,6 +15,8 @@ class TestImageGrab:
         sys.platform not in ("win32", "darwin"), reason="requires Windows or macOS"
     )
     def test_grab(self):
+        if os.environ.get("USERNAME", "") == "ContainerAdministrator":
+            pytest.skip("can't grab screen when running in Docker")
         ImageGrab.grab()
         ImageGrab.grab(include_layered_windows=True)
         ImageGrab.grab(all_screens=True)

--- a/winbuild/test_docker.ps1
+++ b/winbuild/test_docker.ps1
@@ -1,0 +1,26 @@
+param ([string]$python,[string]$arch)
+$ErrorActionPreference  = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+$suffix = if ($arch -eq "x64") {"-amd64"} else {""}
+$url = 'https://www.python.org/ftp/python/{0}/python-{0}{1}.exe' -f ($python, $suffix)
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Invoke-WebRequest -Uri $url -OutFile 'setup.exe'
+Start-Process setup.exe -Wait -NoNewWindow -PassThru -ArgumentList @(
+        '/quiet',
+        'InstallAllUsers=0',
+        'TargetDir=C:\Python',
+        'PrependPath=1',
+        'Shortcuts=0',
+        'Include_doc=0',
+        'Include_pip=1',
+        'Include_test=0'
+    )
+$env:CI = "true"
+$env:path += ";C:\Python\;C:\pillow\winbuild\build\bin\"
+cd C:\pillow
+& python -VV
+& python -m ensurepip
+& python -m pip install pytest pytest-timeout
+& python -m pip install "dist\$(Get-ChildItem dist\*.whl -Name)"
+& python -m pytest -vx Tests\check_wheel.py Tests
+if ((Test-Path -LiteralPath variable:\LASTEXITCODE)) { exit $LASTEXITCODE }


### PR DESCRIPTION
Add test for #6701 and similar issues in earlier releases.
See successful run in my fork: https://github.com/nulano/Pillow/actions/runs/3815551828
See failed run detecting the #6701 issue for 9.3.0 release: https://github.com/nulano/Pillow/actions/runs/3815551828

This runs the tests and checks available features in a Windows Server Core Docker container, similarly to how `run_tests` is run in the pillow-wheels repo.

Marked as draft because:
* [ ] PyPy requires a different download url.
* [ ] I'm not sure when this should be triggered. Running all tests twice for every push seems unnecessary (and takes extra 2min), but at least release wheels should be tested. I think the ideal option might be to run only when pushing a tag, but I think that might not get detected if there is a simultaneous push of the same commit to a branch.