### PR TITLE
Fixed libXau error in wheels for macOS 10.10

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -131,13 +131,13 @@ untar pillow-depends-main.zip
 
 if [[ -n "$IS_MACOS" ]]; then
   # webp, libtiff, libxcb cause a conflict with building webp, libtiff, libxcb
-  # libxdmcp causes an issue on macOS < 11
+  # libxau and libxdmcp cause an issue on macOS < 11
   # if php is installed, brew tries to reinstall these after installing openblas
   # remove cairo to fix building harfbuzz on arm64
   # remove lcms2 and libpng to fix building openjpeg on arm64
   # remove zstd to avoid inclusion on x86_64
   # curl from brew requires zstd, use system curl
-  brew remove --ignore-dependencies webp libpng libtiff libxcb libxdmcp curl php cairo lcms2 ghostscript zstd
+  brew remove --ignore-dependencies webp libpng libtiff libxcb libxau libxdmcp curl php cairo lcms2 ghostscript zstd
 
   brew install pkg-config
 fi

--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -72,13 +72,11 @@ function build {
 
     build_simple xcb-proto 1.16.0 https://xorg.freedesktop.org/archive/individual/proto
     if [ -n "$IS_MACOS" ]; then
-        if [[ "$CIBW_ARCHS" == "arm64" ]]; then
-            build_simple xorgproto 2023.2 https://www.x.org/pub/individual/proto
-            build_simple libXau 1.0.11 https://www.x.org/pub/individual/lib
-            build_simple libpthread-stubs 0.5 https://xcb.freedesktop.org/dist
-            if [ -f /Library/Frameworks/Python.framework/Versions/Current/share/pkgconfig/xcb-proto.pc ]; then
-                cp /Library/Frameworks/Python.framework/Versions/Current/share/pkgconfig/xcb-proto.pc /Library/Frameworks/Python.framework/Versions/Current/lib/pkgconfig/xcb-proto.pc
-            fi
+        build_simple xorgproto 2023.2 https://www.x.org/pub/individual/proto
+        build_simple libXau 1.0.11 https://www.x.org/pub/individual/lib
+        build_simple libpthread-stubs 0.5 https://xcb.freedesktop.org/dist
+        if [ -f /Library/Frameworks/Python.framework/Versions/Current/share/pkgconfig/xcb-proto.pc ]; then
+            cp /Library/Frameworks/Python.framework/Versions/Current/share/pkgconfig/xcb-proto.pc /Library/Frameworks/Python.framework/Versions/Current/lib/pkgconfig/xcb-proto.pc
         fi
     else
         sed s/\${pc_sysrootdir\}// /usr/local/share/pkgconfig/xcb-proto.pc > /usr/local/lib/pkgconfig/xcb-proto.pc


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/issues/6862#issuecomment-1913552472 is a report from a user that Pillow 10.2.0 wheels cause the following error on macOS 10.10
```pytb
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/just/code/git/drawbot/venv312/lib/python3.12/site-packages/PIL/Image.py", line 84, in <module>
    from . import _imaging as core
ImportError: dlopen(/Users/just/code/git/drawbot/venv312/lib/python3.12/site-packages/PIL/_imaging.cpython-312-darwin.so, 2): Library not loaded: @loader_path/libXau.6.0.0.dylib
  Referenced from: /Users/just/code/git/drawbot/venv312/lib/python3.12/site-packages/PIL/.dylibs/libxcb.1.1.0.dylib
  Reason: no suitable image found.  Did find:
	/Users/just/code/git/drawbot/venv312/lib/python3.12/site-packages/PIL/.dylibs/libXau.6.0.0.dylib: cannot load 'libXau.6.0.0.dylib' (load command 0x80000034 is unknown)
	/Users/just/code/git/drawbot/venv312/lib/python3.12/site-packages/PIL/.dylibs/libXau.6.0.0.dylib: cannot load 'libXau.6.0.0.dylib' (load command 0x80000034 is unknown)
```

Investigating, I found that when generating wheels, [GitHub Actions is outputting](https://github.com/python-pillow/Pillow/actions/runs/7415717292/job/20179378868#step:5:2292)
> ld: warning: dylib (/usr/local/Cellar/libxau/1.0.11/lib/libXau.dylib) was built for newer macOS version (12.0) than being linked (10.10)

This PR uninstalls brew's libxau, and starts building libxcb's dependencies on macOS x86-64 instead.

The user has confirmed that the wheels with these changes work on macOS 10.10.