### PR TITLE
Removed deleted file from codecov.yml and increased coverage threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,7 +12,7 @@ coverage:
   status:
     project:
       default:
-        threshold: 0.01%
+        threshold: 0.1%
 
 # Matches 'omit:' in .coveragerc
 ignore:

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,7 +16,6 @@ coverage:
 
 # Matches 'omit:' in .coveragerc
 ignore:
-  - "Tests/32bit_segfault_check.py"
   - "Tests/bench_cffi_access.py"
   - "Tests/check_*.py"
   - "Tests/createfontdatachunk.py"


### PR DESCRIPTION
#7228 removed Tests/32bit_segfault_check.py, so it no longer needs to be ignored in codecov.yml