### PR TITLE
Fixed signedness comparison warning

### DIFF
--- a/src/libImaging/Jpeg2KEncode.c
+++ b/src/libImaging/Jpeg2KEncode.c
@@ -464,7 +464,7 @@ j2k_encode_entry(Imaging im, ImagingCodecState state) {
     }
 
     if (!context->num_resolutions) {
-        while (tile_width < (1 << (params.numresolution - 1U)) || tile_height < (1 << (params.numresolution - 1U))) {
+        while (tile_width < (1U << (params.numresolution - 1U)) || tile_height < (1U << (params.numresolution - 1U))) {
             params.numresolution -= 1;
         }
     }


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/5186598166/jobs/9347921664#step:7:118
>   src/libImaging/Jpeg2KEncode.c: In function ‘j2k_encode_entry’:
>  src/libImaging/Jpeg2KEncode.c:467:27: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]
>    467 |         while (tile_width < (1 << (params.numresolution - 1U)) || tile_height < (1 << (params.numresolution - 1U))) {
        |                           ^
>  src/libImaging/Jpeg2KEncode.c:467:79: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]
>    467 |         while (tile_width < (1 << (params.numresolution - 1U)) || tile_height < (1 << (params.numresolution - 1U))) {
        |                                                                               ^