### PR TITLE
Clean up authors and contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,11 @@
 The Python Imaging Library (PIL) is
 
     Copyright © 1997-2011 by Secret Labs AB
-    Copyright © 1995-2011 by Fredrik Lundh
+    Copyright © 1995-2011 by Fredrik Lundh and contributors
 
 Pillow is the friendly PIL fork. It is
 
-    Copyright © 2010-2024 by Jeffrey A. Clark (Alex) and contributors.
+    Copyright © 2010-2024 by Jeffrey A. Clark and contributors
 
 Like PIL, Pillow is licensed under the open source HPND License:
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 ## Python Imaging Library (Fork)
 
-Pillow is the friendly PIL fork by [Jeffrey A. Clark (Alex) and
+Pillow is the friendly PIL fork by [Jeffrey A. Clark and
 contributors](https://github.com/python-pillow/Pillow/graphs/contributors).
-PIL is the Python Imaging Library by Fredrik Lundh and Contributors.
+PIL is the Python Imaging Library by Fredrik Lundh and contributors.
 As of 2019, Pillow development is
 [supported by Tidelift](https://tidelift.com/subscription/pkg/pypi-pillow?utm_source=pypi-pillow&utm_medium=readme&utm_campaign=enterprise).
 

--- a/docs/COPYING
+++ b/docs/COPYING
@@ -1,11 +1,11 @@
 The Python Imaging Library (PIL) is
 
     Copyright © 1997-2011 by Secret Labs AB
-    Copyright © 1995-2011 by Fredrik Lundh
+    Copyright © 1995-2011 by Fredrik Lundh and contributors
 
 Pillow is the friendly PIL fork. It is
 
-    Copyright © 2010-2024 by Jeffrey A. Clark (Alex) and contributors
+    Copyright © 2010-2024 by Jeffrey A. Clark and contributors
 
 Like PIL, Pillow is licensed under the open source PIL
 Software License:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,10 @@ master_doc = "index"
 
 # General information about the project.
 project = "Pillow (PIL Fork)"
-copyright = "1995-2011 Fredrik Lundh and contributors, 2010-2024 Jeffrey A. Clark and contributors."
+copyright = (
+    "1995-2011 Fredrik Lundh and contributors, "
+    "2010-2024 Jeffrey A. Clark and contributors."
+)
 author = "Fredrik Lundh (PIL), Jeffrey A. Clark (Pillow)"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,9 +53,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Pillow (PIL Fork)"
-copyright = (
-    "1995-2011 Fredrik Lundh and contributors, 2010-2024 Jeffrey A. Clark and contributors."
-)
+copyright = "1995-2011 Fredrik Lundh and contributors, 2010-2024 Jeffrey A. Clark and contributors."
 author = "Fredrik Lundh (PIL), Jeffrey A. Clark (Pillow)"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,9 +54,9 @@ master_doc = "index"
 # General information about the project.
 project = "Pillow (PIL Fork)"
 copyright = (
-    "1995-2011 Fredrik Lundh, 2010-2024 Jeffrey A. Clark (Alex) and contributors"
+    "1995-2011 Fredrik Lundh and contributors, 2010-2024 Jeffrey A. Clark and contributors."
 )
-author = "Fredrik Lundh, Jeffrey A. Clark (Alex), contributors"
+author = "Fredrik Lundh (PIL), Jeffrey A. Clark (Pillow)"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -252,7 +252,7 @@ latex_documents = [
         master_doc,
         "PillowPILFork.tex",
         "Pillow (PIL Fork) Documentation",
-        "Jeffrey A. Clark (Alex)",
+        "Jeffrey A. Clark",
         "manual",
     )
 ]
@@ -302,7 +302,7 @@ texinfo_documents = [
         "Pillow (PIL Fork) Documentation",
         author,
         "PillowPILFork",
-        "Pillow is the friendly PIL fork by Jeffrey A. Clark (Alex) and contributors.",
+        "Pillow is the friendly PIL fork by Jeffrey A. Clark and contributors.",
         "Miscellaneous",
     )
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Pillow
 ======
 
-Pillow is the friendly PIL fork by `Jeffrey A. Clark (Alex) and contributors <https://github.com/python-pillow/Pillow/graphs/contributors>`_. PIL is the Python Imaging Library by Fredrik Lundh and contributors.
+Pillow is the friendly PIL fork by `Jeffrey A. Clark and contributors <https://github.com/python-pillow/Pillow/graphs/contributors>`_. PIL is the Python Imaging Library by Fredrik Lundh and contributors.
 
 Pillow for enterprise is available via the Tidelift Subscription. `Learn more <https://tidelift.com/subscription/pkg/pypi-pillow?utm_source=pypi-pillow&utm_medium=docs&utm_campaign=enterprise>`_.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
   "Imaging",
 ]
 license = {text = "HPND"}
-authors = [{name = "Jeffrey A. Clark (Alex)", email = "aclark@aclark.net"}]
+authors = [{name = "Jeffrey A. Clark", email = "aclark@aclark.net"}]
 requires-python = ">=3.8"
 classifiers = [
   "Development Status :: 6 - Mature",

--- a/src/PIL/__init__.py
+++ b/src/PIL/__init__.py
@@ -1,6 +1,6 @@
 """Pillow (Fork of the Python Imaging Library)
 
-Pillow is the friendly PIL fork by Jeffrey A. Clark (Alex) and contributors.
+Pillow is the friendly PIL fork by Jeffrey A. Clark and contributors.
     https://github.com/python-pillow/Pillow/
 
 Pillow is forked from PIL 1.1.7.


### PR DESCRIPTION
Changes proposed in this pull request:

- `s/Jeffrey A. Clark (Alex)/Jeffrey A. Clark/g`. People can figure out that I am Alex.
- We've added "contributors" to Fredrik's copyright statements because it seems appropriate that it be there based on: https://github.com/python-pillow/Pillow/blob/main/CHANGES.rst#02b5-117.
- Fredrik is the PIL author and I am the Pillow author.
- Consistently apply all of the above everywhere.