### PR TITLE
Remove redundant wheel dep from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 build-backend = "backend"
 requires = [
   "setuptools>=67.8",
-  "wheel",
 ]
 backend-path = [
   "_custom_build",


### PR DESCRIPTION
Changes proposed in this pull request:

 * Remove redundant `wheel` dep from `pyproject.toml`

----

Remove the redundant `wheel` dependency, as it is added by the backend automatically.  Listing it explicitly in the documentation was a historical mistake and has been fixed since, see: https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a

While Pillow uses a custom backend that modifies the `bdist_wheel` method, it does not import `wheel` or use it in a way that would rely on setuptools implementation details.