### PR TITLE
Updated libjpeg-turbo to 3.0.0

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -106,9 +106,9 @@ architectures = {
 deps = {
     "libjpeg": {
         "url": SF_PROJECTS
-        + "/libjpeg-turbo/files/2.1.5.1/libjpeg-turbo-2.1.5.1.tar.gz/download",
-        "filename": "libjpeg-turbo-2.1.5.1.tar.gz",
-        "dir": "libjpeg-turbo-2.1.5.1",
+        + "/libjpeg-turbo/files/3.0.0/libjpeg-turbo-3.0.0.tar.gz/download",
+        "filename": "libjpeg-turbo-3.0.0.tar.gz",
+        "dir": "libjpeg-turbo-3.0.0",
         "license": ["README.ijg", "LICENSE.md"],
         "license_pattern": (
             "(LEGAL ISSUES\n============\n\n.+?)\n\nREFERENCES\n=========="


### PR DESCRIPTION
libjpeg-turbo 3.0.0 has been released - https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/3.0.0