### PR TITLE
Added reading of JPEG2000 palettes

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -364,6 +364,16 @@ def test_subsampling_decode(name: str) -> None:
         assert_image_similar(im, expected, epsilon)
 
 
+@pytest.mark.skipif(
+    not os.path.exists(EXTRA_DIR), reason="Extra image files not installed"
+)
+def test_pclr() -> None:
+    with Image.open(f"{EXTRA_DIR}/issue104_jpxstream.jp2") as im:
+        assert im.mode == "P"
+        assert len(im.palette.colors) == 256
+        assert im.palette.colors[(255, 255, 255)] == 0
+
+
 def test_comment() -> None:
     with Image.open("Tests/images/comment.jp2") as im:
         assert im.info["comment"] == b"Created by OpenJPEG version 2.5.0"

--- a/src/libImaging/Jpeg2KDecode.c
+++ b/src/libImaging/Jpeg2KDecode.c
@@ -615,6 +615,8 @@ j2ku_sycca_rgba(
 
 static const struct j2k_decode_unpacker j2k_unpackers[] = {
     {"L", OPJ_CLRSPC_GRAY, 1, 0, j2ku_gray_l},
+    {"P", OPJ_CLRSPC_SRGB, 1, 0, j2ku_gray_l},
+    {"PA", OPJ_CLRSPC_SRGB, 2, 0, j2ku_graya_la},
     {"I;16", OPJ_CLRSPC_GRAY, 1, 0, j2ku_gray_i},
     {"I;16B", OPJ_CLRSPC_GRAY, 1, 0, j2ku_gray_i},
     {"LA", OPJ_CLRSPC_GRAY, 2, 0, j2ku_graya_la},


### PR DESCRIPTION
Resolves #7511
Requires https://github.com/python-pillow/test-images/pull/2

This reads palette data from the JPEG2000 pclr box, and assigns it to the image's palette.

I used page 28 of https://web.archive.org/web/20230327234610/https://wiki.opf-labs.org/download/attachments/11337762/15444-1annexi.pdf as a reference.