### PR TITLE
Do not raise an error if os.environ does not contain PATH

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -242,9 +242,9 @@ def _find_include_dir(self, dirname, include):
             return subdir
 
 
-def _cmd_exists(cmd):
+def _cmd_exists(cmd: str) -> bool:
     if "PATH" not in os.environ:
-        return
+        return False
     return any(
         os.access(os.path.join(path, cmd), os.X_OK)
         for path in os.environ["PATH"].split(os.pathsep)

--- a/setup.py
+++ b/setup.py
@@ -243,6 +243,8 @@ def _find_include_dir(self, dirname, include):
 
 
 def _cmd_exists(cmd):
+    if "PATH" not in os.environ:
+        return
     return any(
         os.access(os.path.join(path, cmd), os.X_OK)
         for path in os.environ["PATH"].split(os.pathsep)


### PR DESCRIPTION
Resolves #6934

https://github.com/python-pillow/Pillow/blob/7e3bed6834e639cd0f5a410abfd8224d4e5725c5/setup.py#L245-L249
presumes that `os.environ` contains a "PATH" key.

This PR changes the code no longer raise an error if it doesn't.