### PR TITLE
Check types with mypy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [push, pull_request, workflow_dispatch]
 
+env:
+  FORCE_COLOR: 1
+
 permissions:
   contents: read
 
@@ -46,3 +49,6 @@ jobs:
       run: tox -e lint
       env:
         PRE_COMMIT_COLOR: always
+
+    - name: Mypy
+      run: tox -e mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ test-command = "cd {project} && .github/workflows/wheels-test.sh"
 test-extras = "tests"
 
 [tool.ruff]
-line-length = 88
 select = [
   "C4", # flake8-comprehensions
   "E", # pycodestyle errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,3 +125,34 @@ known-first-party = ["PIL"]
 [tool.pytest.ini_options]
 addopts = "-ra --color=yes"
 testpaths = ["Tests"]
+
+[tool.mypy]
+python_version = "3.8"
+pretty = true
+disallow_any_generics = true
+enable_error_code = "ignore-without-code"
+extra_checks = true
+follow_imports = "silent"
+warn_redundant_casts = true
+warn_unreachable = true
+warn_unused_ignores = true
+exclude = [
+  '^src/PIL/_tkinter_finder.py$',
+  '^src/PIL/DdsImagePlugin.py$',
+  '^src/PIL/FpxImagePlugin.py$',
+  '^src/PIL/Image.py$',
+  '^src/PIL/ImageCms.py$',
+  '^src/PIL/ImageFile.py$',
+  '^src/PIL/ImageFont.py$',
+  '^src/PIL/ImageMath.py$',
+  '^src/PIL/ImageMorph.py$',
+  '^src/PIL/ImageQt.py$',
+  '^src/PIL/ImageShow.py$',
+  '^src/PIL/ImImagePlugin.py$',
+  '^src/PIL/MicImagePlugin.py$',
+  '^src/PIL/PdfParser.py$',
+  '^src/PIL/PyAccess.py$',
+  '^src/PIL/TiffImagePlugin.py$',
+  '^src/PIL/TiffTags.py$',
+  '^src/PIL/WebPImagePlugin.py$',
+]

--- a/tox.ini
+++ b/tox.ini
@@ -29,3 +29,10 @@ pass_env =
 commands =
     pre-commit run --all-files --show-diff-on-failure
     check-manifest
+
+[testenv:mypy]
+skip_install = true
+deps =
+    mypy==1.7.1
+commands =
+    mypy src {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -34,5 +34,6 @@ commands =
 skip_install = true
 deps =
     mypy==1.7.1
+    numpy
 commands =
     mypy src {posargs}


### PR DESCRIPTION
Helps #2625.

Run mypy to check type hints:

```sh
tox -e mypy
```

Some good advice here:

* https://mypy.readthedocs.io/en/stable/existing_code.html

So let's start off small with just the `src` directory, and exclude lots of files with warnings, currently 61, so it's running on 34 to begin with.

This adds some fairly lenient settings (happy to tweak them now and later), notably `follow_imports = "silent"`.

When mypy encounters an import, it also checks the imported file, and its imports. They recommend using the default "normal", but lots of things import others which aren't ready yet, so let's change it when we can.

* https://mypy.readthedocs.io/en/stable/running_mypy.html#following-imports
