### PR TITLE
Set `COVERAGE_CORE: sysmon` for faster tests on 3.12+

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,7 @@ init:
 # Uncomment previous line to get RDP access during the build.
 
 environment:
+  COVERAGE_CORE: sysmon
   EXECUTABLE: python.exe
   TEST_OPTIONS:
   DEPLOY: YES

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  COVERAGE_CORE: sysmon
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  COVERAGE_CORE: sysmon
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  COVERAGE_CORE: sysmon
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  COVERAGE_CORE: sysmon
   FORCE_COLOR: 1
 
 jobs:


### PR DESCRIPTION
Python 3.12 introduced [sys.monitoring](https://docs.python.org/3/library/sys.monitoring.html), that tools like coverage.py can use to improve performance.

It's not yet the default in coverage.py. To enable, we can set a `COVERAGE_CORE=sysmon` environment variable, that will switch to the faster mode when available, that is, in Python 3.12 and newer. Older versions will stick to the older method.

For example, on my machine:

test | command | result
-|-|-
No coverage | `python3 -m pytest Tests` | 4269 passed, 224 skipped, 3 xfailed in 48.21s
Coverage: default core | `python3 -m pytest --cov PIL --cov Tests Tests` | 4269 passed, 224 skipped, 3 xfailed in 58.15s
Coverage: sysmon core | `COVERAGE_CORE=sysmon python3 -m pytest --cov PIL --cov Tests Tests` | 4269 passed, 224 skipped, 3 xfailed in 46.73s

Coverage time on CI, default core -> sysmon core:

CI job | before | after | speedup
-- | -- | -- | --
AppVeyor 3.12 | 229.76s (0:03:49) | 198.50s (0:03:18) | 13.6%
macOS 3.13 | 68.55s (0:01:08) | 62.33s (0:01:02) | 9.1%
macOS 3.12 | 84.63s (0:01:24) | 71.83s (0:01:11) | 15.1%
Ubuntu 3.13 | 89.40s (0:01:29) | 65.46s (0:01:05) | 26.8%
Ubuntu 3.12 | 91.20s (0:01:31) | 67.33s (0:01:07) | 26.2%
Windows 3.13 | 156.69s (0:02:36) | 134.59s (0:02:14) | 14.1%
Windows 3.12 | 164.19s (0:02:44) | 146.63s (0:02:26) | 10.7%
**Total** | **884.42 (0:14:41)** | **746.67 (0:12:23)** | **15.6%**


---

I also added the env var to the Cygwin and MinGW workflows, even though they test Python <= 3.11. If they're upgraded to 3.12+ later, it'll take effect.