### PR TITLE
Remove redundant default values

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 HAS_UPLOADER = False
 
-if os.environ.get("SHOW_ERRORS", None):
+if os.environ.get("SHOW_ERRORS"):
     # local img.show for errors.
     HAS_UPLOADER = True
 
@@ -271,7 +271,7 @@ def netpbm_available():
 
 def magick_command():
     if sys.platform == "win32":
-        magickhome = os.environ.get("MAGICK_HOME", "")
+        magickhome = os.environ.get("MAGICK_HOME")
         if magickhome:
             imagemagick = [os.path.join(magickhome, "convert.exe")]
             graphicsmagick = [os.path.join(magickhome, "gm.exe"), "convert"]

--- a/setup.py
+++ b/setup.py
@@ -567,9 +567,7 @@ class pil_build_ext(build_ext):
         ):
             for dirname in _find_library_dirs_ldconfig():
                 _add_directory(library_dirs, dirname)
-            if sys.platform.startswith("linux") and os.environ.get(
-                "ANDROID_ROOT", None
-            ):
+            if sys.platform.startswith("linux") and os.environ.get("ANDROID_ROOT"):
                 # termux support for android.
                 # system libraries (zlib) are installed in /system/lib
                 # headers are at $PREFIX/include

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -1020,7 +1020,7 @@ def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):
             if windir:
                 dirs.append(os.path.join(windir, "fonts"))
         elif sys.platform in ("linux", "linux2"):
-            lindirs = os.environ.get("XDG_DATA_DIRS", "")
+            lindirs = os.environ.get("XDG_DATA_DIRS")
             if not lindirs:
                 # According to the freedesktop spec, XDG_DATA_DIRS should
                 # default to /usr/share


### PR DESCRIPTION
#6847 is still in draft for Windows changes, but it also includes a bit of cleanup, removing unnecessary arguments.

This PR extracts that cleanup, so it at least can be merged.