### PR TITLE
Test build_prepare.py with multiple Python versions in AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,8 +30,8 @@ install:
 - ..\pillow-depends\gs1000w32.exe /S
 - path c:\nasm-2.15.05;C:\Program Files (x86)\gs\gs10.0.0\bin;%PATH%
 - cd c:\pillow\winbuild\
+- '%PYTHON%\%EXECUTABLE% c:\pillow\winbuild\build_prepare.py -v --depends=C:\pillow-depends'
 - ps: |
-        c:\python37\python.exe c:\pillow\winbuild\build_prepare.py -v --depends=C:\pillow-depends\
         c:\pillow\winbuild\build\build_dep_all.cmd
         $host.SetShouldExit(0)
 - path C:\pillow\winbuild\build\bin;%PATH%

--- a/winbuild/build.rst
+++ b/winbuild/build.rst
@@ -100,7 +100,7 @@ The following is a simplified version of the script used on AppVeyor::
 
     set PYTHON=C:\Python38\bin
     cd /D C:\Pillow\winbuild
-    C:\Python37\bin\python.exe build_prepare.py -v --depends=C:\pillow-depends
+    %PYTHON%\python.exe build_prepare.py -v --depends=C:\pillow-depends
     build\build_dep_all.cmd
     build\build_pillow.cmd install
     cd ..


### PR DESCRIPTION
At the moment, AppVeyor always uses Python 3.7 when running `build_prepare.py`.
https://github.com/python-pillow/Pillow/blob/6b71090828a37340a4e552ad24602deb71c119aa/.appveyor.yml#L34

This PR changes it to use the Python version from the matrix, so that we can test it more thoroughly.