### PR TITLE
Do not set size unnecessarily if image fails to open

### DIFF
--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -354,7 +354,6 @@ class EpsImageFile(ImageFile.ImageFile):
         check_required_header_comments()
 
         if not self._size:
-            self._size = 1, 1  # errors if this isn't set. why (1,1)?
             msg = "cannot determine EPS bounding box"
             raise OSError(msg)
 


### PR DESCRIPTION
When opening an image, if the size is missing, EpsImagePlugin sets the image size just before throwing an error.

https://github.com/python-pillow/Pillow/blob/4f7070e24c9cba8fc7ffab8d9f1c291977bbf183/src/PIL/EpsImagePlugin.py#L356-L359

But if an error is thrown when opening, there is no image afterwards. Consider this example code, derived from the test suite.

```python
import io
from PIL import Image

data = io.BytesIO(b'%!PS-Adobe-3.0 EPSF-3.0\n%%BoundingBox: a b c d\n10 setlinewidth\n10 10 moveto\n0 90 rlineto 90 0 rlineto 0 -90 rlineto closepath\nstroke')
try:
    im = Image.open(data)
except OSError:
    pass
print(im)
```
gives
```
Traceback (most recent call last):
  File "demo.py", line 9, in <module>
    print(im)
NameError: name 'im' is not defined
```

So if there is no image afterwards, why does it need a size? This PR removes the line.