### PR TITLE
Fixed a typo in 10.0.0 release notes

### DIFF
--- a/docs/releasenotes/10.0.0.rst
+++ b/docs/releasenotes/10.0.0.rst
@@ -206,4 +206,4 @@ Support reading signed 8-bit TIFF images
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 TIFF images with signed integer data, 8 bits per sample and a photometric
-interpretaton of BlackIsZero can now be read.
+interpretation of BlackIsZero can now be read.


### PR DESCRIPTION
Found a typo in last section:
interpretaton -> interpretation