### PR TITLE
Raise ValueError when TrueType font size is zero or less

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -1074,6 +1074,6 @@ def test_raqm_missing_warning(monkeypatch):
 
 
 @pytest.mark.parametrize("size", [-1, 0])
-def test_invalid_truetype_sizes_raise(layout_engine, size):
+def test_invalid_truetype_sizes_raise_valueerror(layout_engine, size):
     with pytest.raises(ValueError):
         ImageFont.truetype(FONT_PATH, size, layout_engine=layout_engine)

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -1071,3 +1071,9 @@ def test_raqm_missing_warning(monkeypatch):
         "Raqm layout was requested, but Raqm is not available. "
         "Falling back to basic layout."
     )
+
+
+@pytest.mark.parametrize("size", [-1, 0])
+def test_invalid_truetype_sizes_raise(layout_engine, size):
+    with pytest.raises(ValueError):
+        ImageFont.truetype(FONT_PATH, size, layout_engine=layout_engine)

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -788,7 +788,12 @@ def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):
                      .. versionadded:: 4.2.0
     :return: A font object.
     :exception OSError: If the file could not be read.
+    :exception ValueError: If the font size is not greater than zero.
     """
+
+    if size <= 0:
+        msg = "font size must be greater than 0"
+        raise ValueError(msg)
 
     def freetype(font):
         return FreeTypeFont(font, size, index, encoding, layout_engine)


### PR DESCRIPTION
Fixes #7583

## Changes proposed in this pull request:

* Validate `size` before FreeType gets to raise an "invalid ppem value" or "invalid argument" for us.