### PR TITLE
Enable gcov support for codecov/codecov-action

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -87,6 +87,7 @@ jobs:
       with:
         flags: GHA_Docker
         name: ${{ matrix.docker }}
+        gcov: true
 
   success:
     permissions:


### PR DESCRIPTION
I noticed we're missing code coverage for the C files on Codecov.

For example, no C files listed at:

<img width="327" alt="image" src="https://user-images.githubusercontent.com/1324225/218281676-006304d7-ecab-46d9-9299-c5dd25a79240.png">

https://app.codecov.io/gh/python-pillow/Pillow/tree/main/src

Looks like this happened when switched bumped some workflows from v1 of the Codecov Action to v3, and others from the Codecov Bash Uploader to the v3 Action in https://github.com/python-pillow/Pillow/pull/6281, and coverage increased, because there's better average coverage on the Python files (https://app.codecov.io/gh/python-pillow/Pillow/commit/53b6e5f4bf9a6a68e29109c457b12d17761d0035):

<img width="1307" alt="image" src="https://user-images.githubusercontent.com/1324225/218281745-aeaf677b-763e-4fd0-a859-0638d3a12676.png">

Now I remember I had earlier opened https://github.com/codecov/codecov-action/issues/566, where the v1->v2 upgrade lost C coverage. (Codecov never replied.)

Anyway, by now, the Bash Uploader has been retired (https://github.com/codecov/codecov-bash) and there's a new Uploader (https://github.com/codecov/uploader).

Better yet, the Codecov Action has added support for gcov (used for C coverage) in v3 (https://github.com/codecov/codecov-action/pull/688).

I tried enabling it for all workflows, but for some reason it only worked for the Docker one, so let's enable it there at least to get us back on track. The others will need more investigation.