### PR TITLE
Verify the Mastodon docs link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,6 +85,10 @@ Pillow for enterprise is available via the Tidelift Subscription. `Learn more <h
    :target: https://fosstodon.org/@pillow
    :alt: Follow on https://fosstodon.org/@pillow
 
+.. raw:: html
+
+   <link rel="me" href="https://fosstodon.org/@pillow">
+
 Overview
 ========
 


### PR DESCRIPTION
Follow on to https://github.com/python-pillow/Pillow/pull/6861.

Add a hidden verified link to https://fosstodon.org/@pillow, following tips in this thread:  https://fosstodon.org/@readthedocs/109428014312327759

Quick test with my fork:

https://hugovk-pillow.readthedocs.io/en/rtd-verify-mastodon/ contains:

```html
<link rel="me" href="https://fosstodon.org/@pillow"></section>
```

Temporarily adding that to the profile, it verifies like:

![image](https://user-images.githubusercontent.com/1324225/211850440-31d82319-f3b8-4730-8b49-5360fbd13444.png)

Docs: https://docs.joinmastodon.org/user/profile/#verification