### PR TITLE
bench_cffi_access print formatting

### DIFF
--- a/Tests/bench_cffi_access.py
+++ b/Tests/bench_cffi_access.py
@@ -27,25 +27,19 @@ def timer(func, label, *args):
     for x in range(iterations):
         func(*args)
         if time.time() - starttime > 10:
-            print(
-                "{}: breaking at {} iterations, {:.6f}s per iteration".format(
-                    label, x + 1, (time.time() - starttime) / (x + 1.0)
-                )
-            )
             break
-    if x == iterations - 1:
-        endtime = time.time()
-        print(
-            "{}: {:.4f}s total, {:.6f}s per iteration".format(
-                label, endtime - starttime, (endtime - starttime) / (x + 1.0)
-            )
+    endtime = time.time()
+    print(
+        "{}: completed {} iterations in {:.4f}s, {:.6f}s per iteration".format(
+            label, x + 1, endtime - starttime, (endtime - starttime) / (x + 1.0)
         )
+    )
 
 
 def test_direct():
     im = hopper()
     im.load()
-    # im = Image.new( "RGB", (2000, 2000), (1, 3, 2))
+    # im = Image.new("RGB", (2000, 2000), (1, 3, 2))
     caccess = im.im.pixel_access(False)
     access = PyAccess.new(im, False)
 

--- a/Tests/bench_cffi_access.py
+++ b/Tests/bench_cffi_access.py
@@ -28,7 +28,7 @@ def timer(func, label, *args):
         func(*args)
         if time.time() - starttime > 10:
             print(
-                "{}: breaking at {} iterations, {:.6f} per iteration".format(
+                "{}: breaking at {} iterations, {:.6f}s per iteration".format(
                     label, x + 1, (time.time() - starttime) / (x + 1.0)
                 )
             )
@@ -36,7 +36,7 @@ def timer(func, label, *args):
     if x == iterations - 1:
         endtime = time.time()
         print(
-            "{}: {:.4f} s  {:.6f} per iteration".format(
+            "{}: {:.4f}s total, {:.6f}s per iteration".format(
                 label, endtime - starttime, (endtime - starttime) / (x + 1.0)
             )
         )


### PR DESCRIPTION
Changed output format from
`PyAccess - get: breaking at 63 iterations, 0.160498 per iteration`
or
`PyAccess - get: 10.1114 s  0.160498 per iteration`
to
`PyAccess - get: completed 63 iterations in 10.1114s, 0.160498s per iteration`