### PR TITLE
Stop reading when EPS line becomes too long

### DIFF
--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -173,11 +173,13 @@ class PSFile:
         self.fp.seek(offset, whence)
 
     def readline(self):
-        s = [self.char or b""]
-        self.char = None
+        s = []
+        if self.char:
+            s.append(self.char)
+            self.char = None
 
         c = self.fp.read(1)
-        while (c not in b"\r\n") and len(c):
+        while (c not in b"\r\n") and len(c) and len(b"".join(s).strip(b"\r\n")) <= 255:
             s.append(c)
             c = self.fp.read(1)
 


### PR DESCRIPTION
Resolves #6877

Using the following code to check speed (based on [`test_timeout()`](https://github.com/python-pillow/Pillow/blob/50f5eade4724e83fafd791325c6bb0e69558d623/Tests/test_file_eps.py#L286-L295)),
```python
import time
import pytest
from PIL import Image
Image.init()
with open("Tests/images/timeout-d675703545fee17acab56e5fec644c19979175de.eps", "rb") as f:
    start = time.time()
    with pytest.raises(Image.UnidentifiedImageError):
        with Image.open(f):
            pass
    print("Time taken", time.time() - start)
```
I get
```
Time taken 0.07753515243530273
```

In EpsImagePlugin, after each time `fp.readline()` is run, an error is raised if `fp.readline().strip("\r\n")` is longer than 255 characters. So if Pillow isn't going to use the rest of that data, we can stop reading when the line becomes too long.

Applying that change, the speed test gives
```
Time taken 0.0006549358367919922
```

That's 118 times faster. This should be sufficient to stop intermittent timeouts in our CIs.