### PR TITLE
Removed absolute path to ldconfig

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -166,14 +166,14 @@ def _find_library_dirs_ldconfig():
 
         # Assuming GLIBC's ldconfig (with option -p)
         # Alpine Linux uses musl that can't print cache
-        args = ["/sbin/ldconfig", "-p"]
+        args = ["ldconfig", "-p"]
         expr = rf".*\({abi_type}.*\) => (.*)"
         env = dict(os.environ)
         env["LC_ALL"] = "C"
         env["LANG"] = "C"
 
     elif sys.platform.startswith("freebsd"):
-        args = ["/sbin/ldconfig", "-r"]
+        args = ["ldconfig", "-r"]
         expr = r".* => (.*)"
         env = {}
 


### PR DESCRIPTION
Helps #7040

https://github.com/python-pillow/Pillow/issues/7040#issuecomment-1488664881
> the path of ldconfig is hardcoded in the setup, relying on the ldconfig from $PATH would be flexible to different systems.