### PR TITLE
Close file pointer copy in the libtiff encoder if still open

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -1065,3 +1065,9 @@ class TestFileLibTiff(LibTiffTestCase):
         out = str(tmp_path / "temp.tif")
         with pytest.raises(SystemError):
             im.save(out, compression=compression)
+
+    def test_save_many_compressed(self, tmp_path):
+        im = hopper()
+        out = str(tmp_path / "temp.tif")
+        for _ in range(10000):
+            im.save(out, compression="jpeg")

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1850,6 +1850,11 @@ def _save(im, fp, filename):
                 fp.write(data)
             if errcode:
                 break
+        if _fp:
+            try:
+                os.close(_fp)
+            except OSError:
+                pass
         if errcode < 0:
             msg = f"encoder error {errcode} when writing image file"
             raise OSError(msg)


### PR DESCRIPTION
Resolves #6985

**Problem:**
When saving many tiff files with compression="group4" I get the error OSError: [Errno 24] Too many open files (after ~8000 images)

```python
def test_pil():
    im_pil = Image.open("T:/test.jpg")
    im_pil = im_pil.reduce(5)
    im_pil = im_pil.convert("1")
    for i in range(10000)
        file = f"{i:03}"
        out_name = os.path.join(
            "T:/trash", os.path.splitext(os.path.basename(file))[0] + ".tif")
        )
        im_pil.save(out_name, format="TIFF", compression="group4")
```

Without compression="group4" it works fine.

This also happens when a new image is created on each iteration and with explicit close()

```python
def test_pil():
    for i in range(10000):
        file = f"{i:03}"
        im_pil = Image.open("T:/test.jpg")
        im_pil = im_pil.reduce(5)
        im_pil = im_pil.convert("1")
        out_name = os.path.join(
            "T:/trash", os.path.splitext(os.path.basename(file))[0] + ".tif")
        )
        im_pil.save(out_name, format="TIFF", compression="group4")
        im_pil.close()
```


**Changes proposed in this pull request:**

The file pointer seems to be cloned by the libtiff library, but not freed at the end.
Closing to file pointer solve the problem for me.