### PR TITLE
Fixed writing int as UNDEFINED tag

### DIFF
--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -216,6 +216,22 @@ def test_writing_other_types_to_bytes(value, tmp_path):
         assert reloaded.tag_v2[700] == b"\x01"
 
 
+def test_writing_other_types_to_undefined(tmp_path):
+    im = hopper()
+    info = TiffImagePlugin.ImageFileDirectory_v2()
+
+    tag = TiffTags.TAGS_V2[33723]
+    assert tag.type == TiffTags.UNDEFINED
+
+    info[33723] = 1
+
+    out = str(tmp_path / "temp.tiff")
+    im.save(out, tiffinfo=info)
+
+    with Image.open(out) as reloaded:
+        assert reloaded.tag_v2[33723] == b"1"
+
+
 def test_undefined_zero(tmp_path):
     # Check that the tag has not been changed since this test was created
     tag = TiffTags.TAGS_V2[45059]

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -764,6 +764,8 @@ class ImageFileDirectory_v2(MutableMapping):
 
     @_register_writer(7)
     def write_undefined(self, value):
+        if isinstance(value, int):
+            value = str(value).encode("ascii", "replace")
         return value
 
     @_register_loader(10, 8)


### PR DESCRIPTION
Resolves #6948

While https://www.awaresystems.be/imaging/tiff/tifftags/iptc.html is UNDEFINED or BYTE,
> Often times, the datatype is incorrectly specified as LONG.

So this PR allows integers to be written as UNDEFINED tags.