### PR TITLE
`Image.open()` seeks to the start of file objects

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3156,7 +3156,8 @@ def open(fp, mode="r", formats=None):
     :param fp: A filename (string), pathlib.Path object or a file object.
        The file object must implement ``file.read``,
        ``file.seek``, and ``file.tell`` methods,
-       and be opened in binary mode.
+       and be opened in binary mode. The file object will also seek to zero
+       before reading.
     :param mode: The mode.  If given, this argument must be "r".
     :param formats: A list or tuple of formats to attempt to load the file in.
        This can be used to restrict the set of formats checked.


### PR DESCRIPTION
Resolves #7096 by documenting that `Image.open()` seeks to the start of file objects before reading.

https://github.com/python-pillow/Pillow/blob/aec7a8d14ba7a90bbb50b4d0f6af2a805c642882/src/PIL/Image.py#L3202-L3225