### PR TITLE
Include NumPy version in Cygwin pip cache key

### DIFF
--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -76,17 +76,23 @@ jobs:
         with:
           dirs: 'C:\cygwin\bin;C:\cygwin\lib\lapack'
 
+      - name: Select Python version
+        run: |
+          ln -sf c:/cygwin/bin/python3.${{ matrix.python-minor-version }} c:/cygwin/bin/python3
+
+      - name: Get latest NumPy version
+        id: latest-numpy
+        shell: bash.exe -eo pipefail -o igncr "{0}"
+        run: |
+          python3 -m pip list --outdated | grep numpy | sed -r 's/ +/ /g' | cut -d ' ' -f 3 | sed 's/^/version=/' >> $GITHUB_OUTPUT
+
       - name: pip cache
         uses: actions/cache@v3
         with:
           path: 'C:\cygwin\home\runneradmin\.cache\pip'
-          key: ${{ runner.os }}-cygwin-pip3.${{ matrix.python-minor-version }}-${{ hashFiles('.ci/install.sh') }}
+          key: ${{ runner.os }}-cygwin-pip3.${{ matrix.python-minor-version }}-numpy${{ steps.latest-numpy.outputs.version }}-${{ hashFiles('.ci/install.sh') }}
           restore-keys: |
-            ${{ runner.os }}-cygwin-pip3.${{ matrix.python-minor-version }}-
-
-      - name: Select Python version
-        run: |
-          ln -sf c:/cygwin/bin/python3.${{ matrix.python-minor-version }} c:/cygwin/bin/python3
+            ${{ runner.os }}-cygwin-pip3.${{ matrix.python-minor-version }}-numpy${{ steps.latest-numpy.outputs.version }}-
 
       - name: Build system information
         run: |
@@ -96,7 +102,7 @@ jobs:
         run: |
           bash.exe .ci/install.sh
 
-      - name: Install a different NumPy
+      - name: Install latest NumPy
         shell: dash.exe -l "{0}"
         run: |
           python3 -m pip install -U numpy


### PR DESCRIPTION
Resolves #7281

This will update the cache key in the Cygwin job whenever a new version of NumPy is released, keeping build times low.