### PR TITLE
Handle more than one directory returned by pkg-config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -264,19 +264,17 @@ def _pkg_config(name):
                 command_libs.append("--silence-errors")
                 command_cflags.append("--silence-errors")
             libs = re.split(
-                r"\s*-L",
+                r"(^|\s+)-L",
                 subprocess.check_output(command_libs, stderr=stderr)
                 .decode("utf8")
                 .strip(),
-            )
-            libs.remove("")
+            )[::2][1:]
             cflags = re.split(
-                r"\s*-I",
+                r"(^|\s+)-I",
                 subprocess.check_output(command_cflags, stderr=stderr)
                 .decode("utf8")
                 .strip(),
-            )
-            cflags.remove("")
+            )[::2][1:]
             return libs, cflags
         except Exception:
             pass

--- a/setup.py
+++ b/setup.py
@@ -263,18 +263,20 @@ def _pkg_config(name):
             if not DEBUG:
                 command_libs.append("--silence-errors")
                 command_cflags.append("--silence-errors")
-            libs = (
+            libs = re.split(
+                r"\s*-L",
                 subprocess.check_output(command_libs, stderr=stderr)
                 .decode("utf8")
-                .strip()
-                .replace("-L", "")
+                .strip(),
             )
-            cflags = (
-                subprocess.check_output(command_cflags)
+            libs.remove("")
+            cflags = re.split(
+                r"\s*-I",
+                subprocess.check_output(command_cflags, stderr=stderr)
                 .decode("utf8")
-                .strip()
-                .replace("-I", "")
+                .strip(),
             )
+            cflags.remove("")
             return libs, cflags
         except Exception:
             pass
@@ -473,8 +475,12 @@ class pil_build_ext(build_ext):
             else:
                 lib_root = include_root = root
 
-            _add_directory(library_dirs, lib_root)
-            _add_directory(include_dirs, include_root)
+            if lib_root is not None:
+                for lib_dir in lib_root:
+                    _add_directory(library_dirs, lib_dir)
+            if include_root is not None:
+                for include_dir in include_root:
+                    _add_directory(include_dirs, include_dir)
 
         # respect CFLAGS/CPPFLAGS/LDFLAGS
         for k in ("CFLAGS", "CPPFLAGS", "LDFLAGS"):


### PR DESCRIPTION
tiff (4.5.0-1) in Debian results in two include directories being returned:
```
-I/usr/include/x86_64-linux-gnu -I/usr/include
```
These were not added to the compiler include directories, causing tiff support not be enabled because `tiff.h` could not be found.