### PR TITLE
Build macOS arm64 wheels natively

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -130,9 +130,15 @@ if [[ -n "$IS_MACOS" ]]; then
   # libxau and libxdmcp cause an issue on macOS < 11
   # remove cairo to fix building harfbuzz on arm64
   # remove lcms2 and libpng to fix building openjpeg on arm64
-  # remove zstd to avoid inclusion on x86_64
+  # remove jpeg-turbo to avoid inclusion on arm64
+  # remove webp and zstd to avoid inclusion on x86_64
   # curl from brew requires zstd, use system curl
   brew remove --ignore-dependencies libpng libtiff libxcb libxau libxdmcp curl cairo lcms2 zstd
+  if [[ "$CIBW_ARCHS" == "arm64" ]]; then
+    brew remove --ignore-dependencies jpeg-turbo
+  else
+    brew remove --ignore-dependencies webp
+  fi
 
   brew install pkg-config
 fi

--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -62,7 +62,7 @@ function build_brotli {
 
 function build {
     if [[ -n "$IS_MACOS" ]] && [[ "$CIBW_ARCHS" == "arm64" ]]; then
-        export BUILD_PREFIX="/usr/local"
+        sudo chown -R runner /usr/local
     fi
     build_xz
     if [ -z "$IS_ALPINE" ] && [ -z "$IS_MACOS" ]; then
@@ -75,8 +75,8 @@ function build {
         build_simple xorgproto 2023.2 https://www.x.org/pub/individual/proto
         build_simple libXau 1.0.11 https://www.x.org/pub/individual/lib
         build_simple libpthread-stubs 0.5 https://xcb.freedesktop.org/dist
-        if [ -f /Library/Frameworks/Python.framework/Versions/Current/share/pkgconfig/xcb-proto.pc ]; then
-            cp /Library/Frameworks/Python.framework/Versions/Current/share/pkgconfig/xcb-proto.pc /Library/Frameworks/Python.framework/Versions/Current/lib/pkgconfig/xcb-proto.pc
+        if [[ "$CIBW_ARCHS" == "arm64" ]]; then
+            cp /usr/local/share/pkgconfig/xcb-proto.pc /usr/local/lib/pkgconfig
         fi
     else
         sed s/\${pc_sysrootdir\}// /usr/local/share/pkgconfig/xcb-proto.pc > /usr/local/lib/pkgconfig/xcb-proto.pc
@@ -87,11 +87,6 @@ function build {
     build_tiff
     build_libpng
     build_lcms2
-    if [[ -n "$IS_MACOS" ]] && [[ "$CIBW_ARCHS" == "arm64" ]]; then
-        for dylib in libjpeg.dylib libtiff.dylib liblcms2.dylib; do
-            cp $BUILD_PREFIX/lib/$dylib /opt/arm64-builds/lib
-        done
-    fi
     build_openjpeg
     if [ -f /usr/local/lib64/libopenjp2.so ]; then
         cp /usr/local/lib64/libopenjp2.so /usr/local/lib
@@ -131,14 +126,13 @@ curl -fsSL -o pillow-depends-main.zip https://github.com/python-pillow/pillow-de
 untar pillow-depends-main.zip
 
 if [[ -n "$IS_MACOS" ]]; then
-  # webp, libtiff, libxcb cause a conflict with building webp, libtiff, libxcb
+  # libtiff and libxcb cause a conflict with building libtiff and libxcb
   # libxau and libxdmcp cause an issue on macOS < 11
-  # if php is installed, brew tries to reinstall these after installing openblas
   # remove cairo to fix building harfbuzz on arm64
   # remove lcms2 and libpng to fix building openjpeg on arm64
   # remove zstd to avoid inclusion on x86_64
   # curl from brew requires zstd, use system curl
-  brew remove --ignore-dependencies webp libpng libtiff libxcb libxau libxdmcp curl php cairo lcms2 ghostscript zstd
+  brew remove --ignore-dependencies libpng libtiff libxcb libxau libxdmcp curl cairo lcms2 zstd
 
   brew install pkg-config
 fi

--- a/.github/workflows/wheels-test.sh
+++ b/.github/workflows/wheels-test.sh
@@ -4,6 +4,9 @@ set -e
 if [[ "$OSTYPE" == "darwin"* ]]; then
     brew install fribidi
     export PKG_CONFIG_PATH="/usr/local/opt/openblas/lib/pkgconfig"
+    if [ -f /opt/homebrew/lib/libfribidi.dylib ]; then
+        sudo cp /opt/homebrew/lib/libfribidi.dylib /usr/local/lib
+    fi
 elif [ "${AUDITWHEEL_POLICY::9}" == "musllinux" ]; then
     apk add curl fribidi
 else

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -99,7 +99,7 @@ jobs:
             cibw_arch: x86_64
             macosx_deployment_target: "10.10"
           - name: "macOS arm64"
-            os: macos-latest
+            os: macos-14
             cibw_arch: arm64
             macosx_deployment_target: "11.0"
           - name: "manylinux2014 and musllinux x86_64"
@@ -132,7 +132,7 @@ jobs:
           CIBW_MANYLINUX_PYPY_X86_64_IMAGE: ${{ matrix.manylinux }}
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux }}
           CIBW_SKIP: pp38-*
-          CIBW_TEST_SKIP: "*-macosx_arm64"
+          CIBW_TEST_SKIP: cp38-macosx_arm64
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macosx_deployment_target }}
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
#7766 started testing macOS CI jobs on M1 where available.

We can go further, building macOS M1 wheels natively. This also means that we can start testing macOS M1 wheels, [apart from Python 3.8.](https://github.com/pypa/cibuildwheel/blob/ae2451a199bdec6636108b1110cf633157dba7e0/cibuildwheel/macos.py#L520-L523)