### PR TITLE
Raise ValueError for BoxBlur filter with negative radius

### DIFF
--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -179,3 +179,9 @@ def test_consistency_5x5(mode):
 def test_invalid_box_blur_filter():
     with pytest.raises(ValueError):
         ImageFilter.BoxBlur(-2)
+
+    im = hopper()
+    box_blur_filter = ImageFilter.BoxBlur(2)
+    box_blur_filter.radius = -2
+    with pytest.raises(ValueError):
+        im.filter(box_blur_filter)

--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -24,6 +24,7 @@ from .helper import assert_image_equal, hopper
         ImageFilter.ModeFilter,
         ImageFilter.GaussianBlur,
         ImageFilter.GaussianBlur(5),
+        ImageFilter.BoxBlur(0),
         ImageFilter.BoxBlur(5),
         ImageFilter.UnsharpMask,
         ImageFilter.UnsharpMask(10),
@@ -173,3 +174,8 @@ def test_consistency_5x5(mode):
                 Image.merge(mode, source[: len(mode)]).filter(kernel),
                 Image.merge(mode, reference[: len(mode)]),
             )
+
+
+def test_invalid_box_blur_filter():
+    with pytest.raises(ValueError):
+        ImageFilter.BoxBlur(-2)

--- a/src/PIL/ImageFilter.py
+++ b/src/PIL/ImageFilter.py
@@ -183,6 +183,9 @@ class BoxBlur(MultibandFilter):
     name = "BoxBlur"
 
     def __init__(self, radius):
+        if radius < 0:
+            msg = "radius must be >= 0"
+            raise ValueError(msg)
         self.radius = radius
 
     def filter(self, image):

--- a/src/libImaging/BoxBlur.c
+++ b/src/libImaging/BoxBlur.c
@@ -237,6 +237,9 @@ ImagingBoxBlur(Imaging imOut, Imaging imIn, float radius, int n) {
     if (n < 1) {
         return ImagingError_ValueError("number of passes must be greater than zero");
     }
+    if (radius < 0) {
+        return ImagingError_ValueError("radius must be >= 0");
+    }
 
     if (strcmp(imIn->mode, imOut->mode) || imIn->type != imOut->type ||
         imIn->bands != imOut->bands || imIn->xsize != imOut->xsize ||


### PR DESCRIPTION
Fixes #6873.

Changes proposed in this pull request:

 * There's a segmentation fault when _using_ a filter with a negative radius
 * A radius of zero has a special meaning (do not blur, returns identical image)
 * https://pillow.readthedocs.io/en/stable/reference/ImageFilter.html#PIL.ImageFilter.BoxBlur
 * So let's raise a `ValueError` when _creating_ a filter with a negative radius
 * We could raise it when _using_ the filter, but why not already do so when creating?
 
