### PR TITLE
Deprecate support for libtiff < 4

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -100,13 +100,13 @@ ImageMath eval()
 ``ImageMath.eval()`` has been deprecated. Use :py:meth:`~PIL.ImageMath.lambda_eval` or
 :py:meth:`~PIL.ImageMath.unsafe_eval` instead.
 
-Support for libtiff earlier than 4
+Support for LibTIFF earlier than 4
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. deprecated:: 10.4.0
 
-Support for libtiff earlier than 4 has been deprecated. Upgrade to a newer version of
-libtiff instead.
+Support for LibTIFF earlier than version 4 has been deprecated.
+Upgrade to a newer version of LibTIFF instead.
 
 Removed features
 ----------------

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -100,6 +100,14 @@ ImageMath eval()
 ``ImageMath.eval()`` has been deprecated. Use :py:meth:`~PIL.ImageMath.lambda_eval` or
 :py:meth:`~PIL.ImageMath.unsafe_eval` instead.
 
+Support for libtiff earlier than 4
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. deprecated:: 10.4.0
+
+Support for libtiff earlier than 4 has been deprecated. Upgrade to a newer version of
+libtiff instead.
+
 Removed features
 ----------------
 

--- a/docs/releasenotes/10.4.0.rst
+++ b/docs/releasenotes/10.4.0.rst
@@ -1,0 +1,54 @@
+10.4.0
+------
+
+Security
+========
+
+TODO
+^^^^
+
+TODO
+
+:cve:`YYYY-XXXXX`: TODO
+^^^^^^^^^^^^^^^^^^^^^^^
+
+TODO
+
+Backwards Incompatible Changes
+==============================
+
+TODO
+^^^^
+
+Deprecations
+============
+
+Support for LibTIFF earlier than 4
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Support for LibTIFF earlier than version 4 has been deprecated.
+Upgrade to a newer version of LibTIFF instead.
+
+API Changes
+===========
+
+TODO
+^^^^
+
+TODO
+
+API Additions
+=============
+
+TODO
+^^^^
+
+TODO
+
+Other Changes
+=============
+
+TODO
+^^^^
+
+TODO

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -14,6 +14,7 @@ expected to be backported to earlier versions.
 .. toctree::
   :maxdepth: 2
 
+  10.4.0
   10.3.0
   10.2.0
   10.1.0

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -56,6 +56,7 @@ from . import ExifTags, Image, ImageFile, ImageOps, ImagePalette, TiffTags
 from ._binary import i16be as i16
 from ._binary import i32be as i32
 from ._binary import o8
+from ._deprecate import deprecate
 from .TiffTags import TYPES
 
 logger = logging.getLogger(__name__)
@@ -275,6 +276,9 @@ PREFIXES = [
     b"MM\x00\x2B",  # BigTIFF with big-endian byte order
     b"II\x2B\x00",  # BigTIFF with little-endian byte order
 ]
+
+if not getattr(Image.core, "libtiff_support_custom_tags", True):
+    deprecate("Support for libtiff earlier than 4", 12)
 
 
 def _accept(prefix: bytes) -> bool:

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -278,7 +278,7 @@ PREFIXES = [
 ]
 
 if not getattr(Image.core, "libtiff_support_custom_tags", True):
-    deprecate("Support for libtiff earlier than 4", 12)
+    deprecate("Support for LibTIFF earlier than version 4", 12)
 
 
 def _accept(prefix: bytes) -> bool:


### PR DESCRIPTION
libtiff 4.0 was released on 21st December 2011, 12 years ago.

I'm hoping that's long enough to not require a deprecation period for removing support for libtiff < 4.