### PR TITLE
Corrected error code

### DIFF
--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -189,7 +189,7 @@ getfont(PyObject *self_, PyObject *args, PyObject *kw) {
         /* Don't free this before FT_Done_Face */
         self->font_bytes = PyMem_Malloc(font_bytes_size);
         if (!self->font_bytes) {
-            error = 65;  // Out of Memory in Freetype.
+            error = FT_Err_Out_Of_Memory;
         }
         if (!error) {
             memcpy(self->font_bytes, font_bytes, (size_t)font_bytes_size);


### PR DESCRIPTION
Extracting a change from the draft PR #6926

https://github.com/python-pillow/Pillow/blob/599979caae111c22bd15f0103320bf74eb53d963/src/_imagingft.c#L168-L170

On first glance, the PR simply stops this value from being hardcoded, by replacing it with `FT_Err_Out_Of_Memory`, as per https://freetype.org/freetype2/docs/reference/ft2-error_code_values.html.

However, 65 is actually not the out of memory error code. 65 is 0x41, and according to that FreeType doc, 0x40 is "out of memory", while 0x41 is "unlisted object". So this change is not just stylistic, but also corrects the error code.