### PR TITLE
Allow libtiff_support_custom_tags to be missing

### DIFF
--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1807,7 +1807,7 @@ def _save(im, fp, filename):
             # Custom items are supported for int, float, unicode, string and byte
             # values. Other types and tuples require a tagtype.
             if tag not in TiffTags.LIBTIFF_CORE:
-                if not Image.core.libtiff_support_custom_tags:
+                if not getattr(Image.core, "libtiff_support_custom_tags", False):
                     continue
 
                 if tag in ifd.tagtype:


### PR DESCRIPTION
Resolves #7019

`Image.core.libtiff_support_custom_tags` may be missing, if libtiff is unavailable.

https://github.com/python-pillow/Pillow/blob/2d5f451f582262f3b26fa23ad43e1dcd69715d90/src/_imaging.c#L4256-L4272