### PR TITLE
Update wl-paste handling and return None for some errors in grabclipboard() on Linux

### DIFF
--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -171,7 +171,9 @@ def grabclipboard():
             err = p.stderr
             if any(e in err for e in allowed_errors):
                 return None
-            msg = f"{args[0]} error: {err.strip().decode() if err else 'Unknown error'}"
+            msg = f"{args[0]} error"
+            if err:
+                msg += f": {err.strip().decode()}"
             raise ChildProcessError(msg)
 
         data = io.BytesIO(p.stdout)


### PR DESCRIPTION
Simpified logic and made it more robust against edge cases ( see the `allowed_errors` list ). 
Doing error checking this way, makes the behaviour of this function for x11 and wayland platforms more similar to darwin and windows systems.