### PR TITLE
NumPy now supports Python 3.12

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -38,8 +38,7 @@ python3 -m pip install -U pytest-timeout
 python3 -m pip install pyroma
 
 if [[ $(uname) != CYGWIN* ]]; then
-    # TODO Remove condition when NumPy supports 3.12
-    if ! [ "$GHA_PYTHON_VERSION" == "3.12-dev" ]; then python3 -m pip install numpy ; fi
+    python3 -m pip install numpy
 
     # PyQt6 doesn't support PyPy3
     if [[ $GHA_PYTHON_VERSION == 3.* ]]; then

--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -13,8 +13,7 @@ python3 -m pip install -U pytest-cov
 python3 -m pip install -U pytest-timeout
 python3 -m pip install pyroma
 
-# TODO Remove condition when NumPy supports 3.12
-if ! [ "$GHA_PYTHON_VERSION" == "3.12-dev" ]; then python3 -m pip install numpy ; fi
+python3 -m pip install numpy
 
 # extra test images
 pushd depends && ./install_extra_test_images.sh && popd


### PR DESCRIPTION
With the release of NumPy 1.26.0, NumPy supports Python 3.12 - https://github.com/numpy/numpy/releases/tag/v1.26.0