### PR TITLE
Support float font sizes

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -191,6 +191,16 @@ def test_getlength(
         assert length == length_raqm
 
 
+def test_float_size():
+    lengths = []
+    for size in (48, 48.5, 49):
+        f = ImageFont.truetype(
+            "Tests/fonts/NotoSans-Regular.ttf", size, layout_engine=layout_engine
+        )
+        lengths.append(f.getlength("text"))
+    assert lengths[0] != lengths[1] != lengths[2]
+
+
 def test_render_multiline(font):
     im = Image.new(mode="RGB", size=(300, 100))
     draw = ImageDraw.Draw(im)

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -116,7 +116,9 @@ getfont(PyObject *self_, PyObject *args, PyObject *kw) {
     int error = 0;
 
     char *filename = NULL;
-    Py_ssize_t size;
+    float size;
+    FT_Size_RequestRec req;
+    FT_Long width;
     Py_ssize_t index = 0;
     Py_ssize_t layout_engine = 0;
     unsigned char *encoding;
@@ -133,7 +135,7 @@ getfont(PyObject *self_, PyObject *args, PyObject *kw) {
     if (!PyArg_ParseTupleAndKeywords(
             args,
             kw,
-            "etn|nsy#n",
+            "etf|nsy#n",
             kwlist,
             Py_FileSystemDefaultEncoding,
             &filename,
@@ -179,7 +181,13 @@ getfont(PyObject *self_, PyObject *args, PyObject *kw) {
     }
 
     if (!error) {
-        error = FT_Set_Pixel_Sizes(self->face, 0, size);
+        width = size * 64;
+        req.type = FT_SIZE_REQUEST_TYPE_NOMINAL;
+        req.width = width;
+        req.height = width;
+        req.horiResolution = 0;
+        req.vertResolution = 0;
+        error = FT_Request_Size(self->face, &req);
     }
 
     if (!error && encoding && strlen((char *)encoding) == 4) {


### PR DESCRIPTION
Resolves #6689

Pillow calls `FT_Set_Pixel_Sizes` [when loading a font](https://github.com/python-pillow/Pillow/blob/a405e8406b83f8bfb8916e93971edc7407b8b1ff/src/_imagingft.c#L182). [`FT_Set_Pixel_Sizes`](https://gitlab.freedesktop.org/freetype/freetype/-/blob/master/src/base/ftobjs.c#L3561-3593) takes `FT_UInt` as the width/height arguments, but then multiplies those integers by 64 before calling `FT_Request_Size`.

As [suggested](https://github.com/python-pillow/Pillow/issues/6689#issuecomment-1292365173), this PR calls `FT_Request_Size` directly instead, allowing 64 times the control over font sizes.