### PR TITLE
Added TarIO type hints

### DIFF
--- a/src/PIL/ContainerIO.py
+++ b/src/PIL/ContainerIO.py
@@ -24,7 +24,7 @@ class ContainerIO:
     file (for example a TAR file).
     """
 
-    def __init__(self, file, offset, length):
+    def __init__(self, file, offset, length) -> None:
         """
         Create file object.
 

--- a/src/PIL/TarIO.py
+++ b/src/PIL/TarIO.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import io
+from types import TracebackType
 
 from . import ContainerIO
 
@@ -23,7 +24,7 @@ from . import ContainerIO
 class TarIO(ContainerIO.ContainerIO):
     """A file object that provides read access to a given member of a TAR file."""
 
-    def __init__(self, tarfile, file):
+    def __init__(self, tarfile: str, file: str) -> None:
         """
         Create file object.
 
@@ -57,11 +58,16 @@ class TarIO(ContainerIO.ContainerIO):
         super().__init__(self.fh, self.fh.tell(), size)
 
     # Context manager support
-    def __enter__(self):
+    def __enter__(self) -> TarIO:
         return self
 
-    def __exit__(self, *args):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         self.close()
 
-    def close(self):
+    def close(self) -> None:
         self.fh.close()


### PR DESCRIPTION
Helps #2625

I took the `__exit__` argument type hints from https://adamj.eu/tech/2021/07/04/python-type-hints-how-to-type-a-context-manager/#class-based-context-managers