### PR TITLE
Validate self.palette in has_transparency_data()

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1561,7 +1561,7 @@ class Image:
         """
         return (
             self.mode in ("LA", "La", "PA", "RGBA", "RGBa")
-            or (self.mode == "P" and self.palette.mode.endswith("A"))
+            or (self.mode == "P" and self.palette and self.palette.mode.endswith("A"))
             or "transparency" in self.info
         )
 


### PR DESCRIPTION
I have a few files that I was able to open and save in Pillow 9.3.0, that result in an error with the newest (10.2.0) version. I believe that the newer has_transparency_data property can cause an error if the palette is not defined from opening a file.

```python
>>> from PIL import __version__, Image
>>> __version__
'10.2.0'
>>> img = Image.open("icon_6.ico")
>>> img.format
'ICO'
>>> img.height
256
>>> img.width
256
>>> img.save("output", format='WEBP')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../python3.12/site-packages/PIL/Image.py", line 2439, in save
    save_handler(self, fp, filename)
  File ".../python3.12/site-packages/PIL/WebPImagePlugin.py", line 338, in _save
    im = im.convert("RGBA" if im.has_transparency_data else "RGB")
                              ^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../python3.12/site-packages/PIL/Image.py", line 1550, in has_transparency_data
    or (self.mode == "P" and self.palette.mode.endswith("A"))
                             ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'mode'
```

I believe the solution is as simple as that, but feel free to disregard the PR if it needs a more complex fix.