### PR TITLE
Do not use packaged MinGW pip

### DIFF
--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -67,10 +67,10 @@ jobs:
               mingw-w64-x86_64-python3-cffi \
               mingw-w64-x86_64-python3-numpy \
               mingw-w64-x86_64-python3-olefile \
-              mingw-w64-x86_64-python3-pip \
               mingw-w64-x86_64-python3-setuptools \
               mingw-w64-x86_64-python-pyqt6
 
+          python3 -m ensurepip
           python3 -m pip install pyroma pytest pytest-cov pytest-timeout
 
           pushd depends && ./install_extra_test_images.sh && popd


### PR DESCRIPTION
MinGW has started failing in main.

Looking through the output, I saw https://github.com/python-pillow/Pillow/actions/runs/8102796165/job/22146045896#step:6:3514
> ModuleNotFoundError: No module named 'pip._vendor.distlib'

Using `python3 -m ensurepip` instead of the `mingw-w64-x86_64-python3-pip` package fixes the job.