### PR TITLE
Improve iPython interoperability

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -930,10 +930,8 @@ class TestFileJpeg:
             assert_image_similar(im, repr_jpeg, 17)
 
     def test_repr_jpeg_error(self):
-        im = hopper("F")
-
-        with pytest.raises(ValueError):
-            im._repr_jpeg_()
+        im = hopper("BGR;24")
+        assert im._repr_jpeg_() is None
 
 
 @pytest.mark.skipif(not is_win32(), reason="Windows only")

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -533,10 +533,8 @@ class TestFilePng:
             assert_image_equal(im, repr_png)
 
     def test_repr_png_error(self):
-        im = hopper("F")
-
-        with pytest.raises(ValueError):
-            im._repr_png_()
+        im = hopper("BGR;24")
+        assert im._repr_png_() is None
 
     def test_chunk_order(self, tmp_path):
         with Image.open("Tests/images/icc_profile.png") as im:

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -168,6 +168,21 @@ class TestImage:
             assert im2.size == (1500, 1500)
             assert_image_equal(im.resize(im2.size), im2)
 
+        # make sure common modes get converted without a warning
+        im = Image.new("LAB", (100, 100))
+        with pytest.warns(None) as record:
+            bundle = im._repr_mimebundle_()
+        assert len(record) == 0
+        with Image.open(io.BytesIO(bundle["image/png"])) as im2:
+            assert_image_equal(im.convert("RGB"), im2)
+
+        im = Image.new("HSV", (100, 100))
+        with pytest.warns(None) as record:
+            bundle = im._repr_mimebundle_()
+        assert len(record) == 0
+        with Image.open(io.BytesIO(bundle["image/png"])) as im2:
+            assert_image_equal(im.convert("RGB"), im2)
+
     def test_open_formats(self):
         PNGFILE = "Tests/images/hopper.png"
         JPGFILE = "Tests/images/hopper.jpg"

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -106,65 +106,65 @@ class TestImage:
         assert p.pretty_output == "<PIL.Image.Image image mode=L size=100x100>"
 
     def test_repr_mimebundle(self):
-        im = Image.new('L', (100, 100))
+        im = Image.new("L", (100, 100))
 
         # blank image should be most efficiently encoded as PNG
         bundle = im._repr_mimebundle_()
-        with Image.open(io.BytesIO(bundle['image/png'])) as im2:
-            assert im2.format == 'PNG'
+        with Image.open(io.BytesIO(bundle["image/png"])) as im2:
+            assert im2.format == "PNG"
             assert_image_equal(im, im2)
 
         # include pointless restriction
-        bundle = im._repr_mimebundle_(exclude=['test/plain'])
-        with Image.open(io.BytesIO(bundle['image/png'])) as im2:
-            assert im2.format == 'PNG'
+        bundle = im._repr_mimebundle_(exclude=["test/plain"])
+        with Image.open(io.BytesIO(bundle["image/png"])) as im2:
+            assert im2.format == "PNG"
             assert_image_equal(im, im2)
 
-        bundle = im._repr_mimebundle_(include=['image/png'])
-        with Image.open(io.BytesIO(bundle['image/png'])) as im2:
-            assert im2.format == 'PNG'
+        bundle = im._repr_mimebundle_(include=["image/png"])
+        with Image.open(io.BytesIO(bundle["image/png"])) as im2:
+            assert im2.format == "PNG"
             assert_image_equal(im, im2)
 
         # force jpeg to be selected
-        bundle = im._repr_mimebundle_(include=['image/jpeg'])
-        with Image.open(io.BytesIO(bundle['image/jpeg'])) as im2:
-            assert im2.format == 'JPEG'
+        bundle = im._repr_mimebundle_(include=["image/jpeg"])
+        with Image.open(io.BytesIO(bundle["image/jpeg"])) as im2:
+            assert im2.format == "JPEG"
             assert_image_equal(im, im2, 17)
 
         # force jpeg to be selected in a different way
-        bundle = im._repr_mimebundle_(exclude=['image/png'])
-        with Image.open(io.BytesIO(bundle['image/jpeg'])) as im2:
-            assert im2.format == 'JPEG'
+        bundle = im._repr_mimebundle_(exclude=["image/png"])
+        with Image.open(io.BytesIO(bundle["image/jpeg"])) as im2:
+            assert im2.format == "JPEG"
             assert_image_equal(im, im2, 17)
 
         # make sure higher bit depths get converted down to 8BPC with warnings
-        high = Image.new('I;16', (100, 100))
+        high = Image.new("I;16", (100, 100))
         with pytest.warns(UserWarning):
             bundle = high._repr_mimebundle_()
-        with Image.open(io.BytesIO(bundle['image/png'])) as im2:
-            assert im2.format == 'PNG'
+        with Image.open(io.BytesIO(bundle["image/png"])) as im2:
+            assert im2.format == "PNG"
             assert_image_equal(im, im2)
 
-        high = Image.new('F', (100, 100))
+        high = Image.new("F", (100, 100))
         with pytest.warns(UserWarning):
             bundle = high._repr_mimebundle_()
-        with Image.open(io.BytesIO(bundle['image/png'])) as im2:
-            assert im2.format == 'PNG'
+        with Image.open(io.BytesIO(bundle["image/png"])) as im2:
+            assert im2.format == "PNG"
             assert_image_equal(im, im2)
 
-        high = Image.new('I', (100, 100))
+        high = Image.new("I", (100, 100))
         with pytest.warns(UserWarning):
             bundle = high._repr_mimebundle_()
-        with Image.open(io.BytesIO(bundle['image/png'])) as im2:
-            assert im2.format == 'PNG'
+        with Image.open(io.BytesIO(bundle["image/png"])) as im2:
+            assert im2.format == "PNG"
             assert_image_equal(im, im2)
 
         # make sure large image gets scaled down with a warning
-        im = Image.new('L', [3000, 3000])
+        im = Image.new("L", [3000, 3000])
         with pytest.warns(UserWarning):
             bundle = im._repr_mimebundle_()
 
-        with Image.open(io.BytesIO(bundle['image/png'])) as im2:
+        with Image.open(io.BytesIO(bundle["image/png"])) as im2:
             assert im2.size == (1500, 1500)
             assert_image_equal(im.resize(im2.size), im2)
 

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -105,6 +105,69 @@ class TestImage:
         im._repr_pretty_(p, None)
         assert p.pretty_output == "<PIL.Image.Image image mode=L size=100x100>"
 
+    def test_repr_mimebundle(self):
+        im = Image.new('L', (100, 100))
+
+        # blank image should be most efficiently encoded as PNG
+        bundle = im._repr_mimebundle_()
+        with Image.open(io.BytesIO(bundle['image/png'])) as im2:
+            assert im2.format == 'PNG'
+            assert_image_equal(im, im2)
+
+        # include pointless restriction
+        bundle = im._repr_mimebundle_(exclude=['test/plain'])
+        with Image.open(io.BytesIO(bundle['image/png'])) as im2:
+            assert im2.format == 'PNG'
+            assert_image_equal(im, im2)
+
+        bundle = im._repr_mimebundle_(include=['image/png'])
+        with Image.open(io.BytesIO(bundle['image/png'])) as im2:
+            assert im2.format == 'PNG'
+            assert_image_equal(im, im2)
+
+        # force jpeg to be selected
+        bundle = im._repr_mimebundle_(include=['image/jpeg'])
+        with Image.open(io.BytesIO(bundle['image/jpeg'])) as im2:
+            assert im2.format == 'JPEG'
+            assert_image_equal(im, im2, 17)
+
+        # force jpeg to be selected in a different way
+        bundle = im._repr_mimebundle_(exclude=['image/png'])
+        with Image.open(io.BytesIO(bundle['image/jpeg'])) as im2:
+            assert im2.format == 'JPEG'
+            assert_image_equal(im, im2, 17)
+
+        # make sure higher bit depths get converted down to 8BPC with warnings
+        high = Image.new('I;16', (100, 100))
+        with pytest.warns(UserWarning):
+            bundle = high._repr_mimebundle_()
+        with Image.open(io.BytesIO(bundle['image/png'])) as im2:
+            assert im2.format == 'PNG'
+            assert_image_equal(im, im2)
+
+        high = Image.new('F', (100, 100))
+        with pytest.warns(UserWarning):
+            bundle = high._repr_mimebundle_()
+        with Image.open(io.BytesIO(bundle['image/png'])) as im2:
+            assert im2.format == 'PNG'
+            assert_image_equal(im, im2)
+
+        high = Image.new('I', (100, 100))
+        with pytest.warns(UserWarning):
+            bundle = high._repr_mimebundle_()
+        with Image.open(io.BytesIO(bundle['image/png'])) as im2:
+            assert im2.format == 'PNG'
+            assert_image_equal(im, im2)
+
+        # make sure large image gets scaled down with a warning
+        im = Image.new('L', [3000, 3000])
+        with pytest.warns(UserWarning):
+            bundle = im._repr_mimebundle_()
+
+        with Image.open(io.BytesIO(bundle['image/png'])) as im2:
+            assert im2.size == (1500, 1500)
+            assert_image_equal(im.resize(im2.size), im2)
+
     def test_open_formats(self):
         PNGFILE = "Tests/images/hopper.png"
         JPGFILE = "Tests/images/hopper.jpg"

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -462,38 +462,43 @@ def _getscaleoffset(expr):
 
 
 _IPYTHON_MODE_MAP = {
-    'La': 'LA',
-    'LAB': 'RGB',
-    'HSV': 'RGB',
-    'RGBX': 'RGB',
-    'RGBa': 'RGBA',
+    "La": "LA",
+    "LAB": "RGB",
+    "HSV": "RGB",
+    "RGBX": "RGB",
+    "RGBa": "RGBA",
 }
 
 _VALID_MODES_FOR_FORMAT = {
-    'JPEG': {'L', 'RGB', 'YCbCr', 'CMYK'},
-    'PNG': {'1', 'P', 'L', 'RGB', 'RGBA', 'LA', 'PA'},
+    "JPEG": {"L", "RGB", "YCbCr", "CMYK"},
+    "PNG": {"1", "P", "L", "RGB", "RGBA", "LA", "PA"},
 }
+
 
 def _to_ipython_image(image):
     """Simplify image to something suitable for display in IPython/Jupyter.
     Notably, convert to 8BPC and rescale by some integer factor.
     """
-    if image.mode in {'I', 'F'}:
-        warnings.warn("image mode doesn't have well defined min/max value, using extrema")
+    if image.mode in {"I", "F"}:
+        warnings.warn(
+            "image mode doesn't have well defined min/max value, using extrema"
+        )
         # linearly transform extrema to fit in [0, 255]
         # this should have a similar result as Image.histogram
         lo, hi = image.getextrema()
         scale = 256 / (hi - lo) if lo != hi else 1
-        image = image.point(lambda e: (e - lo) * scale).convert('L')
-    elif image.mode == 'I;16':
+        image = image.point(lambda e: (e - lo) * scale).convert("L")
+    elif image.mode == "I;16":
         warnings.warn("converting 16BPC image to 8BPC for display in IPython/Jupyter")
         # linearly transform max down to 255
-        image = image.point(lambda e: e / 256).convert('L')
+        image = image.point(lambda e: e / 256).convert("L")
 
     # shrink large images so they don't take too long to transfer/render
     factor = max(image.size) // IPYTHON_RESIZE_THRESHOLD
     if factor > 1:
-        warnings.warn("scaling large image down to improve performance in IPython/Jupyter")
+        warnings.warn(
+            "scaling large image down to improve performance in IPython/Jupyter"
+        )
         image = image.reduce(factor)
 
     # process remaining modes into things supported by writers
@@ -501,6 +506,7 @@ def _to_ipython_image(image):
         image = image.convert(_IPYTHON_MODE_MAP[image.mode])
 
     return image
+
 
 def _encode_ipython_image(image, image_format):
     """Encode specfied image into something IPython/Jupyter supports.
@@ -706,8 +712,8 @@ class Image:
                 return None
             return _encode_ipython_image(image, image_format)
 
-        jpeg = encode('image/jpeg', 'JPEG')
-        png = encode('image/png', 'PNG')
+        jpeg = encode("image/jpeg", "JPEG")
+        png = encode("image/png", "PNG")
 
         # prefer lossless format if it's not significantly larger
         if jpeg and png:
@@ -718,8 +724,8 @@ class Image:
                 png = None
 
         return {
-            'image/jpeg': jpeg,
-            'image/png': png,
+            "image/jpeg": jpeg,
+            "image/png": png,
         }
 
     def _repr_png_(self):
@@ -727,14 +733,14 @@ class Image:
 
         :returns: PNG version of the image as bytes
         """
-        return _encode_ipython_image(_to_ipython_image(self), 'PNG')
+        return _encode_ipython_image(_to_ipython_image(self), "PNG")
 
     def _repr_jpeg_(self):
         """iPython display hook support for JPEG format.
 
         :returns: JPEG version of the image as bytes
         """
-        return _encode_ipython_image(_to_ipython_image(self), 'JPEG')
+        return _encode_ipython_image(_to_ipython_image(self), "JPEG")
 
     @property
     def __array_interface__(self):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -519,7 +519,7 @@ def _encode_ipython_image(image, image_format):
     try:
         image.save(b, image_format)
     except Exception as e:
-        warnings.warn(f"failed to encode image as {image_format}")
+        warnings.warn(f"failed to encode image as {image_format}: {e}")
         return None
     return b.getvalue()
 


### PR DESCRIPTION
Fixes #7259

Changes proposed in this pull request:

 * support `_repr_mimebundle_`  by returning either PNG or JPEG
 * convert images to a supported `mode` where possible
 * shrink large images by an integer factor
 * output warning messages when changes were made for display purposes
 * refactor `_repr_png|jpeg_` to do the same pre-processing
 * because large are resized it made sense to remove the previously requested `compression_level=1`

I've been finding the current behavior to be unusable in a Jupyter notebook.  The number of dumped backtraces are very painful to work with, so I've tidied up my method in #7259 and incorporated it into the codebase.  Until I get a response to my question from the IPython project I think this code does reasonable things.