### PR TITLE
Increased timeout for Ubuntu 24.04 valgrind

### DIFF
--- a/Tests/test_imagefontpil.py
+++ b/Tests/test_imagefontpil.py
@@ -66,7 +66,7 @@ def test_decompression_bomb() -> None:
         font.getmask("A" * 1_000_000)
 
 
-@pytest.mark.timeout(4)
+@pytest.mark.timeout(5)
 def test_oom() -> None:
     glyph = struct.pack(
         ">hhhhhhhhhh", 1, 0, -32767, -32767, 32767, 32767, -32767, -32767, 32767, 32767


### PR DESCRIPTION
Increased timeout from 4s to 5s to allow the Ubuntu 24.04 valgrind job at https://github.com/python-pillow/docker-images/pull/205 to pass.

See https://github.com/python-pillow/docker-images/actions/runs/8858086345/job/24329257069