### PR TITLE
Fix logged tag name when loading Exif data

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3714,7 +3714,7 @@ class Exif(_ExifBase):
         # returns a dict with any single item tuples/lists as individual values
         return {k: self._fixup(v) for k, v in src_dict.items()}
 
-    def _get_ifd_dict(self, offset):
+    def _get_ifd_dict(self, offset, group=None):
         try:
             # an offset pointer to the location of the nested embedded IFD.
             # It should be a long, but may be corrupted.
@@ -3724,7 +3724,7 @@ class Exif(_ExifBase):
         else:
             from . import TiffImagePlugin
 
-            info = TiffImagePlugin.ImageFileDirectory_v2(self.head)
+            info = TiffImagePlugin.ImageFileDirectory_v2(self.head, group=group)
             info.load(self.fp)
             return self._fixup_dict(info)
 
@@ -3796,14 +3796,14 @@ class Exif(_ExifBase):
 
         # get EXIF extension
         if ExifTags.IFD.Exif in self:
-            ifd = self._get_ifd_dict(self[ExifTags.IFD.Exif])
+            ifd = self._get_ifd_dict(self[ExifTags.IFD.Exif], ExifTags.IFD.Exif)
             if ifd:
                 merged_dict.update(ifd)
 
         # GPS
         if ExifTags.IFD.GPSInfo in self:
             merged_dict[ExifTags.IFD.GPSInfo] = self._get_ifd_dict(
-                self[ExifTags.IFD.GPSInfo]
+                self[ExifTags.IFD.GPSInfo], ExifTags.IFD.GPSInfo
             )
 
         return merged_dict
@@ -3837,7 +3837,7 @@ class Exif(_ExifBase):
             elif tag in [ExifTags.IFD.Exif, ExifTags.IFD.GPSInfo]:
                 offset = self._hidden_data.get(tag, self.get(tag))
                 if offset is not None:
-                    self._ifds[tag] = self._get_ifd_dict(offset)
+                    self._ifds[tag] = self._get_ifd_dict(offset, tag)
             elif tag in [ExifTags.IFD.Interop, ExifTags.IFD.Makernote]:
                 if ExifTags.IFD.Exif not in self._ifds:
                     self.get_ifd(ExifTags.IFD.Exif)
@@ -3919,7 +3919,7 @@ class Exif(_ExifBase):
                         self._ifds[tag] = makernote
                 else:
                     # Interop
-                    self._ifds[tag] = self._get_ifd_dict(tag_data)
+                    self._ifds[tag] = self._get_ifd_dict(tag_data, tag)
         ifd = self._ifds.get(tag, {})
         if tag == ExifTags.IFD.Exif and self._hidden_data:
             ifd = {


### PR DESCRIPTION
In main,
```python
import logging
from PIL import Image, ExifTags
im = Image.open("/Users/andrewmurray/pillow/Pillow/Tests/images/exif_gps.jpg")
exif = im.getexif()

logging.basicConfig(level=logging.DEBUG)
exif.get_ifd(ExifTags.IFD.GPSInfo)
```
gives
```
DEBUG:PIL.TiffImagePlugin:tag: unknown (0) - type: byte (1) - value: b'\x00\x00\x00\x01'
DEBUG:PIL.TiffImagePlugin:tag: unknown (2) - type: rational (5) Tag Location: 392 - Data Location: 428 - value: b'\xff\xff\xff\xff\x00\x00\x00\x01'
DEBUG:PIL.TiffImagePlugin:tag: unknown (5) - type: byte (1) - value: b'\x01'
DEBUG:PIL.TiffImagePlugin:tag: unknown (29) - type: string (2) Tag Location: 416 - Data Location: 436 - value: b'1999:99:99 99:99:99\x00'
DEBUG:PIL.TiffImagePlugin:tag: unknown (30) - type: short (3) - value: b'\xff\xff'
```
This PR aims to improve the "tag: unknown" portion.

The logging can be found at 
https://github.com/python-pillow/Pillow/blob/18af6463650188caf65557203841cbfd2b8dcb11/src/PIL/TiffImagePlugin.py#L842-L879
The problem is that `Image.Exif` isn't populating the `group` when creating the IFD
https://github.com/python-pillow/Pillow/blob/18af6463650188caf65557203841cbfd2b8dcb11/src/PIL/TiffImagePlugin.py#L548

When it is changed to do so, you get a more helpful output.
```
DEBUG:PIL.TiffImagePlugin:tag: GPSVersionID (0) - type: byte (1) - value: b'\x00\x00\x00\x01'
DEBUG:PIL.TiffImagePlugin:tag: GPSLatitude (2) - type: rational (5) Tag Location: 392 - Data Location: 428 - value: b'\xff\xff\xff\xff\x00\x00\x00\x01'
DEBUG:PIL.TiffImagePlugin:tag: GPSAltitudeRef (5) - type: byte (1) - value: b'\x01'
DEBUG:PIL.TiffImagePlugin:tag: GPSDateStamp (29) - type: string (2) Tag Location: 416 - Data Location: 436 - value: b'1999:99:99 99:99:99\x00'
DEBUG:PIL.TiffImagePlugin:tag: GPSDifferential (30) - type: short (3) - value: b'\xff\xff'
```