### PR TITLE
Add mode to ImageOps._lut() error message

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -433,6 +433,12 @@ def test_exif_transpose_in_place():
         assert_image_equal(im, expected)
 
 
+def test_autocontrast_unsupported_mode():
+    im = Image.new("RGBA", (1, 1))
+    with pytest.raises(OSError):
+        ImageOps.autocontrast(im)
+
+
 def test_autocontrast_cutoff():
     # Test the cutoff argument of autocontrast
     with Image.open("Tests/images/bw_gradient.png") as img:

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -56,7 +56,7 @@ def _lut(image, lut):
             lut = lut + lut + lut
         return image.point(lut)
     else:
-        msg = "not supported for this image mode"
+        msg = "not supported for image mode " + image.mode
         raise OSError(msg)
 
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -56,7 +56,7 @@ def _lut(image, lut):
             lut = lut + lut + lut
         return image.point(lut)
     else:
-        msg = "not supported for image mode " + image.mode
+        msg = f"not supported for mode {image.mode}"
         raise OSError(msg)
 
 


### PR DESCRIPTION
Added the image mode to the error message, so you can see what mode it's erroring on.