### PR TITLE
Add type hints for ImageMode

### DIFF
--- a/src/PIL/ImageMode.py
+++ b/src/PIL/ImageMode.py
@@ -26,9 +26,9 @@ class ModeDescriptor:
     def __init__(
         self,
         mode: str,
-        bands: str | tuple[str, ...],
+        bands: tuple[str, ...],
         basemode: str,
-        basetype: str | tuple[str, ...],
+        basetype: str,
         typestr: str,
     ) -> None:
         self.mode = mode

--- a/src/PIL/ImageMode.py
+++ b/src/PIL/ImageMode.py
@@ -23,18 +23,25 @@ _modes = None
 class ModeDescriptor:
     """Wrapper for mode strings."""
 
-    def __init__(self, mode, bands, basemode, basetype, typestr):
+    def __init__(
+        self,
+        mode: str,
+        bands: str | tuple[str, ...],
+        basemode: str,
+        basetype: str | tuple[str, ...],
+        typestr: str,
+    ) -> None:
         self.mode = mode
         self.bands = bands
         self.basemode = basemode
         self.basetype = basetype
         self.typestr = typestr
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.mode
 
 
-def getmode(mode):
+def getmode(mode: str) -> ModeDescriptor:
     """Gets a mode descriptor for the given mode."""
     global _modes
     if not _modes:


### PR DESCRIPTION
Helps #2625.

I also checked in strict mode:

```console
❯ mypy --strict src/PIL/ImageMode.py
Success: no issues found in 1 source file
```

We're not ready to enable strict mode for the tox check, and I don't think we need it for the first pass, but good to fix if not too tricky.
