### PR TITLE
Add Python 3.12 support to Pillow 10.1.0 release notes

### DIFF
--- a/docs/releasenotes/10.1.0.rst
+++ b/docs/releasenotes/10.1.0.rst
@@ -87,6 +87,15 @@ font size for this new builtin font::
 Other Changes
 =============
 
+Python 3.12
+^^^^^^^^^^^
+
+Pillow 10.0.0 had wheels built against Python 3.12 beta, available as a preview to help
+others prepare for 3.12, and ensure Pillow can be used immediately on release day of
+3.12.0 final (2023-10-02, :pep:`693`).
+
+Pillow 10.1.0 now officially supports Python 3.12.
+
 Added support for DDS BC5U and 8-bit color indexed images
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/releasenotes/10.1.0.rst
+++ b/docs/releasenotes/10.1.0.rst
@@ -91,8 +91,8 @@ Python 3.12
 ^^^^^^^^^^^
 
 Pillow 10.0.0 had wheels built against Python 3.12 beta, available as a preview to help
-others prepare for 3.12, and ensure Pillow can be used immediately on release day of
-3.12.0 final (2023-10-02, :pep:`693`).
+others prepare for 3.12, and to ensure Pillow could be used immediately at the release
+of 3.12.0 final (2023-10-02, :pep:`693`).
 
 Pillow 10.1.0 now officially supports Python 3.12.
 


### PR DESCRIPTION
Like https://pillow.readthedocs.io/en/stable/releasenotes/9.3.0.html#python-3-11-wheels