### PR TITLE
32-bit Windows wheels are no longer provided

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -83,10 +83,9 @@ Install Pillow with :command:`pip`::
 .. tab:: Windows
 
     We provide Pillow binaries for Windows compiled for the matrix of
-    supported Pythons in both 32 and 64-bit versions in the wheel format.
-    These binaries include support for all optional libraries except
-    libimagequant and libxcb. Raqm support requires
-    FriBiDi to be installed separately::
+    supported Pythons in 64-bit versions in the wheel format. These binaries include
+    support for all optional libraries except libimagequant and libxcb. Raqm support
+    requires FriBiDi to be installed separately::
 
         python3 -m pip install --upgrade pip
         python3 -m pip install --upgrade Pillow


### PR DESCRIPTION
At https://pillow.readthedocs.io/en/latest/installation.html#basic-installation, under the 'Windows' tab, it states
> We provide Pillow binaries for Windows compiled for the matrix of supported Pythons in both 32 and 64-bit versions in the wheel format.

As of https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#bit-wheels, we no longer provide 32-bit wheels.

This was pointed out in https://github.com/python-pillow/Pillow/issues/7341#issuecomment-1685596122