### PR TITLE
GitHub Actions: use `macos-13` or `macos-14` instead of `macos-latest`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,9 +57,9 @@ jobs:
         - python-version: "3.10"
           PYTHONOPTIMIZE: 2
         # M1 only available for 3.10+
-        - os: "macos-latest"
+        - os: "macos-13"
           python-version: "3.9"
-        - os: "macos-latest"
+        - os: "macos-13"
           python-version: "3.8"
         exclude:
         - os: "macos-14"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -97,7 +97,7 @@ jobs:
       matrix:
         include:
           - name: "macOS x86_64"
-            os: macos-latest
+            os: macos-13
             cibw_arch: x86_64
             macosx_deployment_target: "10.10"
           - name: "macOS arm64"


### PR DESCRIPTION
GitHub is migrating `macos-latest` to point to `macos-14` which is (a) M1 and (b) does not have Python 3.8 or 3.9:

* https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/
* https://github.com/actions/setup-python/issues/696#issuecomment-1637587760

This can cause failed builds for migrated repos.

At least during this migration, let's explicitly use `macos-13` or `macos-14` instead of `macos-latest`.
