### PR TITLE
ImageGrab.grab() bbox on macOS is not 2x on retina screens

### DIFF
--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -22,10 +22,10 @@ or the clipboard to a PIL image memory.
     .. versionadded:: 1.1.3 (Windows), 3.0.0 (macOS), 7.1.0 (Linux)
 
     :param bbox: What region to copy. Default is the entire screen.
-                 On macOS, this is not increased to 2x for retina screens, so the full
-                 width of a retina screen would be 1440, not 2880.
-                 On Windows OS, the top-left point may be negative if
-                 ``all_screens=True`` is used.
+                 On macOS, this is not increased to 2x for Retina screens, so the full
+                 width of a Retina screen would be 1440, not 2880.
+                 On Windows, the top-left point may be negative if ``all_screens=True``
+                 is used.
     :param include_layered_windows: Includes layered windows. Windows OS only.
 
         .. versionadded:: 6.1.0

--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -22,7 +22,10 @@ or the clipboard to a PIL image memory.
     .. versionadded:: 1.1.3 (Windows), 3.0.0 (macOS), 7.1.0 (Linux)
 
     :param bbox: What region to copy. Default is the entire screen.
-                 Note that on Windows OS, the top-left point may be negative if ``all_screens=True`` is used.
+                 On macOS, this is not increased to 2x for retina screens, so the full
+                 width of a retina screen would be 1440, not 2880.
+                 On Windows OS, the top-left point may be negative if
+                 ``all_screens=True`` is used.
     :param include_layered_windows: Includes layered windows. Windows OS only.
 
         .. versionadded:: 6.1.0


### PR DESCRIPTION
Resolves #7677

Improve documentation of `bbox` for `ImageGrab.grab()` on macOS.