### PR TITLE
Support reading CMYK JPEG2000 images

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -289,6 +289,16 @@ def test_rgba(ext: str) -> None:
         assert im.mode == "RGBA"
 
 
+@pytest.mark.skipif(
+    not os.path.exists(EXTRA_DIR), reason="Extra image files not installed"
+)
+@skip_unless_feature_version("jpg_2000", "2.5.1")
+def test_cmyk() -> None:
+    with Image.open(f"{EXTRA_DIR}/issue205.jp2") as im:
+        assert im.mode == "CMYK"
+        assert im.getpixel((0, 0)) == (185, 134, 0, 0)
+
+
 @pytest.mark.parametrize("ext", (".j2k", ".jp2"))
 def test_16bit_monochrome_has_correct_mode(ext: str) -> None:
     with Image.open("Tests/images/16bit.cropped" + ext) as im:

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -176,6 +176,10 @@ def _parse_jp2_header(fp):
                 mode = "RGB"
             elif nc == 4:
                 mode = "RGBA"
+        elif tbox == b"colr" and nc == 4:
+            meth, _, _, enumcs = header.read_fields(">BBBI")
+            if meth == 1 and enumcs == 12:
+                mode = "CMYK"
         elif tbox == b"pclr" and mode in ("L", "LA"):
             ne, npc = header.read_fields(">HB")
             bitdepths = header.read_fields(">" + ("B" * npc))

--- a/src/libImaging/Jpeg2KDecode.c
+++ b/src/libImaging/Jpeg2KDecode.c
@@ -632,6 +632,7 @@ static const struct j2k_decode_unpacker j2k_unpackers[] = {
     {"RGBA", OPJ_CLRSPC_SYCC, 3, 1, j2ku_sycc_rgb},
     {"RGBA", OPJ_CLRSPC_SRGB, 4, 1, j2ku_srgba_rgba},
     {"RGBA", OPJ_CLRSPC_SYCC, 4, 1, j2ku_sycca_rgba},
+    {"CMYK", OPJ_CLRSPC_CMYK, 4, 1, j2ku_srgba_rgba},
 };
 
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
Resolves #7945
Requires https://github.com/python-pillow/test-images/pull/4

Pages 187 and 201-204 of https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=5db74700b2b544695273019e6b4820bc9742973a can be used as a reference for the 'colr' box that specifies the colourspace as CMYK.