### PR TITLE
Corrected check for libtiff feature

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -741,7 +741,7 @@ class TestFileLibTiff(LibTiffTestCase):
             pytest.param(
                 True,
                 marks=pytest.mark.skipif(
-                    not Image.core.libtiff_support_custom_tags,
+                    not getattr(Image.core, "libtiff_support_custom_tags", False),
                     reason="Custom tags not supported by older libtiff",
                 ),
             ),


### PR DESCRIPTION
Follow up to https://github.com/python-pillow/Pillow/pull/7975

- I missed a place where `WRITE_LIBTIFF` is assigned directly in the tests, rather than [using monkeypatch instead.](https://github.com/python-pillow/Pillow/pull/7975#issuecomment-2063257415)
- In parametrizing tests, I forgot that `libtiff_support_custom_tags` is only present if libtiff support is present. While `@skip_unless_feature("libtiff")` is there on this test file, the `parametrize` conditions are still evaluated, so if libtiff support is absent, this causes an error. I've used `getattr` to fix this.