### PR TITLE
Updated libimagequant to 4.3.0

### DIFF
--- a/depends/install_imagequant.sh
+++ b/depends/install_imagequant.sh
@@ -2,7 +2,7 @@
 # install libimagequant
 
 archive_name=libimagequant
-archive_version=4.2.2
+archive_version=4.3.0
 
 archive=$archive_name-$archive_version
 

--- a/docs/installation/building-from-source.rst
+++ b/docs/installation/building-from-source.rst
@@ -60,7 +60,7 @@ Many of Pillow's features require external libraries:
 
 * **libimagequant** provides improved color quantization
 
-  * Pillow has been tested with libimagequant **2.6-4.2.2**
+  * Pillow has been tested with libimagequant **2.6-4.3**
   * Libimagequant is licensed GPLv3, which is more restrictive than
     the Pillow license, therefore we will not be distributing binaries
     with libimagequant support enabled.


### PR DESCRIPTION
libimagequant 4.3.0 has been released - https://github.com/ImageOptim/libimagequant/releases/tag/4.3.0