### PR TITLE
Clip F resampling to prevent negative values

### DIFF
--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -281,6 +281,13 @@ class TestImageResize:
         im = hopper(mode)
         assert im.resize((20, 20), Image.Resampling.BICUBIC) == im.resize((20, 20))
 
+    def test_bicubic_f_clipping(self):
+        im = Image.new("F", (1, 2))
+        im.putpixel((0, 1), 1)
+
+        im = im.resize((1, 3), Image.BICUBIC)
+        assert im.getpixel((0, 0)) >= 0
+
     @pytest.mark.parametrize(
         "mode", ("1", "P", "I;16", "I;16L", "I;16B", "BGR;15", "BGR;16")
     )

--- a/src/libImaging/Resample.c
+++ b/src/libImaging/Resample.c
@@ -535,6 +535,9 @@ ImagingResampleVertical_32bpc(
                     for (y = 0; y < ymax; y++) {
                         ss += IMAGING_PIXEL_F(imIn, xx, y + ymin) * k[y];
                     }
+                    if (ss < 0) {
+                        ss = 0;
+                    }
                     IMAGING_PIXEL_F(imOut, xx, yy) = ss;
                 }
             }


### PR DESCRIPTION
Resolves #4783

The issue found that resizing with F mode images may produce negative pixels. This PR clips the result to prevent that.