### PR TITLE
CI: Use prepackaged NumPy to avoid slow source rebuilds

### DIFF
--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -96,11 +96,6 @@ jobs:
         run: |
           bash.exe .ci/install.sh
 
-      - name: Install a different NumPy
-        shell: dash.exe -l "{0}"
-        run: |
-          python3 -m pip install -U numpy
-
       - name: Build
         shell: bash.exe -eo pipefail -o igncr "{0}"
         run: |


### PR DESCRIPTION
Fixes #7281.

Changes proposed in this pull request:

 * Don't install a newer NumPy, it causes slow rebuilds from source.
 * The prepackaged Cygwin NumPy is good enough.
