### PR TITLE
Stop reading EPS image at EOF marker

### DIFF
--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -436,3 +436,11 @@ def test_eof_before_bounding_box():
     with pytest.raises(OSError):
         with Image.open("Tests/images/zero_bb_eof_before_boundingbox.eps"):
             pass
+
+
+def test_invalid_data_after_eof() -> None:
+    with open("Tests/images/illuCS6_preview.eps", "rb") as f:
+        img_bytes = io.BytesIO(f.read() + b"\r\n%" + (b" " * 255))
+
+    with Image.open(img_bytes) as img:
+        assert img.mode == "RGB"

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -356,14 +356,10 @@ class EpsImageFile(ImageFile.ImageFile):
 
                 self._size = columns, rows
                 return
+            elif bytes_mv[:5] == b"%%EOF":
+                break
             elif trailer_reached and reading_trailer_comments:
                 # Load EPS trailer
-
-                # if this line starts with "%%EOF",
-                # then we've reached the end of the file
-                if bytes_mv[:5] == b"%%EOF":
-                    break
-
                 s = str(bytes_mv[:bytes_read], "latin-1")
                 _read_comment(s)
             elif bytes_mv[:9] == b"%%Trailer":


### PR DESCRIPTION
Helps #7751

In the issue, there is an EPS file that has other image data after the EOF marker. This additional data causes Pillow to fail to open the file, as [one of the lines starts with "%" and is over 255 characters](https://github.com/python-pillow/Pillow/blob/b3a7ae065c4f34b345ecaa3b019bbd1d24e7922c/src/PIL/EpsImagePlugin.py#L282-L289).

This additional image data appears to be a ["preview"](https://en.wikipedia.org/wiki/Encapsulated_PostScript#EPS_previews) - in our test images, it is seen in [illuCS6_preview.eps](https://github.com/python-pillow/Pillow/blob/main/Tests/images/illuCS6_preview.eps), but not [illuCS6_no_preview.eps](https://github.com/python-pillow/Pillow/blob/main/Tests/images/illuCS6_no_preview.eps).

Instead, this PR stops reading the data at the EOF marker.