### PR TITLE
Change `grabclipboard()` to use PNG compression on macOS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog (Pillow)
 10.0.0 (unreleased)
 -------------------
 
+- Changed grabclipboard() to use PNG instead of JPG compression on macOS #7219
+  [abey79]
+
 - Added in_place argument to ImageOps.exif_transpose() #7092
   [radarhere]
 

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -95,7 +95,7 @@ def grab(bbox=None, include_layered_windows=False, all_screens=False, xdisplay=N
 
 def grabclipboard():
     if sys.platform == "darwin":
-        fh, filepath = tempfile.mkstemp(".jpg")
+        fh, filepath = tempfile.mkstemp(".png")
         os.close(fh)
         commands = [
             'set theFile to (open for access POSIX file "'

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -102,7 +102,7 @@ def grabclipboard():
             + filepath
             + '" with write permission)',
             "try",
-            "    write (the clipboard as JPEG picture) to theFile",
+            "    write (the clipboard as «class PNGf») to theFile",
             "end try",
             "close access theFile",
         ]


### PR DESCRIPTION
This PR changes `grabclipboard()` to use a PNG compression instead of a lossy JPG compression when reading images from he clipboard on macOS.

Fixes #7214 