### PR TITLE
Updated harfbuzz to 8.0.0

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -335,9 +335,9 @@ deps = {
         "libs": [r"imagequant.lib"],
     },
     "harfbuzz": {
-        "url": "https://github.com/harfbuzz/harfbuzz/archive/7.3.0.zip",
-        "filename": "harfbuzz-7.3.0.zip",
-        "dir": "harfbuzz-7.3.0",
+        "url": "https://github.com/harfbuzz/harfbuzz/archive/8.0.0.zip",
+        "filename": "harfbuzz-8.0.0.zip",
+        "dir": "harfbuzz-8.0.0",
         "license": "COPYING",
         "build": [
             *cmds_cmake(


### PR DESCRIPTION
harfbuzz 8.0.0 has been released - https://github.com/harfbuzz/harfbuzz/releases/tag/8.0.0