### PR TITLE
If available, use scrot on Linux for ImageGrab

### DIFF
--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -15,8 +15,9 @@ or the clipboard to a PIL image memory.
     returned as an "RGBA" on macOS, or an "RGB" image otherwise.
     If the bounding box is omitted, the entire screen is copied.
 
-    On Linux, if ``xdisplay`` is ``None`` then ``gnome-screenshot`` will be used if it
-    is installed. To capture the default X11 display instead, pass ``xdisplay=""``.
+    On Linux, if ``xdisplay`` is ``None`` then ``gnome-screenshot`` or ``scrot`` will
+    be used if they are installed. To capture the default X11 display instead, pass
+    ``xdisplay=""``.
 
     .. versionadded:: 1.1.3 (Windows), 3.0.0 (macOS), 7.1.0 (Linux)
 

--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -15,9 +15,9 @@ or the clipboard to a PIL image memory.
     returned as an "RGBA" on macOS, or an "RGB" image otherwise.
     If the bounding box is omitted, the entire screen is copied.
 
-    On Linux, if ``xdisplay`` is ``None`` then ``gnome-screenshot`` or ``scrot`` will
-    be used if they are installed. To capture the default X11 display instead, pass
-    ``xdisplay=""``.
+    On Linux, if ``xdisplay`` is ``None`` then (in order) ``scrot`` or
+    ``gnome-screenshot`` will be used if they are installed. To capture the default
+    X11 display instead, pass ``xdisplay=""``.
 
     .. versionadded:: 1.1.3 (Windows), 3.0.0 (macOS), 7.1.0 (Linux)
 

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -64,7 +64,7 @@ def grab(bbox=None, include_layered_windows=False, all_screens=False, xdisplay=N
         elif shutil.which("gnome-screenshot") or shutil.which("scrot"):
             fh, filepath = tempfile.mkstemp(".png")
             os.close(fh)
-            if shutil.which("scrot"):  # use scrot when have
+            if shutil.which("scrot"):  # prefer scrot, as it is less intrusive
                 subprocess.call([shutil.which("scrot"), "-z", "--overwrite", filepath])
             else:
                 subprocess.call([shutil.which("gnome-screenshot"), "-f", filepath])

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -61,10 +61,13 @@ def grab(bbox=None, include_layered_windows=False, all_screens=False, xdisplay=N
                 left, top, right, bottom = bbox
                 im = im.crop((left - x0, top - y0, right - x0, bottom - y0))
             return im
-        elif shutil.which("gnome-screenshot"):
+        elif shutil.which("gnome-screenshot") or shutil.which("scrot"):
             fh, filepath = tempfile.mkstemp(".png")
             os.close(fh)
-            subprocess.call(["gnome-screenshot", "-f", filepath])
+            if shutil.which("scrot"):  # use scrot when have
+                subprocess.call([shutil.which("scrot"), "-z", "--overwrite", filepath])
+            else:
+                subprocess.call([shutil.which("gnome-screenshot"), "-f", filepath])
             im = Image.open(filepath)
             im.load()
             os.unlink(filepath)

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -61,7 +61,7 @@ def grab(bbox=None, include_layered_windows=False, all_screens=False, xdisplay=N
                 left, top, right, bottom = bbox
                 im = im.crop((left - x0, top - y0, right - x0, bottom - y0))
             return im
-        elif shutil.which("gnome-screenshot") or shutil.which("scrot"):
+        elif shutil.which("scrot") or shutil.which("gnome-screenshot"):
             fh, filepath = tempfile.mkstemp(".png")
             os.close(fh)
             if shutil.which("scrot"):  # prefer scrot, as it is less intrusive


### PR DESCRIPTION
Use scrot when this environment have in `ImageGrab.grab()`.

In practical use, although `gnome-screenshot` is widely present in Linux systems, in newer systems such as Ubuntu 20.04, **there will be a full-screen animation effect when taking screenshots, and it is not easy to close**. This feature may cause inconvenience to users in some tasks. Therefore, it has been changed to detect `scrot`. If `scrot` is present, it will be used directly. There will be no similar problems when taking screenshots with `scrot`, and it is very easy to install on Ubuntu and other systems with `apt install -y scrot`, and similar packages are available on other systems such as debian and centos.

Here are some more records about the annoying flash animation on `gnome-screenshot` @radarhere :
* https://www.linux.org/threads/gnome-screenshot-without-the-annoying-flash-more.28655/
* https://askubuntu.com/questions/854350/disable-gnome-screenshots-camera-flash-animation
* https://gitlab.gnome.org/GNOME/gnome-screenshot/-/issues/2  (This is the official explaination)