### PR TITLE
Always redirect pkg-config stderr to DEVNULL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -255,23 +255,21 @@ def _pkg_config(name):
         try:
             command_libs = [command, "--libs-only-L", name]
             command_cflags = [command, "--cflags-only-I", name]
-            stderr = None
             if keep_system:
                 command_libs.append("--keep-system-libs")
                 command_cflags.append("--keep-system-cflags")
-                stderr = subprocess.DEVNULL
             if not DEBUG:
                 command_libs.append("--silence-errors")
                 command_cflags.append("--silence-errors")
             libs = re.split(
                 r"(^|\s+)-L",
-                subprocess.check_output(command_libs, stderr=stderr)
+                subprocess.check_output(command_libs, stderr=subprocess.DEVNULL)
                 .decode("utf8")
                 .strip(),
             )[::2][1:]
             cflags = re.split(
                 r"(^|\s+)-I",
-                subprocess.check_output(command_cflags, stderr=stderr)
+                subprocess.check_output(command_cflags, stderr=subprocess.DEVNULL)
                 .decode("utf8")
                 .strip(),
             )[::2][1:]


### PR DESCRIPTION
In `_pkg_config`, Pillow [silently catches any Python exceptions that occur.](https://github.com/python-pillow/Pillow/blob/2ae55ccbdad9c842929fb238ea1eb81d1f999024/setup.py#L279-L280)

If we're doing that, then it would seem consistent to also silence any errors that `pkg-config` might output.

Just a note about the history of the `stderr` handling in this function - #6261 started this by silencing the libs call for one loop to prevent a specific error.