### PR TITLE
Do not use gnome-screenshot on Linux if X11 can be used instead

### DIFF
--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -15,8 +15,9 @@ or the clipboard to a PIL image memory.
     returned as an "RGBA" on macOS, or an "RGB" image otherwise.
     If the bounding box is omitted, the entire screen is copied.
 
-    On Linux, if ``xdisplay`` is ``None`` then ``gnome-screenshot`` will be used if it
-    is installed. To capture the default X11 display instead, pass ``xdisplay=""``.
+    On Linux, if X11 is in use and Pillow was built with XCB support, libxcb will be
+    used. Otherwise, if no ``xdisplay`` has been specified, ``gnome-screenshot`` will
+    be used if it is installed.
 
     .. versionadded:: 1.1.3 (Windows), 3.0.0 (macOS), 7.1.0 (Linux)
 

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -61,7 +61,9 @@ def grab(bbox=None, include_layered_windows=False, all_screens=False, xdisplay=N
                 left, top, right, bottom = bbox
                 im = im.crop((left - x0, top - y0, right - x0, bottom - y0))
             return im
-        elif shutil.which("gnome-screenshot"):
+        elif not (
+            Image.core.HAVE_XCB and os.environ.get("XDG_SESSION_TYPE") == "x11"
+        ) and shutil.which("gnome-screenshot"):
             fh, filepath = tempfile.mkstemp(".png")
             os.close(fh)
             subprocess.call(["gnome-screenshot", "-f", filepath])


### PR DESCRIPTION
Alternative to #7143

https://github.com/python-pillow/Pillow/pull/7100#issue-1672406340
> although gnome-screenshot is widely present in Linux systems, in newer systems such as Ubuntu 20.04, there will be a full-screen animation effect when taking screenshots, and it is not easy to close. This feature may cause inconvenience to users in some tasks.

For this reason, [a later comment in the thread](https://github.com/python-pillow/Pillow/pull/7100#issuecomment-1537056956) requested that X11 be preferred over gnome-screenshot.

This PR modifies ImageGrab to not use gnome-screenshot if X11 is in use and Pillow has XCB support.