### PR TITLE
Updated redirected URLs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,9 @@
-# Documentation: https://docs.codecov.io/docs/codecov-yaml
+# Documentation: https://docs.codecov.com/docs/codecov-yaml
 
 codecov:
   # Avoid "Missing base report" due to committing CHANGES.rst with "[CI skip]"
   # https://github.com/codecov/support/issues/363
-  # https://docs.codecov.io/docs/comparing-commits
+  # https://docs.codecov.com/docs/comparing-commits
   allow_coverage_offsets: true
 
 comment: false


### PR DESCRIPTION
https://docs.codecov.io/docs redirects to https://docs.codecov.com/docs