### PR TITLE
Restored deleted docstring

### DIFF
--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -463,6 +463,7 @@ class ImageDraw:
         *args,
         **kwargs,
     ):
+        """Draw text."""
         if self._multiline_check(text):
             return self.multiline_text(
                 xy,


### PR DESCRIPTION
A combination of https://github.com/python-pillow/Pillow/pull/1177/commits/77169b2fdba9546c9f6f3842a48c7ba2ee370b16 (which inserted private methods between a comment and `text()`) and https://github.com/python-pillow/Pillow/pull/1926/commits/934485269c4286e9e890597877d73e15a091eb22 (which moved that comment into the first method below it) led to a description for `text()` being in `_multiline_check()` instead.

This restores the docstring to `text()`, as a sequel to #7025