### PR TITLE
Updated raqm to 0.10.1

### DIFF
--- a/depends/install_raqm.sh
+++ b/depends/install_raqm.sh
@@ -2,7 +2,7 @@
 # install raqm
 
 
-archive=libraqm-0.10.0
+archive=libraqm-0.10.1
 
 ./download-and-extract.sh $archive https://raw.githubusercontent.com/python-pillow/pillow-depends/main/$archive.tar.gz
 


### PR DESCRIPTION
raqm 0.10.1 has been released - https://github.com/HOST-Oman/libraqm/releases/tag/v0.10.1