### PR TITLE
Add CVE-2023-44271 to release notes

### DIFF
--- a/docs/releasenotes/10.0.0.rst
+++ b/docs/releasenotes/10.0.0.rst
@@ -173,8 +173,8 @@ been processed before Pillow started checking for decompression bombs.
 Added ImageFont.MAX_STRING_LENGTH
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To protect against potential DOS attacks when using arbitrary strings as text
-input, Pillow will now raise a ``ValueError`` if the number of characters
+:cve:`2023-44271`: To protect against potential DOS attacks when using arbitrary strings as text
+input, Pillow will now raise a :py:exc:`ValueError` if the number of characters
 passed into ImageFont methods is over a certain limit,
 :py:data:`PIL.ImageFont.MAX_STRING_LENGTH`.
 


### PR DESCRIPTION
Document that the security fix in 10.0.0 that added `ImageFont.MAX_STRING_LENGTH` was assigned CVE-2023-44271.

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44271

https://devhub.checkmarx.com/cve-details/CVE-2023-44271/
