### PR TITLE
Corrected big-endian check

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1050,7 +1050,7 @@ class TestImageBytes:
 
     @pytest.mark.parametrize("mode", modes)
     def test_getdata_putdata(self, mode: str) -> None:
-        if is_big_endian and mode == "BGR;15":
+        if is_big_endian() and mode == "BGR;15":
             pytest.xfail("Known failure of BGR;15 on big-endian")
         im = hopper(mode)
         reloaded = helper_image_new(mode, im.size)


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/824db7152d1159bf3a895e7699b16ebc77298e77/Tests/helper.py#L374-L375
is not called as a function in
https://github.com/python-pillow/Pillow/blob/824db7152d1159bf3a895e7699b16ebc77298e77/Tests/test_image.py#L1052-L1053