### PR TITLE
Added PyPy 3.10 and removed PyPy 3.8

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -28,9 +28,9 @@ jobs:
         architecture: ["x86", "x64"]
         include:
           # PyPy 7.3.4+ only ships 64-bit binaries for Windows
-          - python-version: "pypy3.8"
-            architecture: "x64"
           - python-version: "pypy3.9"
+            architecture: "x64"
+          - python-version: "pypy3.10"
             architecture: "x64"
 
     timeout-minutes: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,8 @@ jobs:
           "ubuntu-latest",
         ]
         python-version: [
+          "pypy3.10",
           "pypy3.9",
-          "pypy3.8",
           "3.12-dev",
           "3.11",
           "3.10",


### PR DESCRIPTION
PyPy 7.3.12 has been released with Python 3.9 and 3.10 - https://www.pypy.org/posts/2023/06/pypy-v7312-release.html