### PR TITLE
Optimization of ImageStat.Stat._getcount method

### DIFF
--- a/src/PIL/ImageStat.py
+++ b/src/PIL/ImageStat.py
@@ -21,9 +21,7 @@
 # See the README file for information on usage and redistribution.
 #
 
-import functools
 import math
-import operator
 
 
 class Stat:

--- a/src/PIL/ImageStat.py
+++ b/src/PIL/ImageStat.py
@@ -67,7 +67,7 @@ class Stat:
     def _getcount(self):
         """Get total number of pixels in each layer"""
 
-        return [sum(self.h[i: i + 256]) for i in range(0, len(self.h), 256)]
+        return [sum(self.h[i : i + 256]) for i in range(0, len(self.h), 256)]
 
     def _getsum(self):
         """Get sum of all pixels in each layer"""

--- a/src/PIL/ImageStat.py
+++ b/src/PIL/ImageStat.py
@@ -69,10 +69,7 @@ class Stat:
     def _getcount(self):
         """Get total number of pixels in each layer"""
 
-        v = []
-        for i in range(0, len(self.h), 256):
-            v.append(functools.reduce(operator.add, self.h[i : i + 256]))
-        return v
+        return [sum(self.h[i: i + 256]) for i in range(0, len(self.h), 256)]
 
     def _getsum(self):
         """Get sum of all pixels in each layer"""


### PR DESCRIPTION
The optimized function improves the performance. The new implementation uses "sum" instead of the construct
"functools.reduce(operator.add, ...)". Tests showed that the new function is about three times faster than the original. Also it is shorter and easier to read and the dependency to functools and operator modules can be removed.

Changes proposed in this pull request:

 * Performance optimized ImageStat _getcount function
