### PR TITLE
dist directory is no longer created

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,6 @@ release-test:
 	python3 selftest.py
 	python3 -m pytest Tests
 	python3 -m pip install .
-	-rmdir dist
 	python3 -m pytest -qq
 	python3 -m check_manifest
 	python3 -m pyroma .


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/7957#issue-2231926580
> During the release, the output of make release-test includes:
> 
>> Successfully installed pillow-10.4.0.dev0
>> rm dist/*.egg
>> rm: dist/*.egg: No such file or directory
>> make: [release-test] Error 1 (ignored)
>> rmdir dist
>> rmdir: dist: No such file or directory

This started happening due to #5896. `python3 setup.py install` creates a dist egg, but `python3 -m pip install .` does not.

#7957 removed `-rm dist/*.egg`.

If there's no dist directory, then there's no need remove it either, so `-rmdir dist` can also be removed.