### PR TITLE
Use palette when loading ICO images

### DIFF
--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -38,6 +38,17 @@ def test_black_and_white() -> None:
         assert im.size == (16, 16)
 
 
+def test_palette(tmp_path: Path) -> None:
+    temp_file = str(tmp_path / "temp.ico")
+
+    im = Image.new("P", (16, 16))
+    im.save(temp_file)
+
+    with Image.open(temp_file) as reloaded:
+        assert reloaded.mode == "P"
+        assert reloaded.palette is not None
+
+
 def test_invalid_file() -> None:
     with open("Tests/images/flower.jpg", "rb") as fp:
         with pytest.raises(SyntaxError):

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -329,6 +329,8 @@ class IcoImageFile(ImageFile.ImageFile):
         self.im = im.im
         self.pyaccess = None
         self._mode = im.mode
+        if im.palette:
+            self.palette = im.palette
         if im.size != self.size:
             warnings.warn("Image was not the expected size")
 


### PR DESCRIPTION
When copying image attributes from the image returned by `IcoFile.getimage()`, IcoImageFile copies the mode, but not the palette.

This fixes that.