### PR TITLE
Add type hints to release notes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4325,7 +4325,7 @@ Changelog (Pillow)
 - Documentation changes, URL update, transpose, release checklist
   [radarhere]
 
-- Fixed saving to nonexistant files specified by pathlib.Path objects #1748 (fixes #1747)
+- Fixed saving to nonexistent files specified by pathlib.Path objects #1748 (fixes #1747)
   [radarhere]
 
 - Round Image.crop arguments to the nearest integer #1745 (fixes #1744)
@@ -7536,7 +7536,7 @@ The test suite includes 400 individual tests.
 - A handbook is available (distributed separately).
 
 - The coordinate system is changed so that (0,0) is now located
-  in the upper left corner.  This is in compliancy with ISO 12087
+  in the upper left corner.  This is in compliance with ISO 12087
   and 90% of all other image processing and graphics libraries.
 
 - Modes "1" (bilevel) and "P" (palette) have been introduced.  Note

--- a/Tests/test_locale.py
+++ b/Tests/test_locale.py
@@ -19,7 +19,7 @@ from PIL import Image
 # 7
 # 160
 
-# one of string.whitespace is not freely convertable into ascii.
+# one of string.whitespace is not freely convertible into ascii.
 
 path = "Tests/images/hopper.jpg"
 

--- a/docs/releasenotes/10.3.0.rst
+++ b/docs/releasenotes/10.3.0.rst
@@ -108,5 +108,5 @@ the libwebp decoder.
 Type hints
 ^^^^^^^^^^
 
-Pillow now has type hints, and the package includes a ``py.typed`` file and the
-``Typing :: Typed`` Trove classifier.
+Pillow now has type hints for a large part of its modules, and the package
+includes a ``py.typed`` file and the ``Typing :: Typed`` Trove classifier.

--- a/docs/releasenotes/10.3.0.rst
+++ b/docs/releasenotes/10.3.0.rst
@@ -104,3 +104,9 @@ Release GIL when fetching WebP frames
 
 Python's Global Interpreter Lock is now released when fetching WebP frames from
 the libwebp decoder.
+
+Type hints
+^^^^^^^^^^
+
+Pillow now has type hints, and the package includes a ``py.typed`` file and the
+``Typing :: Typed`` Trove classifier.

--- a/src/libImaging/JpegDecode.c
+++ b/src/libImaging/JpegDecode.c
@@ -180,7 +180,7 @@ ImagingJpegDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t by
 
             /* Decoder settings */
 
-            /* jpegmode indicates whats in the file; if not set, we'll
+            /* jpegmode indicates what's in the file; if not set, we'll
                trust the decoder */
             if (strcmp(context->jpegmode, "L") == 0) {
                 context->cinfo.jpeg_color_space = JCS_GRAYSCALE;


### PR DESCRIPTION
Or hedge it a bit?

```diff
-Pillow now has type hints
+Pillow now mostly has type hints
```

---

And fix some typos.

