### PR TITLE
Added type hints to seven plugins

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3437,7 +3437,7 @@ def register_open(id, factory, accept=None) -> None:
     OPEN[id] = factory, accept
 
 
-def register_mime(id, mimetype) -> None:
+def register_mime(id: str, mimetype: str) -> None:
     """
     Registers an image MIME type by populating ``Image.MIME``. This function
     should not be used in application code.
@@ -3452,7 +3452,7 @@ def register_mime(id, mimetype) -> None:
     MIME[id.upper()] = mimetype
 
 
-def register_save(id, driver) -> None:
+def register_save(id: str, driver) -> None:
     """
     Registers an image save function.  This function should not be
     used in application code.

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3437,7 +3437,7 @@ def register_open(id, factory, accept=None) -> None:
     OPEN[id] = factory, accept
 
 
-def register_mime(id, mimetype):
+def register_mime(id, mimetype) -> None:
     """
     Registers an image MIME type by populating ``Image.MIME``. This function
     should not be used in application code.
@@ -3452,7 +3452,7 @@ def register_mime(id, mimetype):
     MIME[id.upper()] = mimetype
 
 
-def register_save(id, driver):
+def register_save(id, driver) -> None:
     """
     Registers an image save function.  This function should not be
     used in application code.

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -514,7 +514,7 @@ class Parser:
 # --------------------------------------------------------------------
 
 
-def _save(im, fp, tile, bufsize=0):
+def _save(im, fp, tile, bufsize=0) -> None:
     """Helper to save image based on tile list
 
     :param im: Image object.

--- a/src/PIL/ImagePalette.py
+++ b/src/PIL/ImagePalette.py
@@ -192,7 +192,7 @@ class ImagePalette:
 # Internal
 
 
-def raw(rawmode, data):
+def raw(rawmode, data) -> ImagePalette:
     palette = ImagePalette()
     palette.rawmode = rawmode
     palette.palette = data

--- a/src/PIL/McIdasImagePlugin.py
+++ b/src/PIL/McIdasImagePlugin.py
@@ -22,8 +22,8 @@ import struct
 from . import Image, ImageFile
 
 
-def _accept(s):
-    return s[:8] == b"\x00\x00\x00\x00\x00\x00\x00\x04"
+def _accept(prefix: bytes) -> bool:
+    return prefix[:8] == b"\x00\x00\x00\x00\x00\x00\x00\x04"
 
 
 ##
@@ -34,8 +34,10 @@ class McIdasImageFile(ImageFile.ImageFile):
     format = "MCIDAS"
     format_description = "McIdas area file"
 
-    def _open(self):
+    def _open(self) -> None:
         # parse area file directory
+        assert self.fp is not None
+
         s = self.fp.read(256)
         if not _accept(s) or len(s) != 256:
             msg = "not an McIdas area file"

--- a/src/PIL/PcdImagePlugin.py
+++ b/src/PIL/PcdImagePlugin.py
@@ -27,8 +27,10 @@ class PcdImageFile(ImageFile.ImageFile):
     format = "PCD"
     format_description = "Kodak PhotoCD"
 
-    def _open(self):
+    def _open(self) -> None:
         # rough
+        assert self.fp is not None
+
         self.fp.seek(2048)
         s = self.fp.read(2048)
 
@@ -47,9 +49,11 @@ class PcdImageFile(ImageFile.ImageFile):
         self._size = 768, 512  # FIXME: not correct for rotated images!
         self.tile = [("pcd", (0, 0) + self.size, 96 * 2048, None)]
 
-    def load_end(self):
+    def load_end(self) -> None:
         if self.tile_post_rotate:
             # Handle rotated PCDs
+            assert self.im is not None
+
             self.im = self.im.rotate(self.tile_post_rotate)
             self._size = self.im.size
 

--- a/src/PIL/PcxImagePlugin.py
+++ b/src/PIL/PcxImagePlugin.py
@@ -37,7 +37,7 @@ from ._binary import o16le as o16
 logger = logging.getLogger(__name__)
 
 
-def _accept(prefix):
+def _accept(prefix: bytes) -> bool:
     return prefix[0] == 10 and prefix[1] in [0, 2, 3, 5]
 
 
@@ -49,8 +49,10 @@ class PcxImageFile(ImageFile.ImageFile):
     format = "PCX"
     format_description = "Paintbrush"
 
-    def _open(self):
+    def _open(self) -> None:
         # header
+        assert self.fp is not None
+
         s = self.fp.read(128)
         if not _accept(s):
             msg = "not a PCX file"
@@ -141,7 +143,7 @@ SAVE = {
 }
 
 
-def _save(im, fp, filename):
+def _save(im: Image.Image, fp: io.BytesIO, filename: str) -> None:
     try:
         version, bits, planes, rawmode = SAVE[im.mode]
     except KeyError as e:
@@ -199,6 +201,8 @@ def _save(im, fp, filename):
 
     if im.mode == "P":
         # colour palette
+        assert im.im is not None
+
         fp.write(o8(12))
         palette = im.im.getpalette("RGB", "RGB")
         palette += b"\x00" * (768 - len(palette))

--- a/src/PIL/PixarImagePlugin.py
+++ b/src/PIL/PixarImagePlugin.py
@@ -27,7 +27,7 @@ from ._binary import i16le as i16
 # helpers
 
 
-def _accept(prefix):
+def _accept(prefix: bytes) -> bool:
     return prefix[:4] == b"\200\350\000\000"
 
 
@@ -39,8 +39,10 @@ class PixarImageFile(ImageFile.ImageFile):
     format = "PIXAR"
     format_description = "PIXAR raster image"
 
-    def _open(self):
+    def _open(self) -> None:
         # assuming a 4-byte magic label
+        assert self.fp is not None
+
         s = self.fp.read(4)
         if not _accept(s):
             msg = "not a PIXAR file"

--- a/src/PIL/SunImagePlugin.py
+++ b/src/PIL/SunImagePlugin.py
@@ -21,7 +21,7 @@ from . import Image, ImageFile, ImagePalette
 from ._binary import i32be as i32
 
 
-def _accept(prefix):
+def _accept(prefix: bytes) -> bool:
     return len(prefix) >= 4 and i32(prefix) == 0x59A66A95
 
 
@@ -33,7 +33,7 @@ class SunImageFile(ImageFile.ImageFile):
     format = "SUN"
     format_description = "Sun Raster File"
 
-    def _open(self):
+    def _open(self) -> None:
         # The Sun Raster file header is 32 bytes in length
         # and has the following format:
 
@@ -48,6 +48,8 @@ class SunImageFile(ImageFile.ImageFile):
         #         DWORD ColorMapType;     /* Type of color map */
         #         DWORD ColorMapLength;   /* Size of the color map in bytes */
         #     } SUNRASTER;
+
+        assert self.fp is not None
 
         # HEAD
         s = self.fp.read(32)

--- a/src/PIL/XVThumbImagePlugin.py
+++ b/src/PIL/XVThumbImagePlugin.py
@@ -33,7 +33,7 @@ for r in range(8):
             )
 
 
-def _accept(prefix):
+def _accept(prefix: bytes) -> bool:
     return prefix[:6] == _MAGIC
 
 
@@ -45,8 +45,10 @@ class XVThumbImageFile(ImageFile.ImageFile):
     format = "XVThumb"
     format_description = "XV thumbnail image"
 
-    def _open(self):
+    def _open(self) -> None:
         # check magic
+        assert self.fp is not None
+
         if not _accept(self.fp.read(6)):
             msg = "not an XV thumbnail file"
             raise SyntaxError(msg)

--- a/src/PIL/XbmImagePlugin.py
+++ b/src/PIL/XbmImagePlugin.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 import re
+from io import BytesIO
 
 from . import Image, ImageFile
 
@@ -36,7 +37,7 @@ xbm_head = re.compile(
 )
 
 
-def _accept(prefix):
+def _accept(prefix: bytes) -> bool:
     return prefix.lstrip()[:7] == b"#define"
 
 
@@ -48,7 +49,9 @@ class XbmImageFile(ImageFile.ImageFile):
     format = "XBM"
     format_description = "X11 Bitmap"
 
-    def _open(self):
+    def _open(self) -> None:
+        assert self.fp is not None
+
         m = xbm_head.match(self.fp.read(512))
 
         if not m:
@@ -67,7 +70,7 @@ class XbmImageFile(ImageFile.ImageFile):
         self.tile = [("xbm", (0, 0) + self.size, m.end(), None)]
 
 
-def _save(im, fp, filename):
+def _save(im: Image.Image, fp: BytesIO, filename: str) -> None:
     if im.mode != "1":
         msg = f"cannot write mode {im.mode} as XBM"
         raise OSError(msg)


### PR DESCRIPTION
Add type hints to seven plugins that require minimal changes to adhere to `mypy --strict`.

- McIdasImagePlugin
- PcdImagePlugin
- PcxImagePlugin
- PixarImagePlugin
- SunImagePlugin
- XVThumbImagePlugin
- XbmImagePlugin