### PR TITLE
Raise ValueError if kmeans is negative

### DIFF
--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -99,6 +99,10 @@ def test_quantize_dither_diff() -> None:
 )
 def test_quantize_kmeans(method) -> None:
     im = hopper()
+    no_kmeans = im.quantize(kmeans=0, method=method)
+    kmeans = im.quantize(kmeans=1, method=method)
+    assert kmeans.tobytes() != no_kmeans.tobytes()
+
     with pytest.raises(ValueError):
         im.quantize(kmeans=-1, method=method)
 

--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -94,6 +94,15 @@ def test_quantize_dither_diff() -> None:
     assert dither.tobytes() != nodither.tobytes()
 
 
+@pytest.mark.parametrize(
+    "method", (Image.Quantize.MEDIANCUT, Image.Quantize.MAXCOVERAGE)
+)
+def test_quantize_kmeans(method) -> None:
+    im = hopper()
+    with pytest.raises(ValueError):
+        im.quantize(kmeans=-1, method=method)
+
+
 def test_colors() -> None:
     im = hopper()
     colors = 2

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1141,7 +1141,7 @@ class Image:
                        The exception to this is RGBA images. :data:`Quantize.MEDIANCUT`
                        and :data:`Quantize.MAXCOVERAGE` do not support RGBA images, so
                        :data:`Quantize.FASTOCTREE` is used by default instead.
-        :param kmeans: Integer
+        :param kmeans: Integer greater than or equal to zero.
         :param palette: Quantize to the palette of given
                         :py:class:`PIL.Image.Image`.
         :param dither: Dithering method, used when converting from
@@ -1183,6 +1183,10 @@ class Image:
             new_im = self._new(im)
             new_im.palette = palette.palette.copy()
             return new_im
+
+        if kmeans < 0:
+            msg = "kmeans must not be negative"
+            raise ValueError(msg)
 
         im = self._new(self.im.quantize(colors, method, kmeans))
 

--- a/src/libImaging/Quant.c
+++ b/src/libImaging/Quant.c
@@ -1471,7 +1471,7 @@ quantize(
     fflush(stdout);
     timer = clock();
 #endif
-    if (kmeans) {
+    if (kmeans > 0) {
         k_means(pixelData, nPixels, p, nPaletteEntries, qp, kmeans - 1);
     }
 #ifndef NO_OUTPUT
@@ -1627,7 +1627,7 @@ quantize2(
             pixelData, nPixels, p, nQuantPixels, avgDist, avgDistSortKey, qp)) {
         goto error_4;
     }
-    if (kmeans) {
+    if (kmeans > 0) {
         k_means(pixelData, nPixels, p, nQuantPixels, qp, kmeans - 1);
     }
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/issues/7890#issuecomment-2014337747 found that if `kmeans` if negative, `im.quantize()` can become stuck in an infinite loop.

Investigating, I was able to reproduce this for `MEDIANCUT` and `MAXCOVERAGE`.

This PR updates the docstring to specify that `kmeans` should not be negative, raises a ValueError if `kmeans` is negative, and to be safe, also updates the C code to not use negative kmeans either.