### PR TITLE
Use "not in"

### DIFF
--- a/src/PIL/GdImageFile.py
+++ b/src/PIL/GdImageFile.py
@@ -47,7 +47,7 @@ class GdImageFile(ImageFile.ImageFile):
         # Header
         s = self.fp.read(1037)
 
-        if not i16(s) in [65534, 65535]:
+        if i16(s) not in [65534, 65535]:
             msg = "Not a valid GD 2.x .gd file"
             raise SyntaxError(msg)
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1731,7 +1731,7 @@ class Image:
         if not isinstance(dest, (list, tuple)):
             msg = "Destination must be a tuple"
             raise ValueError(msg)
-        if not len(source) in (2, 4):
+        if len(source) not in (2, 4):
             msg = "Source must be a 2 or 4-tuple"
             raise ValueError(msg)
         if not len(dest) == 2:

--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -24,7 +24,7 @@ def check_module(feature):
     :returns: ``True`` if available, ``False`` otherwise.
     :raises ValueError: If the module is not defined in this version of Pillow.
     """
-    if not (feature in modules):
+    if feature not in modules:
         msg = f"Unknown module {feature}"
         raise ValueError(msg)
 


### PR DESCRIPTION
Extracting a formatting change from #6966 that can be made independently of ruff, as we've preferred this style [in the past.](https://github.com/python-pillow/Pillow/commit/eacbd7b04abac95a2f84a3f091642530910f450f#diff-74d414aaf6e27f4f300028b1d09db57e995195807399fd96f63a207bc4f29ab9L63)