### PR TITLE
Restricted environment keys for ImageMath.eval()

### DIFF
--- a/Tests/test_imagemath.py
+++ b/Tests/test_imagemath.py
@@ -69,6 +69,11 @@ def test_prevent_double_underscores():
         ImageMath.eval("1", {"__": None})
 
 
+def test_prevent_builtins():
+    with pytest.raises(ValueError):
+        ImageMath.eval("(lambda: exec('exit()'))()", {"exec": None})
+
+
 def test_logical():
     assert pixel(ImageMath.eval("not A", images)) == 0
     assert pixel(ImageMath.eval("A and B", images)) == "L 2"

--- a/Tests/test_imagemath.py
+++ b/Tests/test_imagemath.py
@@ -64,6 +64,11 @@ def test_prevent_exec(expression):
         ImageMath.eval(expression)
 
 
+def test_prevent_double_underscores():
+    with pytest.raises(ValueError):
+        ImageMath.eval("1", {"__": None})
+
+
 def test_logical():
     assert pixel(ImageMath.eval("not A", images)) == 0
     assert pixel(ImageMath.eval("A and B", images)) == "L 2"

--- a/docs/releasenotes/10.2.0.rst
+++ b/docs/releasenotes/10.2.0.rst
@@ -62,10 +62,13 @@ output only the quantization and Huffman tables for the image.
 Security
 ========
 
-TODO
-^^^^
+Restricted environment keys for ImageMath.eval
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-TODO
+:cve:`2023-50447`: If an attacker has control over the keys passed to the
+``environment`` argument of :py:meth:`PIL.ImageMath.eval`, they may be able to execute
+arbitrary code. To prevent this, keys matching the names of builtins and keys
+containing double underscores will now raise a :py:exc:`ValueError`.
 
 Other Changes
 =============

--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -237,6 +237,10 @@ def eval(expression, _dict={}, **kw):
     args.update(_dict)
     args.update(kw)
     for k, v in args.items():
+        if '__' in k or hasattr(__builtins__, k):
+            msg = f"'{k}' not allowed"
+            raise ValueError(msg)
+
         if hasattr(v, "im"):
             args[k] = _Operand(v)
 

--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -234,13 +234,14 @@ def eval(expression, _dict={}, **kw):
 
     # build execution namespace
     args = ops.copy()
-    args.update(_dict)
-    args.update(kw)
-    for k, v in args.items():
-        if '__' in k or hasattr(__builtins__, k):
+    for k in list(_dict.keys()) + list(kw.keys()):
+        if "__" in k or hasattr(__builtins__, k):
             msg = f"'{k}' not allowed"
             raise ValueError(msg)
 
+    args.update(_dict)
+    args.update(kw)
+    for k, v in args.items():
         if hasattr(v, "im"):
             args[k] = _Operand(v)
 

--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -235,7 +235,7 @@ def eval(expression, _dict={}, **kw):
     # build execution namespace
     args = ops.copy()
     for k in list(_dict.keys()) + list(kw.keys()):
-        if "__" in k or hasattr(__builtins__, k):
+        if "__" in k or hasattr(builtins, k):
             msg = f"'{k}' not allowed"
             raise ValueError(msg)
 


### PR DESCRIPTION
Prevent environment keys matching the names of builtins and keys containing double underscores from being passed to [`ImageMath.eval()`](https://pillow.readthedocs.io/en/stable/reference/ImageMath.html#PIL.ImageMath.eval), by raising a ValueError.