### PR TITLE
Do not retry past formats when loading all formats for the first time

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3268,8 +3268,14 @@ def open(fp, mode="r", formats=None):
     im = _open_core(fp, filename, prefix, formats)
 
     if im is None and formats is ID:
+        checked_formats = formats.copy()
         if init():
-            im = _open_core(fp, filename, prefix, formats)
+            im = _open_core(
+                fp,
+                filename,
+                prefix,
+                tuple(format for format in formats if format not in checked_formats),
+            )
 
     if im:
         im._exclusive_fp = exclusive_fp


### PR DESCRIPTION
When opening an image, Pillow loops through the different possible formats.
https://github.com/python-pillow/Pillow/blob/0b53853941d1b133c3f0b819f5ac6335821bb084/src/PIL/Image.py#L3242-L3244

If I add a `print` statement to see which formats it checks,
```python
    def _open_core(fp, filename, prefix, formats):
        for i in formats:
            print(i)
            i = i.upper()
```
and then run
```python
from PIL import Image
Image.open("Tests/images/hopper.spider")
```
I get
```
BMP
DIB
GIF
JPEG
PPM
PNG
BMP
DIB
GIF
JPEG
PPM
PNG
BLP
BUFR
CUR
PCX
DCX
...
```

The first set of formats are checked twice - BMP, DIB, GIF, JPEG, PPM and PNG.

This is because after the preinit formats fail to load the SPIDER image, Pillow initialises the rest of the formats, and then just checks all the formats again, even the preinit ones that already failed.

https://github.com/python-pillow/Pillow/blob/43bb03539e0f3dca6ee399cbb8162c21e257c05d/src/PIL/Image.py#L3268-L3272

So this PR excludes the already checked formats the second time.