### PR TITLE
Added ImageSourceData to TAGS_V2

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -668,10 +668,15 @@ class TestFileLibTiff(LibTiffTestCase):
             assert reloaded.tag_v2[530] == (1, 1)
             assert reloaded.tag_v2[532] == (0, 255, 128, 255, 128, 255)
 
-    def test_save_imagesourcedata(self, tmp_path):
+    def test_exif_ifd(self, tmp_path):
         outfile = str(tmp_path / "temp.tif")
         with Image.open("Tests/images/tiff_adobe_deflate.tif") as im:
+            assert im.tag_v2[34665] == 125456
             im.save(outfile)
+
+        with Image.open(outfile) as reloaded:
+            if Image.core.libtiff_support_custom_tags:
+                assert reloaded.tag_v2[34665] == 125456
 
     def test_crashing_metadata(self, tmp_path):
         # issue 1597

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -668,6 +668,11 @@ class TestFileLibTiff(LibTiffTestCase):
             assert reloaded.tag_v2[530] == (1, 1)
             assert reloaded.tag_v2[532] == (0, 255, 128, 255, 128, 255)
 
+    def test_save_imagesourcedata(self, tmp_path):
+        outfile = str(tmp_path / "temp.tif")
+        with Image.open("Tests/images/tiff_adobe_deflate.tif") as im:
+            im.save(outfile)
+
     def test_crashing_metadata(self, tmp_path):
         # issue 1597
         with Image.open("Tests/images/rdf.tif") as im:

--- a/docs/releasenotes/9.5.0.rst
+++ b/docs/releasenotes/9.5.0.rst
@@ -72,9 +72,17 @@ data to populate those resources.
 PpmImagePlugin might hold onto the last data read for a pixel value in case the
 pixel value has not been finished yet. However, that data was not being cleared
 afterwards, meaning that infinite data could be available to fill any image
-size.
+size. This has been present since Pillow 9.2.0.
 
 That data is now cleared after use.
+
+Saving TIFF tag ImageSourceData
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If Pillow incorrectly saved the TIFF tag ImageSourceData as ASCII instead of
+UNDEFINED, a segmentation fault was triggered.
+
+The correct tag type will now be used by default instead.
 
 Other Changes
 =============

--- a/src/PIL/TiffTags.py
+++ b/src/PIL/TiffTags.py
@@ -195,6 +195,7 @@ TAGS_V2 = {
     34675: ("ICCProfile", UNDEFINED, 1),
     34853: ("GPSInfoIFD", LONG, 1),
     36864: ("ExifVersion", UNDEFINED, 1),
+    37724: ("ImageSourceData", UNDEFINED, 1),
     40965: ("InteroperabilityIFD", LONG, 1),
     41730: ("CFAPattern", UNDEFINED, 1),
     # MPInfo

--- a/src/encode.c
+++ b/src/encode.c
@@ -904,7 +904,7 @@ PyImaging_LibTiffEncoderNew(PyObject *self, PyObject *args) {
                     &encoder->state, (ttag_t)key_int, (UINT16)PyLong_AsLong(value));
             } else if (type == TIFF_LONG) {
                 status = ImagingLibTiffSetField(
-                    &encoder->state, (ttag_t)key_int, (UINT32)PyLong_AsLong(value));
+                    &encoder->state, (ttag_t)key_int, PyLong_AsLongLong(value));
             } else if (type == TIFF_SSHORT) {
                 status = ImagingLibTiffSetField(
                     &encoder->state, (ttag_t)key_int, (INT16)PyLong_AsLong(value));


### PR DESCRIPTION
In #7008, two images were reported to cause a RuntimeError. Testing on my machine, I found that this caused a segfault instead.

It turns out that this was due to an incorrect tag type being used for [ImageSourceData](https://www.awaresystems.be/imaging/tiff/tifftags/imagesourcedata.html).

Except then I found the RuntimeError, happening on [32-bit Windows.](https://github.com/radarhere/Pillow/actions/runs/4404887057/jobs/7715072523#step:27:726)
```
E       RuntimeError: Error setting from dictionary

C:\hostedtoolcache\windows\Python\3.7.9\x86\lib\site-packages\pillow-9.5.0.dev0-py3.7-win32.egg\PIL\Image.py:437: RuntimeError
---------------------------- Captured stderr call -----------------------------
_TIFFVSetField: C:\Users\runneradmin\AppData\Local\Temp\pytest-of-runneradmin\pytest-0\test_save_imagesourcedata0\temp.tif: Bad LONG8 or IFD8 value 1000052142389717520 for "EXIFIFDOffset" tag 34665 in ClassicTIFF. Tag won't be written to file.
```
When it states 'Bad LONG8 or IFD8 value 1000052142389717520 for "EXIFIFDOffset" tag 34665', that number wasn't the value being passed through for the EXIF IFD offset from Python. When we are about to pass the value through to libtiff in C, we cast it to `UINT32`.
https://github.com/python-pillow/Pillow/blob/31669013d420c2a532f5be6c5631827fe36e6f70/src/encode.c#L906-L907

When libtiff is [throwing the error](https://gitlab.com/libtiff/libtiff/-/blob/master/libtiff/tif_dir.c#L942-955), the variable is `uint64_t`. Changing `UINT32` to `uint64_t` fixed the RunTimeError.