### PR TITLE
Document that QoiImagePlugin uses Python for decoding

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1488,7 +1488,9 @@ QOI
 
 .. versionadded:: 9.5.0
 
-Pillow reads images in Quite OK Image format, using a Python decoder.
+Pillow reads images in Quite OK Image format, using a Python decoder. If you wish to
+write code specifically for this format, https://pypi.org/project/qoi is an alternative
+library that uses C to decode the image, and interfaces with NumPy.
 
 SUN
 ^^^

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1489,7 +1489,7 @@ QOI
 .. versionadded:: 9.5.0
 
 Pillow reads images in Quite OK Image format, using a Python decoder. If you wish to
-write code specifically for this format, https://pypi.org/project/qoi is an alternative
+write code specifically for this format, :pypi:`qoi` is an alternative
 library that uses C to decode the image, and interfaces with NumPy.
 
 SUN

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1488,7 +1488,7 @@ QOI
 
 .. versionadded:: 9.5.0
 
-Pillow identifies and reads images in Quite OK Image format.
+Pillow reads images in Quite OK Image format, using a Python decoder.
 
 SUN
 ^^^

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1488,9 +1488,9 @@ QOI
 
 .. versionadded:: 9.5.0
 
-Pillow reads images in Quite OK Image format, using a Python decoder. If you wish to
+Pillow reads images in Quite OK Image format using a Python decoder. If you wish to
 write code specifically for this format, :pypi:`qoi` is an alternative
-library that uses C to decode the image, and interfaces with NumPy.
+library that uses C to decode the image and interfaces with NumPy.
 
 SUN
 ^^^

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1489,8 +1489,8 @@ QOI
 .. versionadded:: 9.5.0
 
 Pillow reads images in Quite OK Image format using a Python decoder. If you wish to
-write code specifically for this format, :pypi:`qoi` is an alternative
-library that uses C to decode the image and interfaces with NumPy.
+write code specifically for this format, :pypi:`qoi` is an alternative library that
+uses C to decode the image and interfaces with NumPy.
 
 SUN
 ^^^


### PR DESCRIPTION
Resolves #7922

https://github.com/python-pillow/Pillow/issues/7922#issuecomment-2033336635
> That said, Pillow's processing of QOI files in Python, not C, could probably be clarified here: https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#qoi.