### PR TITLE
Fix JpegImagePlugin when XMP meta has trailing 0x00 byte

### DIFF
--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -496,7 +496,7 @@ class JpegImageFile(ImageFile.ImageFile):
 
         for segment, content in self.applist:
             if segment == "APP1":
-                marker, xmp_tags = content.rsplit(b"\x00", 1)
+                marker, xmp_tags = content.strip(b"\x00").rsplit(b"\x00", 1)
                 if marker == b"http://ns.adobe.com/xap/1.0/":
                     return self._getxmp(xmp_tags)
         return {}


### PR DESCRIPTION
I faced the issue with files having trailing 0x00 in xmp meta information. The files was originally generated with Canon Digital Photo Professional and later edited in MacOs Preview to add image description to the meta information. I haven't investigated which program exactly added trailing zero byte but fix is dealing with it fine

Changes proposed in this pull request:
Add xmp content stripping 0x00 bytes