### PR TITLE
Restored testing of non-TrueType default font

### DIFF
--- a/Tests/test_font_leaks.py
+++ b/Tests/test_font_leaks.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw, ImageFont, _util
 
-from .helper import PillowLeakTestCase, skip_unless_feature
+from .helper import PillowLeakTestCase, features, skip_unless_feature
+
+original_core = ImageFont.core
 
 
 class TestTTypeFontLeak(PillowLeakTestCase):
@@ -31,5 +33,9 @@ class TestDefaultFontLeak(TestTTypeFontLeak):
     mem_limit = 1024  # k
 
     def test_leak(self):
+        if features.check_module("freetype2"):
+            ImageFont.core = _util.DeferredError(ImportError)
         default_font = ImageFont.load_default()
+        ImageFont.core = original_core
+
         self._test_font(default_font)

--- a/Tests/test_font_leaks.py
+++ b/Tests/test_font_leaks.py
@@ -35,7 +35,9 @@ class TestDefaultFontLeak(TestTTypeFontLeak):
     def test_leak(self):
         if features.check_module("freetype2"):
             ImageFont.core = _util.DeferredError(ImportError)
-        default_font = ImageFont.load_default()
-        ImageFont.core = original_core
+        try:
+            default_font = ImageFont.load_default()
+        finally:
+            ImageFont.core = original_core
 
         self._test_font(default_font)


### PR DESCRIPTION
Similar to https://github.com/python-pillow/Pillow/pull/7669/commits/ecd3948b45ca9c4c2e8b0b3cb58fe6af9798cfa2

This changes `TestDefaultFontLeak` to test the non-TrueType default font, as it would have been doing before #7354