### PR TITLE
Add BytesIO alias to fix missing references in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,11 @@ extensions = [
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
+# io.BytesIO is incorrectly converted to _io.BytesIO, this alias prevents that
+autodoc_type_aliases = {
+    "BytesIO": "~io.BytesIO",
+}
+
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']


### PR DESCRIPTION
A warning has started appearing in [the Docs build in main](https://github.com/python-pillow/Pillow/actions/runs/7593486569/job/20684003604#step:7:254) due to type hints added in https://github.com/python-pillow/Pillow/pull/7727 and https://github.com/python-pillow/Pillow/pull/7728.

```
/opt/hostedtoolcache/Python/3.12.1/x64/lib/python3.12/site-packages/PIL/GdImageFile.py:docstring of PIL.GdImageFile.open:1: WARNING: py:class reference target not found: _io.BytesIO
/opt/hostedtoolcache/Python/3.12.1/x64/lib/python3.12/site-packages/PIL/MpegImagePlugin.py:docstring of PIL.MpegImagePlugin.BitStream:1: WARNING: py:class reference target not found: _io.BytesIO
```

This PR fixes it using [`autodoc_type_aliases`](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_type_aliases).