### PR TITLE
Release refinement

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -105,11 +105,18 @@ Released as needed privately to individual vendors for critical security-related
   ./update-pillow-tag.sh [[release tag]]
   ```
 * [ ] Download wheels from the [Pillow Wheel Builder release](https://github.com/python-pillow/pillow-wheels/releases)
-  and copy into `dist/`
+  and copy into `dist/`. For example using [GitHub CLI](https://github.com/cli/cli):
+  ```bash
+  gh release download --dir dist --pattern "*.whl" --repo python-pillow/pillow-wheels
+  ```
 
 ### Windows
 * [ ] Download the artifacts from the [GitHub Actions "Test Windows" workflow](https://github.com/python-pillow/Pillow/actions/workflows/test-windows.yml)
-  and copy into `dist/`
+  and copy into `dist/`For example using [GitHub CLI](https://github.com/cli/cli):
+  ```bash
+  gh run download --dir dist
+  # select dist-x.y.z
+  ```
 
 ## Publicize Release
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,7 @@ Released quarterly on January 2nd, April 1st, July 1st and October 15th.
 * [ ] Develop and prepare release in `main` branch.
 * [ ] Check [GitHub Actions](https://github.com/python-pillow/Pillow/actions) and [AppVeyor](https://ci.appveyor.com/project/python-pillow/Pillow) to confirm passing tests in `main` branch.
 * [ ] Check that all of the wheel builds [Pillow Wheel Builder](https://github.com/python-pillow/pillow-wheels) pass the tests in Travis CI and GitHub Actions.
-* [ ] In compliance with [PEP 440](https://www.python.org/dev/peps/pep-0440/), update version identifier in `src/PIL/_version.py`
+* [ ] In compliance with [PEP 440](https://peps.python.org/pep-0440/), update version identifier in `src/PIL/_version.py`
 * [ ] Update `CHANGES.rst`.
 * [ ] Run pre-release check via `make release-test` in a freshly cloned repo.
 * [ ] Create branch and tag for release e.g.:
@@ -31,7 +31,7 @@ Released quarterly on January 2nd, April 1st, July 1st and October 15th.
   python3 -m twine upload dist/Pillow-5.2.0*
   ```
 * [ ] Publish the [release on GitHub](https://github.com/python-pillow/Pillow/releases)
-* [ ] In compliance with [PEP 440](https://www.python.org/dev/peps/pep-0440/),
+* [ ] In compliance with [PEP 440](https://peps.python.org/pep-0440/),
       increment and append `.dev0` to version identifier in `src/PIL/_version.py` and then:
   ```bash
   git push --all
@@ -51,7 +51,7 @@ Released as needed for security, installation or critical bug fixes.
 
 
 * [ ] Check [GitHub Actions](https://github.com/python-pillow/Pillow/actions) and [AppVeyor](https://ci.appveyor.com/project/python-pillow/Pillow) to confirm passing tests in release branch e.g. `5.2.x`.
-* [ ] In compliance with [PEP 440](https://www.python.org/dev/peps/pep-0440/), update version identifier in `src/PIL/_version.py`
+* [ ] In compliance with [PEP 440](https://peps.python.org/pep-0440/), update version identifier in `src/PIL/_version.py`
 * [ ] Run pre-release check via `make release-test`.
 * [ ] Create tag for release e.g.:
   ```bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -97,11 +97,7 @@ Released as needed privately to individual vendors for critical security-related
 
 ## Binary Distributions
 
-### Windows
-* [ ] Download the artifacts from the [GitHub Actions "Test Windows" workflow](https://github.com/python-pillow/Pillow/actions/workflows/test-windows.yml)
-  and copy into `dist/`
-
-### Mac and Linux
+### macOS and Linux
 * [ ] Use the [Pillow Wheel Builder](https://github.com/python-pillow/pillow-wheels):
   ```bash
   git clone https://github.com/python-pillow/pillow-wheels
@@ -109,6 +105,10 @@ Released as needed privately to individual vendors for critical security-related
   ./update-pillow-tag.sh [[release tag]]
   ```
 * [ ] Download wheels from the [Pillow Wheel Builder release](https://github.com/python-pillow/pillow-wheels/releases)
+  and copy into `dist/`
+
+### Windows
+* [ ] Download the artifacts from the [GitHub Actions "Test Windows" workflow](https://github.com/python-pillow/Pillow/actions/workflows/test-windows.yml)
   and copy into `dist/`
 
 ## Publicize Release

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,6 @@ Released quarterly on January 2nd, April 1st, July 1st and October 15th.
   ```bash
   git branch 5.2.x
   git tag 5.2.0
-  git push --all
   git push --tags
   ```
 * [ ] Create and check source distribution:
@@ -32,8 +31,11 @@ Released quarterly on January 2nd, April 1st, July 1st and October 15th.
   python3 -m twine upload dist/Pillow-5.2.0*
   ```
 * [ ] Publish the [release on GitHub](https://github.com/python-pillow/Pillow/releases)
-* [ ] In compliance with [PEP 440](https://www.python.org/dev/peps/pep-0440/), increment and append `.dev0` to version identifier in `src/PIL/_version.py`
-
+* [ ] In compliance with [PEP 440](https://www.python.org/dev/peps/pep-0440/),
+      increment and append `.dev0` to version identifier in `src/PIL/_version.py` and then:
+  ```bash
+  git push --all
+   ```
 ## Point Release
 
 Released as needed for security, installation or critical bug fixes.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -47,16 +47,12 @@ Released as needed for security, installation or critical bug fixes.
   git checkout -t remotes/origin/5.2.x
   ```
 * [ ] Cherry pick individual commits from `main` branch to release branch e.g. `5.2.x`, then `git push`.
-
-
-
 * [ ] Check [GitHub Actions](https://github.com/python-pillow/Pillow/actions) and [AppVeyor](https://ci.appveyor.com/project/python-pillow/Pillow) to confirm passing tests in release branch e.g. `5.2.x`.
 * [ ] In compliance with [PEP 440](https://peps.python.org/pep-0440/), update version identifier in `src/PIL/_version.py`
 * [ ] Run pre-release check via `make release-test`.
 * [ ] Create tag for release e.g.:
   ```bash
   git tag 5.2.1
-  git push
   git push --tags
   ```
 * [ ] Create and check source distribution:
@@ -69,7 +65,10 @@ Released as needed for security, installation or critical bug fixes.
   python3 -m twine check --strict dist/*
   python3 -m twine upload dist/Pillow-5.2.1*
   ```
-* [ ] Publish the [release on GitHub](https://github.com/python-pillow/Pillow/releases)
+* [ ] Publish the [release on GitHub](https://github.com/python-pillow/Pillow/releases) and then:
+  ```bash
+  git push
+  ```
 
 ## Embargoed Release
 
@@ -85,7 +84,6 @@ Released as needed privately to individual vendors for critical security-related
   ```bash
   git checkout 2.5.x
   git tag 2.5.3
-  git push origin 2.5.x
   git push origin --tags
   ```
 * [ ] Create and check source distribution:
@@ -93,7 +91,10 @@ Released as needed privately to individual vendors for critical security-related
   make sdist
   ```
 * [ ] Create [binary distributions](https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#binary-distributions)
-* [ ] Publish the [release on GitHub](https://github.com/python-pillow/Pillow/releases)
+* [ ] Publish the [release on GitHub](https://github.com/python-pillow/Pillow/releases) and then:
+  ```bash
+  git push origin 2.5.x
+  ```
 
 ## Binary Distributions
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -112,7 +112,7 @@ Released as needed privately to individual vendors for critical security-related
 
 ### Windows
 * [ ] Download the artifacts from the [GitHub Actions "Test Windows" workflow](https://github.com/python-pillow/Pillow/actions/workflows/test-windows.yml)
-  and copy into `dist/`For example using [GitHub CLI](https://github.com/cli/cli):
+  and copy into `dist/`. For example using [GitHub CLI](https://github.com/cli/cli):
   ```bash
   gh run download --dir dist
   # select dist-x.y.z

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -106,7 +106,7 @@ Released as needed privately to individual vendors for critical security-related
   ./update-pillow-tag.sh [[release tag]]
   ```
 * [ ] Download wheels from the [Pillow Wheel Builder release](https://github.com/python-pillow/pillow-wheels/releases)
-  and copy into `dist/`. For example using [GitHub CLI](https://github.com/cli/cli):
+  and copy into `dist/`. For example using [GitHub CLI](https://github.com/cli/cli) from the main repo:
   ```bash
   gh release download --dir dist --pattern "*.whl" --repo python-pillow/pillow-wheels
   ```


### PR DESCRIPTION
Some updates to the release checklist, I followed these for [9.5.0](https://github.com/python-pillow/Pillow/issues/6989).

---

First, I moved the `git push --all` from near the start (after removing `.dev0` from the version and updating `CHANGES.rst`), to near the end (after incrementing and adding `.dev0` to the version).

The reason: the CI does a _lot_ of building during releases and there's a lot of waiting around for the release manager. We only need the tags pushed early to build the Windows wheels via `git push --tags`. The Linux and macOS wheels are built using their own dedicated wheel builder. The `git push --all` just delays the CI from building all these wheels.

So  `git push --all` which pushes `main` and `9.5.x` can come after all the wheel building.

---

Next, during the "Binary Distributions" stage, it says to download the Windows wheels (once they're ready); then do some things to kick off the macOS and Linux wheel builder and download once ready.

Let's flip the order. Even if Windows wheels were ready (and they won't be yet), it's better to get the Mac/Linux CI queued up first.

---

Finally, I used the [GitHub CLI `gh`](https://github.com/cli/cli) to download all the wheels before uploading them. Saves a lot of clicking in the UI! So let's include example commands for next time.

(Aside: `gh co 1234` is a really handy command for checking out a PR for local testing.)
