### PR TITLE
Coverage: add more exclusions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,11 +2,8 @@
 
 [report]
 # Regexes for lines to exclude from consideration
-exclude_lines =
-    # Have to re-enable the standard pragma:
-    pragma: no cover
-
-    # Don't complain if non-runnable code isn't run:
+exclude_also =
+    # Don't complain if non-runnable code isn't run
     if 0:
     if __name__ == .__main__.:
     # Don't complain about code that shouldn't run

--- a/.coveragerc
+++ b/.coveragerc
@@ -9,6 +9,8 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if 0:
     if __name__ == .__main__.:
+    # Don't complain about code that shouldn't run
+    def create_lut():
     # Don't complain about debug code
     if DEBUG:
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -10,6 +10,8 @@ exclude_also =
     def create_lut():
     # Don't complain about debug code
     if DEBUG:
+    # Don't complain about compatibility code
+    class TypeGuard:
 
 [run]
 omit =

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,8 +6,6 @@ exclude_also =
     # Don't complain if non-runnable code isn't run
     if 0:
     if __name__ == .__main__.:
-    # Don't complain about code that shouldn't run
-    def create_lut():
     # Don't complain about debug code
     if DEBUG:
     # Don't complain about compatibility code for missing optional dependencies

--- a/.coveragerc
+++ b/.coveragerc
@@ -10,8 +10,8 @@ exclude_also =
     def create_lut():
     # Don't complain about debug code
     if DEBUG:
-    # Don't complain about compatibility code
-    class TypeGuard:
+    # Don't complain about compatibility code for missing optional dependencies
+    except ImportError
 
 [run]
 omit =

--- a/Tests/test_imagemorph.py
+++ b/Tests/test_imagemorph.py
@@ -57,15 +57,6 @@ def test_str_to_img():
     assert_image_equal_tofile(A, "Tests/images/morph_a.png")
 
 
-def create_lut():
-    for op in ("corner", "dilation4", "dilation8", "erosion4", "erosion8", "edge"):
-        lb = ImageMorph.LutBuilder(op_name=op)
-        lut = lb.build_lut()
-        with open(f"Tests/images/{op}.lut", "wb") as f:
-            f.write(lut)
-
-
-# create_lut()
 @pytest.mark.parametrize(
     "op", ("corner", "dilation4", "dilation8", "erosion4", "erosion8", "edge")
 )


### PR DESCRIPTION
Changes proposed in this pull request:

 * With recent Coverage.py, we can use `exclude_also` instead of `exclude_lines` which requires re-enabling the standard pragma
 * `create_lut()` was a helper method not run anywhere, should we delete it instead?
 * `class TypeGuard` is compatibility code being introduced in https://github.com/python-pillow/Pillow/pull/7642. We have a `# type: ignore[no-redef]` on it, and I don't think we need to cover it in tests either.