### PR TITLE
Removed gcov codecov argument

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -105,7 +105,6 @@ jobs:
       with:
         flags: GHA_Docker
         name: ${{ matrix.docker }}
-        gcov: true
 
   success:
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,6 @@ jobs:
       with:
         flags: ${{ matrix.os == 'ubuntu-latest' && 'GHA_Ubuntu' || 'GHA_macOS' }}
         name: ${{ matrix.os }} Python ${{ matrix.python-version }}
-        gcov: true
 
   success:
     permissions:


### PR DESCRIPTION
codecov-action v4 no longer has the 'gcov' argument - https://github.com/codecov/codecov-action?tab=readme-ov-file#arguments. Instead, the README now states that the default behaviour is to run gcov
> plugin | plugins to run. Options: xcode, gcov, pycoverage. The default behavior runs them all.

It has been confirmed that 'gcov' is no longer necessary - https://github.com/codecov/codecov-action/issues/1247#issuecomment-1924946275