### PR TITLE
Announce releases on Mastodon

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ As of 2019, Pillow development is
                 src="https://img.shields.io/badge/tweet-on%20Twitter-00aced.svg"></a>
             <a href="https://fosstodon.org/@pillow"><img
                 alt="Follow on https://fosstodon.org/@pillow"
-                src="https://img.shields.io/badge/publish-on%20Mastodon-595aff"
+                src="https://img.shields.io/badge/publish-on%20Mastodon-595aff.svg"
                 rel="me"></a>
         </td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ As of 2019, Pillow development is
             <a href="https://twitter.com/PythonPillow"><img
                 alt="Follow on https://twitter.com/PythonPillow"
                 src="https://img.shields.io/badge/tweet-on%20Twitter-00aced.svg"></a>
+            <a href="https://fosstodon.org/@pillow"><img
+                alt="Follow on https://fosstodon.org/@pillow"
+                src="https://img.shields.io/badge/publish-on%20Fosstodon-595aff"></a>
         </td>
     </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ As of 2019, Pillow development is
                 src="https://img.shields.io/badge/tweet-on%20Twitter-00aced.svg"></a>
             <a href="https://fosstodon.org/@pillow"><img
                 alt="Follow on https://fosstodon.org/@pillow"
-                src="https://img.shields.io/badge/publish-on%20Fosstodon-595aff"></a>
+                src="https://img.shields.io/badge/publish-on%20Mastodon-595aff"
+                rel="me"></a>
         </td>
     </tr>
 </table>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -111,7 +111,7 @@ Released as needed privately to individual vendors for critical security-related
 
 ## Publicize Release
 
-* [ ] Announce release availability via [Twitter](https://twitter.com/pythonpillow) e.g. https://twitter.com/PythonPillow/status/1013789184354603010
+* [ ] Announce release availability via [Twitter](https://twitter.com/pythonpillow) and [Fosstodon](https://fosstodon.org/@pillow) e.g. https://twitter.com/PythonPillow/status/1013789184354603010
 
 ## Documentation
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -111,7 +111,7 @@ Released as needed privately to individual vendors for critical security-related
 
 ## Publicize Release
 
-* [ ] Announce release availability via [Twitter](https://twitter.com/pythonpillow) and [Fosstodon](https://fosstodon.org/@pillow) e.g. https://twitter.com/PythonPillow/status/1013789184354603010
+* [ ] Announce release availability via [Twitter](https://twitter.com/pythonpillow) and [Mastodon](https://fosstodon.org/@pillow) e.g. https://twitter.com/PythonPillow/status/1013789184354603010
 
 ## Documentation
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,6 +73,18 @@ Pillow for enterprise is available via the Tidelift Subscription. `Learn more <h
    :target: https://bestpractices.coreinfrastructure.org/projects/6331
    :alt: OpenSSF Best Practices
 
+.. image:: https://badges.gitter.im/python-pillow/Pillow.svg
+   :target: https://gitter.im/python-pillow/Pillow?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+   :alt: Join the chat at https://gitter.im/python-pillow/Pillow
+
+.. image:: https://img.shields.io/badge/tweet-on%20Twitter-00aced.svg
+   :target: https://twitter.com/PythonPillow
+   :alt: Follow on https://twitter.com/PythonPillow
+
+.. image:: https://img.shields.io/badge/publish-on%20Mastodon-595aff.svg
+   :target: https://fosstodon.org/@pillow
+   :alt: Follow on https://fosstodon.org/@pillow
+
 Overview
 ========
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ project_urls =
     Release notes=https://pillow.readthedocs.io/en/stable/releasenotes/index.html
     Changelog=https://github.com/python-pillow/Pillow/blob/main/CHANGES.rst
     Twitter=https://twitter.com/PythonPillow
+    Mastodon=https://fosstodon.org/@pillow
 
 [options]
 packages = PIL


### PR DESCRIPTION
After https://fosstodon.org/@pillow/109620196925642582, it seems that we should add posting to Fosstodon to the RELEASING checklist.

I've also added the badge to the README, and the URL to setup.cfg.