### PR TITLE
Moved conversion test to test_imagecms

### DIFF
--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -255,17 +255,6 @@ def test_p2pa_palette():
     assert im_pa.getpalette() == im.getpalette()
 
 
-@pytest.mark.parametrize("mode", ("RGB", "RGBA", "RGBX"))
-def test_rgb_lab(mode):
-    im = Image.new(mode, (1, 1))
-    converted_im = im.convert("LAB")
-    assert converted_im.getpixel((0, 0)) == (0, 128, 128)
-
-    im = Image.new("LAB", (1, 1), (255, 0, 0))
-    converted_im = im.convert(mode)
-    assert converted_im.getpixel((0, 0))[:3] == (0, 255, 255)
-
-
 def test_matrix_illegal_conversion():
     # Arrange
     im = hopper("CMYK")

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -625,3 +625,14 @@ def test_constants_deprecation():
         for name in enum.__members__:
             with pytest.warns(DeprecationWarning):
                 assert getattr(ImageCms, prefix + name) == enum[name]
+
+
+@pytest.mark.parametrize("mode", ("RGB", "RGBA", "RGBX"))
+def test_rgb_lab(mode):
+    im = Image.new(mode, (1, 1))
+    converted_im = im.convert("LAB")
+    assert converted_im.getpixel((0, 0)) == (0, 128, 128)
+
+    im = Image.new("LAB", (1, 1), (255, 0, 0))
+    converted_im = im.convert(mode)
+    assert converted_im.getpixel((0, 0))[:3] == (0, 255, 255)


### PR DESCRIPTION
Testing Alpine in the docker-images repository [without lcms2-dev](https://github.com/radarhere/docker-images/commit/e48cc2d2d8c824f34332348d92648266e396beec), I found that [test_image_convert.py::test_rgb_lab failed](https://github.com/radarhere/docker-images/actions/runs/3853980188/jobs/6567496049). This makes sense, given that [it uses ImageCms.](https://github.com/python-pillow/Pillow/blob/b6c7a837bca6fef6de83bd301dd299a2f77b5b8b/src/PIL/Image.py#L1063-L1074)

This PR moves the test into test_imagecms.py, so that it is skipped if lcms2 is absent.