### PR TITLE
Use subprocess with CREATE_NO_WINDOW flag in ImageShow WindowsViewer

### DIFF
--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -138,6 +138,17 @@ class WindowsViewer(Viewer):
             f'&& del /f "{file}"'
         )
 
+    def show_file(self, path: str, **options: Any) -> int:
+        """
+        Display given file.
+        """
+        subprocess.Popen(
+            self.get_command(path, **options),
+            shell=True,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW"),
+        )  # nosec
+        return 1
+
 
 if sys.platform == "win32":
     register(WindowsViewer)


### PR DESCRIPTION
Resolves #7789

The user has found that calling using ImageShow from within a .pyw file on Windows causes a console to appear, as a result of calling `os.system` from `Viewer`.
https://github.com/python-pillow/Pillow/blob/6782a07b8e404271dbd2e5ddf5fbb93e575ed2bc/src/PIL/ImageShow.py#L121

The user has suggested calling subprocess with the CREATE_NO_WINDOW flag to fix this.
https://stackoverflow.com/questions/58943289 / https://stackoverflow.com/a/7006424/4093019 agree with this solution.

Because `subprocess.CREATE_NO_WINDOW` only exists on Windows, I've added a dedicated WindowsViewer `show_file()` method for this.