### PR TITLE
Prevent TIFF orientation from being applied more than once

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -1035,7 +1035,10 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open("Tests/images/g4_orientation_1.tif") as base_im:
             for i in range(2, 9):
                 with Image.open("Tests/images/g4_orientation_" + str(i) + ".tif") as im:
+                    assert 274 in im.tag_v2
+
                     im.load()
+                    assert 274 not in im.tag_v2
 
                     assert_image_similar(base_im, im, 0.7)
 

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 
 import pytest
 
-from PIL import Image, ImageFilter, TiffImagePlugin, TiffTags, features
+from PIL import Image, ImageFilter, ImageOps, TiffImagePlugin, TiffTags, features
 from PIL.TiffImagePlugin import SAMPLEFORMAT, STRIPOFFSETS, SUBIFD
 
 from .helper import (
@@ -1036,6 +1036,14 @@ class TestFileLibTiff(LibTiffTestCase):
             for i in range(2, 9):
                 with Image.open("Tests/images/g4_orientation_" + str(i) + ".tif") as im:
                     im.load()
+
+                    assert_image_similar(base_im, im, 0.7)
+
+    def test_exif_transpose(self):
+        with Image.open("Tests/images/g4_orientation_1.tif") as base_im:
+            for i in range(2, 9):
+                with Image.open("Tests/images/g4_orientation_" + str(i) + ".tif") as im:
+                    im = ImageOps.exif_transpose(im)
 
                     assert_image_similar(base_im, im, 0.7)
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -588,6 +588,7 @@ def exif_transpose(image, *, in_place=False):
         with the transposition applied. If there is no transposition, a copy of the
         image will be returned.
     """
+    image.load()
     image_exif = image.getexif()
     orientation = image_exif.get(ExifTags.Base.Orientation)
     method = {

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -611,6 +611,10 @@ def exif_transpose(image, *, in_place=False):
         exif = exif_image.getexif()
         if ExifTags.Base.Orientation in exif:
             del exif[ExifTags.Base.Orientation]
+            if in_place and ExifTags.Base.Orientation in getattr(
+                exif_image, "tag_v2", {}
+            ):
+                del exif_image.tag_v2[ExifTags.Base.Orientation]
             if "exif" in exif_image.info:
                 exif_image.info["exif"] = exif.tobytes()
             elif "Raw profile type exif" in exif_image.info:

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -611,10 +611,6 @@ def exif_transpose(image, *, in_place=False):
         exif = exif_image.getexif()
         if ExifTags.Base.Orientation in exif:
             del exif[ExifTags.Base.Orientation]
-            if in_place and ExifTags.Base.Orientation in getattr(
-                exif_image, "tag_v2", {}
-            ):
-                del exif_image.tag_v2[ExifTags.Base.Orientation]
             if "exif" in exif_image.info:
                 exif_image.info["exif"] = exif.tobytes()
             elif "Raw profile type exif" in exif_image.info:

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1220,6 +1220,8 @@ class TiffImageFile(ImageFile.ImageFile):
                 exif.get_ifd(key)
 
         ImageOps.exif_transpose(self, in_place=True)
+        if ExifTags.Base.Orientation in self.tag_v2:
+            del self.tag_v2[ExifTags.Base.Orientation]
 
     def _load_libtiff(self):
         """Overload method triggered when we detect a compressed tiff


### PR DESCRIPTION
Resolves #7381

When a TIFF image is loaded, the orientation is applied.

https://github.com/python-pillow/Pillow/blob/52c6d686135e13df23f05cfe34d393b9d6e981f6/src/PIL/TiffImagePlugin.py#L1545
https://github.com/python-pillow/Pillow/blob/52c6d686135e13df23f05cfe34d393b9d6e981f6/src/PIL/TiffImagePlugin.py#L1205-L1218

However, there is no change in Pillow's information about the image as a result of this. This is not ideal, because
1. if a user inspects the `tag_v2` orientation for an image, it may or may not have been applied already, depending on whether the image has loaded, and that could be confusing.
2. If a user runs `ImageOps.exif_transpose()` afterwards, the orientation is applied a second time.

This PR addresses 1 by deleting the `tag_v2` orientation tag, so that it is consistently present if not applied yet, and removed once it has been applied. It address 2 by calling `ImageOps.exif_transpose(self, in_place=True)` from TiffImagePlugin, which also reduces duplicate code.

The issue also calls `exif_transpose()` immediately after opening an image, without `load()`. So it is necessary to call `load()` the image in `exif_transpose()`, so that the image's orientation is not initially detected by `exif_transpose`, but then quickly changed once the image is loaded to perform a transposition.