### PR TITLE
Automatically add dates to release notes

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,10 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3"
+  jobs:
+    post_checkout:
+    - git remote add upstream https://github.com/python-pillow/Pillow.git # For forks
+    - git fetch upstream --tags
 
 python:
   install:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,7 @@ needs_sphinx = "7.3"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "dater",
     "sphinx.ext.autodoc",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",

--- a/docs/dater.py
+++ b/docs/dater.py
@@ -1,0 +1,52 @@
+"""
+Sphinx extension to add timestamps to release notes based on Git versions.
+
+Based on https://github.com/jaraco/rst.linker, with thanks to Jason R. Coombs.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+import re
+import subprocess
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+
+DOC_NAME_REGEX = re.compile(r"releasenotes/\d+\.\d+\.\d+")
+VERSION_TITLE_REGEX = re.compile(r"^(\d+\.\d+\.\d+)\n-+\n")
+
+
+def get_date_for(git_version: str) -> dt.datetime | None:
+    cmd = ["git", "log", "-1", "--format=%ai", git_version]
+    try:
+        with open(os.devnull, "w", encoding="utf-8") as devnull:
+            out = subprocess.check_output(
+                cmd, stderr=devnull, text=True, encoding="utf-8"
+            )
+            ts = out.strip()
+        return dt.datetime.fromisoformat(ts)
+    except subprocess.CalledProcessError:
+        return None
+
+
+def add_date(app: Sphinx, doc_name: str, source: list[str]) -> None:
+    if DOC_NAME_REGEX.match(doc_name) and (m := VERSION_TITLE_REGEX.match(source[0])):
+        old_title = m.group(1)
+
+        if tag_datetime := get_date_for(old_title):
+            new_title = f"{old_title} ({tag_datetime:%Y-%m-%d})"
+        else:
+            new_title = f"{old_title} (unreleased)"
+
+        new_underline = "-" * len(new_title)
+
+        result = source[0].replace(m.group(0), f"{new_title}\n{new_underline}\n", 1)
+        source[0] = result
+
+
+def setup(app: Sphinx) -> dict[str, bool]:
+    app.connect("source-read", add_date)
+    return {"parallel_read_safe": True}


### PR DESCRIPTION
This adds a small Sphinx extension to add the date to the titles of the release notes, both on the page and tables of contents.

<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td><img src=https://github.com/python-pillow/Pillow/assets/1324225/20f1e2d1-2105-4c72-bb7a-2c5b6e7eac53>
 <td><img src=https://github.com/python-pillow/Pillow/assets/1324225/6313b957-4e23-4fde-9d18-5fd41e0232f6>
</table>

I based this on @jaraco's nifty https://github.com/jaraco/rst.linker, and I've added you as co-author on the commit, hope that's okay?

This PR works by getting the title of pages matching `releasenotes/\d+\.\d+\.\d+"`, then looking up the timestamp from a `git log` call, and then adds "(yyyy-mm-dd)" to the title.

There's some things in rst.linker which make it not suitable to use here, and I think it might not be worth generalising it further:

* It doesn't have wildcard support for the input files
* It's designed to read a date-less file such as https://github.com/pypa/setuptools/blob/main/NEWS.rst which sit out of the docs directory, and create a page with dates like https://setuptools.pypa.io/en/stable/history.html
* It names the output `filename (files).rst` and deletes the original `filename.rst`
* It modifies the `.rst` files, rather than the source output
* It adds the date underneath the title. I considered this, but think it's better for us in the title

Some notes:

* When it can't find a Git tag, this PR adds "(unreleased)" instead of "(yyyy-mm-dd)". This is for when the next version isn't released or tagged yet (see 10.4.0)
* This means, when building from a fork, it will show "(unreleased)" next to any release if you haven't fetched the upstream tags.
* Similarly, it will show "(unreleased)" if you build the docs from a zip or sdist.

I don't think these are problems? For forks, `git fetch upstream --tags` will grab them all; I added it to Read the Docs for forks builds. For sdist builds, we could return early  if a `.git` directory is absent.
