### PR TITLE
Describe difference between font size and bbox

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -232,10 +232,10 @@ Previous code::
 
     im = Image.new("RGB", (100, 100))
     draw = ImageDraw.Draw(im)
-    width, height = draw.textsize("Hello world")
+    width, height = draw.textsize("Hello world", font)
 
     width, height = font.getsize_multiline("Hello\nworld")
-    width, height = draw.multiline_textsize("Hello\nworld")
+    width, height = draw.multiline_textsize("Hello\nworld", font)
 
 Use instead::
 
@@ -247,9 +247,9 @@ Use instead::
 
     im = Image.new("RGB", (100, 100))
     draw = ImageDraw.Draw(im)
-    width = draw.textlength("Hello world")
+    width = draw.textlength("Hello world", font)
 
-    left, top, right, bottom = draw.multiline_textbbox((0, 0), "Hello\nworld")
+    left, top, right, bottom = draw.multiline_textbbox((0, 0), "Hello\nworld", font)
     width, height = right - left, bottom - top
 
 FreeTypeFont.getmask2 fill parameter

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -252,6 +252,10 @@ Use instead::
     left, top, right, bottom = draw.multiline_textbbox((0, 0), "Hello\nworld", font)
     width, height = right - left, bottom - top
 
+Previously, the ``size`` methods returned a ``height`` that included the vertical
+offset of the text, while the new ``bbox`` methods explicitly distinguish this as a
+``top`` offset.
+
 FreeTypeFont.getmask2 fill parameter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releasenotes/9.2.0.rst
+++ b/docs/releasenotes/9.2.0.rst
@@ -69,10 +69,10 @@ Previous code::
 
     im = Image.new("RGB", (100, 100))
     draw = ImageDraw.Draw(im)
-    width, height = draw.textsize("Hello world")
+    width, height = draw.textsize("Hello world", font)
 
     width, height = font.getsize_multiline("Hello\nworld")
-    width, height = draw.multiline_textsize("Hello\nworld")
+    width, height = draw.multiline_textsize("Hello\nworld", font)
 
 Use instead::
 
@@ -84,9 +84,9 @@ Use instead::
 
     im = Image.new("RGB", (100, 100))
     draw = ImageDraw.Draw(im)
-    width = draw.textlength("Hello world")
+    width = draw.textlength("Hello world", font)
 
-    left, top, right, bottom = draw.multiline_textbbox((0, 0), "Hello\nworld")
+    left, top, right, bottom = draw.multiline_textbbox((0, 0), "Hello\nworld", font)
     width, height = right - left, bottom - top
 
 API Additions

--- a/docs/releasenotes/9.2.0.rst
+++ b/docs/releasenotes/9.2.0.rst
@@ -89,6 +89,10 @@ Use instead::
     left, top, right, bottom = draw.multiline_textbbox((0, 0), "Hello\nworld", font)
     width, height = right - left, bottom - top
 
+Previously, the ``size`` methods returned a ``height`` that included the vertical
+offset of the text, while the new ``bbox`` methods explicitly distinguish this as a
+``top`` offset.
+
 API Additions
 =============
 


### PR DESCRIPTION
Helps #7802

The user in the issue thinks that the documentation could use further detail about the transition from `font.getsize()` to `font.getbbox()`.

I've amended the deprecations and release notes documentation with the following
> Previously, the ``size`` methods returned a ``height`` that included the vertical offset of the text, while the new ``bbox`` methods explicitly distinguish this as a ``top`` offset.

While here, I also noticed that some of the example code didn't use the font declared earlier, so I've fixed that.