### PR TITLE
Fixed frombytes() for images with a zero dimension

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -910,6 +910,9 @@ class TestImage:
     def test_zero_frombytes(self, size):
         Image.frombytes("RGB", size, b"")
 
+        im = Image.new("RGB", size)
+        im.frombytes(b"")
+
     def test_has_transparency_data(self):
         for mode in ("1", "L", "P", "RGB"):
             im = Image.new(mode, (1, 1))

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -906,6 +906,10 @@ class TestImage:
         im = Image.new("RGB", size)
         assert im.tobytes() == b""
 
+    @pytest.mark.parametrize("size", ((1, 0), (0, 1), (0, 0)))
+    def test_zero_frombytes(self, size):
+        Image.frombytes("RGB", size, b"")
+
     def test_has_transparency_data(self):
         for mode in ("1", "L", "P", "RGB"):
             im = Image.new(mode, (1, 1))

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2967,15 +2967,16 @@ def frombytes(mode, size, data, decoder_name="raw", *args):
 
     _check_size(size)
 
-    # may pass tuple instead of argument list
-    if len(args) == 1 and isinstance(args[0], tuple):
-        args = args[0]
-
-    if decoder_name == "raw" and args == ():
-        args = mode
-
     im = new(mode, size)
-    im.frombytes(data, decoder_name, args)
+    if im.width != 0 and im.height != 0:
+        # may pass tuple instead of argument list
+        if len(args) == 1 and isinstance(args[0], tuple):
+            args = args[0]
+
+        if decoder_name == "raw" and args == ():
+            args = mode
+
+        im.frombytes(data, decoder_name, args)
     return im
 
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -791,6 +791,9 @@ class Image:
         but loads data into this image instead of creating a new image object.
         """
 
+        if self.width == 0 or self.height == 0:
+            return
+
         # may pass tuple instead of argument list
         if len(args) == 1 and isinstance(args[0], tuple):
             args = args[0]


### PR DESCRIPTION
Resolves #7492

The issue found that calling `Image.frombytes` for an image with zero size and no data - e.g. `Image.frombytes("L", (0, 0), b"")` - raises an error.

This fixes that, and the corresponding situation for `im.frombytes()`.

This is the inverse of #5938