### PR TITLE
Added __int__ to IFDRational for Python >= 3.11

### DIFF
--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -425,6 +425,9 @@ class IFDRational(Rational):
     __ceil__ = _delegate("__ceil__")
     __floor__ = _delegate("__floor__")
     __round__ = _delegate("__round__")
+    # Python >= 3.11
+    if hasattr(Fraction, "__int__"):
+        __int__ = _delegate("__int__")
 
 
 class ImageFileDirectory_v2(MutableMapping):


### PR DESCRIPTION
In Python 3.11, the following code
```python
from PIL.TiffImagePlugin import IFDRational
ifd = IFDRational(1)
int(ifd)
```
gives
```
DeprecationWarning: The delegation of int() to __trunc__ is deprecated.
  int(ifd)
```

I noticed the deprecation warning in https://github.com/python-pillow/Pillow/actions/runs/4342791039/jobs/7584046826#step:8:4230

This deprecation was added in https://github.com/python/cpython/issues/89140

This PR fixes the matter by adding `__int__` to IFDRational - but only for Python >= 3.11. Below Python 3.11, this change gives
```
AttributeError: 'Fraction' object has no attribute '__int__'. Did you mean: '__init__'?
```