### PR TITLE
Match mask size to pasted image size in GifImagePlugin

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1105,6 +1105,21 @@ def test_append_images(tmp_path: Path) -> None:
         assert reread.n_frames == 10
 
 
+def test_append_different_size_image(tmp_path: Path) -> None:
+    out = str(tmp_path / "temp.gif")
+
+    im = Image.new("RGB", (100, 100))
+    bigger_im = Image.new("RGB", (200, 200), "#f00")
+
+    im.save(out, save_all=True, append_images=[bigger_im])
+
+    with Image.open(out) as reread:
+        assert reread.size == (100, 100)
+
+        reread.seek(1)
+        assert reread.size == (100, 100)
+
+
 def test_transparent_optimize(tmp_path: Path) -> None:
     # From issue #2195, if the transparent color is incorrectly optimized out, GIF loses
     # transparency.

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -649,9 +649,7 @@ def _write_multiple_frames(im, fp, palette):
                     if "transparency" in encoderinfo:
                         # When the delta is zero, fill the image with transparency
                         diff_frame = im_frame.copy()
-                        fill = Image.new(
-                            "P", diff_frame.size, encoderinfo["transparency"]
-                        )
+                        fill = Image.new("P", delta.size, encoderinfo["transparency"])
                         if delta.mode == "RGBA":
                             r, g, b, a = delta.split()
                             mask = ImageMath.eval(


### PR DESCRIPTION
Resolves #7777

When looping through images to create a GIF image, the frames may be different sizes.

At the moment, this means that
https://github.com/python-pillow/Pillow/blob/1b6723967440cf8474a9bd1e1c394c90c5c2f986/src/PIL/GifImagePlugin.py#L671
`fill` comes from the size of the new frame, whereas `mask` comes from `ImageChops.subtract_modulo()` between the new and the old frame.

This may cause a mismatch in size between the image being pasted and the mask, which can lead to an error.