### PR TITLE
Do not use transparency when saving GIF if it has been removed when normalizing mode

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1086,6 +1086,21 @@ def test_transparent_optimize(tmp_path):
         assert reloaded.info["transparency"] == reloaded.getpixel((252, 0))
 
 
+def test_removed_transparency(tmp_path):
+    out = str(tmp_path / "temp.gif")
+    im = Image.new("RGB", (256, 1))
+
+    for x in range(256):
+        im.putpixel((x, 0), (x, 0, 0))
+
+    im.info["transparency"] = (255, 255, 255)
+    with pytest.warns(UserWarning):
+        im.save(out)
+
+    with Image.open(out) as reloaded:
+        assert "transparency" not in reloaded.info
+
+
 def test_rgb_transparency(tmp_path):
     out = str(tmp_path / "temp.gif")
 

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -683,11 +683,7 @@ def get_interlace(im):
 def _write_local_header(fp, im, offset, flags):
     transparent_color_exists = False
     try:
-        if "transparency" in im.encoderinfo:
-            transparency = im.encoderinfo["transparency"]
-        else:
-            transparency = im.info["transparency"]
-        transparency = int(transparency)
+        transparency = int(im.encoderinfo["transparency"])
     except (KeyError, ValueError):
         pass
     else:


### PR DESCRIPTION
Resolves #7279

https://github.com/python-pillow/Pillow/blob/7a1e28404d692d4a7fed33dc67019a1d8c4bf9d9/src/PIL/GifImagePlugin.py#L546-L549

When `_normalize_mode` converts the image, transparency may be removed from `im.info` by `convert()`. However, that change is not detected at the moment because the transparency is only removed for the new `im_out` image - `im` still has transparency, and when `_write_local_header` gets passed `im` a few lines later, it is detected.

https://github.com/python-pillow/Pillow/blob/7a1e28404d692d4a7fed33dc67019a1d8c4bf9d9/src/PIL/GifImagePlugin.py#L559

https://github.com/python-pillow/Pillow/blob/7a1e28404d692d4a7fed33dc67019a1d8c4bf9d9/src/PIL/GifImagePlugin.py#L683-L690

This PR simplifies matters by no longer checking `im.info` in `_write_local_header`, only `im.encoderinfo`. Any transparency that needs to be known has been copied into `encoderinfo`. See https://github.com/python-pillow/Pillow/blob/7a1e28404d692d4a7fed33dc67019a1d8c4bf9d9/src/PIL/GifImagePlugin.py#L548-L549 and https://github.com/python-pillow/Pillow/blob/7a1e28404d692d4a7fed33dc67019a1d8c4bf9d9/src/PIL/GifImagePlugin.py#L972