### PR TITLE
Replaced deprecated Py_FileSystemDefaultEncoding for Python >= 3.12

### DIFF
--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -132,6 +132,27 @@ getfont(PyObject *self_, PyObject *args, PyObject *kw) {
         return NULL;
     }
 
+#if PY_MAJOR_VERSION > 3 || PY_MINOR_VERSION > 11
+    PyConfig config;
+    PyConfig_InitPythonConfig(&config);
+    if (!PyArg_ParseTupleAndKeywords(
+            args,
+            kw,
+            "etf|nsy#n",
+            kwlist,
+            config.filesystem_encoding,
+            &filename,
+            &size,
+            &index,
+            &encoding,
+            &font_bytes,
+            &font_bytes_size,
+            &layout_engine)) {
+        PyConfig_Clear(&config);
+        return NULL;
+    }
+    PyConfig_Clear(&config);
+#else
     if (!PyArg_ParseTupleAndKeywords(
             args,
             kw,
@@ -147,6 +168,7 @@ getfont(PyObject *self_, PyObject *args, PyObject *kw) {
             &layout_engine)) {
         return NULL;
     }
+#endif
 
     self = PyObject_New(FontObject, &Font_Type);
     if (!self) {


### PR DESCRIPTION
Python 3.12 reports a deprecation - https://github.com/python-pillow/Pillow/actions/runs/5105776867/jobs/9177570491#step:7:234
> warning: 'Py_FileSystemDefaultEncoding' is deprecated

https://docs.python.org/3.12/whatsnew/3.12.html#id4 instructs us to replace it with `PyConfig.filesystem_encoding`.

Using https://docs.python.org/3.12/c-api/init_config.html#example as a basis, I made that change.

However, I found [this](https://github.com/radarhere/Pillow/commit/cda44e2408d64663ac71cb8f9cc46bef1b298611) [failed on PyPy](https://github.com/radarhere/Pillow/actions/runs/5097051329/jobs/9163321558#step:7:232), with
> error: use of undeclared identifier 'PyConfig'

I asked in https://foss.heptapod.net/pypy/pypy/-/issues/3946, and PyPy has chosen not to implement PyConfig yet. So I've switched to the new code only for Python 3.12 and later, and we can see what happens once PyPy does support Python 3.12.