### PR TITLE
Revert "Do not test PyQt6 on Python 3.12"

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -42,7 +42,7 @@ if [[ $(uname) != CYGWIN* ]]; then
     if ! [ "$GHA_PYTHON_VERSION" == "3.12-dev" ]; then python3 -m pip install numpy ; fi
 
     # PyQt6 doesn't support PyPy3
-    if [[ "$GHA_PYTHON_VERSION" != "3.12-dev" && $GHA_PYTHON_VERSION == 3.* ]]; then
+    if [[ $GHA_PYTHON_VERSION == 3.* ]]; then
         sudo apt-get -qq install libegl1 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxkbcommon-x11-0
         python3 -m pip install pyqt6
     fi


### PR DESCRIPTION
Reverts part of #7188.

For whatever reason, PyQt6 no longer causes a segfault in Python 3.12 on Linux.