### PR TITLE
Skip non-wheel CI runs for tags

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -2,6 +2,8 @@ name: CIFuzz
 
 on:
   push:
+    branches:
+      - "**"
     paths:
       - ".github/workflows/cifuzz.yml"
       - "**.c"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,8 @@ name: Docs
 
 on:
   push:
+    branches:
+      - "**"
     paths:
       - ".github/workflows/docs.yml"
       - "docs/**"

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -2,6 +2,8 @@ name: Test Cygwin
 
 on:
   push:
+    branches:
+      - "**"
     paths-ignore:
       - ".github/workflows/docs.yml"
       - ".github/workflows/wheels*"

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -2,6 +2,8 @@ name: Test Docker
 
 on:
   push:
+    branches:
+      - "**"
     paths-ignore:
       - ".github/workflows/docs.yml"
       - ".github/workflows/wheels*"

--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -2,6 +2,8 @@ name: Test MinGW
 
 on:
   push:
+    branches:
+      - "**"
     paths-ignore:
       - ".github/workflows/docs.yml"
       - ".github/workflows/wheels*"

--- a/.github/workflows/test-valgrind.yml
+++ b/.github/workflows/test-valgrind.yml
@@ -1,9 +1,11 @@
 name: Test Valgrind
 
-# like the docker tests, but running valgrind only on *.c/*.h changes.
+# like the Docker tests, but running valgrind only on *.c/*.h changes.
 
 on:
   push:
+    branches:
+      - "**"
     paths:
       - ".github/workflows/test-valgrind.yml"
       - "**.c"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 
 on:
   push:
+    branches:
+      - "**"
     paths-ignore:
       - ".github/workflows/docs.yml"
       - ".github/workflows/wheels*"


### PR DESCRIPTION
Noticed during https://github.com/python-pillow/Pillow/issues/7348, helps https://github.com/python-pillow/Pillow/issues/7390.

When making a release, and pushing a tag, all the CI workflows run:

![image](https://github.com/python-pillow/Pillow/assets/1324225/22e40641-ac5c-4613-afbc-060787ae0fa9)

By the time we're making a release, the CI has already tested all merges to `main`. Checking this is one of the first items in the [release checklist](https://github.com/python-pillow/Pillow/blob/main/RELEASING.md).

We can save some CI time and skip the non-wheels workflows for tag pushes.

The wheels workflows:

* wheels.yml
* test-windows.yml (for now)
* I also left lint.yml there: it's quick to run

By default, all branches and tags are run. By explicitly specifying all branches `branches: `"**"` has the same effect as not specifying a `tags:` key, and not triggering for tags. Ref: https://stackoverflow.com/a/71879890/724176

# Demo

Pushing as `main` to my fork, all run:

<img width="686" alt="image" src="https://github.com/python-pillow/Pillow/assets/1324225/e1dffdb2-8819-417c-9b73-4ef25ac0485f">

Pushing a tag, only the wheels+lint workflows run:

<img width="669" alt="image" src="https://github.com/python-pillow/Pillow/assets/1324225/e2d502fb-f738-4f51-9539-5b33fb188b3a">
