### PR TITLE
Fixed finding dependencies on Cygwin

### DIFF
--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Build
         shell: bash.exe -eo pipefail -o igncr "{0}"
         run: |
-          SETUPTOOLS_USE_DISTUTILS=stdlib .ci/build.sh
+          .ci/build.sh
 
       - name: Test
         run: |

--- a/setup.py
+++ b/setup.py
@@ -515,6 +515,7 @@ class pil_build_ext(build_ext):
 
         elif sys.platform == "cygwin":
             # pythonX.Y.dll.a is in the /usr/lib/pythonX.Y/config directory
+            self.compiler.shared_lib_extension = ".dll.a"
             _add_directory(
                 library_dirs,
                 os.path.join(


### PR DESCRIPTION
Resolves #7158 by applying the part of the patch from https://github.com/pypa/distutils/pull/209, in case we wanted to avoid waiting.

The modification to setup.py added here should be able to be removed once that PR is merged and setuptools is updated to include it.