### PR TITLE
LOAD_TRUNCATED_IMAGES may allow PNG images to open

### DIFF
--- a/src/PIL/__init__.py
+++ b/src/PIL/__init__.py
@@ -75,6 +75,10 @@ _plugins = [
 class UnidentifiedImageError(OSError):
     """
     Raised in :py:meth:`PIL.Image.open` if an image cannot be opened and identified.
+
+    If a PNG image raises this error, setting :data:`.ImageFile.LOAD_TRUNCATED_IMAGES`
+    to true may allow the image to be opened after all. The setting will ignore missing
+    data and checksum failures.
     """
 
     pass


### PR DESCRIPTION
Helps #6843

As suggested in the issue, document at https://pillow.readthedocs.io/en/stable/PIL.html#PIL.UnidentifiedImageError that `ImageFile.LOAD_TRUNCATED_IMAGES` may allow PNG images to open that would otherwise be unidentified.