### PR TITLE
Use maximum frame size in IHDR chunk when saving APNG images

### DIFF
--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -668,6 +668,16 @@ def test_apng_save_blend(tmp_path: Path) -> None:
         assert im.getpixel((0, 0)) == (0, 255, 0, 255)
 
 
+def test_apng_save_size(tmp_path: Path) -> None:
+    test_file = str(tmp_path / "temp.png")
+
+    im = Image.new("L", (100, 100))
+    im.save(test_file, save_all=True, append_images=[Image.new("L", (200, 200))])
+
+    with Image.open(test_file) as reloaded:
+        assert reloaded.size == (200, 200)
+
+
 def test_seek_after_close() -> None:
     im = Image.open("Tests/images/apng/delay.png")
     im.seek(1)

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -1232,16 +1232,20 @@ def _save(im, fp, filename, chunk=putchunk, save_all=False):
             "default_image", im.info.get("default_image")
         )
         modes = set()
+        sizes = set()
         append_images = im.encoderinfo.get("append_images", [])
         for im_seq in itertools.chain([im], append_images):
             for im_frame in ImageSequence.Iterator(im_seq):
                 modes.add(im_frame.mode)
+                sizes.add(im_frame.size)
         for mode in ("RGBA", "RGB", "P"):
             if mode in modes:
                 break
         else:
             mode = modes.pop()
+        size = tuple(max(frame_size[i] for frame_size in sizes) for i in range(2))
     else:
+        size = im.size
         mode = im.mode
 
     if mode == "P":
@@ -1289,8 +1293,8 @@ def _save(im, fp, filename, chunk=putchunk, save_all=False):
     chunk(
         fp,
         b"IHDR",
-        o32(im.size[0]),  # 0: size
-        o32(im.size[1]),
+        o32(size[0]),  # 0: size
+        o32(size[1]),
         mode,  # 8: depth/type
         b"\0",  # 10: compression
         b"\0",  # 11: filter category


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/issues/1138#issuecomment-1955716795 reported an image that `img.show()` did not successfully open.

Images are temporarily saved as PNGs when used with `show()`. The image has two frames of different sizes, and investigating, I found that https://wiki.mozilla.org/APNG_Specification states
> The boundaries of the entire animation are specified by the width and height parameters of the PNG `IHDR` chunk

and

> each frame's region (x,y,width,height) must lie completely within the parent PNG canvas

This PR expands the size in the IHDR chunk to the maximum size of all of the frames, and that fixes the problem.