### PR TITLE
Pin codecov/codecov-action to v3.1.5

### DIFF
--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -142,7 +142,7 @@ jobs:
           bash.exe .ci/after_success.sh
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3.1.5
         with:
           file: ./coverage.xml
           flags: GHA_Cygwin

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -101,7 +101,7 @@ jobs:
         MATRIX_DOCKER: ${{ matrix.docker }}
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3.1.5
       with:
         flags: GHA_Docker
         name: ${{ matrix.docker }}

--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -82,7 +82,7 @@ jobs:
           python3 -m pytest -vx --cov PIL --cov Tests --cov-report term --cov-report xml Tests
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3.1.5
         with:
           file: ./coverage.xml
           flags: GHA_Windows

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -202,7 +202,7 @@ jobs:
       shell: pwsh
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3.1.5
       with:
         file: ./coverage.xml
         flags: GHA_Windows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,7 @@ jobs:
         .ci/after_success.sh
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3.1.5
       with:
         flags: ${{ matrix.os == 'ubuntu-latest' && 'GHA_Ubuntu' || 'GHA_macOS' }}
         name: ${{ matrix.os }} Python ${{ matrix.python-version }}


### PR DESCRIPTION
There's a breaking change in https://github.com/python-pillow/Pillow/pull/7770 from bumping codecov/codecov-action to v4 which affects us, requiring setting a token due to rate limiting:

https://github.com/codecov/codecov-action/releases/tag/v4.0.0

> Tokenless uploading is unsupported. However, PRs made from forks to the upstream public repos will support tokenless (e.g. contributors to OS projects do not need the upstream repo's Codecov token). This [doc](https://docs.codecov.com/docs/adding-the-codecov-token#github-actions) shows instructions on how to add the Codecov token.

v4 doesn't need a token for PRs from forks, but does for merges. This is why coverage has dropped to ~50% for merges, because it's only recording the coverage from AppVeyor:

https://app.codecov.io/gh/python-pillow/Pillow/commits

<img width="1303" alt="image" src="https://github.com/python-pillow/Pillow/assets/1324225/279573bb-7f07-4feb-ae6f-4ef0da5c2a37">

See:

* https://about.codecov.io/blog/january-product-update-updating-the-codecov-ci-uploaders-to-the-codecov-cli/ 
* https://github.com/codecov/feedback/issues/112#issuecomment-1919718118
* https://github.com/codecov/feedback/issues/112#issuecomment-1920204435
* https://github.com/codecov/feedback/issues/112#issuecomment-1924487786

I think we should stick to v3 for a while, to see what happens. 

This PR uses v3.1.5, which also bumped to Node.js 20 to fix the deprecation warnings. (v3=v3.1.6 went back down to Node.js 16.)

We could adjust the threshold for Codecov to "fail", so we don't miss huge drops like this in https://github.com/python-pillow/Pillow/pull/7770:

<img width="502" alt="image" src="https://github.com/python-pillow/Pillow/assets/1324225/da6ce6f2-47df-4554-83a1-3b9e56782c41">

