### PR TITLE
Added more information about PPM formats

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -861,6 +861,10 @@ PPM
 Pillow reads and writes PBM, PGM, PPM and PNM files containing ``1``, ``L``, ``I`` or
 ``RGB`` data.
 
+"Raw" (P4 to P6) formats can be read, and are used when writing.
+
+Since Pillow 9.2.0, "plain" (P1 to P3) formats can be read as well.
+
 SGI
 ^^^
 


### PR DESCRIPTION
Resolves #7297

This PR documents that Pillow can [read P1 to P6](https://github.com/python-pillow/Pillow/blob/b9451540973ca7915b0ce68e6bbacbed665caec2/src/PIL/PpmImagePlugin.py#L28-L35) PPM image formats (P1 to P3 only since Pillow 9.2.0 with #5242) and [writes images in P4 to P6.](https://github.com/python-pillow/Pillow/blob/b9451540973ca7915b0ce68e6bbacbed665caec2/src/PIL/PpmImagePlugin.py#L309-L320)