### PR TITLE
Prioritise speed in _repr_png_

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -632,7 +632,7 @@ class Image:
             )
         )
 
-    def _repr_image(self, image_format):
+    def _repr_image(self, image_format, **kwargs):
         """Helper function for iPython display hook.
 
         :param image_format: Image format.
@@ -640,7 +640,7 @@ class Image:
         """
         b = io.BytesIO()
         try:
-            self.save(b, image_format)
+            self.save(b, image_format, **kwargs)
         except Exception as e:
             msg = f"Could not save to {image_format} for display"
             raise ValueError(msg) from e
@@ -651,7 +651,7 @@ class Image:
 
         :returns: PNG version of the image as bytes
         """
-        return self._repr_image("PNG")
+        return self._repr_image("PNG", compress_level=1)
 
     def _repr_jpeg_(self):
         """iPython display hook support for JPEG format.


### PR DESCRIPTION
Resolves #7241

When ImageShow saves an image as a PNG, it uses "compress_level" of 1
https://github.com/python-pillow/Pillow/blob/1174a9e7f45d71db1771cae410ab05f12df34b23/src/PIL/ImageShow.py#L177-L178

This prioritises speed over file size, presumably because this image is intended to just be shown, not saved for later use.

That same logic would apply to `_repr_png`, so this PR adds "compress_level" of 1 to that functionality as well.