### PR TITLE
Updated harfbuzz to 7.0.0

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -356,9 +356,9 @@ deps = {
         "libs": [r"imagequant.lib"],
     },
     "harfbuzz": {
-        "url": "https://github.com/harfbuzz/harfbuzz/archive/6.0.0.zip",
-        "filename": "harfbuzz-6.0.0.zip",
-        "dir": "harfbuzz-6.0.0",
+        "url": "https://github.com/harfbuzz/harfbuzz/archive/7.0.0.zip",
+        "filename": "harfbuzz-7.0.0.zip",
+        "dir": "harfbuzz-7.0.0",
         "license": "COPYING",
         "build": [
             cmd_set("CXXFLAGS", "-d2FH4-"),


### PR DESCRIPTION
harfbuzz 7.0.0 has been released - https://github.com/harfbuzz/harfbuzz/releases/tag/7.0.0