### PR TITLE
Do not support using test-image-results to upload images after test failures

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -25,13 +25,6 @@ if os.environ.get("SHOW_ERRORS"):
     uploader = "show"
 elif "GITHUB_ACTIONS" in os.environ:
     uploader = "github_actions"
-else:
-    try:
-        import test_image_results
-
-        uploader = "aws"
-    except ImportError:
-        pass
 
 
 def upload(a: Image.Image, b: Image.Image) -> str | None:
@@ -46,8 +39,6 @@ def upload(a: Image.Image, b: Image.Image) -> str | None:
         a.save(os.path.join(tmpdir, "a.png"))
         b.save(os.path.join(tmpdir, "b.png"))
         return tmpdir
-    elif uploader == "aws":
-        return test_image_results.upload(a, b)
     return None
 
 


### PR DESCRIPTION
Do not use [test-image-results](https://pypi.org/project/test-image-results/) to upload images after test failures.

Suggested in https://github.com/python-pillow/Pillow/pull/7733#discussion_r1460362160