### PR TITLE
Removed mypy excludes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,3 @@ follow_imports = "silent"
 warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_ignores = true
-exclude = [
-  '^src/PIL/FpxImagePlugin.py$',
-  '^src/PIL/MicImagePlugin.py$',
-]

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ deps =
     packaging
     types-cffi
     types-defusedxml
+    types-olefile
 extras =
     typing
 commands =


### PR DESCRIPTION
Sequel to #7790

https://pypi.org/project/types-olefile/ now exists, so this can be used to remove the last of the mypy excludes.