### PR TITLE
Fix for Python 3.13: explicitly include `unistd.h`

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -28,7 +28,8 @@ fi
 
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade wheel
-PYTHONOPTIMIZE=0 python3 -m pip install cffi
+# TODO Update condition when cffi supports 3.13
+if ! [[ "$GHA_PYTHON_VERSION" == "3.13" ]]; then PYTHONOPTIMIZE=0 python3 -m pip install cffi ; fi
 python3 -m pip install coverage
 python3 -m pip install defusedxml
 python3 -m pip install olefile
@@ -38,7 +39,8 @@ python3 -m pip install -U pytest-timeout
 python3 -m pip install pyroma
 
 if [[ $(uname) != CYGWIN* ]]; then
-    python3 -m pip install numpy
+    # TODO Update condition when NumPy supports 3.13
+    if ! [[ "$GHA_PYTHON_VERSION" == "3.13" ]]; then python3 -m pip install numpy ; fi
 
     # PyQt6 doesn't support PyPy3
     if [[ $GHA_PYTHON_VERSION == 3.* ]]; then

--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -5,7 +5,9 @@ set -e
 brew install libtiff libjpeg openjpeg libimagequant webp little-cms2 freetype libraqm
 export PKG_CONFIG_PATH="/usr/local/opt/openblas/lib/pkgconfig"
 
-PYTHONOPTIMIZE=0 python3 -m pip install cffi
+# TODO Update condition when cffi supports 3.13
+if ! [[ "$GHA_PYTHON_VERSION" == "3.13" ]]; then PYTHONOPTIMIZE=0 python3 -m pip install cffi ; fi
+
 python3 -m pip install coverage
 python3 -m pip install defusedxml
 python3 -m pip install olefile
@@ -14,7 +16,8 @@ python3 -m pip install -U pytest-cov
 python3 -m pip install -U pytest-timeout
 python3 -m pip install pyroma
 
-python3 -m pip install numpy
+# TODO Update condition when NumPy supports 3.13
+if ! [[ "$GHA_PYTHON_VERSION" == "3.13" ]]; then python3 -m pip install numpy ; fi
 
 # extra test images
 pushd depends && ./install_extra_test_images.sh && popd

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.10", "pypy3.9", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["pypy3.10", "pypy3.9", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     timeout-minutes: 30
 
@@ -59,6 +59,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
         cache: pip
         cache-dependency-path: ".github/workflows/test-windows.yml"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
         python-version: [
           "pypy3.10",
           "pypy3.9",
+          "3.13",
           "3.12",
           "3.11",
           "3.10",
@@ -64,6 +65,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
         cache: pip
         cache-dependency-path: ".ci/*.sh"
 

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -12,11 +12,11 @@
 
 #include "Imaging.h"
 
-#ifndef _UNISTD_H
+#ifdef HAVE_LIBTIFF
+
+#ifdef HAVE_UNISTD_H
 #include <unistd.h> /* lseek */
 #endif
-
-#ifdef HAVE_LIBTIFF
 
 #ifndef uint
 #define uint uint32

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -12,6 +12,10 @@
 
 #include "Imaging.h"
 
+#ifndef _UNISTD_H
+#include <unistd.h> /* lseek */
+#endif
+
 #ifdef HAVE_LIBTIFF
 
 #ifndef uint

--- a/src/libImaging/TiffDecode.h
+++ b/src/libImaging/TiffDecode.h
@@ -13,12 +13,6 @@
 #include <tiff.h>
 #endif
 
-/* UNDONE -- what are we using from this? */
-/*#ifndef _UNISTD_H
-  # include <unistd.h>
-  # endif
-*/
-
 #ifndef min
 #define min(x, y) ((x > y) ? y : x)
 #define max(x, y) ((x < y) ? y : x)


### PR DESCRIPTION
Changes proposed in this pull request:

 * Test Python 3.13 pre-release
 * Explicitly include `unistd.h` to use `lseek`

Changed in [Python 3.13](https://docs.python.org/dev/whatsnew/3.13.html#id8):

> * ``Python.h`` no longer includes the ``<unistd.h>`` standard header file. If
  needed, it should now be included explicitly. For example, it provides the
  functions: ``read()``, ``write()``, ``close()``, ``isatty()``, ``lseek()``,
  ``getpid()``, ``getcwd()``, ``sysconf()``, ``getpagesize()``, ``alarm()`` and
  ``pause()``.
  As a consequence, ``_POSIX_SEMAPHORES`` and ``_POSIX_THREADS`` macros are no
  longer defined by ``Python.h``. The ``HAVE_UNISTD_H`` and ``HAVE_PTHREAD_H``
  macros defined by ``Python.h`` can be used to decide if ``<unistd.h>`` and
  ``<pthread.h>`` header files can be included.

So we need to `#include <unistd.h>` for `src/libImaging/TiffDecode.c` which uses `lseek`.

---

Also add Python 3.13 to the CI for Ubuntu, macOS and Windows. We need to skip `cffi`, it's not ready for 3.13.

3.13 is in alpha, so we can expect things still to change. I'm fine leaving it out of the CI until later or beta, but it could be useful to get early feedback. If any sudden failures turn up, we can always comment it out until we get it sorted (in Pillow or upstream in CPython, as necessary).
