### PR TITLE
Do not render text if image has zero width or height

### DIFF
--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -767,18 +767,19 @@ class FreeTypeFont:
         offset = offset[0] - stroke_width, offset[1] - stroke_width
         Image._decompression_bomb_check(size)
         im = fill("RGBA" if mode == "RGBA" else "L", size, 0)
-        self.font.render(
-            text,
-            im.id,
-            mode,
-            direction,
-            features,
-            language,
-            stroke_width,
-            ink,
-            start[0],
-            start[1],
-        )
+        if min(size):
+            self.font.render(
+                text,
+                im.id,
+                mode,
+                direction,
+                features,
+                language,
+                stroke_width,
+                ink,
+                start[0],
+                start[1],
+            )
         return im, offset
 
     def font_variant(


### PR DESCRIPTION
In [`FreeTypeFont.getmask2()`](https://pillow.readthedocs.io/en/stable/reference/ImageFont.html#PIL.ImageFont.FreeTypeFont.getmask2), only spend time rendering text if the image it will be rendered onto has a non-zero width or height.