### PR TITLE
array tobytes() always exists in Python >= 3.2

### DIFF
--- a/Tests/test_imagepath.py
+++ b/Tests/test_imagepath.py
@@ -58,10 +58,7 @@ def test_path():
     assert list(p) == [(0.0, 1.0)]
 
     arr = array.array("f", [0, 1])
-    if hasattr(arr, "tobytes"):
-        p = ImagePath.Path(arr.tobytes())
-    else:
-        p = ImagePath.Path(arr.tostring())
+    p = ImagePath.Path(arr.tobytes())
     assert list(p) == [(0.0, 1.0)]
 
 


### PR DESCRIPTION
See https://docs.python.org/3/library/array.html#array.array.tobytes

> New in version 3.2: tostring() is renamed to [tobytes()](https://docs.python.org/3/library/array.html#array.array.tobytes) for clarity.