### PR TITLE
Delegate Image mode and size to ImagingCore

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -662,7 +662,7 @@ class TestImage:
         blank_pa.palette = None
 
         def _make_new(base_image, im, palette_result=None):
-            new_im = base_image._new(im)
+            new_im = base_image._new(im.im)
             assert new_im.mode == im.mode
             assert new_im.size == im.size
             assert new_im.info == base_image.info

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -360,7 +360,7 @@ class EpsImageFile(ImageFile.ImageFile):
 
         check_required_header_comments()
 
-        if not self._size:
+        if not self.size:
             msg = "cannot determine EPS bounding box"
             raise OSError(msg)
 

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -328,8 +328,8 @@ class GifImageFile(ImageFile.ImageFile):
                         self._mode = "RGBA"
                         del self.info["transparency"]
                     else:
-                        self._mode = "RGB"
                         self.im = self.im.convert("RGB", Image.Dither.FLOYDSTEINBERG)
+                        self._mode = "RGB"
 
         def _rgb(color):
             if self._frame_palette:

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -262,7 +262,7 @@ class GifImageFile(ImageFile.ImageFile):
                 x1, y1 = x0 + i16(s, 4), y0 + i16(s, 6)
                 if (x1 > self.size[0] or y1 > self.size[1]) and update_image:
                     self._size = max(x1, self.size[0]), max(y1, self.size[1])
-                    Image._decompression_bomb_check(self._size)
+                    Image._decompression_bomb_check(self.size)
                 frame_dispose_extent = x0, y0, x1, y1
                 flags = s[8]
 

--- a/src/PIL/IcnsImagePlugin.py
+++ b/src/PIL/IcnsImagePlugin.py
@@ -261,11 +261,7 @@ class IcnsImageFile(ImageFile.ImageFile):
             self.best_size[1] * self.best_size[2],
         )
 
-    @property
-    def size(self):
-        return self._size
-
-    @size.setter
+    @Image.Image.size.setter
     def size(self, value):
         info_size = value
         if info_size not in self.info["sizes"] and len(info_size) == 2:
@@ -283,7 +279,10 @@ class IcnsImageFile(ImageFile.ImageFile):
         if info_size not in self.info["sizes"]:
             msg = "This is not one of the allowed sizes of this image"
             raise ValueError(msg)
-        self._size = value
+        if value != self.size:
+            self.im = None
+            self.pyaccess = None
+            self._size = value
 
     def load(self):
         if len(self.size) == 3:
@@ -306,7 +305,7 @@ class IcnsImageFile(ImageFile.ImageFile):
 
         self.im = im.im
         self._mode = im.mode
-        self.size = im.size
+        self._size = im.size
 
         return px
 

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -310,36 +310,36 @@ class IcoImageFile(ImageFile.ImageFile):
         self.size = self.ico.entry[0]["dim"]
         self.load()
 
-    @property
-    def size(self):
-        return self._size
-
-    @size.setter
+    @Image.Image.size.setter
     def size(self, value):
         if value not in self.info["sizes"]:
             msg = "This is not one of the allowed sizes of this image"
             raise ValueError(msg)
-        self._size = value
+        if value != self.size:
+            self.im = None
+            self.pyaccess = None
+            self._size = value
 
     def load(self):
         if self.im is not None and self.im.size == self.size:
             # Already loaded
             return Image.Image.load(self)
-        im = self.ico.getimage(self.size)
+        size_to_load = self.size
+        im = self.ico.getimage(size_to_load)
         # if tile is PNG, it won't really be loaded yet
         im.load()
         self.im = im.im
         self.pyaccess = None
         self._mode = im.mode
-        if im.size != self.size:
+        if im.size != size_to_load:
             warnings.warn("Image was not the expected size")
 
-            index = self.ico.getentryindex(self.size)
+            index = self.ico.getentryindex(size_to_load)
             sizes = list(self.info["sizes"])
             sizes[index] = im.size
             self.info["sizes"] = set(sizes)
 
-            self.size = im.size
+            self._size = im.size
 
     def load_seek(self):
         # Flag the ImageFile.Parser so that it

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -508,37 +508,31 @@ class Image:
 
     @property
     def size(self):
-        return self._size
-
-    @property
-    def _size(self):
         if self._use_im_values():
             return self.im.size
         return self.__size
 
-    @_size.setter
     def _size(self, value):
         # set im.size first in case it raises an exception
         if self._use_im_values():
             self.im.size = value
         self.__size = value
 
-    @property
-    def mode(self):
-        return self._mode
+    _size = property(fset=_size)
 
     @property
-    def _mode(self):
+    def mode(self):
         if self._use_im_values():
             return self.im.mode
         return self.__mode
 
-    @_mode.setter
     def _mode(self, value):
         # set im.mode first in case it raises an exception
         if self._use_im_values():
             self.im.mode = value
         self.__mode = value
+
+    _mode = property(fset=_mode)
 
     def _new(self, im):
         new = Image()

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -492,7 +492,10 @@ class Image:
         self._exif = None
 
     def _use_im_values(self):
-        ''' Whether or not to try using values from self.im in addition to the values in this class. '''
+        """
+        Whether or not to try using values from self.im
+        in addition to the values in this class.
+        """
         return self.im is not None
 
     @property

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -480,15 +480,20 @@ class Image:
 
     def __init__(self):
         # FIXME: take "new" parameters / other image?
-        # FIXME: turn mode and size into delegating properties?
         self.im = None
-        self._mode = ""
-        self._size = (0, 0)
+        # do not directly change __mode; use _mode instead
+        self.__mode = ""
+        # do not directly change __size; use _size instead
+        self.__size = (0, 0)
         self.palette = None
         self.info = {}
         self.readonly = 0
         self.pyaccess = None
         self._exif = None
+
+    def _use_im_values(self):
+        ''' Whether or not to try using values from self.im in addition to the values in this class. '''
+        return self.im is not None
 
     @property
     def width(self):
@@ -503,8 +508,34 @@ class Image:
         return self._size
 
     @property
+    def _size(self):
+        if self._use_im_values():
+            return self.im.size
+        return self.__size
+
+    @_size.setter
+    def _size(self, value):
+        # set im.size first in case it raises an excepton
+        if self._use_im_values():
+            self.im.size = value
+        self.__size = value
+
+    @property
     def mode(self):
         return self._mode
+
+    @property
+    def _mode(self):
+        if self._use_im_values():
+            return self.im.mode
+        return self.__mode
+
+    @_mode.setter
+    def _mode(self, value):
+        # set im.mode first in case it raises an excepton
+        if self._use_im_values():
+            self.im.mode = value
+        self.__mode = value
 
     def _new(self, im):
         new = Image()

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -518,7 +518,7 @@ class Image:
 
     @_size.setter
     def _size(self, value):
-        # set im.size first in case it raises an excepton
+        # set im.size first in case it raises an exception
         if self._use_im_values():
             self.im.size = value
         self.__size = value
@@ -535,7 +535,7 @@ class Image:
 
     @_mode.setter
     def _mode(self, value):
-        # set im.mode first in case it raises an excepton
+        # set im.mode first in case it raises an exception
         if self._use_im_values():
             self.im.mode = value
         self.__mode = value

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -139,6 +139,9 @@ class ImageFile(Image.Image):
         if self.format is not None:
             return Image.MIME.get(self.format.upper())
 
+    def _use_im_values(self):
+        return self.tile is None and self.im is not None
+
     def __setstate__(self, state):
         self.tile = []
         super().__setstate__(state)

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -604,7 +604,7 @@ def exif_transpose(image, *, in_place=False):
         if in_place:
             image.im = transposed_image.im
             image.pyaccess = None
-            image._size = transposed_image._size
+            image._size = transposed_image.size
         exif_image = image if in_place else transposed_image
 
         exif = exif_image.getexif()

--- a/src/PIL/PcxImagePlugin.py
+++ b/src/PIL/PcxImagePlugin.py
@@ -114,7 +114,7 @@ class PcxImageFile(ImageFile.ImageFile):
         # Don't trust the passed in stride.
         # Calculate the approximate position for ourselves.
         # CVE-2020-35653
-        stride = (self._size[0] * bits + 7) // 8
+        stride = (self.size[0] * bits + 7) // 8
 
         # While the specification states that this must be even,
         # not all images follow this

--- a/src/PIL/QoiImagePlugin.py
+++ b/src/PIL/QoiImagePlugin.py
@@ -32,7 +32,7 @@ class QoiImageFile(ImageFile.ImageFile):
         self._mode = "RGB" if channels == 3 else "RGBA"
 
         self.fp.seek(1, os.SEEK_CUR)  # colorspace
-        self.tile = [("qoi", (0, 0) + self._size, self.fp.tell(), None)]
+        self.tile = [("qoi", (0, 0) + self.size, self.fp.tell(), None)]
 
 
 class QoiDecoder(ImageFile.PyDecoder):


### PR DESCRIPTION
This causes a lot of errors. The main issues are that `Image.im` isn't always set, so we still need to keep Python-only variables for these properties, and the Python values are writable, but the C values are not writable from Python.