### PR TITLE
Do not close provided file handles with libtiff

### DIFF
--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1253,9 +1253,8 @@ class TiffImageFile(ImageFile.ImageFile):
         # To be nice on memory footprint, if there's a
         # file descriptor, use that instead of reading
         # into a string in python.
-        # libtiff closes the file descriptor, so pass in a dup.
         try:
-            fp = hasattr(self.fp, "fileno") and os.dup(self.fp.fileno())
+            fp = hasattr(self.fp, "fileno") and self.fp.fileno()
             # flush the file descriptor, prevents error on pypy 2.4+
             # should also eliminate the need for fp.tell
             # in _seek
@@ -1305,18 +1304,11 @@ class TiffImageFile(ImageFile.ImageFile):
             # UNDONE -- so much for that buffer size thing.
             n, err = decoder.decode(self.fp.read())
 
-        if fp:
-            try:
-                os.close(fp)
-            except OSError:
-                pass
-
         self.tile = []
         self.readonly = 0
 
         self.load_end()
 
-        # libtiff closed the fp in a, we need to close self.fp, if possible
         if close_self_fp:
             self.fp.close()
             self.fp = None  # might be shared

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -720,9 +720,14 @@ ImagingLibTiffDecode(
     }
 
  decode_err:
+    // TIFFClose in libtiff calls tif_closeproc and TIFFCleanup
     if (clientstate->fp) {
+        // Pillow will manage the closing of the file rather than libtiff
+        // So only call TIFFCleanup
         TIFFCleanup(tiff);
     } else {
+        // When tif_closeproc refers to our custom _tiffCloseProc though,
+        // that is fine, as it does not close the file
         TIFFClose(tiff);
     }
     TRACE(("Done Decoding, Returning \n"));

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -720,7 +720,11 @@ ImagingLibTiffDecode(
     }
 
  decode_err:
-    TIFFClose(tiff);
+    if (clientstate->fp) {
+        TIFFCleanup(tiff);
+    } else {
+        TIFFClose(tiff);
+    }
     TRACE(("Done Decoding, Returning \n"));
     // Returning -1 here to force ImageFile.load to break, rather than
     // even think about looping back around.


### PR DESCRIPTION
Resolves #7042

libtiff closes file handles, but Pillow might still want access afterwards to seek to other frames in the file. To resolve this, TiffImagePlugin duplicates the file handle.

https://github.com/python-pillow/Pillow/blob/9a560c78a821638662206a51423f987eb095a901/src/PIL/TiffImagePlugin.py#L1256-L1258

#5936 had a problem with too many open files, so the following code was added to ensure that if libtiff did not close the file, Pillow would still close the file.
https://github.com/python-pillow/Pillow/blob/9a560c78a821638662206a51423f987eb095a901/src/PIL/TiffImagePlugin.py#L1308-L1312

#7042 doesn't like this behaviour, feeling that it is not thread-safe to close a file handle more than once.

Investigating how exactly libtiff closes file handles, I found that it is [`_tiffCloseProc`](https://gitlab.com/libtiff/libtiff/-/blob/master/libtiff/tif_unix.c#L132-137) that closes the file handle. This is called by [`TIFFClose`](https://gitlab.com/libtiff/libtiff/-/blob/master/libtiff/tif_close.c#L148-158), which we call from https://github.com/python-pillow/Pillow/blob/9a560c78a821638662206a51423f987eb095a901/src/libImaging/TiffDecode.c#L723

Looking at the code for [`TIFFClose`](https://gitlab.com/libtiff/libtiff/-/blob/master/libtiff/tif_close.c#L148-158), something becomes apparent - if we didn't want to call `_tiffCloseProc` when a file handle is in use, then we could just call `TIFFCleanup` instead of `TIFFClose`. Then we don't need to duplicate the file handle and don't need to try and close the duplicated file handle. Testing, this shouldn't break #5936, and passes #7042's reproduction (although that is [not necessarily indicative](https://github.com/python-pillow/Pillow/issues/7042#issuecomment-1490391771)).