### PR TITLE
Test on macOS M1 where available

### DIFF
--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -2,7 +2,16 @@
 
 set -e
 
-brew install libtiff libjpeg openjpeg libimagequant webp little-cms2 freetype libraqm
+brew install \
+    freetype \
+    ghostscript \
+    libimagequant \
+    libjpeg \
+    libraqm \
+    libtiff \
+    little-cms2 \
+    openjpeg \
+    webp
 export PKG_CONFIG_PATH="/usr/local/opt/openblas/lib/pkgconfig"
 
 # TODO Update condition when cffi supports 3.13

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-          "macos-latest",
+          "macos-14",
           "ubuntu-latest",
         ]
         python-version: [
@@ -50,11 +50,21 @@ jobs:
           "3.8",
         ]
         include:
-        - python-version: "3.9"
+        - python-version: "3.11"
           PYTHONOPTIMIZE: 1
           REVERSE: "--reverse"
-        - python-version: "3.8"
+        - python-version: "3.10"
           PYTHONOPTIMIZE: 2
+        # M1 only available for 3.10+
+        - os: "macos-latest"
+          python-version: "3.9"
+        - os: "macos-latest"
+          python-version: "3.8"
+        exclude:
+        - os: "macos-14"
+          python-version: "3.9"
+        - os: "macos-14"
+          python-version: "3.8"
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} Python ${{ matrix.python-version }}
@@ -141,7 +151,7 @@ jobs:
     - name: Upload coverage
       uses: codecov/codecov-action@v3
       with:
-        flags: ${{ matrix.os == 'macos-latest' && 'GHA_macOS' || 'GHA_Ubuntu' }}
+        flags: ${{ matrix.os == 'ubuntu-latest' && 'GHA_Ubuntu' || 'GHA_macOS' }}
         name: ${{ matrix.os }} Python ${{ matrix.python-version }}
         gcov: true
 


### PR DESCRIPTION
GitHub Actions now has macOS M1 runners:

* https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
* https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

Python 3.9.1 was the first to support Apple Silicon: 

* https://www.python.org/downloads/release/python-391/

But 3.9 is not currently available for M1:

* https://github.com/actions/setup-python/issues/696#issuecomment-1637587760

So let's test 3.10-3.13 on M1, and 3.8-3.9 on Intel.

I bumped the `PYTHONOPTIMIZE` jobs from 3.8/3.9 to 3.10/3.11 to avoid complicating the matrix includes/excludes. And needed to install Ghostscript, it wasn't already on the image.

Here's how long it took to test on M1 (left) and Intel (right). M1 is faster for all, around twice as fast for 3.13 and PyPy3.10, and nearly three times as fast for PyPy3.9!

![image](https://github.com/python-pillow/Pillow/assets/1324225/3fe67ffb-3325-4cad-99ae-99d47ad6e9b4)

That's reduced from about 49 minutes to 25 minutes!