### PR TITLE
ImageMath: Only compute `ops` dict when needed

### DIFF
--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import builtins
-from functools import cache
+from functools import lru_cache
 from types import CodeType
 from typing import Any
 
@@ -225,7 +225,7 @@ def imagemath_convert(self: _Operand, mode: str) -> _Operand:
     return _Operand(self.im.convert(mode))
 
 
-@cache
+@lru_cache
 def _get_ops() -> dict[str, Any]:
     return {k[10:]: v for k, v in globals().items() if k[:10] == "imagemath_"}
 

--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import builtins
+from functools import cache
 from types import CodeType
 from typing import Any
 
@@ -224,10 +225,13 @@ def imagemath_convert(self: _Operand, mode: str) -> _Operand:
     return _Operand(self.im.convert(mode))
 
 
-ops = {}
-for k, v in list(globals().items()):
-    if k[:10] == "imagemath_":
-        ops[k[10:]] = v
+@cache
+def _get_ops() -> dict[str, Any]:
+    ops = {}
+    for k, v in list(globals().items()):
+        if k[:10] == "imagemath_":
+            ops[k[10:]] = v
+    return ops
 
 
 def eval(expression: str, _dict: dict[str, Any] = {}, **kw: Any) -> Any:
@@ -244,7 +248,7 @@ def eval(expression: str, _dict: dict[str, Any] = {}, **kw: Any) -> Any:
     """
 
     # build execution namespace
-    args = ops.copy()
+    args = _get_ops().copy()
     for k in list(_dict.keys()) + list(kw.keys()):
         if "__" in k or hasattr(builtins, k):
             msg = f"'{k}' not allowed"

--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -227,11 +227,7 @@ def imagemath_convert(self: _Operand, mode: str) -> _Operand:
 
 @cache
 def _get_ops() -> dict[str, Any]:
-    ops = {}
-    for k, v in list(globals().items()):
-        if k[:10] == "imagemath_":
-            ops[k[10:]] = v
-    return ops
+    return {k[10:]: v for k, v in globals().items() if k[:10] == "imagemath_"}
 
 
 def eval(expression: str, _dict: dict[str, Any] = {}, **kw: Any) -> Any:


### PR DESCRIPTION
An idea to fix #7717, only compute the `ops` dict when needed, when first calling `eval`, and `functools.lru_cache` it so it's only computed once.

Also rewrite as a dict comprehension. Timings for non-cached use:

200000 loops, best of 5: 1.87 usec per loop
->
200000 loops, best of 5: 1.53 usec per loop
