### PR TITLE
Alex Clark -> Jeffrey A. Clark (Alex)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ The Python Imaging Library (PIL) is
 
 Pillow is the friendly PIL fork. It is
 
-    Copyright © 2010-2023 by Alex Clark and contributors
+    Copyright © 2010-2023 by Jeffrey A. Clark (Alex) and contributors.
 
 Like PIL, Pillow is licensed under the open source HPND License:
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ## Python Imaging Library (Fork)
 
-Pillow is the friendly PIL fork by [Alex Clark and
-Contributors](https://github.com/python-pillow/Pillow/graphs/contributors).
+Pillow is the friendly PIL fork by [Jeffrey A. Clark (Alex) and
+contributors](https://github.com/python-pillow/Pillow/graphs/contributors).
 PIL is the Python Imaging Library by Fredrik Lundh and Contributors.
 As of 2019, Pillow development is
 [supported by Tidelift](https://tidelift.com/subscription/pkg/pypi-pillow?utm_source=pypi-pillow&utm_medium=readme&utm_campaign=enterprise).

--- a/docs/COPYING
+++ b/docs/COPYING
@@ -5,7 +5,7 @@ The Python Imaging Library (PIL) is
 
 Pillow is the friendly PIL fork. It is
 
-    Copyright © 2010-2023 by Alex Clark and contributors
+    Copyright © 2010-2023 by Jeffrey A. Clark (Alex) and contributors
 
 Like PIL, Pillow is licensed under the open source PIL
 Software License:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,9 @@ master_doc = "index"
 
 # General information about the project.
 project = "Pillow (PIL Fork)"
-copyright = "1995-2011 Fredrik Lundh, 2010-2023 Jeffrey A. Clark (Alex) and contributors"
+copyright = (
+    "1995-2011 Fredrik Lundh, 2010-2023 Jeffrey A. Clark (Alex) and contributors"
+)
 author = "Fredrik Lundh, Jeffrey A. Clark (Alex), contributors"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,8 +52,8 @@ master_doc = "index"
 
 # General information about the project.
 project = "Pillow (PIL Fork)"
-copyright = "1995-2011 Fredrik Lundh, 2010-2023 Alex Clark and Contributors"
-author = "Fredrik Lundh, Alex Clark and Contributors"
+copyright = "1995-2011 Fredrik Lundh, 2010-2023 Jeffrey A. Clark (Alex) and contributors"
+author = "Fredrik Lundh, Jeffrey A. Clark (Alex), contributors"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -243,7 +243,7 @@ latex_documents = [
         master_doc,
         "PillowPILFork.tex",
         "Pillow (PIL Fork) Documentation",
-        "Alex Clark",
+        "Jeffrey A. Clark (Alex)",
         "manual",
     )
 ]
@@ -293,7 +293,7 @@ texinfo_documents = [
         "Pillow (PIL Fork) Documentation",
         author,
         "PillowPILFork",
-        "Pillow is the friendly PIL fork by Alex Clark and Contributors.",
+        "Pillow is the friendly PIL fork by Jeffrey A. Clark (Alex) and contributors.",
         "Miscellaneous",
     )
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Pillow
 ======
 
-Pillow is the friendly PIL fork by `Alex Clark and Contributors <https://github.com/python-pillow/Pillow/graphs/contributors>`_. PIL is the Python Imaging Library by Fredrik Lundh and Contributors.
+Pillow is the friendly PIL fork by `Jeffrey A. Clark (Alex) and contributors <https://github.com/python-pillow/Pillow/graphs/contributors>`_. PIL is the Python Imaging Library by Fredrik Lundh and contributors.
 
 Pillow for enterprise is available via the Tidelift Subscription. `Learn more <https://tidelift.com/subscription/pkg/pypi-pillow?utm_source=pypi-pillow&utm_medium=docs&utm_campaign=enterprise>`_.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,8 +4,8 @@ description = Python Imaging Library (Fork)
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://python-pillow.org
-author = Alex Clark (PIL Fork Author)
-author_email = aclark@python-pillow.org
+author = Jeffrey A. Clark (Alex)
+author_email = aclark@aclark.net
 license = HPND
 classifiers =
     Development Status :: 6 - Mature

--- a/src/PIL/__init__.py
+++ b/src/PIL/__init__.py
@@ -1,11 +1,11 @@
 """Pillow (Fork of the Python Imaging Library)
 
-Pillow is the friendly PIL fork by Alex Clark and Contributors.
+Pillow is the friendly PIL fork by Jeffrey A. Clark (Alex) and contributors.
     https://github.com/python-pillow/Pillow/
 
 Pillow is forked from PIL 1.1.7.
 
-PIL is the Python Imaging Library by Fredrik Lundh and Contributors.
+PIL is the Python Imaging Library by Fredrik Lundh and contributors.
 Copyright (c) 1999 by Secret Labs AB.
 
 Use PIL.__version__ for this Pillow version.


### PR DESCRIPTION
I'm still "Alex", just on a Jeffrey A. Clark roll lately.

"Fixes" my name.

Changes proposed in this pull request:

 * Replace "Alex Clark" with "Jeffrey A. Clark (Alex)"
