### PR TITLE
If absent, do not try to close fp when closing image

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1014,6 +1014,21 @@ class TestImage:
             except OSError as e:
                 assert str(e) == "buffer overrun when reading image file"
 
+    @pytest.fixture(scope="function")
+    def inject_caplog(self, caplog):
+        self._caplog = caplog
+
+    @pytest.mark.usefixtures("inject_caplog")
+    def test_close_graceful(self):
+        with Image.open("Tests/images/hopper.jpg") as im:
+            copy = im.copy()
+            im.close()
+            copy.close()
+
+            assert len(self._caplog.records) == 0
+            assert im.fp is None
+            assert copy.fp is None
+
 
 class MockEncoder:
     pass

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -550,12 +550,13 @@ class Image:
         more information.
         """
         try:
-            if getattr(self, "_fp", False):
-                if self._fp != self.fp:
-                    self._fp.close()
-                self._fp = DeferredError(ValueError("Operation on closed image"))
-            if self.fp:
-                self.fp.close()
+            if hasattr(self, "fp"):
+                if getattr(self, "_fp", False):
+                    if self._fp != self.fp:
+                        self._fp.close()
+                    self._fp = DeferredError(ValueError("Operation on closed image"))
+                if self.fp:
+                    self.fp.close()
             self.fp = None
         except Exception as msg:
             logger.debug("Error closing: %s", msg)


### PR DESCRIPTION
Changes proposed in this pull request:

 *  Closes image when they are copied
 * Since image copied doesn't have 'fp' attribute, a message was logged as "error"
