### PR TITLE
Read WebP duration after opening

### DIFF
--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -233,5 +233,4 @@ class TestFileWebp:
             im.save(out_webp, save_all=True)
 
         with Image.open(out_webp) as reloaded:
-            reloaded.load()
             assert reloaded.info["duration"] == 1000

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -74,6 +74,9 @@ class WebPImageFile(ImageFile.ImageFile):
         self.info["background"] = (bg_r, bg_g, bg_b, bg_a)
         self.n_frames = frame_count
         self.is_animated = self.n_frames > 1
+        _,ts=self._decoder.get_next()
+        if ts:
+            self.info["duration"]=ts
         self._mode = "RGB" if mode == "RGBX" else mode
         self.rawmode = mode
         self.tile = []

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -74,9 +74,9 @@ class WebPImageFile(ImageFile.ImageFile):
         self.info["background"] = (bg_r, bg_g, bg_b, bg_a)
         self.n_frames = frame_count
         self.is_animated = self.n_frames > 1
-        _,ts=self._decoder.get_next()
+        _, ts = self._decoder.get_next()
         if ts:
-            self.info["duration"]=ts
+            self.info["duration"] = ts
         self._mode = "RGB" if mode == "RGBX" else mode
         self.rawmode = mode
         self.tile = []

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -74,9 +74,9 @@ class WebPImageFile(ImageFile.ImageFile):
         self.info["background"] = (bg_r, bg_g, bg_b, bg_a)
         self.n_frames = frame_count
         self.is_animated = self.n_frames > 1
-        _, ts = self._decoder.get_next()
-        if ts:
-            self.info["duration"] = ts
+        ret = self._decoder.get_next()
+        if ret is not None:
+            self.info["duration"] = ret[1]
         self._mode = "RGB" if mode == "RGBX" else mode
         self.rawmode = mode
         self.tile = []
@@ -93,7 +93,7 @@ class WebPImageFile(ImageFile.ImageFile):
             self.info["xmp"] = xmp
 
         # Initialize seek state
-        self._reset(reset=True)
+        self._reset()
 
     def _getexif(self):
         if "exif" not in self.info:
@@ -116,9 +116,8 @@ class WebPImageFile(ImageFile.ImageFile):
         # Set logical frame to requested position
         self.__logical_frame = frame
 
-    def _reset(self, reset=True):
-        if reset:
-            self._decoder.reset()
+    def _reset(self):
+        self._decoder.reset()
         self.__physical_frame = 0
         self.__loaded = -1
         self.__timestamp = 0

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -93,7 +93,7 @@ class WebPImageFile(ImageFile.ImageFile):
             self.info["xmp"] = xmp
 
         # Initialize seek state
-        self._reset(reset=False)
+        self._reset(reset=True)
 
     def _getexif(self):
         if "exif" not in self.info:


### PR DESCRIPTION
Many WebP images don't initially have duration in their info dict.  This automatically adds that information during image open.