### PR TITLE
Improved olefile documentation and testing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,7 +43,7 @@ build_script:
 
 test_script:
 - cd c:\pillow
-- '%PYTHON%\%EXECUTABLE% -m pip install pytest pytest-cov pytest-timeout'
+- '%PYTHON%\%EXECUTABLE% -m pip install pytest pytest-cov pytest-timeout defusedxml numpy olefile pyroma'
 - c:\"Program Files (x86)"\"Windows Kits"\10\Debuggers\x86\gflags.exe /p /enable %PYTHON%\%EXECUTABLE%
 - '%PYTHON%\%EXECUTABLE% -c "from PIL import Image"'
 - '%PYTHON%\%EXECUTABLE% -m pytest -vx --cov PIL --cov Tests --cov-report term --cov-report xml Tests'

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -65,8 +65,8 @@ jobs:
     - name: Print build system information
       run: python3 .github/workflows/system-info.py
 
-    - name: python3 -m pip install pytest pytest-cov pytest-timeout defusedxml
-      run: python3 -m pip install pytest pytest-cov pytest-timeout defusedxml
+    - name: python3 -m pip install pytest pytest-cov pytest-timeout defusedxml olefile pyroma
+      run: python3 -m pip install pytest pytest-cov pytest-timeout defusedxml olefile pyroma
 
     - name: Install dependencies
       id: install

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1296,6 +1296,8 @@ Pillow reads Kodak FlashPix files. In the current version, only the highest
 resolution image is read from the file, and the viewing transform is not taken
 into account.
 
+To enable FPX support, you must install olefile.
+
 .. note::
 
     To enable full FlashPix support, you need to build and install the IJG JPEG
@@ -1371,6 +1373,8 @@ the first sprite in the file is loaded. You can use :py:meth:`~PIL.Image.Image.s
 :py:meth:`~PIL.Image.Image.tell` to read other sprites from the file.
 
 Note that there may be an embedded gamma of 2.2 in MIC files.
+
+To enable MIC support, you must install olefile.
 
 MPO
 ^^^


### PR DESCRIPTION
- Document in the 'Image file formats' that olefile is required for FPX and MIC
- Install olefile (and some other optional dependencies) on Windows CIs for better testing