### PR TITLE
Type hints: Add PYI (flake8-pyi) to Ruff and fix errors

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -6,8 +6,8 @@ import itertools
 import os
 import re
 import sys
-from collections import namedtuple
 from pathlib import Path
+from typing import Any, NamedTuple
 
 import pytest
 
@@ -243,36 +243,40 @@ class TestFileLibTiff(LibTiffTestCase):
         TiffImagePlugin.WRITE_LIBTIFF = False
 
     def test_custom_metadata(self, tmp_path: Path) -> None:
-        tc = namedtuple("tc", "value,type,supported_by_default")
+        class Tc(NamedTuple):
+            value: Any
+            type: int
+            supported_by_default: bool
+
         custom = {
             37000 + k: v
             for k, v in enumerate(
                 [
-                    tc(4, TiffTags.SHORT, True),
-                    tc(123456789, TiffTags.LONG, True),
-                    tc(-4, TiffTags.SIGNED_BYTE, False),
-                    tc(-4, TiffTags.SIGNED_SHORT, False),
-                    tc(-123456789, TiffTags.SIGNED_LONG, False),
-                    tc(TiffImagePlugin.IFDRational(4, 7), TiffTags.RATIONAL, True),
-                    tc(4.25, TiffTags.FLOAT, True),
-                    tc(4.25, TiffTags.DOUBLE, True),
-                    tc("custom tag value", TiffTags.ASCII, True),
-                    tc(b"custom tag value", TiffTags.BYTE, True),
-                    tc((4, 5, 6), TiffTags.SHORT, True),
-                    tc((123456789, 9, 34, 234, 219387, 92432323), TiffTags.LONG, True),
-                    tc((-4, 9, 10), TiffTags.SIGNED_BYTE, False),
-                    tc((-4, 5, 6), TiffTags.SIGNED_SHORT, False),
-                    tc(
+                    Tc(4, TiffTags.SHORT, True),
+                    Tc(123456789, TiffTags.LONG, True),
+                    Tc(-4, TiffTags.SIGNED_BYTE, False),
+                    Tc(-4, TiffTags.SIGNED_SHORT, False),
+                    Tc(-123456789, TiffTags.SIGNED_LONG, False),
+                    Tc(TiffImagePlugin.IFDRational(4, 7), TiffTags.RATIONAL, True),
+                    Tc(4.25, TiffTags.FLOAT, True),
+                    Tc(4.25, TiffTags.DOUBLE, True),
+                    Tc("custom tag value", TiffTags.ASCII, True),
+                    Tc(b"custom tag value", TiffTags.BYTE, True),
+                    Tc((4, 5, 6), TiffTags.SHORT, True),
+                    Tc((123456789, 9, 34, 234, 219387, 92432323), TiffTags.LONG, True),
+                    Tc((-4, 9, 10), TiffTags.SIGNED_BYTE, False),
+                    Tc((-4, 5, 6), TiffTags.SIGNED_SHORT, False),
+                    Tc(
                         (-123456789, 9, 34, 234, 219387, -92432323),
                         TiffTags.SIGNED_LONG,
                         False,
                     ),
-                    tc((4.25, 5.25), TiffTags.FLOAT, True),
-                    tc((4.25, 5.25), TiffTags.DOUBLE, True),
+                    Tc((4.25, 5.25), TiffTags.FLOAT, True),
+                    Tc((4.25, 5.25), TiffTags.DOUBLE, True),
                     # array of TIFF_BYTE requires bytes instead of tuple for backwards
                     # compatibility
-                    tc(bytes([4]), TiffTags.BYTE, True),
-                    tc(bytes((4, 9, 10)), TiffTags.BYTE, True),
+                    Tc(bytes([4]), TiffTags.BYTE, True),
+                    Tc(bytes((4, 9, 10)), TiffTags.BYTE, True),
                 ]
             )
         }

--- a/Tests/test_lib_pack.py
+++ b/Tests/test_lib_pack.py
@@ -15,7 +15,7 @@ class TestLibPack:
         mode: str,
         rawmode: str,
         data: int | bytes,
-        *pixels: int | float | tuple[int, ...],
+        *pixels: float | tuple[int, ...],
     ) -> None:
         """
         data - either raw bytes with data or just number of bytes in rawmode.
@@ -239,7 +239,7 @@ class TestLibUnpack:
         mode: str,
         rawmode: str,
         data: int | bytes,
-        *pixels: int | float | tuple[int, ...],
+        *pixels: float | tuple[int, ...],
     ) -> None:
         """
         data - either raw bytes with data or just number of bytes in rawmode.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ ignore = [
   "E221", # Multiple spaces before operator
   "E226", # Missing whitespace around arithmetic operator
   "E241", # Multiple spaces after ','
-  "PYI034", # flake8-pyi: typing.Self added in Python 3.10
+  "PYI034", # flake8-pyi: typing.Self added in Python 3.11
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ select = [
   "ISC", # flake8-implicit-str-concat
   "LOG", # flake8-logging
   "PGH", # pygrep-hooks
+  "PYI", # flake8-pyi
   "RUF100", # unused noqa (yesqa)
   "UP", # pyupgrade
   "W", # pycodestyle warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ ignore = [
   "E221", # Multiple spaces before operator
   "E226", # Missing whitespace around arithmetic operator
   "E241", # Multiple spaces after ','
+  "PYI034", # flake8-pyi: typing.Self added in Python 3.10
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -8,7 +8,7 @@ import os
 import re
 import time
 import zlib
-from typing import TYPE_CHECKING, Any, List, Union
+from typing import TYPE_CHECKING, Any, List, NamedTuple, Union
 
 
 # see 7.9.2.2 Text String Type on page 86 and D.3 PDFDocEncoding Character Set
@@ -81,9 +81,12 @@ def check_format_condition(condition, error_message):
         raise PdfFormatError(error_message)
 
 
-class IndirectReference(
-    collections.namedtuple("IndirectReferenceTuple", ["object_id", "generation"])
-):
+class IndirectReferenceTuple(NamedTuple):
+    object_id: int
+    generation: int
+
+
+class IndirectReference(IndirectReferenceTuple):
     def __str__(self):
         return f"{self.object_id} {self.generation} R"
 

--- a/src/PIL/TiffTags.py
+++ b/src/PIL/TiffTags.py
@@ -18,10 +18,18 @@
 ##
 from __future__ import annotations
 
-from collections import namedtuple
+from typing import NamedTuple
 
 
-class TagInfo(namedtuple("_TagInfo", "value name type length enum")):
+class _TagInfo(NamedTuple):
+    value: int
+    name: str
+    type: int
+    length: int
+    enum: dict[int, str]
+
+
+class TagInfo(_TagInfo):
     __slots__: list[str] = []
 
     def __new__(cls, value=None, name="unknown", type=None, length=None, enum=None):

--- a/src/PIL/TiffTags.py
+++ b/src/PIL/TiffTags.py
@@ -26,7 +26,7 @@ class _TagInfo(NamedTuple):
     name: str
     type: int | None
     length: int | None
-    enum: dict[int, str] | None
+    enum: dict[str, int]
 
 
 class TagInfo(_TagInfo):

--- a/src/PIL/TiffTags.py
+++ b/src/PIL/TiffTags.py
@@ -22,11 +22,11 @@ from typing import NamedTuple
 
 
 class _TagInfo(NamedTuple):
-    value: int
+    value: int | None
     name: str
-    type: int
-    length: int
-    enum: dict[int, str]
+    type: int | None
+    length: int | None
+    enum: dict[int, str] | None
 
 
 class TagInfo(_TagInfo):

--- a/src/PIL/_imaging.pyi
+++ b/src/PIL/_imaging.pyi
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 def __getattr__(name: str) -> Any: ...

--- a/src/PIL/_imagingcms.pyi
+++ b/src/PIL/_imagingcms.pyi
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 def __getattr__(name: str) -> Any: ...

--- a/src/PIL/_imagingft.pyi
+++ b/src/PIL/_imagingft.pyi
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 def __getattr__(name: str) -> Any: ...

--- a/src/PIL/_imagingmath.pyi
+++ b/src/PIL/_imagingmath.pyi
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 def __getattr__(name: str) -> Any: ...

--- a/src/PIL/_imagingmorph.pyi
+++ b/src/PIL/_imagingmorph.pyi
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 def __getattr__(name: str) -> Any: ...

--- a/src/PIL/_webp.pyi
+++ b/src/PIL/_webp.pyi
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 def __getattr__(name: str) -> Any: ...


### PR DESCRIPTION
Add PYI to Ruff to run the flake8-pyi linting rules related to type hints and fix the errors:

```
Tests/test_file_libtiff.py:246:14: PYI024 Use `typing.NamedTuple` instead of `collections.namedtuple`
Tests/test_lib_pack.py:18:18: PYI041 Use `float` instead of `int | float`
Tests/test_lib_pack.py:242:18: PYI041 Use `float` instead of `int | float`
src/PIL/PdfParser.py:85:5: PYI024 Use `typing.NamedTuple` instead of `collections.namedtuple`
src/PIL/TarIO.py:61:9: PYI034 `__enter__` methods in classes like `TarIO` usually return `self` at runtime
src/PIL/TiffTags.py:24:15: PYI024 Use `typing.NamedTuple` instead of `collections.namedtuple`
src/PIL/_imaging.pyi:1:1: PYI044 `from __future__ import annotations` has no effect in stub files, since type checkers automatically treat stubs as having those semantics
src/PIL/_imagingcms.pyi:1:1: PYI044 `from __future__ import annotations` has no effect in stub files, since type checkers automatically treat stubs as having those semantics
src/PIL/_imagingft.pyi:1:1: PYI044 `from __future__ import annotations` has no effect in stub files, since type checkers automatically treat stubs as having those semantics
src/PIL/_imagingmath.pyi:1:1: PYI044 `from __future__ import annotations` has no effect in stub files, since type checkers automatically treat stubs as having those semantics
src/PIL/_imagingmorph.pyi:1:1: PYI044 `from __future__ import annotations` has no effect in stub files, since type checkers automatically treat stubs as having those semantics
src/PIL/_webp.pyi:1:1: PYI044 `from __future__ import annotations` has no effect in stub files, since type checkers automatically treat stubs as having those semantics
Found 12 errors.
```

I skipped [PYI034](https://docs.astral.sh/ruff/rules/non-self-return-type/). The fix is to return `typing.Self`, but that was only added in 3.10, or `typing_extensions.Self` from the backport, which we're not using. Open to other solutions.

* https://docs.astral.sh/ruff/rules/#flake8-pyi-pyi
* https://github.com/PyCQA/flake8-pyi
* https://docs.python.org/3/library/typing.html#typing.Self
