### PR TITLE
Fixed saving TIFF multiframe images with LONG8 tag types

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -96,9 +96,16 @@ class TestFileTiff:
 
             assert_image_similar_tofile(im, "Tests/images/pil136.png", 1)
 
-    def test_bigtiff(self):
+    def test_bigtiff(self, tmp_path):
         with Image.open("Tests/images/hopper_bigtiff.tif") as im:
             assert_image_equal_tofile(im, "Tests/images/hopper.tif")
+
+        with Image.open("Tests/images/hopper_bigtiff.tif") as im:
+            # multistrip support not yet implemented
+            del im.tag_v2[273]
+
+            outfile = str(tmp_path / "temp.tif")
+            im.save(outfile, save_all=True, append_images=[im], tiffinfo=im.tag_v2)
 
     def test_set_legacy_api(self):
         ifd = TiffImagePlugin.ImageFileDirectory_v2()

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1892,6 +1892,10 @@ class AppendingTiffWriter:
         8,  # srational
         4,  # float
         8,  # double
+        4,  # ifd
+        2,  # unicode
+        4,  # complex
+        8,  # long8
     ]
 
     #    StripOffsets = 273


### PR DESCRIPTION
Resolves #7077

The issue points out that
https://github.com/python-pillow/Pillow/blob/b0c76535022b795f2c31d725131c54e8e10d1ff7/src/PIL/TiffImagePlugin.py#L1881-L1895
does not include 'long8', which we first started supporting in #6097.

This PR adds 'long8', https://www.awaresystems.be/imaging/tiff/bigtiff.html
> TIFF_LONG8 = 16, being unsigned 8byte integer

but because `fieldSizes` is a list not a dictionary, the items between 12 ("[12 = DOUBLE](https://www.itu.int/itudoc/itu-t/com16/tiff-fx/docs/tiff6.pdf)") and 16 also need to be added.

https://www.awaresystems.be/imaging/tiff/specification/TIFFPM6.pdf
> TIFF data type 13, “IFD,” is otherwise identical to LONG

So 'ifd' has size 4, like long.

For 14 and 15, information is scarce. The best information I could find was 
https://android.googlesource.com/platform/external/dng_sdk/+/refs/heads/master/source/dng_tag_types.h
> ttByte = 1,
> ttAscii,
> ttShort,
> ttLong,
> ttRational,
> ttSByte,
> ttUndefined,
> ttSShort,
> ttSLong,
> ttSRational,
> ttFloat,
> ttDouble,
> ttIFD,
> ttUnicode,
> ttComplex

https://android.googlesource.com/platform/external/dng_sdk/+/refs/heads/master/source/dng_image_writer.cpp#325
> // Two byte entries.
> ...
>   case ttUnicode:
> ...
> // Four byte entries.
> ...
>   case ttComplex:


