### PR TITLE
NotImplementedError will not be raised by grapclipboard if xclip is available on Linux

### DIFF
--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -64,7 +64,7 @@ $bmp = New-Object Drawing.Bitmap 200, 200
             )
             p.communicate()
         else:
-            if not shutil.which("wl-paste"):
+            if not shutil.which("wl-paste") and not shutil.which("xclip"):
                 with pytest.raises(
                     NotImplementedError,
                     match="wl-paste or xclip is required for"


### PR DESCRIPTION
Resolves #6858

When adding support for xclip in https://github.com/python-pillow/Pillow/pull/6783/commits/2ecf88eaa621266f63405ca7e1fdbdb7ed4d5c8d, I managed to update the error text in the test, but not the conditions under which the error is raised.