### PR TITLE
Removed Python and NumPy pinning on Cygwin

### DIFF
--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Cygwin
-        uses: egor-tensin/setup-cygwin@v4
+        uses: cygwin/cygwin-install-action@v4
         with:
           packages: >
             gcc-g++
@@ -71,7 +71,6 @@ jobs:
             make
             netpbm
             perl
-            python39=3.9.16-1
             python3${{ matrix.python-minor-version }}-cffi
             python3${{ matrix.python-minor-version }}-cython
             python3${{ matrix.python-minor-version }}-devel
@@ -89,7 +88,7 @@ jobs:
 
       - name: Select Python version
         run: |
-          ln -sf c:/tools/cygwin/bin/python3.${{ matrix.python-minor-version }} c:/tools/cygwin/bin/python3
+          ln -sf c:/cygwin/bin/python3.${{ matrix.python-minor-version }} c:/cygwin/bin/python3
 
       - name: Get latest NumPy version
         id: latest-numpy

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -90,19 +90,13 @@ jobs:
         run: |
           ln -sf c:/cygwin/bin/python3.${{ matrix.python-minor-version }} c:/cygwin/bin/python3
 
-      - name: Get latest NumPy version
-        id: latest-numpy
-        shell: bash.exe -eo pipefail -o igncr "{0}"
-        run: |
-          python3 -m pip list --outdated | grep numpy | sed -r 's/ +/ /g' | cut -d ' ' -f 3 | sed 's/^/version=/' >> $GITHUB_OUTPUT
-
       - name: pip cache
         uses: actions/cache@v4
         with:
           path: 'C:\cygwin\home\runneradmin\.cache\pip'
-          key: ${{ runner.os }}-cygwin-pip3.${{ matrix.python-minor-version }}-numpy${{ steps.latest-numpy.outputs.version }}-${{ hashFiles('.ci/install.sh') }}
+          key: ${{ runner.os }}-cygwin-pip3.${{ matrix.python-minor-version }}-${{ hashFiles('.ci/install.sh') }}
           restore-keys: |
-            ${{ runner.os }}-cygwin-pip3.${{ matrix.python-minor-version }}-numpy${{ steps.latest-numpy.outputs.version }}-
+            ${{ runner.os }}-cygwin-pip3.${{ matrix.python-minor-version }}-
 
       - name: Build system information
         run: |
@@ -111,11 +105,6 @@ jobs:
       - name: Install dependencies
         run: |
           bash.exe .ci/install.sh
-
-      - name: Upgrade NumPy
-        shell: dash.exe -l "{0}"
-        run: |
-          python3 -m pip install -U "numpy<1.26"
 
       - name: Build
         shell: bash.exe -eo pipefail -o igncr "{0}"

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -702,7 +702,7 @@ class Image:
                     pass
                 else:
                     if parse_version(numpy.__version__) < parse_version("1.23"):
-                        warnings.warn(e)
+                        warnings.warn(str(e))
             raise
         new["shape"], new["typestr"] = _conv_type_shape(self)
         return new


### PR DESCRIPTION
Alternative to #7875

Two Cygwin changes
1. Reverts #7762, where Python was pinned to Python 3.9.16-1
2. Removes the pinning of NumPy from #7403, but also goes further, and just uses the packaged NumPy. NumPy was originally upgraded in [a commit entitled "CI: Try to get Cygwin workflow working."](https://github.com/python-pillow/Pillow/pull/5878/commits/2d6dee1dae7c6f4ce639e1042c05152ef5d14c9e), so if there wasn't another need for this, then perhaps testing the package version is more valuable?

This also decreases the build time from [31m54s](https://github.com/python-pillow/Pillow/actions/runs/8280312072/job/22656563787) to [10m13s.](https://github.com/python-pillow/Pillow/actions/runs/8294540097/job/22699754552)