### PR TITLE
Added memoryview support to Dib.frombytes()

### DIFF
--- a/Tests/test_imagewin.py
+++ b/Tests/test_imagewin.py
@@ -100,8 +100,11 @@ class TestImageWinDib:
         # Act
         # Make one the same as the using tobytes()/frombytes()
         test_buffer = dib1.tobytes()
-        dib2.frombytes(test_buffer)
+        for datatype in ("bytes", "memoryview"):
+            if datatype == "memoryview":
+                test_buffer = memoryview(test_buffer)
+            dib2.frombytes(test_buffer)
 
-        # Assert
-        # Confirm they're the same
-        assert dib1.tobytes() == dib2.tobytes()
+            # Assert
+            # Confirm they're the same
+            assert dib1.tobytes() == dib2.tobytes()

--- a/src/display.c
+++ b/src/display.c
@@ -202,6 +202,7 @@ _frombytes(ImagingDisplayObject *display, PyObject *args) {
     }
 
     if (display->dib->ysize * display->dib->linesize != buffer.len) {
+        PyBuffer_Release(&buffer);
         PyErr_SetString(PyExc_ValueError, "wrong size");
         return NULL;
     }

--- a/src/display.c
+++ b/src/display.c
@@ -195,20 +195,20 @@ _releasedc(ImagingDisplayObject *display, PyObject *args) {
 
 static PyObject *
 _frombytes(ImagingDisplayObject *display, PyObject *args) {
-    char *ptr;
-    Py_ssize_t bytes;
+    Py_buffer buffer;
 
-    if (!PyArg_ParseTuple(args, "y#:frombytes", &ptr, &bytes)) {
+    if (!PyArg_ParseTuple(args, "y*:frombytes", &buffer)) {
         return NULL;
     }
 
-    if (display->dib->ysize * display->dib->linesize != bytes) {
+    if (display->dib->ysize * display->dib->linesize != buffer.len) {
         PyErr_SetString(PyExc_ValueError, "wrong size");
         return NULL;
     }
 
-    memcpy(display->dib->bits, ptr, bytes);
+    memcpy(display->dib->bits, buffer.buf, buffer.len);
 
+    PyBuffer_Release(&buffer);
     Py_INCREF(Py_None);
     return Py_None;
 }


### PR DESCRIPTION
Resolves #6975

Allows `memoryview` objects to be passed as the `buffer` argument to `Dib.frombytes()`. Similar to #6974