### PR TITLE
Remove old commented-out code

### DIFF
--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -77,8 +77,6 @@ def Ghostscript(tile, size, fp, scale=1, transparency=False):
 
     # Hack to support hi-res rendering
     scale = int(scale) or 1
-    # orig_size = size
-    # orig_bbox = bbox
     size = (size[0] * scale, size[1] * scale)
     # resolution is dependent on bbox and size
     res = (

--- a/src/PIL/FitsImagePlugin.py
+++ b/src/PIL/FitsImagePlugin.py
@@ -54,12 +54,10 @@ class FitsImageFile(ImageFile.ImageFile):
             self._mode = "L"
         elif number_of_bits == 16:
             self._mode = "I"
-            # rawmode = "I;16S"
         elif number_of_bits == 32:
             self._mode = "I"
         elif number_of_bits in (-32, -64):
             self._mode = "F"
-            # rawmode = "F" if number_of_bits == -32 else "F;64F"
 
         offset = math.ceil(self.fp.tell() / 2880) * 2880
         self.tile = [("raw", (0, 0) + self.size, offset, (self.mode, 0, -1))]

--- a/src/PIL/FontFile.py
+++ b/src/PIL/FontFile.py
@@ -78,7 +78,6 @@ class FontFile:
             if glyph:
                 d, dst, src, im = glyph
                 xx = src[2] - src[0]
-                # yy = src[3] - src[1]
                 x0, y0 = x, y
                 x = x + xx
                 if x > WIDTH:

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -281,14 +281,9 @@ class GifImageFile(ImageFile.ImageFile):
                 bits = self.fp.read(1)[0]
                 self.__offset = self.fp.tell()
                 break
-
-            else:
-                pass
-                # raise OSError, "illegal GIF tag `%x`" % s[0]
             s = None
 
         if interlace is None:
-            # self._fp = None
             msg = "image not found in GIF frame"
             raise EOFError(msg)
 

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -174,9 +174,7 @@ class IcoFile:
 
         self.entry = sorted(self.entry, key=lambda x: x["color_depth"])
         # ICO images are usually squares
-        # self.entry = sorted(self.entry, key=lambda x: x['width'])
-        self.entry = sorted(self.entry, key=lambda x: x["square"])
-        self.entry.reverse()
+        self.entry = sorted(self.entry, key=lambda x: x["square"], reverse=True)
 
     def sizes(self):
         """

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -430,7 +430,6 @@ class Parser:
                 with io.BytesIO(self.data) as fp:
                     im = Image.open(fp)
             except OSError:
-                # traceback.print_exc()
                 pass  # not enough data
             else:
                 flag = hasattr(im, "load_seek") or hasattr(im, "load_read")

--- a/src/PIL/ImagePalette.py
+++ b/src/PIL/ImagePalette.py
@@ -257,8 +257,6 @@ def load(filename):
                 if lut:
                     break
             except (SyntaxError, ValueError):
-                # import traceback
-                # traceback.print_exc()
                 pass
         else:
             msg = "cannot load palette"

--- a/src/PIL/ImageQt.py
+++ b/src/PIL/ImageQt.py
@@ -83,16 +83,6 @@ def fromqimage(im):
 
 def fromqpixmap(im):
     return fromqimage(im)
-    # buffer = QBuffer()
-    # buffer.open(QIODevice.ReadWrite)
-    # # im.save(buffer)
-    # # What if png doesn't support some image features like animation?
-    # im.save(buffer, 'ppm')
-    # bytes_io = BytesIO()
-    # bytes_io.write(buffer.data())
-    # buffer.close()
-    # bytes_io.seek(0)
-    # return Image.open(bytes_io)
 
 
 def align8to32(bytes, width, mode):
@@ -208,9 +198,5 @@ def toqimage(im):
 
 
 def toqpixmap(im):
-    # # This doesn't work. For now using a dumb approach.
-    # im_data = _toqclass_helper(im)
-    # result = QPixmap(im_data["size"][0], im_data["size"][1])
-    # result.loadFromData(im_data["data"])
     qimage = toqimage(im)
     return QPixmap.fromImage(qimage)

--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -33,9 +33,6 @@ from . import (
 from ._binary import i16be as i16
 from ._binary import o32le
 
-# def _accept(prefix):
-#     return JpegImagePlugin._accept(prefix)
-
 
 def _save(im, fp, filename):
     JpegImagePlugin._save(im, fp, filename)

--- a/src/PIL/PpmImagePlugin.py
+++ b/src/PIL/PpmImagePlugin.py
@@ -328,9 +328,6 @@ def _save(im, fp, filename):
             fp.write(b"65535\n")
     ImageFile._save(im, fp, [("raw", (0, 0) + im.size, 0, (rawmode, 0, 1))])
 
-    # ALTERNATIVE: save via builtin debug function
-    # im._dump(filename)
-
 
 #
 # --------------------------------------------------------------------

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1885,13 +1885,14 @@ class AppendingTiffWriter:
         8,  # long8
     ]
 
-    #    StripOffsets = 273
-    #    FreeOffsets = 288
-    #    TileOffsets = 324
-    #    JPEGQTables = 519
-    #    JPEGDCTables = 520
-    #    JPEGACTables = 521
-    Tags = {273, 288, 324, 519, 520, 521}
+    Tags = {
+        273,  # StripOffsets
+        288,  # FreeOffsets
+        324,  # TileOffsets
+        519,  # JPEGQTables
+        520,  # JPEGDCTables
+        521,  # JPEGACTables
+    }
 
     def __init__(self, fn, new=False):
         if hasattr(fn, "read"):
@@ -1941,8 +1942,6 @@ class AppendingTiffWriter:
 
         iimm = self.f.read(4)
         if not iimm:
-            # msg = "nothing written into new page"
-            # raise RuntimeError(msg)
             # Make it easy to finish a frame without committing to a new one.
             return
 

--- a/src/PIL/TiffTags.py
+++ b/src/PIL/TiffTags.py
@@ -56,7 +56,7 @@ def lookup(tag, group=None):
 ##
 # Map tag numbers to tag info.
 #
-#  id: (Name, Type, Length, enum_values)
+#  id: (Name, Type, Length[, enum_values])
 #
 # The length here differs from the length in the tiff spec.  For
 # numbers, the tiff spec is for the number of fields returned. We
@@ -437,22 +437,6 @@ _populate()
 # Map type numbers to type names -- defined in ImageFileDirectory.
 
 TYPES = {}
-
-# was:
-# TYPES = {
-#     1: "byte",
-#     2: "ascii",
-#     3: "short",
-#     4: "long",
-#     5: "rational",
-#     6: "signed byte",
-#     7: "undefined",
-#     8: "signed short",
-#     9: "signed long",
-#     10: "signed rational",
-#     11: "float",
-#     12: "double",
-# }
 
 #
 # These tags are handled by default in libtiff, without

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -213,7 +213,6 @@ DEPS = {
         ],
         "headers": [r"libtiff\tiff*.h"],
         "libs": [r"libtiff\*.lib"],
-        # "bins": [r"libtiff\*.dll"],
     },
     "libpng": {
         "url": SF_PROJECTS + "/libpng/files/libpng16/1.6.39/lpng1639.zip/download",
@@ -272,7 +271,6 @@ DEPS = {
             cmd_xcopy("include", "{inc_dir}"),
         ],
         "libs": [r"objs\{msbuild_arch}\Release Static\freetype.lib"],
-        # "bins": [r"objs\{msbuild_arch}\Release\freetype.dll"],
     },
     "lcms2": {
         "url": SF_PROJECTS + "/lcms/files/lcms/2.15/lcms2-2.15.tar.gz/download",


### PR DESCRIPTION
This PR removes a bunch of commented-out code (most of it more than 5 or 10 years old, or recently search-and-replace refactored). I took care not to remove commented-out code that might be useful for future Pillow hackers.

These were found via Ruff's ERA001 lint, which unfortunately also finds some false positives, so I don't think it should get enabled by default. (That said, it does find some suspect bits.)