### PR TITLE
Update pre-commit to fix Sphinx Lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.6
+    rev: v0.1.7
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.11.0
+    rev: 23.12.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.5
+    rev: 1.7.6
     hooks:
     - id: bandit
       args: [--severity-level=high]
@@ -42,7 +42,7 @@ repos:
         exclude: ^.github/.*TEMPLATE|^Tests/(fonts|images)/
 
   - repo: https://github.com/sphinx-contrib/sphinx-lint
-    rev: v0.9.0
+    rev: v0.9.1
     hooks:
       - id: sphinx-lint
 


### PR DESCRIPTION
There was a change in Hatchling that needed a new Sphinx Lint release, let's update to fix pre-commit.

Re: https://github.com/sphinx-contrib/sphinx-lint/pull/106