### PR TITLE
Switched from direct setup.py invocation to "pip install ."

### DIFF
--- a/Tests/oss-fuzz/build.sh
+++ b/Tests/oss-fuzz/build.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-python3 setup.py build --build-base=/tmp/build install
+python3 -m pip install .
 
 # Build fuzzers in $OUT.
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do


### PR DESCRIPTION
Replaces direct `setup.py` invocation with `pip install .`, as per https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html

Sequel to #5896