### PR TITLE
Remove use of deprecated OpenJPEG "bpp" member

### DIFF
--- a/src/libImaging/Jpeg2KEncode.c
+++ b/src/libImaging/Jpeg2KEncode.c
@@ -281,7 +281,6 @@ j2k_encode_entry(Imaging im, ImagingCodecState state) {
     int ret = -1;
 
     unsigned prec = 8;
-    unsigned bpp = 8;
     unsigned _overflow_scale_factor;
 
     stream = opj_stream_create(BUFFER_SIZE, OPJ_FALSE);
@@ -313,7 +312,6 @@ j2k_encode_entry(Imaging im, ImagingCodecState state) {
         color_space = OPJ_CLRSPC_GRAY;
         pack = j2k_pack_i16;
         prec = 16;
-        bpp = 12;
     } else if (strcmp(im->mode, "LA") == 0) {
         components = 2;
         color_space = OPJ_CLRSPC_GRAY;
@@ -342,7 +340,6 @@ j2k_encode_entry(Imaging im, ImagingCodecState state) {
         image_params[n].h = im->ysize;
         image_params[n].x0 = image_params[n].y0 = 0;
         image_params[n].prec = prec;
-        image_params[n].bpp = bpp;
         image_params[n].sgnd = context->sgnd == 0 ? 0 : 1;
     }
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/4696665571/jobs/8326957733#step:6:116
>   src/libImaging/Jpeg2KEncode.c: In function ‘j2k_encode_entry’:
>  src/libImaging/Jpeg2KEncode.c:345:9: warning: ‘bpp’ is deprecated: Use prec instead [-Wdeprecated-declarations]
>    345 |         image_params[n].bpp = bpp;

We are already using `prec` just before this, so `bpp` can just be removed.

https://github.com/python-pillow/Pillow/blob/8740e3261955c70dd113e789dc12326de2e342d0/src/libImaging/Jpeg2KEncode.c#L344-L345

See https://github.com/uclouvain/openjpeg/pull/1383 for more information.