### PR TITLE
Better error message when comparing images

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -15,6 +15,9 @@ from packaging.version import parse as parse_version
 
 from PIL import Image, ImageMath, features
 
+# overridden in conftest.py
+pytestconfig = {"option": {"verbose": 0}}
+
 logger = logging.getLogger(__name__)
 
 
@@ -88,7 +91,10 @@ def assert_image_equal(a, b, msg=None):
     assert a.mode == b.mode, msg or f"got mode {repr(a.mode)}, expected {repr(b.mode)}"
     assert a.size == b.size, msg or f"got size {repr(a.size)}, expected {repr(b.size)}"
 
+    original_verbosity = pytestconfig.option.verbose
     try:
+        # set pytest's verbosity to 0 so that it doesn't show the full bytes diff
+        pytestconfig.option.verbose = 0
         assert a.tobytes() == b.tobytes(), msg or "got different content"
     except AssertionError:
         if HAS_UPLOADER:
@@ -99,6 +105,8 @@ def assert_image_equal(a, b, msg=None):
                 pass
 
         raise
+    finally:
+        pytestconfig.option.verbose = original_verbosity
 
 
 def assert_image_equal_tofile(a, filename, msg=None, mode=None):

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -95,7 +95,7 @@ def assert_image_equal(a, b, msg=None):
             except Exception:
                 pass
 
-        assert False, msg or "got different content"
+        assert a.tobytes() == b.tobytes(), msg or "got different content"
 
 
 def assert_image_equal_tofile(a, filename, msg=None, mode=None):

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -87,7 +87,10 @@ def assert_image(im, mode, size, msg=None):
 def assert_image_equal(a, b, msg=None):
     assert a.mode == b.mode, msg or f"got mode {repr(a.mode)}, expected {repr(b.mode)}"
     assert a.size == b.size, msg or f"got size {repr(a.size)}, expected {repr(b.size)}"
-    if a.tobytes() != b.tobytes():
+
+    try:
+        assert a.tobytes() == b.tobytes(), msg or "got different content"
+    except AssertionError:
         if HAS_UPLOADER:
             try:
                 url = test_image_results.upload(a, b)
@@ -95,7 +98,7 @@ def assert_image_equal(a, b, msg=None):
             except Exception:
                 pass
 
-        assert a.tobytes() == b.tobytes(), msg or "got different content"
+        raise
 
 
 def assert_image_equal_tofile(a, filename, msg=None, mode=None):

--- a/conftest.py
+++ b/conftest.py
@@ -1,1 +1,12 @@
 pytest_plugins = ["Tests.helper"]
+
+
+def pytest_configure(config):
+    """
+    Keep a reference to pytest's configuration in our helper class.
+    This function is called by pytest each time the configuration is updated.
+    https://docs.pytest.org/en/latest/reference/reference.html#pytest.hookspec.pytest_configure
+    """
+    import Tests.helper
+
+    Tests.helper.pytestconfig = config


### PR DESCRIPTION
When comparing images with `assert_image_equal()`, `assert` their bytes instead of `assert`ing `False`. This gives a better error message:

```python
import pytest

def test_assert_false():
    assert False, "message"

def test_assert_compare():
    assert b"abc" == b"abb", "message"
```
```python
================ FAILURES =================
____________ test_assert_false ____________

    def test_assert_false():
>       assert False, "message"
E       AssertionError: message
E       assert False

Tests/test_assert.py:4: AssertionError
___________ test_assert_compare ___________

    def test_assert_compare():
>       assert b"abc" == b"abb", "message"
E       AssertionError: message
E       assert b'abc' == b'abb'
E         At index 2 diff: b'c' != b'b'
E         Use -v to get more diff

Tests/test_assert.py:7: AssertionError
```

However, if the verbosity is too high, it will show a diff of the full image bytes. We can avoid this by temporarily changing the verbosity.