### PR TITLE
Decoders and encoders subclass PyDecoder and PyEncoder

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -986,13 +986,7 @@ class TestFileJpeg:
             def decode(self, buffer: bytes) -> tuple[int, int]:
                 return 0, 0
 
-        decoder = InfiniteMockPyDecoder(None)
-
-        def closure(mode: str, *args) -> InfiniteMockPyDecoder:
-            decoder.__init__(mode, *args)
-            return decoder
-
-        Image.register_decoder("INFINITE", closure)
+        Image.register_decoder("INFINITE", InfiniteMockPyDecoder)
 
         with Image.open(TEST_FILE) as im:
             im.tile = [

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -16,6 +16,7 @@ from PIL import (
     ExifTags,
     Image,
     ImageDraw,
+    ImageFile,
     ImagePalette,
     UnidentifiedImageError,
     features,
@@ -1038,25 +1039,20 @@ class TestImage:
             assert im.fp is None
 
 
-class MockEncoder:
-    args: tuple[str, ...]
-
-
-def mock_encode(*args: str) -> MockEncoder:
-    encoder = MockEncoder()
-    encoder.args = args
-    return encoder
+class MockEncoder(ImageFile.PyEncoder):
+    pass
 
 
 class TestRegistry:
     def test_encode_registry(self) -> None:
-        Image.register_encoder("MOCK", mock_encode)
+        Image.register_encoder("MOCK", MockEncoder)
         assert "MOCK" in Image.ENCODERS
 
         enc = Image._getencoder("RGB", "MOCK", ("args",), extra=("extra",))
 
         assert isinstance(enc, MockEncoder)
-        assert enc.args == ("RGB", "args", "extra")
+        assert enc.mode == "RGB"
+        assert enc.args == ("args", "extra")
 
     def test_encode_registry_fail(self) -> None:
         with pytest.raises(OSError):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -229,8 +229,8 @@ MIME: dict[str, str] = {}
 SAVE: dict[str, Callable[[Image, IO[bytes], str | bytes], None]] = {}
 SAVE_ALL: dict[str, Callable[[Image, IO[bytes], str | bytes], None]] = {}
 EXTENSION: dict[str, str] = {}
-DECODERS: dict[str, object] = {}
-ENCODERS: dict[str, object] = {}
+DECODERS: dict[str, type[ImageFile.PyDecoder]] = {}
+ENCODERS: dict[str, type[ImageFile.PyEncoder]] = {}
 
 # --------------------------------------------------------------------
 # Modes
@@ -3524,28 +3524,26 @@ def registered_extensions():
     return EXTENSION
 
 
-def register_decoder(name: str, decoder) -> None:
+def register_decoder(name: str, decoder: type[ImageFile.PyDecoder]) -> None:
     """
     Registers an image decoder.  This function should not be
     used in application code.
 
     :param name: The name of the decoder
-    :param decoder: A callable(mode, args) that returns an
-                    ImageFile.PyDecoder object
+    :param decoder: An ImageFile.PyDecoder object
 
     .. versionadded:: 4.1.0
     """
     DECODERS[name] = decoder
 
 
-def register_encoder(name, encoder):
+def register_encoder(name: str, encoder: type[ImageFile.PyEncoder]) -> None:
     """
     Registers an image encoder.  This function should not be
     used in application code.
 
     :param name: The name of the encoder
-    :param encoder: A callable(mode, args) that returns an
-                    ImageFile.PyEncoder object
+    :param encoder: An ImageFile.PyEncoder object
 
     .. versionadded:: 4.1.0
     """


### PR DESCRIPTION
`register_decoder()` and `register_encoder()` state that `decoder`/`encoder` are callables that return an object.
https://github.com/python-pillow/Pillow/blob/912a33f5e9815735d994c856fa241856e13c694c/src/PIL/Image.py#L3527-L3534
https://github.com/python-pillow/Pillow/blob/912a33f5e9815735d994c856fa241856e13c694c/src/PIL/Image.py#L3541-L3548

However, if you look at Pillow's source code, it is not a callable, it is just an object.

https://github.com/python-pillow/Pillow/blob/912a33f5e9815735d994c856fa241856e13c694c/src/PIL/BlpImagePlugin.py#L472-L476
https://github.com/python-pillow/Pillow/blob/912a33f5e9815735d994c856fa241856e13c694c/src/PIL/PpmImagePlugin.py#L362-L363
https://github.com/python-pillow/Pillow/blob/912a33f5e9815735d994c856fa241856e13c694c/src/PIL/DdsImagePlugin.py#L569
https://github.com/python-pillow/Pillow/blob/912a33f5e9815735d994c856fa241856e13c694c/src/PIL/SgiImagePlugin.py#L230

This PR updates the docstrings, clarifies this by adding type hints, and updates the tests (which did treat the arguments as callables).