### PR TITLE
Compile FriBiDi for Windows ARM64

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -159,17 +159,11 @@ jobs:
           name: dist
           path: ./wheelhouse/*.whl
 
-      - name: Prepare to upload FriBiDi
-        run: |
-          mkdir fribidi\${{ matrix.arch }}
-          copy winbuild\build\bin\fribidi* fribidi\${{ matrix.arch }}
-        shell: cmd
-
       - name: Upload fribidi.dll
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: fribidi
-          path: fribidi\*
+          name: fribidi-windows-${{ matrix.arch }}
+          path: winbuild\build\bin\fribidi*
 
   sdist:
     runs-on: ubuntu-latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -116,10 +116,7 @@ jobs:
 
           & python.exe -m pip install -r .ci/requirements-cibw.txt
 
-          # Cannot cross-compile FriBiDi (only used for tests)
-          $FLAGS = ("--no-imagequant", "--architecture=${{ matrix.arch }}")
-          if ('${{ matrix.arch }}' -eq 'ARM64') { $FLAGS += "--no-fribidi" }
-          & python.exe winbuild\build_prepare.py -v @FLAGS
+          & python.exe winbuild\build_prepare.py -v --no-imagequant --architecture=${{ matrix.arch }}
         shell: pwsh
 
       - name: Build wheels
@@ -163,14 +160,12 @@ jobs:
           path: ./wheelhouse/*.whl
 
       - name: Prepare to upload FriBiDi
-        if: "matrix.arch != 'ARM64'"
         run: |
           mkdir fribidi\${{ matrix.arch }}
           copy winbuild\build\bin\fribidi* fribidi\${{ matrix.arch }}
         shell: cmd
 
       - name: Upload fribidi.dll
-        if: "matrix.arch != 'ARM64'"
         uses: actions/upload-artifact@v3
         with:
           name: fribidi

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -76,7 +76,7 @@ def cmds_cmake(
                 *params,
                 '-G "{cmake_generator}"',
                 f'-B "{build_dir}"',
-                f"-S .",
+                "-S .",
             ]
         ),
         f'{{cmake}} --build "{build_dir}" --clean-first --parallel --target {target}',

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -56,7 +56,9 @@ def cmd_nmake(
     )
 
 
-def cmds_cmake(target: str | tuple[str, ...] | list[str], *params) -> list[str]:
+def cmds_cmake(
+    target: str | tuple[str, ...] | list[str], *params, build_dir: str = "."
+) -> list[str]:
     if not isinstance(target, str):
         target = " ".join(target)
 
@@ -73,10 +75,11 @@ def cmds_cmake(target: str | tuple[str, ...] | list[str], *params) -> list[str]:
                 "-DCMAKE_CXX_FLAGS=-nologo",
                 *params,
                 '-G "{cmake_generator}"',
-                ".",
+                f'-B "{build_dir}"',
+                f"-S .",
             ]
         ),
-        f"{{cmake}} --build . --clean-first --parallel --target {target}",
+        f'{{cmake}} --build "{build_dir}" --clean-first --parallel --target {target}',
     ]
 
 
@@ -367,7 +370,14 @@ DEPS = {
         "build": [
             cmd_copy(r"COPYING", r"{bin_dir}\fribidi-1.0.13-COPYING"),
             cmd_copy(r"{winbuild_dir}\fribidi.cmake", r"CMakeLists.txt"),
-            *cmds_cmake("fribidi"),
+            # generated tab.i files cannot be cross-compiled
+            " ^&^& ".join(
+                [
+                    "if {architecture}==ARM64 cmd /c call {vcvarsall} x86",
+                    *cmds_cmake("fribidi-gen", "-DARCH=x86", build_dir="build_x86"),
+                ]
+            ),
+            *cmds_cmake("fribidi", "-DARCH={architecture}"),
         ],
         "bins": [r"*.dll"],
     },
@@ -381,10 +391,9 @@ def find_msvs(architecture: str) -> dict[str, str] | None:
         print("Program Files not found")
         return None
 
+    requires = ["-requires", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"]
     if architecture == "ARM64":
-        tools = "Microsoft.VisualStudio.Component.VC.Tools.ARM64"
-    else:
-        tools = "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
+        requires += ["-requires", "Microsoft.VisualStudio.Component.VC.Tools.ARM64"]
 
     try:
         vspath = (
@@ -395,8 +404,7 @@ def find_msvs(architecture: str) -> dict[str, str] | None:
                     ),
                     "-latest",
                     "-prerelease",
-                    "-requires",
-                    tools,
+                    *requires,
                     "-property",
                     "installationPath",
                     "-products",
@@ -706,11 +714,6 @@ if __name__ == "__main__":
     if args.no_imagequant:
         disabled += ["libimagequant"]
     if args.no_fribidi:
-        disabled += ["fribidi"]
-    elif args.architecture == "ARM64" and platform.machine() != "ARM64":
-        import warnings
-
-        warnings.warn("Cross-compiling FriBiDi is currently not supported, disabling")
         disabled += ["fribidi"]
 
     prefs = {


### PR DESCRIPTION
Add a build of ARM64 fribidi.dll to the wheels workflow.

This will simplify manually testing the ARM64 wheels on release day as well as allow users to download a pre-compiled DLL.

Since [CMake does not support mixed host and cross compiling in the same project](https://stackoverflow.com/a/9545369/1648883), the ARM64 build of fribidi.dll is now split into two steps (inspired by [this StackOverflow answer](https://stackoverflow.com/a/36084786/1648883)):
* compile and run helper programs using x86 architecture (x86 programs can also be run on ARM64 using builtin emulation),
* compile fribidi.dll for ARM64 using generated tables from the previous step.

I've also removed the "Prepare to upload FriBiDi" step as it is no longer used with `actions/upload-artifact@v4`.

I've tested the changes as follows.

I first installed the built `pillow-10.2.0.dev0-cp312-cp312-win_arm64` on an ARM64 Windows VM and ran Pytest:
```
C:\Users\UTM\Downloads\Pillow-arm64-fribidi-2\Pillow-arm64-fribidi-2>path
PATH=C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Users\UTM\AppData\Local\Microsoft\WindowsApps

C:\Users\UTM\Downloads\Pillow-arm64-fribidi-2\Pillow-arm64-fribidi-2>"\Program Files\Python312-arm64\python.exe" -m pytest Tests
=== test session starts ===
platform win32 -- Python 3.12.0, pytest-7.4.3, pluggy-1.3.0
--------------------------------------------------------------------
Pillow 10.2.0.dev0
Python 3.12.0 (tags/v3.12.0:0fb18b0, Oct  2 2023, 13:15:47) [MSC v.1935 64 bit (ARM64)]
--------------------------------------------------------------------
Python modules loaded from C:\Program Files\Python312-arm64\Lib\site-packages\PIL
Binary modules loaded from C:\Program Files\Python312-arm64\Lib\site-packages\PIL
--------------------------------------------------------------------
...
*** RAQM (Bidirectional Text) support not installed
...
=== 2999 passed, 296 skipped, 3 xfailed, 1 xpassed in 82.71s (0:01:22) ===
```

I then added the path to the extracted `fribidi-windows-ARM64` artifact to PATH (i.e. cross compiled on GHA) and ran Pytest again:
```
C:\Users\UTM\Downloads\Pillow-arm64-fribidi-2\Pillow-arm64-fribidi-2>path
PATH=C:\Users\UTM\Downloads\windows-fribidi-ARM64\;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Users\UTM\AppData\Local\Microsoft\WindowsApps
...
--- RAQM (Bidirectional Text) support ok, loaded 0.10.1, fribidi 1.0.13, harfbuzz 8.3.0
...
=== 3169 passed, 126 skipped, 3 xfailed, 1 xpassed in 68.30s (0:01:08) ===
```

And finally, I ran `build_prepare.py` and the generated `build_dep_fribidi.cmd` on the ARM64 VM, replaced the directory in PATH with the new build, and ran Pytest for a third time:
```
C:\Users\UTM\Downloads\Pillow-arm64-fribidi-2\Pillow-arm64-fribidi-2>path
PATH=C:\Users\UTM\Downloads\Pillow-arm64-fribidi-2\Pillow-arm64-fribidi-2\winbuild\build\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Users\UTM\AppData\Local\Microsoft\WindowsApps
...
--- RAQM (Bidirectional Text) support ok, loaded 0.10.1, fribidi 1.0.13, harfbuzz 8.3.0
...
=== 3169 passed, 126 skipped, 3 xfailed, 1 xpassed in 71.89s (0:01:11) ===
```