### PR TITLE
Removed unnecessary string length check

### DIFF
--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -712,7 +712,6 @@ class TransposedFont:
         if self.orientation in (Image.Transpose.ROTATE_90, Image.Transpose.ROTATE_270):
             msg = "text length is undefined for text rotated by 90 or 270 degrees"
             raise ValueError(msg)
-        _string_length_check(text)
         return self.font.getlength(text, *args, **kwargs)
 
 


### PR DESCRIPTION
#7244 added `_string_length_check()` in several locations, including `TransposedFont.getlength()`. https://github.com/python-pillow/Pillow/blob/28c173f8d4767c7f6dd22dc840117fe641f4d3ee/src/PIL/ImageFont.py#L711-L716

However, `getlength()` is immediately called after the check, which itself calls `_string_length_check()`.

So this check is unnecessary and can be removed.