### PR TITLE
Use (void) for empty function parameters

### DIFF
--- a/src/libImaging/Access.c
+++ b/src/libImaging/Access.c
@@ -185,7 +185,7 @@ put_pixel_32(Imaging im, int x, int y, const void *color) {
 }
 
 void
-ImagingAccessInit() {
+ImagingAccessInit(void) {
 #define ADD(mode_, get_pixel_, put_pixel_)      \
     {                                           \
         ImagingAccess access = add_item(mode_); \

--- a/src/libImaging/JpegDecode.c
+++ b/src/libImaging/JpegDecode.c
@@ -48,7 +48,7 @@ char *libjpeg_turbo_version = NULL;
 #endif
 
 int
-ImagingJpegUseJCSExtensions() {
+ImagingJpegUseJCSExtensions(void) {
     int use_jcs_extensions = 0;
 #ifdef JCS_EXTENSIONS
 #if defined(LIBJPEG_TURBO_VERSION_NUMBER)


### PR DESCRIPTION
I just happened to notice that these are the only three C functions that don't take any arguments and use `()` instead of `(void)` in their definition.