### PR TITLE
Release automation: create sdist on CI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,21 +20,43 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   macos:
     uses: ./.github/workflows/wheels-macos.yml
     with:
-      artifacts-name: "wheels"
+      artifacts-name: "dist"
 
   linux:
     uses: ./.github/workflows/wheels-linux.yml
     with:
-      artifacts-name: "wheels"
+      artifacts-name: "dist"
+
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+        cache: pip
+        cache-dependency-path: "Makefile"
+
+    - run: make sdist
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: dist/*.tar.gz
 
   success:
     permissions:
       contents: none
-    needs: [macos, linux]
+    needs: [macos, linux, sdist]
     runs-on: ubuntu-latest
     name: Wheels Successful
     steps:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,12 +20,8 @@ Released quarterly on January 2nd, April 1st, July 1st and October 15th.
   git tag 5.2.0
   git push --tags
   ```
-* [ ] Create and check source distribution:
-  ```bash
-  make sdist
-  ```
-* [ ] Create [binary distributions](https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#binary-distributions)
-* [ ] Check and upload all binaries and source distributions e.g.:
+* [ ] Create [source and binary distributions](https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#source-and-binary-distributions)
+* [ ] Check and upload all source and binary distributions e.g.:
   ```bash
   python3 -m twine check --strict dist/*
   python3 -m twine upload dist/Pillow-5.2.0*
@@ -59,8 +55,8 @@ Released as needed for security, installation or critical bug fixes.
   ```bash
   make sdist
   ```
-* [ ] Create [binary distributions](https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#binary-distributions)
-* [ ] Check and upload all binaries and source distributions e.g.:
+* [ ] Create [source and binary distributions](https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#source-and-binary-distributions)
+* [ ] Check and upload all source and binary distributions e.g.:
   ```bash
   python3 -m twine check --strict dist/*
   python3 -m twine upload dist/Pillow-5.2.1*
@@ -90,20 +86,20 @@ Released as needed privately to individual vendors for critical security-related
   ```bash
   make sdist
   ```
-* [ ] Create [binary distributions](https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#binary-distributions)
+* [ ] Create [source and binary distributions](https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#source-and-binary-distributions)
 * [ ] Publish the [release on GitHub](https://github.com/python-pillow/Pillow/releases) and then:
   ```bash
   git push origin 2.5.x
   ```
 
-## Binary Distributions
+## Source and Binary Distributions
 
 ### macOS and Linux
-* [ ] Download wheels from the [GitHub Actions "Wheels" workflow](https://github.com/python-pillow/Pillow/actions/workflows/wheels.yml)
+* [ ] Download sdist and wheels from the [GitHub Actions "Wheels" workflow](https://github.com/python-pillow/Pillow/actions/workflows/wheels.yml)
   and copy into `dist/`. For example using [GitHub CLI](https://github.com/cli/cli):
   ```bash
   gh run download --dir dist
-  # select wheels
+  # select dist
   ```
 * [ ] Download the Linux aarch64 wheels created by Travis CI from [GitHub releases](https://github.com/python-pillow/Pillow/releases)
   and copy into `dist`.


### PR DESCRIPTION
Next step of automation for https://github.com/python-pillow/Pillow/issues/7390.

This creates the sdist on the CI:

* No need to create it locally
* Safer to build on the CI than a potentially compromised local machine
* Better reproduciblity

The sdist is added as a new job to the `wheels.yml` workflow and added to the same GitHub artifact as the wheels, which I've renamed from `wheel` to `dist`.

<img width="645" alt="image" src="https://github.com/python-pillow/Pillow/assets/1324225/61b8615e-23bb-4778-a85f-6f7b6f928459">

---

We'll probably want to rename `wheels.yml` to something not specific to wheels (because we build a source distribution as well), I was thinking about renaming `deploy.yml` once we start publishing to PyPI, but open to renaming now as well.
