### PR TITLE
Simplified RGB to I;16, I;16L and I;16B conversion

### DIFF
--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -254,9 +254,8 @@ static void
 rgb2i16l(UINT8 *out_, const UINT8 *in, int xsize) {
     int x;
     for (x = 0; x < xsize; x++, in += 4) {
-        UINT8 v = CLIP16(L24(in) >> 16);
-        *out_++ = v;
-        *out_++ = v >> 8;
+        *out_++ = L24(in) >> 16;
+        *out_++ = 0;
     }
 }
 
@@ -264,9 +263,8 @@ static void
 rgb2i16b(UINT8 *out_, const UINT8 *in, int xsize) {
     int x;
     for (x = 0; x < xsize; x++, in += 4) {
-        UINT8 v = CLIP16(L24(in) >> 16);
-        *out_++ = v >> 8;
-        *out_++ = v;
+        *out_++ = 0;
+        *out_++ = L24(in) >> 16;
     }
 }
 


### PR DESCRIPTION
Discussion at https://github.com/python-pillow/Pillow/commit/fb6b8601721da507f590c85a1b9f426f6c45cca6#r141279400 has revealed that when converting from RGB to an I;16* mode, the result is not going to be larger than 8 bits, and so the code can be simplified.