### PR TITLE
Corrected ImageCms test

### DIFF
--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -526,9 +526,9 @@ def test_profile_typesafety() -> None:
 def test_transform_typesafety() -> None:
     # core transform should not be directly instantiable
     with pytest.raises(TypeError):
-        ImageCms.core.CmsProfile()
+        ImageCms.core.CmsTransform()
     with pytest.raises(TypeError):
-        ImageCms.core.CmsProfile(0)
+        ImageCms.core.CmsTransform(0)
 
 
 def assert_aux_channel_preserved(


### PR DESCRIPTION
Looking at the duplicate code in https://github.com/python-pillow/Pillow/blob/63cbfcfdea2d163ec93bae8d283fcfe4b73b5dc7/Tests/test_imagecms.py#L517-L531
I think @nulano's intention in #7913 was to test `ImageCms.core.CmsTransform` in `test_transform_typesafety()`