### PR TITLE
Fix codecov after they deleted the Python package from PyPI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -52,8 +52,9 @@ test_script:
 #- '%PYTHON%\%EXECUTABLE% test-installed.py -v -s %TEST_OPTIONS%' TODO TEST_OPTIONS with pytest?
 
 after_test:
-- python -m pip install codecov
-- codecov --file coverage.xml --name %PYTHON% --flags AppVeyor
+- curl -Os https://uploader.codecov.io/latest/windows/codecov.exe
+- chmod +x codecov
+- .\codecov.exe --file coverage.xml --name %PYTHON% --flags AppVeyor
 
 matrix:
   fast_finish: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,7 +53,6 @@ test_script:
 
 after_test:
 - curl -Os https://uploader.codecov.io/latest/windows/codecov.exe
-- chmod +x codecov
 - .\codecov.exe --file coverage.xml --name %PYTHON% --flags AppVeyor
 
 matrix:

--- a/.ci/after_success.sh
+++ b/.ci/after_success.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # gather the coverage data
-python3 -m pip install codecov
+python3 -m pip install coverage
 if [[ $MATRIX_DOCKER ]]; then
   python3 -m coverage xml --ignore-errors
 else


### PR DESCRIPTION
Codecov had deprecated their Python codecov package:

* https://about.codecov.io/blog/introducing-codecovs-new-uploader/

But rather than only deprecating it, they've completely deleted the package from PyPI:

* https://pypi.org/project/codecov/
* https://github.com/codecov/python-standard/issues/31
* https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259?u=hugovk

This is causing failures on our CI.

For AppVeyor, let's switch to the new uploader.

For others, we were pip installing codecov in `.ci/after_success.sh`, called by:

* `.github/workflows/test-docker.yml`
* `.github/workflows/test-cygwin.yml`
* `.github/workflows/test-windows.yml`
* `.github/workflows/test.yml`

We'd already moved all of these to using the Codecov GitHub Action, but were still installing the codecov package. Instead, install _coverage_, which is the actual command we need in `.ci/after_success.sh`.