### PR TITLE
"optimize" default when saving GIF images

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -266,9 +266,12 @@ following options are available::
     :py:class:`PIL.ImagePalette.ImagePalette` object.
 
 **optimize**
-    If present and true, attempt to compress the palette by
-    eliminating unused colors. This is only useful if the palette can
-    be compressed to the next smaller power of 2 elements.
+    Whether to attempt to compress the palette by eliminating unused colors.
+    This is attempted by default, unless a palette is specified as an option or
+    as part of the first image's :py:attr:`~PIL.Image.Image.info` dictionary.
+
+    This is only useful if the palette can be compressed to the next smaller
+    power of 2 elements.
 
 Note that if the image you are saving comes from an existing GIF, it may have
 the following properties in its :py:attr:`~PIL.Image.Image.info` dictionary.

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -656,7 +656,7 @@ def _save(im, fp, filename, save_all=False):
         palette = im.encoderinfo.get("palette", im.info.get("palette"))
     else:
         palette = None
-        im.encoderinfo["optimize"] = im.encoderinfo.get("optimize", True)
+        im.encoderinfo.setdefault("optimize", True)
 
     if not save_all or not _write_multiple_frames(im, fp, palette):
         _write_single_frame(im, fp, palette)


### PR DESCRIPTION
https://pillow.readthedocs.io/en/latest/handbook/image-file-formats.html#gif-saving states that when saving GIF, you can specify "optimize", and that it is off by default.
> **optimize**
> If present and true, attempt to compress the palette by eliminating unused colors. This is only useful if the palette can be compressed to the next smaller power of 2 elements.

This doesn't line up with the reality - it is only off by default if "palette" is provided in `im.encoderinfo` or `im.info`.

https://github.com/python-pillow/Pillow/blob/04a4d54275bb45288e3a6057a914f667e159b348/src/PIL/GifImagePlugin.py#L653-L659

This PR corrects the documentation, and also simplifies the code by using `setdefault()`.