### PR TITLE
Map buffer into (0, 0) image

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3000,7 +3000,7 @@ def frombuffer(mode, size, data, decoder_name="raw", *args):
         if args == ():
             args = mode, 0, 1
         if args[0] in _MAPMODES:
-            im = new(mode, (1, 1))
+            im = new(mode, (0, 0))
             im = im._new(core.map_buffer(data, size, decoder_name, 0, args))
             if mode == "P":
                 from . import ImagePalette


### PR DESCRIPTION
In `frombuffer`, Pillow maps the buffer onto a (1, 1) image.
https://github.com/python-pillow/Pillow/blob/24606216e1e5931a8fe6f41acde9e7e67489905d/src/PIL/Image.py#L3003-L3004

As a small change for the sake of performance, this PR changes it to be a (0, 0) image instead.