### PR TITLE
Clear PPM half token after use

### DIFF
--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -256,6 +256,16 @@ def test_truncated_file(tmp_path):
             im.load()
 
 
+def test_not_enough_image_data(tmp_path):
+    path = str(tmp_path / "temp.ppm")
+    with open(path, "wb") as f:
+        f.write(b"P2 1 2 255 255")
+
+    with Image.open(path) as im:
+        with pytest.raises(ValueError):
+            im.load()
+
+
 @pytest.mark.parametrize("maxval", (b"0", b"65536"))
 def test_invalid_maxval(maxval, tmp_path):
     path = str(tmp_path / "temp.ppm")

--- a/docs/releasenotes/9.5.0.rst
+++ b/docs/releasenotes/9.5.0.rst
@@ -62,10 +62,19 @@ PLT markers.
 Security
 ========
 
-TODO
-^^^^
+Clear PPM half token after use
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-TODO
+Image files that are small on disk are often prevented from expanding to be
+big images consuming a large amount of resources simply because they lack the
+data to populate those resources.
+
+PpmImagePlugin might hold onto the last data read for a pixel value in case the
+pixel value has not been finished yet. However, that data was not being cleared
+afterwards, meaning that infinite data could be available to fill any image
+size.
+
+That data is now cleared after use.
 
 Other Changes
 =============

--- a/src/PIL/PpmImagePlugin.py
+++ b/src/PIL/PpmImagePlugin.py
@@ -237,6 +237,7 @@ class PpmPlainDecoder(ImageFile.PyDecoder):
 
             if half_token:
                 block = half_token + block  # stitch half_token to new block
+                half_token = False
 
             tokens = block.split()
 


### PR DESCRIPTION
Resolves #6963

When PpmImagePlugin is reading an image, it [only reads `ImageFile.SAFEBLOCK` bytes at a time.](https://github.com/python-pillow/Pillow/blob/879e77a44604b31e271711898b035a5caba8cb73/src/PIL/PpmImagePlugin.py#L151-L152)

So when looping through this data, if there is no space after the last digit, [it saves this for the next loop](https://github.com/python-pillow/Pillow/blob/879e77a44604b31e271711898b035a5caba8cb73/src/PIL/PpmImagePlugin.py#L226-L244), in case the read operation stopped partway through a series of digits.

Except that `half_token` isn't cleared after it is used. That means that it keeps getting used, and so infinite data is available to fill the image size.

This PR fixes that.