### PR TITLE
Removed outdated comment

### DIFF
--- a/src/PIL/ImageMode.py
+++ b/src/PIL/ImageMode.py
@@ -42,7 +42,6 @@ class ModeDescriptor:
 @lru_cache
 def getmode(mode: str) -> ModeDescriptor:
     """Gets a mode descriptor for the given mode."""
-    # initialize mode cache
     endian = "<" if sys.byteorder == "little" else ">"
 
     modes = {


### PR DESCRIPTION
Before #7641, `# initialize mode cache` made sense, as it came before initialising a dictionary.

https://github.com/python-pillow/Pillow/blob/17af8eca02fe7b4e0545811e5ab9843e26a030b1/src/PIL/ImageMode.py#L44-L49

Now it doesn't make sense, as the cache is managed by `@lru_cache`, and the following line determining endianness has nothing to do with the cache.
https://github.com/python-pillow/Pillow/blob/a25a1aef059911d29765406c37b1a92797bac3e3/src/PIL/ImageMode.py#L42-L46

This PR removes the comment.