### PR TITLE
Deprecate non-image ImageCms modes

### DIFF
--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -678,7 +678,8 @@ def test_auxiliary_channels_isolated() -> None:
 
 def test_long_modes() -> None:
     p = ImageCms.getOpenProfile("Tests/icc/sGrey-v2-nano.icc")
-    ImageCms.buildTransform(p, p, "ABCDEFGHI", "ABCDEFGHI")
+    with pytest.warns(DeprecationWarning):
+        ImageCms.buildTransform(p, p, "ABCDEFGHI", "ABCDEFGHI")
 
 
 @pytest.mark.parametrize("mode", ("RGB", "RGBA", "RGBX"))
@@ -699,3 +700,9 @@ def test_deprecation() -> None:
         assert ImageCms.VERSION == "1.0.0 pil"
     with pytest.warns(DeprecationWarning):
         assert isinstance(ImageCms.FLAGS, dict)
+
+    profile = ImageCmsProfile(ImageCms.createProfile("sRGB"))
+    with pytest.warns(DeprecationWarning):
+        ImageCms.ImageCmsTransform(profile, profile, "RGBA;16B", "RGB")
+    with pytest.warns(DeprecationWarning):
+        ImageCms.ImageCmsTransform(profile, profile, "RGB", "RGBA;16B")

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -107,6 +107,15 @@ BGR;15, BGR 16 and BGR;24
 
 The experimental BGR;15, BGR;16 and BGR;24 modes have been deprecated.
 
+Non-image modes in ImageCms
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. deprecated:: 10.4.0
+
+The use in :py:mod:`.ImageCms` of input modes and output modes that are not Pillow
+image modes has been deprecated. Defaulting to "L" or "1" if the mode cannot be mapped
+is also deprecated.
+
 Support for LibTIFF earlier than 4
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/releasenotes/10.4.0.rst
+++ b/docs/releasenotes/10.4.0.rst
@@ -28,6 +28,13 @@ BGR;15, BGR 16 and BGR;24
 
 The experimental BGR;15, BGR;16 and BGR;24 modes have been deprecated.
 
+Non-image modes in ImageCms
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The use in :py:mod:`.ImageCms` of input modes and output modes that are not Pillow
+image modes has been deprecated. Defaulting to "L" or "1" if the mode cannot be mapped
+is also deprecated.
+
 Support for LibTIFF earlier than 4
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/PIL/ImageCms.py
+++ b/src/PIL/ImageCms.py
@@ -299,6 +299,31 @@ class ImageCmsTransform(Image.ImagePointHandler):
         proof_intent: Intent = Intent.ABSOLUTE_COLORIMETRIC,
         flags: Flags = Flags.NONE,
     ):
+        supported_modes = (
+            "RGB",
+            "RGBA",
+            "RGBX",
+            "CMYK",
+            "I;16",
+            "I;16L",
+            "I;16B",
+            "YCbCr",
+            "LAB",
+            "L",
+            "1",
+        )
+        for mode in (input_mode, output_mode):
+            if mode not in supported_modes:
+                deprecate(
+                    mode,
+                    12,
+                    {
+                        "L;16": "I;16 or I;16L",
+                        "L:16B": "I;16B",
+                        "YCCA": "YCbCr",
+                        "YCC": "YCbCr",
+                    }.get(mode),
+                )
         if proof is None:
             self.transform = core.buildTransform(
                 input.profile, output.profile, input_mode, output_mode, intent, flags

--- a/src/_imagingcms.c
+++ b/src/_imagingcms.c
@@ -223,20 +223,22 @@ findLCMStype(char *PILmode) {
     if (strcmp(PILmode, "CMYK") == 0) {
         return TYPE_CMYK_8;
     }
-    if (strcmp(PILmode, "L;16") == 0) {
+    if (strcmp(PILmode, "I;16") == 0 || strcmp(PILmode, "I;16L") == 0 ||
+        strcmp(PILmode, "L;16") == 0) {
         return TYPE_GRAY_16;
     }
-    if (strcmp(PILmode, "L;16B") == 0) {
+    if (strcmp(PILmode, "I;16B") == 0 || strcmp(PILmode, "L;16B") == 0) {
         return TYPE_GRAY_16_SE;
     }
-    if (strcmp(PILmode, "YCCA") == 0 || strcmp(PILmode, "YCC") == 0) {
+    if (strcmp(PILmode, "YCbCr") == 0 || strcmp(PILmode, "YCCA") == 0 ||
+        strcmp(PILmode, "YCC") == 0) {
         return TYPE_YCbCr_8;
     }
     if (strcmp(PILmode, "LAB") == 0) {
         // LabX equivalent like ALab, but not reversed -- no #define in lcms2
         return (COLORSPACE_SH(PT_LabV2) | CHANNELS_SH(3) | BYTES_SH(1) | EXTRA_SH(1));
     }
-    /* presume "L" by default */
+    /* presume "1" or "L" by default */
     return TYPE_GRAY_8;
 }
 


### PR DESCRIPTION
Resolves #8007

https://pillow.readthedocs.io/en/stable/reference/ImageCms.html#PIL.ImageCms.buildTransform and https://pillow.readthedocs.io/en/stable/reference/ImageCms.html#PIL.ImageCms.buildProofTransform describe `inMode` and `outMode` as
> String, as a valid PIL mode that the appropriate profile also supports

However, "RGBA;16B", "L;16", "L;16B", "YCCA" and "YCC" are [modes that can be interpreted](https://github.com/python-pillow/Pillow/blob/9b1390792cb941816e59eb9c1ba009f30787b388/src/_imagingcms.c#L215), and there is a [default case](https://github.com/python-pillow/Pillow/blob/9b1390792cb941816e59eb9c1ba009f30787b388/src/_imagingcms.c#L245-L246) if the mode is not recognised.

This deprecates modes that are not Pillow modes, and also deprecates the default value if the mode is not able to be mapped. I've also added I;16, I;16L, I;16B, YCbCr as possible replacement values.