### PR TITLE
Updated libjpeg-turbo to 2.1.5

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -109,9 +109,9 @@ header = [
 deps = {
     "libjpeg": {
         "url": SF_PROJECTS
-        + "/libjpeg-turbo/files/2.1.4/libjpeg-turbo-2.1.4.tar.gz/download",
-        "filename": "libjpeg-turbo-2.1.4.tar.gz",
-        "dir": "libjpeg-turbo-2.1.4",
+        + "/libjpeg-turbo/files/2.1.5/libjpeg-turbo-2.1.5.tar.gz/download",
+        "filename": "libjpeg-turbo-2.1.5.tar.gz",
+        "dir": "libjpeg-turbo-2.1.5",
         "license": ["README.ijg", "LICENSE.md"],
         "license_pattern": (
             "(LEGAL ISSUES\n============\n\n.+?)\n\nREFERENCES\n=========="


### PR DESCRIPTION
libjpeg-turbo 2.1.5 has been released - https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/2.1.5