### PR TITLE
Fixed typo

### DIFF
--- a/src/PIL/TiffTags.py
+++ b/src/PIL/TiffTags.py
@@ -312,7 +312,7 @@ TAGS = {
     34910: "HylaFAX FaxRecvTime",
     36864: "ExifVersion",
     36867: "DateTimeOriginal",
-    36868: "DateTImeDigitized",
+    36868: "DateTimeDigitized",
     37121: "ComponentsConfiguration",
     37122: "CompressedBitsPerPixel",
     37724: "ImageSourceData",


### PR DESCRIPTION
Fixes a typo in
https://github.com/python-pillow/Pillow/blob/4ab4bfe89b30540cfd8d11f51117b52f08603add/src/PIL/TiffTags.py#L315
describing the TIFF Tag seen at https://www.awaresystems.be/imaging/tiff/tifftags/privateifd/exif/datetimedigitized.html