### PR TITLE
Add 'Type hints' as a release note category

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,6 +13,8 @@ categories:
     label: "Removal"
   - title: "Testing"
     label: "Testing"
+  - title: "Type hints"
+    label: "Type hints"
 
 exclude-labels:
   - "changelog: skip"


### PR DESCRIPTION
We have a number of https://github.com/python-pillow/Pillow/labels/Type%20hints PRs in this release, and will do in the future.

Let's add it as a category for https://github.com/python-pillow/Pillow/releases