### PR TITLE
Support setting ROWSPERSTRIP tag

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -612,6 +612,14 @@ class TestFileTiff:
 
             assert_image_equal_tofile(im, tmpfile)
 
+    def test_rowsperstrip(self, tmp_path):
+        outfile = str(tmp_path / "temp.tif")
+        im = hopper()
+        im.save(outfile, tiffinfo={278: 256})
+
+        with Image.open(outfile) as im:
+            assert im.tag_v2[278] == 256
+
     def test_strip_raw(self):
         infile = "Tests/images/tiff_strip_raw.tif"
         with Image.open(infile) as im:

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -123,6 +123,7 @@ def test_write_metadata(tmp_path):
     """Test metadata writing through the python code"""
     with Image.open("Tests/images/hopper.tif") as img:
         f = str(tmp_path / "temp.tiff")
+        del img.tag[278]
         img.save(f, tiffinfo=img.tag)
 
         original = img.tag_v2.named()
@@ -159,6 +160,7 @@ def test_change_stripbytecounts_tag_type(tmp_path):
     out = str(tmp_path / "temp.tiff")
     with Image.open("Tests/images/hopper.tif") as im:
         info = im.tag_v2
+        del info[278]
 
         # Resize the image so that STRIPBYTECOUNTS will be larger than a SHORT
         im = im.resize((500, 500))

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1705,20 +1705,23 @@ def _save(im, fp, filename):
         ifd[COLORMAP] = colormap
     # data orientation
     stride = len(bits) * ((im.size[0] * bits[0] + 7) // 8)
-    # aim for given strip size (64 KB by default) when using libtiff writer
-    if libtiff:
-        im_strip_size = encoderinfo.get("strip_size", STRIP_SIZE)
-        rows_per_strip = 1 if stride == 0 else min(im_strip_size // stride, im.size[1])
-        # JPEG encoder expects multiple of 8 rows
-        if compression == "jpeg":
-            rows_per_strip = min(((rows_per_strip + 7) // 8) * 8, im.size[1])
-    else:
-        rows_per_strip = im.size[1]
-    if rows_per_strip == 0:
-        rows_per_strip = 1
-    strip_byte_counts = 1 if stride == 0 else stride * rows_per_strip
-    strips_per_image = (im.size[1] + rows_per_strip - 1) // rows_per_strip
-    ifd[ROWSPERSTRIP] = rows_per_strip
+    if ROWSPERSTRIP not in ifd:
+        # aim for given strip size (64 KB by default) when using libtiff writer
+        if libtiff:
+            im_strip_size = encoderinfo.get("strip_size", STRIP_SIZE)
+            rows_per_strip = (
+                1 if stride == 0 else min(im_strip_size // stride, im.size[1])
+            )
+            # JPEG encoder expects multiple of 8 rows
+            if compression == "jpeg":
+                rows_per_strip = min(((rows_per_strip + 7) // 8) * 8, im.size[1])
+        else:
+            rows_per_strip = im.size[1]
+        if rows_per_strip == 0:
+            rows_per_strip = 1
+        ifd[ROWSPERSTRIP] = rows_per_strip
+    strip_byte_counts = 1 if stride == 0 else stride * ifd[ROWSPERSTRIP]
+    strips_per_image = (im.size[1] + ifd[ROWSPERSTRIP] - 1) // ifd[ROWSPERSTRIP]
     if strip_byte_counts >= 2**16:
         ifd.tagtype[STRIPBYTECOUNTS] = TiffTags.LONG
     ifd[STRIPBYTECOUNTS] = (strip_byte_counts,) * (strips_per_image - 1) + (


### PR DESCRIPTION
Resolves #6607, allowing the [ROWSPERSTRIP](https://www.awaresystems.be/imaging/tiff/tifftags/rowsperstrip.html) tag to be set by the user when saving TIFF images, instead of calculating the value.