### PR TITLE
Update Travis CI to Python 3.12 and Ubuntu 22.04 Jammy Jellyfish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
 
 language: python
 # Default Python version is usually 3.6
-python: "3.11"
-dist: focal
+python: "3.12"
+dist: jammy
 services: docker
 
 jobs:


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/6941.

Travis CI now has Python 3.12.

We can also bump the Ubuntu version.