### PR TITLE
Relaxed child images check to allow for libjpeg

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -447,7 +447,7 @@ class TestFileJpeg:
             ims = im.get_child_images()
 
         assert len(ims) == 1
-        assert_image_equal_tofile(ims[0], "Tests/images/flower_thumbnail.png")
+        assert_image_similar_tofile(ims[0], "Tests/images/flower_thumbnail.png", 2.1)
 
     def test_mp(self):
         with Image.open("Tests/images/pil_sample_rgb.jpg") as im:


### PR DESCRIPTION
Reported in https://github.com/conda-forge/pillow-feedstock/pull/128#issuecomment-1368705067

`test_get_child_images()` in test_file_jpeg.py is failing with libjpeg. This PR relaxes the check to test for a similarity of 2.1, instead of equality. I have confirmed this in pillow-wheels with libjpeg 9e.