### PR TITLE
Use stdlib for setuptools on MinGW

### DIFF
--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -80,7 +80,7 @@ jobs:
           pushd depends && ./install_extra_test_images.sh && popd
 
       - name: Build Pillow
-        run: CFLAGS="-coverage" python3 -m pip install --global-option="build_ext" .
+        run: SETUPTOOLS_USE_DISTUTILS="stdlib" CFLAGS="-coverage" python3 -m pip install --global-option="build_ext" .
 
       - name: Test Pillow
         run: |


### PR DESCRIPTION
MinGW is currently failing in main - https://github.com/python-pillow/Pillow/actions/runs/4861154081

https://www.msys2.org/docs/python/ states
> [setuptools](https://github.com/pypa/setuptools) >= 60.0 is currently incompatible with MSYS2. You can set export SETUPTOOLS_USE_DISTUTILS=stdlib to work around the issue. We are currently working on restoring compatibility.

Adding in `SETUPTOOLS_USE_DISTUTILS="stdlib"` fixes the problem.