### PR TITLE
Perform font fallback

### DIFF
--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -871,6 +871,287 @@ class FreeTypeFont:
             raise NotImplementedError(msg) from e
 
 
+class FreeTypeFontFamily:
+    """FreeType font family"""
+
+    # example:
+    #   from PIL import Image, ImageDraw, ImageFont
+    #   f1 = ImageFont.truetype("segoeui.ttf", 24)
+    #   f2 = ImageFont.truetype("seguisym.ttf", 24)
+    #   ff = ImageFont.FreeTypeFontFamily(f1, f2)
+    #   s = "a↦ľ"
+    #   im = Image.new("RGBA", (100, 100), "white")
+    #   d = ImageDraw.Draw(im)
+    #   d.text((10, 10), s, "black", f1)
+    #   d.text((10, 40), s, "black", f2)
+    #   d.text((10, 70), s, "black", ff)
+    #   im.show()
+
+    def __init__(self, *fonts):
+        fonts_list = []
+        for font in fonts:
+            try:
+                fonts_list.append(
+                    ("", font.size, font.index, font.encoding, font.font_bytes)
+                )
+            except AttributeError:
+                fonts_list.append((font.path, font.size, font.index, font.encoding))
+
+        self.fonts = tuple(fonts_list)
+        self.font = core.getfamily(self.fonts, layout_engine=Layout.BASIC)
+
+    def getlength(self, text, mode="", direction=None, features=None, language=None):
+        """
+        Returns length (in pixels with 1/64 precision) of given text when rendered
+        in font with provided direction, features, and language.
+
+        This is the amount by which following text should be offset.
+        Text bounding box may extend past the length in some fonts,
+        e.g. when using italics or accents.
+
+        The result is returned as a float; it is a whole number if using basic layout.
+
+        Note that the sum of two lengths may not equal the length of a concatenated
+        string due to kerning. If you need to adjust for kerning, include the following
+        character and subtract its length.
+
+        For example, instead of
+
+        .. code-block:: python
+
+          hello = font.getlength("Hello")
+          world = font.getlength("World")
+          hello_world = hello + world  # not adjusted for kerning
+          assert hello_world == font.getlength("HelloWorld")  # may fail
+
+        use
+
+        .. code-block:: python
+
+          hello = font.getlength("HelloW") - font.getlength("W")  # adjusted for kerning
+          world = font.getlength("World")
+          hello_world = hello + world  # adjusted for kerning
+          assert hello_world == font.getlength("HelloWorld")  # True
+
+        or disable kerning with (requires libraqm)
+
+        .. code-block:: python
+
+          hello = draw.textlength("Hello", font, features=["-kern"])
+          world = draw.textlength("World", font, features=["-kern"])
+          hello_world = hello + world  # kerning is disabled, no need to adjust
+          assert hello_world == draw.textlength("HelloWorld", font, features=["-kern"])
+
+        .. versionadded:: 8.0.0
+
+        :param text: Text to measure.
+        :param mode: Used by some graphics drivers to indicate what mode the
+                     driver prefers; if empty, the renderer may return either
+                     mode. Note that the mode is always a string, to simplify
+                     C-level implementations.
+
+        :param direction: Direction of the text. It can be 'rtl' (right to
+                          left), 'ltr' (left to right) or 'ttb' (top to bottom).
+                          Requires libraqm.
+
+        :param features: A list of OpenType font features to be used during text
+                         layout. This is usually used to turn on optional
+                         font features that are not enabled by default,
+                         for example 'dlig' or 'ss01', but can be also
+                         used to turn off default font features for
+                         example '-liga' to disable ligatures or '-kern'
+                         to disable kerning.  To get all supported
+                         features, see
+                         https://learn.microsoft.com/en-us/typography/opentype/spec/featurelist
+                         Requires libraqm.
+
+        :param language: Language of the text. Different languages may use
+                         different glyph shapes or ligatures. This parameter tells
+                         the font which language the text is in, and to apply the
+                         correct substitutions as appropriate, if available.
+                         It should be a `BCP 47 language code
+                         <https://www.w3.org/International/articles/language-tags/>`_
+                         Requires libraqm.
+
+        :return: Width for horizontal, height for vertical text.
+        """
+        return self.font.getlength(text, mode, direction, features, language) / 64
+
+    def getbbox(
+        self,
+        text,
+        mode="",
+        direction=None,
+        features=None,
+        language=None,
+        stroke_width=0,
+        anchor=None,
+    ):
+        """
+        Returns bounding box (in pixels) of given text relative to given anchor
+        when rendered in font with provided direction, features, and language.
+
+        Use :py:meth:`getlength()` to get the offset of following text with
+        1/64 pixel precision. The bounding box includes extra margins for
+        some fonts, e.g. italics or accents.
+
+        .. versionadded:: 8.0.0
+
+        :param text: Text to render.
+        :param mode: Used by some graphics drivers to indicate what mode the
+                     driver prefers; if empty, the renderer may return either
+                     mode. Note that the mode is always a string, to simplify
+                     C-level implementations.
+
+        :param direction: Direction of the text. It can be 'rtl' (right to
+                          left), 'ltr' (left to right) or 'ttb' (top to bottom).
+                          Requires libraqm.
+
+        :param features: A list of OpenType font features to be used during text
+                         layout. This is usually used to turn on optional
+                         font features that are not enabled by default,
+                         for example 'dlig' or 'ss01', but can be also
+                         used to turn off default font features for
+                         example '-liga' to disable ligatures or '-kern'
+                         to disable kerning.  To get all supported
+                         features, see
+                         https://learn.microsoft.com/en-us/typography/opentype/spec/featurelist
+                         Requires libraqm.
+
+        :param language: Language of the text. Different languages may use
+                         different glyph shapes or ligatures. This parameter tells
+                         the font which language the text is in, and to apply the
+                         correct substitutions as appropriate, if available.
+                         It should be a `BCP 47 language code
+                         <https://www.w3.org/International/articles/language-tags/>`_
+                         Requires libraqm.
+
+        :param stroke_width: The width of the text stroke.
+
+        :param anchor:  The text anchor alignment. Determines the relative location of
+                        the anchor to the text. The default alignment is top left.
+                        See :ref:`text-anchors` for valid values.
+
+        :return: ``(left, top, right, bottom)`` bounding box
+        """
+        size, offset = self.font.getsize(
+            text, mode, direction, features, language, anchor
+        )
+        left, top = offset[0] - stroke_width, offset[1] - stroke_width
+        width, height = size[0] + 2 * stroke_width, size[1] + 2 * stroke_width
+        return left, top, left + width, top + height
+
+    def getmask2(
+        self,
+        text,
+        mode="",
+        *,
+        direction=None,
+        features=None,
+        language=None,
+        stroke_width=0,
+        anchor=None,
+        ink=0,
+        start=None,
+        **kwargs,
+    ):
+        """
+        Create a bitmap for the text.
+
+        If the font uses antialiasing, the bitmap should have mode ``L`` and use a
+        maximum value of 255. If the font has embedded color data, the bitmap
+        should have mode ``RGBA``. Otherwise, it should have mode ``1``.
+
+        :param text: Text to render.
+        :param mode: Used by some graphics drivers to indicate what mode the
+                     driver prefers; if empty, the renderer may return either
+                     mode. Note that the mode is always a string, to simplify
+                     C-level implementations.
+
+                     .. versionadded:: 1.1.5
+
+        :param fill: Optional fill function. By default, an internal Pillow function
+                     will be used.
+
+                     Deprecated. This parameter will be removed in Pillow 10
+                     (2023-07-01).
+
+        :param direction: Direction of the text. It can be 'rtl' (right to
+                          left), 'ltr' (left to right) or 'ttb' (top to bottom).
+                          Requires libraqm.
+
+                          .. versionadded:: 4.2.0
+
+        :param features: A list of OpenType font features to be used during text
+                         layout. This is usually used to turn on optional
+                         font features that are not enabled by default,
+                         for example 'dlig' or 'ss01', but can be also
+                         used to turn off default font features for
+                         example '-liga' to disable ligatures or '-kern'
+                         to disable kerning.  To get all supported
+                         features, see
+                         https://learn.microsoft.com/en-us/typography/opentype/spec/featurelist
+                         Requires libraqm.
+
+                         .. versionadded:: 4.2.0
+
+        :param language: Language of the text. Different languages may use
+                         different glyph shapes or ligatures. This parameter tells
+                         the font which language the text is in, and to apply the
+                         correct substitutions as appropriate, if available.
+                         It should be a `BCP 47 language code
+                         <https://www.w3.org/International/articles/language-tags/>`_
+                         Requires libraqm.
+
+                         .. versionadded:: 6.0.0
+
+        :param stroke_width: The width of the text stroke.
+
+                         .. versionadded:: 6.2.0
+
+        :param anchor:  The text anchor alignment. Determines the relative location of
+                        the anchor to the text. The default alignment is top left.
+                        See :ref:`text-anchors` for valid values.
+
+                         .. versionadded:: 8.0.0
+
+        :param ink: Foreground ink for rendering in RGBA mode.
+
+                         .. versionadded:: 8.0.0
+
+        :param start: Tuple of horizontal and vertical offset, as text may render
+                      differently when starting at fractional coordinates.
+
+                         .. versionadded:: 9.4.0
+
+        :return: A tuple of an internal PIL storage memory instance as defined by the
+                 :py:mod:`PIL.Image.core` interface module, and the text offset, the
+                 gap between the starting coordinate and the first marking
+        """
+        size, offset = self.font.getsize(
+            text, mode, direction, features, language, anchor
+        )
+        if start is None:
+            start = (0, 0)
+        size = tuple(math.ceil(size[i] + stroke_width * 2 + start[i]) for i in range(2))
+        offset = offset[0] - stroke_width, offset[1] - stroke_width
+        Image._decompression_bomb_check(size)
+        im = Image.core.fill("RGBA" if mode == "RGBA" else "L", size, 0)
+        self.font.render(
+            text,
+            im.id,
+            mode,
+            direction,
+            features,
+            language,
+            stroke_width,
+            ink,
+            start[0],
+            start[1],
+        )
+        return im, offset
+
+
 class TransposedFont:
     """Wrapper for writing rotated or mirrored text"""
 

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -876,18 +876,20 @@ class FreeTypeFontFamily:
 
     # example:
     #   from PIL import Image, ImageDraw, ImageFont
-    #   f1 = ImageFont.truetype("segoeui.ttf", 24)
-    #   f2 = ImageFont.truetype("seguisym.ttf", 24)
-    #   ff = ImageFont.FreeTypeFontFamily(f1, f2)
-    #   s = "a↦ľ"
-    #   im = Image.new("RGBA", (100, 100), "white")
-    #   d = ImageDraw.Draw(im)
-    #   d.text((10, 10), s, "black", f1)
-    #   d.text((10, 40), s, "black", f2)
-    #   d.text((10, 70), s, "black", ff)
-    #   im.show()
+    #   le = ImageFont.Layout.RAQM
+    #   f1 = ImageFont.truetype(r"C:\Users\Nulano\AppData\Local\Microsoft\Windows\Fonts\SCRIPTIN.ttf", 24)
+    #   f2 = ImageFont.truetype("segoeui.ttf", 24)
+    #   f3 = ImageFont.truetype("seguisym.ttf", 24)
+    #   ff = ImageFont.FreeTypeFontFamily(f1, f2, f3, layout_engine=le)
+    #   for s in ("testčingšsšccčcč", "ية↦α,abc", "a↦ľ"):
+    #     im = Image.new("RGBA", (300, 300), "white")
+    #     d = ImageDraw.Draw(im)
+    #     d.text((10, 60), s, "black", f1, direction="ltr", anchor="ls")
+    #     d.text((10, 160), s, "black", f2, direction="ltr", anchor="ls")
+    #     d.text((10, 260), s, "black", ff, direction="ltr", anchor="ls")
+    #     im.show()
 
-    def __init__(self, *fonts):
+    def __init__(self, *fonts, layout_engine=None):
         fonts_list = []
         for font in fonts:
             try:
@@ -896,9 +898,21 @@ class FreeTypeFontFamily:
                 )
             except AttributeError:
                 fonts_list.append((font.path, font.size, font.index, font.encoding))
-
         self.fonts = tuple(fonts_list)
-        self.font = core.getfamily(self.fonts, layout_engine=Layout.BASIC)
+
+        if layout_engine not in (Layout.BASIC, Layout.RAQM):
+            layout_engine = Layout.BASIC
+            if core.HAVE_RAQM:
+                layout_engine = Layout.RAQM
+        elif layout_engine == Layout.RAQM and not core.HAVE_RAQM:
+            warnings.warn(
+                "Raqm layout was requested, but Raqm is not available. "
+                "Falling back to basic layout."
+            )
+            layout_engine = Layout.BASIC
+        self.layout_engine = layout_engine
+
+        self.font = core.getfamily(self.fonts, layout_engine=self.layout_engine)
 
     def getlength(self, text, mode="", direction=None, features=None, language=None):
         """

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -882,7 +882,7 @@ class FreeTypeFontFamily:
     #   f2 = ImageFont.truetype("segoeui.ttf", 24)
     #   f3 = ImageFont.truetype("seguisym.ttf", 24)
     #   ff = ImageFont.FreeTypeFontFamily(f1, f2, f3, layout_engine=le)
-    #   for s in ("testčingšsšccčcč", "ية↦α,abc", "a↦ľ"):
+    #   for s in ("testčingšsšccčcč", "ية↦α,abc", "a↦ľ", "ῶ,ω̃,ώ,ώ, ́,á"):
     #     im = Image.new("RGBA", (300, 300), "white")
     #     d = ImageDraw.Draw(im)
     #     d.text((10, 60), s, "black", f1, direction="ltr", anchor="ls")

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -877,7 +877,8 @@ class FreeTypeFontFamily:
     # example:
     #   from PIL import Image, ImageDraw, ImageFont
     #   le = ImageFont.Layout.RAQM
-    #   f1 = ImageFont.truetype(r"C:\Users\Nulano\AppData\Local\Microsoft\Windows\Fonts\SCRIPTIN.ttf", 24)
+    #   f1 = ImageFont.truetype(
+    #       r"C:\Users\Nulano\AppData\Local\Microsoft\Windows\Fonts\SCRIPTIN.ttf", 24)
     #   f2 = ImageFont.truetype("segoeui.ttf", 24)
     #   f3 = ImageFont.truetype("seguisym.ttf", 24)
     #   ff = ImageFont.FreeTypeFontFamily(f1, f2, f3, layout_engine=le)

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -382,7 +382,7 @@ text_layout_raqm(
     int mask,
     int color) {
     int face = 0;
-    size_t i = 0, j = 0, count = 0, start = 0;
+    size_t i = 0, count = 0, start = 0;
     raqm_t *rq = NULL;
     raqm_glyph_t *glyphs = NULL;
     raqm_direction_t direction;
@@ -432,9 +432,8 @@ text_layout_raqm(
             PyErr_SetString(PyExc_ValueError, "failed to allocate fallback buffer.");
             goto failed;
         }
-        fallback[0] = -1;
-        for (j = 1; j < size; j++) {
-            fallback[j] = -2;
+        for (i = 0; i < size; i++) {
+            fallback[i] = -2;
         }
     }
 
@@ -519,25 +518,25 @@ text_layout_raqm(
             }
         } else {
             start = 0;
-            for (j = 0; j <= size; j++) {
-                if (j < size) {
-                    if (fallback[j] == -2) {
+            for (i = 0; i <= size; i++) {
+                if (i < size) {
+                    if (fallback[i] == -2) {
                         /* not a cluster boundary */
                         continue;
                     }
-                    if (fallback[start] == fallback[j]) {
+                    if (fallback[start] == fallback[i]) {
                         /* use same font face for this cluster */
                         continue;
                     }
                 }
-                if (fallback[start] == -1) {
+                if (fallback[start] < 0) {
                     raqm_set_freetype_face_range(
-                        rq, family->faces[face], start, j - start);
+                        rq, family->faces[face], start, i - start);
                 } else {
                     raqm_set_freetype_face_range(
-                        rq, family->faces[fallback[start]], start, j - start);
+                        rq, family->faces[fallback[start]], start, i - start);
                 }
-                start = j;
+                start = i;
             }
         }
 
@@ -553,24 +552,27 @@ text_layout_raqm(
             goto failed;
         }
 
-        if (i + 1 == family->font_count) {
+        //if (face + 1 == family->font_count) {
+        //    break;
+        //}
+        if (family->font_count == 1) {
             break;
         }
 
-        for (j = 1; j < size; j++) {
-            if (fallback[j] == -1) {
-                fallback[j] = -2;
+        for (i = 1; i < size; i++) {
+            if (fallback[i] == -1) {
+                fallback[i] = -2;
             }
         }
 
         int missing = 0;
-        for (j = 0; j < count; j++) {
-            int cluster = glyphs[j].cluster;
-            if (glyphs[j].index == 0) {
+        for (i = 0; i < count; i++) {
+            int cluster = glyphs[i].cluster;
+            if (glyphs[i].index == 0) {
                 /* cluster contains missing glyph */
                 fallback[cluster] = -1;
                 missing = 1;
-            } else if (fallback[cluster] < 0) {
+            } else if (fallback[cluster] == -2) {
                 /* use current font face for this cluster */
                 fallback[cluster] = face;
             }

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -388,6 +388,10 @@ text_layout_raqm(
     raqm_glyph_t *glyphs = NULL;
     raqm_direction_t direction;
 
+    Py_UCS4 *text;
+    Py_ssize_t size;
+    int *fallback = NULL;
+
     rq = raqm_create();
     if (rq == NULL) {
         PyErr_SetString(PyExc_ValueError, "raqm_create() failed.");
@@ -395,24 +399,12 @@ text_layout_raqm(
     }
 
     if (PyUnicode_Check(string)) {
-        Py_UCS4 *text = PyUnicode_AsUCS4Copy(string);
-        Py_ssize_t size = PyUnicode_GET_LENGTH(string);
+        text = PyUnicode_AsUCS4Copy(string);
+        size = PyUnicode_GET_LENGTH(string);
         if (!text || !size) {
             /* return 0 and clean up, no glyphs==no size,
                and raqm fails with empty strings */
             goto failed;
-        }
-        int set_text = raqm_set_text(rq, text, size);
-        PyMem_Free(text);
-        if (!set_text) {
-            PyErr_SetString(PyExc_ValueError, "raqm_set_text() failed");
-            goto failed;
-        }
-        if (lang) {
-            if (!raqm_set_language(rq, lang, start, size)) {
-                PyErr_SetString(PyExc_ValueError, "raqm_set_language() failed");
-                goto failed;
-            }
         }
     } else {
         PyErr_SetString(PyExc_TypeError, "expected string");
@@ -441,63 +433,142 @@ text_layout_raqm(
         }
     }
 
-    if (!raqm_set_par_direction(rq, direction)) {
-        PyErr_SetString(PyExc_ValueError, "raqm_set_par_direction() failed");
-        goto failed;
+    if (family->font_count > 1) {
+        fallback = PyMem_New(int, size);
+        if (!fallback) {
+            PyErr_SetString(PyExc_ValueError, "failed to allocate fallback buffer.");
+            goto failed;
+        }
+        fallback[0] = -1;
+        for (size_t j = 1; j < size; j++) {
+            fallback[j] = -2;
+        }
     }
 
-    if (features != Py_None) {
-        int j, len;
-        PyObject *seq = PySequence_Fast(features, "expected a sequence");
-        if (!seq) {
+    for (int face = 0; face < family->font_count; face++) {
+        raqm_clear_contents(rq);
+
+        int set_text = raqm_set_text(rq, text, size);
+        if (!set_text) {
+            PyErr_SetString(PyExc_ValueError, "raqm_set_text() failed");
+            goto failed;
+        }
+        if (lang) {
+            if (!raqm_set_language(rq, lang, start, size)) {
+                PyErr_SetString(PyExc_ValueError, "raqm_set_language() failed");
+                goto failed;
+            }
+        }
+
+        if (!raqm_set_par_direction(rq, direction)) {
+            PyErr_SetString(PyExc_ValueError, "raqm_set_par_direction() failed");
             goto failed;
         }
 
-        len = PySequence_Fast_GET_SIZE(seq);
-        for (j = 0; j < len; j++) {
-            PyObject *item = PySequence_Fast_GET_ITEM(seq, j);
-            char *feature = NULL;
-            Py_ssize_t size = 0;
-            PyObject *bytes;
+        if (features != Py_None) {
+            int j, len;
+            PyObject *seq = PySequence_Fast(features, "expected a sequence");
+            if (!seq) {
+                goto failed;
+            }
 
-            if (!PyUnicode_Check(item)) {
-                Py_DECREF(seq);
-                PyErr_SetString(PyExc_TypeError, "expected a string");
-                goto failed;
-            }
-            bytes = PyUnicode_AsUTF8String(item);
-            if (bytes == NULL) {
-                Py_DECREF(seq);
-                goto failed;
-            }
-            feature = PyBytes_AS_STRING(bytes);
-            size = PyBytes_GET_SIZE(bytes);
-            if (!raqm_add_font_feature(rq, feature, size)) {
-                Py_DECREF(seq);
+            len = PySequence_Fast_GET_SIZE(seq);
+            for (j = 0; j < len; j++) {
+                PyObject *item = PySequence_Fast_GET_ITEM(seq, j);
+                char *feature = NULL;
+                Py_ssize_t size = 0;
+                PyObject *bytes;
+
+                if (!PyUnicode_Check(item)) {
+                    Py_DECREF(seq);
+                    PyErr_SetString(PyExc_TypeError, "expected a string");
+                    goto failed;
+                }
+                bytes = PyUnicode_AsUTF8String(item);
+                if (bytes == NULL) {
+                    Py_DECREF(seq);
+                    goto failed;
+                }
+                feature = PyBytes_AS_STRING(bytes);
+                size = PyBytes_GET_SIZE(bytes);
+                if (!raqm_add_font_feature(rq, feature, size)) {
+                    Py_DECREF(seq);
+                    Py_DECREF(bytes);
+                    PyErr_SetString(PyExc_ValueError, "raqm_add_font_feature() failed");
+                    goto failed;
+                }
                 Py_DECREF(bytes);
-                PyErr_SetString(PyExc_ValueError, "raqm_add_font_feature() failed");
+            }
+            Py_DECREF(seq);
+        }
+
+        if (face == 0) {
+            if (!raqm_set_freetype_face(rq, family->faces[0])) {
+                PyErr_SetString(PyExc_RuntimeError, "raqm_set_freetype_face() failed.");
                 goto failed;
             }
-            Py_DECREF(bytes);
+        } else {
+            start = 0;
+            for (size_t j = 0; j <= size; j++) {
+                if (j < size) {
+                    if (fallback[j] == -2) {
+                        /* not a cluster boundary */
+                        continue;
+                    }
+                    if (fallback[start] == fallback[j]) {
+                        /* use same font face for this cluster */
+                        continue;
+                    }
+                }
+                if (fallback[start] == -1) {
+                    raqm_set_freetype_face_range(
+                        rq, family->faces[face], start, j - start);
+                } else {
+                    raqm_set_freetype_face_range(
+                        rq, family->faces[fallback[start]], start, j - start);
+                }
+                start = j;
+            }
         }
-        Py_DECREF(seq);
-    }
 
-    if (!raqm_set_freetype_face(rq, family->faces[0])) {
-        PyErr_SetString(PyExc_RuntimeError, "raqm_set_freetype_face() failed.");
-        goto failed;
-    }
+        if (!raqm_layout(rq)) {
+            PyErr_SetString(PyExc_RuntimeError, "raqm_layout() failed.");
+            goto failed;
+        }
 
-    if (!raqm_layout(rq)) {
-        PyErr_SetString(PyExc_RuntimeError, "raqm_layout() failed.");
-        goto failed;
-    }
+        glyphs = raqm_get_glyphs(rq, &count);
+        if (glyphs == NULL) {
+            PyErr_SetString(PyExc_ValueError, "raqm_get_glyphs() failed.");
+            count = 0;
+            goto failed;
+        }
 
-    glyphs = raqm_get_glyphs(rq, &count);
-    if (glyphs == NULL) {
-        PyErr_SetString(PyExc_ValueError, "raqm_get_glyphs() failed.");
-        count = 0;
-        goto failed;
+        if (i + 1 == family->font_count) {
+            break;
+        }
+
+        for (size_t j = 1; j < size; j++) {
+            if (fallback[j] == -1) {
+                fallback[j] = -2;
+            }
+        }
+
+        int missing = 0;
+        for (size_t j = 0; j < count; j++) {
+            int cluster = glyphs[j].cluster;
+            if (glyphs[j].index == 0) {
+                /* cluster contains missing glyph */
+                fallback[cluster] = -1;
+                missing = 1;
+            } else if (fallback[cluster] < 0) {
+                /* use current font face for this cluster */
+                fallback[cluster] = face;
+            }
+        }
+
+        if (!missing) {
+            break;
+        }
     }
 
     (*glyph_info) = PyMem_New(GlyphInfo, count);
@@ -508,16 +579,27 @@ text_layout_raqm(
     }
 
     for (i = 0; i < count; i++) {
-        (*glyph_info)[i].face = family->faces[0];
         (*glyph_info)[i].index = glyphs[i].index;
         (*glyph_info)[i].x_offset = glyphs[i].x_offset;
         (*glyph_info)[i].x_advance = glyphs[i].x_advance;
         (*glyph_info)[i].y_offset = glyphs[i].y_offset;
         (*glyph_info)[i].y_advance = glyphs[i].y_advance;
-        (*glyph_info)[i].cluster = glyphs[i].cluster;
+
+        uint32_t cluster = glyphs[i].cluster;
+        (*glyph_info)[i].cluster = cluster;
+        if (fallback && fallback[cluster] >= 0) {
+            (*glyph_info)[i].face = family->faces[fallback[cluster]];
+        } else {
+            /* FIXME use first font's missing glyph, not last font's */
+            (*glyph_info)[i].face = family->faces[family->font_count - 1];
+        }
     }
 
 failed:
+    PyMem_Free(text);
+    if (fallback) {
+        PyMem_Free(fallback);
+    }
     raqm_destroy(rq);
     return count;
 }

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -600,8 +600,7 @@ text_layout_raqm(
         if (fallback && fallback[cluster] >= 0) {
             (*glyph_info)[i].face = family->faces[fallback[cluster]];
         } else {
-            /* FIXME use first font's missing glyph, not last font's */
-            (*glyph_info)[i].face = family->faces[family->font_count - 1];
+            (*glyph_info)[i].face = family->faces[0];
         }
     }
 

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -225,7 +225,7 @@ getfont(PyObject *self_, PyObject *args, PyObject *kw) {
 static PyObject *
 getfamily(PyObject *self_, PyObject *args, PyObject *kw) {
     /* create a font family object from a list of file names and a sizes (in pixels) */
-
+    int i, j;
     FontFamilyObject *self;
     FontFamily *family;
     int error = 0;
@@ -270,7 +270,7 @@ getfamily(PyObject *self_, PyObject *args, PyObject *kw) {
         return NULL;
     }
 
-    for (int i = 0; i < family->font_count; i++) {
+    for (i = 0; i < family->font_count; i++) {
         char *filename;
         Py_ssize_t size;
         Py_ssize_t index;
@@ -340,23 +340,21 @@ getfamily(PyObject *self_, PyObject *args, PyObject *kw) {
             geterror(error);
             goto err;
         }
-
-        continue;
-
-    err:
-        for (int j = 0; j < i; j++) {
-            if (family->faces[j]) {
-                FT_Done_Face(family->faces[j]);
-            }
-            if (self->font_bytes[j]) {
-                PyMem_Free(self->font_bytes[j]);
-            }
-        }
-        PyObject_Del(self);
-        return NULL;
     }
 
     return (PyObject *)self;
+
+err:
+    for (j = 0; j < i; j++) {
+        if (family->faces[j]) {
+            FT_Done_Face(family->faces[j]);
+        }
+        if (self->font_bytes[j]) {
+            PyMem_Free(self->font_bytes[j]);
+        }
+    }
+    PyObject_Del(self);
+    return NULL;
 }
 
 static int
@@ -383,20 +381,15 @@ text_layout_raqm(
     GlyphInfo **glyph_info,
     int mask,
     int color) {
-    size_t i = 0, count = 0, start = 0;
-    raqm_t *rq;
+    int face = 0;
+    size_t i = 0, j = 0, count = 0, start = 0;
+    raqm_t *rq = NULL;
     raqm_glyph_t *glyphs = NULL;
     raqm_direction_t direction;
 
-    Py_UCS4 *text;
+    Py_UCS4 *text = NULL;
     Py_ssize_t size;
     int *fallback = NULL;
-
-    rq = raqm_create();
-    if (rq == NULL) {
-        PyErr_SetString(PyExc_ValueError, "raqm_create() failed.");
-        goto failed;
-    }
 
     if (PyUnicode_Check(string)) {
         text = PyUnicode_AsUCS4Copy(string);
@@ -440,13 +433,29 @@ text_layout_raqm(
             goto failed;
         }
         fallback[0] = -1;
-        for (size_t j = 1; j < size; j++) {
+        for (j = 1; j < size; j++) {
             fallback[j] = -2;
         }
     }
 
-    for (int face = 0; face < family->font_count; face++) {
-        raqm_clear_contents(rq);
+    for (face = 0; face < family->font_count; face++) {
+#ifdef RAQM_VERSION_ATLEAST
+#if RAQM_VERSION_ATLEAST(0, 9, 0)
+        if (face >= 1) {
+            raqm_clear_contents(rq);
+        } else
+#endif
+#endif
+        {
+            if (rq != NULL) {
+                raqm_destroy(rq);
+            }
+            rq = raqm_create();
+            if (rq == NULL) {
+                PyErr_SetString(PyExc_ValueError, "raqm_create() failed.");
+                goto failed;
+            }
+        }
 
         int set_text = raqm_set_text(rq, text, size);
         if (!set_text) {
@@ -454,6 +463,7 @@ text_layout_raqm(
             goto failed;
         }
         if (lang) {
+            start = 0;
             if (!raqm_set_language(rq, lang, start, size)) {
                 PyErr_SetString(PyExc_ValueError, "raqm_set_language() failed");
                 goto failed;
@@ -509,7 +519,7 @@ text_layout_raqm(
             }
         } else {
             start = 0;
-            for (size_t j = 0; j <= size; j++) {
+            for (j = 0; j <= size; j++) {
                 if (j < size) {
                     if (fallback[j] == -2) {
                         /* not a cluster boundary */
@@ -547,14 +557,14 @@ text_layout_raqm(
             break;
         }
 
-        for (size_t j = 1; j < size; j++) {
+        for (j = 1; j < size; j++) {
             if (fallback[j] == -1) {
                 fallback[j] = -2;
             }
         }
 
         int missing = 0;
-        for (size_t j = 0; j < count; j++) {
+        for (j = 0; j < count; j++) {
             int cluster = glyphs[j].cluster;
             if (glyphs[j].index == 0) {
                 /* cluster contains missing glyph */
@@ -596,11 +606,15 @@ text_layout_raqm(
     }
 
 failed:
-    PyMem_Free(text);
+    if (text) {
+        PyMem_Free(text);
+    }
     if (fallback) {
         PyMem_Free(fallback);
     }
-    raqm_destroy(rq);
+    if (rq != NULL) {
+        raqm_destroy(rq);
+    }
     return count;
 }
 
@@ -621,7 +635,7 @@ text_layout_fallback(
     Py_ssize_t count;
     FT_GlyphSlot glyph;
     FT_UInt last_index = 0;
-    int i;
+    int i, j;
 
     if (features != Py_None || dir != NULL || lang != NULL) {
         PyErr_SetString(
@@ -659,7 +673,7 @@ text_layout_fallback(
 #endif
     for (i = 0; font_getchar(string, i, &ch); i++) {
         int found = 0;
-        for (int j = 0; !found && j < family->font_count; j++) {
+        for (j = 0; !found && j < family->font_count; j++) {
             FT_Face face = family->faces[j];
             (*glyph_info)[i].index = FT_Get_Char_Index(face, ch);
             if ((*glyph_info)[i].index != 0) {
@@ -1641,7 +1655,8 @@ static PyTypeObject Font_Type = {
 
 static void
 family_dealloc(FontFamilyObject *self) {
-    for (int i = 0; i < self->data.font_count; i++) {
+    int i;
+    for (i = 0; i < self->data.font_count; i++) {
         if (self->data.faces[i]) {
             FT_Done_Face(self->data.faces[i]);
         }

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -72,9 +72,10 @@ static int have_raqm = 0;
 #define LAYOUT_RAQM 1
 
 typedef struct {
-    FT_Face face;
-    unsigned char *font_bytes;
-} FontFamilyFont;
+    FT_Face *faces;
+    int font_count;
+    int layout_engine;
+} FontFamily;
 
 typedef struct {
     FT_Face face;
@@ -101,9 +102,8 @@ typedef struct {
 } FontObject;
 
 typedef struct {
-    PyObject_HEAD int font_count;
-    FontFamilyFont *fonts;
-    int layout_engine;
+    PyObject_HEAD FontFamily data;
+    unsigned char **font_bytes;
 } FontFamilyObject;
 
 static PyTypeObject Font_Type;
@@ -227,6 +227,7 @@ getfamily(PyObject *self_, PyObject *args, PyObject *kw) {
     /* create a font family object from a list of file names and a sizes (in pixels) */
 
     FontFamilyObject *self;
+    FontFamily *family;
     int error = 0;
 
     PyTupleObject *fonts_tuple = NULL;
@@ -253,16 +254,23 @@ getfamily(PyObject *self_, PyObject *args, PyObject *kw) {
         return NULL;
     }
 
-    self->font_count = PyTuple_GET_SIZE(fonts_tuple);
-    self->layout_engine = layout_engine;
-    self->fonts = PyMem_New(FontFamilyFont, self->font_count);
-    if (!self->fonts) {
+    family = &self->data;
+
+    family->font_count = PyTuple_GET_SIZE(fonts_tuple);
+    family->layout_engine = layout_engine;
+    family->faces = PyMem_New(FT_Face, family->font_count);
+    if (!family->faces) {
+        PyObject_Del(self);
+        return NULL;
+    }
+    self->font_bytes = PyMem_New(unsigned char *, family->font_count);
+    if (!self->font_bytes) {
+        PyMem_Free(family->faces);
         PyObject_Del(self);
         return NULL;
     }
 
-    FontFamilyFont *font = self->fonts;
-    for (int i = 0; i < self->font_count; ++i, ++font) {
+    for (int i = 0; i < family->font_count; i++) {
         char *filename;
         Py_ssize_t size;
         Py_ssize_t index;
@@ -283,38 +291,38 @@ getfamily(PyObject *self_, PyObject *args, PyObject *kw) {
             goto err;
         }
 
-        font->face = NULL;
+        family->faces[i] = NULL;
 
         if (filename && font_bytes_size <= 0) {
-            font->font_bytes = NULL;
-            error = FT_New_Face(library, filename, index, &font->face);
+            self->font_bytes[i] = NULL;
+            error = FT_New_Face(library, filename, index, &family->faces[i]);
         } else {
             /* need to have allocated storage for font_bytes for the life of the
              * object.*/
             /* Don't free this before FT_Done_Face */
-            font->font_bytes = PyMem_Malloc(font_bytes_size);
-            if (!font->font_bytes) {
+            self->font_bytes[i] = PyMem_Malloc(font_bytes_size);
+            if (!self->font_bytes[i]) {
                 error = FT_Err_Out_Of_Memory;
             }
             if (!error) {
-                memcpy(font->font_bytes, font_bytes, (size_t)font_bytes_size);
+                memcpy(self->font_bytes[i], font_bytes, (size_t)font_bytes_size);
                 error = FT_New_Memory_Face(
                     library,
-                    (FT_Byte *)font->font_bytes,
+                    (FT_Byte *)self->font_bytes[i],
                     font_bytes_size,
                     index,
-                    &font->face);
+                    &family->faces[i]);
             }
         }
 
         if (!error) {
-            error = FT_Set_Pixel_Sizes(font->face, 0, size);
+            error = FT_Set_Pixel_Sizes(family->faces[i], 0, size);
         }
 
         if (!error && encoding && strlen((char *)encoding) == 4) {
             FT_Encoding encoding_tag =
                 FT_MAKE_TAG(encoding[0], encoding[1], encoding[2], encoding[3]);
-            error = FT_Select_Charmap(font->face, encoding_tag);
+            error = FT_Select_Charmap(family->faces[i], encoding_tag);
         }
 
         if (filename) {
@@ -322,31 +330,33 @@ getfamily(PyObject *self_, PyObject *args, PyObject *kw) {
         }
 
         if (error) {
-            if (font->font_bytes) {
-                PyMem_Free(font->font_bytes);
-                font->font_bytes = NULL;
+            if (self->font_bytes[i]) {
+                PyMem_Free(self->font_bytes[i]);
+                self->font_bytes[i] = NULL;
+            }
+            if (family->faces[i]) {
+                FT_Done_Face(family->faces[i]);
             }
             geterror(error);
             goto err;
         }
+
+        continue;
+
+    err:
+        for (int j = 0; j < i; j++) {
+            if (family->faces[j]) {
+                FT_Done_Face(family->faces[j]);
+            }
+            if (self->font_bytes[j]) {
+                PyMem_Free(self->font_bytes[j]);
+            }
+        }
+        PyObject_Del(self);
+        return NULL;
     }
 
     return (PyObject *)self;
-
-err:
-    for (FontFamilyFont *f = self->fonts; f != font; ++f) {
-        if (f->font_bytes) {
-            PyMem_Free(f->font_bytes);
-            f->font_bytes = NULL;
-        }
-        if (f->face) {
-            FT_Done_Face(f->face);
-            f->face = NULL;
-        }
-    }
-
-    PyObject_Del(self);
-    return NULL;
 }
 
 static int
@@ -366,7 +376,7 @@ font_getchar(PyObject *string, int index, FT_ULong *char_out) {
 static size_t
 text_layout_raqm(
     PyObject *string,
-    FontObject *self,
+    FontFamily *family,
     const char *dir,
     PyObject *features,
     const char *lang,
@@ -473,7 +483,7 @@ text_layout_raqm(
         Py_DECREF(seq);
     }
 
-    if (!raqm_set_freetype_face(rq, self->face)) {
+    if (!raqm_set_freetype_face(rq, family->faces[0])) {
         PyErr_SetString(PyExc_RuntimeError, "raqm_set_freetype_face() failed.");
         goto failed;
     }
@@ -498,7 +508,7 @@ text_layout_raqm(
     }
 
     for (i = 0; i < count; i++) {
-        (*glyph_info)[i].face = self->face;
+        (*glyph_info)[i].face = family->faces[0];
         (*glyph_info)[i].index = glyphs[i].index;
         (*glyph_info)[i].x_offset = glyphs[i].x_offset;
         (*glyph_info)[i].x_advance = glyphs[i].x_advance;
@@ -517,92 +527,7 @@ failed:
 static size_t
 text_layout_fallback(
     PyObject *string,
-    FontObject *self,
-    const char *dir,
-    PyObject *features,
-    const char *lang,
-    GlyphInfo **glyph_info,
-    int mask,
-    int color) {
-    int error, load_flags;
-    FT_ULong ch;
-    Py_ssize_t count;
-    FT_GlyphSlot glyph;
-    FT_Bool kerning = FT_HAS_KERNING(self->face);
-    FT_UInt last_index = 0;
-    int i;
-
-    if (features != Py_None || dir != NULL || lang != NULL) {
-        PyErr_SetString(
-            PyExc_KeyError,
-            "setting text direction, language or font features is not supported "
-            "without libraqm");
-    }
-    if (!PyUnicode_Check(string)) {
-        PyErr_SetString(PyExc_TypeError, "expected string");
-        return 0;
-    }
-
-    count = 0;
-    while (font_getchar(string, count, &ch)) {
-        count++;
-    }
-    if (count == 0) {
-        return 0;
-    }
-
-    (*glyph_info) = PyMem_New(GlyphInfo, count);
-    if ((*glyph_info) == NULL) {
-        PyErr_SetString(PyExc_MemoryError, "PyMem_New() failed");
-        return 0;
-    }
-
-    load_flags = FT_LOAD_DEFAULT;
-    if (mask) {
-        load_flags |= FT_LOAD_TARGET_MONO;
-    }
-#ifdef FT_LOAD_COLOR
-    if (color) {
-        load_flags |= FT_LOAD_COLOR;
-    }
-#endif
-    for (i = 0; font_getchar(string, i, &ch); i++) {
-        (*glyph_info)[i].face = self->face;
-        (*glyph_info)[i].index = FT_Get_Char_Index(self->face, ch);
-        error = FT_Load_Glyph(self->face, (*glyph_info)[i].index, load_flags);
-        if (error) {
-            geterror(error);
-            return 0;
-        }
-        glyph = self->face->glyph;
-        (*glyph_info)[i].x_offset = 0;
-        (*glyph_info)[i].y_offset = 0;
-        if (kerning && last_index && (*glyph_info)[i].index) {
-            FT_Vector delta;
-            if (FT_Get_Kerning(
-                    self->face,
-                    last_index,
-                    (*glyph_info)[i].index,
-                    ft_kerning_default,
-                    &delta) == 0) {
-                (*glyph_info)[i - 1].x_advance += PIXEL(delta.x);
-                (*glyph_info)[i - 1].y_advance += PIXEL(delta.y);
-            }
-        }
-
-        (*glyph_info)[i].x_advance = glyph->metrics.horiAdvance;
-        // y_advance is only used in ttb, which is not supported by basic layout
-        (*glyph_info)[i].y_advance = 0;
-        last_index = (*glyph_info)[i].index;
-        (*glyph_info)[i].cluster = ch;
-    }
-    return count;
-}
-
-static size_t
-text_layout_family(
-    PyObject *string,
-    FontFamilyObject *self,
+    FontFamily *family,
     const char *dir,
     PyObject *features,
     const char *lang,
@@ -651,24 +576,27 @@ text_layout_family(
     }
 #endif
     for (i = 0; font_getchar(string, i, &ch); i++) {
-        FontFamilyFont *font = self->fonts;
         int found = 0;
-        for (int j = 0; !found && j < self->font_count; j++, font++) {
-            (*glyph_info)[i].index = FT_Get_Char_Index(font->face, ch);
+        for (int j = 0; !found && j < family->font_count; j++) {
+            FT_Face face = family->faces[j];
+            (*glyph_info)[i].index = FT_Get_Char_Index(face, ch);
             if ((*glyph_info)[i].index != 0) {
                 found = 1;
             }
-            if (j == 0 || found) {  /* use first font's missing glyph */
-                (*glyph_info)[i].face = font->face;
-                error = FT_Load_Glyph(font->face, (*glyph_info)[i].index, load_flags);
+            /* prefer first font's missing glyph if no font support this codepoint */
+            if (j == 0 || found) {
+                (*glyph_info)[i].face = face;
+                error = FT_Load_Glyph(face, (*glyph_info)[i].index, load_flags);
                 if (error) {
                     geterror(error);
                     return 0;
                 }
-                glyph = font->face->glyph;
+                glyph = face->glyph;
                 (*glyph_info)[i].x_offset = 0;
                 (*glyph_info)[i].y_offset = 0;
-                if (FT_HAS_KERNING(font->face) && last_index &&
+
+                /* This has been broken and had no effect for many years now...
+                if (FT_HAS_KERNING(face) && last_index &&
                     (*glyph_info)[i].index) {
                     FT_Vector delta;
                     if (FT_Get_Kerning(
@@ -681,9 +609,10 @@ text_layout_family(
                         (*glyph_info)[i - 1].y_advance += PIXEL(delta.y);
                     }
                 }
+                */
 
                 (*glyph_info)[i].x_advance = glyph->metrics.horiAdvance;
-                // y_advance is only used in ttb, which is not supported by basic layout
+                /* y_advance is only used in ttb, which is not supported by basic layout */
                 (*glyph_info)[i].y_advance = 0;
                 last_index = (*glyph_info)[i].index;
                 (*glyph_info)[i].cluster = ch;
@@ -696,7 +625,7 @@ text_layout_family(
 static size_t
 text_layout(
     PyObject *string,
-    FontObject *self,
+    FontFamily *family,
     const char *dir,
     PyObject *features,
     const char *lang,
@@ -705,20 +634,20 @@ text_layout(
     int color) {
     size_t count;
 #ifdef HAVE_RAQM
-    if (have_raqm && self->layout_engine == LAYOUT_RAQM) {
+    if (have_raqm && family->layout_engine == LAYOUT_RAQM) {
         count = text_layout_raqm(
-            string, self, dir, features, lang, glyph_info, mask, color);
+            string, family, dir, features, lang, glyph_info, mask, color);
     } else
 #endif
     {
         count = text_layout_fallback(
-            string, self, dir, features, lang, glyph_info, mask, color);
+            string, family, dir, features, lang, glyph_info, mask, color);
     }
     return count;
 }
 
 static PyObject *
-text_getlength(void *self, int is_font_family, PyObject *args) {
+text_getlength(FontFamily *family, PyObject *args) {
     int length;                   /* length along primary axis, in 26.6 precision */
     GlyphInfo *glyph_info = NULL; /* computed text layout */
     size_t i, count;              /* glyph_info index and length */
@@ -743,20 +672,8 @@ text_getlength(void *self, int is_font_family, PyObject *args) {
     mask = mode && strcmp(mode, "1") == 0;
     color = mode && strcmp(mode, "RGBA") == 0;
 
-    if (is_font_family) {
-        count = text_layout_family(
-            string,
-            (FontFamilyObject *)self,
-            dir,
-            features,
-            lang,
-            &glyph_info,
-            mask,
-            color);
-    } else {
-        count = text_layout(
-            string, (FontObject *)self, dir, features, lang, &glyph_info, mask, color);
-    }
+    count = text_layout(string, family, dir, features, lang, &glyph_info, mask, color);
+
     if (PyErr_Occurred()) {
         return NULL;
     }
@@ -780,16 +697,22 @@ text_getlength(void *self, int is_font_family, PyObject *args) {
 
 static PyObject *
 font_getlength(FontObject *self, PyObject *args) {
-    return text_getlength(self, 0, args);
+    FontFamily family;
+
+    family.faces = &self->face;
+    family.font_count = 1;
+    family.layout_engine = self->layout_engine;
+
+    return text_getlength(&family, args);
 }
 
 static PyObject *
 family_getlength(FontFamilyObject *self, PyObject *args) {
-    return text_getlength(self, 1, args);
+    return text_getlength(&self->data, args);
 }
 
 static PyObject *
-text_getsize(void *self, int is_font_family, PyObject *args) {
+text_getsize(FontFamily *family, PyObject *args) {
     int position; /* pen position along primary axis, in 26.6 precision */
     int advanced; /* pen position along primary axis, in pixels */
     int px, py;   /* position of current glyph, in pixels */
@@ -798,7 +721,6 @@ text_getsize(void *self, int is_font_family, PyObject *args) {
     int load_flags;                 /* FreeType load_flags parameter */
     int error;
     FT_Face face;
-    FT_Face primaryFace;
     FT_Glyph glyph;
     FT_BBox bbox;                 /* glyph bounding box */
     GlyphInfo *glyph_info = NULL; /* computed text layout */
@@ -832,17 +754,7 @@ text_getsize(void *self, int is_font_family, PyObject *args) {
         goto bad_anchor;
     }
 
-    if (is_font_family) {
-        FontFamilyObject *family = (FontFamilyObject *)self;
-        primaryFace = family->fonts->face;
-        count = text_layout_family(
-            string, family, dir, features, lang, &glyph_info, mask, color);
-    } else {
-        FontObject *font = (FontObject *) self;
-        primaryFace = font->face;
-        count = text_layout(
-            string, font, dir, features, lang, &glyph_info, mask, color);
-    }
+    count = text_layout(string, family, dir, features, lang, &glyph_info, mask, color);
     if (PyErr_Occurred()) {
         return NULL;
     }
@@ -943,15 +855,15 @@ text_getsize(void *self, int is_font_family, PyObject *args) {
             }
             switch (anchor[1]) {
                 case 'a':  // ascender
-                    y_anchor = PIXEL(primaryFace->size->metrics.ascender);
+                    y_anchor = PIXEL(family->faces[0]->size->metrics.ascender);
                     break;
                 case 't':  // top
                     y_anchor = y_max;
                     break;
                 case 'm':  // middle (ascender + descender) / 2
                     y_anchor = PIXEL(
-                        (primaryFace->size->metrics.ascender +
-                         primaryFace->size->metrics.descender) /
+                        (family->faces[0]->size->metrics.ascender +
+                         family->faces[0]->size->metrics.descender) /
                         2);
                     break;
                 case 's':  // horizontal baseline
@@ -961,7 +873,7 @@ text_getsize(void *self, int is_font_family, PyObject *args) {
                     y_anchor = y_min;
                     break;
                 case 'd':  // descender
-                    y_anchor = PIXEL(primaryFace->size->metrics.descender);
+                    y_anchor = PIXEL(family->faces[0]->size->metrics.descender);
                     break;
                 default:
                     goto bad_anchor;
@@ -1016,16 +928,22 @@ bad_anchor:
 
 static PyObject *
 font_getsize(FontObject *self, PyObject *args) {
-    return text_getsize(self, 0, args);
+    FontFamily family;
+
+    family.faces = &self->face;
+    family.font_count = 1;
+    family.layout_engine = self->layout_engine;
+
+    return text_getsize(&family, args);
 }
 
 static PyObject *
 family_getsize(FontFamilyObject *self, PyObject *args) {
-    return text_getsize(self, 1, args);
+    return text_getsize(&self->data, args);
 }
 
 static PyObject *
-text_render(void *self, int is_font_family, PyObject *args) {
+text_render(FontFamily *family, PyObject *args) {
     int x, y;         /* pen position, in 26.6 precision */
     int px, py;       /* position of current glyph, in pixels */
     int x_min, y_max; /* text offset in 26.6 precision */
@@ -1085,30 +1003,8 @@ text_render(void *self, int is_font_family, PyObject *args) {
 
     foreground_ink = foreground_ink_long;
 
-    if (is_font_family) {
-        FontFamilyObject *family = (FontFamilyObject *)self;
-
 #ifdef FT_COLOR_H
-        for (int i = 0; i < family->font_count; i++) {
-            if (color) {
-                FT_Color foreground_color;
-                FT_Byte *ink = (FT_Byte *)&foreground_ink;
-                foreground_color.red = ink[0];
-                foreground_color.green = ink[1];
-                foreground_color.blue = ink[2];
-                foreground_color.alpha =
-                    (FT_Byte)255; /* ink alpha is handled in ImageDraw.text */
-                FT_Palette_Set_Foreground_Color(family->fonts[i].face, foreground_color);
-            }
-        }
-#endif
-
-        count =
-            text_layout_family(string, family, dir, features, lang, &glyph_info, mask, color);
-    } else {
-        FontObject *font = (FontObject *)self;
-
-#ifdef FT_COLOR_H
+    for (int i = 0; i < family->font_count; i++) {
         if (color) {
             FT_Color foreground_color;
             FT_Byte *ink = (FT_Byte *)&foreground_ink;
@@ -1117,13 +1013,13 @@ text_render(void *self, int is_font_family, PyObject *args) {
             foreground_color.blue = ink[2];
             foreground_color.alpha =
                 (FT_Byte)255; /* ink alpha is handled in ImageDraw.text */
-            FT_Palette_Set_Foreground_Color(font->face, foreground_color);
+            FT_Palette_Set_Foreground_Color(family->faces[i], foreground_color);
         }
+    }
 #endif
 
-        count =
-            text_layout(string, font, dir, features, lang, &glyph_info, mask, color);
-    }
+    count = text_layout(string, family, dir, features, lang, &glyph_info, mask, color);
+    
     if (PyErr_Occurred()) {
         return NULL;
     }
@@ -1375,12 +1271,18 @@ glyph_error:
 
 static PyObject *
 font_render(FontObject *self, PyObject *args) {
-    return text_render(self, 0, args);
+    FontFamily family;
+
+    family.faces = &self->face;
+    family.font_count = 1;
+    family.layout_engine = self->layout_engine;
+
+    return text_render(&family, args);
 }
 
 static PyObject *
 family_render(FontFamilyObject *self, PyObject *args) {
-    return text_render(self, 1, args);
+    return text_render(&self->data, args);
 }
 
 #if FREETYPE_MAJOR > 2 || (FREETYPE_MAJOR == 2 && FREETYPE_MINOR > 9) || \
@@ -1657,16 +1559,16 @@ static PyTypeObject Font_Type = {
 
 static void
 family_dealloc(FontFamilyObject *self) {
-    FontFamilyFont *font = self->fonts;
-    for (int i = 0; i < self->font_count; ++i, ++font) {
-        if (font->face) {
-            FT_Done_Face(font->face);
+    for (int i = 0; i < self->data.font_count; i++) {
+        if (self->data.faces[i]) {
+            FT_Done_Face(self->data.faces[i]);
         }
-        if (font->font_bytes) {
-            PyMem_Free(font->font_bytes);
+        if (self->font_bytes[i]) {
+            PyMem_Free(self->font_bytes[i]);
         }
     }
-    PyMem_Free(self->fonts);
+    PyMem_Free(self->data.faces);
+    PyMem_Free(self->font_bytes);
     PyObject_Del(self);
 }
 

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -437,7 +437,7 @@ text_layout_raqm(
         }
     }
 
-    for (face = 0; face < family->font_count; face++) {
+    for (face = 0; ; face++) {
 #ifdef RAQM_VERSION_ATLEAST
 #if RAQM_VERSION_ATLEAST(0, 9, 0)
         if (face >= 1) {
@@ -518,7 +518,9 @@ text_layout_raqm(
             }
         } else {
             start = 0;
-            for (i = 0; i <= size; i++) {
+            /* use first font's missing glyph */
+            int f = face < family->font_count ? face : 0;
+            for (i = 1; i <= size; i++) {
                 if (i < size) {
                     if (fallback[i] == -2) {
                         /* not a cluster boundary */
@@ -531,7 +533,7 @@ text_layout_raqm(
                 }
                 if (fallback[start] < 0) {
                     raqm_set_freetype_face_range(
-                        rq, family->faces[face], start, i - start);
+                        rq, family->faces[f], start, i - start);
                 } else {
                     raqm_set_freetype_face_range(
                         rq, family->faces[fallback[start]], start, i - start);
@@ -552,14 +554,11 @@ text_layout_raqm(
             goto failed;
         }
 
-        //if (face + 1 == family->font_count) {
-        //    break;
-        //}
-        if (family->font_count == 1) {
+        if (family->font_count == 1 || face == family->font_count) {
             break;
         }
 
-        for (i = 1; i < size; i++) {
+        for (i = 0; i < size; i++) {
             if (fallback[i] == -1) {
                 fallback[i] = -2;
             }
@@ -577,7 +576,6 @@ text_layout_raqm(
                 fallback[cluster] = face;
             }
         }
-
         if (!missing) {
             break;
         }


### PR DESCRIPTION
Fixes #4808.

Add a new type, `ImageFont.FreeTypeFontFamily(font1, font2, ..., layout_engine=layout_engine)`, that can be used with `ImageDraw.text*(...)` functions performing font fallback. Font fallback is done per cluster with Raqm layout (similar to Chromium) and per codepoint with basic layout.

This PR is far from complete, several TODOs:
* [ ] Font families have only a minimal API so far, e.g. retrieving metrics or setting font variations should be supported
* [ ] Maybe add a wrapper similar to `ImageFont.truetype(...)`, perhaps `ImageFont.truetype_family(...)`?
* [ ] Lots of tests
* [ ] Documentation

I would like to get some feedback, both on the API and the implementation, before working on the TODOs above.
A dev build for Windows is available here: https://github.com/nulano/Pillow/suites/10741759296/artifacts/538936223

<details>
<summary>A few examples (click to expand):</summary>

All examples use this helper block:
```python
from PIL import Image, ImageDraw, ImageFont

im = Image.new("RGBA", (500, 200), "white")
draw = ImageDraw.Draw(im)
def line(y, string, font, name, **kwargs):
  draw.text((10, y), name, fill="black", font=font, **kwargs)
  draw.text((300, y), string, fill="black", font=font, **kwargs)

example()

im.show()
```

Combining Latin, symbols, and an emoji:
```python
def example():
  s = "smile ⊗ 😀"

  times = ImageFont.truetype("times.ttf", 24)
  segoe_ui_emoji = ImageFont.truetype("seguiemj.ttf", 24)
  segoe_ui_symbol = ImageFont.truetype("seguisym.ttf", 24)
  family = ImageFont.FreeTypeFontFamily(times, segoe_ui_emoji, segoe_ui_symbol)

  line(30, s, times, "Times New Roman", anchor="ls", embedded_color=True)
  line(80, s, segoe_ui_emoji, "Segoe UI Emoji", anchor="ls", embedded_color=True)
  line(130, s, segoe_ui_symbol, "Segoe UI Symbol", anchor="ls", embedded_color=True)
  line(180, s, family, "Font Family", anchor="ls", embedded_color=True)
```

![fallback_emoji](https://user-images.githubusercontent.com/3819630/216381707-950e87bf-227a-4fa4-9df6-a598fa679060.png)

Combining Arabic, Greek, Latin, and a symbol:
```python
def example():
  s = "ية↦α,abc"

  scriptin = ImageFont.truetype(r"C:\Users\Nulano\AppData\Local\Microsoft\Windows\Fonts\SCRIPTIN.ttf", 24)
  segoe_ui = ImageFont.truetype("segoeui.ttf", 24)
  segoe_ui_symbol = ImageFont.truetype("seguisym.ttf", 24)
  family = ImageFont.FreeTypeFontFamily(scriptin, segoe_ui, segoe_ui_symbol)

  line(30, s, scriptin, "Scriptina", direction="ltr", anchor="ls")
  line(80, s, segoe_ui, "Segoe UI", direction="ltr", anchor="ls")
  line(130, s, segoe_ui_symbol, "Segoe UI Symbol", direction="ltr", anchor="ls")
  line(180, s, family, "Font Family", direction="ltr", anchor="ls")
```

![fallback_arabic](https://user-images.githubusercontent.com/3819630/216383682-4cc698ba-3c5a-4dce-825e-edb5fec20ec8.png)

Combining characters are treated as part of a single cluster (with Raqm layout):
```python
def example():
  import unicodedata

  s = " ̌,ῶ,ω̃,ώ,ώ, ́,á,č,č"
  for c in s:
    print(unicodedata.name(c))

  le = ImageFont.Layout.RAQM  # or ImageFont.Layout.BASIC
  scriptin = ImageFont.truetype(r"C:\Users\Nulano\AppData\Local\Microsoft\Windows\Fonts\SCRIPTIN.ttf", 24, layout_engine=le)
  dubai = ImageFont.truetype(r"DUBAI-REGULAR.TTF", 24, layout_engine=le)
  gentium = ImageFont.truetype(r"C:\Users\Nulano\AppData\Local\Microsoft\Windows\Fonts\GentiumPlus-Regular.ttf", 24, layout_engine=le)
  family = ImageFont.FreeTypeFontFamily(scriptin, dubai, gentium, layout_engine=le)

  line(30, s, scriptin, "Scriptina", anchor="ls")
  line(80, s, dubai, "Dubai", anchor="ls")
  line(130, s, gentium, "GentiumPlus", anchor="ls")
  line(180, s, family, "Font Family", anchor="ls")
```

Raqm layout:
![fallback_greek](https://user-images.githubusercontent.com/3819630/216385929-0d81168b-29d7-4422-8d09-466ae941d6d7.png)

Basic layout:
![fallback_greek_basic](https://user-images.githubusercontent.com/3819630/216387116-6608b581-24ef-4989-9074-f1edd0ae0a53.png)

The string `s` contains:
```text
SPACE
COMBINING CARON
COMMA
GREEK SMALL LETTER OMEGA WITH PERISPOMENI
COMMA
GREEK SMALL LETTER OMEGA
COMBINING TILDE
COMMA
GREEK SMALL LETTER OMEGA WITH TONOS
COMMA
GREEK SMALL LETTER OMEGA
COMBINING ACUTE ACCENT
COMMA
SPACE
COMBINING ACUTE ACCENT
COMMA
LATIN SMALL LETTER A
COMBINING ACUTE ACCENT
COMMA
LATIN SMALL LETTER C WITH CARON
COMMA
LATIN SMALL LETTER C
COMBINING CARON
```

</details>