### PR TITLE
Build docs in own workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,50 @@
+name: Docs
+
+on:
+  push:
+    paths:
+      - ".github/workflows/docs.yml"
+      - "docs/**"
+  pull_request:
+    paths:
+      - ".github/workflows/docs.yml"
+      - "docs/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    name: Docs
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+        cache: pip
+        cache-dependency-path: ".ci/*.sh"
+
+    - name: Build system information
+      run: python3 .github/workflows/system-info.py
+
+    - name: Install Linux dependencies
+      run: |
+        .ci/install.sh
+
+    - name: Build
+      run: |
+        .ci/build.sh
+
+    - name: Docs
+      run: |
+        make doccheck

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -1,6 +1,15 @@
 name: Test Cygwin
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    paths-ignore:
+      - ".github/workflows/docs.yml"
+      - "docs/**"
+  pull_request:
+    paths-ignore:
+      - ".github/workflows/docs.yml"
+      - "docs/**"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -1,6 +1,15 @@
 name: Test Docker
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    paths-ignore:
+      - ".github/workflows/docs.yml"
+      - "docs/**"
+  pull_request:
+    paths-ignore:
+      - ".github/workflows/docs.yml"
+      - "docs/**"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -1,6 +1,15 @@
 name: Test MinGW
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    paths-ignore:
+      - ".github/workflows/docs.yml"
+      - "docs/**"
+  pull_request:
+    paths-ignore:
+      - ".github/workflows/docs.yml"
+      - "docs/**"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,6 +1,15 @@
 name: Test Windows
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    paths-ignore:
+      - ".github/workflows/docs.yml"
+      - "docs/**"
+  pull_request:
+    paths-ignore:
+      - ".github/workflows/docs.yml"
+      - "docs/**"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,15 @@
 name: Test
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    paths-ignore:
+      - ".github/workflows/docs.yml"
+      - "docs/**"
+  pull_request:
+    paths-ignore:
+      - ".github/workflows/docs.yml"
+      - "docs/**"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -95,11 +104,6 @@ jobs:
       with:
         name: errors
         path: Tests/errors
-
-    - name: Docs
-      if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == 3.11
-      run: |
-        make doccheck
 
     - name: After success
       run: |


### PR DESCRIPTION
So far the `make doccheck` docs test has been piggybacking on the main `test.yml` build.

We have a pretty big (and slow!) CI matrix, I think it's time to split the it into its own workflow.

This way, we can run the docs workflow only when the docs change (or the docs workflow file), and have the other workflows ignore docs-only changes.

It will make it much quicker for docs-only PRs.

For example, the first commit here still ran all the workflows:

<img width="1131" alt="image" src="https://user-images.githubusercontent.com/1324225/222922197-06ef1b63-2487-4ec0-9298-3b19be7fd76f.png">

And the second only ran the docs (plus linting):

<img width="1131" alt="image" src="https://user-images.githubusercontent.com/1324225/222922207-abf08219-ff35-47ba-9e71-fc7b433ec7f2.png">
