### PR TITLE
CI: Cache libimagequant on Linux builds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,9 @@ jobs:
       with:
         python-version: "3.x"
         cache: pip
-        cache-dependency-path: ".ci/*.sh"
+        cache-dependency-path: |
+          ".ci/*.sh"
+          "pyproject.toml"
 
     - name: Build system information
       run: python3 .github/workflows/system-info.py

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,11 +44,19 @@ jobs:
     - name: Build system information
       run: python3 .github/workflows/system-info.py
 
+    - name: Cache libimagequant
+      uses: actions/cache@v4
+      id: cache-libimagequant
+      with:
+        path: ~/cache-libimagequant
+        key: ${{ runner.os }}-libimagequant-${{ hashFiles('depends/install_imagequant.sh') }}
+
     - name: Install Linux dependencies
       run: |
         .ci/install.sh
       env:
         GHA_PYTHON_VERSION: "3.x"
+        GHA_LIBIMAGEQUANT_CACHE_HIT: ${{ steps.cache-libimagequant.outputs.cache-hit }}
 
     - name: Build
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build:
 
@@ -65,7 +68,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
         cache: pip
-        cache-dependency-path: ".ci/*.sh"
+        cache-dependency-path: |
+          ".ci/*.sh"
+          "pyproject.toml"
 
     - name: Build system information
       run: python3 .github/workflows/system-info.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,12 +75,21 @@ jobs:
     - name: Build system information
       run: python3 .github/workflows/system-info.py
 
+    - name: Cache libimagequant
+      if: startsWith(matrix.os, 'ubuntu')
+      uses: actions/cache@v4
+      id: cache-libimagequant
+      with:
+        path: ~/cache-libimagequant
+        key: ${{ runner.os }}-libimagequant-${{ hashFiles('depends/install_imagequant.sh') }}
+
     - name: Install Linux dependencies
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         .ci/install.sh
       env:
         GHA_PYTHON_VERSION: ${{ matrix.python-version }}
+        GHA_LIBIMAGEQUANT_CACHE_HIT: ${{ steps.cache-libimagequant.outputs.cache-hit }}
 
     - name: Install macOS dependencies
       if: startsWith(matrix.os, 'macOS')

--- a/depends/download-and-extract.sh
+++ b/depends/download-and-extract.sh
@@ -5,7 +5,7 @@ archive=$1
 url=$2
 
 if [ ! -f $archive.tar.gz ]; then
-    wget -O $archive.tar.gz $url
+    wget --no-verbose -O $archive.tar.gz $url
 fi
 
 rmdir $archive

--- a/depends/install_imagequant.sh
+++ b/depends/install_imagequant.sh
@@ -19,18 +19,20 @@ else
 
     pushd $archive/imagequant-sys
 
-    time cargo install cargo-c
-    time cargo cinstall --prefix=/usr --destdir=.
+    cargo install cargo-c
+    cargo cinstall --prefix=/usr --destdir=.
 
     # Copy into place
     sudo cp usr/lib/libimagequant.so* /usr/lib/
     sudo cp usr/include/libimagequant.h /usr/include/
 
-    # Copy to cache
-    rm -rf ~/cache-$archive_name
-    mkdir ~/cache-$archive_name
-    cp usr/lib/libimagequant.so* ~/cache-$archive_name/
-    cp usr/include/libimagequant.h ~/cache-$archive_name/
+    if [ -n "$GITHUB_ACTIONS" ]; then
+        # Copy to cache
+        rm -rf ~/cache-$archive_name
+        mkdir ~/cache-$archive_name
+        cp usr/lib/libimagequant.so* ~/cache-$archive_name/
+        cp usr/include/libimagequant.h ~/cache-$archive_name/
+    fi
 
     popd
 

--- a/depends/install_imagequant.sh
+++ b/depends/install_imagequant.sh
@@ -1,15 +1,37 @@
 #!/bin/bash
 # install libimagequant
 
-archive=libimagequant-4.2.2
+archive_name=libimagequant
+archive_version=4.2.2
 
-./download-and-extract.sh $archive https://raw.githubusercontent.com/python-pillow/pillow-depends/main/$archive.tar.gz
+archive=$archive_name-$archive_version
 
-pushd $archive/imagequant-sys
+if [[ "$GHA_LIBIMAGEQUANT_CACHE_HIT" == "true" ]]; then
 
-cargo install cargo-c
-cargo cinstall --prefix=/usr --destdir=.
-sudo cp usr/lib/libimagequant.so* /usr/lib/
-sudo cp usr/include/libimagequant.h /usr/include/
+    # Copy cached files into place
+    sudo cp ~/cache-$archive_name/libimagequant.so* /usr/lib/
+    sudo cp ~/cache-$archive_name/libimagequant.h /usr/include/
 
-popd
+else
+
+    # Build from source
+    ./download-and-extract.sh $archive https://raw.githubusercontent.com/python-pillow/pillow-depends/main/$archive.tar.gz
+
+    pushd $archive/imagequant-sys
+
+    time cargo install cargo-c
+    time cargo cinstall --prefix=/usr --destdir=.
+
+    # Copy into place
+    sudo cp usr/lib/libimagequant.so* /usr/lib/
+    sudo cp usr/include/libimagequant.h /usr/include/
+
+    # Copy to cache
+    rm -rf ~/cache-$archive_name
+    mkdir ~/cache-$archive_name
+    cp usr/lib/libimagequant.so* ~/cache-$archive_name/
+    cp usr/include/libimagequant.h ~/cache-$archive_name/
+
+    popd
+
+fi


### PR DESCRIPTION
On the CI, the step to "Install Linux dependencies" takes between 6m10s and 6m30s.

The step runs `.ci/install.sh` and its slowest commands are:

```sh
    # webp
    pushd depends && ./install_webp.sh && popd

    # libimagequant
    pushd depends && ./install_imagequant.sh && popd

    # raqm
    pushd depends && ./install_raqm.sh && popd
```

They take ~25s, ~4m30s and ~40s respectively.

Given the Linux jobs mostly take around 8m30s, caching these steps can save up to 5m30s, and would greatly improve the CI time.

Let's start with the slowest: libimagequant.


First, add to the workflow a cache step:

```yaml
    - name: Cache libimagequant
      uses: actions/cache@v4
      id: cache-libimagequant
      with:
        path: ~/cache-libimagequant
        key: ${{ runner.os }}-libimagequant-${{ hashFiles('depends/install_imagequant.sh') }}
```

If there's a matching cache file, it unpacks the cache to `~/cache-libimagequant` and we have a cache hit.

Then we pass in the cache hit status as an environment variable (`GHA_LIBIMAGEQUANT_CACHE_HIT`) to `install.sh`.

`install.sh` calls `depends/install_imagequant.sh`, which checks the env var.

 * If there's a cache hit, it sudo copies the cached files from `~/cache-libimagequant` to `/usr/...`.

 * If there's a cache miss, we need to build from source, as before. Except we also copy the built files into `~/cache-libimagequant` so they can be cached for next time. (Delete and recreate the dir, just to be sure no old cached files are retained.)

This reduces the "Install Linux dependencies" step from 6.5-8 minutes to to 1.5-2 minutes, and saves about 45 minutes of CPU time in total.

Total time for some jobs:

 Job | [Before](https://github.com/python-pillow/Pillow/actions/runs/7599977497/usage) | [After (cached)](https://github.com/hugovk/Pillow/actions/runs/7601980197/usage)
-- | -- | --
ubuntu-latest Python pypy3.10 | 13m 1s | 7m 28s
ubuntu-latest Python pypy3.9 | 12m 29s | 7m 16s
ubuntu-latest Python 3.13 | 9m 49s | 4m 16s
ubuntu-latest Python 3.12 | 10m 46s | 4m 21s
ubuntu-latest Python 3.11 | 9m 54s | 4m 8s
ubuntu-latest Python 3.10 | 10m 24s | 3m 54s
ubuntu-latest Python 3.9 | 8m 47s | 4m 22s
ubuntu-latest Python 3.8 | 9m 2s | 4m 4s
Total | 81m 20s | 37 m37s

---

After this, we can do a similar thing for `install_raqm.sh` and `install_webp.sh` to shave off another minute or so per job; I left them out because I wasn't sure what the filenames are that need caching; what are they?

---

Also:

* Include `pyproject.toml` along with `.ci/*.sh` in the pip cache key, because we define test/docs dependencies in there too

* Disable the wget progress bar but not all output, to omit hundreds of lines in the logs like:

```
     0K .......... .......... .......... .......... ..........  1% 40.7M 0s
    50K .......... .......... .......... .......... ..........  2% 38.5M 0s
   100K .......... .......... .......... .......... ..........  3% 41.2M 0s
   150K .......... .......... .......... .......... ..........  4%  218M 0s
   200K .......... .......... .......... .......... ..........  6%  160M 0s
   250K .......... .......... .......... .......... ..........  7%  130M 0s
   300K .......... .......... .......... .......... ..........  8% 75.3M 0s
   350K .......... .......... .......... .......... ..........  9%  206M 0s
   400K .......... .......... .......... .......... .......... 11%  124M 0s
   450K .......... .......... .......... .......... .......... 12%  220M 0s
```