### PR TITLE
Add gcc problem matcher to test.yml

### DIFF
--- a/.github/problem-matchers/gcc.json
+++ b/.github/problem-matchers/gcc.json
@@ -1,0 +1,18 @@
+{
+    "__comment": "Based on vscode-cpptools' Extension/package.json gcc rule",
+    "problemMatcher": [
+        {
+            "owner": "gcc-problem-matcher",
+            "pattern": [
+                {
+                    "regexp": "^\\s*(.*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,10 @@ jobs:
       env:
         GHA_PYTHON_VERSION: ${{ matrix.python-version }}
 
+    - name: Register gcc problem matcher
+      if: "matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'"
+      run: echo "::add-matcher::.github/problem-matchers/gcc.json"
+
     - name: Build
       run: |
         .ci/build.sh


### PR DESCRIPTION
Similar to https://github.com/python/cpython/pull/18567, but I found there are extra spaces printed before the file name.
Would help find issues like https://github.com/python-pillow/Pillow/pull/7497#discussion_r1406492621 faster.

The matcher is only run on a single Ubuntu job to prevent duplicate annotations; I found that the macOS jobs created two annotations per warning.

See https://github.com/nulano/Pillow/pull/25 for an example.

Not adding a problem matcher for MSVC yet because there are already many warnings that need to be fixed first to avoid noise.