### PR TITLE
When saving GIF frame that restores to background color, do not fill identical pixels

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -647,6 +647,9 @@ def test_dispose2_palette(tmp_path: Path) -> None:
             # Center remains red every frame
             assert rgb_img.getpixel((50, 50)) == circle
 
+            # Check that frame transparency wasn't added unnecessarily
+            assert img._frame_transparency is None
+
 
 def test_dispose2_diff(tmp_path: Path) -> None:
     out = str(tmp_path / "temp.gif")

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -737,6 +737,25 @@ def test_dispose2_background_frame(tmp_path: Path) -> None:
         assert im.n_frames == 3
 
 
+def test_dispose2_previous_frame(tmp_path: Path) -> None:
+    out = str(tmp_path / "temp.gif")
+
+    im = Image.new("P", (100, 100))
+    im.info["transparency"] = 0
+    d = ImageDraw.Draw(im)
+    d.rectangle([(0, 0), (100, 50)], 1)
+    im.putpalette((0, 0, 0, 255, 0, 0))
+
+    im2 = Image.new("P", (100, 100))
+    im2.putpalette((0, 0, 0))
+
+    im.save(out, save_all=True, append_images=[im2], disposal=[0, 2])
+
+    with Image.open(out) as im:
+        im.seek(1)
+        assert im.getpixel((0, 0)) == (0, 0, 0, 255)
+
+
 def test_transparency_in_second_frame(tmp_path: Path) -> None:
     out = str(tmp_path / "temp.gif")
     with Image.open("Tests/images/different_transparency.gif") as im:

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -638,7 +638,11 @@ def _write_multiple_frames(im, fp, palette):
                         background_im = Image.new("P", im_frame.size, background)
                         background_im.putpalette(im_frames[0]["im"].palette)
                     delta, bbox = _getbbox(background_im, im_frame)
-                if encoderinfo.get("optimize") and im_frame.mode != "1":
+                if (
+                    encoderinfo.get("optimize")
+                    and im_frames[-1]["encoderinfo"].get("disposal") != 2
+                    and im_frame.mode != "1"
+                ):
                     if "transparency" not in encoderinfo:
                         try:
                             encoderinfo["transparency"] = (

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -629,7 +629,7 @@ def _write_multiple_frames(im, fp, palette):
                             "duration"
                         ]
                     continue
-                if encoderinfo.get("disposal") == 2:
+                if im_frames[-1]["encoderinfo"].get("disposal") == 2:
                     if background_im is None:
                         color = im.encoderinfo.get(
                             "transparency", im.info.get("transparency", (0, 0, 0))
@@ -637,12 +637,8 @@ def _write_multiple_frames(im, fp, palette):
                         background = _get_background(im_frame, color)
                         background_im = Image.new("P", im_frame.size, background)
                         background_im.putpalette(im_frames[0]["im"].palette)
-                    delta, bbox = _getbbox(background_im, im_frame)
-                if (
-                    encoderinfo.get("optimize")
-                    and im_frames[-1]["encoderinfo"].get("disposal") != 2
-                    and im_frame.mode != "1"
-                ):
+                    bbox = _getbbox(background_im, im_frame)[1]
+                elif encoderinfo.get("optimize") and im_frame.mode != "1":
                     if "transparency" not in encoderinfo:
                         try:
                             encoderinfo["transparency"] = (


### PR DESCRIPTION
Resolves #7787

#7568 set identical pixels in subsequent GIF frames to be transparency.

This new issue has found that for disposal 2, when GIF disposes the previous frame and restores it to the background color, filling the identical pixels with transparency results in those pixels being seen as transparent by viewers.

This PR skips the optimisation step of filling identical pixels when the previous frame is restored to the background colour, as it is unnecessary when the frame is being compared with a single color (the background). The filling of pixels that match the previous frame is only an optimisation when it is reducing multiple possible matching colors to one color.