### PR TITLE
Build docs for Python changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,10 +7,12 @@ on:
     paths:
       - ".github/workflows/docs.yml"
       - "docs/**"
+      - "src/PIL/**"
   pull_request:
     paths:
       - ".github/workflows/docs.yml"
       - "docs/**"
+      - "src/PIL/**"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Also run the docs workflow when Python files are updated, as this can affect Documentation if e.g. type hints are changed. This could have prevented issues such as what caused https://github.com/python-pillow/Pillow/pull/7812.