### PR TITLE
Optimise `ImageMode.getmode` using `functools.lru_cache`

### DIFF
--- a/src/PIL/ImageMode.py
+++ b/src/PIL/ImageMode.py
@@ -15,9 +15,7 @@
 from __future__ import annotations
 
 import sys
-
-# mode descriptor cache
-_modes = None
+from functools import lru_cache
 
 
 class ModeDescriptor:
@@ -41,58 +39,59 @@ class ModeDescriptor:
         return self.mode
 
 
+@lru_cache
 def getmode(mode: str) -> ModeDescriptor:
     """Gets a mode descriptor for the given mode."""
-    global _modes
-    if not _modes:
-        # initialize mode cache
-        modes = {}
-        endian = "<" if sys.byteorder == "little" else ">"
-        for m, (basemode, basetype, bands, typestr) in {
-            # core modes
-            # Bits need to be extended to bytes
-            "1": ("L", "L", ("1",), "|b1"),
-            "L": ("L", "L", ("L",), "|u1"),
-            "I": ("L", "I", ("I",), endian + "i4"),
-            "F": ("L", "F", ("F",), endian + "f4"),
-            "P": ("P", "L", ("P",), "|u1"),
-            "RGB": ("RGB", "L", ("R", "G", "B"), "|u1"),
-            "RGBX": ("RGB", "L", ("R", "G", "B", "X"), "|u1"),
-            "RGBA": ("RGB", "L", ("R", "G", "B", "A"), "|u1"),
-            "CMYK": ("RGB", "L", ("C", "M", "Y", "K"), "|u1"),
-            "YCbCr": ("RGB", "L", ("Y", "Cb", "Cr"), "|u1"),
-            # UNDONE - unsigned |u1i1i1
-            "LAB": ("RGB", "L", ("L", "A", "B"), "|u1"),
-            "HSV": ("RGB", "L", ("H", "S", "V"), "|u1"),
-            # extra experimental modes
-            "RGBa": ("RGB", "L", ("R", "G", "B", "a"), "|u1"),
-            "BGR;15": ("RGB", "L", ("B", "G", "R"), "|u1"),
-            "BGR;16": ("RGB", "L", ("B", "G", "R"), "|u1"),
-            "BGR;24": ("RGB", "L", ("B", "G", "R"), "|u1"),
-            "LA": ("L", "L", ("L", "A"), "|u1"),
-            "La": ("L", "L", ("L", "a"), "|u1"),
-            "PA": ("RGB", "L", ("P", "A"), "|u1"),
-        }.items():
-            modes[m] = ModeDescriptor(m, bands, basemode, basetype, typestr)
-        # mapping modes
-        for i16mode, typestr in {
-            # I;16 == I;16L, and I;32 == I;32L
-            "I;16": "<u2",
-            "I;16S": "<i2",
-            "I;16L": "<u2",
-            "I;16LS": "<i2",
-            "I;16B": ">u2",
-            "I;16BS": ">i2",
-            "I;16N": endian + "u2",
-            "I;16NS": endian + "i2",
-            "I;32": "<u4",
-            "I;32B": ">u4",
-            "I;32L": "<u4",
-            "I;32S": "<i4",
-            "I;32BS": ">i4",
-            "I;32LS": "<i4",
-        }.items():
-            modes[i16mode] = ModeDescriptor(i16mode, ("I",), "L", "L", typestr)
-        # set global mode cache atomically
-        _modes = modes
-    return _modes[mode]
+    # if not _modes:
+    # initialize mode cache
+    endian = "<" if sys.byteorder == "little" else ">"
+
+    modes = {
+        # core modes
+        # Bits need to be extended to bytes
+        "1": ("L", "L", ("1",), "|b1"),
+        "L": ("L", "L", ("L",), "|u1"),
+        "I": ("L", "I", ("I",), endian + "i4"),
+        "F": ("L", "F", ("F",), endian + "f4"),
+        "P": ("P", "L", ("P",), "|u1"),
+        "RGB": ("RGB", "L", ("R", "G", "B"), "|u1"),
+        "RGBX": ("RGB", "L", ("R", "G", "B", "X"), "|u1"),
+        "RGBA": ("RGB", "L", ("R", "G", "B", "A"), "|u1"),
+        "CMYK": ("RGB", "L", ("C", "M", "Y", "K"), "|u1"),
+        "YCbCr": ("RGB", "L", ("Y", "Cb", "Cr"), "|u1"),
+        # UNDONE - unsigned |u1i1i1
+        "LAB": ("RGB", "L", ("L", "A", "B"), "|u1"),
+        "HSV": ("RGB", "L", ("H", "S", "V"), "|u1"),
+        # extra experimental modes
+        "RGBa": ("RGB", "L", ("R", "G", "B", "a"), "|u1"),
+        "BGR;15": ("RGB", "L", ("B", "G", "R"), "|u1"),
+        "BGR;16": ("RGB", "L", ("B", "G", "R"), "|u1"),
+        "BGR;24": ("RGB", "L", ("B", "G", "R"), "|u1"),
+        "LA": ("L", "L", ("L", "A"), "|u1"),
+        "La": ("L", "L", ("L", "a"), "|u1"),
+        "PA": ("RGB", "L", ("P", "A"), "|u1"),
+    }
+    if mode in modes:
+        base_mode, base_type, bands, type_str = modes[mode]
+        return ModeDescriptor(mode, bands, base_mode, base_type, type_str)
+
+    mapping_modes = {
+        # I;16 == I;16L, and I;32 == I;32L
+        "I;16": "<u2",
+        "I;16S": "<i2",
+        "I;16L": "<u2",
+        "I;16LS": "<i2",
+        "I;16B": ">u2",
+        "I;16BS": ">i2",
+        "I;16N": endian + "u2",
+        "I;16NS": endian + "i2",
+        "I;32": "<u4",
+        "I;32B": ">u4",
+        "I;32L": "<u4",
+        "I;32S": "<i4",
+        "I;32BS": ">i4",
+        "I;32LS": "<i4",
+    }
+
+    type_str = mapping_modes[mode]
+    return ModeDescriptor(mode, ("I",), "L", "L", type_str)

--- a/src/PIL/ImageMode.py
+++ b/src/PIL/ImageMode.py
@@ -42,7 +42,6 @@ class ModeDescriptor:
 @lru_cache
 def getmode(mode: str) -> ModeDescriptor:
     """Gets a mode descriptor for the given mode."""
-    # if not _modes:
     # initialize mode cache
     endian = "<" if sys.byteorder == "little" else ">"
 


### PR DESCRIPTION
Use `functools.lru_cache` instead of our own global cache, to only cache those which are requested.

With no argument, `lru_cache` defaults to `maxsize=128`, plenty for the 33 valid inputs.

https://docs.python.org/3/library/functools.html#functools.lru_cache

Performance improves for all the following cases.

# A mode from the top half: 33.6 -> 28.5 nsec

Before and after:

```console
❯ python3 -m timeit -s "from PIL import ImageMode" "ImageMode.getmode('RGB')"
10000000 loops, best of 5: 33.6 nsec per loop

❯ python3 -m timeit -s "from PIL import ImageMode" "ImageMode.getmode('RGB')"
10000000 loops, best of 5: 28.5 nsec per loop
```

# A mapping mode from the bottom half: 36 -> 28.9 nsec

```console
❯ python3 -m timeit -s "from PIL import ImageMode" "ImageMode.getmode('I;16N')"
10000000 loops, best of 5: 36 nsec per loop

❯ python3 -m timeit -s "from PIL import ImageMode" "ImageMode.getmode('I;16N')"
10000000 loops, best of 5: 28.9 nsec per loop
```

# All modes: 1.25 -> 1.01 usec

```console
❯ python3 -m timeit -s "from PIL import ImageMode" "ImageMode.getmode('1'); ImageMode.getmode('L'); ImageMode.getmode('I'); ImageMode.getmode('F'); ImageMode.getmode('P'); ImageMode.getmode('RGB'); ImageMode.getmode('RGBX'); ImageMode.getmode('RGBA'); ImageMode.getmode('CMYK'); ImageMode.getmode('YCbCr'); ImageMode.getmode('LAB'); ImageMode.getmode('HSV'); ImageMode.getmode('RGBa'); ImageMode.getmode('BGR;15'); ImageMode.getmode('BGR;16'); ImageMode.getmode('BGR;24'); ImageMode.getmode('LA'); ImageMode.getmode('La'); ImageMode.getmode('PA'); ImageMode.getmode('I;16'); ImageMode.getmode('I;16S'); ImageMode.getmode('I;16L'); ImageMode.getmode('I;16LS'); ImageMode.getmode('I;16B'); ImageMode.getmode('I;16BS'); ImageMode.getmode('I;16N'); ImageMode.getmode('I;16NS'); ImageMode.getmode('I;32'); ImageMode.getmode('I;32B'); ImageMode.getmode('I;32L'); ImageMode.getmode('I;32S'); ImageMode.getmode('I;32BS'); ImageMode.getmode('I;32LS')"
200000 loops, best of 5: 1.25 usec per loop

❯ python3 -m timeit -s "from PIL import ImageMode" "ImageMode.getmode('1'); ImageMode.getmode('L'); ImageMode.getmode('I'); ImageMode.getmode('F'); ImageMode.getmode('P'); ImageMode.getmode('RGB'); ImageMode.getmode('RGBX'); ImageMode.getmode('RGBA'); ImageMode.getmode('CMYK'); ImageMode.getmode('YCbCr'); ImageMode.getmode('LAB'); ImageMode.getmode('HSV'); ImageMode.getmode('RGBa'); ImageMode.getmode('BGR;15'); ImageMode.getmode('BGR;16'); ImageMode.getmode('BGR;24'); ImageMode.getmode('LA'); ImageMode.getmode('La'); ImageMode.getmode('PA'); ImageMode.getmode('I;16'); ImageMode.getmode('I;16S'); ImageMode.getmode('I;16L'); ImageMode.getmode('I;16LS'); ImageMode.getmode('I;16B'); ImageMode.getmode('I;16BS'); ImageMode.getmode('I;16N'); ImageMode.getmode('I;16NS'); ImageMode.getmode('I;32'); ImageMode.getmode('I;32B'); ImageMode.getmode('I;32L'); ImageMode.getmode('I;32S'); ImageMode.getmode('I;32BS'); ImageMode.getmode('I;32LS')"
200000 loops, best of 5: 1.01 usec per loop
```
