### PR TITLE
Add link to PIL.Image.Image.putpalette in WAL documentation

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1404,7 +1404,7 @@ the open function in the :py:mod:`~PIL.WalImageFile` module to read files in
 this format.
 
 By default, a Quake2 standard palette is attached to the texture. To override
-the palette, use the putpalette method.
+the palette, use the :py:func:`PIL.Image.Image.putpalette()` method.
 
 WMF, EMF
 ^^^^^^^^


### PR DESCRIPTION
~I didn´t generate the doc to check if the link was correct but I picked it from [here](https://github.com/python-pillow/Pillow/blob/3ee925915085ee0f7ad72fbede5d9a9e6ea902a7/src/PIL/WalImageFile.py#L65C38-L65C77).~

Works as expected: https://pillow--7262.org.readthedocs.build/en/7262/handbook/image-file-formats.html#wal