### PR TITLE
Remove TIFF tag OSUBFILETYPE when saving using libtiff

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 
 from PIL import Image, ImageFilter, ImageOps, TiffImagePlugin, TiffTags, features
-from PIL.TiffImagePlugin import SAMPLEFORMAT, STRIPOFFSETS, SUBIFD
+from PIL.TiffImagePlugin import OSUBFILETYPE, SAMPLEFORMAT, STRIPOFFSETS, SUBIFD
 
 from .helper import (
     assert_image_equal,
@@ -324,6 +324,12 @@ class TestFileLibTiff(LibTiffTestCase):
                 }
             )
         TiffImagePlugin.WRITE_LIBTIFF = False
+
+    def test_osubfiletype(self, tmp_path: Path) -> None:
+        outfile = str(tmp_path / "temp.tif")
+        with Image.open("Tests/images/g4_orientation_6.tif") as im:
+            im.tag_v2[OSUBFILETYPE] = 1
+            im.save(outfile)
 
     def test_subifd(self, tmp_path: Path) -> None:
         outfile = str(tmp_path / "temp.tif")

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -74,6 +74,7 @@ MM = b"MM"  # big-endian (Motorola style)
 # Read TIFF files
 
 # a few tag names, just to make the code below a bit more readable
+OSUBFILETYPE = 255
 IMAGEWIDTH = 256
 IMAGELENGTH = 257
 BITSPERSAMPLE = 258
@@ -1784,11 +1785,13 @@ def _save(im, fp, filename):
         types = {}
         # STRIPOFFSETS and STRIPBYTECOUNTS are added by the library
         # based on the data in the strip.
+        # OSUBFILETYPE is deprecated.
         # The other tags expect arrays with a certain length (fixed or depending on
         # BITSPERSAMPLE, etc), passing arrays with a different length will result in
         # segfaults. Block these tags until we add extra validation.
         # SUBIFD may also cause a segfault.
         blocklist += [
+            OSUBFILETYPE,
             REFERENCEBLACKWHITE,
             STRIPBYTECOUNTS,
             STRIPOFFSETS,


### PR DESCRIPTION
Resolves #7892

The issue has found a TIFF image with tag 255, OSUBFILETYPE, that fails to save using libtiff.

It is described at https://www.awaresystems.be/imaging/tiff/tifftags/subfiletype.html as 'deprecated', and TiffTags.py says that we don't support it.
https://github.com/python-pillow/Pillow/blob/ca973709a079b5152b9670e5cd684003aa71f913/src/PIL/TiffTags.py#L536

So this PR simply removes it when saving using libtiff.