### PR TITLE
Add pillow logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img width="248" height="250" src="https://raw.githubusercontent.com/python-pillow/pillow-logo/main/pillow-logo-248x250.png" alt="Pillow logo">
+    <img width="248" height="250" src="https://python-pillow.org/images/pillow-logo-light-text-1280x640.png" alt="Pillow logo">
 </p>
 
 # Pillow


### PR DESCRIPTION
old pillow logo was not working so i added pillow logo from official pillow site

Fixes #
The pillow logo wasn't working in readme.md 

Changes proposed in this pull request:
- replaced the broken link to new working one from python-pillow.org