### PR TITLE
Do not discard error message if _imagingft fails to import

### DIFF
--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -54,17 +54,12 @@ def __getattr__(name):
     raise AttributeError(msg)
 
 
-class _ImagingFtNotInstalled:
-    # module placeholder
-    def __getattr__(self, id):
-        msg = "The _imagingft C module is not installed"
-        raise ImportError(msg)
-
-
 try:
     from . import _imagingft as core
-except ImportError:
-    core = _ImagingFtNotInstalled()
+except ImportError as ex:
+    from ._util import DeferredError
+
+    core = DeferredError(ex)
 
 
 _UNSPECIFIED = object()

--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -33,7 +33,10 @@ def check_module(feature):
     try:
         __import__(module)
         return True
-    except ImportError:
+    except ModuleNotFoundError:
+        return False
+    except ImportError as ex:
+        warnings.warn(str(ex))
         return False
 
 
@@ -145,7 +148,10 @@ def check_feature(feature):
     try:
         imported_module = __import__(module, fromlist=["PIL"])
         return getattr(imported_module, flag)
-    except ImportError:
+    except ModuleNotFoundError:
+        return None
+    except ImportError as ex:
+        warnings.warn(str(ex))
         return None
 
 

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -33,12 +33,6 @@
 #include FT_COLOR_H
 #endif
 
-#define KEEP_PY_UNICODE
-
-#if !defined(FT_LOAD_TARGET_MONO)
-#define FT_LOAD_TARGET_MONO FT_LOAD_MONOCHROME
-#endif
-
 /* -------------------------------------------------------------------- */
 /* error table */
 
@@ -420,11 +414,9 @@ text_layout_fallback(
     if (mask) {
         load_flags |= FT_LOAD_TARGET_MONO;
     }
-#ifdef FT_LOAD_COLOR
     if (color) {
         load_flags |= FT_LOAD_COLOR;
     }
-#endif
     for (i = 0; font_getchar(string, i, &ch); i++) {
         (*glyph_info)[i].index = FT_Get_Char_Index(self->face, ch);
         error = FT_Load_Glyph(self->face, (*glyph_info)[i].index, load_flags);
@@ -581,11 +573,9 @@ font_getsize(FontObject *self, PyObject *args) {
     if (mask) {
         load_flags |= FT_LOAD_TARGET_MONO;
     }
-#ifdef FT_LOAD_COLOR
     if (color) {
         load_flags |= FT_LOAD_COLOR;
     }
-#endif
 
     /*
      * text bounds are given by:
@@ -844,11 +834,9 @@ font_render(FontObject *self, PyObject *args) {
     if (mask) {
         load_flags |= FT_LOAD_TARGET_MONO;
     }
-#ifdef FT_LOAD_COLOR
     if (color) {
         load_flags |= FT_LOAD_COLOR;
     }
-#endif
 
     /*
      * calculate x_min and y_max
@@ -958,13 +946,11 @@ font_render(FontObject *self, PyObject *args) {
                 /* bitmap is now FT_PIXEL_MODE_GRAY, fall through */
             case FT_PIXEL_MODE_GRAY:
                 break;
-#ifdef FT_LOAD_COLOR
             case FT_PIXEL_MODE_BGRA:
                 if (color) {
                     break;
                 }
                 /* we didn't ask for color, fall through to default */
-#endif
             default:
                 PyErr_SetString(PyExc_OSError, "unsupported bitmap pixel mode");
                 goto glyph_error;
@@ -995,7 +981,6 @@ font_render(FontObject *self, PyObject *args) {
                 } else {
                     target = im->image8[yy] + xx;
                 }
-#ifdef FT_LOAD_COLOR
                 if (color && bitmap.pixel_mode == FT_PIXEL_MODE_BGRA) {
                     /* paste color glyph */
                     for (k = x0; k < x1; k++) {
@@ -1010,9 +995,7 @@ font_render(FontObject *self, PyObject *args) {
                             target[k * 4 + 3] = source[k * 4 + 3];
                         }
                     }
-                } else
-#endif
-                    if (bitmap.pixel_mode == FT_PIXEL_MODE_GRAY) {
+                } else if (bitmap.pixel_mode == FT_PIXEL_MODE_GRAY) {
                     if (color) {
                         unsigned char *ink = (unsigned char *)&foreground_ink;
                         for (k = x0; k < x1; k++) {


### PR DESCRIPTION
Helps #7040 

Changes:
* use `_util.DeferredError` if `_imagingft` fails to import instead of a custom helper from before the fork (similarly to `ImageCms`, added in #600),
* if a module fails to import but is present (i.e. triggers `ImportError` but not `ModuleNotFoundError`), raise a warning in `PIL.features`,
* remove no longer needed backwards compatibility code:
  * `FT_LOAD_COLOR` was added in [FreeType 2.5](https://freetype.org/freetype2/docs/reference/ft2-base_interface.html#ft_load_color), Pillow currently requires FreeType>=2.8 (#5777)
  * `FT_LOAD_TARGET_MONO` version added is undocumented, but has been around since [FreeType 2.1.3](https://gitlab.freedesktop.org/freetype/freetype/-/blob/0db6997026a05798eb0cbcbb3b37bf6121fb5f6a/docs/CHANGES#L3700),
  * remove `#define KEEP_PY_UNICODE`, was only used in file `py3.h` which was removed in #4109
 
I've tested these changes by compiling Pillow in a Fedora 26 Docker container (with FreeType 2.7.1 and no other optional dependencies) with an intentional error in `_imagingft`:

```
# python3.7 -c "import PIL.ImageFont
> PIL.ImageFont.core.test"
Traceback (most recent call last):
  File "<string>", line 2, in <module>
  File "/usr/lib64/python3.7/site-packages/PIL/_util.py", line 19, in __getattr__
    raise self.ex
  File "/usr/lib64/python3.7/site-packages/PIL/ImageFont.py", line 58, in <module>
    from . import _imagingft as core
ImportError: /usr/lib64/python3.7/site-packages/PIL/_imagingft.cpython-37m-x86_64-linux-gnu.so: undefined symbol: FT_Done_MM_Var
```

```
# python3.7 -m PIL
--------------------------------------------------------------------
Pillow 9.5.0.dev0
Python 3.7.0b4 (default, May 16 2018, 15:51:23)
       [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
--------------------------------------------------------------------
Python modules loaded from /usr/lib64/python3.7/site-packages/PIL
Binary modules loaded from /usr/lib64/python3.7/site-packages/PIL
--------------------------------------------------------------------
--- PIL CORE support ok, compiled for 9.5.0.dev0
--- TKINTER support ok, loaded 8.6
/usr/lib64/python3.7/site-packages/PIL/features.py:39: UserWarning: /usr/lib64/python3.7/site-packages/PIL/_imagingft.cpython-37m-x86_64-linux-gnu.so: undefined symbol: FT_Done_MM_Var
  warnings.warn(str(ex))
*** FREETYPE2 support not installed
*** LITTLECMS2 support not installed
*** WEBP support not installed
*** WEBP Transparency support not installed
*** WEBPMUX support not installed
*** WEBP Animation support not installed
--- JPEG support ok, compiled for libjpeg-turbo 1.5.3
*** OPENJPEG (JPEG2000) support not installed
--- ZLIB (PNG/ZIP) support ok, loaded 1.2.11
*** LIBTIFF support not installed
/usr/lib64/python3.7/site-packages/PIL/features.py:154: UserWarning: /usr/lib64/python3.7/site-packages/PIL/_imagingft.cpython-37m-x86_64-linux-gnu.so: undefined symbol: FT_Done_MM_Var
  warnings.warn(str(ex))
*** RAQM (Bidirectional Text) support not installed
*** LIBIMAGEQUANT (Quantization method) support not installed
*** XCB (X protocol) support not installed
--------------------------------------------------------------------
...
``` 