### PR TITLE
Handling for deprecations to be removed in Pillow 11

### DIFF
--- a/Tests/test_deprecate.py
+++ b/Tests/test_deprecate.py
@@ -12,6 +12,11 @@ from PIL import _deprecate
             r"\(2023-07-01\)\. Use new thing instead\.",
         ),
         (
+            11,
+            "Old thing is deprecated and will be removed in Pillow 11 "
+            r"\(2024-10-15\)\. Use new thing instead\.",
+        ),
+        (
             None,
             r"Old thing is deprecated and will be removed in a future version\. "
             r"Use new thing instead\.",

--- a/src/PIL/_deprecate.py
+++ b/src/PIL/_deprecate.py
@@ -47,6 +47,8 @@ def deprecate(
         raise RuntimeError(msg)
     elif when == 10:
         removed = "Pillow 10 (2023-07-01)"
+    elif when == 11:
+        removed = "Pillow 11 (2024-10-15)"
     else:
         msg = f"Unknown removal version, update {__name__}?"
         raise ValueError(msg)


### PR DESCRIPTION
Changes proposed in this pull request:

 * Things usually need to be deprecated for at least a year before removal in a major version
 * We're past the cutoff for things that can be removed in Pillow 10 (2023-07-01)
 * Add handling for things that can be removed in Pillow 11 (2024-11-15) 
 
---

Relatedly, after Python 3.7 is end-of-life in June, the EOL for 3.8 and later will have aligned with CPython's annual release cycle in October.

And because Pillow aligns major versions with CPython EOLs, it'll go like something this:

* October 2024: Python 3.13 release, Python 3.8 EOL, Pillow 11.0 release
* October 2025: Python 3.14 release, Python 3.9 EOL, Pillow 12.0 release
* etc

Docs:

* https://devguide.python.org/versions/
* https://peps.python.org/topic/release/
