### PR TITLE
Corrected ImageShow UnixViewer command

### DIFF
--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -199,7 +199,7 @@ class UnixViewer(Viewer):
 
     def get_command(self, file: str, **options: Any) -> str:
         command = self.get_command_ex(file, **options)[0]
-        return f"({command} {quote(file)}"
+        return f"{command} {quote(file)}"
 
 
 class XDGViewer(UnixViewer):


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/commit/993bb23ce0e9cd1ee4a2e6f05a1225ff0df20e4f#r141044477 pointed out an unclosed bracket.