### PR TITLE
Updated pattern for skipping builds based on file changes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,9 +1,9 @@
 skip_commits:
   files:
-    - ".github/**"
+    - ".github/**/*"
     - ".gitmodules"
-    - "docs/**"
-    - "wheels/**"
+    - "docs/**/*"
+    - "wheels/**/*"
 
 version: '{build}'
 clone_folder: c:\pillow


### PR DESCRIPTION
It has been [noted](https://github.com/python-pillow/Pillow/pull/7933#issuecomment-2031184944) that #7909 is not causing AppVeyor to skip building as intended for irrelevant files.

Googling, I found https://help.appveyor.com/discussions/problems/31954-skip_commitsfiles-does-not-work-for-files-in-github-folder, which suggests that ".github/**/*" is the pattern to use for skipping files inside the .github directory.