### PR TITLE
List optional dependencies in pyproject (apart from docs and tests)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ docs = [
   "sphinx-removed-in",
   "sphinxext-opengraph",
 ]
+fpx_mic = [
+  "olefile",
+]
 tests = [
   "check-manifest",
   "coverage",
@@ -58,6 +61,9 @@ tests = [
   "pytest",
   "pytest-cov",
   "pytest-timeout",
+]
+xmp = [
+  "defusedxml",
 ]
 [project.urls]
 Changelog = "https://github.com/python-pillow/Pillow/blob/main/CHANGES.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,10 @@ docs = [
   "sphinx-removed-in",
   "sphinxext-opengraph",
 ]
-fpx_mic = [
+fpx = [
+  "olefile",
+]
+mic = [
   "olefile",
 ]
 tests = [


### PR DESCRIPTION
In thinking about #7502, it occurred to me that listing `olefile` and `defusedxml` as optional dependencies in pyproject.toml is probably helpful, as a form of documentation.