### PR TITLE
Set SMaskInData to 1 for PDFs with alpha

### DIFF
--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -152,17 +152,17 @@ def _save(im, fp, filename, save_all=False):
                     )
                 else:
                     filter = "DCTDecode"
-                colorspace = PdfParser.PdfName("DeviceGray")
+                dict_obj["ColorSpace"] = PdfParser.PdfName("DeviceGray")
                 procset = "ImageB"  # grayscale
             elif im.mode == "L":
                 filter = "DCTDecode"
                 # params = f"<< /Predictor 15 /Columns {width-2} >>"
-                colorspace = PdfParser.PdfName("DeviceGray")
+                dict_obj["ColorSpace"] = PdfParser.PdfName("DeviceGray")
                 procset = "ImageB"  # grayscale
             elif im.mode == "P":
                 filter = "ASCIIHexDecode"
                 palette = im.getpalette()
-                colorspace = [
+                dict_obj["ColorSpace"] = [
                     PdfParser.PdfName("Indexed"),
                     PdfParser.PdfName("DeviceRGB"),
                     255,
@@ -171,16 +171,15 @@ def _save(im, fp, filename, save_all=False):
                 procset = "ImageI"  # indexed color
             elif im.mode == "RGB":
                 filter = "DCTDecode"
-                colorspace = PdfParser.PdfName("DeviceRGB")
+                dict_obj["ColorSpace"] = PdfParser.PdfName("DeviceRGB")
                 procset = "ImageC"  # color images
             elif im.mode == "RGBA":
                 filter = "JPXDecode"
-                colorspace = PdfParser.PdfName("DeviceRGB")
                 procset = "ImageC"  # color images
                 dict_obj["SMaskInData"] = 1
             elif im.mode == "CMYK":
                 filter = "DCTDecode"
-                colorspace = PdfParser.PdfName("DeviceCMYK")
+                dict_obj["ColorSpace"] = PdfParser.PdfName("DeviceCMYK")
                 procset = "ImageC"  # color images
                 decode = [1, 0, 1, 0, 1, 0, 1, 0]
             else:
@@ -232,7 +231,6 @@ def _save(im, fp, filename, save_all=False):
                 Filter=filter,
                 Decode=decode,
                 DecodeParms=params,
-                ColorSpace=colorspace,
                 **dict_obj,
             )
 

--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -128,6 +128,7 @@ def _save(im, fp, filename, save_all=False):
             bits = 8
             params = None
             decode = None
+            smaskindata = 0
 
             #
             # Get image characteristics
@@ -177,6 +178,7 @@ def _save(im, fp, filename, save_all=False):
                 filter = "JPXDecode"
                 colorspace = PdfParser.PdfName("DeviceRGB")
                 procset = "ImageC"  # color images
+                smaskindata = 1
             elif im.mode == "CMYK":
                 filter = "DCTDecode"
                 colorspace = PdfParser.PdfName("DeviceCMYK")
@@ -232,6 +234,7 @@ def _save(im, fp, filename, save_all=False):
                 Decode=decode,
                 DecodeParms=params,
                 ColorSpace=colorspace,
+                SMaskInData=smaskindata,
             )
 
             #


### PR DESCRIPTION
Helps #7312

Pillow can convert a PNG with transparency to PDF
```python
from PIL import Image
im = Image.open("Tests/images/transparent.png")
im.save("transparent.pdf")
```
However, what does transparency mean exactly in PDF? There is debate about this in #7312, and various image viewers are discussed, so I'll try and keep it simple here by saving it that if I convert the PDF back to PNG with ImageMagick, `convert transparent.pdf out.png`, at the moment, I get a black background instead of transparency.

In https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf, under 7.4.9 'JPXDecode Filter', it states
> **SMaskInData** specifies whether soft-mask information packaged with the image samples shall be used (see 11.6.5.3, "Soft-Mask Images"); if it is, the **SMask** entry shall not be present. If **SMaskInData** is nonzero, there shall be only one opacity channel in the JPEG2000 data and it shall apply to all colour channels.

If I set `SMaskInData` to 1 when saving the PDF, the roundtripped PNG keeps its transparency.