### PR TITLE
ruff: Minor optimizations of list comprehensions, x in set, etc.

### DIFF
--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -67,7 +67,7 @@ def test_quantize_no_dither():
 
 def test_quantize_no_dither2():
     im = Image.new("RGB", (9, 1))
-    im.putdata(list((p,) * 3 for p in range(0, 36, 4)))
+    im.putdata([(p,) * 3 for p in range(0, 36, 4)])
 
     palette = Image.new("P", (1, 1))
     data = (0, 0, 0, 32, 32, 32)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ version = {attr = "PIL.__version__"}
 target-version = "py38"
 line-length = 88
 select = [
+  "C4", # flake8-comprehensions
   "E", # pycodestyle errors
   "EM", # flake8-errmsg
   "F", # pyflakes errors

--- a/setup.py
+++ b/setup.py
@@ -440,17 +440,17 @@ class pil_build_ext(build_ext):
 
         #
         # add configured kits
-        for root_name, lib_name in dict(
-            JPEG_ROOT="libjpeg",
-            JPEG2K_ROOT="libopenjp2",
-            TIFF_ROOT=("libtiff-5", "libtiff-4"),
-            ZLIB_ROOT="zlib",
-            FREETYPE_ROOT="freetype2",
-            HARFBUZZ_ROOT="harfbuzz",
-            FRIBIDI_ROOT="fribidi",
-            LCMS_ROOT="lcms2",
-            IMAGEQUANT_ROOT="libimagequant",
-        ).items():
+        for root_name, lib_name in {
+            "JPEG_ROOT": "libjpeg",
+            "JPEG2K_ROOT": "libopenjp2",
+            "TIFF_ROOT": ("libtiff-5", "libtiff-4"),
+            "ZLIB_ROOT": "zlib",
+            "FREETYPE_ROOT": "freetype2",
+            "HARFBUZZ_ROOT": "harfbuzz",
+            "FRIBIDI_ROOT": "fribidi",
+            "LCMS_ROOT": "lcms2",
+            "IMAGEQUANT_ROOT": "libimagequant",
+        }.items():
             root = globals()[root_name]
 
             if root is None and root_name in os.environ:

--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -396,7 +396,7 @@ def _save(im, fp, filename, bitmap_header=True):
     dpi = info.get("dpi", (96, 96))
 
     # 1 meter == 39.3701 inches
-    ppm = tuple(map(lambda x: int(x * 39.3701 + 0.5), dpi))
+    ppm = tuple((int(x * 39.3701 + 0.5) for x in dpi))
 
     stride = ((im.size[0] * bits + 7) // 8 + 3) & (~3)
     header = 40  # or 64 for OS/2 version 2

--- a/src/PIL/CurImagePlugin.py
+++ b/src/PIL/CurImagePlugin.py
@@ -64,7 +64,6 @@ class CurImageFile(BmpImagePlugin.BmpImageFile):
         d, e, o, a = self.tile[0]
         self.tile[0] = d, (0, 0) + self.size, o, a
 
-        return
 
 
 #

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -40,7 +40,7 @@ from enum import IntEnum
 from pathlib import Path
 
 try:
-    import defusedxml.ElementTree as ElementTree
+    from defusedxml import ElementTree
 except ImportError:
     ElementTree = None
 
@@ -1159,7 +1159,7 @@ class Image:
             if palette.mode != "P":
                 msg = "bad mode for palette image"
                 raise ValueError(msg)
-            if self.mode != "RGB" and self.mode != "L":
+            if self.mode not in {"RGB", "L"}:
                 msg = "only RGB or L mode images can be quantized to a palette"
                 raise ValueError(msg)
             im = self.im.convert("P", dither, palette.im)

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -921,7 +921,7 @@ def floodfill(image, xy, value, border=None, thresh=0):
                     if border is None:
                         fill = _color_diff(p, background) <= thresh
                     else:
-                        fill = p != value and p != border
+                        fill = p not in (value, border)
                     if fill:
                         pixel[s, t] = value
                         new_edge.add((s, t))

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -334,10 +334,8 @@ def _save(im, fp, filename):
     if quality_layers is not None and not (
         isinstance(quality_layers, (list, tuple))
         and all(
-            [
-                isinstance(quality_layer, (int, float))
+            isinstance(quality_layer, (int, float))
                 for quality_layer in quality_layers
-            ]
         )
     ):
         msg = "quality_layers must be a sequence of numbers"

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -397,7 +397,7 @@ class JpegImageFile(ImageFile.ImageFile):
                     # self.__offset = self.fp.tell()
                     break
                 s = self.fp.read(1)
-            elif i == 0 or i == 0xFFFF:
+            elif i in {0, 0xFFFF}:
                 # padded marker or junk; move on
                 s = b"\xff"
             elif i == 0xFF00:  # Skip extraneous data (escaped 0xFF)

--- a/src/PIL/SgiImagePlugin.py
+++ b/src/PIL/SgiImagePlugin.py
@@ -123,7 +123,7 @@ class SgiImageFile(ImageFile.ImageFile):
 
 
 def _save(im, fp, filename):
-    if im.mode != "RGB" and im.mode != "RGBA" and im.mode != "L":
+    if im.mode not in {"RGB", "RGBA", "L"}:
         msg = "Unsupported SGI image mode"
         raise ValueError(msg)
 
@@ -155,7 +155,7 @@ def _save(im, fp, filename):
     # Z Dimension: Number of channels
     z = len(im.mode)
 
-    if dim == 1 or dim == 2:
+    if dim in {1, 2}:
         z = 1
 
     # assert we've got the right number of bands.

--- a/src/PIL/TiffTags.py
+++ b/src/PIL/TiffTags.py
@@ -427,7 +427,7 @@ def _populate():
 
         TAGS_V2[k] = TagInfo(k, *v)
 
-    for group, tags in TAGS_V2_GROUPS.items():
+    for tags in TAGS_V2_GROUPS.values():
         for k, v in tags.items():
             tags[k] = TagInfo(k, *v)
 

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -471,7 +471,7 @@ def extract_dep(url: str, filename: str) -> None:
                     msg = "Attempted Path Traversal in Zip File"
                     raise RuntimeError(msg)
             zf.extractall(sources_dir)
-    elif filename.endswith(".tar.gz") or filename.endswith(".tgz"):
+    elif filename.endswith((".tar.gz", ".tgz")):
         with tarfile.open(file, "r:gz") as tgz:
             for member in tgz.getnames():
                 member_abspath = os.path.abspath(os.path.join(sources_dir, member))


### PR DESCRIPTION
Changes proposed in this pull request:
 * Add ruff rules C4 to the linting process - https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
 * Use ruff rule PERF102 to speed up dict iteration - https://docs.astral.sh/ruff/rules/incorrect-dict-iterator
 * Use ruff rule PIE810 to speed up `str.endswith()` - https://docs.astral.sh/ruff/rules/multiple-starts-ends-with
 * Use ruff rules PyLint Refactor to speed up comparisons and remove useless code
     * https://docs.astral.sh/ruff/rules/#pylint-pl