### PR TITLE
Removed unused code

### DIFF
--- a/src/PIL/BlpImagePlugin.py
+++ b/src/PIL/BlpImagePlugin.py
@@ -442,7 +442,7 @@ class BLPEncoder(ImageFile.PyEncoder):
         return len(data), 0, data
 
 
-def _save(im, fp, filename, save_all=False):
+def _save(im, fp, filename):
     if im.mode != "P":
         msg = "Unsupported BLP image mode"
         raise ValueError(msg)


### PR DESCRIPTION
`save_all` is not used in the following code.

https://github.com/python-pillow/Pillow/blob/aaa758751d0127cac40e39ecd5bdd021eab11ca5/src/PIL/BlpImagePlugin.py#L445-L463

It isn't necessary. See JpegImagePlugin for example.

https://github.com/python-pillow/Pillow/blob/aaa758751d0127cac40e39ecd5bdd021eab11ca5/src/PIL/JpegImagePlugin.py#L633