### PR TITLE
Skip PyPy3.8 Windows wheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -143,6 +143,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
           CIBW_BEFORE_ALL: "{package}\\winbuild\\build\\build_dep_all.cmd"
           CIBW_CACHE_PATH: "C:\\cibw"
+          CIBW_SKIP: pp38-*
           CIBW_TEST_SKIP: "*-win_arm64"
           CIBW_TEST_COMMAND: 'docker run --rm
             -v {project}:C:\pillow


### PR DESCRIPTION
As the PyPy3.8 wheels is skipped on macOS and Linux - https://github.com/python-pillow/Pillow/pull/7552#issuecomment-1812871988
https://github.com/python-pillow/Pillow/blob/dacd92853094414ab6a4326e7f5805666b92996c/.github/workflows/wheels.yml#L74