### PR TITLE
Updated libjpeg shared library name

### DIFF
--- a/Tests/oss-fuzz/build.sh
+++ b/Tests/oss-fuzz/build.sh
@@ -20,7 +20,7 @@ python3 setup.py build --build-base=/tmp/build install
 # Build fuzzers in $OUT.
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
   compile_python_fuzzer $fuzzer \
-      --add-binary /usr/local/lib/libjpeg.so.62.3.0:. \
+      --add-binary /usr/local/lib/libjpeg.so.62.4.0:. \
       --add-binary /usr/local/lib/libfreetype.so.6:. \
       --add-binary /usr/local/lib/liblcms2.so.2:. \
       --add-binary /usr/local/lib/libopenjp2.so.7:. \


### PR DESCRIPTION
CIFuzz has started failing in main - https://github.com/python-pillow/Pillow/actions/runs/5454631686/jobs/9925010430#step:4:10489
> Unable to find "/usr/local/lib/libjpeg.so.62.3.0" when adding binary and data files.

Earlier in the log, you see - https://github.com/python-pillow/Pillow/actions/runs/5454631686/jobs/9925010430#step:4:3597
> -- Set runtime path of "/usr/local/lib/libjpeg.so.62.4.0" to "/usr/local/lib"

So this PR updates the version.