### PR TITLE
Downgrade TravisCI to Focal and Python 3.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ env:
 
 language: python
 # Default Python version is usually 3.6
-python: "3.12"
-dist: jammy
+python: "3.11"
+dist: focal
 services: docker
 
 jobs:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -87,7 +87,7 @@ Released as needed privately to individual vendors for critical security-related
   and copy into `dist`. Check and upload them e.g.:
   ```bash
   python3 -m twine check --strict dist/*
-  python3 -m twine upload dist/Pillow-5.2.0*
+  python3 -m twine upload dist/pillow-5.2.0*
   ```
 
 ## Publicize Release


### PR DESCRIPTION
- During [an attempt to get TravisCI working](https://github.com/python-pillow/Pillow/issues/7485#issuecomment-1840514584) in #7485, I found that downgrading to Focal (reverting #7501) resolved the following error
> /home/travis/.rvm/gems/ruby-3.1.2/gems/faraday-0.15.4/lib/faraday/options.rb:166:in `new': tried to create Proc object without a block (ArgumentError)
- When following the releasing process in #7571, I found that the wheel filenames now include 'pillow' in lowercase. This is likely a result of cibuildwheel in #7552