### PR TITLE
Clarify that line() and polygon() include xy pixels

### DIFF
--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -243,6 +243,7 @@ Methods
 .. py:method:: ImageDraw.line(xy, fill=None, width=0, joint=None)
 
     Draws a line between the coordinates in the ``xy`` list.
+    The coordinate pixels are included in the drawn line.
 
     :param xy: Sequence of either 2-tuples like ``[(x, y), (x, y), ...]`` or
                numeric values like ``[x, y, x, y, ...]``.
@@ -287,7 +288,7 @@ Methods
 
     The polygon outline consists of straight lines between the given
     coordinates, plus a straight line between the last and the first
-    coordinate.
+    coordinate. The coordinate pixels are included in the drawn polygon.
 
     :param xy: Sequence of either 2-tuples like ``[(x, y), (x, y), ...]`` or
                numeric values like ``[x, y, x, y, ...]``.


### PR DESCRIPTION
Resolves #367

#6625 documented that ImageDraw's `rectangle()` included the endpoints. This continues that clarification of the documentation for `line()` and `polygon()`.

As a demonstration, see the following code comparing the three functions.
```python
from PIL import Image, ImageDraw

img = Image.new('RGB', (10, 10), (255, 255, 255))
draw = ImageDraw.Draw(img, 'RGBA')
draw.polygon([(2,2), (2, 8), (8,8), (8, 2)], fill=(0, 255, 0, 127))
draw.rectangle([(2,2), (8,8)], fill=(255, 0, 0, 127))
draw.line([(2,2), (8,8)], fill=(0, 0, 0, 255))

img.resize((200, 200), Image.NONE).save("out.png")
```
<img src="https://user-images.githubusercontent.com/3112309/236812405-4dd0c3f1-f2db-4f5c-97a0-6bfa457687c3.png" />