### PR TITLE
Added memoryview support to frombytes()

### DIFF
--- a/Tests/test_image_frombytes.py
+++ b/Tests/test_image_frombytes.py
@@ -1,10 +1,17 @@
+import pytest
+
 from PIL import Image
 
 from .helper import assert_image_equal, hopper
 
 
-def test_sanity():
+@pytest.mark.parametrize("data_type", ("bytes", "memoryview"))
+def test_sanity(data_type):
     im1 = hopper()
-    im2 = Image.frombytes(im1.mode, im1.size, im1.tobytes())
+
+    data = im1.tobytes()
+    if data_type == "memoryview":
+        data = memoryview(data)
+    im2 = Image.frombytes(im1.mode, im1.size, data)
 
     assert_image_equal(im1, im2)

--- a/src/decode.c
+++ b/src/decode.c
@@ -116,12 +116,11 @@ _dealloc(ImagingDecoderObject *decoder) {
 
 static PyObject *
 _decode(ImagingDecoderObject *decoder, PyObject *args) {
-    UINT8 *buffer;
-    Py_ssize_t bufsize;
+    Py_buffer buffer;
     int status;
     ImagingSectionCookie cookie;
 
-    if (!PyArg_ParseTuple(args, "y#", &buffer, &bufsize)) {
+    if (!PyArg_ParseTuple(args, "y*", &buffer)) {
         return NULL;
     }
 
@@ -129,7 +128,7 @@ _decode(ImagingDecoderObject *decoder, PyObject *args) {
         ImagingSectionEnter(&cookie);
     }
 
-    status = decoder->decode(decoder->im, &decoder->state, buffer, bufsize);
+    status = decoder->decode(decoder->im, &decoder->state, buffer.buf, buffer.len);
 
     if (!decoder->pulls_fd) {
         ImagingSectionLeave(&cookie);


### PR DESCRIPTION
Resolves #6933. Alternative to #6937

Adds support for using `memoryview` objects in `frombytes()`, by changing
https://github.com/python-pillow/Pillow/blob/dbcd7372e554ee420a156b968eb9a609ec66ffd1/src/decode.c#L124
to use `y*` instead. This is actually the ["recommended way to accept binary data"](https://docs.python.org/3/c-api/arg.html#strings-and-buffers).

See https://bugs.python.org/issue30625 for a discussion about why this change allows `memoryview` objects to be accepted.