### PR TITLE
Updated redirected links

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ As of 2019, Pillow development is
             <a href="https://pypi.org/project/Pillow/"><img
                 alt="Number of PyPI downloads"
                 src="https://img.shields.io/pypi/dm/pillow.svg"></a>
-            <a href="https://bestpractices.coreinfrastructure.org/projects/6331"><img
+            <a href="https://www.bestpractices.dev/projects/6331"><img
                 alt="OpenSSF Best Practices"
-                src="https://bestpractices.coreinfrastructure.org/projects/6331/badge"></a>
+                src="https://www.bestpractices.dev/projects/6331/badge"></a>
         </td>
     </tr>
     <tr>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -318,7 +318,7 @@ def setup(app):
 
 
 linkcheck_allowed_redirects = {
-    r"https://bestpractices.coreinfrastructure.org/projects/6331": r"https://bestpractices.coreinfrastructure.org/en/.*",  # noqa: E501
+    r"https://www.bestpractices.dev/projects/6331": r"https://www.bestpractices.dev/en/.*",  # noqa: E501
     r"https://badges.gitter.im/python-pillow/Pillow.svg": r"https://badges.gitter.im/repo.svg",  # noqa: E501
     r"https://gitter.im/python-pillow/Pillow?.*": r"https://app.gitter.im/#/room/#python-pillow_Pillow:gitter.im?.*",  # noqa: E501
     r"https://pillow.readthedocs.io/?badge=latest": r"https://pillow.readthedocs.io/en/stable/?badge=latest",  # noqa: E501

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,8 +69,8 @@ Pillow for enterprise is available via the Tidelift Subscription. `Learn more <h
    :target: https://pypi.org/project/Pillow/
    :alt: Number of PyPI downloads
 
-.. image:: https://bestpractices.coreinfrastructure.org/projects/6331/badge
-   :target: https://bestpractices.coreinfrastructure.org/projects/6331
+.. image:: https://www.bestpractices.dev/projects/6331/badge
+   :target: https://www.bestpractices.dev/projects/6331
    :alt: OpenSSF Best Practices
 
 .. image:: https://badges.gitter.im/python-pillow/Pillow.svg


### PR DESCRIPTION
https://bestpractices.coreinfrastructure.org/ now redirects to https://www.bestpractices.dev/

https://github.com/python-pillow/Pillow/actions/runs/6439243260/job/17486706271#step:7:371
> /home/runner/work/Pillow/Pillow/docs/index.rst:2: WARNING: redirect  https://bestpractices.coreinfrastructure.org/projects/6331/badge - with Found to https://www.bestpractices.dev/projects/6331/badge
> (           index: line    2) (    installation: line  264) ok        https://brew.sh/
> (           index: line    2) ok        https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:pillow
> /home/runner/work/Pillow/Pillow/docs/index.rst:2: WARNING: redirect  https://bestpractices.coreinfrastructure.org/projects/6331 - with Found to https://www.bestpractices.dev/en/projects/6331