### PR TITLE
PyPI project page URL is now lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ As of 2019, Pillow development is
             <a href="https://tidelift.com/subscription/pkg/pypi-pillow?utm_source=pypi-pillow&utm_medium=badge"><img
                 alt="Tidelift"
                 src="https://tidelift.com/badges/package/pypi/Pillow?style=flat"></a>
-            <a href="https://pypi.org/project/Pillow/"><img
+            <a href="https://pypi.org/project/pillow/"><img
                 alt="Newest PyPI version"
                 src="https://img.shields.io/pypi/v/pillow.svg"></a>
-            <a href="https://pypi.org/project/Pillow/"><img
+            <a href="https://pypi.org/project/pillow/"><img
                 alt="Number of PyPI downloads"
                 src="https://img.shields.io/pypi/dm/pillow.svg"></a>
             <a href="https://www.bestpractices.dev/projects/6331"><img

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -13,7 +13,7 @@ The fork author's goal is to foster and support active development of PIL throug
 .. _GitHub Actions: https://github.com/python-pillow/Pillow/actions
 .. _AppVeyor: https://ci.appveyor.com/project/Python-pillow/pillow
 .. _GitHub: https://github.com/python-pillow/Pillow
-.. _Python Package Index: https://pypi.org/project/Pillow/
+.. _Python Package Index: https://pypi.org/project/pillow/
 
 License
 -------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,11 +58,11 @@ Pillow for enterprise is available via the Tidelift Subscription. `Learn more <h
    :alt: Fuzzing Status
 
 .. image:: https://img.shields.io/pypi/v/pillow.svg
-   :target: https://pypi.org/project/Pillow/
+   :target: https://pypi.org/project/pillow/
    :alt: Latest PyPI version
 
 .. image:: https://img.shields.io/pypi/dm/pillow.svg
-   :target: https://pypi.org/project/Pillow/
+   :target: https://pypi.org/project/pillow/
    :alt: Number of PyPI downloads
 
 .. image:: https://www.bestpractices.dev/projects/6331/badge

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -385,7 +385,7 @@ After navigating to the Pillow directory, run::
     python3 -m pip install --upgrade pip
     python3 -m pip install .
 
-.. _compressed archive from PyPI: https://pypi.org/project/Pillow/#files
+.. _compressed archive from PyPI: https://pypi.org/project/pillow/#files
 
 Build Options
 """""""""""""
@@ -602,5 +602,5 @@ Old Versions
 ------------
 
 You can download old distributions from the `release history at PyPI
-<https://pypi.org/project/Pillow/#history>`_ and by direct URL access
-eg. https://pypi.org/project/Pillow/1.0/.
+<https://pypi.org/project/pillow/#history>`_ and by direct URL access
+eg. https://pypi.org/project/pillow/1.0/.


### PR DESCRIPTION
Because the wheels now use lowercase `pillow`, the PyPI page has changed name to also be lowercase, which causes `make doccheck` to warn on main: https://github.com/python-pillow/Pillow/actions/runs/7432229048/job/20223791525#step:7:556