### PR TITLE
Update PyTypeObject slot names

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -3725,18 +3725,18 @@ static PySequenceMethods image_as_sequence = {
 
 static PyTypeObject Imaging_Type = {
     PyVarObject_HEAD_INIT(NULL, 0) "ImagingCore", /*tp_name*/
-    sizeof(ImagingObject),                        /*tp_size*/
+    sizeof(ImagingObject),                        /*tp_basicsize*/
     0,                                            /*tp_itemsize*/
     /* methods */
     (destructor)_dealloc, /*tp_dealloc*/
-    0,                    /*tp_print*/
+    0,                    /*tp_vectorcall_offset*/
     0,                    /*tp_getattr*/
     0,                    /*tp_setattr*/
-    0,                    /*tp_compare*/
+    0,                    /*tp_as_async*/
     0,                    /*tp_repr*/
-    0,                    /*tp_as_number */
-    &image_as_sequence,   /*tp_as_sequence */
-    0,                    /*tp_as_mapping */
+    0,                    /*tp_as_number*/
+    &image_as_sequence,   /*tp_as_sequence*/
+    0,                    /*tp_as_mapping*/
     0,                    /*tp_hash*/
     0,                    /*tp_call*/
     0,                    /*tp_str*/
@@ -3760,18 +3760,18 @@ static PyTypeObject Imaging_Type = {
 
 static PyTypeObject ImagingFont_Type = {
     PyVarObject_HEAD_INIT(NULL, 0) "ImagingFont", /*tp_name*/
-    sizeof(ImagingFontObject),                    /*tp_size*/
+    sizeof(ImagingFontObject),                    /*tp_basicsize*/
     0,                                            /*tp_itemsize*/
     /* methods */
     (destructor)_font_dealloc, /*tp_dealloc*/
-    0,                         /*tp_print*/
+    0,                         /*tp_vectorcall_offset*/
     0,                         /*tp_getattr*/
     0,                         /*tp_setattr*/
-    0,                         /*tp_compare*/
+    0,                         /*tp_as_async*/
     0,                         /*tp_repr*/
-    0,                         /*tp_as_number */
-    0,                         /*tp_as_sequence */
-    0,                         /*tp_as_mapping */
+    0,                         /*tp_as_number*/
+    0,                         /*tp_as_sequence*/
+    0,                         /*tp_as_mapping*/
     0,                         /*tp_hash*/
     0,                         /*tp_call*/
     0,                         /*tp_str*/
@@ -3793,18 +3793,18 @@ static PyTypeObject ImagingFont_Type = {
 
 static PyTypeObject ImagingDraw_Type = {
     PyVarObject_HEAD_INIT(NULL, 0) "ImagingDraw", /*tp_name*/
-    sizeof(ImagingDrawObject),                    /*tp_size*/
+    sizeof(ImagingDrawObject),                    /*tp_basicsize*/
     0,                                            /*tp_itemsize*/
     /* methods */
     (destructor)_draw_dealloc, /*tp_dealloc*/
-    0,                         /*tp_print*/
+    0,                         /*tp_vectorcall_offset*/
     0,                         /*tp_getattr*/
     0,                         /*tp_setattr*/
-    0,                         /*tp_compare*/
+    0,                         /*tp_as_async*/
     0,                         /*tp_repr*/
-    0,                         /*tp_as_number */
-    0,                         /*tp_as_sequence */
-    0,                         /*tp_as_mapping */
+    0,                         /*tp_as_number*/
+    0,                         /*tp_as_sequence*/
+    0,                         /*tp_as_mapping*/
     0,                         /*tp_hash*/
     0,                         /*tp_call*/
     0,                         /*tp_str*/
@@ -3835,19 +3835,19 @@ static PyMappingMethods pixel_access_as_mapping = {
 /* type description */
 
 static PyTypeObject PixelAccess_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0) "PixelAccess",
-    sizeof(PixelAccessObject),
-    0,
+    PyVarObject_HEAD_INIT(NULL, 0) "PixelAccess", /*tp_name*/
+    sizeof(PixelAccessObject),                    /*tp_basicsize*/
+    0,                                            /*tp_itemsize*/
     /* methods */
     (destructor)pixel_access_dealloc, /*tp_dealloc*/
-    0,                                /*tp_print*/
+    0,                                /*tp_vectorcall_offset*/
     0,                                /*tp_getattr*/
     0,                                /*tp_setattr*/
-    0,                                /*tp_compare*/
+    0,                                /*tp_as_async*/
     0,                                /*tp_repr*/
-    0,                                /*tp_as_number */
-    0,                                /*tp_as_sequence */
-    &pixel_access_as_mapping,         /*tp_as_mapping */
+    0,                                /*tp_as_number*/
+    0,                                /*tp_as_sequence*/
+    &pixel_access_as_mapping,         /*tp_as_mapping*/
     0                                 /*tp_hash*/
 };
 

--- a/src/_imagingcms.c
+++ b/src/_imagingcms.c
@@ -1421,19 +1421,19 @@ static struct PyGetSetDef cms_profile_getsetters[] = {
     {NULL}};
 
 static PyTypeObject CmsProfile_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0) "PIL._imagingcms.CmsProfile", /*tp_name */
-    sizeof(CmsProfileObject),
-    0, /*tp_basicsize, tp_itemsize */
+    PyVarObject_HEAD_INIT(NULL, 0) "PIL._imagingcms.CmsProfile", /*tp_name*/
+    sizeof(CmsProfileObject),                                    /*tp_basicsize*/
+    0,                                                           /*tp_itemsize*/
     /* methods */
     (destructor)cms_profile_dealloc, /*tp_dealloc*/
-    0,                               /*tp_print*/
+    0,                               /*tp_vectorcall_offset*/
     0,                               /*tp_getattr*/
     0,                               /*tp_setattr*/
-    0,                               /*tp_compare*/
+    0,                               /*tp_as_async*/
     0,                               /*tp_repr*/
-    0,                               /*tp_as_number */
-    0,                               /*tp_as_sequence */
-    0,                               /*tp_as_mapping */
+    0,                               /*tp_as_number*/
+    0,                               /*tp_as_sequence*/
+    0,                               /*tp_as_mapping*/
     0,                               /*tp_hash*/
     0,                               /*tp_call*/
     0,                               /*tp_str*/
@@ -1473,19 +1473,19 @@ static struct PyGetSetDef cms_transform_getsetters[] = {
     {NULL}};
 
 static PyTypeObject CmsTransform_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0) "CmsTransform",
-    sizeof(CmsTransformObject),
-    0,
+    PyVarObject_HEAD_INIT(NULL, 0) "CmsTransform", /*tp_name*/
+    sizeof(CmsTransformObject),                    /*tp_basicsize*/
+    0,                                             /*tp_itemsize*/
     /* methods */
     (destructor)cms_transform_dealloc, /*tp_dealloc*/
-    0,                                 /*tp_print*/
+    0,                                 /*tp_vectorcall_offset*/
     0,                                 /*tp_getattr*/
     0,                                 /*tp_setattr*/
-    0,                                 /*tp_compare*/
+    0,                                 /*tp_as_async*/
     0,                                 /*tp_repr*/
-    0,                                 /*tp_as_number */
-    0,                                 /*tp_as_sequence */
-    0,                                 /*tp_as_mapping */
+    0,                                 /*tp_as_number*/
+    0,                                 /*tp_as_sequence*/
+    0,                                 /*tp_as_mapping*/
     0,                                 /*tp_hash*/
     0,                                 /*tp_call*/
     0,                                 /*tp_str*/

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -1401,19 +1401,19 @@ static struct PyGetSetDef font_getsetters[] = {
     {NULL}};
 
 static PyTypeObject Font_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0) "Font",
-    sizeof(FontObject),
-    0,
+    PyVarObject_HEAD_INIT(NULL, 0) "Font", /*tp_name*/
+    sizeof(FontObject),                    /*tp_basicsize*/
+    0,                                     /*tp_itemsize*/
     /* methods */
-    (destructor)font_dealloc, /* tp_dealloc */
-    0,                        /* tp_print */
+    (destructor)font_dealloc, /*tp_dealloc*/
+    0,                        /*tp_vectorcall_offset*/
     0,                        /*tp_getattr*/
     0,                        /*tp_setattr*/
-    0,                        /*tp_compare*/
+    0,                        /*tp_as_async*/
     0,                        /*tp_repr*/
-    0,                        /*tp_as_number */
-    0,                        /*tp_as_sequence */
-    0,                        /*tp_as_mapping */
+    0,                        /*tp_as_number*/
+    0,                        /*tp_as_sequence*/
+    0,                        /*tp_as_mapping*/
     0,                        /*tp_hash*/
     0,                        /*tp_call*/
     0,                        /*tp_str*/

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -487,18 +487,18 @@ static struct PyMethodDef _anim_encoder_methods[] = {
 // WebPAnimEncoder type definition
 static PyTypeObject WebPAnimEncoder_Type = {
     PyVarObject_HEAD_INIT(NULL, 0) "WebPAnimEncoder", /*tp_name */
-    sizeof(WebPAnimEncoderObject),                    /*tp_size */
+    sizeof(WebPAnimEncoderObject),                    /*tp_basicsize */
     0,                                                /*tp_itemsize */
     /* methods */
     (destructor)_anim_encoder_dealloc, /*tp_dealloc*/
-    0,                                 /*tp_print*/
+    0,                                 /*tp_vectorcall_offset*/
     0,                                 /*tp_getattr*/
     0,                                 /*tp_setattr*/
-    0,                                 /*tp_compare*/
+    0,                                 /*tp_as_async*/
     0,                                 /*tp_repr*/
-    0,                                 /*tp_as_number */
-    0,                                 /*tp_as_sequence */
-    0,                                 /*tp_as_mapping */
+    0,                                 /*tp_as_number*/
+    0,                                 /*tp_as_sequence*/
+    0,                                 /*tp_as_mapping*/
     0,                                 /*tp_hash*/
     0,                                 /*tp_call*/
     0,                                 /*tp_str*/
@@ -530,18 +530,18 @@ static struct PyMethodDef _anim_decoder_methods[] = {
 // WebPAnimDecoder type definition
 static PyTypeObject WebPAnimDecoder_Type = {
     PyVarObject_HEAD_INIT(NULL, 0) "WebPAnimDecoder", /*tp_name */
-    sizeof(WebPAnimDecoderObject),                    /*tp_size */
+    sizeof(WebPAnimDecoderObject),                    /*tp_basicsize */
     0,                                                /*tp_itemsize */
     /* methods */
     (destructor)_anim_decoder_dealloc, /*tp_dealloc*/
-    0,                                 /*tp_print*/
+    0,                                 /*tp_vectorcall_offset*/
     0,                                 /*tp_getattr*/
     0,                                 /*tp_setattr*/
-    0,                                 /*tp_compare*/
+    0,                                 /*tp_as_async*/
     0,                                 /*tp_repr*/
-    0,                                 /*tp_as_number */
-    0,                                 /*tp_as_sequence */
-    0,                                 /*tp_as_mapping */
+    0,                                 /*tp_as_number*/
+    0,                                 /*tp_as_sequence*/
+    0,                                 /*tp_as_mapping*/
     0,                                 /*tp_hash*/
     0,                                 /*tp_call*/
     0,                                 /*tp_str*/

--- a/src/decode.c
+++ b/src/decode.c
@@ -258,18 +258,18 @@ static struct PyGetSetDef getseters[] = {
 
 static PyTypeObject ImagingDecoderType = {
     PyVarObject_HEAD_INIT(NULL, 0) "ImagingDecoder", /*tp_name*/
-    sizeof(ImagingDecoderObject),                    /*tp_size*/
+    sizeof(ImagingDecoderObject),                    /*tp_basicsize*/
     0,                                               /*tp_itemsize*/
     /* methods */
     (destructor)_dealloc, /*tp_dealloc*/
-    0,                    /*tp_print*/
+    0,                    /*tp_vectorcall_offset*/
     0,                    /*tp_getattr*/
     0,                    /*tp_setattr*/
-    0,                    /*tp_compare*/
+    0,                    /*tp_as_async*/
     0,                    /*tp_repr*/
-    0,                    /*tp_as_number */
-    0,                    /*tp_as_sequence */
-    0,                    /*tp_as_mapping */
+    0,                    /*tp_as_number*/
+    0,                    /*tp_as_sequence*/
+    0,                    /*tp_as_mapping*/
     0,                    /*tp_hash*/
     0,                    /*tp_call*/
     0,                    /*tp_str*/

--- a/src/display.c
+++ b/src/display.c
@@ -251,18 +251,18 @@ static struct PyGetSetDef getsetters[] = {
 
 static PyTypeObject ImagingDisplayType = {
     PyVarObject_HEAD_INIT(NULL, 0) "ImagingDisplay", /*tp_name*/
-    sizeof(ImagingDisplayObject),                    /*tp_size*/
+    sizeof(ImagingDisplayObject),                    /*tp_basicsize*/
     0,                                               /*tp_itemsize*/
     /* methods */
     (destructor)_delete, /*tp_dealloc*/
-    0,                   /*tp_print*/
+    0,                   /*tp_vectorcall_offset*/
     0,                   /*tp_getattr*/
     0,                   /*tp_setattr*/
-    0,                   /*tp_compare*/
+    0,                   /*tp_as_async*/
     0,                   /*tp_repr*/
-    0,                   /*tp_as_number */
-    0,                   /*tp_as_sequence */
-    0,                   /*tp_as_mapping */
+    0,                   /*tp_as_number*/
+    0,                   /*tp_as_sequence*/
+    0,                   /*tp_as_mapping*/
     0,                   /*tp_hash*/
     0,                   /*tp_call*/
     0,                   /*tp_str*/

--- a/src/encode.c
+++ b/src/encode.c
@@ -323,18 +323,18 @@ static struct PyGetSetDef getseters[] = {
 
 static PyTypeObject ImagingEncoderType = {
     PyVarObject_HEAD_INIT(NULL, 0) "ImagingEncoder", /*tp_name*/
-    sizeof(ImagingEncoderObject),                    /*tp_size*/
+    sizeof(ImagingEncoderObject),                    /*tp_basicsize*/
     0,                                               /*tp_itemsize*/
     /* methods */
     (destructor)_dealloc, /*tp_dealloc*/
-    0,                    /*tp_print*/
+    0,                    /*tp_vectorcall_offset*/
     0,                    /*tp_getattr*/
     0,                    /*tp_setattr*/
-    0,                    /*tp_compare*/
+    0,                    /*tp_as_async*/
     0,                    /*tp_repr*/
-    0,                    /*tp_as_number */
-    0,                    /*tp_as_sequence */
-    0,                    /*tp_as_mapping */
+    0,                    /*tp_as_number*/
+    0,                    /*tp_as_sequence*/
+    0,                    /*tp_as_mapping*/
     0,                    /*tp_hash*/
     0,                    /*tp_call*/
     0,                    /*tp_str*/

--- a/src/outline.c
+++ b/src/outline.c
@@ -155,18 +155,18 @@ static struct PyMethodDef _outline_methods[] = {
 
 static PyTypeObject OutlineType = {
     PyVarObject_HEAD_INIT(NULL, 0) "Outline", /*tp_name*/
-    sizeof(OutlineObject),                    /*tp_size*/
+    sizeof(OutlineObject),                    /*tp_basicsize*/
     0,                                        /*tp_itemsize*/
     /* methods */
     (destructor)_outline_dealloc, /*tp_dealloc*/
-    0,                            /*tp_print*/
+    0,                            /*tp_vectorcall_offset*/
     0,                            /*tp_getattr*/
     0,                            /*tp_setattr*/
-    0,                            /*tp_compare*/
+    0,                            /*tp_as_async*/
     0,                            /*tp_repr*/
-    0,                            /*tp_as_number */
-    0,                            /*tp_as_sequence */
-    0,                            /*tp_as_mapping */
+    0,                            /*tp_as_number*/
+    0,                            /*tp_as_sequence*/
+    0,                            /*tp_as_mapping*/
     0,                            /*tp_hash*/
     0,                            /*tp_call*/
     0,                            /*tp_str*/

--- a/src/path.c
+++ b/src/path.c
@@ -583,18 +583,18 @@ static PyMappingMethods path_as_mapping = {
 
 static PyTypeObject PyPathType = {
     PyVarObject_HEAD_INIT(NULL, 0) "Path", /*tp_name*/
-    sizeof(PyPathObject),                  /*tp_size*/
+    sizeof(PyPathObject),                  /*tp_basicsize*/
     0,                                     /*tp_itemsize*/
     /* methods */
     (destructor)path_dealloc, /*tp_dealloc*/
-    0,                        /*tp_print*/
+    0,                        /*tp_vectorcall_offset*/
     0,                        /*tp_getattr*/
     0,                        /*tp_setattr*/
-    0,                        /*tp_compare*/
+    0,                        /*tp_as_async*/
     0,                        /*tp_repr*/
-    0,                        /*tp_as_number */
-    &path_as_sequence,        /*tp_as_sequence */
-    &path_as_mapping,         /*tp_as_mapping */
+    0,                        /*tp_as_number*/
+    &path_as_sequence,        /*tp_as_sequence*/
+    &path_as_mapping,         /*tp_as_mapping*/
     0,                        /*tp_hash*/
     0,                        /*tp_call*/
     0,                        /*tp_str*/


### PR DESCRIPTION
tp_print was renamed to tp_vectorcall_offset with Python 3.8, and tp_compare was renamed to tp_as_async with Python 3.5. tp_size has always been tp_basicsize; I don't know why that one was wrong.