### PR TITLE
Update Windows wheels info

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -94,7 +94,6 @@ Released as needed privately to individual vendors for critical security-related
 
 ## Source and Binary Distributions
 
-### macOS and Linux
 * [ ] Download sdist and wheels from the [GitHub Actions "Wheels" workflow](https://github.com/python-pillow/Pillow/actions/workflows/wheels.yml)
   and copy into `dist/`. For example using [GitHub CLI](https://github.com/cli/cli):
   ```bash
@@ -103,14 +102,6 @@ Released as needed privately to individual vendors for critical security-related
   ```
 * [ ] Download the Linux aarch64 wheels created by Travis CI from [GitHub releases](https://github.com/python-pillow/Pillow/releases)
   and copy into `dist`.
-
-### Windows
-* [ ] Download the artifacts from the [GitHub Actions "Test Windows" workflow](https://github.com/python-pillow/Pillow/actions/workflows/test-windows.yml)
-  and copy into `dist/`. For example using [GitHub CLI](https://github.com/cli/cli):
-  ```bash
-  gh run download --dir dist
-  # select dist-x.y.z
-  ```
 
 ## Publicize Release
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -95,11 +95,10 @@ and :pypi:`olefile` for Pillow to read FPX and MIC images::
 
 .. tab:: Windows
 
-    .. warning:: Pillow > 9.5.0 no longer includes 32-bit wheels.
-
-    We provide Pillow binaries for Windows compiled for the matrix of
-    supported Pythons in 64-bit versions in the wheel format. These binaries include
-    support for all optional libraries except libimagequant and libxcb. Raqm support
+    We provide Pillow binaries for Windows compiled for the matrix of supported
+    Pythons in the wheel format. These include x86, x86-64 and arm64 versions
+    (with the exception of Python 3.8 on arm64). These binaries include support
+    for all optional libraries except libimagequant and libxcb. Raqm support
     requires FriBiDi to be installed separately::
 
         python3 -m pip install --upgrade pip


### PR DESCRIPTION
Update Windows wheels information in light of #7580 restoring 32-bit wheels for Windows and adding arm64 wheels.

This reverts #7347 and #7447