### PR TITLE
Add type hints to _binary

### DIFF
--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -20,17 +20,20 @@ import os
 import tempfile
 
 from . import Image, ImageFile
-from ._binary import i8, o8
 from ._binary import i16be as i16
 from ._binary import i32be as i32
 
 COMPRESSION = {1: "raw", 5: "jpeg"}
 
-PAD = o8(0) * 4
+PAD = b"\0\0\0\0"
 
 
 #
 # Helpers
+
+
+def _i8(c: int | bytes) -> int:
+    return c if isinstance(c, int) else c[0]
 
 
 def i(c):
@@ -39,7 +42,7 @@ def i(c):
 
 def dump(c):
     for i in c:
-        print("%02x" % i8(i), end=" ")
+        print("%02x" % _i8(i), end=" ")
     print()
 
 
@@ -103,10 +106,10 @@ class IptcImageFile(ImageFile.ImageFile):
                 self.info[tag] = tagdata
 
         # mode
-        layers = i8(self.info[(3, 60)][0])
-        component = i8(self.info[(3, 60)][1])
+        layers = self.info[(3, 60)][0]
+        component = self.info[(3, 60)][1]
         if (3, 65) in self.info:
-            id = i8(self.info[(3, 65)][0]) - 1
+            id = self.info[(3, 65)][0] - 1
         else:
             id = 0
         if layers == 1 and not component:

--- a/src/PIL/_binary.py
+++ b/src/PIL/_binary.py
@@ -18,16 +18,16 @@ from __future__ import annotations
 from struct import pack, unpack_from
 
 
-def i8(c) -> int:
-    return c if c.__class__ is int else c[0]
+def i8(c: int | bytes) -> int:
+    return c if c.__class__ is int else c[0]  # type: ignore[index, return-value]
 
 
-def o8(i):
+def o8(i: int) -> bytes:
     return bytes((i & 255,))
 
 
 # Input, le = little endian, be = big endian
-def i16le(c, o=0):
+def i16le(c: bytes, o: int = 0) -> int:
     """
     Converts a 2-bytes (16 bits) string to an unsigned integer.
 
@@ -37,7 +37,7 @@ def i16le(c, o=0):
     return unpack_from("<H", c, o)[0]
 
 
-def si16le(c, o=0):
+def si16le(c: bytes, o: int = 0) -> int:
     """
     Converts a 2-bytes (16 bits) string to a signed integer.
 
@@ -47,7 +47,7 @@ def si16le(c, o=0):
     return unpack_from("<h", c, o)[0]
 
 
-def si16be(c, o=0):
+def si16be(c: bytes, o: int = 0) -> int:
     """
     Converts a 2-bytes (16 bits) string to a signed integer, big endian.
 
@@ -57,7 +57,7 @@ def si16be(c, o=0):
     return unpack_from(">h", c, o)[0]
 
 
-def i32le(c, o=0) -> int:
+def i32le(c: bytes, o: int = 0) -> int:
     """
     Converts a 4-bytes (32 bits) string to an unsigned integer.
 
@@ -67,7 +67,7 @@ def i32le(c, o=0) -> int:
     return unpack_from("<I", c, o)[0]
 
 
-def si32le(c, o=0):
+def si32le(c: bytes, o: int = 0) -> int:
     """
     Converts a 4-bytes (32 bits) string to a signed integer.
 
@@ -77,26 +77,26 @@ def si32le(c, o=0):
     return unpack_from("<i", c, o)[0]
 
 
-def i16be(c, o=0):
+def i16be(c: bytes, o: int = 0) -> int:
     return unpack_from(">H", c, o)[0]
 
 
-def i32be(c, o=0):
+def i32be(c: bytes, o: int = 0) -> int:
     return unpack_from(">I", c, o)[0]
 
 
 # Output, le = little endian, be = big endian
-def o16le(i):
+def o16le(i: int) -> bytes:
     return pack("<H", i)
 
 
-def o32le(i):
+def o32le(i: int) -> bytes:
     return pack("<I", i)
 
 
-def o16be(i) -> bytes:
+def o16be(i: int) -> bytes:
     return pack(">H", i)
 
 
-def o32be(i):
+def o32be(i: int) -> bytes:
     return pack(">I", i)

--- a/src/PIL/_binary.py
+++ b/src/PIL/_binary.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 from struct import pack, unpack_from
 
 
-def i8(c: int | bytes) -> int:
-    return c if c.__class__ is int else c[0]  # type: ignore[index, return-value]
+def i8(c: bytes) -> int:
+    return c[0]
 
 
 def o8(i: int) -> bytes:


### PR DESCRIPTION
There are two tricky parts in adding type hints to `PIL._binary`:

The `i16*` and `i32*` give a "Returning Any from function declared to return int" in `--strict` mode due to the use of `struct.unpack_from`. This can be properly silenced with `#type: ignore[no-any-return]`, but that gives a "Unused type ignore comment" when running without `--strict`, so I have left it out for now.

The `i8` function distinguishes between `int` and `bytes` inputs in a way that mypy doesn't recognize. Since `i8` is called with an `int` input only from `IptcImagePlugin`, I have removed those calls there and removed `int` support as input to `i8`.

Although the values in `self.info[(3, 60)]` and `self.info[(3, 65)]` can be lists if the tags are duplicated, these tags are marked as "non-repeatable" in [the specification](https://www.iptc.org/std/IIM/4.1/specification/Dnprv4.pdf) (pg. 13-14). The specification recommends using the first entry if the tags are duplicated (sec. 1.5-d), but this recommendation was already ignored in `IptcImagePlugin` and I was unable to find any images to test this with.

In doing so, I found that `IptcImagePlugin.dump`, `IptcImagePlugin.i`, and `IptcImagePlugin.PAD` are simple helpers that should probably be deprecated (edit: #7664).