### PR TITLE
Updated Gitter URL

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Bug fixes, feature additions, tests, documentation and more can be contributed v
 
 ## Bug fixes, feature additions, etc.
 
-Please send a pull request to the `main` branch. Please include [documentation](https://pillow.readthedocs.io) and [tests](../Tests/README.rst) for new features. Tests or documentation without bug fixes or feature additions are welcome too. Feel free to ask questions [via issues](https://github.com/python-pillow/Pillow/issues/new), [discussions](https://github.com/python-pillow/Pillow/discussions/new), [Gitter](https://gitter.im/python-pillow/Pillow) or irc://irc.freenode.net#pil
+Please send a pull request to the `main` branch. Please include [documentation](https://pillow.readthedocs.io) and [tests](../Tests/README.rst) for new features. Tests or documentation without bug fixes or feature additions are welcome too. Feel free to ask questions [via issues](https://github.com/python-pillow/Pillow/issues/new), [discussions](https://github.com/python-pillow/Pillow/discussions/new), [Gitter](https://app.gitter.im/#/room/#python-pillow_Pillow:gitter.im) or irc://irc.freenode.net#pil
 
 - Fork the Pillow repository.
 - Create a branch from `main`.

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ As of 2019, Pillow development is
     <tr>
         <th>social</th>
         <td>
-            <a href="https://gitter.im/python-pillow/Pillow?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"><img
-                alt="Join the chat at https://gitter.im/python-pillow/Pillow"
+            <a href="https://app.gitter.im/#/room/#python-pillow_Pillow:gitter.im?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"><img
+                alt="Join the chat at https://app.gitter.im/#/room/#python-pillow_Pillow:gitter.im"
                 src="https://badges.gitter.im/python-pillow/Pillow.svg"></a>
             <a href="https://twitter.com/PythonPillow"><img
                 alt="Follow on https://twitter.com/PythonPillow"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,8 +74,8 @@ Pillow for enterprise is available via the Tidelift Subscription. `Learn more <h
    :alt: OpenSSF Best Practices
 
 .. image:: https://badges.gitter.im/python-pillow/Pillow.svg
-   :target: https://gitter.im/python-pillow/Pillow?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
-   :alt: Join the chat at https://gitter.im/python-pillow/Pillow
+   :target: https://app.gitter.im/#/room/#python-pillow_Pillow:gitter.im?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+   :alt: Join the chat at https://app.gitter.im/#/room/#python-pillow_Pillow:gitter.im
 
 .. image:: https://img.shields.io/badge/tweet-on%20Twitter-00aced.svg
    :target: https://twitter.com/PythonPillow


### PR DESCRIPTION
https://gitter.im/python-pillow/Pillow now redirects to https://app.gitter.im/#/room/#python-pillow_Pillow:gitter.im