### PR TITLE
Do not have Renovate update pinned dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,5 +13,6 @@
             "separateMajorMinor": "false"
         }
     ],
-    "schedule": ["on the 3rd day of the month"]
+    "schedule": ["on the 3rd day of the month"],
+    "updatePinnedDependencies": false
 }


### PR DESCRIPTION
Since codecov/codecov-action was pinned to 3.1.5 in #7776, it is listed for updating in #6604. I expect Renovate will try and create a PR to update it on March 3rd.

To dissuade it from this idea, this PR sets "updatePinnedDependencies" to false in the Renovate config.

Read more at https://docs.renovatebot.com/configuration-options/#updatepinneddependencies