### PR TITLE
Pin to Python 3.9.16-1

### DIFF
--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Cygwin
-        uses: cygwin/cygwin-install-action@v4
+        uses: egor-tensin/setup-cygwin@v4
         with:
           platform: x86_64
           packages: >
@@ -69,6 +69,7 @@ jobs:
             make
             netpbm
             perl
+            python39=3.9.16-1
             python3${{ matrix.python-minor-version }}-cffi
             python3${{ matrix.python-minor-version }}-cython
             python3${{ matrix.python-minor-version }}-devel
@@ -86,7 +87,7 @@ jobs:
 
       - name: Select Python version
         run: |
-          ln -sf c:/cygwin/bin/python3.${{ matrix.python-minor-version }} c:/cygwin/bin/python3
+          ln -sf c:/tools/cygwin/bin/python3.${{ matrix.python-minor-version }} c:/tools/cygwin/bin/python3
 
       - name: Get latest NumPy version
         id: latest-numpy


### PR DESCRIPTION
Our Cygwin jobs have been failing for several days - https://github.com/python-pillow/Pillow/actions/workflows/test-cygwin.yml

In looking at a discussion over at NumPy about this, there was a suggestion to use the egor-tension/setup-cygwin action and pin to Python 3.9.16-1 - https://github.com/numpy/numpy/issues/25708#issuecomment-1913885487