### PR TITLE
Package name is now lowercase in wheel filenames

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -87,7 +87,7 @@ Released as needed privately to individual vendors for critical security-related
   and copy into `dist`. Check and upload them e.g.:
   ```bash
   python3 -m twine check --strict dist/*
-  python3 -m twine upload dist/Pillow-5.2.0*
+  python3 -m twine upload dist/pillow-5.2.0*
   ```
 
 ## Publicize Release


### PR DESCRIPTION
When following the releasing process in https://github.com/python-pillow/Pillow/issues/7571, I found that the wheel filenames now include 'pillow' in lowercase. This is likely a result of cibuildwheel in https://github.com/python-pillow/Pillow/pull/7552