### PR TITLE
Do not unintentionally load TIFF format at first

### DIFF
--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -41,7 +41,7 @@ import sys
 import tempfile
 import warnings
 
-from . import Image, ImageFile, TiffImagePlugin
+from . import Image, ImageFile
 from ._binary import i16be as i16
 from ._binary import i32be as i32
 from ._binary import o8
@@ -524,6 +524,8 @@ def _getmp(self):
     head = file_contents.read(8)
     endianness = ">" if head[:4] == b"\x4d\x4d\x00\x2a" else "<"
     # process dictionary
+    from . import TiffImagePlugin
+
     try:
         info = TiffImagePlugin.ImageFileDirectory_v2(head)
         file_contents.seek(info.next)


### PR DESCRIPTION
```python
from PIL import Image
Image.preinit()
print(Image.ID)
```
prints
```
['BMP', 'DIB', 'GIF', 'TIFF', 'JPEG', 'PPM', 'PNG']
```

But `preinit()` doesn't list TIFF. In fact, it is commented out
https://github.com/python-pillow/Pillow/blob/43bb03539e0f3dca6ee399cbb8162c21e257c05d/src/PIL/Image.py#L321-L364

So why is TIFF part of the preinit list? Because when JPEG is loaded, it imports TiffImagePlugin.

https://github.com/python-pillow/Pillow/blob/43bb03539e0f3dca6ee399cbb8162c21e257c05d/src/PIL/JpegImagePlugin.py#L44

This PR changes the import to only run when it is used, removing TIFF from the list.