### PR TITLE
Allow writing IFDRational to UNDEFINED tag

### DIFF
--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -224,14 +224,17 @@ def test_writing_other_types_to_bytes(value: int | IFDRational, tmp_path: Path) 
         assert reloaded.tag_v2[700] == b"\x01"
 
 
-def test_writing_other_types_to_undefined(tmp_path: Path) -> None:
+@pytest.mark.parametrize("value", (1, IFDRational(1)))
+def test_writing_other_types_to_undefined(
+    value: int | IFDRational, tmp_path: Path
+) -> None:
     im = hopper()
     info = TiffImagePlugin.ImageFileDirectory_v2()
 
     tag = TiffTags.TAGS_V2[33723]
     assert tag.type == TiffTags.UNDEFINED
 
-    info[33723] = 1
+    info[33723] = value
 
     out = str(tmp_path / "temp.tiff")
     im.save(out, tiffinfo=info)

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -790,6 +790,8 @@ class ImageFileDirectory_v2(_IFDv2Base):
 
     @_register_writer(7)
     def write_undefined(self, value):
+        if isinstance(value, IFDRational):
+            value = int(value)
         if isinstance(value, int):
             value = str(value).encode("ascii", "replace")
         return value


### PR DESCRIPTION
Resolves https://github.com/python-pillow/Pillow/issues/7839. Similar to https://github.com/python-pillow/Pillow/pull/6890

The issue provides an image where the InteropVersion tag has type RATIONAL.
https://exiftool.org/TagNames/EXIF.html states that it should have type UNDEFINED. The tag is loaded as RATIONALs, but this causes an error when Pillow tries to write it as UNDEFINED when saving the EXIF data.

This PR simply handles the IFDRational value when saving UNDEFINED tags.