### PR TITLE
Replace SVN with Git for installing extra test images

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,9 +21,11 @@ environment:
 install:
 - '%PYTHON%\%EXECUTABLE% --version'
 - curl -fsSL -o pillow-depends.zip https://github.com/python-pillow/pillow-depends/archive/main.zip
+- curl -fsSL -o pillow-test-images.zip https://github.com/python-pillow/test-images/archive/main.zip
 - 7z x pillow-depends.zip -oc:\
+- 7z x pillow-test-images.zip -oc:\
 - mv c:\pillow-depends-main c:\pillow-depends
-- xcopy /S /Y c:\pillow-depends\test_images\* c:\pillow\tests\images
+- xcopy /S /Y c:\test-images-main\* c:\pillow\tests\images
 - 7z x ..\pillow-depends\nasm-2.15.05-win64.zip -oc:\
 - ..\pillow-depends\gs1000w32.exe /S
 - path c:\nasm-2.15.05;C:\Program Files (x86)\gs\gs10.0.0\bin;%PATH%

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -34,18 +34,34 @@ jobs:
         with:
           platform: x86_64
           packages: >
-            ImageMagick gcc-g++ ghostscript jpeg libfreetype-devel
-            libimagequant-devel libjpeg-devel liblapack-devel
-            liblcms2-devel libopenjp2-devel libraqm-devel
-            libtiff-devel libwebp-devel libxcb-devel libxcb-xinerama0
-            make netpbm perl
+            gcc-g++
+            ghostscript
+            ImageMagick
+            jpeg
+            libfreetype-devel
+            libimagequant-devel
+            libjpeg-devel
+            liblapack-devel
+            liblcms2-devel
+            libopenjp2-devel
+            libraqm-devel
+            libtiff-devel
+            libwebp-devel
+            libxcb-devel
+            libxcb-xinerama0
+            make
+            netpbm
+            perl
             python3${{ matrix.python-minor-version }}-cffi
             python3${{ matrix.python-minor-version }}-cython
             python3${{ matrix.python-minor-version }}-devel
             python3${{ matrix.python-minor-version }}-numpy
             python3${{ matrix.python-minor-version }}-sip
             python3${{ matrix.python-minor-version }}-tkinter
-            qt5-devel-tools subversion xorg-server-extra zlib-devel
+            qt5-devel-tools
+            subversion
+            xorg-server-extra
+            zlib-devel
 
       - name: Add Lapack to PATH
         uses: egor-tensin/cleanup-path@v3

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -59,7 +59,7 @@ jobs:
             python3${{ matrix.python-minor-version }}-sip
             python3${{ matrix.python-minor-version }}-tkinter
             qt5-devel-tools
-            subversion
+            wget
             xorg-server-extra
             zlib-devel
 

--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -45,11 +45,6 @@ jobs:
       - name: Install dependencies
         run: |
           pacman -S --noconfirm \
-              ${{ matrix.package }}-python3-cffi \
-              ${{ matrix.package }}-python3-numpy \
-              ${{ matrix.package }}-python3-olefile \
-              ${{ matrix.package }}-python3-pip \
-              ${{ matrix.package }}-python3-setuptools \
               ${{ matrix.package }}-freetype \
               ${{ matrix.package }}-gcc \
               ${{ matrix.package }}-ghostscript \
@@ -60,6 +55,11 @@ jobs:
               ${{ matrix.package }}-libtiff \
               ${{ matrix.package }}-libwebp \
               ${{ matrix.package }}-openjpeg2 \
+              ${{ matrix.package }}-python3-cffi \
+              ${{ matrix.package }}-python3-numpy \
+              ${{ matrix.package }}-python3-olefile \
+              ${{ matrix.package }}-python3-pip \
+              ${{ matrix.package }}-python3-setuptools \
               subversion
 
           if [ ${{ matrix.package }} == "mingw-w64-x86_64" ]; then

--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -60,7 +60,7 @@ jobs:
               ${{ matrix.package }}-python3-olefile \
               ${{ matrix.package }}-python3-pip \
               ${{ matrix.package }}-python3-setuptools \
-              subversion
+              ${{ matrix.package }}-wget
 
           if [ ${{ matrix.package }} == "mingw-w64-x86_64" ]; then
               pacman -S --noconfirm \

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -62,7 +62,10 @@ jobs:
         winbuild\depends\gs1000w32.exe /S
         echo "C:\Program Files (x86)\gs\gs10.0.0\bin" >> $env:GITHUB_PATH
 
-        xcopy /S /Y winbuild\depends\test_images\* Tests\images\
+        # Install extra test images
+        curl -fsSL -o pillow-test-images.zip https://github.com/hugovk/test-images/archive/main.zip
+        7z x pillow-test-images.zip -oc:\
+        xcopy /S /Y c:\test-images-main\* Tests\images\
 
         # make cache key depend on VS version
         & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" `

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,15 @@ Changelog (Pillow)
 9.5.0 (unreleased)
 ------------------
 
+- Do not retry past formats when loading all formats for the first time #6902
+  [radarhere]
+
+- Do not retry specified formats if they failed when opening #6893
+  [radarhere]
+
+- Do not unintentionally load TIFF format at first #6892
+  [radarhere]
+
 - Stop reading when EPS line becomes too long #6897
   [radarhere]
 

--- a/depends/download-and-extract.sh
+++ b/depends/download-and-extract.sh
@@ -8,5 +8,5 @@ if [ ! -f $archive.tar.gz ]; then
     wget -O $archive.tar.gz $url
 fi
 
-rm -r $archive
+rmdir $archive
 tar -xvzf $archive.tar.gz

--- a/depends/install_extra_test_images.sh
+++ b/depends/install_extra_test_images.sh
@@ -1,15 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # install extra test images
 
-# Use SVN to just fetch a single Git subdirectory
-svn_export()
-{
-    if [ ! -z $1 ]; then
-        echo ""
-        echo "Retrying svn export..."
-        echo ""
-    fi
+archive=test-images-main
 
-    svn export --force https://github.com/python-pillow/pillow-depends/trunk/test_images ../Tests/images
-}
-svn_export || svn_export retry || svn_export retry || svn_export retry
+./download-and-extract.sh $archive https://github.com/hugovk/test-images/archive/refs/heads/main.tar.gz
+
+mv $archive/* ../Tests/images/
+
+# Cleanup old tarball and empty directory
+rm $archive.tar.gz
+rm -r $archive

--- a/depends/install_extra_test_images.sh
+++ b/depends/install_extra_test_images.sh
@@ -3,7 +3,7 @@
 
 archive=test-images-main
 
-./download-and-extract.sh $archive https://github.com/python-pillow/test-images/archive/refs/heads/main.tar.gz
+./download-and-extract.sh $archive https://github.com/python-pillow/test-images/archive/main.tar.gz
 
 mv $archive/* ../Tests/images/
 

--- a/depends/install_extra_test_images.sh
+++ b/depends/install_extra_test_images.sh
@@ -9,4 +9,4 @@ mv $archive/* ../Tests/images/
 
 # Cleanup old tarball and empty directory
 rm $archive.tar.gz
-rm -r $archive
+rmdir $archive


### PR DESCRIPTION
GitHub is removing support for Subversion on January 8, 2024.

* https://github.blog/2023-01-20-sunsetting-subversion-support/

Why do we care?

Well, we're using `svn` in our CI to extract only the `test_images` directory from https://github.com/python-pillow/pillow-depends.

https://github.com/python-pillow/pillow-depends is a big repo full of binary files.

For our purposes, I think we're better off moving the test images into their own repo, so we can instead simply download the new repo as a zipball.

I've made a new repo at https://github.com/hugovk/test-images, which is just the relevant directory from https://github.com/python-pillow/pillow-depends, and preserves the Git history (following [these instructions](https://stackoverflow.com/a/68536044/724176)).

Let's move that repo into https://github.com/python-pillow. Because I don't have permission to create repos in the org, we need two steps:

@aclark4life I've sent a request to transfer the repo to you. Once you accept, please could you transfer it to https://github.com/python-pillow, and check the usual suspects have admin rights?

* Transfer docs here: https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository

Once it's transferred, I'll update the paths in this PR.

# Checklist

* [x] Transfer repo https://github.com/hugovk/test-images to https://github.com/python-pillow org
* [x] Update paths in this PR (the `TODO`s)
* [ ] Merge this PR
* [ ] Remove `test_images` directory from https://github.com/python-pillow/pillow-depends: https://github.com/python-pillow/pillow-depends/pull/41
