### PR TITLE
Only install python-pyqt6 package on 64-bit

### DIFF
--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 permissions:
   contents: read
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -49,7 +49,6 @@ jobs:
               ${{ matrix.package }}-python3-numpy \
               ${{ matrix.package }}-python3-olefile \
               ${{ matrix.package }}-python3-pip \
-              ${{ matrix.package }}-python-pyqt6 \
               ${{ matrix.package }}-python3-setuptools \
               ${{ matrix.package }}-freetype \
               ${{ matrix.package }}-gcc \
@@ -62,6 +61,11 @@ jobs:
               ${{ matrix.package }}-libwebp \
               ${{ matrix.package }}-openjpeg2 \
               subversion
+
+          if [ ${{ matrix.package }} == "mingw-w64-x86_64" ]; then
+              pacman -S --noconfirm \
+                  ${{ matrix.package }}-python-pyqt6
+          fi
 
           python3 -m pip install pyroma pytest pytest-cov pytest-timeout
 


### PR DESCRIPTION
MinGW has started [failing in main](https://github.com/python-pillow/Pillow/actions/runs/3902362791/jobs/6672642893)
> error: target not found: mingw-w64-i686-python-pyqt6

This would be because of https://github.com/msys2/MINGW-packages/commit/4ecf214bd4f045eb1b7ea66db323325f596e94b4

This PR no longer installs the python-pyqt6 package on 32-bit.