### PR TITLE
Do not assign new fp attribute when exiting context manager

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1015,6 +1015,11 @@ class TestImage:
             except OSError as e:
                 assert str(e) == "buffer overrun when reading image file"
 
+    def test_exit_fp(self):
+        with Image.new("L", (1, 1)) as im:
+            pass
+        assert not hasattr(im, "fp")
+
     def test_close_graceful(self, caplog):
         with Image.open("Tests/images/hopper.jpg") as im:
             copy = im.copy()

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -527,15 +527,18 @@ class Image:
     def __enter__(self):
         return self
 
+    def _close_fp(self):
+        if getattr(self, "_fp", False):
+            if self._fp != self.fp:
+                self._fp.close()
+            self._fp = DeferredError(ValueError("Operation on closed image"))
+        if self.fp:
+            self.fp.close()
+
     def __exit__(self, *args):
         if hasattr(self, "fp"):
             if getattr(self, "_exclusive_fp", False):
-                if getattr(self, "_fp", False):
-                    if self._fp != self.fp:
-                        self._fp.close()
-                    self._fp = DeferredError(ValueError("Operation on closed image"))
-                if self.fp:
-                    self.fp.close()
+                self._close_fp()
             self.fp = None
 
     def close(self):
@@ -552,12 +555,7 @@ class Image:
         """
         if hasattr(self, "fp"):
             try:
-                if getattr(self, "_fp", False):
-                    if self._fp != self.fp:
-                        self._fp.close()
-                    self._fp = DeferredError(ValueError("Operation on closed image"))
-                if self.fp:
-                    self.fp.close()
+                self._close_fp()
                 self.fp = None
             except Exception as msg:
                 logger.debug("Error closing: %s", msg)

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -528,14 +528,15 @@ class Image:
         return self
 
     def __exit__(self, *args):
-        if hasattr(self, "fp") and getattr(self, "_exclusive_fp", False):
-            if getattr(self, "_fp", False):
-                if self._fp != self.fp:
-                    self._fp.close()
-                self._fp = DeferredError(ValueError("Operation on closed image"))
-            if self.fp:
-                self.fp.close()
-        self.fp = None
+        if hasattr(self, "fp"):
+            if getattr(self, "_exclusive_fp", False):
+                if getattr(self, "_fp", False):
+                    if self._fp != self.fp:
+                        self._fp.close()
+                    self._fp = DeferredError(ValueError("Operation on closed image"))
+                if self.fp:
+                    self.fp.close()
+            self.fp = None
 
     def close(self):
         """


### PR DESCRIPTION
At the moment,
```python
from PIL import Image
with Image.new("L", (1, 1)) as im:
  print(hasattr(im, "fp"))
print(hasattr(im, "fp"))
```
gives
```
False
True
```
`im` does not have an `fp` attribute inside the context manager, but once it leaves, it is set.

This PR keeps it unset.
