### PR TITLE
Fixed invalid argument warning

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3749,6 +3749,7 @@ class Exif(MutableMapping):
             self.endian = self._info._endian
         if offset is None:
             offset = self._info.next
+        self.fp.tell()
         self.fp.seek(offset)
         self._info.load(self.fp)
 


### PR DESCRIPTION
I noticed [a warning was being raised in tests](https://github.com/python-pillow/Pillow/actions/runs/6398432650/job/17370348716#step:8:4448)
> Tests/test_file_libtiff.py::TestFileLibTiff::test_multipage
> Tests/test_file_libtiff.py::TestFileLibTiff::test_multipage_seek_backwards
> Tests/test_file_libtiff.py::TestFileLibTiff::test_page_number_x_0
> Tests/test_imagesequence.py::test_libtiff
>   /opt/hostedtoolcache/Python/3.11.5/x64/lib/python3.11/site-packages/PIL/TiffImagePlugin.py:866: UserWarning: [Errno 22] Invalid argument
>     warnings.warn(str(msg))

A fuller traceback is
```pytb
___________________________________________________ TestFileLibTiff.test_multipage _____________________________________________________

self = <Tests.test_file_libtiff.TestFileLibTiff object at 0x108cf1850>

    def test_multipage(self):
        # issue #862
        TiffImagePlugin.READ_LIBTIFF = True
        with Image.open("Tests/images/multipage.tiff") as im:
            # file is a multipage tiff,  10x10 green, 10x10 red, 20x20 blue
    
            im.seek(0)
            assert im.size == (10, 10)
>           assert im.convert("RGB").getpixel((0, 0)) == (0, 128, 0)

Tests/test_file_libtiff.py:59: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
PIL/Image.py:916: in convert
    self.load()
PIL/TiffImagePlugin.py:1205: in load
    return self._load_libtiff()
PIL/TiffImagePlugin.py:1303: in _load_libtiff
    self.load_end()
PIL/TiffImagePlugin.py:1225: in load_end
    ImageOps.exif_transpose(self, in_place=True)
PIL/ImageOps.py:592: in exif_transpose
    image_exif = image.getexif()
PIL/Image.py:1439: in getexif
    self._exif.load_from_fp(self.fp, self.tag_v2._offset)
PIL/Image.py:3753: in load_from_fp
    self._info.load(self.fp)
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <PIL.TiffImagePlugin.ImageFileDirectory_v2 object at 0x108f555b0>, fp = <_io.BufferedReader name='Tests/images/multipage.tiff'>

    def load(self, fp):
        self.reset()
        self._offset = fp.tell()
    
        if True:#try:
            tag_count = (
                self._unpack("Q", self._ensure_read(fp, 8))
                if self._bigtiff
                else self._unpack("H", self._ensure_read(fp, 2))
            )[0]
            for i in range(tag_count):
                tag, typ, count, data = (
                    self._unpack("HHQ8s", self._ensure_read(fp, 20))
                    if self._bigtiff
                    else self._unpack("HHL4s", self._ensure_read(fp, 12))
                )
    
                tagname = TiffTags.lookup(tag, self.group).name
                typname = TYPES.get(typ, "unknown")
                msg = f"tag: {tagname} ({tag}) - type: {typname} ({typ})"
    
                try:
                    unit_size, handler = self._load_dispatch[typ]
                except KeyError:
                    logger.debug("%s - unsupported type %s", msg, typ)
                    continue  # ignore unsupported type
                size = count * unit_size
                if size > (8 if self._bigtiff else 4):
                    here = fp.tell()
                    (offset,) = self._unpack("Q" if self._bigtiff else "L", data)
                    msg += f" Tag Location: {here} - Data Location: {offset}"
                    fp.seek(offset)
                    data = ImageFile._safe_read(fp, size)
>                   fp.seek(here)
E                   OSError: [Errno 22] Invalid argument
```
where `here` is a negative number.

Taking inspiration from
https://github.com/python-pillow/Pillow/blob/54aa8fa85252478229ed95c20d247bd71993527c/src/PIL/TiffImagePlugin.py#L1131-L1133
I've added `self.fp.tell()` into `Exif.load_from_fp()` to fix this.