### PR TITLE
Determine mask mode in Python instead of C

### DIFF
--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -565,16 +565,16 @@ class FreeTypeFont:
         im = None
         size = None
 
-        def fill(mode, im_size):
+        def fill(width, height):
             nonlocal im, size
 
-            size = im_size
+            size = (width, height)
             if Image.MAX_IMAGE_PIXELS is not None:
-                pixels = max(1, size[0]) * max(1, size[1])
+                pixels = max(1, width) * max(1, height)
                 if pixels > 2 * Image.MAX_IMAGE_PIXELS:
                     return
 
-            im = Image.core.fill(mode, size)
+            im = Image.core.fill("RGBA" if mode == "RGBA" else "L", size)
             return im
 
         offset = self.font.render(

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -877,7 +877,7 @@ font_render(FontObject *self, PyObject *args) {
 
     width += stroke_width * 2 + ceil(x_start);
     height += stroke_width * 2 + ceil(y_start);
-    image = PyObject_CallFunction(fill, "s(ii)", strcmp(mode, "RGBA") == 0 ? "RGBA" : "L", width, height);
+    image = PyObject_CallFunction(fill, "ii", width, height);
     if (image == Py_None) {
         PyMem_Del(glyph_info);
         return Py_BuildValue("ii", 0, 0);


### PR DESCRIPTION
A minor cleanup.

At the moment, `getmask2` passes `mode` to the C method `font_render`, which determines if the image should be RGBA or L, and then passes that final mode back to Python.

The C method `font_render` doesn't change the value of the `mode` variable passed into it though, so rather than passing an extra piece of information back to Python, the mode can just be set in the Python layer.