### PR TITLE
Updated libimagequant to 4.2.2

### DIFF
--- a/depends/install_imagequant.sh
+++ b/depends/install_imagequant.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # install libimagequant
 
-archive=libimagequant-4.2.1
+archive=libimagequant-4.2.2
 
 ./download-and-extract.sh $archive https://raw.githubusercontent.com/python-pillow/pillow-depends/main/$archive.tar.gz
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -182,7 +182,7 @@ Many of Pillow's features require external libraries:
 
 * **libimagequant** provides improved color quantization
 
-  * Pillow has been tested with libimagequant **2.6-4.2.1**
+  * Pillow has been tested with libimagequant **2.6-4.2.2**
   * Libimagequant is licensed GPLv3, which is more restrictive than
     the Pillow license, therefore we will not be distributing binaries
     with libimagequant support enabled.


### PR DESCRIPTION
libimagequant 4.2.2 has been released - https://github.com/ImageOptim/libimagequant/releases/tag/4.2.2