### PR TITLE
Added messages to errors

### DIFF
--- a/Tests/test_file_palm.py
+++ b/Tests/test_file_palm.py
@@ -27,7 +27,7 @@ def open_with_magick(magick, tmp_path, f):
         magick + [f, outfile], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT
     )
     if rc:
-        raise OSError
+        assert False
     return Image.open(outfile)
 
 

--- a/src/PIL/FliImagePlugin.py
+++ b/src/PIL/FliImagePlugin.py
@@ -150,7 +150,8 @@ class FliImageFile(ImageFile.ImageFile):
 
         s = self.fp.read(4)
         if not s:
-            raise EOFError
+            msg = "missing frame size"
+            raise EOFError(msg)
 
         framesize = i32(s)
 

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -183,7 +183,8 @@ class GifImageFile(ImageFile.ImageFile):
 
         s = self.fp.read(1)
         if not s or s == b";":
-            raise EOFError
+            msg = "no more images in GIF file"
+            raise EOFError(msg)
 
         palette = None
 
@@ -288,7 +289,8 @@ class GifImageFile(ImageFile.ImageFile):
 
         if interlace is None:
             # self._fp = None
-            raise EOFError
+            msg = "image not found in GIF frame"
+            raise EOFError(msg)
 
         self.__frame = frame
         if not update_image:

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1862,7 +1862,8 @@ class Image:
                     # do things the hard way
                     im = self.im.convert(mode)
                     if im.mode not in ("LA", "PA", "RGBA"):
-                        raise ValueError from e  # sanity check
+                        msg = "alpha channel could not be added"
+                        raise ValueError(msg) from e  # sanity check
                     self.im = im
                 self.pyaccess = None
                 self._mode = self.im.mode
@@ -2467,7 +2468,8 @@ class Image:
 
         # overridden by file handlers
         if frame != 0:
-            raise EOFError
+            msg = "no more images in file"
+            raise EOFError(msg)
 
     def show(self, title=None):
         """

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -200,8 +200,8 @@ class ImageFile(Image.Image):
                     with open(self.filename) as fp:
                         self.map = mmap.mmap(fp.fileno(), 0, access=mmap.ACCESS_READ)
                     if offset + self.size[1] * args[1] > self.map.size():
-                        # buffer is not large enough
-                        raise OSError
+                        msg = "buffer is not large enough"
+                        raise OSError(msg)
                     self.im = Image.core.map_buffer(
                         self.map, self.size, decoder_name, offset, args
                     )
@@ -690,7 +690,8 @@ class PyDecoder(PyCodec):
             If finished with decoding return -1 for the bytes consumed.
             Err codes are from :data:`.ImageFile.ERRORS`.
         """
-        raise NotImplementedError()
+        msg = "unavailable in base decoder"
+        raise NotImplementedError(msg)
 
     def set_as_raw(self, data, rawmode=None):
         """
@@ -739,7 +740,8 @@ class PyEncoder(PyCodec):
             If finished with encoding return 1 for the error code.
             Err codes are from :data:`.ImageFile.ERRORS`.
         """
-        raise NotImplementedError()
+        msg = "unavailable in base encoder"
+        raise NotImplementedError(msg)
 
     def encode_to_pyfd(self):
         """

--- a/src/PIL/ImagePalette.py
+++ b/src/PIL/ImagePalette.py
@@ -205,7 +205,8 @@ def make_linear_lut(black, white):
         for i in range(256):
             lut.append(white * i // 255)
     else:
-        raise NotImplementedError  # FIXME
+        msg = "unavailable when black is non-zero"
+        raise NotImplementedError(msg)  # FIXME
     return lut
 
 

--- a/src/PIL/ImageSequence.py
+++ b/src/PIL/ImageSequence.py
@@ -40,7 +40,8 @@ class Iterator:
             self.im.seek(ix)
             return self.im
         except EOFError as e:
-            raise IndexError from e  # end of sequence
+            msg = "end of sequence"
+            raise IndexError(msg) from e
 
     def __iter__(self):
         return self
@@ -51,7 +52,8 @@ class Iterator:
             self.position += 1
             return self.im
         except EOFError as e:
-            raise StopIteration from e
+            msg = "end of sequence"
+            raise StopIteration(msg) from e
 
 
 def all_frames(im, func=None):

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -99,7 +99,8 @@ class Viewer:
         Returns the command used to display the file.
         Not implemented in the base class.
         """
-        raise NotImplementedError
+        msg = "unavailable in base viewer"
+        raise NotImplementedError(msg)
 
     def save_image(self, image):
         """Save to temporary file and return filename."""

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -165,7 +165,8 @@ def APP(self, marker):
             except TypeError:
                 dpi = x_resolution
             if math.isnan(dpi):
-                raise ValueError
+                msg = "DPI is not a number"
+                raise ValueError(msg)
             if resolution_unit == 3:  # cm
                 # 1 dpcm = 2.54 dpi
                 dpi *= 2.54
@@ -719,7 +720,8 @@ def _save(im, fp, filename):
             for idx, table in enumerate(qtables):
                 try:
                     if len(table) != 64:
-                        raise TypeError
+                        msg = "Invalid quantization table"
+                        raise TypeError(msg)
                     table = array.array("H", table)
                 except TypeError as e:
                     msg = "Invalid quantization table"

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -438,11 +438,12 @@ class PngStream(ChunkStream):
             tile = [("zip", (0, 0) + self.im_size, pos, self.im_rawmode)]
         self.im_tile = tile
         self.im_idat = length
-        raise EOFError
+        msg = "image data found"
+        raise EOFError(msg)
 
     def chunk_IEND(self, pos, length):
-        # end of PNG image
-        raise EOFError
+        msg = "end of PNG image"
+        raise EOFError(msg)
 
     def chunk_PLTE(self, pos, length):
         # palette
@@ -891,7 +892,8 @@ class PngImageFile(ImageFile.ImageFile):
             self.dispose_extent = self.info.get("bbox")
 
             if not self.tile:
-                raise EOFError
+                msg = "image not found in APNG frame"
+                raise EOFError(msg)
 
         # setup frame disposal (actual disposal done when needed in the next _seek())
         if self._prev_im is None and self.dispose_op == Disposal.OP_PREVIOUS:


### PR DESCRIPTION
In main, lint has started insisting that "Built-in Exceptions must not be thrown without being called" and "Built-in Exceptions must have a useful message" - https://github.com/python-pillow/Pillow/actions/runs/6570025729/job/17846816725#step:7:63

This PR adds messages to errors when they are raised, and replaces an error raised in the tests with a failed assertion.