### PR TITLE
Build all readthedocs formats

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,7 @@
 version: 2
 
+formats: all
+
 build:
   os: ubuntu-22.04
   tools:


### PR DESCRIPTION
Resolves #7114

The issue reports that there are no downloads at https://readthedocs.org/projects/pillow/downloads/

After looking at https://docs.readthedocs.io/en/stable/config-file/v2.html#formats, I've inserted `formats: all` to .readthedocs.yml.

As evidence that this works, https://readthedocs.org/projects/pillow-radarhere/versions/ lists 'latest' and 'formats' as versions, https://readthedocs.org/projects/pillow-radarhere/builds/ shows recent builds of both, but only 'formats' is visible at https://readthedocs.org/projects/pillow-radarhere/downloads/ as downloads (while 'stable' also appears, it is very old).