### PR TITLE
ImageMath: Inline `isinstance` check

### DIFF
--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -20,10 +20,6 @@ import builtins
 from . import Image, _imagingmath
 
 
-def _isconstant(v):
-    return isinstance(v, (int, float))
-
-
 class _Operand:
     """Wraps an image operand, providing standard operators"""
 
@@ -43,7 +39,7 @@ class _Operand:
                 raise ValueError(msg)
         else:
             # argument was a constant
-            if _isconstant(im1) and self.im.mode in ("1", "L", "I"):
+            if isinstance(im1, (int, float)) and self.im.mode in ("1", "L", "I"):
                 return Image.new("I", self.im.size, im1)
             else:
                 return Image.new("F", self.im.size, im1)


### PR DESCRIPTION
`_isconstant()` is short and only called once, we might as well inline it, it's also quicker:

```console
❯ python -m timeit -s "def _isconstant(v): return isinstance(v, (int, float))" "_isconstant(12.34)"
5000000 loops, best of 5: 54.1 nsec per loop

❯ python -m timeit "isinstance(12.34, (int, float))"
10000000 loops, best of 5: 38.3 nsec per loop
```


History:

The current one is from 2019:

```python
def _isconstant(v):
    return isinstance(v, (int, float))
```

The 2013, 2to3 version was:

```python
def _isconstant(v):
    return isinstance(v, int) or isinstance(v, float)
```

The original 2006, PIL 1.1.6 version was:

```python
def _isconstant(v):
    return isinstance(v, type(0)) or isinstance(v, type(0.0))
```