### PR TITLE
Remove outdated installation warnings

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -504,3 +504,27 @@ PIL.OleFileIO
 the upstream :pypi:`olefile` Python package, and replaced with an :py:exc:`ImportError` in 5.0.0
 (2018-01). The deprecated file has now been removed from Pillow. If needed, install from
 PyPI (eg. ``python3 -m pip install olefile``).
+
+import _imaging
+~~~~~~~~~~~~~~~
+
+.. versionremoved:: 2.1.0
+
+Pillow >= 2.1.0 no longer supports ``import _imaging``.
+Please use ``from PIL.Image import core as _imaging`` instead.
+
+Pillow and PIL
+~~~~~~~~~~~~~~
+
+Pillow and PIL cannot co-exist in the same environment.
+Before installing Pillow, please uninstall PIL.
+
+.. versionremoved:: 1.0.0
+
+import Image
+~~~~~~~~~~~~
+
+.. versionremoved:: 1.0.0
+
+Pillow >= 1.0 no longer supports ``import Image``.
+Please use ``from PIL import Image`` instead.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,15 +9,6 @@ Installation
     });
     </script>
 
-Warnings
---------
-
-.. warning:: Pillow and PIL cannot co-exist in the same environment. Before installing Pillow, please uninstall PIL.
-
-.. warning:: Pillow >= 1.0 no longer supports ``import Image``. Please use ``from PIL import Image`` instead.
-
-.. warning:: Pillow >= 2.1.0 no longer supports ``import _imaging``. Please use ``from PIL.Image import core as _imaging`` instead.
-
 Python Support
 --------------
 


### PR DESCRIPTION
I think we can remove the three warnings from the top of https://pillow.readthedocs.io/en/stable/installation.html

---

> Pillow and PIL cannot co-exist in the same environment. Before installing Pillow, please uninstall PIL.

I seem to remember that around ten years ago, it used to be possible to install PIL from PyPI. 

It used to be that PyPI would allow installing files hosted elsewhere, but now all files must be uploaded to PyPI, and there are no downloadable files at https://pypi.org/project/PIL/.

I don't think it's possible now to install PIL and Pillow at the same time, even if you tried installing PIL from source.

---


> Pillow >= 1.0 no longer supports `import Image`. Please use `from PIL import Image` instead.

https://pypi.org/project/pillow/1.0/ was released in 2010. I don't think we need to warn about this any more.

---

> Pillow >= 2.1.0 no longer supports `import _imaging`. Please use `from PIL.Image import core as _imaging` instead.

https://pypi.org/project/pillow/2.1.0/ was released in 2013. I don't think we need to warn about this either.
