### PR TITLE
Turn off nullability warnings for macOS SDK

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -569,6 +569,9 @@ class pil_build_ext(build_ext):
             if sdk_path:
                 _add_directory(library_dirs, os.path.join(sdk_path, "usr", "lib"))
                 _add_directory(include_dirs, os.path.join(sdk_path, "usr", "include"))
+
+                for extension in self.extensions:
+                    extension.extra_compile_args = ["-Wno-nullability-completeness"]
         elif (
             sys.platform.startswith("linux")
             or sys.platform.startswith("gnu")


### PR DESCRIPTION
Resolves #7759

The issue describes many warnings being raised when verbosely building Pillow on macOS. They are mostly warnings of "pointer is missing a nullability type specifier"

```
  /Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include/stdlib.h:136:23: warning: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Wnullability-completeness]
  long     atol(const char *);
                           ^
  /Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include/stdlib.h:136:23: note: insert '_Nullable' if the pointer may be null
  long     atol(const char *);
                           ^
                            _Nullable
  /Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include/stdlib.h:136:23: note: insert '_Nonnull' if the pointer should never be null
  long     atol(const char *);
                           ^
                            _Nonnull
```

Investigating, I found https://gist.github.com/software-mariodiana/de55a56935730b08d7a5a2a05c44dcd3 stating "These warning are added so that Objective-C code will be compatible with Swift"

https://stackoverflow.com/questions/32539285/pointer-is-missing-a-nullability-type-specifier pointed me to https://developer.apple.com/swift/blog/?id=25 for some more detail about this compatibility.

So given that it is something that is acknowledged, the solution is just to turn off the warnings, with `-Wno-nullability-completeness`.