### PR TITLE
Do not retry specified formats if they failed when opening

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3267,7 +3267,7 @@ def open(fp, mode="r", formats=None):
 
     im = _open_core(fp, filename, prefix, formats)
 
-    if im is None:
+    if im is None and formats is ID:
         if init():
             im = _open_core(fp, filename, prefix, formats)
 


### PR DESCRIPTION
When opening an image, Pillow loop through the different possible formats.
https://github.com/python-pillow/Pillow/blob/43bb03539e0f3dca6ee399cbb8162c21e257c05d/src/PIL/Image.py#L3242-L3244

If I add a `print` statement to see which formats it checks,
```python
    def _open_core(fp, filename, prefix, formats):
        for i in formats:
            print(i)
            i = i.upper()
```
and then attempt to open a SPIDER image, while only asking Pillow to check the JPEG format,
```python
from PIL import Image
im = Image.open("Tests/images/hopper.spider", formats=["JPEG"])
```
it prints
```
JPEG
JPEG
Traceback (most recent call last):
  File "Tests/test_image.py", line 2, in <module>
    im = Image.open("Tests/images/hopper.spider", formats=["JPEG"])
  File "PIL/Image.py", line 3284, in open
    raise UnidentifiedImageError(msg)
PIL.UnidentifiedImageError: cannot identify image file 'Tests/images/hopper.spider'
```
JPEG is checked twice.

This is because in the following code, Pillow doesn't recognise that `formats` is a fixed list, and that calling `init()` will not increase the number of formats to try.

https://github.com/python-pillow/Pillow/blob/43bb03539e0f3dca6ee399cbb8162c21e257c05d/src/PIL/Image.py#L3268-L3272

So this PR changes it to only retry `_open_core` if `formats` has not been specified.

```python
    im = _open_core(fp, filename, prefix, formats)

    if im is None and formats is ID:
        if init():
            im = _open_core(fp, filename, prefix, formats)
```

But wait, you say, you've also skipped calling `init()`. What if the needed format hasn't been imported before the call to `_open_core`?

Not to worry. `_open_core` already automatically calls `init()` if there is something surprising in `formats`

https://github.com/python-pillow/Pillow/blob/43bb03539e0f3dca6ee399cbb8162c21e257c05d/src/PIL/Image.py#L3242-L3246