### PR TITLE
Removed duplicate config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,10 +13,6 @@ indent_style = space
 
 trim_trailing_whitespace = true
 
-[*.rst]
-# Four-space indentation
-indent_size = 4
-
 [*.yml]
 # Two-space indentation
 indent_size = 2


### PR DESCRIPTION
It seems to me that if all files by `indent_size = 4` by default,
https://github.com/python-pillow/Pillow/blob/3e3378fc23b1445b818bacfe3a92586bfbeb39fe/.editorconfig#L4-L11

then we don't need to specify that RST files do as well.
https://github.com/python-pillow/Pillow/blob/3e3378fc23b1445b818bacfe3a92586bfbeb39fe/.editorconfig#L16-L18