### PR TITLE
If the clipboard fails to open on Windows, wait and try again

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -437,8 +437,14 @@ PyImaging_GrabClipboardWin32(PyObject *self, PyObject *args) {
     LPCSTR format_names[] = {"DIB", "DIB", "file", "png", NULL};
 
     if (!OpenClipboard(NULL)) {
-        PyErr_SetString(PyExc_OSError, "failed to open clipboard");
-        return NULL;
+        // Maybe the clipboard is temporarily in use by another process.
+        // Wait and try again
+        Sleep(500);
+
+        if (!OpenClipboard(NULL)) {
+            PyErr_SetString(PyExc_OSError, "failed to open clipboard");
+            return NULL;
+        }
     }
 
     // find best format as set by clipboard owner


### PR DESCRIPTION
Resolves #7133

The user is intermittently hitting https://github.com/python-pillow/Pillow/blob/2467db492e7e50efaf39d445c92190c713e40f6f/src/display.c#L439-L440

https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-openclipboard states
> OpenClipboard fails if another window has the clipboard open.

If the error is hit, this PR pauses for 0.5s, and then tries again.