### PR TITLE
Update Image.show docs to list all viewers used on Linux

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2451,8 +2451,8 @@ class Image:
         The image is first saved to a temporary file. By default, it will be in
         PNG format.
 
-        On Unix, the image is then opened using the **xdg-open**, **display**, **gm**, **eog** or
-        **xv** utility, depending on which one can be found.
+        On Unix, the image is then opened using the **xdg-open**, **display**,
+        **gm**, **eog** or **xv** utility, depending on which one can be found.
 
         On macOS, the image is opened with the native Preview application.
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2451,7 +2451,7 @@ class Image:
         The image is first saved to a temporary file. By default, it will be in
         PNG format.
 
-        On Unix, the image is then opened using the **display**, **eog** or
+        On Unix, the image is then opened using the **xdg-open**, **display**, **gm**, **eog** or
         **xv** utility, depending on which one can be found.
 
         On macOS, the image is opened with the native Preview application.


### PR DESCRIPTION
[ci skip]
More accurate description of how default viewer is chosen

Reference to the actual code, that registers the default viewer: https://github.com/python-pillow/Pillow/blob/73fc73038a8360d00437be062ca265a9209e866f/src/PIL/ImageShow.py#L288C1-L288C1

Changes proposed in this pull request:

 * Mention "xdg-open" and "gm" in Unix section of Image.show docstring
