### PR TITLE
Allow custom builds to be triggered in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-if: tag IS present
+if: tag IS present OR type = api
 
 env:
   global:


### PR DESCRIPTION
I just went to "Trigger a custom build" in Travis CI, as was [intended to be possible](https://github.com/python-pillow/Pillow/pull/7418#issuecomment-1741600488), but found it was "Skipped as per condition: IF tag IS present"

https://github.com/python-pillow/Pillow/blob/ae9a9b08f1387c07a2d88d37b66546ef6c7e8276/.travis.yml#L1

So this PR updates it to `if: tag IS present OR type = api`. See https://docs.travis-ci.com/user/conditions-v1 for documentation.

To demonstrate, I pushed the branch to this repository, and triggered a custom build - https://app.travis-ci.com/github/python-pillow/pillow/builds/266441553