### PR TITLE
Prefer screenshots using XCB over gnome-screenshot

### DIFF
--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -15,8 +15,9 @@ or the clipboard to a PIL image memory.
     returned as an "RGBA" on macOS, or an "RGB" image otherwise.
     If the bounding box is omitted, the entire screen is copied.
 
-    On Linux, if ``xdisplay`` is ``None`` then ``gnome-screenshot`` will be used if it
-    is installed. To capture the default X11 display instead, pass ``xdisplay=""``.
+    On Linux, if ``xdisplay`` is ``None`` and the default X11 display does not return
+    a snapshot of the screen, ``gnome-screenshot`` will be used as fallback if it is
+    installed. To disable this behaviour, pass ``xdisplay=""`` instead.
 
     .. versionadded:: 1.1.3 (Windows), 3.0.0 (macOS), 7.1.0 (Linux)
 

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -66,10 +66,6 @@ def grab(bbox=None, include_layered_windows=False, all_screens=False, xdisplay=N
             msg = "Pillow was built without XCB support"
             raise OSError(msg)
         size, data = Image.core.grabscreen_x11(xdisplay)
-        im = Image.frombytes("RGB", size, data, "raw", "BGRX", size[0] * 4, 1)
-        if bbox:
-            im = im.crop(bbox)
-        return im
     except OSError:
         if (
             xdisplay is None
@@ -89,6 +85,11 @@ def grab(bbox=None, include_layered_windows=False, all_screens=False, xdisplay=N
             return im
         else:
             raise
+    else:
+        im = Image.frombytes("RGB", size, data, "raw", "BGRX", size[0] * 4, 1)
+        if bbox:
+            im = im.crop(bbox)
+        return im
 
 
 def grabclipboard():

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -71,7 +71,11 @@ def grab(bbox=None, include_layered_windows=False, all_screens=False, xdisplay=N
             im = im.crop(bbox)
         return im
     except OSError:
-        if xdisplay is None and shutil.which("gnome-screenshot"):
+        if (
+            xdisplay is None
+            and sys.platform not in ("darwin", "win32")
+            and shutil.which("gnome-screenshot")
+        ):
             fh, filepath = tempfile.mkstemp(".png")
             os.close(fh)
             subprocess.call(["gnome-screenshot", "-f", filepath])


### PR DESCRIPTION
Alternative to #7139

From https://github.com/python-pillow/Pillow/pull/7100#issuecomment-1537056956

> > Is the problem just a user trying to ignore `gnome-screenshot` when it is installed in favour of `Image.core.grabscreen_x11`? If so, then `ImageGrab.grab(xdisplay=":0")` should be sufficient with the current version of Pillow.
> 
> [...] I have just tested setting `xdisplay=':0'`, and it ran on my end without any white flash. I believe this usage needs to be tested across different platforms. If the test is successful, it should be set as the default option. [...]

