### PR TITLE
Simplify isinstance, key in dict, enumerate

### DIFF
--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -168,8 +168,7 @@ def test_mp_no_data():
 def test_mp_attribute(test_file):
     with Image.open(test_file) as im:
         mpinfo = im._getmp()
-    frame_number = 0
-    for mpentry in mpinfo[0xB002]:
+    for frame_number, mpentry in enumerate(mpinfo[0xB002]):
         mpattr = mpentry["Attribute"]
         if frame_number:
             assert not mpattr["RepresentativeImageFlag"]
@@ -180,7 +179,6 @@ def test_mp_attribute(test_file):
         assert mpattr["ImageDataFormat"] == "JPEG"
         assert mpattr["MPType"] == "Multi-Frame Image: (Disparity)"
         assert mpattr["Reserved"] == 0
-        frame_number += 1
 
 
 @pytest.mark.parametrize("test_file", test_files)

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -593,7 +593,7 @@ class TestFilePng:
 
     def test_textual_chunks_after_idat(self):
         with Image.open("Tests/images/hopper.png") as im:
-            assert "comment" in im.text.keys()
+            assert "comment" in im.text
             for k, v in {
                 "date:create": "2014-09-04T09:37:08+03:00",
                 "date:modify": "2014-09-04T09:37:08+03:00",

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -487,7 +487,7 @@ def _normalize_mode(im):
     if Image.getmodebase(im.mode) == "RGB":
         im = im.convert("P", palette=Image.Palette.ADAPTIVE)
         if im.palette.mode == "RGBA":
-            for rgba in im.palette.colors.keys():
+            for rgba in im.palette.colors:
                 if rgba[3] == 0:
                     im.info["transparency"] = im.palette.colors[rgba]
                     break

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3841,7 +3841,7 @@ class Exif(MutableMapping):
     def __str__(self):
         if self._info is not None:
             # Load all keys into self._data
-            for tag in self._info.keys():
+            for tag in self._info:
                 self[tag]
 
         return str(self._data)

--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -328,9 +328,7 @@ def pdf_repr(x):
         return b"null"
     elif isinstance(x, (PdfName, PdfDict, PdfArray, PdfBinary)):
         return bytes(x)
-    elif isinstance(x, int):
-        return str(x).encode("us-ascii")
-    elif isinstance(x, float):
+    elif isinstance(x, (int, float)):
         return str(x).encode("us-ascii")
     elif isinstance(x, time.struct_time):
         return b"(D:" + time.strftime("%Y%m%d%H%M%SZ", x).encode("us-ascii") + b")"

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -238,15 +238,13 @@ def _layerinfo(fp, ct_bytes):
         layers.append((name, mode, (x0, y0, x1, y1)))
 
     # get tiles
-    i = 0
-    for name, mode, bbox in layers:
+    for i, (name, mode, bbox) in enumerate(layers):
         tile = []
         for m in mode:
             t = _maketile(fp, m, bbox, 1)
             if t:
                 tile.extend(t)
         layers[i] = name, mode, bbox, tile
-        i += 1
 
     return layers
 

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -257,7 +257,7 @@ OPEN_INFO = {
     (MM, 8, (1,), 1, (8, 8, 8), ()): ("LAB", "LAB"),
 }
 
-MAX_SAMPLESPERPIXEL = max(len(key_tp[4]) for key_tp in OPEN_INFO.keys())
+MAX_SAMPLESPERPIXEL = max(len(key_tp[4]) for key_tp in OPEN_INFO)
 
 PREFIXES = [
     b"MM\x00\x2A",  # Valid TIFF header with big-endian byte order
@@ -1222,7 +1222,7 @@ class TiffImageFile(ImageFile.ImageFile):
 
             # load IFD data from fp before it is closed
             exif = self.getexif()
-            for key in TiffTags.TAGS_V2_GROUPS.keys():
+            for key in TiffTags.TAGS_V2_GROUPS:
                 if key not in exif:
                     continue
                 exif.get_ifd(key)
@@ -1629,7 +1629,7 @@ def _save(im, fp, filename):
     if isinstance(info, ImageFileDirectory_v1):
         info = info.to_v2()
     for key in info:
-        if isinstance(info, Image.Exif) and key in TiffTags.TAGS_V2_GROUPS.keys():
+        if isinstance(info, Image.Exif) and key in TiffTags.TAGS_V2_GROUPS:
             ifd[key] = info.get_ifd(key)
         else:
             ifd[key] = info.get(key)

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -39,7 +39,7 @@ def cmd_rmdir(path):
 def cmd_nmake(makefile=None, target="", params=None):
     if params is None:
         params = ""
-    elif isinstance(params, list) or isinstance(params, tuple):
+    elif isinstance(params, (list, tuple)):
         params = " ".join(params)
     else:
         params = str(params)
@@ -58,7 +58,7 @@ def cmd_nmake(makefile=None, target="", params=None):
 def cmd_cmake(params=None, file="."):
     if params is None:
         params = ""
-    elif isinstance(params, list) or isinstance(params, tuple):
+    elif isinstance(params, (list, tuple)):
         params = " ".join(params)
     else:
         params = str(params)


### PR DESCRIPTION
# Use single `isinstance` call for multiple types

For example, instead of:

```python
isinstance(params, list) or isinstance(params, tuple)
```

Use:

```python
isinstance(params, (list, tuple))
```

Docs: "If _classinfo_ is a tuple of type objects (or recursively, other such tuples) or a Union Type of multiple types, return `True` if _object_ is an instance of any of the types."

https://docs.python.org/3/library/functions.html#isinstance

# Use `key in mydict`

For example, instead of:

```python
key in TiffTags.TAGS_V2_GROUPS.keys()
```

Use:

```python
key in TiffTags.TAGS_V2_GROUPS
```

Docs: "For mapping objects, this should consider the keys of the mapping rather than the values or the key-item pairs."

https://docs.python.org/3/reference/datamodel.html#object.__contains__

# Use `enumerate`

For example, instead of:

```python
frame_number = 0
for mpentry in mpinfo[0xB002]:
    ...
    frame_number += 1
```

Use:

```python
for frame_number, mpentry in enumerate(mpinfo[0xB002]):
    ...
```

Docs: https://docs.python.org/3/library/functions.html#enumerate

