### PR TITLE
Close OleFileIO instance when closing or exiting FPX or MIC

### DIFF
--- a/Tests/test_file_bufrstub.py
+++ b/Tests/test_file_bufrstub.py
@@ -56,6 +56,7 @@ def test_handler(tmp_path):
 
         def load(self, im):
             self.loaded = True
+            im.fp.close()
             return Image.new("RGB", (1, 1))
 
         def save(self, im, fp, filename):

--- a/Tests/test_file_fits.py
+++ b/Tests/test_file_fits.py
@@ -60,6 +60,7 @@ def test_stub_deprecated():
 
         def load(self, im):
             self.loaded = True
+            im.fp.close()
             return Image.new("RGB", (1, 1))
 
     handler = Handler()

--- a/Tests/test_file_fpx.py
+++ b/Tests/test_file_fpx.py
@@ -18,6 +18,16 @@ def test_sanity():
         assert_image_equal_tofile(im, "Tests/images/input_bw_one_band.png")
 
 
+def test_close():
+    with Image.open("Tests/images/input_bw_one_band.fpx") as im:
+        pass
+    assert im.ole.fp.closed
+
+    im = Image.open("Tests/images/input_bw_one_band.fpx")
+    im.close()
+    assert im.ole.fp.closed
+
+
 def test_invalid_file():
     # Test an invalid OLE file
     invalid_file = "Tests/images/flower.jpg"

--- a/Tests/test_file_gribstub.py
+++ b/Tests/test_file_gribstub.py
@@ -56,6 +56,7 @@ def test_handler(tmp_path):
 
         def load(self, im):
             self.loaded = True
+            im.fp.close()
             return Image.new("RGB", (1, 1))
 
         def save(self, im, fp, filename):

--- a/Tests/test_file_hdf5stub.py
+++ b/Tests/test_file_hdf5stub.py
@@ -57,6 +57,7 @@ def test_handler(tmp_path):
 
         def load(self, im):
             self.loaded = True
+            im.fp.close()
             return Image.new("RGB", (1, 1))
 
         def save(self, im, fp, filename):

--- a/Tests/test_file_mic.py
+++ b/Tests/test_file_mic.py
@@ -51,6 +51,16 @@ def test_seek():
         assert im.tell() == 0
 
 
+def test_close():
+    with Image.open(TEST_FILE) as im:
+        pass
+    assert im.ole.fp.closed
+
+    im = Image.open(TEST_FILE)
+    im.close()
+    assert im.ole.fp.closed
+
+
 def test_invalid_file():
     # Test an invalid OLE file
     invalid_file = "Tests/images/flower.jpg"

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -55,8 +55,8 @@ def test_show_without_viewers():
     viewers = ImageShow._viewers
     ImageShow._viewers = []
 
-    im = hopper()
-    assert not ImageShow.show(im)
+    with hopper() as im:
+        assert not ImageShow.show(im)
 
     ImageShow._viewers = viewers
 

--- a/src/PIL/FpxImagePlugin.py
+++ b/src/PIL/FpxImagePlugin.py
@@ -235,6 +235,14 @@ class FpxImageFile(ImageFile.ImageFile):
 
         return ImageFile.ImageFile.load(self)
 
+    def close(self):
+        self.ole.close()
+        super().close()
+
+    def __exit__(self, *args):
+        self.ole.close()
+        super().__exit__()
+
 
 #
 # --------------------------------------------------------------------

--- a/src/PIL/MicImagePlugin.py
+++ b/src/PIL/MicImagePlugin.py
@@ -89,6 +89,14 @@ class MicImageFile(TiffImagePlugin.TiffImageFile):
     def tell(self):
         return self.frame
 
+    def close(self):
+        self.ole.close()
+        super().close()
+
+    def __exit__(self, *args):
+        self.ole.close()
+        super().__exit__()
+
 
 #
 # --------------------------------------------------------------------


### PR DESCRIPTION
There are various [unclosed file warnings in GHA for main at the moment](https://github.com/python-pillow/Pillow/actions/runs/4384362988/jobs/7675750272#step:8:4182). Most of them are problems in the tests, and I've fixed those here, but there are also warnings for unclosed FPX and MIC files.

Those two formats use OleFileIO. This PR fixes those by closing `self.ole` when closing or exiting images of those formats.