### PR TITLE
Attempt memory mapping when tile args is a string

### DIFF
--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -187,6 +187,8 @@ class ImageFile(Image.Image):
         if use_mmap:
             # try memory mapping
             decoder_name, extents, offset, args = self.tile[0]
+            if isinstance(args, str):
+                args = (args, 0, 1)
             if (
                 decoder_name == "raw"
                 and len(args) >= 3

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -168,6 +168,9 @@ class WebPImageFile(ImageFile.ImageFile):
 
         return super().load()
 
+    def load_seek(self, pos):
+        pass
+
     def tell(self):
         if not _webp.HAVE_WEBPANIM:
             return super().tell()


### PR DESCRIPTION
Here is the logic used to determine whether or not to try memory mapping.
https://github.com/python-pillow/Pillow/blob/9694cfcfda5ca37b771caeaac260ec4d2fc09b58/src/PIL/ImageFile.py#L187-L195

It is expecting `args` to be a tuple, as in the following.
https://github.com/python-pillow/Pillow/blob/9694cfcfda5ca37b771caeaac260ec4d2fc09b58/src/PIL/SunImagePlugin.py#L125

However, here are a few place where the `args` for the "raw" tile is just a string.
https://github.com/python-pillow/Pillow/blob/9694cfcfda5ca37b771caeaac260ec4d2fc09b58/src/PIL/DdsImagePlugin.py#L163
https://github.com/python-pillow/Pillow/blob/9694cfcfda5ca37b771caeaac260ec4d2fc09b58/src/PIL/PsdImagePlugin.py#L265-L268
https://github.com/python-pillow/Pillow/blob/9694cfcfda5ca37b771caeaac260ec4d2fc09b58/src/PIL/WebPImagePlugin.py#L55
https://github.com/python-pillow/Pillow/blob/9694cfcfda5ca37b771caeaac260ec4d2fc09b58/src/PIL/WebPImagePlugin.py#L167

So this PR updates the logic in ImageFile to allow for this possibility as well.

Testing it however, [this](https://github.com/radarhere/Pillow/commit/599465b62a3178b692b2ca40442318fec1e3143a) causes [WebPImagePlugin to start failing](https://github.com/radarhere/Pillow/actions/runs/6943095361/job/18887431510#step:8:1561), so I've added `load_seek` to [stop it attempting memory mapping](https://github.com/python-pillow/Pillow/blob/9694cfcfda5ca37b771caeaac260ec4d2fc09b58/src/PIL/ImageFile.py#L174-L179).