### PR TITLE
Add packers for RGB;15/16 and BGR;15/16

### DIFF
--- a/Tests/test_lib_pack.py
+++ b/Tests/test_lib_pack.py
@@ -67,6 +67,10 @@ class TestLibPack:
 
     def test_RGB(self) -> None:
         self.assert_pack("RGB", "RGB", 3, (1, 2, 3), (4, 5, 6), (7, 8, 9))
+        self.assert_pack("RGB", "RGB;15", b"\xe0\x81\x00\x88", (8, 131, 0), (24, 0, 8))
+        self.assert_pack("RGB", "BGR;15", b"\xe0\x81\x00\x88", (0, 131, 8), (8, 0, 24))
+        self.assert_pack("RGB", "RGB;16", b"\xe0\x01\xe0\x13", (8, 64, 0), (24, 129, 0))
+        self.assert_pack("RGB", "BGR;16", b"\xe0\x01\xe0\x13", (0, 64, 8), (0, 129, 24))
         self.assert_pack(
             "RGB", "RGBX", b"\x01\x02\x03\xff\x05\x06\x07\xff", (1, 2, 3), (5, 6, 7)
         )

--- a/src/libImaging/Pack.c
+++ b/src/libImaging/Pack.c
@@ -282,6 +282,30 @@ ImagingPackRGB(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
+ImagingPackRGB15(UINT8 *out, const UINT8 *in, int pixels) {
+    for (int i = 0; i < pixels; out += 2, in += 4, i++) {
+        /* XRGB, 1/5/5/5 bits per pixel, little-endian */
+        const UINT8 r = (UINT16)in[0] * 31 / 255;
+        const UINT8 g = (UINT16)in[1] * 31 / 255;
+        const UINT8 b = (UINT16)in[2] * 31 / 255;
+        out[1] = 0x80 | (r << 2) | (g >> 3);
+        out[0] = (g << 5) | b;
+    }
+}
+
+void
+ImagingPackRGB16(UINT8 *out, const UINT8 *in, int pixels) {
+    for (int i = 0; i < pixels; out += 2, in += 4, i++) {
+        /* RGB, 5/6/5 bits per pixel, little-endian */
+        const UINT8 r = (UINT16)in[0] * 31 / 255;
+        const UINT8 g = (UINT16)in[1] * 63 / 255;
+        const UINT8 b = (UINT16)in[2] * 31 / 255;
+        out[1] = (r << 3) | (g >> 3);
+        out[0] = (g << 5) | b;
+    }
+}
+
+void
 ImagingPackXRGB(UINT8 *out, const UINT8 *in, int pixels) {
     int i;
     /* XRGB, triplets with left padding */
@@ -305,6 +329,30 @@ ImagingPackBGR(UINT8 *out, const UINT8 *in, int pixels) {
         out[2] = in[R];
         out += 3;
         in += 4;
+    }
+}
+
+void
+ImagingPackBGR15(UINT8 *out, const UINT8 *in, int pixels) {
+    for (int i = 0; i < pixels; out += 2, in += 4, i++) {
+        /* XBGR, 1/5/5/5 bits per pixel, little-endian */
+        const UINT8 r = (UINT16)in[0] * 31 / 255;
+        const UINT8 g = (UINT16)in[1] * 31 / 255;
+        const UINT8 b = (UINT16)in[2] * 31 / 255;
+        out[1] = 0x80 | (b << 2) | (g >> 3);
+        out[0] = (g << 5) | r;
+    }
+}
+
+void
+ImagingPackBGR16(UINT8 *out, const UINT8 *in, int pixels) {
+    for (int i = 0; i < pixels; out += 2, in += 4, i++) {
+        /* BGR, 5/6/5 bits per pixel, little-endian */
+        const UINT8 r = (UINT16)in[0] * 31 / 255;
+        const UINT8 g = (UINT16)in[1] * 63 / 255;
+        const UINT8 b = (UINT16)in[2] * 31 / 255;
+        out[1] = (b << 3) | (g >> 3);
+        out[0] = (g << 5) | r;
     }
 }
 
@@ -573,10 +621,14 @@ static struct {
 
     /* true colour */
     {"RGB", "RGB", 24, ImagingPackRGB},
+    {"RGB", "RGB;15", 16, ImagingPackRGB15},
+    {"RGB", "RGB;16", 16, ImagingPackRGB16},
     {"RGB", "RGBX", 32, copy4},
     {"RGB", "RGBA", 32, copy4},
     {"RGB", "XRGB", 32, ImagingPackXRGB},
     {"RGB", "BGR", 24, ImagingPackBGR},
+    {"RGB", "BGR;15", 16, ImagingPackBGR15},
+    {"RGB", "BGR;16", 16, ImagingPackBGR16},
     {"RGB", "BGRX", 32, ImagingPackBGRX},
     {"RGB", "XBGR", 32, ImagingPackXBGR},
     {"RGB", "RGB;L", 24, packRGBL},


### PR DESCRIPTION
I made these to be the opposite of the unpackers for these rawmodes, but this conversion method isn't actually roundtrippable. I know of two other methods that are roundtrippable, but I would have to change the unpackers as well for that.