### PR TITLE
Added release notes for #6842 and #6846

### DIFF
--- a/docs/releasenotes/9.4.0.rst
+++ b/docs/releasenotes/9.4.0.rst
@@ -81,6 +81,13 @@ check the image size before allocating memory for it. This dates to the PIL
 fork. Pilllow 8.2.0 added a check for large sizes, but did not consider the
 case where one dimension was zero.
 
+Null pointer dereference crash in ImageFont
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Pillow attempted to dereference a null pointer in ``ImageFont``, leading to a
+crash. An error is now raised instead. This would have been present since
+Pillow 8.0.0.
+
 Other Changes
 =============
 

--- a/docs/releasenotes/9.4.0.rst
+++ b/docs/releasenotes/9.4.0.rst
@@ -78,14 +78,14 @@ Fix memory DOS in ImageFont
 A corrupt or specially crafted TTF font could have font metrics that lead to
 unreasonably large sizes when rendering text in font. ``ImageFont.py`` did not
 check the image size before allocating memory for it. This dates to the PIL
-fork. Pilllow 8.2.0 added a check for large sizes, but did not consider the
-case where one dimension was zero.
+fork. Pillow 8.2.0 added a check for large sizes, but did not consider the
+case where one dimension is zero.
 
 Null pointer dereference crash in ImageFont
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Pillow attempted to dereference a null pointer in ``ImageFont``, leading to a
-crash. An error is now raised instead. This would have been present since
+crash. An error is now raised instead. This has been present since
 Pillow 8.0.0.
 
 Other Changes

--- a/docs/releasenotes/9.4.0.rst
+++ b/docs/releasenotes/9.4.0.rst
@@ -1,30 +1,6 @@
 9.4.0
 -----
 
-Backwards Incompatible Changes
-==============================
-
-TODO
-^^^^
-
-TODO
-
-Deprecations
-============
-
-TODO
-^^^^
-
-TODO
-
-API Changes
-===========
-
-TODO
-^^^^
-
-TODO
-
 API Additions
 =============
 
@@ -96,10 +72,14 @@ When saving a JPEG image, a comment can now be written from
 Security
 ========
 
-TODO
-^^^^
+Fix memory DOS in ImageFont
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-TODO
+A corrupt or specially crafted TTF font could have font metrics that lead to
+unreasonably large sizes when rendering text in font. ``ImageFont.py`` did not
+check the image size before allocating memory for it. This dates to the PIL
+fork. Pilllow 8.2.0 added a check for large sizes, but did not consider the
+case where one dimension was zero.
 
 Other Changes
 =============


### PR DESCRIPTION
Added release notes for
- #6842, largely copying https://pillow.readthedocs.io/en/stable/releasenotes/8.2.0.html#fix-memory-dos-in-imagefont, since the solution came from a new version of that problem
- #6846, which would have only been present since Pillow 8.0.0, when `FT_Bitmap_Convert` was added by https://github.com/python-pillow/Pillow/pull/4955.