### PR TITLE
Docs: Clarify that a single value is returned, and depends on the text direction

### DIFF
--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -538,7 +538,7 @@ Methods
                      It should be a `BCP 47 language code`_.
                      Requires libraqm.
     :param embedded_color: Whether to use font embedded color glyphs (COLR, CBDT, SBIX).
-    :return: Width for horizontal, height for vertical text.
+    :return: Either width for horizontal text, or height for vertical text.
 
 .. py:method:: ImageDraw.textbbox(xy, text, font=None, anchor=None, spacing=4, align="left", direction=None, features=None, language=None, stroke_width=0, embedded_color=False)
 

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -318,7 +318,7 @@ class FreeTypeFont:
                          <https://www.w3.org/International/articles/language-tags/>`_
                          Requires libraqm.
 
-        :return: Width for horizontal, height for vertical text.
+        :return: Either width for horizontal text, or height for vertical text.
         """
         _string_length_check(text)
         return self.font.getlength(text, mode, direction, features, language) / 64


### PR DESCRIPTION
Fixes https://github.com/python-pillow/Pillow/issues/7304.

Changes proposed in this pull request:

 * Clarify that a tuple isn't returned, but a single value is (that it depends on the direction of the text)
