### PR TITLE
Document JPEG `streamtype` option

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -521,6 +521,19 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
 
     .. versionadded:: 2.5.0
 
+**streamtype**
+    Allows storing images without quantization and Huffman tables, or with
+    these tables but without image data.  This is useful for container formats
+    or network protocols that handle tables separately and share them between
+    images.
+
+    * ``0`` (default): interchange datastream, with tables and image data
+    * ``1``: abbreviated table specification (tables-only) datastream
+
+      .. versionadded:: 10.2.0
+
+    * ``2``: abbreviated image (image-only) datastream
+
 **comment**
     A comment about the image.
 


### PR DESCRIPTION
`streamtype=1` is new in 10.2.0 (#7491); the other values have existed since Git pre-history.

See also [libjpeg-turbo's documentation](https://github.com/libjpeg-turbo/libjpeg-turbo/blob/abeca1f0cc638a6492d81f4c3b956c2dec817c3e/libjpeg.txt#L2429-L2459) on abbreviated datastreams.