### PR TITLE
Use "non-zero" consistently

### DIFF
--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -270,7 +270,7 @@ def test_render_scale1():
         image1_scale1_compare.load()
         assert_image_similar(image1_scale1, image1_scale1_compare, 5)
 
-    # Non-Zero bounding box
+    # Non-zero bounding box
     with Image.open(FILE2) as image2_scale1:
         image2_scale1.load()
         with Image.open(FILE2_COMPARE) as image2_scale1_compare:
@@ -292,7 +292,7 @@ def test_render_scale2():
         image1_scale2_compare.load()
         assert_image_similar(image1_scale2, image1_scale2_compare, 5)
 
-    # Non-Zero bounding box
+    # Non-zero bounding box
     with Image.open(FILE2) as image2_scale2:
         image2_scale2.load(scale=2)
         with Image.open(FILE2_COMPARE_SCALE2) as image2_scale2_compare:

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -403,7 +403,7 @@ class TestCoreResampleCoefficients:
             if px[2, 0] != test_color // 2:
                 assert test_color // 2 == px[2, 0]
 
-    def test_nonzero_coefficients(self):
+    def test_non_zero_coefficients(self):
         # regression test for the wrong coefficients calculation
         # due to bug https://github.com/python-pillow/Pillow/issues/2161
         im = Image.new("RGBA", (1280, 1280), (0x20, 0x40, 0x60, 0xFF))

--- a/src/libImaging/GifEncode.c
+++ b/src/libImaging/GifEncode.c
@@ -105,7 +105,7 @@ encode_loop:
                 st->head = st->codes[st->probe] >> 20;
                 goto encode_loop;
             } else {
-        /* Reprobe decrement must be nonzero and relatively prime to table
+        /* Reprobe decrement must be non-zero and relatively prime to table
          * size. So, any odd positive number for power-of-2 size. */
                 if ((st->probe -= ((st->tail << 2) | 1)) < 0) {
                     st->probe += TABLE_SIZE;

--- a/src/libImaging/Jpeg.h
+++ b/src/libImaging/Jpeg.h
@@ -74,7 +74,7 @@ typedef struct {
     /* Optimize Huffman tables (slow) */
     int optimize;
 
-    /* Disable automatic conversion of RGB images to YCbCr if nonzero */
+    /* Disable automatic conversion of RGB images to YCbCr if non-zero */
     int keep_rgb;
 
     /* Stream type (0=full, 1=tables only, 2=image only) */


### PR DESCRIPTION
"non-zero" is used in Pillow [more frequently](https://github.com/search?q=repo%3Apython-pillow%2FPillow+non-zero&type=code) than ["nonzero"](https://github.com/search?q=repo%3Apython-pillow%2FPillow+nonzero&type=code)

This PR makes some changes for consistency.