### PR TITLE
Load before getting size in __getstate__

### DIFF
--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -1,4 +1,5 @@
 import warnings
+from copy import deepcopy
 
 import pytest
 
@@ -223,6 +224,14 @@ def test_zero_size():
 def test_load_first():
     with Image.open("Tests/images/g4_orientation_5.tif") as im:
         a = numpy.array(im)
+        assert a.shape == (88, 590)
+
+
+@skip_unless_feature("libtiff")
+def test_load_first_deepcopy():
+    with Image.open("Tests/images/g4_orientation_5.tif") as im:
+        im_deepcopy = deepcopy(im)
+        a = numpy.array(im_deepcopy)
         assert a.shape == (88, 590)
 
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -672,7 +672,8 @@ class Image:
         return new
 
     def __getstate__(self):
-        return [self.info, self.mode, self.size, self.getpalette(), self.tobytes()]
+        im_data = self.tobytes()  # load image first
+        return [self.info, self.mode, self.size, self.getpalette(), im_data]
 
     def __setstate__(self, state):
         Image.__init__(self)


### PR DESCRIPTION
Fixes the same what was in https://github.com/python-pillow/Pillow/issues/7032 but for `deepcopy(im)` operation.

Changes proposed in this pull request:

 * first we load image data in `__getstate__` and then only fill list with it's attributes.

