### PR TITLE
Document order of kernel weights

### DIFF
--- a/src/PIL/ImageFilter.py
+++ b/src/PIL/ImageFilter.py
@@ -35,7 +35,7 @@ class BuiltinFilter(MultibandFilter):
 
 class Kernel(BuiltinFilter):
     """
-    Create a convolution kernel.  The current version only
+    Create a convolution kernel. The current version only
     supports 3x3 and 5x5 integer and floating point kernels.
 
     In the current version, kernels can only be applied to
@@ -43,9 +43,10 @@ class Kernel(BuiltinFilter):
 
     :param size: Kernel size, given as (width, height). In the current
                     version, this must be (3,3) or (5,5).
-    :param kernel: A sequence containing kernel weights.
+    :param kernel: A sequence containing kernel weights. The kernel will
+                   be flipped vertically before being applied to the image.
     :param scale: Scale factor. If given, the result for each pixel is
-                    divided by this value.  The default is the sum of the
+                    divided by this value. The default is the sum of the
                     kernel weights.
     :param offset: Offset. If given, this value is added to the result,
                     after it has been divided by the scale factor.


### PR DESCRIPTION
Resolves #3678

https://pillow.readthedocs.io/en/stable/reference/ImageFilter.html#PIL.ImageFilter.Kernel
> kernel – A sequence containing kernel weights.

The issue notes that this doesn't specify the order. As #3134 notes, Pillow does not use convolution order or correlation order.

https://towardsdatascience.com/convolution-vs-correlation-af868b6b4fb5 has figures 5d and 6g of this,

<img src="https://github.com/python-pillow/Pillow/assets/3112309/2002c446-cd94-4061-a99b-be91c0a414c3">
<img src="https://github.com/python-pillow/Pillow/assets/3112309/811f1ff4-fb36-43ac-b46e-249de3602699">

noting that
> In Convolution operation, the kernel is first flipped by an angle of 180 degrees and is then applied to the image.

So our order, as noted by #3134, is
```python
# result:
#[[0 0 0 0 0 0 0]
# [0 0 0 0 0 0 0]
# [0 0 3 2 1 0 0]
# [0 0 6 5 4 0 0]
# [0 0 9 8 7 0 0]
# [0 0 0 0 0 0 0]
# [0 0 0 0 0 0 0]]
```
which would be flipping the kernel vertically before applying it. I've added that note to the documentation.