### PR TITLE
Release buffer

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -134,6 +134,7 @@ _decode(ImagingDecoderObject *decoder, PyObject *args) {
         ImagingSectionLeave(&cookie);
     }
 
+    PyBuffer_Release(&buffer);
     return Py_BuildValue("ii", status, decoder->state.errcode);
 }
 


### PR DESCRIPTION
Sequel to #6974, addressing https://github.com/python-pillow/Pillow/pull/6974#issuecomment-1445131593
> I think this is missing a call to `PyBuffer_Release()`.

This makes sense, as per https://docs.python.org/3/c-api/buffer.html
> There are two ways for a consumer of the buffer interface to acquire a buffer over a target object:
>
> - call [PyObject_GetBuffer()](https://docs.python.org/3/c-api/buffer.html#c.PyObject_GetBuffer) with the right parameters;
> - call [PyArg_ParseTuple()](https://docs.python.org/3/c-api/arg.html#c.PyArg_ParseTuple) (or one of its siblings) with one of the y*, w* or s* [format codes](https://docs.python.org/3/c-api/arg.html#arg-parsing).
>
> In both cases, [PyBuffer_Release()](https://docs.python.org/3/c-api/buffer.html#c.PyBuffer_Release) must be called when the buffer isn’t needed anymore. Failure to do so could lead to various issues such as resource leaks.