### PR TITLE
Move potential error earlier

### DIFF
--- a/src/_webp.c
+++ b/src/_webp.c
@@ -955,6 +955,13 @@ addTransparencyFlagToModule(PyObject *m) {
 
 static int
 setup_module(PyObject *m) {
+#ifdef HAVE_WEBPANIM
+    /* Ready object types */
+    if (PyType_Ready(&WebPAnimDecoder_Type) < 0 ||
+        PyType_Ready(&WebPAnimEncoder_Type) < 0) {
+        return -1;
+    }
+#endif
     PyObject *d = PyModule_GetDict(m);
     addMuxFlagToModule(m);
     addAnimFlagToModule(m);
@@ -963,13 +970,6 @@ setup_module(PyObject *m) {
     PyDict_SetItemString(
         d, "webpdecoder_version", PyUnicode_FromString(WebPDecoderVersion_str()));
 
-#ifdef HAVE_WEBPANIM
-    /* Ready object types */
-    if (PyType_Ready(&WebPAnimDecoder_Type) < 0 ||
-        PyType_Ready(&WebPAnimEncoder_Type) < 0) {
-        return -1;
-    }
-#endif
     return 0;
 }
 


### PR DESCRIPTION
For
https://github.com/python-pillow/Pillow/blob/6b71090828a37340a4e552ad24602deb71c119aa/src/_webp.c#L956-L974
this PR rearranges the code to run the `PyType_Ready` conditional first, so it the code fails earlier, and `d` is not created for potentially no reason ([`m` isn't used if `setup_module` returns `-1`](https://github.com/python-pillow/Pillow/blob/6b71090828a37340a4e552ad24602deb71c119aa/src/_webp.c#L988-L993)).