### PR TITLE
Add `from __future__ import annotations` using Ruff/isort

### DIFF
--- a/.github/workflows/system-info.py
+++ b/.github/workflows/system-info.py
@@ -6,6 +6,8 @@ This sort of info is missing from GitHub Actions.
 Requested here:
 https://github.com/actions/virtual-environments/issues/79
 """
+from __future__ import annotations
+
 import os
 import platform
 import sys

--- a/Tests/32bit_segfault_check.py
+++ b/Tests/32bit_segfault_check.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 import sys
 

--- a/Tests/bench_cffi_access.py
+++ b/Tests/bench_cffi_access.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import time
 
 from PIL import PyAccess

--- a/Tests/check_fli_oob.py
+++ b/Tests/check_fli_oob.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 from PIL import Image
 

--- a/Tests/check_fli_overflow.py
+++ b/Tests/check_fli_overflow.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PIL import Image
 
 TEST_FILE = "Tests/images/fli_overflow.fli"

--- a/Tests/check_icns_dos.py
+++ b/Tests/check_icns_dos.py
@@ -1,5 +1,6 @@
 # Tests potential DOS of IcnsImagePlugin with 0 length block.
 # Run from anywhere that PIL is importable.
+from __future__ import annotations
 
 from io import BytesIO
 

--- a/Tests/check_imaging_leaks.py
+++ b/Tests/check_imaging_leaks.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/check_j2k_dos.py
+++ b/Tests/check_j2k_dos.py
@@ -1,5 +1,6 @@
 # Tests potential DOS of Jpeg2kImagePlugin with 0 length block.
 # Run from anywhere that PIL is importable.
+from __future__ import annotations
 
 from io import BytesIO
 

--- a/Tests/check_j2k_leaks.py
+++ b/Tests/check_j2k_leaks.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from io import BytesIO
 
 import pytest

--- a/Tests/check_j2k_overflow.py
+++ b/Tests/check_j2k_overflow.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/check_jp2_overflow.py
+++ b/Tests/check_jp2_overflow.py
@@ -12,6 +12,7 @@
 # the output should be empty. There may be python issues
 # in the valgrind especially if run in a debug python
 # version.
+from __future__ import annotations
 
 
 from PIL import Image

--- a/Tests/check_jpeg_leaks.py
+++ b/Tests/check_jpeg_leaks.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from io import BytesIO
 
 import pytest

--- a/Tests/check_large_memory.py
+++ b/Tests/check_large_memory.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 
 import pytest

--- a/Tests/check_large_memory_numpy.py
+++ b/Tests/check_large_memory_numpy.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 
 import pytest

--- a/Tests/check_libtiff_segfault.py
+++ b/Tests/check_libtiff_segfault.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/check_png_dos.py
+++ b/Tests/check_png_dos.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import zlib
 from io import BytesIO
 

--- a/Tests/check_release_notes.py
+++ b/Tests/check_release_notes.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 from pathlib import Path
 

--- a/Tests/check_wheel.py
+++ b/Tests/check_wheel.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 
 from PIL import features

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import io
 
 

--- a/Tests/createfontdatachunk.py
+++ b/Tests/createfontdatachunk.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 import base64
 import os
 

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -1,6 +1,7 @@
 """
 Helper functions.
 """
+from __future__ import annotations
 
 import logging
 import os

--- a/Tests/oss-fuzz/fuzz_font.py
+++ b/Tests/oss-fuzz/fuzz_font.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 
 import atheris

--- a/Tests/oss-fuzz/fuzz_pillow.py
+++ b/Tests/oss-fuzz/fuzz_pillow.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 
 import atheris

--- a/Tests/oss-fuzz/fuzzers.py
+++ b/Tests/oss-fuzz/fuzzers.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import io
 import warnings
 

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import subprocess
 import sys
 

--- a/Tests/test_000_sanity.py
+++ b/Tests/test_000_sanity.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PIL import Image
 
 

--- a/Tests/test_binary.py
+++ b/Tests/test_binary.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PIL import _binary
 
 

--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import warnings
 

--- a/Tests/test_box_blur.py
+++ b/Tests/test_box_blur.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageFilter

--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from array import array
 
 import pytest

--- a/Tests/test_core_resources.py
+++ b/Tests/test_core_resources.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 
 import pytest

--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/test_deprecate.py
+++ b/Tests/test_deprecate.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import _deprecate

--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import io
 import re
 

--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageSequence, PngImagePlugin

--- a/Tests/test_file_blp.py
+++ b/Tests/test_file_blp.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import io
 
 import pytest

--- a/Tests/test_file_bufrstub.py
+++ b/Tests/test_file_bufrstub.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import BufrStubImagePlugin, Image

--- a/Tests/test_file_container.py
+++ b/Tests/test_file_container.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import ContainerIO, Image

--- a/Tests/test_file_cur.py
+++ b/Tests/test_file_cur.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import CurImagePlugin, Image

--- a/Tests/test_file_dcx.py
+++ b/Tests/test_file_dcx.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import warnings
 
 import pytest

--- a/Tests/test_file_dds.py
+++ b/Tests/test_file_dds.py
@@ -1,4 +1,5 @@
 """Test DdsImagePlugin"""
+from __future__ import annotations
 from io import BytesIO
 
 import pytest

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import io
 
 import pytest

--- a/Tests/test_file_fits.py
+++ b/Tests/test_file_fits.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from io import BytesIO
 
 import pytest

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import warnings
 
 import pytest

--- a/Tests/test_file_fpx.py
+++ b/Tests/test_file_fpx.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/test_file_ftex.py
+++ b/Tests/test_file_ftex.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import FtexImagePlugin, Image

--- a/Tests/test_file_gbr.py
+++ b/Tests/test_file_gbr.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import GbrImagePlugin, Image

--- a/Tests/test_file_gd.py
+++ b/Tests/test_file_gd.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import GdImageFile, UnidentifiedImageError

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import warnings
 from io import BytesIO
 

--- a/Tests/test_file_gimpgradient.py
+++ b/Tests/test_file_gimpgradient.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PIL import GimpGradientFile, ImagePalette
 
 

--- a/Tests/test_file_gimppalette.py
+++ b/Tests/test_file_gimppalette.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL.GimpPaletteFile import GimpPaletteFile

--- a/Tests/test_file_gribstub.py
+++ b/Tests/test_file_gribstub.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import GribStubImagePlugin, Image

--- a/Tests/test_file_hdf5stub.py
+++ b/Tests/test_file_hdf5stub.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Hdf5StubImagePlugin, Image

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import io
 import os
 import warnings

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import io
 import os
 

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import filecmp
 import warnings
 

--- a/Tests/test_file_imt.py
+++ b/Tests/test_file_imt.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import io
 
 import pytest

--- a/Tests/test_file_iptc.py
+++ b/Tests/test_file_iptc.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 from io import BytesIO, StringIO
 

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import re
 import warnings

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import re
 from io import BytesIO

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import base64
 import io
 import itertools

--- a/Tests/test_file_libtiff_small.py
+++ b/Tests/test_file_libtiff_small.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from io import BytesIO
 
 from PIL import Image

--- a/Tests/test_file_mcidas.py
+++ b/Tests/test_file_mcidas.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, McIdasImagePlugin

--- a/Tests/test_file_mic.py
+++ b/Tests/test_file_mic.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImagePalette

--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import warnings
 from io import BytesIO
 

--- a/Tests/test_file_msp.py
+++ b/Tests/test_file_msp.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 
 import pytest

--- a/Tests/test_file_palm.py
+++ b/Tests/test_file_palm.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os.path
 import subprocess
 

--- a/Tests/test_file_pcd.py
+++ b/Tests/test_file_pcd.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PIL import Image
 
 

--- a/Tests/test_file_pcx.py
+++ b/Tests/test_file_pcx.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageFile, PcxImagePlugin

--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import io
 import os
 import os.path

--- a/Tests/test_file_pixar.py
+++ b/Tests/test_file_pixar.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, PixarImagePlugin

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import re
 import sys
 import warnings

--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 from io import BytesIO
 

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import warnings
 
 import pytest

--- a/Tests/test_file_qoi.py
+++ b/Tests/test_file_qoi.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, QoiImagePlugin

--- a/Tests/test_file_sgi.py
+++ b/Tests/test_file_sgi.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, SgiImagePlugin

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import tempfile
 import warnings
 from io import BytesIO

--- a/Tests/test_file_sun.py
+++ b/Tests/test_file_sun.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 
 import pytest

--- a/Tests/test_file_tar.py
+++ b/Tests/test_file_tar.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import warnings
 
 import pytest

--- a/Tests/test_file_tga.py
+++ b/Tests/test_file_tga.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 from glob import glob
 from itertools import product

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import warnings
 from io import BytesIO

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import io
 import struct
 

--- a/Tests/test_file_wal.py
+++ b/Tests/test_file_wal.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PIL import WalImageFile
 
 from .helper import assert_image_equal_tofile

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import io
 import re
 import sys

--- a/Tests/test_file_webp_alpha.py
+++ b/Tests/test_file_webp_alpha.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/test_file_webp_animated.py
+++ b/Tests/test_file_webp_animated.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 from packaging.version import parse as parse_version
 

--- a/Tests/test_file_webp_lossless.py
+++ b/Tests/test_file_webp_lossless.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/test_file_webp_metadata.py
+++ b/Tests/test_file_webp_metadata.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from io import BytesIO
 
 import pytest

--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, WmfImagePlugin

--- a/Tests/test_file_xbm.py
+++ b/Tests/test_file_xbm.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from io import BytesIO
 
 import pytest

--- a/Tests/test_file_xpm.py
+++ b/Tests/test_file_xpm.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, XpmImagePlugin

--- a/Tests/test_file_xvthumb.py
+++ b/Tests/test_file_xvthumb.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, XVThumbImagePlugin

--- a/Tests/test_font_bdf.py
+++ b/Tests/test_font_bdf.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import BdfFontFile, FontFile

--- a/Tests/test_font_crash.py
+++ b/Tests/test_font_crash.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageDraw, ImageFont

--- a/Tests/test_font_leaks.py
+++ b/Tests/test_font_leaks.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PIL import Image, ImageDraw, ImageFont
 
 from .helper import PillowLeakTestCase, skip_unless_feature

--- a/Tests/test_font_pcf.py
+++ b/Tests/test_font_pcf.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 
 import pytest

--- a/Tests/test_font_pcf_charsets.py
+++ b/Tests/test_font_pcf_charsets.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 
 import pytest

--- a/Tests/test_format_hsv.py
+++ b/Tests/test_format_hsv.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import colorsys
 import itertools
 

--- a/Tests/test_format_lab.py
+++ b/Tests/test_format_lab.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PIL import Image
 
 

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import io
 import logging
 import os

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import subprocess
 import sys

--- a/Tests/test_image_array.py
+++ b/Tests/test_image_array.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 from packaging.version import parse as parse_version
 

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/test_image_copy.py
+++ b/Tests/test_image_copy.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import copy
 
 import pytest

--- a/Tests/test_image_crop.py
+++ b/Tests/test_image_crop.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/test_image_draft.py
+++ b/Tests/test_image_draft.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PIL import Image
 
 from .helper import fromstring, skip_unless_feature, tostring

--- a/Tests/test_image_entropy.py
+++ b/Tests/test_image_entropy.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .helper import hopper
 
 

--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageFilter

--- a/Tests/test_image_frombytes.py
+++ b/Tests/test_image_frombytes.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/test_image_fromqimage.py
+++ b/Tests/test_image_fromqimage.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import warnings
 
 import pytest

--- a/Tests/test_image_getbands.py
+++ b/Tests/test_image_getbands.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PIL import Image
 
 

--- a/Tests/test_image_getbbox.py
+++ b/Tests/test_image_getbbox.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/test_image_getcolors.py
+++ b/Tests/test_image_getcolors.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .helper import hopper
 
 

--- a/Tests/test_image_getdata.py
+++ b/Tests/test_image_getdata.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PIL import Image
 
 from .helper import hopper

--- a/Tests/test_image_getextrema.py
+++ b/Tests/test_image_getextrema.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PIL import Image
 
 from .helper import hopper

--- a/Tests/test_image_getim.py
+++ b/Tests/test_image_getim.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .helper import hopper
 
 

--- a/Tests/test_image_getpalette.py
+++ b/Tests/test_image_getpalette.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PIL import Image
 
 from .helper import hopper

--- a/Tests/test_image_getprojection.py
+++ b/Tests/test_image_getprojection.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PIL import Image
 
 from .helper import hopper

--- a/Tests/test_image_histogram.py
+++ b/Tests/test_image_histogram.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .helper import hopper
 
 

--- a/Tests/test_image_load.py
+++ b/Tests/test_image_load.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import logging
 import os
 

--- a/Tests/test_image_mode.py
+++ b/Tests/test_image_mode.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageMode

--- a/Tests/test_image_paste.py
+++ b/Tests/test_image_paste.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/test_image_point.py
+++ b/Tests/test_image_point.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from .helper import assert_image_equal, hopper

--- a/Tests/test_image_putalpha.py
+++ b/Tests/test_image_putalpha.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PIL import Image
 
 

--- a/Tests/test_image_putdata.py
+++ b/Tests/test_image_putdata.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 from array import array
 

--- a/Tests/test_image_putpalette.py
+++ b/Tests/test_image_putpalette.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImagePalette

--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 from packaging.version import parse as parse_version
 

--- a/Tests/test_image_reduce.py
+++ b/Tests/test_image_reduce.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageMath, ImageMode

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from contextlib import contextmanager
 
 import pytest

--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -1,6 +1,7 @@
 """
 Tests for resize functionality.
 """
+from __future__ import annotations
 from itertools import permutations
 
 import pytest

--- a/Tests/test_image_rotate.py
+++ b/Tests/test_image_rotate.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/test_image_split.py
+++ b/Tests/test_image_split.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, features

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/test_image_tobitmap.py
+++ b/Tests/test_image_tobitmap.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from .helper import assert_image_equal, fromstring, hopper

--- a/Tests/test_image_tobytes.py
+++ b/Tests/test_image_tobytes.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .helper import hopper
 
 

--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import math
 
 import pytest

--- a/Tests/test_image_transpose.py
+++ b/Tests/test_image_transpose.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL.Image import Transpose

--- a/Tests/test_imagechops.py
+++ b/Tests/test_imagechops.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PIL import Image, ImageChops
 
 from .helper import assert_image_equal, hopper

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import datetime
 import os
 import re

--- a/Tests/test_imagecolor.py
+++ b/Tests/test_imagecolor.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageColor

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import contextlib
 import os.path
 

--- a/Tests/test_imagedraw2.py
+++ b/Tests/test_imagedraw2.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os.path
 
 import pytest

--- a/Tests/test_imageenhance.py
+++ b/Tests/test_imageenhance.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageEnhance

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from io import BytesIO
 
 import pytest

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import copy
 import os
 import re

--- a/Tests/test_imagefontctl.py
+++ b/Tests/test_imagefontctl.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageDraw, ImageFont

--- a/Tests/test_imagefontpil.py
+++ b/Tests/test_imagefontpil.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageDraw, ImageFont, features

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import shutil
 import subprocess

--- a/Tests/test_imagemath.py
+++ b/Tests/test_imagemath.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageMath

--- a/Tests/test_imagemorph.py
+++ b/Tests/test_imagemorph.py
@@ -1,4 +1,5 @@
 # Test the ImageMorphology functionality
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageMorph, _imagingmorph

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageDraw, ImageOps, ImageStat, features

--- a/Tests/test_imageops_usm.py
+++ b/Tests/test_imageops_usm.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageFilter

--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImagePalette

--- a/Tests/test_imagepath.py
+++ b/Tests/test_imagepath.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import array
 import math
 import struct

--- a/Tests/test_imageqt.py
+++ b/Tests/test_imageqt.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import warnings
 
 import pytest

--- a/Tests/test_imagesequence.py
+++ b/Tests/test_imagesequence.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageSequence, TiffImagePlugin

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageShow

--- a/Tests/test_imagestat.py
+++ b/Tests/test_imagestat.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image, ImageStat

--- a/Tests/test_imagetk.py
+++ b/Tests/test_imagetk.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/test_imagewin.py
+++ b/Tests/test_imagewin.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import ImageWin

--- a/Tests/test_imagewin_pointers.py
+++ b/Tests/test_imagewin_pointers.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from io import BytesIO
 
 from PIL import Image, ImageWin

--- a/Tests/test_lib_image.py
+++ b/Tests/test_lib_image.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/test_lib_pack.py
+++ b/Tests/test_lib_pack.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 
 import pytest

--- a/Tests/test_locale.py
+++ b/Tests/test_locale.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import locale
 
 import pytest

--- a/Tests/test_main.py
+++ b/Tests/test_main.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import subprocess
 import sys

--- a/Tests/test_map.py
+++ b/Tests/test_map.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 
 import pytest

--- a/Tests/test_mode_i16.py
+++ b/Tests/test_mode_i16.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import warnings
 
 import pytest

--- a/Tests/test_pdfparser.py
+++ b/Tests/test_pdfparser.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import time
 
 import pytest

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pickle
 
 import pytest

--- a/Tests/test_psdraw.py
+++ b/Tests/test_psdraw.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import sys
 from io import BytesIO

--- a/Tests/test_pyroma.py
+++ b/Tests/test_pyroma.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import __version__

--- a/Tests/test_qt_image_qapplication.py
+++ b/Tests/test_qt_image_qapplication.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import ImageQt

--- a/Tests/test_qt_image_toqimage.py
+++ b/Tests/test_qt_image_toqimage.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import ImageQt

--- a/Tests/test_sgi_crash.py
+++ b/Tests/test_sgi_crash.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import Image

--- a/Tests/test_shell_injection.py
+++ b/Tests/test_shell_injection.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import shutil
 
 import pytest

--- a/Tests/test_tiff_crashes.py
+++ b/Tests/test_tiff_crashes.py
@@ -10,6 +10,7 @@
 # the output should be empty. There may be Python issues
 # in the valgrind especially if run in a debug Python
 # version.
+from __future__ import annotations
 
 import pytest
 

--- a/Tests/test_tiff_ifdrational.py
+++ b/Tests/test_tiff_ifdrational.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from fractions import Fraction
 
 from PIL import Image, TiffImagePlugin, features

--- a/Tests/test_uploader.py
+++ b/Tests/test_uploader.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .helper import assert_image_equal, assert_image_similar, hopper
 
 

--- a/Tests/test_util.py
+++ b/Tests/test_util.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from PIL import _util

--- a/Tests/test_webp_leaks.py
+++ b/Tests/test_webp_leaks.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from io import BytesIO
 
 from PIL import Image

--- a/_custom_build/backend.py
+++ b/_custom_build/backend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 from setuptools.build_meta import *  # noqa: F403

--- a/conftest.py
+++ b/conftest.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 pytest_plugins = ["Tests.helper"]

--- a/docs/Guardfile
+++ b/docs/Guardfile
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 from livereload.compiler import shell
 from livereload.task import Task
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath('.'))
+from __future__ import annotations
 
 import PIL
 

--- a/docs/example/DdsImagePlugin.py
+++ b/docs/example/DdsImagePlugin.py
@@ -9,6 +9,7 @@ The contents of this file are hereby released in the public domain (CC0)
 Full text of the CC0 license:
   https://creativecommons.org/publicdomain/zero/1.0/
 """
+from __future__ import annotations
 
 import struct
 from io import BytesIO

--- a/docs/example/anchors.py
+++ b/docs/example/anchors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from PIL import Image, ImageDraw, ImageFont
 
 font = ImageFont.truetype("Tests/fonts/NotoSans-Regular.ttf", 16)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ extend-ignore = [
 
 [tool.ruff.isort]
 known-first-party = ["PIL"]
+required-imports = ["from __future__ import annotations"]
 
 [tool.pytest.ini_options]
 addopts = "-ra --color=yes"

--- a/selftest.py
+++ b/selftest.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # minimal sanity check
+from __future__ import annotations
 
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@
 # Final rating: 10/10
 # Your cheese is so fresh most people think it's a cream: Mascarpone
 # ------------------------------
+from __future__ import annotations
 
 import os
 import re

--- a/src/PIL/BdfFontFile.py
+++ b/src/PIL/BdfFontFile.py
@@ -20,7 +20,7 @@
 """
 Parse X Bitmap Distribution Format (BDF)
 """
-
+from __future__ import annotations
 
 from . import FontFile, Image
 

--- a/src/PIL/BlpImagePlugin.py
+++ b/src/PIL/BlpImagePlugin.py
@@ -28,6 +28,7 @@ BLP files come in many different flavours:
   - DXT3 compression is used if alpha_encoding == 1.
   - DXT5 compression is used if alpha_encoding == 7.
 """
+from __future__ import annotations
 
 import os
 import struct

--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -22,7 +22,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
-
+from __future__ import annotations
 
 import os
 

--- a/src/PIL/BufrStubImagePlugin.py
+++ b/src/PIL/BufrStubImagePlugin.py
@@ -8,6 +8,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 from . import Image, ImageFile
 

--- a/src/PIL/ContainerIO.py
+++ b/src/PIL/ContainerIO.py
@@ -13,7 +13,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
-
+from __future__ import annotations
 
 import io
 

--- a/src/PIL/CurImagePlugin.py
+++ b/src/PIL/CurImagePlugin.py
@@ -15,6 +15,8 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
+
 from . import BmpImagePlugin, Image
 from ._binary import i16le as i16
 from ._binary import i32le as i32

--- a/src/PIL/DcxImagePlugin.py
+++ b/src/PIL/DcxImagePlugin.py
@@ -20,6 +20,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 from . import Image
 from ._binary import i32le as i32

--- a/src/PIL/DdsImagePlugin.py
+++ b/src/PIL/DdsImagePlugin.py
@@ -9,6 +9,7 @@ The contents of this file are hereby released in the public domain (CC0)
 Full text of the CC0 license:
 https://creativecommons.org/publicdomain/zero/1.0/
 """
+from __future__ import annotations
 
 import io
 import struct

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -19,6 +19,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import io
 import os

--- a/src/PIL/ExifTags.py
+++ b/src/PIL/ExifTags.py
@@ -13,6 +13,7 @@
 This module provides constants and clear-text names for various
 well-known EXIF tags.
 """
+from __future__ import annotations
 
 from enum import IntEnum
 

--- a/src/PIL/FitsImagePlugin.py
+++ b/src/PIL/FitsImagePlugin.py
@@ -8,6 +8,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import math
 

--- a/src/PIL/FliImagePlugin.py
+++ b/src/PIL/FliImagePlugin.py
@@ -14,6 +14,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import os
 

--- a/src/PIL/FontFile.py
+++ b/src/PIL/FontFile.py
@@ -13,7 +13,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
-
+from __future__ import annotations
 
 import os
 

--- a/src/PIL/FpxImagePlugin.py
+++ b/src/PIL/FpxImagePlugin.py
@@ -14,6 +14,8 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
+
 import olefile
 
 from . import Image, ImageFile

--- a/src/PIL/FtexImagePlugin.py
+++ b/src/PIL/FtexImagePlugin.py
@@ -50,6 +50,7 @@ bytes for that mipmap level.
 
 Note: All data is stored in little-Endian (Intel) byte order.
 """
+from __future__ import annotations
 
 import struct
 from enum import IntEnum

--- a/src/PIL/GbrImagePlugin.py
+++ b/src/PIL/GbrImagePlugin.py
@@ -23,6 +23,7 @@
 # Version 2 files are saved by GIMP v2.8 (at least)
 # Version 3 files have a format specifier of 18 for 16bit floats in
 #   the color depth field. This is currently unsupported by Pillow.
+from __future__ import annotations
 
 from . import Image, ImageFile
 from ._binary import i32be as i32

--- a/src/PIL/GdImageFile.py
+++ b/src/PIL/GdImageFile.py
@@ -25,7 +25,7 @@
     implementation is provided for convenience and demonstrational
     purposes only.
 """
-
+from __future__ import annotations
 
 from . import ImageFile, ImagePalette, UnidentifiedImageError
 from ._binary import i16be as i16

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -23,6 +23,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import itertools
 import math

--- a/src/PIL/GimpGradientFile.py
+++ b/src/PIL/GimpGradientFile.py
@@ -18,7 +18,7 @@ Stuff to translate curve segments to palette values (derived from
 the corresponding code in GIMP, written by Federico Mena Quintero.
 See the GIMP distribution for more information.)
 """
-
+from __future__ import annotations
 
 from math import log, pi, sin, sqrt
 

--- a/src/PIL/GimpPaletteFile.py
+++ b/src/PIL/GimpPaletteFile.py
@@ -13,6 +13,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import re
 

--- a/src/PIL/GribStubImagePlugin.py
+++ b/src/PIL/GribStubImagePlugin.py
@@ -8,6 +8,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 from . import Image, ImageFile
 

--- a/src/PIL/Hdf5StubImagePlugin.py
+++ b/src/PIL/Hdf5StubImagePlugin.py
@@ -8,6 +8,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 from . import Image, ImageFile
 

--- a/src/PIL/IcnsImagePlugin.py
+++ b/src/PIL/IcnsImagePlugin.py
@@ -16,6 +16,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import io
 import os

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -20,7 +20,7 @@
 # Icon format references:
 #   * https://en.wikipedia.org/wiki/ICO_(file_format)
 #   * https://msdn.microsoft.com/en-us/library/ms997538.aspx
-
+from __future__ import annotations
 
 import warnings
 from io import BytesIO

--- a/src/PIL/ImImagePlugin.py
+++ b/src/PIL/ImImagePlugin.py
@@ -24,7 +24,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
-
+from __future__ import annotations
 
 import os
 import re

--- a/src/PIL/ImageCms.py
+++ b/src/PIL/ImageCms.py
@@ -14,6 +14,7 @@
 
 # See the README file for information on usage and redistribution.  See
 # below for the original description.
+from __future__ import annotations
 
 import sys
 from enum import IntEnum

--- a/src/PIL/ImageColor.py
+++ b/src/PIL/ImageColor.py
@@ -16,6 +16,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import re
 

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -29,6 +29,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import math
 import numbers

--- a/src/PIL/ImageDraw2.py
+++ b/src/PIL/ImageDraw2.py
@@ -22,7 +22,7 @@
 
 .. seealso:: :py:mod:`PIL.ImageDraw`
 """
-
+from __future__ import annotations
 
 from . import Image, ImageColor, ImageDraw, ImageFont, ImagePath
 

--- a/src/PIL/ImageEnhance.py
+++ b/src/PIL/ImageEnhance.py
@@ -17,6 +17,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 from . import Image, ImageFilter, ImageStat
 

--- a/src/PIL/ImageFilter.py
+++ b/src/PIL/ImageFilter.py
@@ -14,6 +14,8 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
+
 import functools
 
 

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -14,6 +14,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import io
 import os

--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -14,6 +14,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import builtins
 

--- a/src/PIL/ImageMode.py
+++ b/src/PIL/ImageMode.py
@@ -12,6 +12,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import sys
 

--- a/src/PIL/ImageMorph.py
+++ b/src/PIL/ImageMorph.py
@@ -4,6 +4,7 @@
 #   2014-06-04 Initial version.
 #
 # Copyright (c) 2014 Dov Grobgeld <dov.grobgeld@gmail.com>
+from __future__ import annotations
 
 import re
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -16,6 +16,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import functools
 import operator

--- a/src/PIL/ImagePalette.py
+++ b/src/PIL/ImagePalette.py
@@ -15,6 +15,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import array
 

--- a/src/PIL/ImagePath.py
+++ b/src/PIL/ImagePath.py
@@ -13,6 +13,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 from . import Image
 

--- a/src/PIL/ImageQt.py
+++ b/src/PIL/ImageQt.py
@@ -15,6 +15,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import sys
 from io import BytesIO

--- a/src/PIL/ImageSequence.py
+++ b/src/PIL/ImageSequence.py
@@ -14,6 +14,7 @@
 #
 
 ##
+from __future__ import annotations
 
 
 class Iterator:

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -11,6 +11,8 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
+
 import os
 import shutil
 import subprocess

--- a/src/PIL/ImageStat.py
+++ b/src/PIL/ImageStat.py
@@ -20,6 +20,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import math
 

--- a/src/PIL/ImageTk.py
+++ b/src/PIL/ImageTk.py
@@ -24,6 +24,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import tkinter
 from io import BytesIO

--- a/src/PIL/ImageTransform.py
+++ b/src/PIL/ImageTransform.py
@@ -12,6 +12,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 from . import Image
 

--- a/src/PIL/ImageWin.py
+++ b/src/PIL/ImageWin.py
@@ -16,6 +16,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 from . import Image
 

--- a/src/PIL/ImtImagePlugin.py
+++ b/src/PIL/ImtImagePlugin.py
@@ -13,7 +13,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
-
+from __future__ import annotations
 
 import re
 

--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -14,6 +14,8 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
+
 import os
 import tempfile
 

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -13,6 +13,8 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
+
 import io
 import os
 import struct

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -31,6 +31,8 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
+
 import array
 import io
 import math

--- a/src/PIL/JpegPresets.py
+++ b/src/PIL/JpegPresets.py
@@ -64,6 +64,8 @@ https://web.archive.org/web/20120328125543/http://www.jpegcameras.com/libjpeg/li
 """
 
 # fmt: off
+from __future__ import annotations
+
 presets = {
             'web_low':      {'subsampling':  2,  # "4:2:0"
                              'quantization': [

--- a/src/PIL/JpegPresets.py
+++ b/src/PIL/JpegPresets.py
@@ -62,10 +62,9 @@ Libjpeg ref.:
 https://web.archive.org/web/20120328125543/http://www.jpegcameras.com/libjpeg/libjpeg-3.html
 
 """
-
-# fmt: off
 from __future__ import annotations
 
+# fmt: off
 presets = {
             'web_low':      {'subsampling':  2,  # "4:2:0"
                              'quantization': [

--- a/src/PIL/McIdasImagePlugin.py
+++ b/src/PIL/McIdasImagePlugin.py
@@ -15,6 +15,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import struct
 

--- a/src/PIL/MicImagePlugin.py
+++ b/src/PIL/MicImagePlugin.py
@@ -15,7 +15,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
-
+from __future__ import annotations
 
 import olefile
 

--- a/src/PIL/MpegImagePlugin.py
+++ b/src/PIL/MpegImagePlugin.py
@@ -12,7 +12,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
-
+from __future__ import annotations
 
 from . import Image, ImageFile
 from ._binary import i8

--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -17,6 +17,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import itertools
 import os

--- a/src/PIL/MspImagePlugin.py
+++ b/src/PIL/MspImagePlugin.py
@@ -22,6 +22,7 @@
 # Figure 206. Windows Paint Version 2: "LinS" Format. Used in Windows V2.03
 #
 # See also: https://www.fileformat.info/format/mspaint/egff.htm
+from __future__ import annotations
 
 import io
 import struct

--- a/src/PIL/PSDraw.py
+++ b/src/PIL/PSDraw.py
@@ -14,6 +14,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import sys
 

--- a/src/PIL/PaletteFile.py
+++ b/src/PIL/PaletteFile.py
@@ -12,6 +12,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 from ._binary import o8
 

--- a/src/PIL/PalmImagePlugin.py
+++ b/src/PIL/PalmImagePlugin.py
@@ -6,6 +6,7 @@
 ##
 # Image plugin for Palm pixmap images (output only).
 ##
+from __future__ import annotations
 
 from . import Image, ImageFile
 from ._binary import o8

--- a/src/PIL/PcdImagePlugin.py
+++ b/src/PIL/PcdImagePlugin.py
@@ -13,7 +13,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
-
+from __future__ import annotations
 
 from . import Image, ImageFile
 

--- a/src/PIL/PcfFontFile.py
+++ b/src/PIL/PcfFontFile.py
@@ -15,6 +15,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import io
 

--- a/src/PIL/PcxImagePlugin.py
+++ b/src/PIL/PcxImagePlugin.py
@@ -24,6 +24,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import io
 import logging

--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -19,6 +19,7 @@
 ##
 # Image plugin for PDF images (output only).
 ##
+from __future__ import annotations
 
 import io
 import math

--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import calendar
 import codecs
 import collections

--- a/src/PIL/PixarImagePlugin.py
+++ b/src/PIL/PixarImagePlugin.py
@@ -18,6 +18,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 from . import Image, ImageFile
 from ._binary import i16le as i16

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -30,6 +30,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import itertools
 import logging

--- a/src/PIL/PpmImagePlugin.py
+++ b/src/PIL/PpmImagePlugin.py
@@ -13,7 +13,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
-
+from __future__ import annotations
 
 from . import Image, ImageFile
 from ._binary import i16be as i16

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -15,6 +15,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import io
 

--- a/src/PIL/PyAccess.py
+++ b/src/PIL/PyAccess.py
@@ -18,6 +18,7 @@
 #    * Fill.c uses the integer form, but it's still going to use the old
 #      Access.c implementation.
 #
+from __future__ import annotations
 
 import logging
 import sys

--- a/src/PIL/QoiImagePlugin.py
+++ b/src/PIL/QoiImagePlugin.py
@@ -5,6 +5,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import os
 

--- a/src/PIL/SgiImagePlugin.py
+++ b/src/PIL/SgiImagePlugin.py
@@ -20,7 +20,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
-
+from __future__ import annotations
 
 import os
 import struct

--- a/src/PIL/SpiderImagePlugin.py
+++ b/src/PIL/SpiderImagePlugin.py
@@ -32,6 +32,8 @@
 # Details about the Spider image format:
 # https://spider.wadsworth.org/spider_doc/spider/docs/image_doc.html
 #
+from __future__ import annotations
+
 import os
 import struct
 import sys

--- a/src/PIL/SunImagePlugin.py
+++ b/src/PIL/SunImagePlugin.py
@@ -15,7 +15,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
-
+from __future__ import annotations
 
 from . import Image, ImageFile, ImagePalette
 from ._binary import i32be as i32

--- a/src/PIL/TarIO.py
+++ b/src/PIL/TarIO.py
@@ -13,6 +13,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import io
 

--- a/src/PIL/TgaImagePlugin.py
+++ b/src/PIL/TgaImagePlugin.py
@@ -15,7 +15,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
-
+from __future__ import annotations
 
 import warnings
 

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -38,6 +38,8 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
+
 import io
 import itertools
 import logging

--- a/src/PIL/TiffTags.py
+++ b/src/PIL/TiffTags.py
@@ -16,6 +16,7 @@
 # This module provides constants and clear-text names for various
 # well-known TIFF tags.
 ##
+from __future__ import annotations
 
 from collections import namedtuple
 

--- a/src/PIL/WalImageFile.py
+++ b/src/PIL/WalImageFile.py
@@ -22,6 +22,7 @@ and has been tested with a few sample files found using google.
     is not registered for use with :py:func:`PIL.Image.open()`.
     To open a WAL file, use the :py:func:`PIL.WalImageFile.open()` function instead.
 """
+from __future__ import annotations
 
 from . import Image, ImageFile
 from ._binary import i32le as i32

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from io import BytesIO
 
 from . import Image, ImageFile

--- a/src/PIL/WmfImagePlugin.py
+++ b/src/PIL/WmfImagePlugin.py
@@ -18,6 +18,7 @@
 # https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-WMF/[MS-WMF].pdf
 # http://wvware.sourceforge.net/caolan/index.html
 # http://wvware.sourceforge.net/caolan/ora-wmf.html
+from __future__ import annotations
 
 from . import Image, ImageFile
 from ._binary import i16le as word

--- a/src/PIL/XVThumbImagePlugin.py
+++ b/src/PIL/XVThumbImagePlugin.py
@@ -16,6 +16,7 @@
 # To do:
 # FIXME: make save work (this requires quantization support)
 #
+from __future__ import annotations
 
 from . import Image, ImageFile, ImagePalette
 from ._binary import o8

--- a/src/PIL/XbmImagePlugin.py
+++ b/src/PIL/XbmImagePlugin.py
@@ -18,6 +18,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
+from __future__ import annotations
 
 import re
 

--- a/src/PIL/XpmImagePlugin.py
+++ b/src/PIL/XpmImagePlugin.py
@@ -13,7 +13,7 @@
 #
 # See the README file for information on usage and redistribution.
 #
-
+from __future__ import annotations
 
 import re
 

--- a/src/PIL/__init__.py
+++ b/src/PIL/__init__.py
@@ -12,6 +12,7 @@ Use PIL.__version__ for this Pillow version.
 
 ;-)
 """
+from __future__ import annotations
 
 from . import _version
 

--- a/src/PIL/__main__.py
+++ b/src/PIL/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .features import pilinfo
 
 pilinfo()

--- a/src/PIL/_binary.py
+++ b/src/PIL/_binary.py
@@ -13,7 +13,7 @@
 
 
 """Binary input/output support routines."""
-
+from __future__ import annotations
 
 from struct import pack, unpack_from
 

--- a/src/PIL/_tkinter_finder.py
+++ b/src/PIL/_tkinter_finder.py
@@ -1,5 +1,7 @@
 """ Find compiled module linking to Tcl / Tk libraries
 """
+from __future__ import annotations
+
 import sys
 import tkinter
 from tkinter import _tkinter as tk

--- a/src/PIL/_util.py
+++ b/src/PIL/_util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 

--- a/src/PIL/_version.py
+++ b/src/PIL/_version.py
@@ -1,2 +1,4 @@
 # Master version for Pillow
+from __future__ import annotations
+
 __version__ = "10.2.0.dev0"

--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import os
 import sys


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/issues/2625.

Adds the `from __future__ import annotations` to all files, and will ensure it's added for new files too, so we can use newer type annotations for older Pythons.

For example, use `list` and `tuple` directly instead of first `from typing import List, Tuple`.