### PR TITLE
Scale values when converting RGB to BGR;15/16

### DIFF
--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -280,24 +280,30 @@ rgb2f(UINT8 *out_, const UINT8 *in, int xsize) {
 }
 
 static void
-rgb2bgr15(UINT8 *out_, const UINT8 *in, int xsize) {
+rgb2bgr15(UINT8 *out, const UINT8 *in, const int xsize) {
     int x;
-    for (x = 0; x < xsize; x++, in += 4, out_ += 2) {
-        UINT16 v = ((((UINT16)in[0]) << 7) & 0x7c00) +
-                   ((((UINT16)in[1]) << 2) & 0x03e0) +
-                   ((((UINT16)in[2]) >> 3) & 0x001f);
-        memcpy(out_, &v, sizeof(v));
+    for (x = 0; x < xsize; x++, in += 4, out += 2) {
+        const UINT16 r = (UINT16)in[0] * 31 / 255;
+        const UINT16 g = (UINT16)in[1] * 31 / 255;
+        const UINT16 b = (UINT16)in[2] * 31 / 255;
+        const UINT16 v = ((b & 31) << 10) +
+                         ((g & 31) << 5) +
+                         (r & 31);
+        memcpy(out, &v, sizeof(v));
     }
 }
 
 static void
-rgb2bgr16(UINT8 *out_, const UINT8 *in, int xsize) {
+rgb2bgr16(UINT8 *out, const UINT8 *in, const int xsize) {
     int x;
-    for (x = 0; x < xsize; x++, in += 4, out_ += 2) {
-        UINT16 v = ((((UINT16)in[0]) << 8) & 0xf800) +
-                   ((((UINT16)in[1]) << 3) & 0x07e0) +
-                   ((((UINT16)in[2]) >> 3) & 0x001f);
-        memcpy(out_, &v, sizeof(v));
+    for (x = 0; x < xsize; x++, in += 4, out += 2) {
+        const UINT16 r = (UINT16)in[0] * 31 / 255;
+        const UINT16 g = (UINT16)in[1] * 63 / 255;
+        const UINT16 b = (UINT16)in[2] * 31 / 255;
+        const UINT16 v = ((b & 31) << 11) +
+                         ((g & 63) << 6) +
+                         (r & 31);
+        memcpy(out, &v, sizeof(v));
     }
 }
 


### PR DESCRIPTION
Currently it just cuts off the lower three bytes. This should give a slightly more accurate conversion.