### PR TITLE
Use setup_module() to open images so they aren't opened if skipped

### DIFF
--- a/Tests/test_image_fromqimage.py
+++ b/Tests/test_image_fromqimage.py
@@ -16,12 +16,13 @@ pytestmark = pytest.mark.skipif(
     not ImageQt.qt_is_installed, reason="Qt bindings are not installed"
 )
 
-ims = [
-    hopper(),
-    Image.open("Tests/images/transparent.png"),
-    Image.open("Tests/images/7x13.png"),
-]
+ims = []
 
+
+def setup_module() -> None:
+    ims.append(hopper())
+    ims.append(Image.open("Tests/images/transparent.png"))
+    ims.append(Image.open("Tests/images/7x13.png"))
 
 def teardown_module() -> None:
     for im in ims:

--- a/Tests/test_image_fromqimage.py
+++ b/Tests/test_image_fromqimage.py
@@ -24,6 +24,7 @@ def setup_module() -> None:
     ims.append(Image.open("Tests/images/transparent.png"))
     ims.append(Image.open("Tests/images/7x13.png"))
 
+
 def teardown_module() -> None:
     for im in ims:
         im.close()

--- a/Tests/test_image_fromqimage.py
+++ b/Tests/test_image_fromqimage.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.skipif(
     not ImageQt.qt_is_installed, reason="Qt bindings are not installed"
 )
 
-ims = []
+ims: list[Image.Image] = []
 
 
 def setup_module() -> None:


### PR DESCRIPTION
This entire file is skipped if Qt isn't available. This means `teardown_module()` is also skipped. But opening the images isn't skipped because they're not in a function. By moving the image loading to `setup_module()` it will also be skipped when Qt isn't available.