### PR TITLE
Only read when necessary in EpsImagePlugin

### DIFF
--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -316,21 +316,22 @@ class EpsImageFile(ImageFile.ImageFile):
 
     def _find_offset(self, fp):
 
-        s = fp.read(160)
+        s = fp.read(4)
 
-        if s[:4] == b"%!PS":
+        if s == b"%!PS":
             # for HEAD without binary preview
             fp.seek(0, io.SEEK_END)
             length = fp.tell()
             offset = 0
-        elif i32(s, 0) == 0xC6D3D0C5:
+        elif i32(s) == 0xC6D3D0C5:
             # FIX for: Some EPS file not handled correctly / issue #302
             # EPS can contain binary data
             # or start directly with latin coding
             # more info see:
             # https://web.archive.org/web/20160528181353/http://partners.adobe.com/public/developer/en/ps/5002.EPSF_Spec.pdf
-            offset = i32(s, 4)
-            length = i32(s, 8)
+            s = fp.read(8)
+            offset = i32(s)
+            length = i32(s, 4)
         else:
             msg = "not an EPS file"
             raise SyntaxError(msg)


### PR DESCRIPTION
EpsImagePlugin reads 160 characters from the file when finding the offset.

https://github.com/python-pillow/Pillow/blob/c2e2da4a2245dd42131fb47e19aa0ff06ee088cb/src/PIL/EpsImagePlugin.py#L319

However, it only uses 4 or 12 characters.