### PR TITLE
Removed rectangle example from co-ordinate system documentation

### DIFF
--- a/docs/handbook/concepts.rst
+++ b/docs/handbook/concepts.rst
@@ -95,9 +95,8 @@ in the upper left corner. Note that the coordinates refer to the implied pixel
 corners; the centre of a pixel addressed as (0, 0) actually lies at (0.5, 0.5).
 
 Coordinates are usually passed to the library as 2-tuples (x, y). Rectangles
-are represented as 4-tuples, with the upper left corner given first. For
-example, a rectangle covering all of an 800x600 pixel image is written as (0,
-0, 800, 600).
+are represented as 4-tuples, (x1, y1, x2, y2), with the upper left corner given
+first.
 
 Palette
 -------


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/discussions/7155#discussion-5182709
> In the docs, it says, for the [Coordinate System](https://pillow.readthedocs.io/en/stable/handbook/concepts.html#coordinate-system):
>
> > For example, a rectangle covering all of an 800x600 pixel image is written as (0, 0, 800, 600).
>
> Is this not incorrect, as since the images are zero-based, that text ((0, 0, 800, 600)) should actually be for an image 801 x 601? And so that line of text should really be:
>
> > For example, a rectangle covering all of an 800x600 pixel image is written as (0, 0, 799, 599).

My first attempt to address this was #7156, but while ImageDraw's `rectangle()` includes endpoints, it was [pointed out](https://github.com/python-pillow/Pillow/pull/7156#issuecomment-1542959676) that `crop()` does not.

In this PR, I simplify things by removing the description of how a rectangle will relate to an image.