### PR TITLE
Added `_repr_jpeg_` for IPython display

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -922,18 +922,18 @@ class TestFileJpeg:
             im.load()
             ImageFile.LOAD_TRUNCATED_IMAGES = False
 
-    def test_repr_jpg(self):
+    def test_repr_jpeg(self):
         im = hopper()
 
-        with Image.open(BytesIO(im._repr_jpg_())) as repr_jpg:
-            assert repr_jpg.format == "JPEG"
-            assert_image_equal(im, repr_jpg)
+        with Image.open(BytesIO(im._repr_jpeg_())) as repr_jpeg:
+            assert repr_jpeg.format == "JPEG"
+            assert_image_similar(im, repr_jpeg, 17)
 
-    def test_repr_jpg_error(self):
+    def test_repr_jpeg_error(self):
         im = hopper("F")
 
         with pytest.raises(ValueError):
-            im._repr_jpg_()
+            im._repr_jpeg_()
 
 
 @pytest.mark.skipif(not is_win32(), reason="Windows only")

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -922,6 +922,19 @@ class TestFileJpeg:
             im.load()
             ImageFile.LOAD_TRUNCATED_IMAGES = False
 
+    def test_repr_jpg(self):
+        im = hopper()
+
+        with Image.open(BytesIO(im._repr_jpg_())) as repr_jpg:
+            assert repr_jpg.format == "JPEG"
+            assert_image_equal(im, repr_jpg)
+
+    def test_repr_jpg_error(self):
+        im = hopper("F")
+
+        with pytest.raises(ValueError):
+            im._repr_jpg_()
+
 
 @pytest.mark.skipif(not is_win32(), reason="Windows only")
 @skip_unless_feature("jpg")

--- a/docs/releasenotes/10.0.0.rst
+++ b/docs/releasenotes/10.0.0.rst
@@ -160,6 +160,18 @@ TODO
 Other Changes
 =============
 
+Support display_jpeg() in IPython
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In addition to ``display()`` and ``display_png``, ``display_jpeg()`` can now
+also be used to display images in IPython::
+
+    from PIL import Image
+    from IPython.display import display_jpeg
+
+    im = Image.new("RGB", (100, 100), (255, 0, 0))
+    display_jpeg(im)
+
 Support reading signed 8-bit TIFF images
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -633,18 +633,35 @@ class Image:
             )
         )
 
-    def _repr_png_(self):
+    def _repr_image(self, format):
         """iPython display hook support
 
+        :param format: Image format.
         :returns: png version of the image as bytes
         """
         b = io.BytesIO()
         try:
-            self.save(b, "PNG")
+            self.save(b, format)
         except Exception as e:
-            msg = "Could not save to PNG for display"
+            msg = f"Could not save to {format} for display"
             raise ValueError(msg) from e
         return b.getvalue()
+
+    def _repr_png_(self):
+        """iPython display hook support for PNG format.
+
+        :returns: png version of the image as bytes
+        """
+        return self._repr_image("PNG")
+
+    def _repr_jpg_(self):
+        """iPython display hook support for JPEG format.
+
+        :returns: jpg version of the image as bytes
+        """
+        return self._repr_image("JPEG")
+
+    _repr_jpeg_ = _repr_jpg_
 
     @property
     def __array_interface__(self):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -634,7 +634,8 @@ class Image:
         )
 
     def _repr_image(self, image_format):
-        """Helper function for iPython display hook
+        """Helper function for iPython display hook.
+
         :param image_format: Image format.
         :returns: image as bytes, saved into the given format.
         """
@@ -1122,7 +1123,6 @@ class Image:
            Available methods are :data:`Dither.NONE` or :data:`Dither.FLOYDSTEINBERG`
            (default).
         :returns: A new image
-
         """
 
         self.load()

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -633,17 +633,17 @@ class Image:
             )
         )
 
-    def _repr_image(self, format):
+    def _repr_image(self, image_format):
         """iPython display hook support
 
-        :param format: Image format.
+        :param image_format: Image format.
         :returns: image as bytes, saved into the given format.
         """
         b = io.BytesIO()
         try:
-            self.save(b, format)
+            self.save(b, image_format)
         except Exception as e:
-            msg = f"Could not save to {format} for display"
+            msg = f"Could not save to {image_format} for display"
             raise ValueError(msg) from e
         return b.getvalue()
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -654,14 +654,12 @@ class Image:
         """
         return self._repr_image("PNG")
 
-    def _repr_jpg_(self):
+    def _repr_jpeg_(self):
         """iPython display hook support for JPEG format.
 
         :returns: jpg version of the image as bytes
         """
         return self._repr_image("JPEG")
-
-    _repr_jpeg_ = _repr_jpg_
 
     @property
     def __array_interface__(self):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -637,7 +637,7 @@ class Image:
         """iPython display hook support
 
         :param format: Image format.
-        :returns: png version of the image as bytes
+        :returns: image as bytes, saved into the given format.
         """
         b = io.BytesIO()
         try:

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -650,14 +650,14 @@ class Image:
     def _repr_png_(self):
         """iPython display hook support for PNG format.
 
-        :returns: png version of the image as bytes
+        :returns: PNG version of the image as bytes
         """
         return self._repr_image("PNG")
 
     def _repr_jpeg_(self):
         """iPython display hook support for JPEG format.
 
-        :returns: jpeg version of the image as bytes
+        :returns: JPEG version of the image as bytes
         """
         return self._repr_image("JPEG")
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -634,8 +634,7 @@ class Image:
         )
 
     def _repr_image(self, image_format):
-        """iPython display hook support
-
+        """Helper function for iPython display hook
         :param image_format: Image format.
         :returns: image as bytes, saved into the given format.
         """
@@ -657,7 +656,7 @@ class Image:
     def _repr_jpeg_(self):
         """iPython display hook support for JPEG format.
 
-        :returns: jpg version of the image as bytes
+        :returns: jpeg version of the image as bytes
         """
         return self._repr_image("JPEG")
 


### PR DESCRIPTION
Changes proposed in this pull request:

 *  Add `_repr_jpg_` and `_repr_jpeg_` method for ipython display (similar to currently existing `_repr_png_`)

