### PR TITLE
Increase flexibility when reading IPTC fields

### DIFF
--- a/Tests/test_file_iptc.py
+++ b/Tests/test_file_iptc.py
@@ -30,6 +30,19 @@ def test_getiptcinfo_jpg_found():
     assert iptc[(2, 101)] == b"Hungary"
 
 
+def test_getiptcinfo_zero_padding():
+    # Arrange
+    with Image.open(TEST_FILE) as im:
+        im.info["photoshop"][0x0404] += b"\x00\x00\x00"
+
+        # Act
+        iptc = IptcImagePlugin.getiptcinfo(im)
+
+    # Assert
+    assert isinstance(iptc, dict)
+    assert len(iptc) == 3
+
+
 def test_getiptcinfo_tiff_none():
     # Arrange
     with Image.open("Tests/images/hopper.tif") as im:

--- a/Tests/test_file_iptc.py
+++ b/Tests/test_file_iptc.py
@@ -1,5 +1,5 @@
 import sys
-from io import StringIO
+from io import BytesIO, StringIO
 
 from PIL import Image, IptcImagePlugin
 
@@ -28,6 +28,23 @@ def test_getiptcinfo_jpg_found():
     assert isinstance(iptc, dict)
     assert iptc[(2, 90)] == b"Budapest"
     assert iptc[(2, 101)] == b"Hungary"
+
+
+def test_getiptcinfo_fotostation():
+    # Arrange
+    with open(TEST_FILE, "rb") as fp:
+        data = bytearray(fp.read())
+    data[86] = 240
+    f = BytesIO(data)
+    with Image.open(f) as im:
+        # Act
+        iptc = IptcImagePlugin.getiptcinfo(im)
+
+    # Assert
+    for tag in iptc.keys():
+        if tag[0] == 240:
+            return
+    assert False, "FotoStation tag not found"
 
 
 def test_getiptcinfo_zero_padding():

--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -58,7 +58,7 @@ class IptcImageFile(ImageFile.ImageFile):
         #
         # get a IPTC field header
         s = self.fp.read(5)
-        if not len(s):
+        if not s.strip(b"\x00"):
             return None, 0
 
         tag = s[1], s[2]

--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -64,7 +64,7 @@ class IptcImageFile(ImageFile.ImageFile):
         tag = s[1], s[2]
 
         # syntax
-        if s[0] != 0x1C or tag[0] < 1 or tag[0] > 9:
+        if s[0] != 0x1C or tag[0] not in [1, 2, 3, 4, 5, 6, 7, 8, 9, 240]:
             msg = "invalid IPTC/NAA file"
             raise SyntaxError(msg)
 


### PR DESCRIPTION
Resolves #7318

1. The issue has found an image where `im.info["photoshop"][0x0404]` appears to be zero padded. I've added a commit ignoring an IPTC field if it is only zero bytes, resolving the problem.
2. A later post in the issue has found an image where `tag[0]`
https://github.com/python-pillow/Pillow/blob/52206c71e4c3882d6ab0ffa8e8de986986f2fd62/src/PIL/IptcImagePlugin.py#L67
is 240. This doesn't line up with page 12 (PDF page 12, not page 12 according to the footer) of http://www.iptc.org/std/IIM/4.1/specification/IIMV4.1.pdf, which lists 1 to 9. However, https://exiftool.org/TagNames/IPTC.html lists 240, making me think that this is a proprietary extension, rather than something mentioned in the format. I've adjusted the code to also accept 240 as a value.