### PR TITLE
Added type hints to selftest.py, docs/conf.py and docs/example/anchors.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -233,7 +233,7 @@ htmlhelp_basename = "PillowPILForkdoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
-latex_elements = {
+latex_elements: dict[str, str] = {
     # The paper size ('letterpaper' or 'a4paper').
     # 'papersize': 'letterpaper',
     # The font size ('10pt', '11pt' or '12pt').

--- a/docs/example/anchors.py
+++ b/docs/example/anchors.py
@@ -5,7 +5,7 @@ from PIL import Image, ImageDraw, ImageFont
 font = ImageFont.truetype("Tests/fonts/NotoSans-Regular.ttf", 16)
 
 
-def test(anchor):
+def test(anchor: str) -> Image.Image:
     im = Image.new("RGBA", (200, 100), "white")
     d = ImageDraw.Draw(im)
     d.line(((100, 0), (100, 100)), "gray")

--- a/selftest.py
+++ b/selftest.py
@@ -15,7 +15,7 @@ except AttributeError:
     pass
 
 
-def testimage():
+def testimage() -> None:
     """
     PIL lets you create in-memory images with various pixel types:
 


### PR DESCRIPTION
Three files where the changes were minor enough that it felt worth bundling them together.