### PR TITLE
Updated harfbuzz to 8.2.0

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -335,9 +335,9 @@ deps = {
         "libs": [r"imagequant.lib"],
     },
     "harfbuzz": {
-        "url": "https://github.com/harfbuzz/harfbuzz/archive/8.1.1.zip",
-        "filename": "harfbuzz-8.1.1.zip",
-        "dir": "harfbuzz-8.1.1",
+        "url": "https://github.com/harfbuzz/harfbuzz/archive/8.2.0.zip",
+        "filename": "harfbuzz-8.2.0.zip",
+        "dir": "harfbuzz-8.2.0",
         "license": "COPYING",
         "build": [
             *cmds_cmake(


### PR DESCRIPTION
harfbuzz 8.2.0 has been released - https://github.com/harfbuzz/harfbuzz/releases/tag/8.2.0