### PR TITLE
Remove temporary file when error is raised

### DIFF
--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -134,6 +134,13 @@ def Ghostscript(tile, size, fp, scale=1, transparency=False):
 
     if gs_windows_binary is not None:
         if not gs_windows_binary:
+            try:
+                os.unlink(outfile)
+                if infile_temp:
+                    os.unlink(infile_temp)
+            except OSError:
+                pass
+
             msg = "Unable to locate Ghostscript on paths"
             raise OSError(msg)
         command[0] = gs_windows_binary

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -457,6 +457,11 @@ class JpegImageFile(ImageFile.ImageFile):
         if os.path.exists(self.filename):
             subprocess.check_call(["djpeg", "-outfile", path, self.filename])
         else:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
             msg = "Invalid Filename"
             raise ValueError(msg)
 


### PR DESCRIPTION
Helps #7147 by ensuring that temporary files are still removed, even if the code returns early due to an error.