### PR TITLE
Docs: Add description of olefile to "External Libraries"

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -173,6 +173,9 @@ Many of Pillow's features require external libraries:
 
 * **tcl/tk** provides support for tkinter bitmap and photo images.
 
+* **olefile** provides support for Kodak FlashPix (FPX) and Microsoft
+  Image Composer (MIC) files.
+
 * **openjpeg** provides JPEG 2000 functionality.
 
   * Pillow has been tested with openjpeg **2.0.0**, **2.1.0**, **2.3.1**,

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -171,11 +171,6 @@ Many of Pillow's features require external libraries:
     transparent WebP files. Versions **0.3.0** and above support
     transparency.
 
-* **tcl/tk** provides support for tkinter bitmap and photo images.
-
-* **olefile** provides support for Kodak FlashPix (FPX) and Microsoft
-  Image Composer (MIC) files.
-
 * **openjpeg** provides JPEG 2000 functionality.
 
   * Pillow has been tested with openjpeg **2.0.0**, **2.1.0**, **2.3.1**,
@@ -209,6 +204,12 @@ Many of Pillow's features require external libraries:
   * Previous versions of Pillow (5.0.0 to 8.1.2) linked libraqm dynamically at runtime.
 
 * **libxcb** provides X11 screengrab support.
+
+* **tcl/tk** and the **tkinter** Python bindings provide support for tkinter
+  bitmap and photo images.
+
+* **olefile** provides support for Kodak FlashPix (FPX) and Microsoft
+  Image Composer (MIC) files.
 
 .. tab:: Linux
 


### PR DESCRIPTION
olefile became an optional dependency in commit 9175706, but it hasn't been mentioned in the library list so far.