### PR TITLE
Corrected exiv2.org links

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -825,7 +825,7 @@ class TestFileJpeg:
         with Image.open("Tests/images/no-dpi-in-exif.jpg") as im:
             # Act / Assert
             # "When the image resolution is unknown, 72 [dpi] is designated."
-            # https://exiv2.org/tags.html
+            # https://web.archive.org/web/20240227115053/https://exiv2.org/tags.html
             assert im.info.get("dpi") == (72, 72)
 
     def test_invalid_exif(self) -> None:

--- a/src/PIL/JpegPresets.py
+++ b/src/PIL/JpegPresets.py
@@ -37,7 +37,7 @@ You can get the subsampling of a JPEG with the
 :func:`.JpegImagePlugin.get_sampling` function.
 
 In JPEG compressed data a JPEG marker is used instead of an EXIF tag.
-(ref.: https://exiv2.org/tags.html)
+(ref.: https://web.archive.org/web/20240227115053/https://exiv2.org/tags.html)
 
 
 Quantization tables


### PR DESCRIPTION
https://exiv2.org/tags.html no longer works.

It looks like they're aware of this - https://github.com/Exiv2/exiv2/issues/2875

This fixes the links using the Wayback Machine.