### PR TITLE
Correct PDF palette size when saving

### DIFF
--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -96,7 +96,7 @@ def _write_image(im, filename, existing_pdf, image_refs):
         dict_obj["ColorSpace"] = [
             PdfParser.PdfName("Indexed"),
             PdfParser.PdfName("DeviceRGB"),
-            255,
+            len(palette) // 3 - 1,
             PdfParser.PdfBinary(palette),
         ]
         procset = "ImageI"  # indexed color


### PR DESCRIPTION
Resolves #7554

#7289 set the C palette to be empty by default. The issue has found that this causes P PDFs to appear blank. Testing, I find that the problem is that there can now be fewer than 256 palette entries saved to the PDF file, and that padding the palette to 256 entries fixes it.