### PR TITLE
Support unpacking more rawmodes to RGBA palettes

### DIFF
--- a/Tests/test_image_putpalette.py
+++ b/Tests/test_image_putpalette.py
@@ -79,6 +79,7 @@ def test_putpalette_with_alpha_values() -> None:
     (
         ("RGBA", (1, 2, 3, 4)),
         ("RGBAX", (1, 2, 3, 4, 0)),
+        ("ARGB", (4, 1, 2, 3)),
     ),
 )
 def test_rgba_palette(mode: str, palette: tuple[int, ...]) -> None:

--- a/src/PIL/DdsImagePlugin.py
+++ b/src/PIL/DdsImagePlugin.py
@@ -379,6 +379,7 @@ class DdsImageFile(ImageFile.ImageFile):
         elif pfflags & DDPF.PALETTEINDEXED8:
             self._mode = "P"
             self.palette = ImagePalette.raw("RGBA", self.fp.read(1024))
+            self.palette.mode = "RGBA"
         elif pfflags & DDPF.FOURCC:
             offset = header_size + 4
             if fourcc == D3DFMT.DXT1:

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -429,7 +429,7 @@ class GifImageFile(ImageFile.ImageFile):
             self._prev_im = self.im
             if self._frame_palette:
                 self.im = Image.core.fill("P", self.size, self._frame_transparency or 0)
-                self.im.putpalette(*self._frame_palette.getdata())
+                self.im.putpalette("RGB", *self._frame_palette.getdata())
             else:
                 self.im = None
         self._mode = temp_mode

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -873,7 +873,7 @@ class Image:
         if self.im is not None and self.palette and self.palette.dirty:
             # realize palette
             mode, arr = self.palette.getdata()
-            self.im.putpalette(mode, arr)
+            self.im.putpalette(self.palette.mode, mode, arr)
             self.palette.dirty = 0
             self.palette.rawmode = None
             if "transparency" in self.info and mode in ("LA", "PA"):
@@ -883,9 +883,9 @@ class Image:
                     self.im.putpalettealphas(self.info["transparency"])
                 self.palette.mode = "RGBA"
             else:
-                palette_mode = "RGBA" if mode.startswith("RGBA") else "RGB"
-                self.palette.mode = palette_mode
-                self.palette.palette = self.im.getpalette(palette_mode, palette_mode)
+                self.palette.palette = self.im.getpalette(
+                    self.palette.mode, self.palette.mode
+                )
 
         if self.im is not None:
             if cffi and USE_CFFI_ACCESS:
@@ -1998,7 +1998,7 @@ class Image:
             palette = ImagePalette.raw(rawmode, data)
         self._mode = "PA" if "A" in self.mode else "P"
         self.palette = palette
-        self.palette.mode = "RGB"
+        self.palette.mode = "RGBA" if "A" in rawmode else "RGB"
         self.load()  # install new palette
 
     def putpixel(self, xy, value):
@@ -2113,7 +2113,7 @@ class Image:
         # m_im.putpalette(mapping_palette, 'L')  # converts to 'P'
         # or just force it.
         # UNDONE -- this is part of the general issue with palettes
-        m_im.im.putpalette(palette_mode + ";L", m_im.palette.tobytes())
+        m_im.im.putpalette(palette_mode, palette_mode + ";L", m_im.palette.tobytes())
 
         m_im = m_im.convert("L")
 

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1725,10 +1725,11 @@ _putpalette(ImagingObject *self, PyObject *args) {
     ImagingShuffler unpack;
     int bits;
 
-    char *rawmode, *palette_mode;
+    char *palette_mode, *rawmode;
     UINT8 *palette;
     Py_ssize_t palettesize;
-    if (!PyArg_ParseTuple(args, "sy#", &rawmode, &palette, &palettesize)) {
+    if (!PyArg_ParseTuple(
+            args, "ssy#", &palette_mode, &rawmode, &palette, &palettesize)) {
         return NULL;
     }
 
@@ -1738,7 +1739,6 @@ _putpalette(ImagingObject *self, PyObject *args) {
         return NULL;
     }
 
-    palette_mode = strncmp("RGBA", rawmode, 4) == 0 ? "RGBA" : "RGB";
     unpack = ImagingFindUnpacker(palette_mode, rawmode, &bits);
     if (!unpack) {
         PyErr_SetString(PyExc_ValueError, wrong_raw_mode);


### PR DESCRIPTION
Helps #7965

At the moment, only modes that start with 'RGBA' can be unpacked to RGBA palettes. This does not allow for rawmodes such as 'ARGB'.