### PR TITLE
Moved __future__ import to beginning of file

### DIFF
--- a/Tests/oss-fuzz/fuzz_font.py
+++ b/Tests/oss-fuzz/fuzz_font.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+from __future__ import annotations
+
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
 
 
 import atheris

--- a/Tests/oss-fuzz/fuzz_pillow.py
+++ b/Tests/oss-fuzz/fuzz_pillow.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+from __future__ import annotations
+
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
 
 
 import atheris


### PR DESCRIPTION
oss-fuzz coverage has started failing after #7631 - https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65341&sort=-opened&can=1&q=proj%3Apillow
> Syntax error in /src/Pillow/Tests/oss-fuzz/fuzz_font.py
>   File "/src/Pillow/Tests/oss-fuzz/fuzz_font.py", line 27
>      from \_\_future__ import annotations
>      ^
>  SyntaxError: from \_\_future__ imports must occur at the beginning of the file