### PR TITLE
Sort imports in `Tests/`

### DIFF
--- a/Tests/bench_cffi_access.py
+++ b/Tests/bench_cffi_access.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import time
 
 from PIL import PyAccess

--- a/Tests/check_fli_overflow.py
+++ b/Tests/check_fli_overflow.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from PIL import Image
 
 TEST_FILE = "Tests/images/fli_overflow.fli"

--- a/Tests/check_imaging_leaks.py
+++ b/Tests/check_imaging_leaks.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/check_j2k_leaks.py
+++ b/Tests/check_j2k_leaks.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from io import BytesIO
 
 import pytest

--- a/Tests/check_j2k_overflow.py
+++ b/Tests/check_j2k_overflow.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/check_jp2_overflow.py
+++ b/Tests/check_jp2_overflow.py
@@ -14,7 +14,6 @@
 # version.
 from __future__ import annotations
 
-
 from PIL import Image
 
 repro = ("00r0_gray_l.jp2", "00r1_graya_la.jp2")

--- a/Tests/check_jpeg_leaks.py
+++ b/Tests/check_jpeg_leaks.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from io import BytesIO
 
 import pytest

--- a/Tests/check_large_memory.py
+++ b/Tests/check_large_memory.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import sys
 
 import pytest

--- a/Tests/check_large_memory_numpy.py
+++ b/Tests/check_large_memory_numpy.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import sys
 
 import pytest

--- a/Tests/check_libtiff_segfault.py
+++ b/Tests/check_libtiff_segfault.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/check_png_dos.py
+++ b/Tests/check_png_dos.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import zlib
 from io import BytesIO
 

--- a/Tests/check_release_notes.py
+++ b/Tests/check_release_notes.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import sys
 from pathlib import Path
 

--- a/Tests/check_wheel.py
+++ b/Tests/check_wheel.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import sys
 
 from PIL import features

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import io
 
 

--- a/Tests/createfontdatachunk.py
+++ b/Tests/createfontdatachunk.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
+
 import base64
 import os
 

--- a/Tests/oss-fuzz/fuzzers.py
+++ b/Tests/oss-fuzz/fuzzers.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import io
 import warnings
 

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import subprocess
 import sys
 

--- a/Tests/test_000_sanity.py
+++ b/Tests/test_000_sanity.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from PIL import Image
 
 

--- a/Tests/test_binary.py
+++ b/Tests/test_binary.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from PIL import _binary
 
 

--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os
 import warnings
 

--- a/Tests/test_box_blur.py
+++ b/Tests/test_box_blur.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImageFilter

--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from array import array
 
 import pytest

--- a/Tests/test_core_resources.py
+++ b/Tests/test_core_resources.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import sys
 
 import pytest

--- a/Tests/test_decompression_bomb.py
+++ b/Tests/test_decompression_bomb.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/test_deprecate.py
+++ b/Tests/test_deprecate.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import _deprecate

--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import io
 import re
 

--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImageSequence, PngImagePlugin

--- a/Tests/test_file_blp.py
+++ b/Tests/test_file_blp.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import io
 
 import pytest

--- a/Tests/test_file_bufrstub.py
+++ b/Tests/test_file_bufrstub.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import BufrStubImagePlugin, Image

--- a/Tests/test_file_container.py
+++ b/Tests/test_file_container.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import ContainerIO, Image

--- a/Tests/test_file_cur.py
+++ b/Tests/test_file_cur.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import CurImagePlugin, Image

--- a/Tests/test_file_dcx.py
+++ b/Tests/test_file_dcx.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import warnings
 
 import pytest

--- a/Tests/test_file_dds.py
+++ b/Tests/test_file_dds.py
@@ -1,5 +1,6 @@
 """Test DdsImagePlugin"""
 from __future__ import annotations
+
 from io import BytesIO
 
 import pytest

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import io
 
 import pytest

--- a/Tests/test_file_fits.py
+++ b/Tests/test_file_fits.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from io import BytesIO
 
 import pytest

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import warnings
 
 import pytest

--- a/Tests/test_file_fpx.py
+++ b/Tests/test_file_fpx.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/test_file_ftex.py
+++ b/Tests/test_file_ftex.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import FtexImagePlugin, Image

--- a/Tests/test_file_gbr.py
+++ b/Tests/test_file_gbr.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import GbrImagePlugin, Image

--- a/Tests/test_file_gd.py
+++ b/Tests/test_file_gd.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import GdImageFile, UnidentifiedImageError

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import warnings
 from io import BytesIO
 

--- a/Tests/test_file_gimpgradient.py
+++ b/Tests/test_file_gimpgradient.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from PIL import GimpGradientFile, ImagePalette
 
 

--- a/Tests/test_file_gimppalette.py
+++ b/Tests/test_file_gimppalette.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL.GimpPaletteFile import GimpPaletteFile

--- a/Tests/test_file_gribstub.py
+++ b/Tests/test_file_gribstub.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import GribStubImagePlugin, Image

--- a/Tests/test_file_hdf5stub.py
+++ b/Tests/test_file_hdf5stub.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Hdf5StubImagePlugin, Image

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import io
 import os
 import warnings

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import io
 import os
 

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import filecmp
 import warnings
 

--- a/Tests/test_file_imt.py
+++ b/Tests/test_file_imt.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import io
 
 import pytest

--- a/Tests/test_file_iptc.py
+++ b/Tests/test_file_iptc.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import sys
 from io import BytesIO, StringIO
 

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os
 import re
 import warnings

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os
 import re
 from io import BytesIO

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import base64
 import io
 import itertools

--- a/Tests/test_file_libtiff_small.py
+++ b/Tests/test_file_libtiff_small.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from io import BytesIO
 
 from PIL import Image

--- a/Tests/test_file_mcidas.py
+++ b/Tests/test_file_mcidas.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, McIdasImagePlugin

--- a/Tests/test_file_mic.py
+++ b/Tests/test_file_mic.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImagePalette

--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import warnings
 from io import BytesIO
 

--- a/Tests/test_file_msp.py
+++ b/Tests/test_file_msp.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os
 
 import pytest

--- a/Tests/test_file_palm.py
+++ b/Tests/test_file_palm.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os.path
 import subprocess
 

--- a/Tests/test_file_pcd.py
+++ b/Tests/test_file_pcd.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from PIL import Image
 
 

--- a/Tests/test_file_pcx.py
+++ b/Tests/test_file_pcx.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImageFile, PcxImagePlugin

--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import io
 import os
 import os.path

--- a/Tests/test_file_pixar.py
+++ b/Tests/test_file_pixar.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, PixarImagePlugin

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import re
 import sys
 import warnings

--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import sys
 from io import BytesIO
 

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import warnings
 
 import pytest

--- a/Tests/test_file_qoi.py
+++ b/Tests/test_file_qoi.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, QoiImagePlugin

--- a/Tests/test_file_sgi.py
+++ b/Tests/test_file_sgi.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, SgiImagePlugin

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import tempfile
 import warnings
 from io import BytesIO

--- a/Tests/test_file_sun.py
+++ b/Tests/test_file_sun.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os
 
 import pytest

--- a/Tests/test_file_tar.py
+++ b/Tests/test_file_tar.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import warnings
 
 import pytest

--- a/Tests/test_file_tga.py
+++ b/Tests/test_file_tga.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os
 from glob import glob
 from itertools import product

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os
 import warnings
 from io import BytesIO

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import io
 import struct
 

--- a/Tests/test_file_wal.py
+++ b/Tests/test_file_wal.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from PIL import WalImageFile
 
 from .helper import assert_image_equal_tofile

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import io
 import re
 import sys

--- a/Tests/test_file_webp_alpha.py
+++ b/Tests/test_file_webp_alpha.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/test_file_webp_animated.py
+++ b/Tests/test_file_webp_animated.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 from packaging.version import parse as parse_version
 

--- a/Tests/test_file_webp_lossless.py
+++ b/Tests/test_file_webp_lossless.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/test_file_webp_metadata.py
+++ b/Tests/test_file_webp_metadata.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from io import BytesIO
 
 import pytest

--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, WmfImagePlugin

--- a/Tests/test_file_xbm.py
+++ b/Tests/test_file_xbm.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from io import BytesIO
 
 import pytest

--- a/Tests/test_file_xpm.py
+++ b/Tests/test_file_xpm.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, XpmImagePlugin

--- a/Tests/test_file_xvthumb.py
+++ b/Tests/test_file_xvthumb.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, XVThumbImagePlugin

--- a/Tests/test_font_bdf.py
+++ b/Tests/test_font_bdf.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import BdfFontFile, FontFile

--- a/Tests/test_font_crash.py
+++ b/Tests/test_font_crash.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImageDraw, ImageFont

--- a/Tests/test_font_leaks.py
+++ b/Tests/test_font_leaks.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from PIL import Image, ImageDraw, ImageFont
 
 from .helper import PillowLeakTestCase, skip_unless_feature

--- a/Tests/test_font_pcf.py
+++ b/Tests/test_font_pcf.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os
 
 import pytest

--- a/Tests/test_font_pcf_charsets.py
+++ b/Tests/test_font_pcf_charsets.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os
 
 import pytest

--- a/Tests/test_fontfile.py
+++ b/Tests/test_fontfile.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import FontFile

--- a/Tests/test_format_hsv.py
+++ b/Tests/test_format_hsv.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import colorsys
 import itertools
 

--- a/Tests/test_format_lab.py
+++ b/Tests/test_format_lab.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from PIL import Image
 
 

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import io
 import logging
 import os

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os
 import subprocess
 import sys

--- a/Tests/test_image_array.py
+++ b/Tests/test_image_array.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 from packaging.version import parse as parse_version
 

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/test_image_copy.py
+++ b/Tests/test_image_copy.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import copy
 
 import pytest

--- a/Tests/test_image_crop.py
+++ b/Tests/test_image_crop.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/test_image_draft.py
+++ b/Tests/test_image_draft.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from PIL import Image
 
 from .helper import fromstring, skip_unless_feature, tostring

--- a/Tests/test_image_entropy.py
+++ b/Tests/test_image_entropy.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from .helper import hopper
 
 

--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImageFilter

--- a/Tests/test_image_frombytes.py
+++ b/Tests/test_image_frombytes.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/test_image_fromqimage.py
+++ b/Tests/test_image_fromqimage.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import warnings
 
 import pytest

--- a/Tests/test_image_getbands.py
+++ b/Tests/test_image_getbands.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from PIL import Image
 
 

--- a/Tests/test_image_getbbox.py
+++ b/Tests/test_image_getbbox.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/test_image_getcolors.py
+++ b/Tests/test_image_getcolors.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from .helper import hopper
 
 

--- a/Tests/test_image_getdata.py
+++ b/Tests/test_image_getdata.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from PIL import Image
 
 from .helper import hopper

--- a/Tests/test_image_getextrema.py
+++ b/Tests/test_image_getextrema.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from PIL import Image
 
 from .helper import hopper

--- a/Tests/test_image_getim.py
+++ b/Tests/test_image_getim.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from .helper import hopper
 
 

--- a/Tests/test_image_getpalette.py
+++ b/Tests/test_image_getpalette.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from PIL import Image
 
 from .helper import hopper

--- a/Tests/test_image_getprojection.py
+++ b/Tests/test_image_getprojection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from PIL import Image
 
 from .helper import hopper

--- a/Tests/test_image_histogram.py
+++ b/Tests/test_image_histogram.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from .helper import hopper
 
 

--- a/Tests/test_image_load.py
+++ b/Tests/test_image_load.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import logging
 import os
 

--- a/Tests/test_image_mode.py
+++ b/Tests/test_image_mode.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImageMode

--- a/Tests/test_image_paste.py
+++ b/Tests/test_image_paste.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/test_image_point.py
+++ b/Tests/test_image_point.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from .helper import assert_image_equal, hopper

--- a/Tests/test_image_putalpha.py
+++ b/Tests/test_image_putalpha.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from PIL import Image
 
 

--- a/Tests/test_image_putdata.py
+++ b/Tests/test_image_putdata.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import sys
 from array import array
 

--- a/Tests/test_image_putpalette.py
+++ b/Tests/test_image_putpalette.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImagePalette

--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 from packaging.version import parse as parse_version
 

--- a/Tests/test_image_reduce.py
+++ b/Tests/test_image_reduce.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImageMath, ImageMode

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from contextlib import contextmanager
 
 import pytest

--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -2,6 +2,7 @@
 Tests for resize functionality.
 """
 from __future__ import annotations
+
 from itertools import permutations
 
 import pytest

--- a/Tests/test_image_rotate.py
+++ b/Tests/test_image_rotate.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/test_image_split.py
+++ b/Tests/test_image_split.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, features

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/test_image_tobitmap.py
+++ b/Tests/test_image_tobitmap.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from .helper import assert_image_equal, fromstring, hopper

--- a/Tests/test_image_tobytes.py
+++ b/Tests/test_image_tobytes.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from .helper import hopper
 
 

--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import math
 
 import pytest

--- a/Tests/test_image_transpose.py
+++ b/Tests/test_image_transpose.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL.Image import Transpose

--- a/Tests/test_imagechops.py
+++ b/Tests/test_imagechops.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from PIL import Image, ImageChops
 
 from .helper import assert_image_equal, hopper

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import datetime
 import os
 import re

--- a/Tests/test_imagecolor.py
+++ b/Tests/test_imagecolor.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImageColor

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import contextlib
 import os.path
 

--- a/Tests/test_imagedraw2.py
+++ b/Tests/test_imagedraw2.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os.path
 
 import pytest

--- a/Tests/test_imageenhance.py
+++ b/Tests/test_imageenhance.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImageEnhance

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from io import BytesIO
 
 import pytest

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import copy
 import os
 import re

--- a/Tests/test_imagefontctl.py
+++ b/Tests/test_imagefontctl.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImageDraw, ImageFont

--- a/Tests/test_imagefontpil.py
+++ b/Tests/test_imagefontpil.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
+
 import struct
-import pytest
 from io import BytesIO
 
-from PIL import Image, ImageDraw, ImageFont, features, _util
+import pytest
+
+from PIL import Image, ImageDraw, ImageFont, _util, features
 
 from .helper import assert_image_equal_tofile
 

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os
 import shutil
 import subprocess

--- a/Tests/test_imagemath.py
+++ b/Tests/test_imagemath.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImageMath

--- a/Tests/test_imagemorph.py
+++ b/Tests/test_imagemorph.py
@@ -1,5 +1,6 @@
 # Test the ImageMorphology functionality
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImageMorph, _imagingmorph

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImageDraw, ImageOps, ImageStat, features

--- a/Tests/test_imageops_usm.py
+++ b/Tests/test_imageops_usm.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImageFilter

--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImagePalette

--- a/Tests/test_imagepath.py
+++ b/Tests/test_imagepath.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import array
 import math
 import struct

--- a/Tests/test_imageqt.py
+++ b/Tests/test_imageqt.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import warnings
 
 import pytest

--- a/Tests/test_imagesequence.py
+++ b/Tests/test_imagesequence.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImageSequence, TiffImagePlugin

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImageShow

--- a/Tests/test_imagestat.py
+++ b/Tests/test_imagestat.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image, ImageStat

--- a/Tests/test_imagetk.py
+++ b/Tests/test_imagetk.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/test_imagewin.py
+++ b/Tests/test_imagewin.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import ImageWin

--- a/Tests/test_imagewin_pointers.py
+++ b/Tests/test_imagewin_pointers.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from io import BytesIO
 
 from PIL import Image, ImageWin

--- a/Tests/test_lib_image.py
+++ b/Tests/test_lib_image.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/test_lib_pack.py
+++ b/Tests/test_lib_pack.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import sys
 
 import pytest

--- a/Tests/test_locale.py
+++ b/Tests/test_locale.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import locale
 
 import pytest

--- a/Tests/test_main.py
+++ b/Tests/test_main.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os
 import subprocess
 import sys

--- a/Tests/test_map.py
+++ b/Tests/test_map.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import sys
 
 import pytest

--- a/Tests/test_mode_i16.py
+++ b/Tests/test_mode_i16.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import warnings
 
 import pytest

--- a/Tests/test_pdfparser.py
+++ b/Tests/test_pdfparser.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import time
 
 import pytest

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pickle
 
 import pytest

--- a/Tests/test_psdraw.py
+++ b/Tests/test_psdraw.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os
 import sys
 from io import BytesIO

--- a/Tests/test_pyroma.py
+++ b/Tests/test_pyroma.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import __version__

--- a/Tests/test_qt_image_qapplication.py
+++ b/Tests/test_qt_image_qapplication.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import ImageQt

--- a/Tests/test_qt_image_toqimage.py
+++ b/Tests/test_qt_image_toqimage.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import ImageQt

--- a/Tests/test_sgi_crash.py
+++ b/Tests/test_sgi_crash.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import Image

--- a/Tests/test_shell_injection.py
+++ b/Tests/test_shell_injection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import shutil
 
 import pytest

--- a/Tests/test_tiff_ifdrational.py
+++ b/Tests/test_tiff_ifdrational.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from fractions import Fraction
 
 from PIL import Image, TiffImagePlugin, features

--- a/Tests/test_uploader.py
+++ b/Tests/test_uploader.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from .helper import assert_image_equal, assert_image_similar, hopper
 
 

--- a/Tests/test_util.py
+++ b/Tests/test_util.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 
 from PIL import _util

--- a/Tests/test_webp_leaks.py
+++ b/Tests/test_webp_leaks.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from io import BytesIO
 
 from PIL import Image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,6 @@ extend-ignore = [
 ]
 
 [tool.ruff.per-file-ignores]
-"Tests/*.py" = ["I001"]
 "Tests/oss-fuzz/fuzz_font.py" = ["I002"]
 "Tests/oss-fuzz/fuzz_pillow.py" = ["I002"]
 


### PR DESCRIPTION
Ruff didn't isort imports in https://github.com/python-pillow/Pillow/pull/7733 and https://github.com/python-pillow/Pillow/pull/7732, it didn't move `from typing import ...` imports to the stdlib group because we're skipping isort for `Tests/`.

This config was added in the original Ruff PR: https://github.com/python-pillow/Pillow/pull/6966. I had a quick check but couldn't see the reason why we added it there.

Anyway, let's remove it now and allow isorting `Tests/`.