### PR TITLE
Update installation docs

### DIFF
--- a/docs/installation/basic-installation.rst
+++ b/docs/installation/basic-installation.rst
@@ -1,7 +1,7 @@
 .. _basic-installation:
 
 Basic Installation
-------------------
+==================
 
 .. note::
 

--- a/docs/installation/basic-installation.rst
+++ b/docs/installation/basic-installation.rst
@@ -68,7 +68,7 @@ and :pypi:`olefile` for Pillow to read FPX and MIC images::
         python3 -m pip install --upgrade pip
         python3 -m pip install --upgrade Pillow
 
-    To install Pillow in MSYS2, see `Building on Windows using MSYS2/MinGW`_.
+    To install Pillow in MSYS2, see :ref:`Building on Windows using MSYS2/MinGW`.
 
 .. tab:: FreeBSD
 

--- a/docs/installation/basic-installation.rst
+++ b/docs/installation/basic-installation.rst
@@ -87,11 +87,3 @@ and :pypi:`olefile` for Pillow to read FPX and MIC images::
         The `Pillow FreeBSD port
         <https://www.freshports.org/graphics/py-pillow/>`_ and packages
         are tested by the ports team with all supported FreeBSD versions.
-
-
-.. _Building on Linux:
-.. _Building on macOS:
-.. _Building on Windows:
-.. _Building on Windows using MSYS2/MinGW:
-.. _Building on FreeBSD:
-.. _Building on Android:

--- a/docs/installation/basic-installation.rst
+++ b/docs/installation/basic-installation.rst
@@ -1,3 +1,11 @@
+.. raw:: html
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      activateTab(getOS());
+    });
+    </script>
+
 .. _basic-installation:
 
 Basic Installation

--- a/docs/installation/building-from-source.rst
+++ b/docs/installation/building-from-source.rst
@@ -304,3 +304,12 @@ Build Options
 Sample usage::
 
     python3 -m pip install --upgrade Pillow -C [feature]=enable
+
+.. _old-versions:
+
+Old Versions
+============
+
+You can download old distributions from the `release history at PyPI
+<https://pypi.org/project/pillow/#history>`_ and by direct URL access
+eg. https://pypi.org/project/pillow/1.0/.

--- a/docs/installation/building-from-source.rst
+++ b/docs/installation/building-from-source.rst
@@ -1,3 +1,9 @@
+.. _Building on Linux:
+.. _Building on macOS:
+.. _Building on Windows:
+.. _Building on Windows using MSYS2/MinGW:
+.. _Building on FreeBSD:
+.. _Building on Android:
 .. _building-from-source:
 
 Building From Source

--- a/docs/installation/building-from-source.rst
+++ b/docs/installation/building-from-source.rst
@@ -7,12 +7,12 @@
 .. _building-from-source:
 
 Building From Source
---------------------
+====================
 
 .. _external-libraries:
 
 External Libraries
-^^^^^^^^^^^^^^^^^^
+------------------
 
 .. note::
 
@@ -227,7 +227,7 @@ Many of Pillow's features require external libraries:
     This has been tested within the Termux app on ChromeOS, on x86.
 
 Installing
-^^^^^^^^^^
+----------
 
 Once you have installed the prerequisites, to install Pillow from the source
 code on PyPI, run::
@@ -262,7 +262,7 @@ After navigating to the Pillow directory, run::
 .. _compressed archive from PyPI: https://pypi.org/project/pillow/#files
 
 Build Options
-"""""""""""""
+^^^^^^^^^^^^^
 
 * Environment variable: ``MAX_CONCURRENCY=n``. Pillow can use
   multiprocessing to build the extension. Setting ``MAX_CONCURRENCY``

--- a/docs/installation/building-from-source.rst
+++ b/docs/installation/building-from-source.rst
@@ -1,3 +1,11 @@
+.. raw:: html
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      activateTab(getOS());
+    });
+    </script>
+
 .. _Building on Linux:
 .. _Building on macOS:
 .. _Building on Windows:

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -8,4 +8,3 @@ Installation
   python-support
   platform-support
   building-from-source
-  old-versions

--- a/docs/installation/old-versions.rst
+++ b/docs/installation/old-versions.rst
@@ -1,8 +1,0 @@
-.. _old-versions:
-
-Old Versions
-------------
-
-You can download old distributions from the `release history at PyPI
-<https://pypi.org/project/pillow/#history>`_ and by direct URL access
-eg. https://pypi.org/project/pillow/1.0/.

--- a/docs/installation/platform-support.rst
+++ b/docs/installation/platform-support.rst
@@ -1,7 +1,7 @@
 .. _platform-support:
 
 Platform Support
-----------------
+================
 
 Current platform support for Pillow. Binary distributions are
 contributed for each release on a volunteer basis, but the source
@@ -10,7 +10,7 @@ general, we aim to support all current versions of Linux, macOS, and
 Windows.
 
 Continuous Integration Targets
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------
 
 These platforms are built and tested for every change.
 
@@ -66,7 +66,7 @@ These platforms are built and tested for every change.
 
 
 Other Platforms
-^^^^^^^^^^^^^^^
+---------------
 
 These platforms have been reported to work at the versions mentioned.
 

--- a/docs/installation/python-support.rst
+++ b/docs/installation/python-support.rst
@@ -1,7 +1,7 @@
 .. _python-support:
 
 Python Support
---------------
+==============
 
 Pillow supports these Python versions.
 


### PR DESCRIPTION
Follow on from https://github.com/python-pillow/Pillow/pull/7832.

Fix:

* Move anchors back into place
* Fix reference link
* Fix tab activation per OS
* Consistent header underlines

The Old Versions section is very short, I don't think it needs its own page. How about move it to the end of the 'Building From Source' page?

