### PR TITLE
Added ImageFont.load_pilfont()

### DIFF
--- a/Tests/test_imagefontpil.py
+++ b/Tests/test_imagefontpil.py
@@ -4,42 +4,48 @@ from PIL import Image, ImageDraw, ImageFont, features
 
 from .helper import assert_image_equal_tofile
 
-pytestmark = pytest.mark.skipif(
-    features.check_module("freetype2"),
-    reason="PILfont superseded if FreeType is supported",
-)
+funcs = [ImageFont.load_pilfont]
+if not features.check_module("freetype2"):
+    funcs.append(ImageFont.load_default)
 
 
-def test_default_font():
+@pytest.mark.parametrize("func", funcs)
+def test_default_font(func):
     # Arrange
     txt = 'This is a "better than nothing" default font.'
     im = Image.new(mode="RGB", size=(300, 100))
     draw = ImageDraw.Draw(im)
 
     # Act
-    default_font = ImageFont.load_default()
+    default_font = func()
     draw.text((10, 10), txt, font=default_font)
 
     # Assert
     assert_image_equal_tofile(im, "Tests/images/default_font.png")
 
 
+@pytest.mark.skipif(
+    features.check_module("freetype2"),
+    reason="PILfont superseded if FreeType is supported",
+)
 def test_size_without_freetype():
     with pytest.raises(ImportError):
         ImageFont.load_default(size=14)
 
 
-def test_unicode():
+@pytest.mark.parametrize("func", funcs)
+def test_unicode(func):
     # should not segfault, should return UnicodeDecodeError
     # issue #2826
-    font = ImageFont.load_default()
+    font = func()
     with pytest.raises(UnicodeEncodeError):
         font.getbbox("’")
 
 
-def test_textbbox():
+@pytest.mark.parametrize("func", funcs)
+def test_textbbox(func):
     im = Image.new("RGB", (200, 200))
     d = ImageDraw.Draw(im)
-    default_font = ImageFont.load_default()
+    default_font = func()
     assert d.textlength("test", font=default_font) == 24
     assert d.textbbox((0, 0), "test", font=default_font) == (0, 0, 24, 11)

--- a/docs/reference/ImageFont.rst
+++ b/docs/reference/ImageFont.rst
@@ -53,6 +53,7 @@ Functions
 .. autofunction:: PIL.ImageFont.load_path
 .. autofunction:: PIL.ImageFont.truetype
 .. autofunction:: PIL.ImageFont.load_default
+.. autofunction:: PIL.ImageFont.load_pilfont
 
 Methods
 -------

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -1107,12 +1107,21 @@ AAAAAAQAAAADa3tfFAAAAANAan9kAAAAA4QodoQ==
             layout_engine=Layout.BASIC,
         )
     else:
-        f = ImageFont()
-        f._load_pilfont_data(
-            # courB08
-            BytesIO(
-                base64.b64decode(
-                    b"""
+        f = load_pilfont()
+    return f
+
+
+def load_pilfont():
+    """Load a "better than nothing" font.
+
+    :return: A font object.
+    """
+    f = ImageFont()
+    f._load_pilfont_data(
+        # courB08
+        BytesIO(
+            base64.b64decode(
+                b"""
 UElMZm9udAo7Ozs7OzsxMDsKREFUQQoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
@@ -1205,12 +1214,12 @@ pQAKAKwAEgAGAAD////4AAYAAACsAAoAswASAAYAAP////gABgAAALMACgC6ABIABgAA////+QAG
 AAAAugAKAMEAEQAGAAD////4AAYAAgDBAAoAyAAUAAYAAP////kABQACAMgACgDOABMABgAA////
 +QAGAAIAzgAKANUAEw==
 """
-                )
-            ),
-            Image.open(
-                BytesIO(
-                    base64.b64decode(
-                        b"""
+            )
+        ),
+        Image.open(
+            BytesIO(
+                base64.b64decode(
+                    b"""
 iVBORw0KGgoAAAANSUhEUgAAAx4AAAAUAQAAAAArMtZoAAAEwElEQVR4nABlAJr/AHVE4czCI/4u
 Mc4b7vuds/xzjz5/3/7u/n9vMe7vnfH/9++vPn/xyf5zhxzjt8GHw8+2d83u8x27199/nxuQ6Od9
 M43/5z2I+9n9ZtmDBwMQECDRQw/eQIQohJXxpBCNVE6QCCAAAAD//wBlAJr/AgALyj1t/wINwq0g
@@ -1235,8 +1244,8 @@ AAD//2Ji2FrkY3iYpYC5qDeGgeEMAwPDvwQBBoYvcTwOVLMEAAAA//9isDBgkP///0EOg9z35v//
 Gc/eeW7BwPj5+QGZhANUswMAAAD//2JgqGBgYGBgqEMXlvhMPUsAAAAA//8iYDd1AAAAAP//AwDR
 w7IkEbzhVQAAAABJRU5ErkJggg==
 """
-                    )
                 )
-            ),
-        )
+            )
+        ),
+    )
     return f


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/7354#issuecomment-1767239100 feels that even though the new default font provided by #7354 is superior to the old one, it breaks backwards compatibility to remove access to the old one (without the user disabling FreeType support).

This adds a `load_pilfont()` method to restore access.