### PR TITLE
Require coverage.py 7.4.2+ for `COVERAGE_CORE: sysmon`

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -69,8 +69,16 @@ jobs:
     - name: Print build system information
       run: python3 .github/workflows/system-info.py
 
-    - name: python3 -m pip install pytest pytest-cov pytest-timeout defusedxml olefile pyroma
-      run: python3 -m pip install pytest pytest-cov pytest-timeout defusedxml olefile pyroma
+    - name: Install Python dependencies
+      run: >
+        python3 -m pip install
+        coverage>=7.4.2
+        defusedxml
+        olefile
+        pyroma
+        pytest
+        pytest-cov
+        pytest-timeout
 
     - name: Install dependencies
       id: install


### PR DESCRIPTION
Re: https://github.com/python-pillow/Pillow/pull/7820#issuecomment-1960938189

Coverage.py 7.4.0 added support for Python 3.12's `sys.monitoring` and `COVERAGE_CORE: sysmon`, but would also enable it on older versions of Python and fail.

Coverage.py 7.4.2 only uses `sys.monitoring` when `COVERAGE_CORE: sysmon` and we're on 3.12+.

So let's make sure we have at least 7.4.2 installed.

I only set it for the workflow that started failing (probably due to caching). We could add it to the others, but I think it's fine if they're passing.