### PR TITLE
Specify build backend via pyproject.toml

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,7 +72,7 @@ before_deploy:
   - cd c:\pillow
   - '%PYTHON%\%EXECUTABLE% -m pip install wheel'
   - cd c:\pillow\winbuild\
-  - c:\pillow\winbuild\build\build_pillow.cmd bdist_wheel
+  - c:\pillow\winbuild\build\build_pillow.cmd --global-option="bdist_wheel"
   - cd c:\pillow
   - ps: Get-ChildItem .\dist\*.* | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,6 +20,7 @@ environment:
 
 install:
 - '%PYTHON%\%EXECUTABLE% --version'
+- '%PYTHON%\%EXECUTABLE% -m pip install --upgrade pip'
 - curl -fsSL -o pillow-depends.zip https://github.com/python-pillow/pillow-depends/archive/main.zip
 - curl -fsSL -o pillow-test-images.zip https://github.com/python-pillow/test-images/archive/main.zip
 - 7z x pillow-depends.zip -oc:\

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -65,8 +65,8 @@ jobs:
     - name: Print build system information
       run: python3 .github/workflows/system-info.py
 
-    - name: python3 -m pip install setuptools wheel pytest pytest-cov pytest-timeout defusedxml
-      run: python3 -m pip install setuptools wheel pytest pytest-cov pytest-timeout defusedxml
+    - name: python3 -m pip install wheel pytest pytest-cov pytest-timeout defusedxml
+      run: python3 -m pip install wheel pytest pytest-cov pytest-timeout defusedxml
 
     - name: Install dependencies
       id: install

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -166,8 +166,8 @@ jobs:
     - name: Build Pillow
       run: |
         $FLAGS=""
-        if ('${{ github.event_name }}' -ne 'pull_request') { $FLAGS="--disable-imagequant" }
-        & winbuild\build\build_pillow.cmd $FLAGS install
+        if ('${{ github.event_name }}' -ne 'pull_request') { $FLAGS='--global-option="--disable-imagequant"' }
+        & winbuild\build\build_pillow.cmd $FLAGS --global-option="install"
         & $env:pythonLocation\python.exe selftest.py --installed
       shell: pwsh
 
@@ -231,7 +231,7 @@ jobs:
           )
         )
         for /f "tokens=3 delims=/" %%a in ("${{ github.ref }}") do echo dist=dist-%%a >> %GITHUB_OUTPUT%
-        winbuild\\build\\build_pillow.cmd --disable-imagequant bdist_wheel
+        winbuild\\build\\build_pillow.cmd --global-option="--disable-imagequant" --global-option="bdist_wheel"
       shell: cmd
 
     - name: Upload wheel

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
       - id: sphinx-lint
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 0.11.2
+    rev: 0.12.1
     hooks:
       - id: pyproject-fmt
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,12 +49,23 @@ repos:
     hooks:
       - id: check-merge-conflict
       - id: check-json
+      - id: check-toml
       - id: check-yaml
 
   - repo: https://github.com/sphinx-contrib/sphinx-lint
     rev: v0.6.7
     hooks:
       - id: sphinx-lint
+
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: 0.11.2
+    hooks:
+      - id: pyproject-fmt
+
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.13
+    hooks:
+      - id: validate-pyproject
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
     rev: 1.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [
+  "setuptools>=61.2",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-  "setuptools>=61.2",
+  "setuptools>=67.8",
 ]

--- a/setup.py
+++ b/setup.py
@@ -847,14 +847,7 @@ class pil_build_ext(build_ext):
         if struct.unpack("h", b"\0\1")[0] == 1:
             defs.append(("WORDS_BIGENDIAN", None))
 
-        if (
-            sys.platform == "win32"
-            and sys.version_info < (3, 9)
-            and not (PLATFORM_PYPY or PLATFORM_MINGW)
-        ):
-            defs.append(("PILLOW_VERSION", f'"\\"{PILLOW_VERSION}\\""'))
-        else:
-            defs.append(("PILLOW_VERSION", f'"{PILLOW_VERSION}"'))
+        defs.append(("PILLOW_VERSION", f'"{PILLOW_VERSION}"'))
 
         self._update_extension("PIL._imaging", libs, defs)
 

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,6 @@ class RequiredDependencyException(Exception):
 
 
 PLATFORM_MINGW = os.name == "nt" and "GCC" in sys.version
-PLATFORM_PYPY = hasattr(sys, "pypy_version_info")
 
 
 def _dbg(s, tp=None):

--- a/winbuild/README.md
+++ b/winbuild/README.md
@@ -20,10 +20,10 @@ set PYTHON=C:\Python38\bin
 cd /D C:\Pillow\winbuild
 C:\Python39\bin\python.exe build_prepare.py -v --depends=C:\pillow-depends
 build\build_dep_all.cmd
-build\build_pillow.cmd install
+build\build_pillow.cmd --global-option="install"
 cd ..
 path C:\Pillow\winbuild\build\bin;%PATH%
 %PYTHON%\python.exe selftest.py
 %PYTHON%\python.exe -m pytest -vx --cov PIL --cov Tests --cov-report term --cov-report xml Tests
-build\build_pillow.cmd bdist_wheel
+build\build_pillow.cmd --global-option="bdist_wheel"
 ```

--- a/winbuild/build.rst
+++ b/winbuild/build.rst
@@ -87,9 +87,9 @@ Building Pillow
 ---------------
 
 Once the dependencies are built, run
-``winbuild\build\build_pillow.cmd install`` to build and install
+``winbuild\build\build_pillow.cmd --global-option="install"`` to build and install
 Pillow for the selected version of Python.
-``winbuild\build\build_pillow.cmd bdist_wheel`` will build wheels
+``winbuild\build\build_pillow.cmd --global-option="bdist_wheel"`` will build wheels
 instead of installing Pillow.
 
 You can also use ``winbuild\build\build_pillow.cmd --inplace develop`` to build
@@ -114,9 +114,9 @@ The following is a simplified version of the script used on AppVeyor::
     cd /D C:\Pillow\winbuild
     C:\Python39\bin\python.exe build_prepare.py -v --depends C:\pillow-depends
     build\build_dep_all.cmd
-    build\build_pillow.cmd install
+    build\build_pillow.cmd --global-option="install"
     cd ..
     path C:\Pillow\winbuild\build\bin;%PATH%
     %PYTHON%\python.exe selftest.py
     %PYTHON%\python.exe -m pytest -vx --cov PIL --cov Tests --cov-report term --cov-report xml Tests
-    build\build_pillow.cmd bdist_wheel
+    build\build_pillow.cmd --global-option="bdist_wheel"

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -569,6 +569,7 @@ def build_pillow():
         *prefs["header"],
         cmd_set("DISTUTILS_USE_SDK", "1"),  # use same compiler to build Pillow
         cmd_set("py_vcruntime_redist", "true"),  # always use /MD, never /MT
+        r'"{python_dir}\{python_exe}" -m pip install --upgrade pip',
         r'"{python_dir}\{python_exe}" -m pip install . '
         r'--global-option="--vendor-raqm" '
         r'--global-option="--vendor-fribidi" '

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -569,7 +569,10 @@ def build_pillow():
         *prefs["header"],
         cmd_set("DISTUTILS_USE_SDK", "1"),  # use same compiler to build Pillow
         cmd_set("py_vcruntime_redist", "true"),  # always use /MD, never /MT
-        r'"{python_dir}\{python_exe}" setup.py build_ext --vendor-raqm --vendor-fribidi %*',  # noqa: E501
+        r'"{python_dir}\{python_exe}" -m pip install . '
+        r'--global-option="--vendor-raqm" '
+        r'--global-option="--vendor-fribidi" '
+        r'--global-option="%*"',
     ]
 
     write_script("build_pillow.cmd", lines)

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -569,7 +569,6 @@ def build_pillow():
         *prefs["header"],
         cmd_set("DISTUTILS_USE_SDK", "1"),  # use same compiler to build Pillow
         cmd_set("py_vcruntime_redist", "true"),  # always use /MD, never /MT
-        r'"{python_dir}\{python_exe}" -m pip install --upgrade pip',
         r'"{python_dir}\{python_exe}" -m pip install . '
         r'--global-option="--vendor-raqm" '
         r'--global-option="--vendor-fribidi" '

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -572,7 +572,7 @@ def build_pillow():
         r'"{python_dir}\{python_exe}" -m pip install . '
         r'--global-option="--vendor-raqm" '
         r'--global-option="--vendor-fribidi" '
-        r'--global-option="%*"',
+        r"%*",
     ]
 
     write_script("build_pillow.cmd", lines)


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/6941.

https://github.com/python-pillow/Pillow/pull/7188 added setuptools to the CI installation for Python 3.12, because 3.12 dropped setuptools:

* https://docs.python.org/3.12/whatsnew/3.12.html#removed

This is actually a bit bigger problem than the CI because users could theoretically have a system that does not have setuptools installed.

---

With pyproject.toml, we can specify the "build backend". In our case, this is setuptools. (The "build frontend" is what reads this file and does the install, often pip.)

So when installing, the frontend will install the required backend, so we don't need to worry whether users have already installed it. We can also specify a minimum version. I just went with the current latest, and it also seems we can remove the extra `PILLOW_VERSION` double quotes hack we needed for Windows on Python 3.8.

It's also possible to move more config from `setup.cfg` to `pyproject.toml`, but I ran into some problems when moving `[options]` and `[options.extras_require]` over, so let's leave those for later. We can also move the tools config, but that can also wait to keep the diff smaller here and the PR focused.

---

About `winbuild/build_prepare.py`: it had a direct invocation of `setup.py` which is a no-go because it assumes setuptools is already installed. So we need `pip install` instead (reminder of https://blog.ganssle.io/tag/setuptools.html).

I went with `--global-option` for now, to follow the current approach elsewhere, but that will need changing as part of https://github.com/python-pillow/Pillow/issues/7167.

I did hit one blocker though: `test-windows.yml` builds a wheel, it calls:

```
winbuild\\build\\build_pillow.cmd --disable-imagequant bdist_wheel
```

Before, that was handled by this: 

```
        r'"{python_dir}\{python_exe}" setup.py build_ext --vendor-raqm --vendor-fribidi %*',  # noqa: E501
```

Which wrote out a command that was called like:

```
2023-04-28T14:37:47.1413330Z D:\a\Pillow\Pillow>"C:\hostedtoolcache\windows\Python\3.8.10\x86\python.exe" setup.py build_ext --vendor-raqm --vendor-fribidi --disable-imagequant bdist_wheel 
```

Now, those two args `--disable-imagequant bdist_wheel` each need wrapping as `--global-option="--disable-imagequant" --global-option="bdist_wheel"`

But this PR does:

```python
        r'"{python_dir}\{python_exe}" -m pip install --upgrade pip',
        r'"{python_dir}\{python_exe}" -m pip install . '
        r'--global-option="--vendor-raqm" '
        r'--global-option="--vendor-fribidi" '
        r'--global-option="%*"',
```

And those two args were both passed into `%*` meaning they both were wrapped in a single `global-option` which doesn't work, so it doesn't build the wheel:

```
2023-05-27T14:56:57.1800310Z D:\a\Pillow\Pillow>"C:\hostedtoolcache\windows\Python\3.8.10\x86\python.exe" -m pip install . --global-option="--vendor-raqm" --global-option="--vendor-fribidi" --global-option="--disable-imagequant bdist_wheel" 
```

Any ideas?

Maybe replace the `build_pillow.cmd` call entirely, and use something like https://pypi.org/project/build/ to call `python -m build --wheel`?
