### PR TITLE
Fix warning that variable may be uninitialized

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -502,7 +502,7 @@ getink(PyObject *color, Imaging im, char *ink) {
        be cast to either UINT8 or INT32 */
 
     int rIsInt = 0;
-    int tupleSize;
+    int tupleSize = 0;
     if (PyTuple_Check(color)) {
         tupleSize = PyTuple_GET_SIZE(color);
         if (tupleSize == 1) {

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -502,12 +502,9 @@ getink(PyObject *color, Imaging im, char *ink) {
        be cast to either UINT8 or INT32 */
 
     int rIsInt = 0;
-    int tupleSize = 0;
-    if (PyTuple_Check(color)) {
-        tupleSize = PyTuple_GET_SIZE(color);
-        if (tupleSize == 1) {
-            color = PyTuple_GetItem(color, 0);
-        }
+    int tupleSize = PyTuple_Check(color) ? PyTuple_GET_SIZE(color) : -1;
+    if (tupleSize == 1) {
+        color = PyTuple_GetItem(color, 0);
     }
     if (im->type == IMAGING_TYPE_UINT8 || im->type == IMAGING_TYPE_INT32 ||
         im->type == IMAGING_TYPE_SPECIAL) {
@@ -521,7 +518,7 @@ getink(PyObject *color, Imaging im, char *ink) {
             PyErr_SetString(
                 PyExc_TypeError, "color must be int or single-element tuple");
             return NULL;
-        } else if (!PyTuple_Check(color)) {
+        } else if (tupleSize == -1) {
             PyErr_SetString(PyExc_TypeError, "color must be int or tuple");
             return NULL;
         }


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/4571913703/jobs/8070643875#step:7:66
>   src/_imaging.c: In function ‘getink’:
>  src/_imaging.c:555:44: warning: ‘tupleSize’ may be used uninitialized in this function [-Wmaybe-uninitialized]
>    555 |                         if (tupleSize != 1 && tupleSize != 2) {
>        |                             ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~

This variable was added in #7010.