### PR TITLE
Windows arm64 dependency cross-compilation fixes

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -375,7 +375,7 @@ DEPS = {
 
 
 # based on distutils._msvccompiler from CPython 3.7.4
-def find_msvs(architecture) -> dict[str, str] | None:
+def find_msvs(architecture: str) -> dict[str, str] | None:
     root = os.environ.get("ProgramFiles(x86)") or os.environ.get("ProgramFiles")
     if not root:
         print("Program Files not found")


### PR DESCRIPTION
For #6679 and https://github.com/python-pillow/Pillow/issues/7390#issuecomment-1813365035

When compiling Pillow directly on an ARM64 system, I found it worked after installing the correct Visual Studio components.
Cross-compiling required a few patches to the dependencies.

Changes proposed in this pull request:

 * Select Visual Studio version only if it has ARM64 build tools installed (https://github.com/python-pillow/Pillow/issues/6679#issuecomment-1295644192)
 * Fix ARM64 target detection when cross-compiling libjpeg-turbo (if NASM is installed) and libimagequant (https://github.com/python-pillow/Pillow/issues/6679#issuecomment-1292620454)
 * Do not cross-compile FriBiDi (https://github.com/python-pillow/Pillow/issues/6679#issuecomment-1295510138)
