### PR TITLE
Select Python version in Cygwin

### DIFF
--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -84,6 +84,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cygwin-pip3.${{ matrix.python-minor-version }}-
 
+      - name: Select Python version
+        run: |
+          ln -sf c:/cygwin/bin/python3.${{ matrix.python-minor-version }} c:/cygwin/bin/python3
+
       - name: Build system information
         run: |
           dash.exe -c "python3 .github/workflows/system-info.py"

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Install a different NumPy
         shell: dash.exe -l "{0}"
         run: |
-          python3 -m pip install -U 'numpy!=1.21.*'
+          python3 -m pip install -U numpy
 
       - name: Build
         shell: bash.exe -eo pipefail -o igncr "{0}"


### PR DESCRIPTION
Cygwin started failing in main, with https://github.com/python-pillow/Pillow/actions/runs/4696586061/jobs/8329527067#step:8:157
>       gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -DFFI_BUILDING=1 -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/usr/include/python3.9 -c c/_cffi_backend.c -o build/temp.cygwin-3.4.6-x86_64-cpython-39/c/_cffi_backend.o
>       c/_cffi_backend.c:2:10: fatal error: Python.h: No such file or directory
>          2 | #include <Python.h>
>            |          ^~~~~~~~~~

The above lines mention Python 3.9, but this should be a Python 3.8 build.

This PR links `python3` to the correct Python version.

However, [problems with ImageMagick started happening a day later](https://github.com/python-pillow/Pillow/actions/runs/4704782919/jobs/8344709658#step:11:808), so the Cygwin builds are still failing.