### PR TITLE
Implement `streamtype=1` option for tables-only JPEG encoding

### DIFF
--- a/src/libImaging/JpegEncode.c
+++ b/src/libImaging/JpegEncode.c
@@ -218,9 +218,9 @@ ImagingJpegEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
             }
             switch (context->streamtype) {
                 case 1:
-                    /* tables only -- not yet implemented */
-                    state->errcode = IMAGING_CODEC_CONFIG;
-                    return -1;
+                    /* tables only */
+                    jpeg_write_tables(&context->cinfo);
+                    goto cleanup;
                 case 2:
                     /* image only */
                     jpeg_suppress_tables(&context->cinfo, TRUE);
@@ -316,6 +316,7 @@ ImagingJpegEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
             }
             jpeg_finish_compress(&context->cinfo);
 
+cleanup:
             /* Clean up */
             if (context->comment) {
                 free(context->comment);


### PR DESCRIPTION
We already support `streamtype=2` to skip producing JPEG tables, but `streamtype=1`, which skips everything but the tables, was never implemented. The `streamtype=1` stub code dates to Git pre-history, so it's not immediately clear why.  Implement the missing support.

`jpeg_write_tables()` can't resume after a full output buffer (it fails with `JERR_CANT_SUSPEND`), so it might seem that Pillow needs to pre-compute the necessary buffer size.  However, in the normal case of producing an interchange stream, the tables are written via the same libjpeg codepath during the first `jpeg_write_scanlines()` call, and table writes aren't resumable there either.  Thus, any buffer large enough for the normal case will also be large enough for a tables-only file.

I've opted to implement the early exit with a `goto` rather than refactoring the state machine.  If the `goto` is not desired, it would be possible to add a dedicated cleanup state, do an early return after writing tables, and require a second call into the state machine to finish cleanup.

The `streamtype` option isn't documented and this PR doesn't change that. It does add a test though.