### PR TITLE
Use previous pixel alpha for QOI_OP_RGB

### DIFF
--- a/Tests/test_file_qoi.py
+++ b/Tests/test_file_qoi.py
@@ -2,7 +2,7 @@ import pytest
 
 from PIL import Image, QoiImagePlugin
 
-from .helper import assert_image_equal_tofile, assert_image_similar_tofile
+from .helper import assert_image_equal_tofile
 
 
 def test_sanity():
@@ -18,7 +18,7 @@ def test_sanity():
         assert im.size == (162, 150)
         assert im.format == "QOI"
 
-        assert_image_similar_tofile(im, "Tests/images/pil123rgba.png", 0.03)
+        assert_image_equal_tofile(im, "Tests/images/pil123rgba.png")
 
 
 def test_invalid_file():

--- a/src/PIL/QoiImagePlugin.py
+++ b/src/PIL/QoiImagePlugin.py
@@ -55,7 +55,7 @@ class QoiDecoder(ImageFile.PyDecoder):
         while len(data) < self.state.xsize * self.state.ysize * bands:
             byte = self.fd.read(1)[0]
             if byte == 0b11111110:  # QOI_OP_RGB
-                value = self.fd.read(3) + o8(255)
+                value = self.fd.read(3) + self._previous_pixel[3:]
             elif byte == 0b11111111:  # QOI_OP_RGBA
                 value = self.fd.read(4)
             else:


### PR DESCRIPTION
Resolves #7356

The [specification](https://qoiformat.org/qoi-specification.pdf) states that for QOI_OP_DIFF,
> The alpha value remains unchanged from the previous pixel.

And we do that correctly
https://github.com/python-pillow/Pillow/blob/24606216e1e5931a8fe6f41acde9e7e67489905d/src/PIL/QoiImagePlugin.py#L66-L74

However, the specification also states the same thing for QOI_OP_RGB, and we do not use the previous pixel value for alpha.
https://github.com/python-pillow/Pillow/blob/24606216e1e5931a8fe6f41acde9e7e67489905d/src/PIL/QoiImagePlugin.py#L57-L58

This PR fixes that.