### PR TITLE
Update `make release-test`: no more eggs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,6 @@ release-test:
 	python3 selftest.py
 	python3 -m pytest Tests
 	python3 -m pip install .
-	-rm dist/*.egg
 	-rmdir dist
 	python3 -m pytest -qq
 	python3 -m check_manifest


### PR DESCRIPTION
During the release, the output of `make release-test` includes:

```
Successfully installed pillow-10.4.0.dev0
rm dist/*.egg
rm: dist/*.egg: No such file or directory
make: [release-test] Error 1 (ignored)
rmdir dist
rmdir: dist: No such file or directory
make: [release-test] Error 1 (ignored)
python3 -m pytest -qq
```

Eggs are no longer used: https://peps.python.org/pep-0715/

Let's remove `-rm dist/*.egg`.