### PR TITLE
Skip non-wheel CI runs for tags: Windows

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -2,6 +2,8 @@ name: Test Windows
 
 on:
   push:
+    branches:
+      - "**"
     paths-ignore:
       - ".github/workflows/docs.yml"
       - ".github/workflows/wheels*"


### PR DESCRIPTION
Like https://github.com/python-pillow/Pillow/pull/7468.

Since then, https://github.com/python-pillow/Pillow/pull/7580 moved Windows wheel building from `test-windows.yml` to `wheels.yml` so we can also skip running `test-windows.yml` for tags:

![image](https://github.com/python-pillow/Pillow/assets/1324225/24cc4443-c3dd-4ca7-a40d-6bbadd448e79)

This will speed up releases, especially given https://github.com/python-pillow/Pillow/pull/7690 which needs as much CI capacity as possible.