### PR TITLE
Add release check to make sure no TODOs remain in release notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ debug:
 
 .PHONY: release-test
 release-test:
+	python3 Tests/check_release_notes.py
 	python3 -m pip install -e .[tests]
 	python3 selftest.py
 	python3 -m pytest Tests

--- a/Tests/check_release_notes.py
+++ b/Tests/check_release_notes.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+for rst in Path("docs/releasenotes/").rglob("[1-9]*.rst"):
+    if "TODO" in open(rst).read():
+        sys.exit(f"Error: remove TODO from {rst}")

--- a/Tests/check_release_notes.py
+++ b/Tests/check_release_notes.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
 
-for rst in Path("docs/releasenotes/").rglob("[1-9]*.rst"):
+for rst in Path("docs/releasenotes").glob("[1-9]*.rst"):
     if "TODO" in open(rst).read():
         sys.exit(f"Error: remove TODO from {rst}")


### PR DESCRIPTION
To avoid mistakes like https://github.com/python-pillow/Pillow/pull/7054.

We could use something like `grep -P TODO docs/releasenotes/[1-9]*.rst` but the `-P` option isn't available in the system `grep` on macOS (see https://stackoverflow.com/a/22704387/724176), and a short script is also cross platform for Windows too.