### PR TITLE
Updated libtiff to 4.5.1

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -155,7 +155,7 @@ Many of Pillow's features require external libraries:
 
 * **libtiff** provides compressed TIFF functionality
 
-  * Pillow has been tested with libtiff versions **3.x** and **4.0-4.5**
+  * Pillow has been tested with libtiff versions **3.x** and **4.0-4.5.1**
 
 * **libfreetype** provides type related services
 

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -186,9 +186,9 @@ deps = {
         "libs": [r"output\release-static\{architecture}\lib\*.lib"],
     },
     "libtiff": {
-        "url": "https://download.osgeo.org/libtiff/tiff-4.5.0.tar.gz",
-        "filename": "tiff-4.5.0.tar.gz",
-        "dir": "tiff-4.5.0",
+        "url": "https://download.osgeo.org/libtiff/tiff-4.5.1.tar.gz",
+        "filename": "tiff-4.5.1.tar.gz",
+        "dir": "tiff-4.5.1",
         "license": "LICENSE.md",
         "patch": {
             r"libtiff\tif_lzma.c": {
@@ -198,6 +198,12 @@ deps = {
             r"libtiff\tif_webp.c": {
                 # link against webp.lib
                 "#ifdef WEBP_SUPPORT": '#ifdef WEBP_SUPPORT\n#pragma comment(lib, "webp.lib")',  # noqa: E501
+            },
+            r"test/CMakeLists.txt": {
+                "add_executable(test_write_read_tags ../placeholder.h)": "",
+                "target_sources(test_write_read_tags PRIVATE test_write_read_tags.c)": "",  # noqa: E501
+                "target_link_libraries(test_write_read_tags PRIVATE tiff)": "",
+                "list(APPEND simple_tests test_write_read_tags)": "",
             },
         },
         "build": [

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -199,7 +199,7 @@ deps = {
                 # link against webp.lib
                 "#ifdef WEBP_SUPPORT": '#ifdef WEBP_SUPPORT\n#pragma comment(lib, "webp.lib")',  # noqa: E501
             },
-            r"test/CMakeLists.txt": {
+            r"test\CMakeLists.txt": {
                 "add_executable(test_write_read_tags ../placeholder.h)": "",
                 "target_sources(test_write_read_tags PRIVATE test_write_read_tags.c)": "",  # noqa: E501
                 "target_link_libraries(test_write_read_tags PRIVATE tiff)": "",


### PR DESCRIPTION
libtiff 4.5.1 has been released - http://www.simplesystems.org/libtiff/

In https://download.osgeo.org/libtiff/tiff-4.5.1.tar.gz, test/CMakeLists.txt refers to test_write_read_tags.c, but that file is missing. It can be seen at https://gitlab.com/libtiff/libtiff/-/tree/master/test, so I presume this was a packaging error.

Since it is only a test, I've patched test/CMakeLists.txt in winbuild/build_prepare.py to remove the references to it.