### PR TITLE
Fix missing symbols as libtiff can depend on libjpeg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -816,6 +816,15 @@ class pil_build_ext(build_ext):
 
         libs = self.add_imaging_libs.split()
         defs = []
+        if feature.tiff:
+            libs.append(feature.tiff)
+            defs.append(("HAVE_LIBTIFF", None))
+            if sys.platform == "win32":
+                # This define needs to be defined if-and-only-if it was defined
+                # when compiling LibTIFF. LibTIFF doesn't expose it in `tiffconf.h`,
+                # so we have to guess; by default it is defined in all Windows builds.
+                # See #4237, #5243, #5359 for more information.
+                defs.append(("USE_WIN32_FILEIO", None))
         if feature.jpeg:
             libs.append(feature.jpeg)
             defs.append(("HAVE_LIBJPEG", None))
@@ -830,15 +839,6 @@ class pil_build_ext(build_ext):
         if feature.imagequant:
             libs.append(feature.imagequant)
             defs.append(("HAVE_LIBIMAGEQUANT", None))
-        if feature.tiff:
-            libs.append(feature.tiff)
-            defs.append(("HAVE_LIBTIFF", None))
-            if sys.platform == "win32":
-                # This define needs to be defined if-and-only-if it was defined
-                # when compiling LibTIFF. LibTIFF doesn't expose it in `tiffconf.h`,
-                # so we have to guess; by default it is defined in all Windows builds.
-                # See #4237, #5243, #5359 for more information.
-                defs.append(("USE_WIN32_FILEIO", None))
         if feature.xcb:
             libs.append(feature.xcb)
             defs.append(("HAVE_XCB", None))


### PR DESCRIPTION
when compiling Pillow with libtiff and libjpeg (with jpeg12 enabled - which is the default with libjpeg-3.0.0) the libtiff object tif_jpeg_12.c.o uses the following libjpeg12 functions: jpeg12_read_raw_data, jpeg12_read_scanlines, jpeg12_write_raw_data, jpeg12_write_scanlines.

update the ordering of libs.append(feature.tiff) to be before libs.append(feature.jpeg) to allow the linker to include the required functions.

this issue occurs when the libtiff and libjpeg libraries are static (not shared.)

Fixes #7269.

Changes proposed in this pull request:

 * reorder libraries due to dependency of tiff on jpeg

### before - missing functions in _imaging.so
```
readelf -Ws build.LibreELEC-Generic.x86_64-12.0-devel/install_pkg/Pillow-10.0.0/usr/lib/python3.11/site-packages/PIL/_imaging.so | grep jpeg12_[rw]
    10: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND jpeg12_write_scanlines
    11: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND jpeg12_read_scanlines
    12: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND jpeg12_read_raw_data
    13: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND jpeg12_write_raw_data

```

### after - functions in _imaging.so
```
readelf -Ws build.LibreELEC-Generic.x86_64-12.0-devel/install_pkg/Pillow-10.0.0/usr/lib/python3.11/site-packages/PIL/_imaging.so | grep jpeg12_[rw]
   287: 00000000000a1d70   218 FUNC    GLOBAL DEFAULT   11 jpeg12_write_scanlines
   369: 00000000000a1e50   276 FUNC    GLOBAL DEFAULT   11 jpeg12_write_raw_data
   688: 00000000000a2aa0   292 FUNC    GLOBAL DEFAULT   11 jpeg12_read_raw_data
   929: 00000000000a2280   240 FUNC    GLOBAL DEFAULT   11 jpeg12_read_scanlines
```