### PR TITLE
Replace deprecated "extend-ignore" with "ignore"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ select = [
   "YTT", # flake8-2020
   # "LOG", # TODO: enable flake8-logging when it's not in preview anymore
 ]
-extend-ignore = [
+ignore = [
   "E203", # Whitespace before ':'
   "E221", # Multiple spaces before operator
   "E226", # Missing whitespace around arithmetic operator


### PR DESCRIPTION
https://docs.astral.sh/ruff/settings/#lint_extend-ignore
> [extend-ignore](https://docs.astral.sh/ruff/settings/#lint_extend-ignore)
> This option has been deprecated. The extend-ignore option is now interchangeable with ignore. Please update your configuration to use the ignore option instead.