### PR TITLE
Pin Python 3.13 on Windows to a3

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.10", "pypy3.9", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["pypy3.10", "pypy3.9", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-alpha.3"]
 
     timeout-minutes: 30
 


### PR DESCRIPTION
Python 3.13 on Windows in GitHub Actions has started failing, with https://github.com/python-pillow/Pillow/actions/runs/7937029330/job/21673447008#step:25:535
> LINK : fatal error LNK1104: cannot open file 'python313t.lib'

The failure started with 3.13.0a4.

https://github.com/python/cpython/pull/109922 leads me to believe that the 't' relates to builds without gil.
So I conclude that this problem has been reported as https://github.com/python/cpython/issues/115545, which says
> It seems the free-threaded and non-free-threaded build got mixed up, and so the main executable in the package is nogil and looking for the wrong DLL.
> ...
> This needs to be fixed before the next alpha.

a5 is scheduled to be released on March 12. So this PR pins to a3 to allow our CIs to pass in the meantime.