### PR TITLE
Fixed closing file pointer with olefile 0.47

### DIFF
--- a/src/PIL/FpxImagePlugin.py
+++ b/src/PIL/FpxImagePlugin.py
@@ -227,6 +227,7 @@ class FpxImageFile(ImageFile.ImageFile):
                     break  # isn't really required
 
         self.stream = stream
+        self._fp = self.fp
         self.fp = None
 
     def load(self):

--- a/src/PIL/MicImagePlugin.py
+++ b/src/PIL/MicImagePlugin.py
@@ -66,6 +66,7 @@ class MicImageFile(TiffImagePlugin.TiffImageFile):
         self._n_frames = len(self.images)
         self.is_animated = self._n_frames > 1
 
+        self.__fp = self.fp
         self.seek(0)
 
     def seek(self, frame):
@@ -87,10 +88,12 @@ class MicImageFile(TiffImagePlugin.TiffImageFile):
         return self.frame
 
     def close(self):
+        self.__fp.close()
         self.ole.close()
         super().close()
 
     def __exit__(self, *args):
+        self.__fp.close()
         self.ole.close()
         super().__exit__()
 


### PR DESCRIPTION
[olefile 0.47](https://pypi.org/project/olefile/0.47/) was released in the last day. It has made a change since 0.46, that if it did not open a file pointer, it will no longer close it with `close()`. This is mentioned on PyPI as 'improved file closure'.

This has broken our file closing tests in the [Test](https://github.com/python-pillow/Pillow/actions/runs/7065902689/job/19236794955#step:8:651) and [Test Windows](https://github.com/python-pillow/Pillow/actions/runs/7065904261/job/19236800345#step:27:647) workflows for FPX and MIC.

To fix them,
- for FPX, I have simply kept the original file pointer as `self._fp`, which is then closed by [`Image.close()`](https://github.com/python-pillow/Pillow/blob/76446ee45066554380e08b2f0c4c514f43a297c1/src/PIL/Image.py#L556) or [`Image.__exit__()`](https://github.com/python-pillow/Pillow/blob/76446ee45066554380e08b2f0c4c514f43a297c1/src/PIL/Image.py#L534).
- MIC [uses](https://github.com/python-pillow/Pillow/blob/76446ee45066554380e08b2f0c4c514f43a297c1/src/PIL/MicImagePlugin.py#L82) TiffImagePlugin which also [uses `_fp`](https://github.com/python-pillow/Pillow/blob/76446ee45066554380e08b2f0c4c514f43a297c1/src/PIL/TiffImagePlugin.py#L1098), so I have slightly less simply kept the original file pointer as `self.__fp` and closed it within MicImagePlugin.

I checked that this still works with olefile 0.46 by [downgrading it](https://github.com/radarhere/Pillow/commit/57b222e6395876fa3028c71942f2ec1be6f1c2bc) and observing that it passes on the [Test](https://github.com/radarhere/Pillow/actions/runs/7066487172) and [Test WIndows](https://github.com/radarhere/Pillow/actions/runs/7066487171) workflows.