### PR TITLE
Raise ValueError for negative values when loading P1-P3 PPM images

### DIFF
--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -241,13 +241,23 @@ def test_plain_ppm_token_too_long(tmp_path: Path, data: bytes) -> None:
             im.load()
 
 
+def test_plain_ppm_value_negative(tmp_path: Path) -> None:
+    path = str(tmp_path / "temp.ppm")
+    with open(path, "wb") as f:
+        f.write(b"P3\n128 128\n255\n-1")
+
+    with Image.open(path) as im:
+        with pytest.raises(ValueError, match="Channel value is negative"):
+            im.load()
+
+
 def test_plain_ppm_value_too_large(tmp_path: Path) -> None:
     path = str(tmp_path / "temp.ppm")
     with open(path, "wb") as f:
         f.write(b"P3\n128 128\n255\n256")
 
     with Image.open(path) as im:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Channel value too large"):
             im.load()
 
 

--- a/src/PIL/PpmImagePlugin.py
+++ b/src/PIL/PpmImagePlugin.py
@@ -270,6 +270,9 @@ class PpmPlainDecoder(ImageFile.PyDecoder):
                     msg = b"Token too long found in data: %s" % token[: max_len + 1]
                     raise ValueError(msg)
                 value = int(token)
+                if value < 0:
+                    msg_str = f"Channel value is negative: {value}"
+                    raise ValueError(msg_str)
                 if value > maxval:
                     msg_str = f"Channel value too large for this mode: {value}"
                     raise ValueError(msg_str)


### PR DESCRIPTION
Helps #7876

Pillow currently raises a ValueError when a value is too large in a P1-P3 PPM image.

https://github.com/python-pillow/Pillow/blob/794a7d691fcc70ffd3f6dad58737cc1ad2b8da26/src/PIL/PpmImagePlugin.py#L273-L275

This adds another ValueError if the value is negative.