### PR TITLE
Fix up some pytest style issues

### DIFF
--- a/Tests/test_core_resources.py
+++ b/Tests/test_core_resources.py
@@ -177,13 +177,14 @@ class TestEnvVars:
         Image._apply_env_variables({"PILLOW_BLOCK_SIZE": "2m"})
         assert Image.core.get_block_size() == 2 * 1024 * 1024
 
-    def test_warnings(self):
-        pytest.warns(
-            UserWarning, Image._apply_env_variables, {"PILLOW_ALIGNMENT": "15"}
-        )
-        pytest.warns(
-            UserWarning, Image._apply_env_variables, {"PILLOW_BLOCK_SIZE": "1024"}
-        )
-        pytest.warns(
-            UserWarning, Image._apply_env_variables, {"PILLOW_BLOCKS_MAX": "wat"}
-        )
+    @pytest.mark.parametrize(
+        "vars",
+        [
+            {"PILLOW_ALIGNMENT": "15"},
+            {"PILLOW_BLOCK_SIZE": "1024"},
+            {"PILLOW_BLOCKS_MAX": "wat"},
+        ],
+    )
+    def test_warnings(self, vars):
+        with pytest.warns(UserWarning):
+            Image._apply_env_variables(vars)

--- a/Tests/test_core_resources.py
+++ b/Tests/test_core_resources.py
@@ -179,11 +179,11 @@ class TestEnvVars:
 
     @pytest.mark.parametrize(
         "var",
-        [
+        (
             {"PILLOW_ALIGNMENT": "15"},
             {"PILLOW_BLOCK_SIZE": "1024"},
             {"PILLOW_BLOCKS_MAX": "wat"},
-        ],
+        ),
     )
     def test_warnings(self, var):
         with pytest.warns(UserWarning):

--- a/Tests/test_core_resources.py
+++ b/Tests/test_core_resources.py
@@ -178,13 +178,13 @@ class TestEnvVars:
         assert Image.core.get_block_size() == 2 * 1024 * 1024
 
     @pytest.mark.parametrize(
-        "vars",
+        "var",
         [
             {"PILLOW_ALIGNMENT": "15"},
             {"PILLOW_BLOCK_SIZE": "1024"},
             {"PILLOW_BLOCKS_MAX": "wat"},
         ],
     )
-    def test_warnings(self, vars):
+    def test_warnings(self, var):
         with pytest.warns(UserWarning):
-            Image._apply_env_variables(vars)
+            Image._apply_env_variables(var)

--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -36,11 +36,9 @@ class TestDecompressionBomb:
         Image.MAX_IMAGE_PIXELS = 128 * 128 - 1
         assert Image.MAX_IMAGE_PIXELS == 128 * 128 - 1
 
-        def open():
+        with pytest.warns(Image.DecompressionBombWarning):
             with Image.open(TEST_FILE):
                 pass
-
-        pytest.warns(Image.DecompressionBombWarning, open)
 
     def test_exception(self):
         # Set limit to trigger exception on the test file
@@ -87,7 +85,8 @@ class TestDecompressionCrop:
         # same decompression bomb warnings on them.
         with hopper() as src:
             box = (0, 0, src.width * 2, src.height * 2)
-            pytest.warns(Image.DecompressionBombWarning, src.crop, box)
+            with pytest.warns(Image.DecompressionBombWarning):
+                src.crop(box)
 
     def test_crop_decompression_checks(self):
         im = Image.new("RGB", (100, 100))
@@ -95,7 +94,8 @@ class TestDecompressionCrop:
         for value in ((-9999, -9999, -9990, -9990), (-999, -999, -990, -990)):
             assert im.crop(value).size == (9, 9)
 
-        pytest.warns(Image.DecompressionBombWarning, im.crop, (-160, -160, 99, 99))
+        with pytest.warns(Image.DecompressionBombWarning):
+            im.crop((-160, -160, 99, 99))
 
         with pytest.raises(Image.DecompressionBombError):
             im.crop((-99909, -99990, 99999, 99999))

--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -263,12 +263,9 @@ def test_apng_chunk_errors():
     with Image.open("Tests/images/apng/chunk_no_actl.png") as im:
         assert not im.is_animated
 
-    def open():
+    with pytest.warns(UserWarning):
         with Image.open("Tests/images/apng/chunk_multi_actl.png") as im:
             im.load()
-        assert not im.is_animated
-
-    pytest.warns(UserWarning, open)
 
     with Image.open("Tests/images/apng/chunk_actl_after_idat.png") as im:
         assert not im.is_animated
@@ -287,20 +284,16 @@ def test_apng_chunk_errors():
 
 
 def test_apng_syntax_errors():
-    def open_frames_zero():
+    with pytest.warns(UserWarning):
         with Image.open("Tests/images/apng/syntax_num_frames_zero.png") as im:
             assert not im.is_animated
             with pytest.raises(OSError):
                 im.load()
 
-    pytest.warns(UserWarning, open_frames_zero)
-
-    def open_frames_zero_default():
+    with pytest.warns(UserWarning):
         with Image.open("Tests/images/apng/syntax_num_frames_zero_default.png") as im:
             assert not im.is_animated
             im.load()
-
-    pytest.warns(UserWarning, open_frames_zero_default)
 
     # we can handle this case gracefully
     exception = None
@@ -316,12 +309,10 @@ def test_apng_syntax_errors():
             im.seek(im.n_frames - 1)
             im.load()
 
-    def open():
+    with pytest.warns(UserWarning):
         with Image.open("Tests/images/apng/syntax_num_frames_invalid.png") as im:
             assert not im.is_animated
             im.load()
-
-    pytest.warns(UserWarning, open)
 
 
 @pytest.mark.parametrize(

--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -266,6 +266,7 @@ def test_apng_chunk_errors():
     with pytest.warns(UserWarning):
         with Image.open("Tests/images/apng/chunk_multi_actl.png") as im:
             im.load()
+        assert not im.is_animated
 
     with Image.open("Tests/images/apng/chunk_actl_after_idat.png") as im:
         assert not im.is_animated

--- a/Tests/test_file_dcx.py
+++ b/Tests/test_file_dcx.py
@@ -24,10 +24,12 @@ def test_sanity():
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file():
-    with pytest.warns(ResourceWarning):
+    def open():
         im = Image.open(TEST_FILE)
         im.load()
-        del im
+
+    with pytest.warns(ResourceWarning):
+        open()
 
 
 def test_closed_file():

--- a/Tests/test_file_dcx.py
+++ b/Tests/test_file_dcx.py
@@ -24,11 +24,10 @@ def test_sanity():
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file():
-    def open():
+    with pytest.warns(ResourceWarning):
         im = Image.open(TEST_FILE)
         im.load()
-
-    pytest.warns(ResourceWarning, open)
+        del im
 
 
 def test_closed_file():

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -32,10 +32,12 @@ def test_sanity():
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file():
-    with pytest.warns(ResourceWarning):
+    def open():
         im = Image.open(static_test_file)
         im.load()
-        del im
+
+    with pytest.warns(ResourceWarning):
+        open()
 
 
 def test_closed_file():

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -32,11 +32,10 @@ def test_sanity():
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file():
-    def open():
+    with pytest.warns(ResourceWarning):
         im = Image.open(static_test_file)
         im.load()
-
-    pytest.warns(ResourceWarning, open)
+        del im
 
 
 def test_closed_file():

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -32,11 +32,10 @@ def test_sanity():
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file():
-    def open():
+    with pytest.warns(ResourceWarning):
         im = Image.open(TEST_GIF)
         im.load()
-
-    pytest.warns(ResourceWarning, open)
+        del im
 
 
 def test_closed_file():
@@ -1087,7 +1086,8 @@ def test_rgb_transparency(tmp_path):
     im = Image.new("RGB", (1, 1))
     im.info["transparency"] = b""
     ims = [Image.new("RGB", (1, 1))]
-    pytest.warns(UserWarning, im.save, out, save_all=True, append_images=ims)
+    with pytest.warns(UserWarning):
+        im.save(out, save_all=True, append_images=ims)
 
     with Image.open(out) as reloaded:
         assert "transparency" not in reloaded.info

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -32,10 +32,12 @@ def test_sanity():
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file():
-    with pytest.warns(ResourceWarning):
+    def open():
         im = Image.open(TEST_GIF)
         im.load()
-        del im
+
+    with pytest.warns(ResourceWarning):
+        open()
 
 
 def test_closed_file():

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -212,11 +212,9 @@ def test_save_append_images(tmp_path):
 def test_unexpected_size():
     # This image has been manually hexedited to state that it is 16x32
     # while the image within is still 16x16
-    def open():
+    with pytest.warns(UserWarning):
         with Image.open("Tests/images/hopper_unexpected.ico") as im:
             assert im.size == (16, 16)
-
-    pytest.warns(UserWarning, open)
 
 
 def test_draw_reloaded(tmp_path):

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -28,10 +28,12 @@ def test_name_limit(tmp_path):
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file():
-    with pytest.warns(ResourceWarning):
+    def open():
         im = Image.open(TEST_IM)
         im.load()
-        del im
+
+    with pytest.warns(ResourceWarning):
+        open()
 
 
 def test_closed_file():

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -28,11 +28,10 @@ def test_name_limit(tmp_path):
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file():
-    def open():
+    with pytest.warns(ResourceWarning):
         im = Image.open(TEST_IM)
         im.load()
-
-    pytest.warns(ResourceWarning, open)
+        del im
 
 
 def test_closed_file():

--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -38,10 +38,12 @@ def test_sanity(test_file):
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file():
-    with pytest.warns(ResourceWarning):
+    def open():
         im = Image.open(test_files[0])
         im.load()
-        del im
+
+    with pytest.warns(ResourceWarning):
+        open()
 
 
 def test_closed_file():

--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -38,11 +38,10 @@ def test_sanity(test_file):
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file():
-    def open():
+    with pytest.warns(ResourceWarning):
         im = Image.open(test_files[0])
         im.load()
-
-    pytest.warns(ResourceWarning, open)
+        del im
 
 
 def test_closed_file():

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -23,10 +23,12 @@ def test_sanity():
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file():
-    with pytest.warns(ResourceWarning):
+    def open():
         im = Image.open(test_file)
         im.load()
-        del im
+
+    with pytest.warns(ResourceWarning):
+        open()
 
 
 def test_closed_file():

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -23,11 +23,10 @@ def test_sanity():
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file():
-    def open():
+    with pytest.warns(ResourceWarning):
         im = Image.open(test_file)
         im.load()
-
-    pytest.warns(ResourceWarning, open)
+        del im
 
 
 def test_closed_file():

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -21,11 +21,10 @@ def test_sanity():
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file():
-    def open():
+    with pytest.warns(ResourceWarning):
         im = Image.open(TEST_FILE)
         im.load()
-
-    pytest.warns(ResourceWarning, open)
+        del im
 
 
 def test_closed_file():

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -21,10 +21,12 @@ def test_sanity():
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file():
-    with pytest.warns(ResourceWarning):
+    def open():
         im = Image.open(TEST_FILE)
         im.load()
-        del im
+
+    with pytest.warns(ResourceWarning):
+        open()
 
 
 def test_closed_file():

--- a/Tests/test_file_tar.py
+++ b/Tests/test_file_tar.py
@@ -29,10 +29,8 @@ def test_sanity(codec, test_path, format):
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file():
-    def open():
+    with pytest.warns(ResourceWarning):
         TarIO.TarIO(TEST_TAR_FILE, "hopper.jpg")
-
-    pytest.warns(ResourceWarning, open)
 
 
 def test_close():

--- a/Tests/test_file_tga.py
+++ b/Tests/test_file_tga.py
@@ -163,7 +163,9 @@ def test_save_id_section(tmp_path):
 
     # Save with custom id section greater than 255 characters
     id_section = b"Test content" * 25
-    pytest.warns(UserWarning, lambda: im.save(out, id_section=id_section))
+    with pytest.warns(UserWarning):
+        im.save(out, id_section=id_section)
+
     with Image.open(out) as test_im:
         assert test_im.info["id_section"] == id_section[:255]
 

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -57,11 +57,10 @@ class TestFileTiff:
 
     @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
     def test_unclosed_file(self):
-        def open():
+        with pytest.warns(ResourceWarning):
             im = Image.open("Tests/images/multipage.tiff")
             im.load()
-
-        pytest.warns(ResourceWarning, open)
+            del im
 
     def test_closed_file(self):
         with warnings.catch_warnings():
@@ -231,7 +230,8 @@ class TestFileTiff:
     def test_bad_exif(self):
         with Image.open("Tests/images/hopper_bad_exif.jpg") as i:
             # Should not raise struct.error.
-            pytest.warns(UserWarning, i._getexif)
+            with pytest.warns(UserWarning):
+                i._getexif()
 
     def test_save_rgba(self, tmp_path):
         im = hopper("RGBA")

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -57,10 +57,12 @@ class TestFileTiff:
 
     @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
     def test_unclosed_file(self):
-        with pytest.warns(ResourceWarning):
+        def open():
             im = Image.open("Tests/images/multipage.tiff")
             im.load()
-            del im
+
+        with pytest.warns(ResourceWarning):
+            open()
 
     def test_closed_file(self):
         with warnings.catch_warnings():

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -252,7 +252,8 @@ def test_empty_metadata():
     head = f.read(8)
     info = TiffImagePlugin.ImageFileDirectory(head)
     # Should not raise struct.error.
-    pytest.warns(UserWarning, info.load, f)
+    with pytest.warns(UserWarning):
+        info.load(f)
 
 
 def test_iccprofile(tmp_path):
@@ -422,7 +423,8 @@ def test_too_many_entries():
     ifd.tagtype[277] = TiffTags.SHORT
 
     # Should not raise ValueError.
-    pytest.warns(UserWarning, lambda: ifd[277])
+    with pytest.warns(UserWarning):
+        _ = ifd[277]
 
 
 def test_tag_group_data():

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -419,12 +419,12 @@ def test_too_many_entries():
     ifd = TiffImagePlugin.ImageFileDirectory_v2()
 
     #    277: ("SamplesPerPixel", SHORT, 1),
-    ifd._tagdata[277] = struct.pack("hh", 4, 4)
+    ifd._tagdata[277] = struct.pack("<hh", 4, 4)
     ifd.tagtype[277] = TiffTags.SHORT
 
     # Should not raise ValueError.
     with pytest.warns(UserWarning):
-        _ = ifd[277]
+        assert ifd[277] == 4
 
 
 def test_tag_group_data():

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -31,7 +31,8 @@ class TestUnsupportedWebp:
         file_path = "Tests/images/hopper.webp"
         with pytest.warns(UserWarning):
             with pytest.raises(OSError):
-                Image.open(file_path)
+                with Image.open(file_path):
+                    pass
 
         if HAVE_WEBP:
             WebPImagePlugin.SUPPORTED = True

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -29,7 +29,9 @@ class TestUnsupportedWebp:
             WebPImagePlugin.SUPPORTED = False
 
         file_path = "Tests/images/hopper.webp"
-        pytest.warns(UserWarning, lambda: pytest.raises(OSError, Image.open, file_path))
+        with pytest.warns(UserWarning):
+            with pytest.raises(OSError):
+                Image.open(file_path)
 
         if HAVE_WEBP:
             WebPImagePlugin.SUPPORTED = True

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -351,7 +351,8 @@ def test_rotated_transposed_font(font, orientation):
     assert bbox_b[3] == 20 + bbox_a[2] - bbox_a[0]
 
     # text length is undefined for vertical text
-    pytest.raises(ValueError, draw.textlength, word)
+    with pytest.raises(ValueError):
+        draw.textlength(word)
 
 
 @pytest.mark.parametrize(
@@ -872,25 +873,23 @@ def test_anchor_invalid(font):
     d.font = font
 
     for anchor in ["", "l", "a", "lax", "sa", "xa", "lx"]:
-        pytest.raises(ValueError, lambda: font.getmask2("hello", anchor=anchor))
-        pytest.raises(ValueError, lambda: font.getbbox("hello", anchor=anchor))
-        pytest.raises(ValueError, lambda: d.text((0, 0), "hello", anchor=anchor))
-        pytest.raises(ValueError, lambda: d.textbbox((0, 0), "hello", anchor=anchor))
-        pytest.raises(
-            ValueError, lambda: d.multiline_text((0, 0), "foo\nbar", anchor=anchor)
-        )
-        pytest.raises(
-            ValueError,
-            lambda: d.multiline_textbbox((0, 0), "foo\nbar", anchor=anchor),
-        )
+        with pytest.raises(ValueError):
+            font.getmask2("hello", anchor=anchor)
+        with pytest.raises(ValueError):
+            font.getbbox("hello", anchor=anchor)
+        with pytest.raises(ValueError):
+            d.text((0, 0), "hello", anchor=anchor)
+        with pytest.raises(ValueError):
+            d.textbbox((0, 0), "hello", anchor=anchor)
+        with pytest.raises(ValueError):
+            d.multiline_text((0, 0), "foo\nbar", anchor=anchor)
+        with pytest.raises(ValueError):
+            d.multiline_textbbox((0, 0), "foo\nbar", anchor=anchor)
     for anchor in ["lt", "lb"]:
-        pytest.raises(
-            ValueError, lambda: d.multiline_text((0, 0), "foo\nbar", anchor=anchor)
-        )
-        pytest.raises(
-            ValueError,
-            lambda: d.multiline_textbbox((0, 0), "foo\nbar", anchor=anchor),
-        )
+        with pytest.raises(ValueError):
+            d.multiline_text((0, 0), "foo\nbar", anchor=anchor)
+        with pytest.raises(ValueError):
+            d.multiline_textbbox((0, 0), "foo\nbar", anchor=anchor)
 
 
 @pytest.mark.parametrize("bpp", (1, 2, 4, 8))

--- a/Tests/test_imagefontctl.py
+++ b/Tests/test_imagefontctl.py
@@ -360,37 +360,20 @@ def test_anchor_invalid_ttb():
     d.font = font
 
     for anchor in ["", "l", "a", "lax", "xa", "la", "ls", "ld", "lx"]:
-        pytest.raises(
-            ValueError, lambda: font.getmask2("hello", anchor=anchor, direction="ttb")
-        )
-        pytest.raises(
-            ValueError, lambda: font.getbbox("hello", anchor=anchor, direction="ttb")
-        )
-        pytest.raises(
-            ValueError, lambda: d.text((0, 0), "hello", anchor=anchor, direction="ttb")
-        )
-        pytest.raises(
-            ValueError,
-            lambda: d.textbbox((0, 0), "hello", anchor=anchor, direction="ttb"),
-        )
-        pytest.raises(
-            ValueError,
-            lambda: d.multiline_text(
-                (0, 0), "foo\nbar", anchor=anchor, direction="ttb"
-            ),
-        )
-        pytest.raises(
-            ValueError,
-            lambda: d.multiline_textbbox(
-                (0, 0), "foo\nbar", anchor=anchor, direction="ttb"
-            ),
-        )
+        with pytest.raises(ValueError):
+            font.getmask2("hello", anchor=anchor, direction="ttb")
+        with pytest.raises(ValueError):
+            font.getbbox("hello", anchor=anchor, direction="ttb")
+        with pytest.raises(ValueError):
+            d.text((0, 0), "hello", anchor=anchor, direction="ttb")
+        with pytest.raises(ValueError):
+            d.textbbox((0, 0), "hello", anchor=anchor, direction="ttb")
+        with pytest.raises(ValueError):
+            d.multiline_text((0, 0), "foo\nbar", anchor=anchor, direction="ttb")
+        with pytest.raises(ValueError):
+            d.multiline_textbbox((0, 0), "foo\nbar", anchor=anchor, direction="ttb")
     # ttb multiline text does not support anchors at all
-    pytest.raises(
-        ValueError,
-        lambda: d.multiline_text((0, 0), "foo\nbar", anchor="mm", direction="ttb"),
-    )
-    pytest.raises(
-        ValueError,
-        lambda: d.multiline_textbbox((0, 0), "foo\nbar", anchor="mm", direction="ttb"),
-    )
+    with pytest.raises(ValueError):
+        d.multiline_text((0, 0), "foo\nbar", anchor="mm", direction="ttb")
+    with pytest.raises(ValueError):
+        d.multiline_textbbox((0, 0), "foo\nbar", anchor="mm", direction="ttb")


### PR DESCRIPTION
This PR fixes tests to use `pytest.raises` and `pytest.warns` as context managers everywhere possible.