### PR TITLE
Removed unused profile_fromstring method

### DIFF
--- a/src/_imagingcms.c
+++ b/src/_imagingcms.c
@@ -116,7 +116,7 @@ cms_profile_open(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-cms_profile_fromstring(PyObject *self, PyObject *args) {
+cms_profile_frombytes(PyObject *self, PyObject *args) {
     cmsHPROFILE hProfile;
 
     char *pProfile;
@@ -960,8 +960,7 @@ _is_intent_supported(CmsProfileObject *self, int clut) {
 static PyMethodDef pyCMSdll_methods[] = {
 
     {"profile_open", cms_profile_open, METH_VARARGS},
-    {"profile_frombytes", cms_profile_fromstring, METH_VARARGS},
-    {"profile_fromstring", cms_profile_fromstring, METH_VARARGS},
+    {"profile_frombytes", cms_profile_frombytes, METH_VARARGS},
     {"profile_tobytes", cms_profile_tobytes, METH_VARARGS},
 
     /* profile and transform functions */


### PR DESCRIPTION
While ImageCms calls `profile_frombytes`,
https://github.com/python-pillow/Pillow/blob/1457d2c14667d9901d7bc2552beed4a1ab81742b/src/PIL/ImageCms.py#L187-L191
`profile_fromstring` is unused.

`profile_fromstring` actually calls the same code as `profile_frombytes`.

https://github.com/python-pillow/Pillow/blob/1457d2c14667d9901d7bc2552beed4a1ab81742b/src/_imagingcms.c#L963-L964

So this PR removes the `profile_fromstring` method declaration, and renames the C method to `cms_profile_frombytes` for clarity.