### PR TITLE
Remove _SupportsGetMesh from docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,10 @@ extensions = [
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
+autodoc_type_aliases = {
+    "_SupportsGetMesh": "object",
+}
+
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']


### PR DESCRIPTION
After #7786, the docs have started failing in main - https://github.com/python-pillow/Pillow/actions/runs/7951921486/job/21705919173#step:8:254
> /opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/site-packages/PIL/ImageOps.py:docstring of PIL.ImageOps.deform:1: WARNING: py:class reference target not found: PIL.ImageOps._SupportsGetMesh

This fixes it by adding `_SupportsGetMesh` to the docs.