### PR TITLE
Load before getting size in __array_interface__

### DIFF
--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -4,7 +4,7 @@ import pytest
 
 from PIL import Image
 
-from .helper import assert_deep_equal, assert_image, hopper
+from .helper import assert_deep_equal, assert_image, hopper, skip_unless_feature
 
 numpy = pytest.importorskip("numpy", reason="NumPy not installed")
 
@@ -217,6 +217,13 @@ def test_zero_size():
     im = Image.fromarray(numpy.empty((0, 0), dtype=numpy.uint8))
 
     assert im.size == (0, 0)
+
+
+@skip_unless_feature("libtiff")
+def test_load_first():
+    with Image.open("Tests/images/g4_orientation_5.tif") as im:
+        a = numpy.array(im)
+        assert a.shape == (88, 590)
 
 
 def test_bool():

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -686,11 +686,7 @@ class Image:
     @property
     def __array_interface__(self):
         # numpy array interface support
-        new = {}
-        shape, typestr = _conv_type_shape(self)
-        new["shape"] = shape
-        new["typestr"] = typestr
-        new["version"] = 3
+        new = {"version": 3}
         try:
             if self.mode == "1":
                 # Binary images need to be extended from bits to bytes
@@ -709,6 +705,7 @@ class Image:
                     if parse_version(numpy.__version__) < parse_version("1.23"):
                         warnings.warn(e)
             raise
+        new["shape"], new["typestr"] = _conv_type_shape(self)
         return new
 
     def __getstate__(self):


### PR DESCRIPTION
Resolves #7032

Rearranges code so that the image is loaded before setting the size, as TIFF images may be [rotated and have the size changed in `load_end()`](https://github.com/python-pillow/Pillow/blob/f1aeb5ea7aa7588f8b5544d8f3916c569503dd5f/src/PIL/TiffImagePlugin.py#L1192-L1196).

This is similar to #6186 for `thumbnail()` and #6190 for `resize()`, except now for `__array_interface__`.