### PR TITLE
Improved conversion from RGB to RGBa, LA and La

### DIFF
--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -191,6 +191,10 @@ def test_trns_RGB(tmp_path: Path) -> None:
     assert "transparency" not in im_rgba.info
     im_rgba.save(f)
 
+    im_rgba = im.convert("RGBa")
+    assert "transparency" not in im_rgba.info
+    assert im_rgba.getpixel((0, 0)) == (0, 0, 0, 0)
+
     im_p = pytest.warns(UserWarning, im.convert, "P", palette=Image.Palette.ADAPTIVE)
     assert "transparency" not in im_p.info
     im_p.save(f)

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -183,6 +183,10 @@ def test_trns_RGB(tmp_path: Path) -> None:
     assert im_l.info["transparency"] == im_l.getpixel((0, 0))  # undone
     im_l.save(f)
 
+    im_la = im.convert("LA")
+    assert "transparency" not in im_la.info
+    im_la.save(f)
+
     im_p = im.convert("P")
     assert "transparency" in im_p.info
     im_p.save(f)

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -187,6 +187,10 @@ def test_trns_RGB(tmp_path: Path) -> None:
     assert "transparency" not in im_la.info
     im_la.save(f)
 
+    im_la = im.convert("La")
+    assert "transparency" not in im_la.info
+    assert im_la.getpixel((0, 0)) == (0, 0)
+
     im_p = im.convert("P")
     assert "transparency" in im_p.info
     im_p.save(f)

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -979,7 +979,7 @@ class Image:
         # transparency handling
         if has_transparency:
             if (self.mode in ("1", "L", "I", "I;16") and mode in ("LA", "RGBA")) or (
-                self.mode == "RGB" and mode in ("RGBa", "RGBA")
+                self.mode == "RGB" and mode in ("LA", "RGBa", "RGBA")
             ):
                 # Use transparent conversion to promote from transparent
                 # color to an alpha channel.

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -979,7 +979,7 @@ class Image:
         # transparency handling
         if has_transparency:
             if (self.mode in ("1", "L", "I", "I;16") and mode in ("LA", "RGBA")) or (
-                self.mode == "RGB" and mode in ("LA", "RGBa", "RGBA")
+                self.mode == "RGB" and mode in ("La", "LA", "RGBa", "RGBA")
             ):
                 # Use transparent conversion to promote from transparent
                 # color to an alpha channel.

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -979,7 +979,7 @@ class Image:
         # transparency handling
         if has_transparency:
             if (self.mode in ("1", "L", "I", "I;16") and mode in ("LA", "RGBA")) or (
-                self.mode == "RGB" and mode == "RGBA"
+                self.mode == "RGB" and mode in ("RGBa", "RGBA")
             ):
                 # Use transparent conversion to promote from transparent
                 # color to an alpha channel.

--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -500,12 +500,12 @@ rgba2rgb_(UINT8 *out, const UINT8 *in, int xsize) {
 
 /*
  * Conversion of RGB + single transparent color either to
- * RGBA, where any pixel matching the color will have the alpha channel set to 0, or
+ * RGBA or LA, where any pixel matching the color will have the alpha channel set to 0, or
  * RGBa, where any pixel matching the color will have all channels set to 0
  */
 
 static void
-rgbT2rgba(UINT8 *out, int xsize, int r, int g, int b, int premultiplied) {
+rgbT2a(UINT8 *out, UINT8 *in, int xsize, int r, int g, int b, int premultiplied) {
 #ifdef WORDS_BIGENDIAN
     UINT32 trns = ((r & 0xff) << 24) | ((g & 0xff) << 16) | ((b & 0xff) << 8) | 0xff;
     UINT32 repl = premultiplied ? 0 : (trns & 0xffffff00);
@@ -516,9 +516,10 @@ rgbT2rgba(UINT8 *out, int xsize, int r, int g, int b, int premultiplied) {
 
     int i;
 
-    for (i = 0; i < xsize; i++, out += sizeof(trns)) {
+    UINT8 *ref = in != NULL ? in : out;
+    for (i = 0; i < xsize; i++, ref += sizeof(trns), out += sizeof(trns)) {
         UINT32 v;
-        memcpy(&v, out, sizeof(v));
+        memcpy(&v, ref, sizeof(v));
         if (v == trns) {
             memcpy(out, &repl, sizeof(repl));
         }
@@ -1683,6 +1684,9 @@ ImagingConvertTransparent(Imaging imIn, const char *mode, int r, int g, int b) {
     ImagingShuffler convert;
     Imaging imOut = NULL;
     int premultiplied = 0;
+    // If the transparency matches pixels in the source image, not the converted image
+    UINT8 *source;
+    int source_transparency = 0;
     int y;
 
     if (!imIn) {
@@ -1694,6 +1698,9 @@ ImagingConvertTransparent(Imaging imIn, const char *mode, int r, int g, int b) {
         if (strcmp(mode, "RGBa") == 0) {
             premultiplied = 1;
         }
+    } else if (strcmp(imIn->mode, "RGB") == 0 && strcmp(mode, "LA") == 0) {
+        convert = rgb2la;
+        source_transparency = 1;
     } else if ((strcmp(imIn->mode, "1") == 0 ||
                 strcmp(imIn->mode, "I") == 0 ||
                 strcmp(imIn->mode, "I;16") == 0 ||
@@ -1731,7 +1738,9 @@ ImagingConvertTransparent(Imaging imIn, const char *mode, int r, int g, int b) {
     ImagingSectionEnter(&cookie);
     for (y = 0; y < imIn->ysize; y++) {
         (*convert)((UINT8 *)imOut->image[y], (UINT8 *)imIn->image[y], imIn->xsize);
-        rgbT2rgba((UINT8 *)imOut->image[y], imIn->xsize, r, g, b, premultiplied);
+
+        source = source_transparency ? (UINT8 *)imIn->image[y] : NULL;
+        rgbT2a((UINT8 *)imOut->image[y], source, imIn->xsize, r, g, b, premultiplied);
     }
     ImagingSectionLeave(&cookie);
 

--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -501,7 +501,7 @@ rgba2rgb_(UINT8 *out, const UINT8 *in, int xsize) {
 /*
  * Conversion of RGB + single transparent color either to
  * RGBA or LA, where any pixel matching the color will have the alpha channel set to 0, or
- * RGBa, where any pixel matching the color will have all channels set to 0
+ * RGBa or La, where any pixel matching the color will have all channels set to 0
  */
 
 static void
@@ -942,6 +942,7 @@ static struct {
     {"RGB", "1", rgb2bit},
     {"RGB", "L", rgb2l},
     {"RGB", "LA", rgb2la},
+    {"RGB", "La", rgb2la},
     {"RGB", "I", rgb2i},
     {"RGB", "F", rgb2f},
     {"RGB", "BGR;15", rgb2bgr15},
@@ -1698,9 +1699,12 @@ ImagingConvertTransparent(Imaging imIn, const char *mode, int r, int g, int b) {
         if (strcmp(mode, "RGBa") == 0) {
             premultiplied = 1;
         }
-    } else if (strcmp(imIn->mode, "RGB") == 0 && strcmp(mode, "LA") == 0) {
+    } else if (strcmp(imIn->mode, "RGB") == 0 && (strcmp(mode, "LA") == 0 || strcmp(mode, "La") == 0)) {
         convert = rgb2la;
         source_transparency = 1;
+        if (strcmp(mode, "La") == 0) {
+            premultiplied = 1;
+        }
     } else if ((strcmp(imIn->mode, "1") == 0 ||
                 strcmp(imIn->mode, "I") == 0 ||
                 strcmp(imIn->mode, "I;16") == 0 ||


### PR DESCRIPTION
#7209 has started support from RGB to RGBa and La, but doesn't consider transparency.

1. Add support for conversion from RGB to RGBa

When Pillow converts from RGB to RGBA, if there is an `info["transparency"]` entry, the pixels matching that value have their alpha channel set to zero.

This PR adds support for converting from RGB to RGBa in a similar way, except that the matching pixels have all channels set to zero, because the alpha is premultiplied, and zero alpha means every channel should be zero.

https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes
> Premultiplied alpha is where the values for each other channel have been multiplied by the alpha. For example, an RGBA pixel of (10, 20, 30, 127) would convert to an RGBa pixel of (5, 10, 15, 127). The values of the R, G and B channels are halved as a result of the half transparency in the alpha channel.

2. Use transparency info when converting from RGB to LA

Currently in `ImagingConvertTransparent`, the image is being converted from an image that may or may not be RGB, and the RGB transparency relates to the final image. From RGB to LA, the original image is RGB and the final image is not. So that additional path has been added.

3. Add support for conversion from RGB to La

Now that RGB to LA works with transparency, converting from RGB to La is similar, except like 1 it premultiplies the values for transparent pixels so that the channels are all zero.