### PR TITLE
Changed IPTC tile tuple to match other plugins

### DIFF
--- a/Tests/test_file_iptc.py
+++ b/Tests/test_file_iptc.py
@@ -11,6 +11,15 @@ from .helper import hopper
 TEST_FILE = "Tests/images/iptc.jpg"
 
 
+def test_open():
+    f = BytesIO(
+        b"\x1c\x03<\x00\x02\x01\x00\x1c\x03x\x00\x01\x01\x1c"
+        b"\x03\x14\x00\x01\x01\x1c\x03\x1e\x00\x01\x01\x1c\x08\n\x00\x00"
+    )
+    with Image.open(f) as im:
+        assert im.tile == [("iptc", (0, 0, 1, 1), 25, "raw")]
+
+
 def test_getiptcinfo_jpg_none():
     # Arrange
     with hopper() as im:

--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -128,24 +128,20 @@ class IptcImageFile(ImageFile.ImageFile):
 
         # tile
         if tag == (8, 10):
-            self.tile = [
-                ("iptc", (compression, offset), (0, 0, self.size[0], self.size[1]))
-            ]
+            self.tile = [("iptc", (0, 0) + self.size, offset, compression)]
 
     def load(self):
         if len(self.tile) != 1 or self.tile[0][0] != "iptc":
             return ImageFile.ImageFile.load(self)
 
-        type, tile, box = self.tile[0]
-
-        encoding, offset = tile
+        offset, compression = self.tile[0][2:]
 
         self.fp.seek(offset)
 
         # Copy image data to temporary file
         o_fd, outfile = tempfile.mkstemp(text=False)
         o = os.fdopen(o_fd)
-        if encoding == "raw":
+        if compression == "raw":
             # To simplify access to the extracted file,
             # prepend a PPM header
             o.write("P5\n%d %d\n255\n" % self.size)


### PR DESCRIPTION
Looking at
https://github.com/python-pillow/Pillow/blob/0988703a90582540d3a2d6576cab11edd6673e5b/src/PIL/IptcImagePlugin.py#L131-L133
I find this odd, as it does not match the structure that we otherwise have for `self.tile`.
https://github.com/python-pillow/Pillow/blob/0988703a90582540d3a2d6576cab11edd6673e5b/src/PIL/ImageFile.py#L93-L97
https://github.com/python-pillow/Pillow/blob/0988703a90582540d3a2d6576cab11edd6673e5b/src/PIL/JpegImagePlugin.py#L396

The reason this problem has not been found by the test suite is that no test actually opens a valid IPTC image.

This PR changes the `self.tile` tuple to match the format used in other plugins.
```python
self.tile = [("iptc", (0, 0) + self.size, offset, compression)]
```

I've reversed-engineered test data for `_open` from the code.