### PR TITLE
Removed platform argument from setup-cygwin action

### DIFF
--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -49,7 +49,6 @@ jobs:
       - name: Install Cygwin
         uses: egor-tensin/setup-cygwin@v4
         with:
-          platform: x86_64
           packages: >
             gcc-g++
             ghostscript


### PR DESCRIPTION
When #7762 switched from [cygwin/cygwin-install-action](https://github.com/cygwin/cygwin-install-action) to [egor-tensin/setup-cygwin](https://github.com/egor-tensin/setup-cygwin), I didn't remove the 'platform' argument that the new action doesn't use.

This has led to a warning - https://github.com/python-pillow/Pillow/actions/runs/7764314475/job/21177567318#step:4:1
> Warning: Unexpected input(s) 'platform', valid inputs are ['install-dir', 'packages', 'env', 'hardlinks']