### PR TITLE
Moved error from truetype() to FreeTypeFont

### DIFF
--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -188,6 +188,10 @@ class FreeTypeFont:
     def __init__(self, font=None, size=10, index=0, encoding="", layout_engine=None):
         # FIXME: use service provider instead
 
+        if size <= 0:
+            msg = "font size must be greater than 0"
+            raise ValueError(msg)
+
         self.path = font
         self.size = size
         self.index = index
@@ -790,10 +794,6 @@ def truetype(font=None, size=10, index=0, encoding="", layout_engine=None):
     :exception OSError: If the file could not be read.
     :exception ValueError: If the font size is not greater than zero.
     """
-
-    if size <= 0:
-        msg = "font size must be greater than 0"
-        raise ValueError(msg)
 
     def freetype(font):
         return FreeTypeFont(font, size, index, encoding, layout_engine)


### PR DESCRIPTION
Follow up to #7584

Since `ImageFont.truetype()` really just constructs an `ImageFont.FreeTypeFont` instance, I think it makes sense to move the new ValueError from `ImageFont.truetype()` to `ImageFont.FreeTypeFont`, allowing `ImageFont.FreeTypeFont` to also have this validation.