### PR TITLE
Use consistent arguments for load_read and load_seek

### DIFF
--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -408,7 +408,7 @@ class EpsImageFile(ImageFile.ImageFile):
             self.tile = []
         return Image.Image.load(self)
 
-    def load_seek(self, *args, **kwargs):
+    def load_seek(self, pos):
         # we can't incrementally load, so force ImageFile.parser to
         # use our custom load method by defining this method.
         pass

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -339,7 +339,7 @@ class IcoImageFile(ImageFile.ImageFile):
 
             self.size = im.size
 
-    def load_seek(self):
+    def load_seek(self, pos):
         # Flag the ImageFile.Parser so that it
         # just does all the decode at the end.
         pass

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -328,7 +328,7 @@ class ImageFile(Image.Image):
     #     pass
 
     # may be defined for blocked formats (e.g. PNG)
-    # def load_read(self, bytes):
+    # def load_read(self, read_bytes):
     #     pass
 
     def _seek_check(self, frame):

--- a/src/PIL/XpmImagePlugin.py
+++ b/src/PIL/XpmImagePlugin.py
@@ -103,7 +103,7 @@ class XpmImageFile(ImageFile.ImageFile):
 
         self.tile = [("raw", (0, 0) + self.size, self.fp.tell(), ("P", 0, 1))]
 
-    def load_read(self, bytes):
+    def load_read(self, read_bytes):
         #
         # load all image data in one chunk
 


### PR DESCRIPTION
`load_read()` does not have a consistent signature across the plugins where it is used. For example,
https://github.com/python-pillow/Pillow/blob/9923531742726419732618c6f2aef0bb8c21e259/src/PIL/JpegImagePlugin.py#L411
https://github.com/python-pillow/Pillow/blob/9923531742726419732618c6f2aef0bb8c21e259/src/PIL/XpmImagePlugin.py#L106

Neither does `load_seek()`. For example,
https://github.com/python-pillow/Pillow/blob/9923531742726419732618c6f2aef0bb8c21e259/src/PIL/FtexImagePlugin.py#L105
https://github.com/python-pillow/Pillow/blob/9923531742726419732618c6f2aef0bb8c21e259/src/PIL/IcoImagePlugin.py#L342