### PR TITLE
Added saving LA images as PDFs

### DIFF
--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -43,8 +43,9 @@ def test_save(tmp_path, mode):
 
 
 @skip_unless_feature("jpg_2000")
-def test_save_rgba(tmp_path):
-    helper_save_as_pdf(tmp_path, "RGBA")
+@pytest.mark.parametrize("mode", ("LA", "RGBA"))
+def test_save_alpha(tmp_path, mode):
+    helper_save_as_pdf(tmp_path, mode)
 
 
 def test_monochrome(tmp_path):
@@ -57,8 +58,8 @@ def test_monochrome(tmp_path):
 
 
 def test_unsupported_mode(tmp_path):
-    im = hopper("LA")
-    outfile = str(tmp_path / "temp_LA.pdf")
+    im = hopper("PA")
+    outfile = str(tmp_path / "temp_PA.pdf")
 
     with pytest.raises(ValueError):
         im.save(outfile)

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1486,7 +1486,7 @@ files. Different encoding methods are used, depending on the image mode.
   unavailable
 * L, RGB and CMYK mode images use JPEG encoding
 * P mode images use HEX encoding
-* RGBA mode images use JPEG2000 encoding
+* LA and RGBA mode images use JPEG2000 encoding
 
 .. _pdf-saving:
 

--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -159,6 +159,11 @@ def _save(im, fp, filename, save_all=False):
                 # params = f"<< /Predictor 15 /Columns {width-2} >>"
                 colorspace = PdfParser.PdfName("DeviceGray")
                 procset = "ImageB"  # grayscale
+            elif im.mode == "LA":
+                filter = "JPXDecode"
+                # params = f"<< /Predictor 15 /Columns {width-2} >>"
+                colorspace = PdfParser.PdfName("DeviceGray")
+                procset = "ImageB"  # grayscale
             elif im.mode == "P":
                 filter = "ASCIIHexDecode"
                 palette = im.getpalette()

--- a/src/libImaging/Jpeg2KEncode.c
+++ b/src/libImaging/Jpeg2KEncode.c
@@ -490,6 +490,8 @@ j2k_encode_entry(Imaging im, ImagingCodecState state) {
 
     if (strcmp(im->mode, "RGBA") == 0) {
         image->comps[3].alpha = 1;
+    } else if (strcmp(im->mode, "LA") == 0) {
+        image->comps[1].alpha = 1;
     }
 
     opj_set_error_handler(codec, j2k_error, context);


### PR DESCRIPTION
Resolves #7293

This is similar to #6925, except for LA instead of RGBA, and so uses
https://github.com/python-pillow/Pillow/blob/ea0abb94cce2aa8b6aed33f57b3871053f2aad59/src/PIL/PdfImagePlugin.py#L160-L161
instead of
https://github.com/python-pillow/Pillow/blob/ea0abb94cce2aa8b6aed33f57b3871053f2aad59/src/PIL/PdfImagePlugin.py#L174-L175