### PR TITLE
Install Ghostscript using Chocolatey

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,8 +27,8 @@ install:
 - mv c:\pillow-depends-main c:\pillow-depends
 - xcopy /S /Y c:\test-images-main\* c:\pillow\tests\images
 - 7z x ..\pillow-depends\nasm-2.15.05-win64.zip -oc:\
-- ..\pillow-depends\gs1000w32.exe /S
-- path c:\nasm-2.15.05;C:\Program Files (x86)\gs\gs10.0.0\bin;%PATH%
+- choco install ghostscript --version=10.0.0.20230317
+- path c:\nasm-2.15.05;C:\Program Files\gs\gs10.00.0\bin;%PATH%
 - cd c:\pillow\winbuild\
 - ps: |
         c:\python37\python.exe c:\pillow\winbuild\build_prepare.py -v --depends=C:\pillow-depends\

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -74,8 +74,8 @@ jobs:
         7z x winbuild\depends\nasm-2.15.05-win64.zip "-o$env:RUNNER_WORKSPACE\"
         echo "$env:RUNNER_WORKSPACE\nasm-2.15.05" >> $env:GITHUB_PATH
 
-        winbuild\depends\gs1000w32.exe /S
-        echo "C:\Program Files (x86)\gs\gs10.0.0\bin" >> $env:GITHUB_PATH
+        choco install ghostscript --version=10.0.0.20230317
+        echo "C:\Program Files\gs\gs10.00.0\bin" >> $env:GITHUB_PATH
 
         # Install extra test images
         xcopy /S /Y Tests\test-images\* Tests\images


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/7033#issuecomment-1480327216 pointed out that despite our use of the Ghostscript installer,

https://github.com/python-pillow/Pillow/blob/4e0ac449a54539d91486d726b6ac9db948d42f06/.github/workflows/test-windows.yml#L77-L78

Ghostscript is not being detected in our CI builds, either in [GitHub Actions](https://github.com/python-pillow/Pillow/actions/runs/4508121856/jobs/7936778506#step:27:3335) or in [AppVeyor](https://ci.appveyor.com/project/Python-pillow/pillow/builds/46585687/job/pdgrtu2yo3slrfgf?fullLog=true#L6176).

This PR proposes using [Chocolately](https://chocolatey.org/) instead, a package manager already installed in our CIs.