### PR TITLE
Changed name of first _Tile parameter

### DIFF
--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -91,7 +91,7 @@ def _tilesort(t):
 
 
 class _Tile(NamedTuple):
-    encoder_name: str
+    codec_name: str
     extents: tuple[int, int, int, int]
     offset: int
     args: tuple[Any, ...] | str | None


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/e47877587fb8aa1853ef7473285a2964f5e98520/src/PIL/ImageFile.py#L93-L97

Because tiles can be used to indicate either how an image is to be encoded or decoded, I suggest `codec_name` instead of `encoder_name`.