### PR TITLE
Declare support for Python 3.12

### DIFF
--- a/docs/newer-versions.csv
+++ b/docs/newer-versions.csv
@@ -1,7 +1,8 @@
-﻿Python,3.11,3.10,3.9,3.8,3.7,3.6,3.5
-Pillow >= 10,Yes,Yes,Yes,Yes,,,
-Pillow 9.3 - 9.5,Yes,Yes,Yes,Yes,Yes,,
-Pillow 9.0 - 9.2,,Yes,Yes,Yes,Yes,,
-Pillow 8.3.2 - 8.4,,Yes,Yes,Yes,Yes,Yes,
-Pillow 8.0 - 8.3.1,,,Yes,Yes,Yes,Yes,
-Pillow 7.0 - 7.2,,,,Yes,Yes,Yes,Yes
+﻿Python,3.12,3.11,3.1,3.9,3.8,3.7,3.6,3.5
+Pillow >= 10.1,Yes,Yes,Yes,Yes,Yes,,,
+Pillow 10.0,,Yes,Yes,Yes,Yes,,,
+Pillow 9.3 - 9.5,,Yes,Yes,Yes,Yes,Yes,,
+Pillow 9.0 - 9.2,,,Yes,Yes,Yes,Yes,,
+Pillow 8.3.2 - 8.4,,,Yes,Yes,Yes,Yes,Yes,
+Pillow 8.0 - 8.3.1,,,,Yes,Yes,Yes,Yes,
+Pillow 7.0 - 7.2,,,,,Yes,Yes,Yes,Yes

--- a/docs/newer-versions.csv
+++ b/docs/newer-versions.csv
@@ -1,4 +1,4 @@
-﻿Python,3.12,3.11,3.1,3.9,3.8,3.7,3.6,3.5
+﻿Python,3.12,3.11,3.10,3.9,3.8,3.7,3.6,3.5
 Pillow >= 10.1,Yes,Yes,Yes,Yes,Yes,,,
 Pillow 10.0,,Yes,Yes,Yes,Yes,,,
 Pillow 9.3 - 9.5,,Yes,Yes,Yes,Yes,Yes,,

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Multimedia :: Graphics

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
     tox>=4.2
 env_list =
     lint
-    py{py3, 311, 310, 39, 38}
+    py{py3, 312, 311, 310, 39, 38}
 
 [testenv]
 deps =


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/6941.

* Add to support table: https://pillow--7280.org.readthedocs.build/en/7280/installation.html#python-support
* Add `"Programming Language :: Python :: 3.12"` Trove classifier
* Add to `tox.ini`