### PR TITLE
Tests: Replace `assert False` with `pytest.fail()`

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -95,7 +95,7 @@ def assert_image_equal(a, b, msg=None):
             except Exception:
                 pass
 
-        assert False, msg or "got different content"
+        pytest.fail(msg or "got different content")
 
 
 def assert_image_equal_tofile(a, filename, msg=None, mode=None):

--- a/Tests/test_file_iptc.py
+++ b/Tests/test_file_iptc.py
@@ -1,6 +1,8 @@
 import sys
 from io import BytesIO, StringIO
 
+import pytest
+
 from PIL import Image, IptcImagePlugin
 
 from .helper import hopper
@@ -44,7 +46,7 @@ def test_getiptcinfo_fotostation():
     for tag in iptc.keys():
         if tag[0] == 240:
             return
-    assert False, "FotoStation tag not found"
+    pytest.fail("FotoStation tag not found")
 
 
 def test_getiptcinfo_zero_padding():

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -416,7 +416,7 @@ def test_plt_marker():
     while True:
         marker = out.read(2)
         if not marker:
-            assert False, "End of stream without PLT"
+            pytest.fail("End of stream without PLT")
 
         jp2_boxid = _binary.i16be(marker)
         if jp2_boxid == 0xFF4F:
@@ -426,7 +426,7 @@ def test_plt_marker():
             # PLT
             return
         elif jp2_boxid == 0xFF93:
-            assert False, "SOD without finding PLT first"
+            pytest.fail("SOD without finding PLT first")
 
         hdr = out.read(2)
         length = _binary.i16be(hdr)

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -999,7 +999,7 @@ class TestImage:
         with Image.open(os.path.join("Tests/images", path)) as im:
             try:
                 im.load()
-                assert False
+                pytest.fail()
             except OSError as e:
                 buffer_overrun = str(e) == "buffer overrun when reading image file"
                 truncated = "image file is truncated" in str(e)
@@ -1010,7 +1010,7 @@ class TestImage:
         with Image.open("Tests/images/fli_overrun2.bin") as im:
             try:
                 im.seek(1)
-                assert False
+                pytest.fail()
             except OSError as e:
                 assert str(e) == "buffer overrun when reading image file"
 

--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -195,7 +195,7 @@ class TestReducingGapResize:
             (52, 34), Image.Resampling.BICUBIC, box=box, reducing_gap=1.0
         )
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(pytest.fail.Exception):
             assert_image_equal(ref, im)
 
         assert_image_similar(ref, im, epsilon)
@@ -210,7 +210,7 @@ class TestReducingGapResize:
             (52, 34), Image.Resampling.BICUBIC, box=box, reducing_gap=2.0
         )
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(pytest.fail.Exception):
             assert_image_equal(ref, im)
 
         assert_image_similar(ref, im, epsilon)
@@ -225,7 +225,7 @@ class TestReducingGapResize:
             (52, 34), Image.Resampling.BICUBIC, box=box, reducing_gap=3.0
         )
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(pytest.fail.Exception):
             assert_image_equal(ref, im)
 
         assert_image_similar(ref, im, epsilon)

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -147,7 +147,7 @@ def test_reducing_gap_values():
 
     ref = hopper()
     ref.thumbnail((18, 18), Image.Resampling.BICUBIC, reducing_gap=None)
-    with pytest.raises(AssertionError):
+    with pytest.raises(pytest.fail.Exception):
         assert_image_equal(ref, im)
 
     assert_image_similar(ref, im, 3.5)

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -85,7 +85,7 @@ def test_ipythonviewer():
             test_viewer = viewer
             break
     else:
-        assert False
+        pytest.fail()
 
     im = hopper()
     assert test_viewer.show(im) == 1


### PR DESCRIPTION
`pytest.fail()` gives slightly nicer errors:

https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest-fail


```python
import pytest


def test_a():
    assert False


def test_b():
    assert False, "abc"


def test_c():
    pytest.fail()


def test_d():
    pytest.fail("abc")
```

```python
============================================================================================= FAILURES =============================================================================================
______________________________________________________________________________________________ test_a ______________________________________________________________________________________________

    def test_a():
>       assert False
E       assert False

1.py:5: AssertionError
______________________________________________________________________________________________ test_b ______________________________________________________________________________________________

    def test_b():
>       assert False, "abc"
E       AssertionError: abc
E       assert False

1.py:9: AssertionError
______________________________________________________________________________________________ test_c ______________________________________________________________________________________________

    def test_c():
>       pytest.fail()
E       Failed

1.py:13: Failed
______________________________________________________________________________________________ test_d ______________________________________________________________________________________________

    def test_d():
>       pytest.fail("abc")
E       Failed: abc

1.py:17: Failed
===================================================================================== short test summary info ======================================================================================
FAILED 1.py::test_a - assert False
FAILED 1.py::test_b - AssertionError: abc
FAILED 1.py::test_c - Failed
FAILED 1.py::test_d - Failed: abc
======================================================================================== 4 failed in 0.06s =========================================================================================
```
