### PR TITLE
If Image is created directly, add missing core image when loading

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -94,6 +94,18 @@ class TestImage:
         # with pytest.raises(MemoryError):
         #   Image.new("L", (1000000, 1000000))
 
+    def test_direct(self):
+        # Test that a directly instantiated Image()
+        # is given a core image during load()
+        im = Image.Image()
+        assert im.im is None
+
+        im.load()
+        assert im.im is not None
+
+        # Test equality
+        assert Image.Image() == Image.Image()
+
     def test_repr_pretty(self):
         class Pretty:
             def text(self, text):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -826,6 +826,10 @@ class Image:
         :returns: An image access object.
         :rtype: :ref:`PixelAccess` or :py:class:`PIL.PyAccess`
         """
+        if self._mode == "":
+            # This image was instantiated directly
+            self._mode = "1"
+            self.im = core.new(self.mode, self.size)
         if self.im is not None and self.palette and self.palette.dirty:
             # realize palette
             mode, arr = self.palette.getdata()


### PR DESCRIPTION
Resolves #7455

Normally, image instances are created with `Image.new()` or `Image.open()`. The issue would like to be able to use `Image()` directly.

The only thing that [`_new()`](https://github.com/python-pillow/Pillow/blob/4ecf1df4ea63457040f63adaeea35996913b6ac1/src/PIL/Image.py#L511) provides that [`__init__`](https://github.com/python-pillow/Pillow/blob/4ecf1df4ea63457040f63adaeea35996913b6ac1/src/PIL/Image.py#L483) doesn't is a core image instance. Pillow allows for `im.im` to be `None`, but expects `load()` to populate it.

Using the fact that `__init__` sets `_mode` to `""`
https://github.com/python-pillow/Pillow/blob/4ecf1df4ea63457040f63adaeea35996913b6ac1/src/PIL/Image.py#L483-L487
this PR detects in `load()` if an image has been directly instantiated, and if so, adds a core image instance with mode 1, as that is the simplest mode.