### PR TITLE
Update release checklist: macOS/Linux artifact is called 'wheels'

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -103,7 +103,7 @@ Released as needed privately to individual vendors for critical security-related
   and copy into `dist/`. For example using [GitHub CLI](https://github.com/cli/cli):
   ```bash
   gh run download --dir dist
-  # select dist-x.y.z
+  # select wheels
   ```
 * [ ] Download the Linux aarch64 wheels created by Travis CI from [GitHub releases](https://github.com/python-pillow/Pillow/releases)
   and copy into `dist`.


### PR DESCRIPTION
Noticed during https://github.com/python-pillow/Pillow/issues/7348, helps https://github.com/python-pillow/Pillow/issues/7390.

# Windows

The Windows instructions are correct, it's artifact is "dist-x.y.z":

https://github.com/python-pillow/Pillow/blob/0be67e5544185b76a33f2adf7f34f8be20e4f262/.github/workflows/test-windows.yml#L233
https://github.com/python-pillow/Pillow/blob/0be67e5544185b76a33f2adf7f34f8be20e4f262/.github/workflows/test-windows.yml#L238-L243

* `dist-10.1.0` https://github.com/python-pillow/Pillow/actions/runs/6523153069


# macOS/Linux

But macOS/Linux is simply "wheels":

https://github.com/python-pillow/Pillow/blob/0be67e5544185b76a33f2adf7f34f8be20e4f262/.github/workflows/wheels.yml#L25-L27
https://github.com/python-pillow/Pillow/blob/0be67e5544185b76a33f2adf7f34f8be20e4f262/.github/workflows/wheels.yml#L30-L32
https://github.com/python-pillow/Pillow/blob/0be67e5544185b76a33f2adf7f34f8be20e4f262/.github/workflows/wheels-linux.yml#L62-L65
https://github.com/python-pillow/Pillow/blob/0be67e5544185b76a33f2adf7f34f8be20e4f262/.github/workflows/wheels-macos.yml#L50-L53

* `wheels` https://github.com/python-pillow/Pillow/actions/runs/6523153075