### PR TITLE
Improved coordinate system documentation

### DIFF
--- a/docs/handbook/concepts.rst
+++ b/docs/handbook/concepts.rst
@@ -96,8 +96,8 @@ corners; the centre of a pixel addressed as (0, 0) actually lies at (0.5, 0.5).
 
 Coordinates are usually passed to the library as 2-tuples (x, y). Rectangles
 are represented as 4-tuples, with the upper left corner given first. For
-example, a rectangle covering all of an 800x600 pixel image is written as (0,
-0, 800, 600).
+example, a rectangle covering all of a 2x2 pixel image is written as (0, 0, 1,
+1).
 
 Palette
 -------


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/discussions/7155#discussion-5182709
> In the docs, it says, for the [Coordinate System](https://pillow.readthedocs.io/en/stable/handbook/concepts.html#coordinate-system):
>
> > For example, a rectangle covering all of an 800x600 pixel image is written as (0, 0, 800, 600).
>
> Is this not incorrect, as since the images are zero-based, that text ((0, 0, 800, 600)) should actually be for an image 801 x 601? And so that line of text should really be:
>
> > For example, a rectangle covering all of an 800x600 pixel image is written as (0, 0, 799, 599).

I've changed the third and fourth items in the tuple to be one less, but I've also changed it to a (2, 2) image instead of (800, 600). I think that's easier to understand.