### PR TITLE
Fix libbrotli build for Windows wheels

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -233,7 +233,7 @@ DEPS = {
         "dir": "brotli-1.1.0",
         "license": "LICENSE",
         "build": [
-            *cmds_cmake(("brotlicommon", "brotlidec")),
+            *cmds_cmake(("brotlicommon", "brotlidec"), "-DBUILD_SHARED_LIBS:BOOL=OFF"),
             cmd_xcopy(r"c\include", "{inc_dir}"),
         ],
         "libs": ["*.lib"],


### PR DESCRIPTION
#7451 broke FreeType support on Windows due to changing libbrotli from a static to a dynamic (dll) build, this PR fixes that change.