### PR TITLE
Mention defusedxml and olefile in installation instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -42,8 +42,7 @@ Install Pillow with :command:`pip`::
     python3 -m pip install --upgrade pip
     python3 -m pip install --upgrade Pillow
 
-:pypi:`olefile` can additionally be installed to allow Pillow to read FPX and
-MIC images::
+Optionally, install :pypi:`olefile` for Pillow to read FPX and MIC images::
 
     python3 -m pip install --upgrade olefile
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -42,9 +42,10 @@ Install Pillow with :command:`pip`::
     python3 -m pip install --upgrade pip
     python3 -m pip install --upgrade Pillow
 
-Optionally, install :pypi:`olefile` for Pillow to read FPX and MIC images::
+Optionally, install :pypi:`defusedxml` for Pillow to read XMP data,
+and :pypi:`olefile` for Pillow to read FPX and MIC images::
 
-    python3 -m pip install --upgrade olefile
+    python3 -m pip install --upgrade defusedxml olefile
 
 
 .. tab:: Linux

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -42,6 +42,11 @@ Install Pillow with :command:`pip`::
     python3 -m pip install --upgrade pip
     python3 -m pip install --upgrade Pillow
 
+:pypi:`olefile` can additionally be installed to allow Pillow to read FPX and
+MIC images::
+
+    python3 -m pip install --upgrade olefile
+
 
 .. tab:: Linux
 


### PR DESCRIPTION
Alternative to #7502

Under 'Basic Installation', mention that olefile can additionally be installed to allow Pillow to read FPX and
MIC images.