### PR TITLE
Updated package name for Tidelift

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-tidelift: "pypi/Pillow"
+tidelift: "pypi/pillow"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ As of 2019, Pillow development is
                 src="https://zenodo.org/badge/17549/python-pillow/Pillow.svg"></a>
             <a href="https://tidelift.com/subscription/pkg/pypi-pillow?utm_source=pypi-pillow&utm_medium=badge"><img
                 alt="Tidelift"
-                src="https://tidelift.com/badges/package/pypi/Pillow?style=flat"></a>
+                src="https://tidelift.com/badges/package/pypi/pillow?style=flat"></a>
             <a href="https://pypi.org/project/pillow/"><img
                 alt="Newest PyPI version"
                 src="https://img.shields.io/pypi/v/pillow.svg"></a>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -326,7 +326,7 @@ linkcheck_allowed_redirects = {
     r"https://gitter.im/python-pillow/Pillow?.*": r"https://app.gitter.im/#/room/#python-pillow_Pillow:gitter.im?.*",
     r"https://pillow.readthedocs.io/?badge=latest": r"https://pillow.readthedocs.io/en/stable/?badge=latest",
     r"https://pillow.readthedocs.io": r"https://pillow.readthedocs.io/en/stable/",
-    r"https://tidelift.com/badges/package/pypi/Pillow?.*": r"https://img.shields.io/badge/.*",
+    r"https://tidelift.com/badges/package/pypi/pillow?.*": r"https://img.shields.io/badge/.*",
     r"https://zenodo.org/badge/17549/python-pillow/Pillow.svg": r"https://zenodo.org/badge/doi/[\.0-9]+/zenodo.[0-9]+.svg",
     r"https://zenodo.org/badge/latestdoi/17549/python-pillow/Pillow": r"https://zenodo.org/record/[0-9]+",
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,7 +49,7 @@ Pillow for enterprise is available via the Tidelift Subscription. `Learn more <h
    :target: https://zenodo.org/badge/latestdoi/17549/python-pillow/Pillow
    :alt: Zenodo
 
-.. image:: https://tidelift.com/badges/package/pypi/Pillow?style=flat
+.. image:: https://tidelift.com/badges/package/pypi/pillow?style=flat
    :target: https://tidelift.com/subscription/pkg/pypi-pillow?utm_source=pypi-pillow&utm_medium=badge
    :alt: Tidelift
 


### PR DESCRIPTION
Relates to #7681

In the README and at https://pillow.readthedocs.io/en/latest/, our Tidelift badge currently reads "not lifted!".
The image source is https://tidelift.com/badges/package/pypi/Pillow?style=flat
Changing 'Pillow' to 'pillow', I find that it works again.

Similarly, the 'Sponsor our project' sidebar item at https://github.com/python-pillow/Pillow links to https://tidelift.com/funding/github/pypi/Pillow, but redirects to https://tidelift.com/subscription/how-to-connect-tidelift-with-github.
Changing 'Pillow' to 'pillow', I find that it works again.

