### PR TITLE
Restored testing of ImageFont class

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -1053,11 +1053,11 @@ def test_too_many_characters(font):
     with pytest.raises(ValueError):
         transposed_font.getlength("A" * 1_000_001)
 
-    default_font = ImageFont.load_default()
+    imagefont = ImageFont.ImageFont()
     with pytest.raises(ValueError):
-        default_font.getlength("A" * 1_000_001)
+        imagefont.getlength("A" * 1_000_001)
     with pytest.raises(ValueError):
-        default_font.getbbox("A" * 1_000_001)
+        imagefont.getbbox("A" * 1_000_001)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#7244 added the following test code
https://github.com/python-pillow/Pillow/blob/78b96c037597b56b125257f568de04b4d8921118/Tests/test_imagefont.py#L1056-L1060

At the time, this was testing the "better than nothing" font that uses ImageFont class. However, #7354 changed the default font in some environments, so the ImageFont class would no longer have been covered in this test.

This PR fixes that by creating an instance of the ImageFont class directly.