### PR TITLE
Only call text_layout once in getmask2

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -463,6 +463,11 @@ def test_default_font():
     assert_image_equal_tofile(im, "Tests/images/default_font.png")
 
 
+@pytest.mark.parametrize("mode", (None, "1", "RGBA"))
+def test_getbbox(font, mode):
+    assert (0, 4, 12, 16) == font.getbbox("A", mode)
+
+
 def test_getbbox_empty(font):
     # issue #2614, should not crash.
     assert (0, 0, 0, 0) == font.getbbox("")

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -26,7 +26,6 @@
 #
 
 import base64
-import math
 import os
 import sys
 import warnings
@@ -551,28 +550,23 @@ class FreeTypeFont:
                  :py:mod:`PIL.Image.core` interface module, and the text offset, the
                  gap between the starting coordinate and the first marking
         """
-        size, offset = self.font.getsize(
-            text, mode, direction, features, language, anchor
-        )
         if start is None:
             start = (0, 0)
-        size = tuple(math.ceil(size[i] + stroke_width * 2 + start[i]) for i in range(2))
-        offset = offset[0] - stroke_width, offset[1] - stroke_width
+        im, size, offset = self.font.render(
+            text,
+            Image.core.fill,
+            mode,
+            direction,
+            features,
+            language,
+            stroke_width,
+            anchor,
+            ink,
+            start[0],
+            start[1],
+            Image.MAX_IMAGE_PIXELS,
+        )
         Image._decompression_bomb_check(size)
-        im = Image.core.fill("RGBA" if mode == "RGBA" else "L", size, 0)
-        if min(size):
-            self.font.render(
-                text,
-                im.id,
-                mode,
-                direction,
-                features,
-                language,
-                stroke_width,
-                ink,
-                start[0],
-                start[1],
-            )
         return im, offset
 
     def font_variant(


### PR DESCRIPTION
Helps #6618

**Backstory**
The following is an earlier version of `ImageFont`'s `getmask2()`, as described in the quoted comment.
https://github.com/python-pillow/Pillow/blob/3cfdef395e7c57e4c88a23c7c7458a045894ffe5/src/PIL/ImageFont.py#L752-L777

https://github.com/python-pillow/Pillow/issues/6618#issuecomment-1257086823
> The function getmask2 performs the following steps:
> 
> 1. calls getsize to get the size of the text
> 2. calls Image._decompression_bomb_check to compare size with MAX_IMAGE_PIXELS
> 3. calls the fill function passed as argument to create a blank image
> 4. calls render to draw text into the blank image
> 
> After Pillow 10 the deprecated fill parameter will be replaced by a direct call to the internal function. After this, the only Python function to be called between the two C functions is the decompression bomb check. If this was moved into C, the two functions could be combined to remove the duplicate call to text_layout.

#7059 removed the deprecated fill parameter. So here is the current version of `ImageFont`'s `getmask2()`.

https://github.com/python-pillow/Pillow/blob/1fc8d825fa578ee020ba41affc594fe48b41f660/src/PIL/ImageFont.py#L554-L575

This is the only place that `font.render` is called.

**Change**
So I added a change to make `font.getsize` a builtin part of `font.render`, meaning that `text_layout` is not called once by each, but only once.

From my tests, this causes `getmask2` to be 10% faster.

There is an awkward part of this change though - the _imagingft extension is not connected to the C code for creating new images. I couldn't call `ImagingNewDirty` and `ImagingFill`. Despite the quoted comment's expectation that this could all be done in C, it didn't realise that our C code is actually split up into these extensions. Instead, I've passed `Image.core.fill` into C, to then be called by `PyObject_CallFunction`.