### PR TITLE
Replace `io.BytesIO` in type hints

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,6 +10,9 @@ exclude_also =
     if DEBUG:
     # Don't complain about compatibility code for missing optional dependencies
     except ImportError
+    # Empty bodies in protocols or abstract methods
+    ^\s*def [a-zA-Z0-9_]+\(.*\)(\s*->.*)?:\s*\.\.\.(\s*#.*)?$
+    ^\s*\.\.\.(\s*#.*)?$
 
 [run]
 omit =

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import tempfile
 import warnings
+from pathlib import Path
 
 import pytest
 
@@ -161,8 +162,6 @@ class TestImage:
                 pass
 
     def test_pathlib(self, tmp_path):
-        from PIL.Image import Path
-
         with Image.open(Path("Tests/images/multipage-mmap.tiff")) as im:
             assert im.mode == "P"
             assert im.size == (10, 10)

--- a/Tests/test_util.py
+++ b/Tests/test_util.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PurePath
 
 import pytest
 
 from PIL import _util
 
 
-@pytest.mark.parametrize("test_path", ["filename.ext", Path("filename.ext")])
+@pytest.mark.parametrize(
+    "test_path", ["filename.ext", Path("filename.ext"), PurePath("filename.ext")]
+)
 def test_is_path(test_path):
     # Act
     it_is = _util.is_path(test_path)

--- a/Tests/test_util.py
+++ b/Tests/test_util.py
@@ -1,27 +1,14 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from PIL import _util
 
 
-def test_is_path():
-    # Arrange
-    fp = "filename.ext"
-
-    # Act
-    it_is = _util.is_path(fp)
-
-    # Assert
-    assert it_is
-
-
-def test_path_obj_is_path():
-    # Arrange
-    from pathlib import Path
-
-    test_path = Path("filename.ext")
-
+@pytest.mark.parametrize("test_path", ["filename.ext", Path("filename.ext")])
+def test_is_path(test_path):
     # Act
     it_is = _util.is_path(test_path)
 

--- a/docs/reference/internal_design.rst
+++ b/docs/reference/internal_design.rst
@@ -1,5 +1,5 @@
-Internal Reference Docs
-=======================
+Internal Reference
+==================
 
 .. toctree::
   :maxdepth: 2

--- a/docs/reference/internal_modules.rst
+++ b/docs/reference/internal_modules.rst
@@ -33,6 +33,18 @@ Internal Modules
 Provides a convenient way to import type hints that are not available
 on some Python versions.
 
+.. py:class:: FileDescriptor
+
+    Typing alias.
+
+.. py:class:: StrOrBytesPath
+
+    Typing alias.
+
+.. py:class:: SupportsRead
+
+    An object that supports the read method.
+
 .. py:data:: TypeGuard
     :value: typing.TypeGuard
 

--- a/docs/reference/internal_modules.rst
+++ b/docs/reference/internal_modules.rst
@@ -33,10 +33,6 @@ Internal Modules
 Provides a convenient way to import type hints that are not available
 on some Python versions.
 
-.. py:class:: FileDescriptor
-
-    Typing alias.
-
 .. py:class:: StrOrBytesPath
 
     Typing alias.

--- a/docs/reference/open_files.rst
+++ b/docs/reference/open_files.rst
@@ -3,7 +3,7 @@
 File Handling in Pillow
 =======================
 
-When opening a file as an image, Pillow requires a filename, ``pathlib.Path``
+When opening a file as an image, Pillow requires a filename, ``os.PathLike``
 object, or a file-like object. Pillow uses the filename or ``Path`` to open a
 file, so for the rest of this article, they will all be treated as a file-like
 object.

--- a/src/PIL/GdImageFile.py
+++ b/src/PIL/GdImageFile.py
@@ -27,11 +27,12 @@
 """
 from __future__ import annotations
 
-from io import BytesIO
+from typing import IO
 
 from . import ImageFile, ImagePalette, UnidentifiedImageError
 from ._binary import i16be as i16
 from ._binary import i32be as i32
+from ._typing import FileDescriptor, StrOrBytesPath
 
 
 class GdImageFile(ImageFile.ImageFile):
@@ -80,7 +81,9 @@ class GdImageFile(ImageFile.ImageFile):
         ]
 
 
-def open(fp: BytesIO, mode: str = "r") -> GdImageFile:
+def open(
+    fp: StrOrBytesPath | FileDescriptor | IO[bytes], mode: str = "r"
+) -> GdImageFile:
     """
     Load texture from a GD image file.
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -39,7 +39,6 @@ import tempfile
 import warnings
 from collections.abc import Callable, MutableMapping
 from enum import IntEnum
-from pathlib import Path
 
 try:
     from defusedxml import ElementTree
@@ -2370,7 +2369,7 @@ class Image:
         implement the ``seek``, ``tell``, and ``write``
         methods, and be opened in binary mode.
 
-        :param fp: A filename (string), pathlib.Path object or file object.
+        :param fp: A filename (string), os.PathLike object or file object.
         :param format: Optional format override.  If omitted, the
            format to use is determined from the filename extension.
            If a file object was used instead of a filename, this
@@ -2385,11 +2384,8 @@ class Image:
 
         filename = ""
         open_fp = False
-        if isinstance(fp, Path):
-            filename = str(fp)
-            open_fp = True
-        elif is_path(fp):
-            filename = fp
+        if is_path(fp):
+            filename = os.fspath(fp)
             open_fp = True
         elif fp == sys.stdout:
             try:
@@ -3206,7 +3202,7 @@ def open(fp, mode="r", formats=None) -> Image:
     :py:meth:`~PIL.Image.Image.load` method).  See
     :py:func:`~PIL.Image.new`. See :ref:`file-handling`.
 
-    :param fp: A filename (string), pathlib.Path object or a file object.
+    :param fp: A filename (string), os.PathLike object or a file object.
        The file object must implement ``file.read``,
        ``file.seek``, and ``file.tell`` methods,
        and be opened in binary mode. The file object will also seek to zero
@@ -3244,8 +3240,8 @@ def open(fp, mode="r", formats=None) -> Image:
 
     exclusive_fp = False
     filename = ""
-    if isinstance(fp, Path):
-        filename = str(fp.resolve())
+    if isinstance(fp, os.PathLike):
+        filename = os.path.realpath(os.fspath(fp))
     elif is_path(fp):
         filename = fp
 

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -230,7 +230,7 @@ class FreeTypeFont:
             )
 
         if is_path(font):
-            if isinstance(font, Path):
+            if isinstance(font, os.PathLike):
                 font = str(font)
             if sys.platform == "win32":
                 font_bytes_path = font if isinstance(font, bytes) else font.encode()

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -230,8 +230,7 @@ class FreeTypeFont:
             )
 
         if is_path(font):
-            if isinstance(font, os.PathLike):
-                font = str(font)
+            font = os.fspath(font)
             if sys.platform == "win32":
                 font_bytes_path = font if isinstance(font, bytes) else font.encode()
                 try:

--- a/src/PIL/MpegImagePlugin.py
+++ b/src/PIL/MpegImagePlugin.py
@@ -14,17 +14,16 @@
 #
 from __future__ import annotations
 
-from io import BytesIO
-
 from . import Image, ImageFile
 from ._binary import i8
+from ._typing import SupportsRead
 
 #
 # Bitstream parser
 
 
 class BitStream:
-    def __init__(self, fp: BytesIO) -> None:
+    def __init__(self, fp: SupportsRead[bytes]) -> None:
         self.fp = fp
         self.bits = 0
         self.bitbuffer = 0

--- a/src/PIL/_typing.py
+++ b/src/PIL/_typing.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import sys
+from typing import Protocol, TypeVar, Union
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
@@ -15,4 +17,16 @@ else:
                 return bool
 
 
-__all__ = ["TypeGuard"]
+_T_co = TypeVar("_T_co", covariant=True)
+
+
+class SupportsRead(Protocol[_T_co]):
+    def read(self, __length: int = ...) -> _T_co:
+        ...
+
+
+FileDescriptor = int
+StrOrBytesPath = Union[str, bytes, "os.PathLike[str]", "os.PathLike[bytes]"]
+
+
+__all__ = ["FileDescriptor", "TypeGuard", "StrOrBytesPath", "SupportsRead"]

--- a/src/PIL/_util.py
+++ b/src/PIL/_util.py
@@ -11,7 +11,7 @@ def is_path(f: Any) -> TypeGuard[StrOrBytesPath]:
     return isinstance(f, (bytes, str, os.PathLike))
 
 
-def is_directory(f: Any) -> TypeGuard[bytes | str | Path]:
+def is_directory(f: Any) -> TypeGuard[StrOrBytesPath]:
     """Checks if an object is a string, and that it points to a directory."""
     return is_path(f) and os.path.isdir(f)
 

--- a/src/PIL/_util.py
+++ b/src/PIL/_util.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 from typing import Any, NoReturn
 
 from ._typing import StrOrBytesPath, TypeGuard

--- a/src/PIL/_util.py
+++ b/src/PIL/_util.py
@@ -8,7 +8,7 @@ from ._typing import StrOrBytesPath, TypeGuard
 
 
 def is_path(f: Any) -> TypeGuard[StrOrBytesPath]:
-    return isinstance(f, (bytes, str, Path))
+    return isinstance(f, (bytes, str, os.PathLike))
 
 
 def is_directory(f: Any) -> TypeGuard[bytes | str | Path]:

--- a/src/PIL/_util.py
+++ b/src/PIL/_util.py
@@ -4,10 +4,10 @@ import os
 from pathlib import Path
 from typing import Any, NoReturn
 
-from ._typing import TypeGuard
+from ._typing import StrOrBytesPath, TypeGuard
 
 
-def is_path(f: Any) -> TypeGuard[bytes | str | Path]:
+def is_path(f: Any) -> TypeGuard[StrOrBytesPath]:
     return isinstance(f, (bytes, str, Path))
 
 


### PR DESCRIPTION
Alternative to and closes https://github.com/python-pillow/Pillow/pull/7737.

In type hints like `fp: io.BytesIO`, we should avoid the concrete `io.BytesIO`, and use more specific type hints to reflect what the file-like object actually does.

The one in `GdImageFile.py` is used in many ways, so has more complex hints; the one in `MpegImagePlugin.py` is used in fewer so is more focused.

This takes some type hints from typeshed:

* https://github.com/python/typeshed/blob/2168ab5ff4e40c37505b3e5048944603b71a857d/stdlib/_typeshed/__init__.pyi#L239-L257
* https://github.com/python/typeshed/blob/2168ab5ff4e40c37505b3e5048944603b71a857d/stdlib/_typeshed/__init__.pyi#L162
* (which are also in the useful_types package: https://github.com/hauntsaninja/useful_types/blob/951d36b2aaaee6ab9fa1efcb8c4f1e2733247ff5/useful_types/__init__.py#L233-L246)

I'm open to better suggestions for the docs in `internal_modules.rst`, like can we use `automodule` or something?

Four other plugins have `BytesIO` hints to replace, this PR deals with the two which block the docs build.

Thank you to @AlexWaygood for the advice!