### PR TITLE
Updated installation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The core image library is designed for fast access to data stored in a few basic
 ## More Information
 
 - [Documentation](https://pillow.readthedocs.io/)
-  - [Installation](https://pillow.readthedocs.io/en/latest/installation.html)
+  - [Installation](https://pillow.readthedocs.io/en/latest/installation/basic-installation.html)
   - [Handbook](https://pillow.readthedocs.io/en/latest/handbook/index.html)
 - [Contribute](https://github.com/python-pillow/Pillow/blob/main/.github/CONTRIBUTING.md)
   - [Issues](https://github.com/python-pillow/Pillow/issues)

--- a/setup.py
+++ b/setup.py
@@ -1018,7 +1018,7 @@ The headers or library files could not be found for {str(err)},
 a required dependency when compiling Pillow from source.
 
 Please see the install instructions at:
-   https://pillow.readthedocs.io/en/latest/installation.html
+   https://pillow.readthedocs.io/en/latest/installation/basic-installation.html
 
 """
     sys.stderr.write(msg)


### PR DESCRIPTION
Helps #7980

Replace https://pillow.readthedocs.io/en/latest/installation.html with https://pillow.readthedocs.io/en/latest/installation/basic-installation.html after #7832