### PR TITLE
Removed FIXME comment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -681,10 +681,6 @@ class pil_build_ext(build_ext):
                 # Add the directory to the include path so we can include
                 # <openjpeg.h> rather than having to cope with the versioned
                 # include path
-                # FIXME (melvyn-sopacua):
-                # At this point it's possible that best_path is already in
-                # self.compiler.include_dirs. Should investigate how that is
-                # possible.
                 _add_directory(self.compiler.include_dirs, best_path, 0)
                 feature.jpeg2000 = "openjp2"
                 feature.openjpeg_version = ".".join(str(x) for x in best_version)


### PR DESCRIPTION
PR #2544 resolved the immediate problem of #2563, but it also added a comment.

https://github.com/python-pillow/Pillow/blob/943a7a89c5b8b6cd3d531da756ece661f30b0c5b/setup.py#L684-L687

The user was thinking about the logic of the hardcoded paths in setup.py and our use of `pkg-config`, but it is possible for any given path to be in `self.compiler.include_dirs` from the very beginning of `build_extensions()` if the user added it in their install command, like
```
python3 -m pip install . -v --global-option=build_ext --global-option="-Iinsertedpath"
```

If the user wants to be eager in adding include directories, I don't think that is a problem. So this PR removes the comment, as it is at least misleading.