### PR TITLE
Added has_transparency_data

### DIFF
--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -234,3 +234,13 @@ class TestFileWebp:
 
         with Image.open(out_webp) as reloaded:
             assert reloaded.info["duration"] == 1000
+
+    def test_roundtrip_rgba_palette(self, tmp_path):
+        temp_file = str(tmp_path / "temp.webp")
+        im = Image.new("RGBA", (1, 1)).convert("P")
+        assert im.mode == "P"
+        assert im.palette.mode == "RGBA"
+        im.save(temp_file)
+
+        with Image.open(temp_file) as im:
+            assert im.getpixel((0, 0)) == (0, 0, 0, 0)

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -909,27 +909,27 @@ class TestImage:
     def test_has_transparency_data(self):
         for mode in ("1", "L", "P", "RGB"):
             im = Image.new(mode, (1, 1))
-            assert not im.has_transparency_data()
+            assert not im.has_transparency_data
 
         for mode in ("LA", "La", "PA", "RGBA", "RGBa"):
             im = Image.new(mode, (1, 1))
-            assert im.has_transparency_data()
+            assert im.has_transparency_data
 
         # P mode with "transparency" info
         with Image.open("Tests/images/first_frame_transparency.gif") as im:
             assert "transparency" in im.info
-            assert im.has_transparency_data()
+            assert im.has_transparency_data
 
         # RGB mode with "transparency" info
         with Image.open("Tests/images/rgb_trns.png") as im:
             assert "transparency" in im.info
-            assert im.has_transparency_data()
+            assert im.has_transparency_data
 
         # P mode with RGBA palette
         im = Image.new("RGBA", (1, 1)).convert("P")
         assert im.mode == "P"
         assert im.palette.mode == "RGBA"
-        assert im.has_transparency_data()
+        assert im.has_transparency_data
 
     def test_apply_transparency(self):
         im = Image.new("P", (1, 1))

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -906,6 +906,31 @@ class TestImage:
         im = Image.new("RGB", size)
         assert im.tobytes() == b""
 
+    def test_has_transparency_data(self):
+        for mode in ("1", "L", "P", "RGB"):
+            im = Image.new(mode, (1, 1))
+            assert not im.has_transparency_data()
+
+        for mode in ("LA", "La", "PA", "RGBA", "RGBa"):
+            im = Image.new(mode, (1, 1))
+            assert im.has_transparency_data()
+
+        # P mode with "transparency" info
+        with Image.open("Tests/images/first_frame_transparency.gif") as im:
+            assert "transparency" in im.info
+            assert im.has_transparency_data()
+
+        # RGB mode with "transparency" info
+        with Image.open("Tests/images/rgb_trns.png") as im:
+            assert "transparency" in im.info
+            assert im.has_transparency_data()
+
+        # P mode with RGBA palette
+        im = Image.new("RGBA", (1, 1)).convert("P")
+        assert im.mode == "P"
+        assert im.palette.mode == "RGBA"
+        assert im.has_transparency_data()
+
     def test_apply_transparency(self):
         im = Image.new("P", (1, 1))
         im.putpalette((0, 0, 0, 1, 1, 1))

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -195,6 +195,7 @@ This helps to get the bounding box coordinates of the input image::
 .. automethod:: PIL.Image.Image.getpalette
 .. automethod:: PIL.Image.Image.getpixel
 .. automethod:: PIL.Image.Image.getprojection
+.. automethod:: PIL.Image.Image.has_transparency_data
 .. automethod:: PIL.Image.Image.histogram
 .. automethod:: PIL.Image.Image.paste
 .. automethod:: PIL.Image.Image.point

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -195,7 +195,7 @@ This helps to get the bounding box coordinates of the input image::
 .. automethod:: PIL.Image.Image.getpalette
 .. automethod:: PIL.Image.Image.getpixel
 .. automethod:: PIL.Image.Image.getprojection
-.. automethod:: PIL.Image.Image.has_transparency_data
+.. autoproperty:: PIL.Image.Image.has_transparency_data
 .. automethod:: PIL.Image.Image.histogram
 .. automethod:: PIL.Image.Image.paste
 .. automethod:: PIL.Image.Image.point

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -195,7 +195,6 @@ This helps to get the bounding box coordinates of the input image::
 .. automethod:: PIL.Image.Image.getpalette
 .. automethod:: PIL.Image.Image.getpixel
 .. automethod:: PIL.Image.Image.getprojection
-.. autoproperty:: PIL.Image.Image.has_transparency_data
 .. automethod:: PIL.Image.Image.histogram
 .. automethod:: PIL.Image.Image.paste
 .. automethod:: PIL.Image.Image.point
@@ -351,6 +350,8 @@ Instances of the :py:class:`Image` class have the following attributes:
     aware of in an image regardless of its format.
 
     .. seealso:: :attr:`~Image.is_animated`, :func:`~Image.seek` and :func:`~Image.tell`
+
+.. autoattribute:: PIL.Image.Image.has_transparency_data
 
 Classes
 -------

--- a/docs/releasenotes/10.1.0.rst
+++ b/docs/releasenotes/10.1.0.rst
@@ -32,10 +32,16 @@ TODO
 API Additions
 =============
 
-TODO
-^^^^
+has_transparency_data
+^^^^^^^^^^^^^^^^^^^^^
 
-TODO
+Images now have :py:attr:`~PIL.Image.Image.has_transparency_data` to indicate
+whether the image has transparency data, whether in the form of an alpha
+channel, a palette with an alpha channel, or a "transparency" key in the
+:py:attr:`~PIL.Image.Image.info` dictionary.
+
+Even if this attribute is true, the image might still appear solid, if all of
+the values shown within are opaque.
 
 Security
 ========

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -915,7 +915,7 @@ class Image:
 
         self.load()
 
-        has_transparency = self.info.get("transparency") is not None
+        has_transparency = "transparency" in self.info
         if not mode and self.mode == "P":
             # determine default mode
             if self.palette:
@@ -1530,6 +1530,23 @@ class Image:
         if rawmode is None:
             rawmode = mode
         return list(self.im.getpalette(mode, rawmode))
+
+    def has_transparency_data(self):
+        """
+        Determine if an image has transparency data, whether in the form of an
+        alpha channel, a palette with an alpha channel, or a "transparency" key
+        in the info dictionary.
+
+        Note the image might still appear solid, if all of the values shown
+        within are opaque.
+
+        :returns: A boolean.
+        """
+        return (
+            self.mode in ("LA", "La", "PA", "RGBA", "RGBa")
+            or (self.mode == "P" and self.palette.mode == "RGBA")
+            or "transparency" in self.info
+        )
 
     def apply_transparency(self):
         """

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1531,7 +1531,7 @@ class Image:
             rawmode = mode
         return list(self.im.getpalette(mode, rawmode))
 
-    def has_transparency_data(self):
+    def has_transparency_data(self) -> bool:
         """
         Determine if an image has transparency data, whether in the form of an
         alpha channel, a palette with an alpha channel, or a "transparency" key

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1531,6 +1531,7 @@ class Image:
             rawmode = mode
         return list(self.im.getpalette(mode, rawmode))
 
+    @property
     def has_transparency_data(self) -> bool:
         """
         Determine if an image has transparency data, whether in the form of an

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1544,7 +1544,7 @@ class Image:
         """
         return (
             self.mode in ("LA", "La", "PA", "RGBA", "RGBa")
-            or (self.mode == "P" and self.palette.mode == "RGBA")
+            or (self.mode == "P" and self.palette.mode.endswith("A"))
             or "transparency" in self.info
         )
 

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -332,12 +332,7 @@ def _save(im, fp, filename):
     exact = 1 if im.encoderinfo.get("exact") else 0
 
     if im.mode not in _VALID_WEBP_LEGACY_MODES:
-        alpha = (
-            "A" in im.mode
-            or "a" in im.mode
-            or (im.mode == "P" and "transparency" in im.info)
-        )
-        im = im.convert("RGBA" if alpha else "RGB")
+        im = im.convert("RGBA" if im.has_transparency_data() else "RGB")
 
     data = _webp.WebPEncode(
         im.tobytes(),

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -332,7 +332,7 @@ def _save(im, fp, filename):
     exact = 1 if im.encoderinfo.get("exact") else 0
 
     if im.mode not in _VALID_WEBP_LEGACY_MODES:
-        im = im.convert("RGBA" if im.has_transparency_data() else "RGB")
+        im = im.convert("RGBA" if im.has_transparency_data else "RGB")
 
     data = _webp.WebPEncode(
         im.tobytes(),


### PR DESCRIPTION
Resolves #7384

Adds a method to determine if an image has transparency data - an alpha channel, an RGBA palette or "transparency" in the image's `info` directory.

I chose this method name to try and indicate that the image may still be opaque. For example, `hopper("RGB").convert("RGBA")` has an alpha channel, but has no transparent or translucent pixels.

In doing so, I found a similar check in WebPImagePlugin.
https://github.com/python-pillow/Pillow/blob/b723e9e62e4706a85f7e44cb42b3d838dae5e546/src/PIL/WebPImagePlugin.py#L335-L340

So I've changed that to use this new method.