### PR TITLE
Fix Python 3.12 failures

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -42,7 +42,7 @@ if [[ $(uname) != CYGWIN* ]]; then
     if ! [ "$GHA_PYTHON_VERSION" == "3.12-dev" ]; then python3 -m pip install numpy ; fi
 
     # PyQt6 doesn't support PyPy3
-    if [[ $GHA_PYTHON_VERSION == 3.* ]]; then
+    if [[ "$GHA_PYTHON_VERSION" != "3.12-dev" && $GHA_PYTHON_VERSION == 3.* ]]; then
         sudo apt-get -qq install libegl1 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxkbcommon-x11-0
         python3 -m pip install pyqt6
     fi

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -65,8 +65,8 @@ jobs:
     - name: Print build system information
       run: python3 .github/workflows/system-info.py
 
-    - name: python3 -m pip install wheel pytest pytest-cov pytest-timeout defusedxml
-      run: python3 -m pip install wheel pytest pytest-cov pytest-timeout defusedxml
+    - name: python3 -m pip install setuptools wheel pytest pytest-cov pytest-timeout defusedxml
+      run: python3 -m pip install setuptools wheel pytest pytest-cov pytest-timeout defusedxml
 
     - name: Install dependencies
       id: install


### PR DESCRIPTION
The Windows Python 3.12 builds on main have started failing - https://github.com/python-pillow/Pillow/actions/runs/5089366014/jobs/9146907439#step:25:41
> ModuleNotFoundError: No module named 'setuptools'

This installs setuptools to fix that.

The Linux Python 3.12 build on main has also started failing with a segfault - https://github.com/python-pillow/Pillow/actions/runs/5089395395/jobs/9146969201

Skipping testing PyQt6 on Python 3.12 fixes that. I'm able to [reproduce the segfault](https://github.com/radarhere/Pillow/actions/runs/5095982782/jobs/9161438269) [without Pillow](https://github.com/radarhere/Pillow/commit/6ce891977a328b774db72880d6a2cfc563aa732f), so it is not a problem directly with our code.