### PR TITLE
Relax roundtrip check

### DIFF
--- a/Tests/test_qt_image_qapplication.py
+++ b/Tests/test_qt_image_qapplication.py
@@ -48,7 +48,7 @@ if ImageQt.qt_is_installed:
 def roundtrip(expected):
     result = ImageQt.fromqpixmap(ImageQt.toqpixmap(expected))
     # Qt saves all pixmaps as rgb
-    assert_image_similar(result, expected.convert("RGB"), 0.3)
+    assert_image_similar(result, expected.convert("RGB"), 0.5)
 
 
 @pytest.mark.skipif(not ImageQt.qt_is_installed, reason="Qt bindings are not installed")


### PR DESCRIPTION
After PR #6915, the intermittent failure of #6875 has been quiet, until https://github.com/python-pillow/Pillow/actions/runs/4252238465/jobs/7395566372

This PR relaxes the roundtrip check further.