### PR TITLE
Update tests to allow for zlib-ng

### DIFF
--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -37,6 +37,8 @@ def test_version() -> None:
         else:
             assert function(name) == version
             if name != "PIL":
+                if name == "zlib" and version is not None:
+                    version = version.replace(".zlib-ng", "")
                 assert version is None or re.search(r"\d+(\.\d+)*$", version)
 
     for module in features.modules:

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -85,7 +85,9 @@ class TestFilePng:
 
     def test_sanity(self, tmp_path: Path) -> None:
         # internal version number
-        assert re.search(r"\d+(\.\d+){1,3}$", features.version_codec("zlib"))
+        assert re.search(
+            r"\d+(\.\d+){1,3}(\.zlib\-ng)?$", features.version_codec("zlib")
+        )
 
         test_file = str(tmp_path / "temp.png")
 


### PR DESCRIPTION
I created https://github.com/python-pillow/docker-images/pull/203 after the release of Fedora 40, but the tests are failing.

This is because Fedora 40 uses [zlib-ng instead of zlib](https://fedoraproject.org/wiki/Releases/40/ChangeSet#Changes/ZlibNGTransition), and [zlib-ng appends '.zlib-ng' to its version string.](https://github.com/zlib-ng/zlib-ng/blob/3f35bfccff2d1dacdfe9844712be1e042d028700/zlib.h.in#L61)

This updates our tests to allow for that suffix.