### PR TITLE
Do not install PyQt6-Qt6 6.5.0

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -43,7 +43,7 @@ if [[ $(uname) != CYGWIN* ]]; then
     # PyQt6 doesn't support PyPy3
     if [[ $GHA_PYTHON_VERSION == 3.* ]]; then
         sudo apt-get -qq install libegl1 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxkbcommon-x11-0
-        python3 -m pip install pyqt6
+        python3 -m pip install pyqt6 PyQt6-Qt6!=6.5.0
     fi
 
     # webp


### PR DESCRIPTION
PyQt6-Qt6 6.5.0 was [released an hour ago on PyPI](https://pypi.org/project/PyQt6-Qt6/#history) (although hasn't been announced yet at https://www.riverbankcomputing.com/news), and since then, the "test" Ubuntu builds on main have [started failing](https://github.com/python-pillow/Pillow/actions/runs/4656595509/jobs/8240380107).

This PR is a temporary workaround, that skips only 6.5.0. If a new version is released and there is still a problem, the tests will start failing again to confirm that this is something to investigate.

I say PyQt6-Qt6, and not PyQt6. [Not installing PyQt6 6.5.0](https://github.com/radarhere/Pillow/commit/07295106a681496733fdccb7921af52061498f38) [does not resolve the situation](https://github.com/radarhere/Pillow/actions/runs/4656884611/jobs/8240944063).