### PR TITLE
Added gs_binary to control Ghostscript use on all platforms

### DIFF
--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -8,6 +8,7 @@ from .helper import (
     assert_image_similar,
     assert_image_similar_tofile,
     hopper,
+    is_win32,
     mark_if_feature_version,
     skip_unless_feature,
 )
@@ -96,6 +97,20 @@ def test_load():
 
         # Test again now that it has already been loaded once
         assert im.load()[0, 0] == (255, 255, 255)
+
+
+def test_binary():
+    if HAS_GHOSTSCRIPT:
+        assert EpsImagePlugin.gs_binary is not None
+    else:
+        assert EpsImagePlugin.gs_binary is False
+
+    if not is_win32():
+        assert EpsImagePlugin.gs_windows_binary is None
+    elif not HAS_GHOSTSCRIPT:
+        assert EpsImagePlugin.gs_windows_binary is False
+    else:
+        assert EpsImagePlugin.gs_windows_binary is not None
 
 
 def test_invalid_file():

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -88,8 +88,14 @@ in ``L``, ``RGB`` and ``CMYK`` modes.
 Loading
 ~~~~~~~
 
+To use Ghostscript, Pillow searches for the "gs" executable. On Windows, it
+also searches for "gswin32c" and "gswin64c". If you would like to customise
+this behaviour, ``EpsImagePlugin.gs_binary = "gswin64"`` will set the name of
+the executable to use. ``EpsImagePlugin.gs_binary = False`` will prevent
+Ghostscript from being used altogether.
+
 If Ghostscript is available, you can call the :py:meth:`~PIL.Image.Image.load`
-method with the following parameters to affect how Ghostscript renders the EPS
+method with the following parameters to affect how Ghostscript renders the EPS.
 
 **scale**
     Affects the scale of the resultant rasterized image. If the EPS suggests

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -89,10 +89,9 @@ Loading
 ~~~~~~~
 
 To use Ghostscript, Pillow searches for the "gs" executable. On Windows, it
-also searches for "gswin32c" and "gswin64c". If you would like to customise
-this behaviour, ``EpsImagePlugin.gs_binary = "gswin64"`` will set the name of
-the executable to use. ``EpsImagePlugin.gs_binary = False`` will prevent
-Ghostscript from being used altogether.
+also searches for "gswin32c" and "gswin64c". To customise this behaviour,
+``EpsImagePlugin.gs_binary = "gswin64"`` will set the name of the executable to
+use. ``EpsImagePlugin.gs_binary = False`` will prevent Ghostscript use.
 
 If Ghostscript is available, you can call the :py:meth:`~PIL.Image.Image.load`
 method with the following parameters to affect how Ghostscript renders the EPS.


### PR DESCRIPTION
Resolves #7391 

The user in that issue would like an API to prevent Ghostscript use. Since we already have `EpsImagePlugin.gs_windows_binary` that stores the name of the Ghostscript binary on Windows,
https://github.com/python-pillow/Pillow/blob/e1889544cdd959c60e2526505053e81a8f43c7e4/src/PIL/EpsImagePlugin.py#L40
this PR suggests adding `EpsImagePlugin.gs_binary`, that stores the name of the Ghostscript binary on all platforms.

Setting it to false would result in `OSError: Unable to locate Ghostscript on paths` when trying to load an EPS image.