### PR TITLE
Round duration when saving animated WebP images

### DIFF
--- a/Tests/test_file_webp_animated.py
+++ b/Tests/test_file_webp_animated.py
@@ -134,6 +134,18 @@ def test_timestamp_and_duration(tmp_path):
             ts += durations[frame]
 
 
+def test_float_duration(tmp_path):
+    temp_file = str(tmp_path / "temp.webp")
+    with Image.open("Tests/images/iss634.apng") as im:
+        assert im.info["duration"] == 70.0
+
+        im.save(temp_file, save_all=True)
+
+    with Image.open(temp_file) as reloaded:
+        reloaded.load()
+        assert reloaded.info["duration"] == 70
+
+
 def test_seeking(tmp_path):
     """
     Create an animated WebP file, and then try seeking through frames in reverse-order,

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -285,7 +285,7 @@ def _save_all(im, fp, filename):
                 # Append the frame to the animation encoder
                 enc.add(
                     frame.tobytes("raw", rawmode),
-                    timestamp,
+                    round(timestamp),
                     frame.size[0],
                     frame.size[1],
                     rawmode,
@@ -305,7 +305,7 @@ def _save_all(im, fp, filename):
         im.seek(cur_idx)
 
     # Force encoder to flush frames
-    enc.add(None, timestamp, 0, 0, "", lossless, quality, 0)
+    enc.add(None, round(timestamp), 0, 0, "", lossless, quality, 0)
 
     # Get the final output from the encoder
     data = enc.assemble(icc_profile, exif, xmp)


### PR DESCRIPTION
Helps #7015

Alternative to #6977. This uses `round()` instead of `int()` to better approximate the data, and has a test using one of our existing images.

Animated PNGs can have float durations
https://github.com/python-pillow/Pillow/blob/cdf5fd439cbe381e6c796acc3ab3150242d8e861/src/PIL/PngImagePlugin.py#L677
but when WebP goes to save the duration, it expects an integer.
https://github.com/python-pillow/Pillow/blob/cdf5fd439cbe381e6c796acc3ab3150242d8e861/src/PIL/WebPImagePlugin.py#L308
https://github.com/python-pillow/Pillow/blob/cdf5fd439cbe381e6c796acc3ab3150242d8e861/src/_webp.c#L206-L209
The WebP API itself also expects the duration to be an integer. See https://developers.google.com/speed/webp/docs/container-api#webpanimencoderadd
> int WebPAnimEncoderAdd(
    WebPAnimEncoder* enc, struct WebPPicture* frame, int timestamp_ms,
    const struct WebPConfig* config);

So this PR rounds the duration.