### PR TITLE
Removed missing anchor from link

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -186,8 +186,8 @@ Many of Pillow's features require external libraries:
   * Pillow wheels since version 8.2.0 include a modified version of libraqm that
     loads libfribidi at runtime if it is installed.
     On Windows this requires compiling FriBiDi and installing ``fribidi.dll``
-    into a directory listed in the `Dynamic-Link Library Search Order (Microsoft Docs)
-    <https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#search-order-for-desktop-applications>`_
+    into a directory listed in the `Dynamic-link library search order (Microsoft Docs)
+    <https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order>`_
     (``fribidi-0.dll`` or ``libfribidi-0.dll`` are also detected).
     See `Build Options`_ to see how to build this version.
   * Previous versions of Pillow (5.0.0 to 8.1.2) linked libraqm dynamically at runtime.


### PR DESCRIPTION
When building the docs, there is an error - https://github.com/python-pillow/Pillow/actions/runs/4334555177/jobs/7568531757#step:11:504
> (    installation: line  186) broken    https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#search-order-for-desktop-applications - Anchor 'search-order-for-desktop-applications' not found

Here's the page on the Wayback Machine, demonstrating that the anchor did exist once - https://web.archive.org/web/20221204000032/https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#search-order-for-uwp-apps

This PR removes the missing anchor from the link, and also updates the link text, as comparing https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order with the Wayback Machine link I can see that the title of the page changed capitalisation.

The link was added in #5365