### PR TITLE
Use IO[bytes] in type hints

### DIFF
--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -32,7 +32,7 @@ import io
 import itertools
 import struct
 import sys
-from typing import Any, NamedTuple
+from typing import IO, Any, NamedTuple
 
 from . import Image
 from ._deprecate import deprecate
@@ -616,7 +616,7 @@ class PyCodecState:
 
 
 class PyCodec:
-    fd: io.BytesIO | None
+    fd: IO[bytes] | None
 
     def __init__(self, mode, *args):
         self.im = None

--- a/src/PIL/MspImagePlugin.py
+++ b/src/PIL/MspImagePlugin.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import io
 import struct
+from typing import IO
 
 from . import Image, ImageFile
 from ._binary import i16le as i16
@@ -163,7 +164,7 @@ Image.register_decoder("MSP", MspDecoder)
 # write MSP files (uncompressed only)
 
 
-def _save(im: Image.Image, fp: io.BytesIO, filename: str) -> None:
+def _save(im: Image.Image, fp: IO[bytes], filename: str) -> None:
     if im.mode != "1":
         msg = f"cannot write mode {im.mode} as MSP"
         raise OSError(msg)

--- a/src/PIL/PcxImagePlugin.py
+++ b/src/PIL/PcxImagePlugin.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import io
 import logging
+from typing import IO
 
 from . import Image, ImageFile, ImagePalette
 from ._binary import i16le as i16
@@ -143,7 +144,7 @@ SAVE = {
 }
 
 
-def _save(im: Image.Image, fp: io.BytesIO, filename: str) -> None:
+def _save(im: Image.Image, fp: IO[bytes], filename: str) -> None:
     try:
         version, bits, planes, rawmode = SAVE[im.mode]
     except KeyError as e:

--- a/src/PIL/PpmImagePlugin.py
+++ b/src/PIL/PpmImagePlugin.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 import math
-from io import BytesIO
+from typing import IO
 
 from . import Image, ImageFile
 from ._binary import i16be as i16
@@ -324,7 +324,7 @@ class PpmDecoder(ImageFile.PyDecoder):
 # --------------------------------------------------------------------
 
 
-def _save(im: Image.Image, fp: BytesIO, filename: str) -> None:
+def _save(im: Image.Image, fp: IO[bytes], filename: str) -> None:
     if im.mode == "1":
         rawmode, head = "1;I", b"P4"
     elif im.mode == "L":

--- a/src/PIL/SgiImagePlugin.py
+++ b/src/PIL/SgiImagePlugin.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import os
 import struct
-from io import BytesIO
+from typing import IO
 
 from . import Image, ImageFile
 from ._binary import i16be as i16
@@ -125,7 +125,7 @@ class SgiImageFile(ImageFile.ImageFile):
             ]
 
 
-def _save(im: Image.Image, fp: BytesIO, filename: str) -> None:
+def _save(im: Image.Image, fp: IO[bytes], filename: str) -> None:
     if im.mode not in {"RGB", "RGBA", "L"}:
         msg = "Unsupported SGI image mode"
         raise ValueError(msg)

--- a/src/PIL/TgaImagePlugin.py
+++ b/src/PIL/TgaImagePlugin.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import warnings
-from io import BytesIO
+from typing import IO
 
 from . import Image, ImageFile, ImagePalette
 from ._binary import i16le as i16
@@ -175,7 +175,7 @@ SAVE = {
 }
 
 
-def _save(im: Image.Image, fp: BytesIO, filename: str) -> None:
+def _save(im: Image.Image, fp: IO[bytes], filename: str) -> None:
     try:
         rawmode, bits, colormaptype, imagetype = SAVE[im.mode]
     except KeyError as e:

--- a/src/PIL/XbmImagePlugin.py
+++ b/src/PIL/XbmImagePlugin.py
@@ -21,7 +21,7 @@
 from __future__ import annotations
 
 import re
-from io import BytesIO
+from typing import IO
 
 from . import Image, ImageFile
 
@@ -70,7 +70,7 @@ class XbmImageFile(ImageFile.ImageFile):
         self.tile = [("xbm", (0, 0) + self.size, m.end(), None)]
 
 
-def _save(im: Image.Image, fp: BytesIO, filename: str) -> None:
+def _save(im: Image.Image, fp: IO[bytes], filename: str) -> None:
     if im.mode != "1":
         msg = f"cannot write mode {im.mode} as XBM"
         raise OSError(msg)


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/7750#issue-2096982939
> Four other plugins have BytesIO hints to replace

This PR replaces `BytesIO` in type hints with `IO[bytes]`