### PR TITLE
Fixed saving multiple 1 mode frames to GIF

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -252,6 +252,19 @@ def test_roundtrip_save_all(tmp_path):
         assert reread.n_frames == 5
 
 
+def test_roundtrip_save_all_1(tmp_path):
+    out = str(tmp_path / "temp.gif")
+    im = Image.new("1", (1, 1))
+    im2 = Image.new("1", (1, 1), 1)
+    im.save(out, save_all=True, append_images=[im2])
+
+    with Image.open(out) as reloaded:
+        assert reloaded.getpixel((0, 0)) == 0
+
+        reloaded.seek(1)
+        assert reloaded.getpixel((0, 0)) == 255
+
+
 @pytest.mark.parametrize(
     "path, mode",
     (

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -879,7 +879,7 @@ def _get_palette_bytes(im):
     :param im: Image object
     :returns: Bytes, len<=768 suitable for inclusion in gif header
     """
-    return im.palette.palette
+    return im.palette.palette if im.palette else b""
 
 
 def _get_background(im, info_background):


### PR DESCRIPTION
Updates GifImagePlugin so that
https://github.com/python-pillow/Pillow/blob/5aa3f2d20977673b6420f3f2c4e43ac2ca9a27a1/src/PIL/GifImagePlugin.py#L875-L882
returns an empty bytestring if there is no palette.

The test case I've added otherwise fails with `AttributeError: 'NoneType' object has no attribute 'palette'` in the above function.