### PR TITLE
Updated redirected URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -317,6 +317,17 @@ def setup(app):
     app.add_css_file("css/dark.css")
 
 
+linkcheck_allowed_redirects = {
+    r"https://bestpractices.coreinfrastructure.org/projects/6331": r"https://bestpractices.coreinfrastructure.org/en/.*",  # noqa: E501
+    r"https://badges.gitter.im/python-pillow/Pillow.svg": r"https://badges.gitter.im/repo.svg",  # noqa: E501
+    r"https://gitter.im/python-pillow/Pillow?.*": r"https://app.gitter.im/#/room/#python-pillow_Pillow:gitter.im?.*",  # noqa: E501
+    r"https://pillow.readthedocs.io/?badge=latest": r"https://pillow.readthedocs.io/en/stable/?badge=latest",  # noqa: E501
+    r"https://pillow.readthedocs.io": r"https://pillow.readthedocs.io/en/stable/",
+    r"https://tidelift.com/badges/package/pypi/Pillow?.*": r"https://img.shields.io/badge/.*",  # noqa: E501
+    r"https://zenodo.org/badge/17549/python-pillow/Pillow.svg": r"https://zenodo.org/badge/doi/[\.0-9]+/zenodo.[0-9]+.svg",  # noqa: E501
+    r"https://zenodo.org/badge/latestdoi/17549/python-pillow/Pillow": r"https://zenodo.org/record/[0-9]+",  # noqa: E501
+}
+
 # sphinx.ext.extlinks
 # This config is a dictionary of external sites,
 # mapping unique short aliases to a base URL and a prefix.

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -210,7 +210,7 @@ open-source users (and will reach EOL on 2023-12-08 for commercial licence holde
 
 Support for PyQt5 and PySide2 has been removed from ``ImageQt``. Upgrade to
 `PyQt6 <https://www.riverbankcomputing.com/static/Docs/PyQt6/>`_ or
-`PySide6 <https://doc.qt.io/qtforpython/>`_ instead.
+`PySide6 <https://doc.qt.io/qtforpython-6/>`_ instead.
 
 Image.coerce_e
 ~~~~~~~~~~~~~~

--- a/docs/releasenotes/10.0.0.rst
+++ b/docs/releasenotes/10.0.0.rst
@@ -117,7 +117,7 @@ open-source users (and will reach EOL on 2023-12-08 for commercial licence holde
 
 Support for PyQt5 and PySide2 has been removed from ``ImageQt``. Upgrade to
 `PyQt6 <https://www.riverbankcomputing.com/static/Docs/PyQt6/>`_ or
-`PySide6 <https://doc.qt.io/qtforpython/>`_ instead.
+`PySide6 <https://doc.qt.io/qtforpython-6/>`_ instead.
 
 Image.coerce_e
 ^^^^^^^^^^^^^^

--- a/docs/releasenotes/9.2.0.rst
+++ b/docs/releasenotes/9.2.0.rst
@@ -15,7 +15,7 @@ open-source users (and will reach EOL on 2023-12-08 for commercial licence holde
 Support for PyQt5 and PySide2 has been deprecated from ``ImageQt`` and will be removed
 in Pillow 10 (2023-07-01). Upgrade to
 `PyQt6 <https://www.riverbankcomputing.com/static/Docs/PyQt6/>`_ or
-`PySide6 <https://doc.qt.io/qtforpython/>`_ instead.
+`PySide6 <https://doc.qt.io/qtforpython-6/>`_ instead.
 
 FreeTypeFont.getmask2 fill parameter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/4892060254/jobs/8733344399#step:7:423
> (    deprecations: line  211) redirect  https://doc.qt.io/qtforpython/ - permanently to https://doc.qt.io/qtforpython-6/