### PR TITLE
Removed __future__ import from fuzz_font.py and fuzz_pillow.py

### DIFF
--- a/Tests/oss-fuzz/fuzz_font.py
+++ b/Tests/oss-fuzz/fuzz_font.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
 
-from __future__ import annotations
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/Tests/oss-fuzz/fuzz_pillow.py
+++ b/Tests/oss-fuzz/fuzz_pillow.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
 
-from __future__ import annotations
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,8 @@ extend-ignore = [
 
 [tool.ruff.per-file-ignores]
 "Tests/*.py" = ["I001"]
+"Tests/oss-fuzz/fuzz_font.py" = ["I002"]
+"Tests/oss-fuzz/fuzz_pillow.py" = ["I002"]
 
 [tool.ruff.isort]
 known-first-party = ["PIL"]


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65341 is still open, complaining that `from __future__ imports must occur at the beginning of the file`, despite #7637 moving the imports.

I asked about this at https://github.com/google/oss-fuzz/issues/11415, and was told that oss-fuzz [prepends code to the files](https://github.com/google/oss-fuzz/blob/55650963e17693deedfe2ed86df2544cf124ab8b/infra/base-images/base-builder/compile_python_fuzzer#L56-L75).

I think the solution here is to just remove `from __future__ import annotations` from fuzz_font.py and fuzz_pillow.py. I've tested it in my oss-fuzz fork, and [it fails without this](https://github.com/radarhere/oss-fuzz/actions/runs/7352047687/job/20016249063), but [passes with.](https://github.com/radarhere/oss-fuzz/actions/runs/7352388832)