### PR TITLE
Fixed calling putpalette() on L and LA images before load()

### DIFF
--- a/Tests/test_image_putpalette.py
+++ b/Tests/test_image_putpalette.py
@@ -32,6 +32,14 @@ def test_putpalette():
     with pytest.raises(ValueError):
         palette("YCbCr")
 
+    with Image.open("Tests/images/hopper_gray.jpg") as im:
+        assert im.mode == "L"
+        im.putpalette(list(range(256)) * 3)
+
+    with Image.open("Tests/images/la.tga") as im:
+        assert im.mode == "LA"
+        im.putpalette(list(range(256)) * 3)
+
 
 def test_imagepalette():
     im = hopper("P")

--- a/src/libImaging/Unpack.c
+++ b/src/libImaging/Unpack.c
@@ -1552,10 +1552,12 @@ static struct {
     {"P", "P;4L", 4, unpackP4L},
     {"P", "P", 8, copy1},
     {"P", "P;R", 8, unpackLR},
+    {"P", "L", 8, copy1},
 
     /* palette w. alpha */
     {"PA", "PA", 16, unpackLA},
     {"PA", "PA;L", 16, unpackLAL},
+    {"PA", "LA", 16, unpackLA},
 
     /* true colour */
     {"RGB", "RGB", 24, ImagingUnpackRGB},


### PR DESCRIPTION
Address the problem raised in #7186

`putpalette()`'s strategy for attaching a palette to an image is to change the mode, set the palette, and then call `load()`.
https://github.com/python-pillow/Pillow/blob/117618b01f959f016833158b7b128e896c6d38b6/src/PIL/Image.py#L1918-L1921

We have been testing this with [all of the valid modes.](https://github.com/python-pillow/Pillow/blob/117618b01f959f016833158b7b128e896c6d38b6/Tests/test_image_putpalette.py#L19-L23)

However, the user found an error when calling `putpalette()` on an image directly after opening it, before `load()` is called. This means that L and LA images are attempted to be unpacked directly into P and PA images respectively, which Unpack.c doesn't currently support.

This PR fixes that.