### PR TITLE
Fix image URL in "Reading from URL" example

### DIFF
--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -542,7 +542,7 @@ Reading from URL
 
     from PIL import Image
     from urllib.request import urlopen
-    url = "https://python-pillow.org/images/pillow-logo.png"
+    url = "https://python-pillow.org/assets/images/pillow-logo.png"
     img = Image.open(urlopen(url))
 
 


### PR DESCRIPTION
While testing https://github.com/python-pillow/Pillow/issues/7673#issuecomment-1873401715 I found that the image has moved from https://python-pillow.org/images/pillow-logo.png to https://python-pillow.org/assets/images/pillow-logo.png.