### PR TITLE
Simplified access code

### DIFF
--- a/src/libImaging/Access.c
+++ b/src/libImaging/Access.c
@@ -128,15 +128,6 @@ get_pixel_32B(Imaging im, int x, int y, void *color) {
 /* store individual pixel */
 
 static void
-put_pixel(Imaging im, int x, int y, const void *color) {
-    if (im->image8) {
-        im->image8[y][x] = *((UINT8 *)color);
-    } else {
-        memcpy(&im->image32[y][x], color, sizeof(INT32));
-    }
-}
-
-static void
 put_pixel_8(Imaging im, int x, int y, const void *color) {
     im->image8[y][x] = *((UINT8 *)color);
 }
@@ -186,8 +177,8 @@ ImagingAccessInit() {
     /* populate access table */
     ADD("1", get_pixel_8, put_pixel_8);
     ADD("L", get_pixel_8, put_pixel_8);
-    ADD("LA", get_pixel, put_pixel);
-    ADD("La", get_pixel, put_pixel);
+    ADD("LA", get_pixel, put_pixel_32);
+    ADD("La", get_pixel, put_pixel_32);
     ADD("I", get_pixel_32, put_pixel_32);
     ADD("I;16", get_pixel_16L, put_pixel_16L);
     ADD("I;16L", get_pixel_16L, put_pixel_16L);
@@ -197,7 +188,7 @@ ImagingAccessInit() {
     ADD("I;32B", get_pixel_32B, put_pixel_32B);
     ADD("F", get_pixel_32, put_pixel_32);
     ADD("P", get_pixel_8, put_pixel_8);
-    ADD("PA", get_pixel, put_pixel);
+    ADD("PA", get_pixel, put_pixel_32);
     ADD("RGB", get_pixel_32, put_pixel_32);
     ADD("RGBA", get_pixel_32, put_pixel_32);
     ADD("RGBa", get_pixel_32, put_pixel_32);

--- a/src/libImaging/Access.c
+++ b/src/libImaging/Access.c
@@ -46,22 +46,11 @@ add_item(const char *mode) {
 /* fetch individual pixel */
 
 static void
-get_pixel(Imaging im, int x, int y, void *color) {
+get_pixel_32_2bands(Imaging im, int x, int y, void *color) {
     char *out = color;
-
-    /* generic pixel access*/
-
-    if (im->image8) {
-        out[0] = im->image8[y][x];
-    } else {
-        UINT8 *p = (UINT8 *)&im->image32[y][x];
-        if (im->type == IMAGING_TYPE_UINT8 && im->bands == 2) {
-            out[0] = p[0];
-            out[1] = p[3];
-            return;
-        }
-        memcpy(out, p, im->pixelsize);
-    }
+    UINT8 *p = (UINT8 *)&im->image32[y][x];
+    out[0] = p[0];
+    out[1] = p[3];
 }
 
 static void
@@ -177,8 +166,8 @@ ImagingAccessInit() {
     /* populate access table */
     ADD("1", get_pixel_8, put_pixel_8);
     ADD("L", get_pixel_8, put_pixel_8);
-    ADD("LA", get_pixel, put_pixel_32);
-    ADD("La", get_pixel, put_pixel_32);
+    ADD("LA", get_pixel_32_2bands, put_pixel_32);
+    ADD("La", get_pixel_32_2bands, put_pixel_32);
     ADD("I", get_pixel_32, put_pixel_32);
     ADD("I;16", get_pixel_16L, put_pixel_16L);
     ADD("I;16L", get_pixel_16L, put_pixel_16L);
@@ -188,7 +177,7 @@ ImagingAccessInit() {
     ADD("I;32B", get_pixel_32B, put_pixel_32B);
     ADD("F", get_pixel_32, put_pixel_32);
     ADD("P", get_pixel_8, put_pixel_8);
-    ADD("PA", get_pixel, put_pixel_32);
+    ADD("PA", get_pixel_32_2bands, put_pixel_32);
     ADD("RGB", get_pixel_32, put_pixel_32);
     ADD("RGBA", get_pixel_32, put_pixel_32);
     ADD("RGBa", get_pixel_32, put_pixel_32);


### PR DESCRIPTION
1. The `put_pixel` function is only currently used for LA, La and PA.
https://github.com/python-pillow/Pillow/blob/b9451540973ca7915b0ce68e6bbacbed665caec2/src/libImaging/Access.c#L187-L208

https://github.com/python-pillow/Pillow/blob/b9451540973ca7915b0ce68e6bbacbed665caec2/src/libImaging/Access.c#L130-L137

Since these are [not image8 modes](https://github.com/python-pillow/Pillow/blob/b9451540973ca7915b0ce68e6bbacbed665caec2/src/libImaging/Storage.c#L75-L97), it would be simpler to just call `put_pixel_32` instead

https://github.com/python-pillow/Pillow/blob/b9451540973ca7915b0ce68e6bbacbed665caec2/src/libImaging/Access.c#L172-L175

and remove `put_pixel`.

2. `get_pixel` is similarly only currently used for LA, La and PA.

It does have unique behaviour, so we can't remove it completely.

https://github.com/python-pillow/Pillow/blob/b9451540973ca7915b0ce68e6bbacbed665caec2/src/libImaging/Access.c#L48-L65

However, this PR removes the check for image8, since it is false for these modes, and the check if this is UINT8 2 bands, since it is true for these modes, and renames the function to `get_pixel_32_2bands` to indicate that it is specific.