### PR TITLE
Use --config-settings instead of deprecated --global-option

### DIFF
--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -80,7 +80,7 @@ jobs:
           pushd depends && ./install_extra_test_images.sh && popd
 
       - name: Build Pillow
-        run: SETUPTOOLS_USE_DISTUTILS="stdlib" CFLAGS="-coverage" python3 -m pip install --global-option="build_ext" .
+        run: SETUPTOOLS_USE_DISTUTILS="stdlib" CFLAGS="-coverage" python3 -m pip install .
 
       - name: Test Pillow
         run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,6 +15,7 @@ graft src
 graft depends
 graft winbuild
 graft docs
+graft _custom_build
 
 # build/src control detritus
 exclude .appveyor.yml

--- a/Makefile
+++ b/Makefile
@@ -46,17 +46,12 @@ help:
 	@echo "  docserve           run an HTTP server on the docs directory"
 	@echo "  html               make HTML docs"
 	@echo "  htmlview           open the index page built by the html target in your browser"
-	@echo "  inplace            make inplace extension"
 	@echo "  install            make and install"
 	@echo "  install-coverage   make and install with C coverage"
 	@echo "  lint               run the lint checks"
 	@echo "  lint-fix           run Black and isort to (mostly) fix lint issues"
 	@echo "  release-test       run code and package tests before release"
 	@echo "  test               run tests on installed Pillow"
-
-.PHONY: inplace
-inplace: clean
-	python3 -m pip install -e --global-option="build_ext" --global-option="--inplace" .
 
 .PHONY: install
 install:

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ install:
 
 .PHONY: install-coverage
 install-coverage:
-	CFLAGS="-coverage -Werror=implicit-function-declaration" python3 -m pip -v install --global-option="build_ext" .
+	CFLAGS="-coverage -Werror=implicit-function-declaration" python3 -m pip -v install .
 	python3 selftest.py
 
 .PHONY: debug
@@ -74,7 +74,7 @@ debug:
 # for our stuff, kills optimization, and redirects to dev null so we
 # see any build failures.
 	make clean > /dev/null
-	CFLAGS='-g -O0' python3 -m pip -v install --global-option="build_ext" . > /dev/null
+	CFLAGS='-g -O0' python3 -m pip -v install . > /dev/null
 
 .PHONY: release-test
 release-test:

--- a/_custom_build/backend.py
+++ b/_custom_build/backend.py
@@ -1,0 +1,31 @@
+import sys
+
+from setuptools.build_meta import *  # noqa: F401, F403
+from setuptools.build_meta import _BuildMetaBackend
+
+
+class _CustomBuildMetaBackend(_BuildMetaBackend):
+    def run_setup(self, setup_script="setup.py"):
+        if self.config_settings:
+            flags = []
+            for key in ("enable", "disable", "vendor"):
+                settings = self.config_settings.get(key)
+                if settings:
+                    if not isinstance(settings, list):
+                        settings = [settings]
+                    for value in settings:
+                        flags.append("--" + key + "-" + value)
+            if self.config_settings.get("debug") == "true":
+                flags.append("--debug")
+            if flags:
+                sys.argv = sys.argv[:1] + ["build_ext"] + flags + sys.argv[1:]
+        return super().run_setup(setup_script)
+
+    def build_wheel(
+        self, wheel_directory, config_settings=None, metadata_directory=None
+    ):
+        self.config_settings = config_settings
+        return super().build_wheel(wheel_directory, config_settings, metadata_directory)
+
+
+build_wheel = _CustomBuildMetaBackend().build_wheel

--- a/_custom_build/backend.py
+++ b/_custom_build/backend.py
@@ -7,14 +7,37 @@ from setuptools.build_meta import _BuildMetaBackend
 class _CustomBuildMetaBackend(_BuildMetaBackend):
     def run_setup(self, setup_script="setup.py"):
         if self.config_settings:
-            flags = []
-            for key in ("enable", "disable", "vendor"):
+
+            def config_has(key, value):
                 settings = self.config_settings.get(key)
                 if settings:
                     if not isinstance(settings, list):
                         settings = [settings]
-                    for value in settings:
-                        flags.append("--" + key + "-" + value)
+                    return value in settings
+
+            flags = []
+            for dependency in (
+                "zlib",
+                "jpeg",
+                "tiff",
+                "freetype",
+                "raqm",
+                "lcms",
+                "webp",
+                "webpmux",
+                "jpeg2000",
+                "imagequant",
+                "xcb",
+            ):
+                if config_has(dependency, "enable"):
+                    flags.append("--enable-" + dependency)
+                elif config_has(dependency, "disable"):
+                    flags.append("--disable-" + dependency)
+            for dependency in ("raqm", "fribidi"):
+                if config_has(dependency, "vendor"):
+                    flags.append("--vendor-" + dependency)
+            if self.config_settings.get("platform-guessing") == "disable":
+                flags.append("--disable-platform-guessing")
             if self.config_settings.get("debug") == "true":
                 flags.append("--debug")
             if flags:

--- a/_custom_build/backend.py
+++ b/_custom_build/backend.py
@@ -1,10 +1,12 @@
 import sys
 
 from setuptools.build_meta import *  # noqa: F401, F403
-from setuptools.build_meta import _BuildMetaBackend
+from setuptools.build_meta import build_wheel
+
+backend_class = build_wheel.__self__.__class__
 
 
-class _CustomBuildMetaBackend(_BuildMetaBackend):
+class _CustomBuildMetaBackend(backend_class):
     def run_setup(self, setup_script="setup.py"):
         if self.config_settings:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -380,40 +380,40 @@ Build Options
   using a setting of 1. By default, it uses 4 CPUs, or if 4 are not
   available, as many as are present.
 
-* Build flags: ``--disable-zlib``, ``--disable-jpeg``,
-  ``--disable-tiff``, ``--disable-freetype``, ``--disable-raqm``,
-  ``--disable-lcms``, ``--disable-webp``, ``--disable-webpmux``,
-  ``--disable-jpeg2000``, ``--disable-imagequant``, ``--disable-xcb``.
+* Config settings: ``-C disable=zlib``, ``-C disable=jpeg``,
+  ``-C disable=tiff``, ``-C disable=freetype``, ``-C disable=raqm``,
+  ``-C disable=lcms``, ``-C disable=webp``, ``-C disable=webpmux``,
+  ``-C disable=jpeg2000``, ``-C disable=imagequant``, ``-C disable=xcb``.
   Disable building the corresponding feature even if the development
   libraries are present on the building machine.
 
-* Build flags: ``--enable-zlib``, ``--enable-jpeg``,
-  ``--enable-tiff``, ``--enable-freetype``, ``--enable-raqm``,
-  ``--enable-lcms``, ``--enable-webp``, ``--enable-webpmux``,
-  ``--enable-jpeg2000``, ``--enable-imagequant``, ``--enable-xcb``.
+* Config settings: ``-C enable=zlib``, ``-C enable=jpeg``,
+  ``-C enable=tiff``, ``-C enable=freetype``, ``-C enable=raqm``,
+  ``-C enable=lcms``, ``-C enable=webp``, ``-C enable=webpmux``,
+  ``-C enable=jpeg2000``, ``-C enable=imagequant``, ``-C enable=xcb``.
   Require that the corresponding feature is built. The build will raise
   an exception if the libraries are not found. Webpmux (WebP metadata)
   relies on WebP support. Tcl and Tk also must be used together.
 
-* Build flags: ``--vendor-raqm``, ``--vendor-fribidi``.
+* Config settings: ``-C vendor=raqm``, ``-C vendor=fribidi``.
   These flags are used to compile a modified version of libraqm and
   a shim that dynamically loads libfribidi at runtime. These are
   used to compile the standard Pillow wheels. Compiling libraqm requires
   a C99-compliant compiler.
 
-* Build flag: ``--disable-platform-guessing``. Skips all of the
+* Build flag: ``-C disable=platform-guessing``. Skips all of the
   platform dependent guessing of include and library directories for
   automated build systems that configure the proper paths in the
   environment variables (e.g. Buildroot).
 
-* Build flag: ``--debug``. Adds a debugging flag to the include and
+* Build flag: ``-C debug=true``. Adds a debugging flag to the include and
   library search process to dump all paths searched for and found to
   stdout.
 
 
 Sample usage::
 
-    python3 -m pip install --upgrade Pillow --global-option="build_ext" --global-option="--enable-[feature]"
+    python3 -m pip install --upgrade Pillow -C enable=[feature]
 
 Platform Support
 ----------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -380,28 +380,28 @@ Build Options
   using a setting of 1. By default, it uses 4 CPUs, or if 4 are not
   available, as many as are present.
 
-* Config settings: ``-C disable=zlib``, ``-C disable=jpeg``,
-  ``-C disable=tiff``, ``-C disable=freetype``, ``-C disable=raqm``,
-  ``-C disable=lcms``, ``-C disable=webp``, ``-C disable=webpmux``,
-  ``-C disable=jpeg2000``, ``-C disable=imagequant``, ``-C disable=xcb``.
+* Config settings: ``-C zlib=disable``, ``-C jpeg=disable``,
+  ``-C tiff=disable``, ``-C freetype=disable``, ``-C raqm=disable``,
+  ``-C lcms=disable``, ``-C webp=disable``, ``-C webpmux=disable``,
+  ``-C jpeg2000=disable``, ``-C imagequant=disable``, ``-C xcb=disable``.
   Disable building the corresponding feature even if the development
   libraries are present on the building machine.
 
-* Config settings: ``-C enable=zlib``, ``-C enable=jpeg``,
-  ``-C enable=tiff``, ``-C enable=freetype``, ``-C enable=raqm``,
-  ``-C enable=lcms``, ``-C enable=webp``, ``-C enable=webpmux``,
-  ``-C enable=jpeg2000``, ``-C enable=imagequant``, ``-C enable=xcb``.
+* Config settings: ``-C zlib=enable``, ``-C jpeg=enable``,
+  ``-C tiff=enable``, ``-C freetype=enable``, ``-C raqm=enable``,
+  ``-C lcms=enable``, ``-C webp=enable``, ``-C webpmux=enable``,
+  ``-C jpeg2000=enable``, ``-C imagequant=enable``, ``-C xcb=enable``.
   Require that the corresponding feature is built. The build will raise
   an exception if the libraries are not found. Webpmux (WebP metadata)
   relies on WebP support. Tcl and Tk also must be used together.
 
-* Config settings: ``-C vendor=raqm``, ``-C vendor=fribidi``.
+* Config settings: ``-C raqm=vendor``, ``-C fribidi=vendor``.
   These flags are used to compile a modified version of libraqm and
   a shim that dynamically loads libfribidi at runtime. These are
   used to compile the standard Pillow wheels. Compiling libraqm requires
   a C99-compliant compiler.
 
-* Build flag: ``-C disable=platform-guessing``. Skips all of the
+* Build flag: ``-C platform-guessing=disable``. Skips all of the
   platform dependent guessing of include and library directories for
   automated build systems that configure the proper paths in the
   environment variables (e.g. Buildroot).
@@ -413,7 +413,7 @@ Build Options
 
 Sample usage::
 
-    python3 -m pip install --upgrade Pillow -C enable=[feature]
+    python3 -m pip install --upgrade Pillow -C [feature]=enable
 
 Platform Support
 ----------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools >= 40.8.0", "wheel"]
+build-backend = "backend"
+backend-path = ["_custom_build"]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ extras =
     tests
 commands =
     make clean
-    {envpython} -m pip install --global-option="build_ext" --global-option="--inplace" .
+    {envpython} -m pip install .
     {envpython} selftest.py
     {envpython} -m pytest -W always {posargs}
 allowlist_externals =


### PR DESCRIPTION
Resolves #7167

https://github.com/python-pillow/Pillow/actions/runs/4999985216/jobs/8956875899#step:7:23
> DEPRECATION: --build-option and --global-option are deprecated. pip 23.3 will enforce this behaviour change. A possible replacement is to use --config-settings. Discussion can be found at https://github.com/pypa/pip/issues/11859

`--config-settings` is described at https://peps.python.org/pep-0517/#config-settings

So I think our [build options](https://pillow.readthedocs.io/en/stable/installation.html#build-options) should change from
```
python3 -m pip install --upgrade Pillow --global-option="build_ext" --global-option="--enable-[feature]"
```
to
```
python3 -m pip install --upgrade Pillow -C enable=[feature]
```

However, setuptools does not currently pass the config settings through to the backend - https://github.com/pypa/setuptools/issues/2491

Inspired by https://setuptools.pypa.io/en/latest/build_meta.html#dynamic-build-dependencies-and-other-build-meta-tweaks, my suggestion is to instead have a custom backend that translates the config-settings into a form that setuptools will understand. This should work until setuptools resolve their issue.

For pyproject.toml, I used the fallback setting for the `require` value - https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/#fallback-behaviour