### PR TITLE
Set SMaskInData to 1 for LA PDFs

### DIFF
--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -162,7 +162,6 @@ def _save(im, fp, filename, save_all=False):
             elif im.mode == "LA":
                 filter = "JPXDecode"
                 # params = f"<< /Predictor 15 /Columns {width-2} >>"
-                colorspace = PdfParser.PdfName("DeviceGray")
                 procset = "ImageB"  # grayscale
                 dict_obj["SMaskInData"] = 1
             elif im.mode == "P":

--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -164,6 +164,7 @@ def _save(im, fp, filename, save_all=False):
                 # params = f"<< /Predictor 15 /Columns {width-2} >>"
                 colorspace = PdfParser.PdfName("DeviceGray")
                 procset = "ImageB"  # grayscale
+                dict_obj["SMaskInData"] = 1
             elif im.mode == "P":
                 filter = "ASCIIHexDecode"
                 palette = im.getpalette()


### PR DESCRIPTION
The combination of #7299 and #7316 has led to a [lint error in main](https://github.com/python-pillow/Pillow/actions/runs/5760256344/job/15615858900#step:7:26).

This fixes that, while also applying the RGBA changes from #7316 to the new LA saving from #7299.
- `ColorSpace` is removed for LA, since [the specification](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) states under 7.4.9 "JPXDecode Filter" that "ColorSpace shall be optional since JPEG2000 data contain colour space specifications"
- `SMaskInData` is set to 1, allowing
```python
from PIL import Image
im = Image.open("/Users/andrewmurray/pillow/Pillow/Tests/images/transparent.png")
im.convert("LA").save("la.pdf")
```
followed by an ImageMagick `convert la.pdf la.png` to result in an image with transparency.