### PR TITLE
Build only PDF in addition to default html

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 version: 2
 
-formats: all
+formats: [pdf]
 
 build:
   os: ubuntu-22.04


### PR DESCRIPTION

Changes proposed in this pull request:

 * https://github.com/python-pillow/Pillow/issues/7114 requested PDF (or at least zipped HTML)
 * PDF was also requested in https://github.com/python-pillow/Pillow/issues/7163
 * https://github.com/python-pillow/Pillow/pull/7116 added PDF, epub and htmlzip
 * To save docs build time, only build PDF in addition to default HTML; skips epub and htmlzip

Build times:

* epub 34s
* htmlzip 16s
* pdf 25s
