### PR TITLE
Consider default image when selecting mode for PNG save_all

### DIFF
--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -673,10 +673,16 @@ def test_seek_after_close():
 
 
 @pytest.mark.parametrize("mode", ("RGBA", "RGB", "P"))
-def test_different_modes_in_later_frames(mode, tmp_path):
+@pytest.mark.parametrize("default_image", (True, False))
+def test_different_modes_in_later_frames(mode, default_image, tmp_path):
     test_file = str(tmp_path / "temp.png")
 
     im = Image.new("L", (1, 1))
-    im.save(test_file, save_all=True, append_images=[Image.new(mode, (1, 1))])
+    im.save(
+        test_file,
+        save_all=True,
+        default_image=default_image,
+        append_images=[Image.new(mode, (1, 1))],
+    )
     with Image.open(test_file) as reloaded:
         assert reloaded.mode == mode

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -1166,6 +1166,8 @@ def _write_multiple_frames(im, fp, chunk, rawmode, default_image, append_images)
 
     # default image IDAT (if it exists)
     if default_image:
+        if im.mode != rawmode:
+            im = im.convert(rawmode)
         ImageFile._save(im, _idat(fp, chunk), [("zip", (0, 0) + im.size, 0, rawmode)])
 
     seq_num = 0
@@ -1227,11 +1229,7 @@ def _save(im, fp, filename, chunk=putchunk, save_all=False):
         )
         modes = set()
         append_images = im.encoderinfo.get("append_images", [])
-        if default_image:
-            chain = itertools.chain(append_images)
-        else:
-            chain = itertools.chain([im], append_images)
-        for im_seq in chain:
+        for im_seq in itertools.chain([im], append_images):
             for im_frame in ImageSequence.Iterator(im_seq):
                 modes.add(im_frame.mode)
         for mode in ("RGBA", "RGB", "P"):

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -1104,10 +1104,7 @@ def _write_multiple_frames(im, fp, chunk, rawmode, default_image, append_images)
             if im_frame.mode == rawmode:
                 im_frame = im_frame.copy()
             else:
-                if rawmode == "P":
-                    im_frame = im_frame.convert(rawmode, palette=im.palette)
-                else:
-                    im_frame = im_frame.convert(rawmode)
+                im_frame = im_frame.convert(rawmode)
             encoderinfo = im.encoderinfo.copy()
             if isinstance(duration, (list, tuple)):
                 encoderinfo["duration"] = duration[frame_count]


### PR DESCRIPTION
Resolves #7459

Sequel to #6610

1. While that PR theoretically considers all images, and "upgrades" images to more complex modes, it did not consider the default image.
https://github.com/python-pillow/Pillow/blob/aaa758751d0127cac40e39ecd5bdd021eab11ca5/src/PIL/PngImagePlugin.py#L1230-L1239
This means that [when the default image is saved](https://github.com/python-pillow/Pillow/blob/aaa758751d0127cac40e39ecd5bdd021eab11ca5/src/PIL/PngImagePlugin.py#L1168-L1169) with the chosen mode, it may not be the ideal choice. This PR considers the mode of the default image, and converts the default image before saving if needed.

2. Because that PR made it so that P images are "upgraded" to RGB if there are any RGB images present, a RGB to P conversion will no longer occur at
https://github.com/python-pillow/Pillow/blob/aaa758751d0127cac40e39ecd5bdd021eab11ca5/src/PIL/PngImagePlugin.py#L1102-L1110
meaning that the palette argument is unneeded.
https://github.com/python-pillow/Pillow/blob/aaa758751d0127cac40e39ecd5bdd021eab11ca5/src/PIL/Image.py#L907-L909