### PR TITLE
Allow getpixel() to accept a list

### DIFF
--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -213,6 +213,10 @@ class TestImageGetPixel(AccessTest):
     def test_basic(self, mode):
         self.check(mode)
 
+    def test_list(self):
+        im = hopper()
+        assert im.getpixel([0, 0]) == (20, 20, 70)
+
     @pytest.mark.parametrize("mode", ("I;16", "I;16B"))
     @pytest.mark.parametrize(
         "expected_color", (2**15 - 1, 2**15, 2**15 + 1, 2**16 - 1)

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1565,6 +1565,8 @@ class Image:
         self.load()
         if self.pyaccess:
             return self.pyaccess.getpixel(xy)
+        if isinstance(xy, list):
+            xy = tuple(xy)
         return self.im.getpixel(xy)
 
     def getprojection(self):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1565,9 +1565,7 @@ class Image:
         self.load()
         if self.pyaccess:
             return self.pyaccess.getpixel(xy)
-        if isinstance(xy, list):
-            xy = tuple(xy)
-        return self.im.getpixel(xy)
+        return self.im.getpixel(tuple(xy))
 
     def getprojection(self):
         """

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1146,11 +1146,15 @@ static inline int
 _getxy(PyObject *xy, int *x, int *y) {
     PyObject *value;
 
-    if (!PyTuple_Check(xy) || PyTuple_GET_SIZE(xy) != 2) {
+    int tuple = PyTuple_Check(xy);
+    if (
+      !(tuple && PyTuple_GET_SIZE(xy) == 2) &&
+      !(PyList_Check(xy) && PyList_GET_SIZE(xy) == 2)
+    ) {
         goto badarg;
     }
 
-    value = PyTuple_GET_ITEM(xy, 0);
+    value = tuple ? PyTuple_GET_ITEM(xy, 0) : PyList_GET_ITEM(xy, 0);
     if (PyLong_Check(value)) {
         *x = PyLong_AS_LONG(value);
     } else if (PyFloat_Check(value)) {
@@ -1164,7 +1168,7 @@ _getxy(PyObject *xy, int *x, int *y) {
         }
     }
 
-    value = PyTuple_GET_ITEM(xy, 1);
+    value = tuple ? PyTuple_GET_ITEM(xy, 1) : PyList_GET_ITEM(xy, 1);
     if (PyLong_Check(value)) {
         *y = PyLong_AS_LONG(value);
     } else if (PyFloat_Check(value)) {

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1146,15 +1146,11 @@ static inline int
 _getxy(PyObject *xy, int *x, int *y) {
     PyObject *value;
 
-    int tuple = PyTuple_Check(xy);
-    if (
-      !(tuple && PyTuple_GET_SIZE(xy) == 2) &&
-      !(PyList_Check(xy) && PyList_GET_SIZE(xy) == 2)
-    ) {
+    if (!PyTuple_Check(xy) || PyTuple_GET_SIZE(xy) != 2) {
         goto badarg;
     }
 
-    value = tuple ? PyTuple_GET_ITEM(xy, 0) : PyList_GET_ITEM(xy, 0);
+    value = PyTuple_GET_ITEM(xy, 0);
     if (PyLong_Check(value)) {
         *x = PyLong_AS_LONG(value);
     } else if (PyFloat_Check(value)) {
@@ -1168,7 +1164,7 @@ _getxy(PyObject *xy, int *x, int *y) {
         }
     }
 
-    value = tuple ? PyTuple_GET_ITEM(xy, 1) : PyList_GET_ITEM(xy, 1);
+    value = PyTuple_GET_ITEM(xy, 1);
     if (PyLong_Check(value)) {
         *y = PyLong_AS_LONG(value);
     } else if (PyFloat_Check(value)) {


### PR DESCRIPTION
Resolves #7352

The issue points out that while `im.getpixel()` accepts a tuple, `im.getpixel((0, 0))`, it does not accept a list.
```pytb
>>> im.getpixel([0, 0])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/Image.py", line 1568, in getpixel
TypeError: argument must be sequence of length 2
```
Even though the list supplied is still a "sequence of length 2".

It is worth noting that this error string is shared with another situation.
```pytb
>>> im.load()[0, 0, 0]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: argument must be sequence of length 2
```
So the error message cannot be simply reworded to say "tuple", as I don't think that clearly explains the problem with `im.load()[0, 0, 0]` .

Instead, this PR allows `im.getpixel()` to accept a list.