### PR TITLE
Removed direct invocation of setup.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 
 .PHONY: clean
 clean:
-	python3 setup.py clean
 	rm src/PIL/*.so || true
 	rm -r build || true
 	find . -name __pycache__ | xargs rm -r || true


### PR DESCRIPTION
Addresses https://github.com/python-pillow/docker-images/pull/207#issuecomment-2081490046 and https://github.com/python-pillow/Pillow/pull/5896#issuecomment-997217443

https://github.com/python-pillow/Pillow/blob/c250a44177ac1e82d300aef702d5c2feef15fd03/Makefile#L4-L8

This removes `python3 setup.py clean`.

From https://github.com/pypa/setuptools/blob/main/setuptools/_distutils/command/clean.py, all it does is remove the 'build_temp' and 'build_base' directories. If I print those variables on my local machine, they are 'build/temp.macosx-14.0-arm64-cpython-38' and 'build', and we're already removing the 'build' directory ourselves.