### PR TITLE
Skip AppVeyor builds for irrelevant files

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,10 @@
+skip_commits:
+  files:
+    - ".github/**"
+    - ".gitmodules"
+    - "docs/**"
+    - "wheels/**"
+
 version: '{build}'
 clone_folder: c:\pillow
 init:


### PR DESCRIPTION
Similar to GitHub Actions, we can skip AppVeyor builds when irrelevant files are changed.

For example, we don't need to test Windows for changes that are exclusively docs, or cibuildwheel.

This is based on GHA's `test-windows.yml`:

https://github.com/python-pillow/Pillow/blob/fac81d6228fa649d915edfa0888ed20554f1d38f/.github/workflows/test-windows.yml#L7-L12

Except widened one skip to the whole `.github` directory.

Docs: https://www.appveyor.com/docs/how-to/filtering-commits/#commit-files-github-and-bitbucket-only

> `skip_commits.files` allows skipping AppVeyor build if **all of the files** modified in push’s **head commit** match any of the file matching rules.

I've not tried this out before on AppVeyor. We only have two jobs on AppVeyor, and they run in serial (max parallel runners=1), but it's not causing a particular bottleneck compared to the big GHA matrix. However, one minor annoyance, in PRs like https://github.com/python-pillow/Pillow/pull/7905, we skip the regular tests on GHA, but AppVeyor still runs, meaning we get a code coverage report of ~50%.
