### PR TITLE
Document handling of modes when converting to or from NumPy

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3041,6 +3041,10 @@ def fromarray(obj, mode=None):
     If ``obj`` is not contiguous, then the ``tobytes`` method is called
     and :py:func:`~PIL.Image.frombuffer` is used.
 
+    In the case of NumPy, be aware that Pillow modes do not always correspond
+    to NumPy dtypes. Pillow modes only offer 1-bit pixels, 8-bit pixels,
+    32-signed integer pixels and 32-bit floating point pixels.
+
     Pillow images can also be converted to arrays::
 
       from PIL import Image

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3031,21 +3031,25 @@ def frombuffer(mode, size, data, decoder_name="raw", *args):
 def fromarray(obj, mode=None):
     """
     Creates an image memory from an object exporting the array interface
-    (using the buffer protocol).
+    (using the buffer protocol)::
+
+      from PIL import Image
+      import numpy as np
+      a = np.zeros((5, 5))
+      im = Image.fromarray(a)
 
     If ``obj`` is not contiguous, then the ``tobytes`` method is called
     and :py:func:`~PIL.Image.frombuffer` is used.
 
-    If you have an image in NumPy::
+    Pillow images can also be converted to arrays::
 
       from PIL import Image
       import numpy as np
       im = Image.open("hopper.jpg")
       a = np.asarray(im)
 
-    Then this can be used to convert it to a Pillow image::
-
-      im = Image.fromarray(a)
+    When converting Pillow images to arrays however, only pixel values are
+    transferred. This means that P and PA mode images will lose their palette.
 
     :param obj: Object with array interface
     :param mode: Optional mode to use when reading ``obj``. Will be determined from


### PR DESCRIPTION
Resolves #5850 by documenting the available pixel types of Pillow modes, and noting that they do not always correspond to NumPy dtypes.

Helps #7045 by documenting that converting P or PA images to NumPy will not include the palette.