### PR TITLE
Removed nitpick_ignore by updating Sphinx to 7.3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ import PIL
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "2.4"
+needs_sphinx = "7.3"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -121,12 +121,7 @@ nitpicky = True
 # generating warnings in “nitpicky mode”. Note that type should include the domain name
 # if present. Example entries would be ('py:func', 'int') or
 # ('envvar', 'LD_LIBRARY_PATH').
-nitpick_ignore = [
-    # Sphinx does not understand typing.Literal[-1]
-    # Will be fixed in a future version.
-    # https://github.com/sphinx-doc/sphinx/pull/11904
-    ("py:obj", "typing.Literal[-1, 1]"),
-]
+# nitpick_ignore = []
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dynamic = [
 docs = [
   "furo",
   "olefile",
-  "sphinx>=2.4",
+  "sphinx>=7.3",
   "sphinx-copybutton",
   "sphinx-inline-tabs",
   "sphinx-removed-in",


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/0e90c1c9ae308ba768725ec1644189a942f729fb/docs/conf.py#L124-L129

A new version of Sphinx has been [released](https://github.com/sphinx-doc/sphinx/releases), so this can be removed.