### PR TITLE
Trim negative glyph offsets in ImageFont.getmask()

### DIFF
--- a/Tests/test_imagefontpil.py
+++ b/Tests/test_imagefontpil.py
@@ -66,7 +66,9 @@ def test_decompression_bomb():
 
 @pytest.mark.timeout(4)
 def test_oom():
-    glyph = struct.pack(">hhhhhhhhhh", 1, 0, 0, 0, 32767, 32767, 0, 0, 32767, 32767)
+    glyph = struct.pack(
+        ">hhhhhhhhhh", 1, 0, -32767, -32767, 32767, 32767, -32767, -32767, 32767, 32767
+    )
     fp = BytesIO(b"PILfont\n\nDATA\n" + glyph * 256)
 
     font = ImageFont.ImageFont()

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -2652,6 +2652,14 @@ _font_new(PyObject *self_, PyObject *args) {
 
         // Do not allow glyphs to extend beyond bitmap image
         // Helps prevent DOS by stopping cropped images being larger than the original
+        if (self->glyphs[i].sx0 < 0) {
+            self->glyphs[i].dx0 -= self->glyphs[i].sx0;
+            self->glyphs[i].sx0 = 0;
+        }
+        if (self->glyphs[i].sy0 < 0) {
+            self->glyphs[i].dy0 -= self->glyphs[i].sy0;
+            self->glyphs[i].sy0 = 0;
+        }
         if (self->glyphs[i].sx1 > self->bitmap->xsize) {
             self->glyphs[i].dx1 -= self->glyphs[i].sx1 - self->bitmap->xsize;
             self->glyphs[i].sx1 = self->bitmap->xsize;


### PR DESCRIPTION
Suggestion for #7669