### PR TITLE
Allow comments in FITS images

### DIFF
--- a/Tests/test_file_fits.py
+++ b/Tests/test_file_fits.py
@@ -44,6 +44,12 @@ def test_naxis_zero():
             pass
 
 
+def test_comment():
+    image_data = b"SIMPLE  =                    T / comment string"
+    with pytest.raises(OSError):
+        FitsImagePlugin.FitsImageFile(BytesIO(image_data))
+
+
 def test_stub_deprecated():
     class Handler:
         opened = False

--- a/src/PIL/FitsImagePlugin.py
+++ b/src/PIL/FitsImagePlugin.py
@@ -32,7 +32,7 @@ class FitsImageFile(ImageFile.ImageFile):
             keyword = header[:8].strip()
             if keyword == b"END":
                 break
-            value = header[8:].strip()
+            value = header[8:].split(b"/")[0].strip()
             if value.startswith(b"="):
                 value = value[1:].strip()
             if not headers and (not _accept(keyword) or value != b"T"):


### PR DESCRIPTION
Resolves #6972

https://fits.gsfc.nasa.gov/fits_primer.html states that
> Each header unit contains a sequence of fixed-length 80-character keyword records which have the general form:
>
> `KEYNAME = value / comment string`

This PR removes the comment string when determining the value.