### PR TITLE
Revert "Pin Python 3.13 on Windows to a3"

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.10", "pypy3.9", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-alpha.3"]
+        python-version: ["pypy3.10", "pypy3.9", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     timeout-minutes: 30
 


### PR DESCRIPTION
Reverts #7805 now that Python 3.13a5 has been released - https://github.com/python/cpython/releases/tag/v3.13.0a5