### PR TITLE
Skip tests that require FreeType if FreeType is not available

### DIFF
--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -6,6 +6,7 @@ import packaging
 import pytest
 
 from PIL import Image, features
+from Tests.helper import skip_unless_feature
 
 if sys.platform.startswith("win32"):
     pytest.skip("Fuzzer is linux only", allow_module_level=True)
@@ -48,6 +49,7 @@ def test_fuzz_images(path):
         fuzzers.disable_decompressionbomb_error()
 
 
+@skip_unless_feature("freetype2")
 @pytest.mark.parametrize(
     "path", subprocess.check_output("find Tests/fonts -type f", shell=True).split(b"\n")
 )

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -1326,6 +1326,7 @@ def test_stroke_multiline():
     assert_image_similar_tofile(im, "Tests/images/imagedraw_stroke_multiline.png", 3.3)
 
 
+@skip_unless_feature("freetype2")
 def test_setting_default_font():
     # Arrange
     im = Image.new("RGB", (100, 250))

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -112,6 +112,7 @@ def helper_assert_pickled_font_images(font1, font2):
     assert_image_equal(im1, im2)
 
 
+@skip_unless_feature("freetype2")
 @pytest.mark.parametrize("protocol", list(range(0, pickle.HIGHEST_PROTOCOL + 1)))
 def test_pickle_font_string(protocol):
     # Arrange
@@ -125,6 +126,7 @@ def test_pickle_font_string(protocol):
     helper_assert_pickled_font_images(font, unpickled_font)
 
 
+@skip_unless_feature("freetype2")
 @pytest.mark.parametrize("protocol", list(range(0, pickle.HIGHEST_PROTOCOL + 1)))
 def test_pickle_font_file(tmp_path, protocol):
     # Arrange


### PR DESCRIPTION
If I disable the optional dependency FreeType, various tests fail.

This PR skips them if FreeType is not available.