### PR TITLE
Simplify FreeTypeFont.render

### DIFF
--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -582,22 +582,13 @@ class FreeTypeFont:
         _string_length_check(text)
         if start is None:
             start = (0, 0)
-        im = None
-        size = None
 
         def fill(width, height):
-            nonlocal im, size
-
             size = (width, height)
-            if Image.MAX_IMAGE_PIXELS is not None:
-                pixels = max(1, width) * max(1, height)
-                if pixels > 2 * Image.MAX_IMAGE_PIXELS:
-                    return
+            Image._decompression_bomb_check(size)
+            return Image.core.fill("RGBA" if mode == "RGBA" else "L", size)
 
-            im = Image.core.fill("RGBA" if mode == "RGBA" else "L", size)
-            return im
-
-        offset = self.font.render(
+        return self.font.render(
             text,
             fill,
             mode,
@@ -610,8 +601,6 @@ class FreeTypeFont:
             start[0],
             start[1],
         )
-        Image._decompression_bomb_check(size)
-        return im, offset
 
     def font_variant(
         self, font=None, size=None, index=None, encoding=None, layout_engine=None

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -880,7 +880,7 @@ font_render(FontObject *self, PyObject *args) {
     image = PyObject_CallFunction(fill, "ii", width, height);
     if (image == Py_None) {
         PyMem_Del(glyph_info);
-        return Py_BuildValue("ii", 0, 0);
+        return Py_BuildValue("N(ii)", image, 0, 0);
     } else if (image == NULL) {
         PyMem_Del(glyph_info);
         return NULL;
@@ -894,7 +894,7 @@ font_render(FontObject *self, PyObject *args) {
     y_offset -= stroke_width;
     if (count == 0 || width == 0 || height == 0) {
         PyMem_Del(glyph_info);
-        return Py_BuildValue("ii", x_offset, y_offset);
+        return Py_BuildValue("N(ii)", image, x_offset, y_offset);
     }
 
     if (stroke_width) {
@@ -1130,18 +1130,12 @@ font_render(FontObject *self, PyObject *args) {
     if (bitmap_converted_ready) {
         FT_Bitmap_Done(library, &bitmap_converted);
     }
-    Py_DECREF(image);
     FT_Stroker_Done(stroker);
     PyMem_Del(glyph_info);
-    return Py_BuildValue("ii", x_offset, y_offset);
+    return Py_BuildValue("N(ii)", image, x_offset, y_offset);
 
 glyph_error:
-    if (im->destroy) {
-        im->destroy(im);
-    }
-    if (im->image) {
-        free(im->image);
-    }
+    Py_DECREF(image);
     if (stroker != NULL) {
         FT_Done_Glyph(glyph);
     }


### PR DESCRIPTION
Changes proposed in this pull request:

 * Call `Image._decompression_bomb_check` directly in `fill` rather than duplicating its code. If an error is raised, it is propagated via the `if (image == NULL)` branch.
 * On error, delete the Python `image` object by releasing the only reference to it (causing Python to call its `tp_dealloc` slot, i.e. `_dealloc` in `_imaging.c`) instead of just freeing the memory it points to (added in #7218).
 * Avoid nonlocal variables (to simplify adding type hints in a future PR by avoiding the need for a `typing.cast` or `assert size is not None`).

This partially reverts changes from #7246, which was connected to an oss-fuzz error, but I do not see any added tests or reproduction steps. IIUC, the original error was a memory leak, which I avoid in a different way in this PR:

The original code (before #7246) returned `image` via `O` format (returning a new reference) and did not `Py_DECREF` (causing a memory leak).
#7246 instead returns a reference via a nonlocal Python variable and added `Py_DECREF`.
In this PR I have removed the nonlocal variable and return the existing reference via `N` format.
See https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue for the difference between `O` and `N`.
