### PR TITLE
Install libxcb-cursor0

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -42,7 +42,7 @@ if [[ $(uname) != CYGWIN* ]]; then
 
     # PyQt6 doesn't support PyPy3
     if [[ $GHA_PYTHON_VERSION == 3.* ]]; then
-        sudo apt-get -qq install libegl1 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxkbcommon-x11-0
+        sudo apt-get -qq install libegl1 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxkbcommon-x11-0
         python3 -m pip install pyqt6
     fi
 

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -43,7 +43,7 @@ if [[ $(uname) != CYGWIN* ]]; then
     # PyQt6 doesn't support PyPy3
     if [[ $GHA_PYTHON_VERSION == 3.* ]]; then
         sudo apt-get -qq install libegl1 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxkbcommon-x11-0
-        python3 -m pip install pyqt6 PyQt6-Qt6!=6.5.0
+        python3 -m pip install pyqt6
     fi
 
     # webp


### PR DESCRIPTION
#7081 disabled installing of PyQt6-Qt6 6.5.0 because "test" Ubuntu builds had started failing in main.

Starting [QApplication with `QT_DEBUG_PLUGINS` enabled](https://github.com/radarhere/Pillow/commit/16ff78dd983764d7f76ea8ba4fe170d8441e9b16), I find the message ["libxcb-cursor.so.0: cannot open shared object file: No such file or directory"](https://github.com/radarhere/Pillow/actions/runs/4666980576/jobs/8262200783#step:4:268)

So this PR reverts #7081 and installs libxcb-cursor0.

A similar thing has happened before, with #6438 and #4662