### PR TITLE
Added session type check in grabclipboard for Linux

### DIFF
--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -147,7 +147,7 @@ def grabclipboard():
         else:  # Session type check failed
             session_type = None
 
-        if shutil.which("wl-paste") and session_type in ["wayland", None]:
+        if shutil.which("wl-paste") and session_type in ("wayland", None):
             output = subprocess.check_output(["wl-paste", "-l"]).decode()
             mimetypes = output.splitlines()
             if "image/png" in mimetypes:
@@ -160,7 +160,7 @@ def grabclipboard():
             args = ["wl-paste"]
             if mimetype:
                 args.extend(["-t", mimetype])
-        elif shutil.which("xclip") and session_type in ["x11", None]:
+        elif shutil.which("xclip") and session_type in ("x11", None):
             args = ["xclip", "-selection", "clipboard", "-t", "image/png", "-o"]
         else:
             msg = "wl-paste or xclip is required for ImageGrab.grabclipboard() on Linux"

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -140,27 +140,10 @@ def grabclipboard():
                 return BmpImagePlugin.DibImageFile(data)
         return None
     else:
-        if shutil.which("loginctl"):
-            try:
-                loginctl = subprocess.check_output("loginctl").decode().split("\n")
-            except subprocess.CalledProcessError:
-                loginctl = None
-        else:
-            loginctl = None
-
-        if loginctl is not None:
-            username = os.getlogin()
-            sessionid = [
-                line.split()[0] for line in loginctl if username in line.split()
-            ][0]
-            sessiontype = (
-                subprocess.check_output(
-                    ["loginctl", "show-session", sessionid, "-p", "Type"]
-                )
-                .decode()
-                .strip("\n")
-                .split("=")[1]
-            )
+        if os.getenv("WAYLAND_DISPLAY"):
+            sessiontype = "wayland"
+        elif os.getenv("DISPLAY"):
+            sessiontype = "x11"
         else:  # Session type check failed
             sessiontype = None
 

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -149,7 +149,7 @@ def grabclipboard():
             loginctl = None
 
         if loginctl is not None:
-            username = subprocess.check_output("whoami").decode().strip("\n")
+            username = os.getlogin()
             sessionid = [
                 line.split()[0] for line in loginctl if username in line.split()
             ][0]

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -164,9 +164,7 @@ def grabclipboard():
         else:  # Session type check failed
             sessiontype = None
 
-        if shutil.which("wl-paste") and (
-            (sessiontype == "wayland") or (sessiontype is None)
-        ):
+        if shutil.which("wl-paste") and sessiontype in ["wayland", None]:
             output = subprocess.check_output(["wl-paste", "-l"]).decode()
             mimetypes = output.splitlines()
             if "image/png" in mimetypes:
@@ -179,9 +177,7 @@ def grabclipboard():
             args = ["wl-paste"]
             if mimetype:
                 args.extend(["-t", mimetype])
-        elif shutil.which("xclip") and (
-            (sessiontype == "x11") or (sessiontype is None)
-        ):
+        elif shutil.which("xclip") and sessiontype in ["x11", None]:
             args = ["xclip", "-selection", "clipboard", "-t", "image/png", "-o"]
         else:
             msg = "wl-paste or xclip is required for ImageGrab.grabclipboard() on Linux"

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -141,13 +141,13 @@ def grabclipboard():
         return None
     else:
         if os.getenv("WAYLAND_DISPLAY"):
-            sessiontype = "wayland"
+            session_type = "wayland"
         elif os.getenv("DISPLAY"):
-            sessiontype = "x11"
+            session_type = "x11"
         else:  # Session type check failed
-            sessiontype = None
+            session_type = None
 
-        if shutil.which("wl-paste") and sessiontype in ["wayland", None]:
+        if shutil.which("wl-paste") and session_type in ["wayland", None]:
             output = subprocess.check_output(["wl-paste", "-l"]).decode()
             mimetypes = output.splitlines()
             if "image/png" in mimetypes:
@@ -160,7 +160,7 @@ def grabclipboard():
             args = ["wl-paste"]
             if mimetype:
                 args.extend(["-t", mimetype])
-        elif shutil.which("xclip") and sessiontype in ["x11", None]:
+        elif shutil.which("xclip") and session_type in ["x11", None]:
             args = ["xclip", "-selection", "clipboard", "-t", "image/png", "-o"]
         else:
             msg = "wl-paste or xclip is required for ImageGrab.grabclipboard() on Linux"

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -146,18 +146,27 @@ def grabclipboard():
             except subprocess.CalledProcessError:
                 loginctl = None
         else:
-            loginctl =  None
+            loginctl = None
 
         if loginctl is not None:
             username = subprocess.check_output("whoami").decode().strip("\n")
-            sessionid = [line.split()[0] for line in loginctl if username in line.split()][0]
-            sessiontype = subprocess.check_output(
-                ["loginctl", "show-session", sessionid, "-p", "Type"]
-                ).decode().strip("\n").split("=")[1]
-        else: # Session type check failed
+            sessionid = [
+                line.split()[0] for line in loginctl if username in line.split()
+            ][0]
+            sessiontype = (
+                subprocess.check_output(
+                    ["loginctl", "show-session", sessionid, "-p", "Type"]
+                )
+                .decode()
+                .strip("\n")
+                .split("=")[1]
+            )
+        else:  # Session type check failed
             sessiontype = None
 
-        if shutil.which("wl-paste") and ((sessiontype == "wayland") or (sessiontype is None)):
+        if shutil.which("wl-paste") and (
+            (sessiontype == "wayland") or (sessiontype is None)
+        ):
             output = subprocess.check_output(["wl-paste", "-l"]).decode()
             mimetypes = output.splitlines()
             if "image/png" in mimetypes:
@@ -170,7 +179,9 @@ def grabclipboard():
             args = ["wl-paste"]
             if mimetype:
                 args.extend(["-t", mimetype])
-        elif shutil.which("xclip") and ((sessiontype == "x11") or (sessiontype is None)):
+        elif shutil.which("xclip") and (
+            (sessiontype == "x11") or (sessiontype is None)
+        ):
             args = ["xclip", "-selection", "clipboard", "-t", "image/png", "-o"]
         else:
             msg = "wl-paste or xclip is required for ImageGrab.grabclipboard() on Linux"


### PR DESCRIPTION
Fixes #7331

Changes proposed in this pull request:

* Check if current session is X11 or Wayland and decide which command to use. This is done by using `loginctl` command (based on [this](https://unix.stackexchange.com/a/371164)). If the session check failed (loginctl not available because eg. not on systemd), fall back to previous routine (assume Wayland first, if `wl-paste` unavailable then assume X11)
* Raise `NotImplementedError` if `xclip` unavailable on X11 session or `wl-paste` unavailable on Wayland session