### PR TITLE
Fixed "may be used uninitialized" warning

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1577,6 +1577,7 @@ if (PySequence_Check(op)) { \
             if (image->bands == 1) {
                 int bigendian = 0;
                 if (image->type == IMAGING_TYPE_SPECIAL) {
+                    // I;16*
                     bigendian = strcmp(image->mode, "I;16B") == 0;
                 }
                 for (i = x = y = 0; i < n; i++) {

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1575,11 +1575,7 @@ if (PySequence_Check(op)) { \
             }
             double value;
             if (image->bands == 1) {
-                int bigendian;
-                if (image->type == IMAGING_TYPE_SPECIAL) {
-                    // I;16*
-                    bigendian = strcmp(image->mode, "I;16B") == 0;
-                }
+                int bigendian = image->type == IMAGING_TYPE_SPECIAL && strcmp(image->mode, "I;16B") == 0;
                 for (i = x = y = 0; i < n; i++) {
                     set_value_to_item(seq, i);
                     if (scale != 1.0 || offset != 0.0) {

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1575,7 +1575,10 @@ if (PySequence_Check(op)) { \
             }
             double value;
             if (image->bands == 1) {
-                int bigendian = image->type == IMAGING_TYPE_SPECIAL && strcmp(image->mode, "I;16B") == 0;
+                int bigendian = 0;
+                if (image->type == IMAGING_TYPE_SPECIAL) {
+                    bigendian = strcmp(image->mode, "I;16B") == 0;
+                }
                 for (i = x = y = 0; i < n; i++) {
                     set_value_to_item(seq, i);
                     if (scale != 1.0 || offset != 0.0) {


### PR DESCRIPTION
After #7303 was merged, I noticed a warning.

https://github.com/python-pillow/Pillow/actions/runs/6430296173/job/17461014310#step:7:231
>   src/_imaging.c: In function ‘_putdata’:
>  src/_imaging.c:1578:21: warning: ‘bigendian’ may be used uninitialized in this function [-Wmaybe-uninitialized]
>   1578 |                 int bigendian;
>        |                     ^~~~~~~~~