### PR TITLE
Install cibuildwheel from requirements file

### DIFF
--- a/.ci/requirements-cibw.txt
+++ b/.ci/requirements-cibw.txt
@@ -1,0 +1,1 @@
+cibuildwheel==2.16.2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -52,10 +52,14 @@ jobs:
         with:
           submodules: true
 
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+      - uses: actions/setup-python@v4
         with:
-          output-dir: wheelhouse
+          python-version: "3.x"
+
+      - name: Build wheels
+        run: |
+          python3 -m pip install -r .ci/requirements-cibw.txt
+          python3 -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD: ${{ matrix.build }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
         - CIBW_BUILD="*musllinux*"
 
 install:
-    - python3 -m pip install cibuildwheel==2.16.2
+    - python3 -m pip install -r .ci/requirements-cibw.txt
 
 script:
     - python3 -m cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/issues/7390.

Switch back to the PyPI-installed cibuildwheel for GitHub Actions, also use it from Travis CI.

* https://cibuildwheel.readthedocs.io/en/stable/faq/#option-2-requirement-files

The upcoming Windows wheel build can't use the action, so Renovate can update all three at the same time.

* https://github.com/python-pillow/Pillow/pull/7580#discussion_r1406769153
