### PR TITLE
Handle exceptions in _repr_jpeg_ and _repr_png_

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -929,11 +929,10 @@ class TestFileJpeg:
             assert repr_jpeg.format == "JPEG"
             assert_image_similar(im, repr_jpeg, 17)
 
-    def test_repr_jpeg_error(self):
+    def test_repr_jpeg_error_returns_none(self):
         im = hopper("F")
 
-        with pytest.raises(ValueError):
-            im._repr_jpeg_()
+        assert im._repr_jpeg_() is None
 
 
 @pytest.mark.skipif(not is_win32(), reason="Windows only")

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -532,11 +532,10 @@ class TestFilePng:
             assert repr_png.format == "PNG"
             assert_image_equal(im, repr_png)
 
-    def test_repr_png_error(self):
+    def test_repr_png_error_returns_none(self):
         im = hopper("F")
 
-        with pytest.raises(ValueError):
-            im._repr_png_()
+        assert im._repr_png_() is None
 
     def test_chunk_order(self, tmp_path):
         with Image.open("Tests/images/icc_profile.png") as im:

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -651,14 +651,20 @@ class Image:
 
         :returns: PNG version of the image as bytes
         """
-        return self._repr_image("PNG", compress_level=1)
+        try:
+            return self._repr_image("PNG", compress_level=1)
+        except Exception:
+            return None
 
     def _repr_jpeg_(self):
         """iPython display hook support for JPEG format.
 
         :returns: JPEG version of the image as bytes
         """
-        return self._repr_image("JPEG")
+        try:
+            self._repr_image("JPEG")
+        except Exception:
+            return None
 
     @property
     def __array_interface__(self):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -662,7 +662,7 @@ class Image:
         :returns: JPEG version of the image as bytes
         """
         try:
-            self._repr_image("JPEG")
+            return self._repr_image("JPEG")
         except Exception:
             return None
 


### PR DESCRIPTION
Resolves #7283

In 10.0.0 a `_repr_jpeg_` implementation was added to the Image object to enable the use of `display_jpeg()` in IPython environments. However, in some cases the implementation of this method could result in an exception being raised while trying to generate the jpeg data. The best example is if the image data is in an RGBA format as a result of the object being created by opening a PNG file. In this case trying to save the Image object as a jpeg will error because the jpeg format can't represent the transparency in the alpha channel. This results in an exception being raised in the IPython/Jupyter context when outputting the image object. However, in cases like this IPython allows the repr methods to return None to indicate there is no representation in that format available. [1] This commit updates the `_repr_png_` and `_repr_jpeg_` methods to catch any exception that might be raised while trying to generate the image data. If an exception is raised we treat that as not being able to generate image data in that format and return None instead.

Related to #7259

[1] https://ipython.readthedocs.io/en/stable/config/integrating.html#custom-methods

Changes proposed in this pull request:

 * Handle any exceptions raised by generating image data in `Image._repr_png_` and return `None` instead of raising to users.
 * Handle any exceptions raised by generating image data in `Image._repr_jpeg_` and return `None` instead of raising to users.