### PR TITLE
Release GIL while calling `WebPAnimDecoderGetNext`

### DIFF
--- a/docs/releasenotes/10.3.0.rst
+++ b/docs/releasenotes/10.3.0.rst
@@ -79,3 +79,9 @@ Portable FloatMap (PFM) images
 
 Support has been added for reading and writing grayscale (Pf format)
 Portable FloatMap (PFM) files containing ``F`` data.
+
+Release GIL when fetching WebP frames
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Python's Global Interpreter Lock is now released when fetching WebP frames from
+the libwebp decoder.

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -450,12 +450,16 @@ _anim_decoder_get_next(PyObject *self) {
     int timestamp;
     PyObject *bytes;
     PyObject *ret;
+    ImagingSectionCookie cookie;
     WebPAnimDecoderObject *decp = (WebPAnimDecoderObject *)self;
 
+    ImagingSectionEnter(&cookie);
     if (!WebPAnimDecoderGetNext(decp->dec, &buf, &timestamp)) {
+        ImagingSectionLeave(&cookie);
         PyErr_SetString(PyExc_OSError, "failed to read next frame");
         return NULL;
     }
+    ImagingSectionLeave(&cookie);
 
     bytes = PyBytes_FromStringAndSize(
         (char *)buf, decp->info.canvas_width * 4 * decp->info.canvas_height);

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -455,7 +455,7 @@ _anim_decoder_get_next(PyObject *self) {
     WebPAnimDecoderObject *decp = (WebPAnimDecoderObject *)self;
 
     ImagingSectionEnter(&cookie);
-    ok = WebPAnimDecoderGetNext(decp->dec, &buf, &timestamp)
+    ok = WebPAnimDecoderGetNext(decp->dec, &buf, &timestamp);
     ImagingSectionLeave(&cookie);
     if (!ok) {
         PyErr_SetString(PyExc_OSError, "failed to read next frame");

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -448,18 +448,19 @@ PyObject *
 _anim_decoder_get_next(PyObject *self) {
     uint8_t *buf;
     int timestamp;
+    int ok;
     PyObject *bytes;
     PyObject *ret;
     ImagingSectionCookie cookie;
     WebPAnimDecoderObject *decp = (WebPAnimDecoderObject *)self;
 
     ImagingSectionEnter(&cookie);
-    if (!WebPAnimDecoderGetNext(decp->dec, &buf, &timestamp)) {
-        ImagingSectionLeave(&cookie);
+    ok = WebPAnimDecoderGetNext(decp->dec, &buf, &timestamp)
+    ImagingSectionLeave(&cookie);
+    if (!ok) {
         PyErr_SetString(PyExc_OSError, "failed to read next frame");
         return NULL;
     }
-    ImagingSectionLeave(&cookie);
 
     bytes = PyBytes_FromStringAndSize(
         (char *)buf, decp->info.canvas_width * 4 * decp->info.canvas_height);


### PR DESCRIPTION
`WebPAnimDecoderGetNext` is a relatively expensive pure-C call that currently holds the Python GIL. Release it!

(Haven't tested this branch but it seemed like a straightforward change.)