### PR TITLE
Added argument to raise warnings from factory errors on UnidentifiedImageError

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -117,6 +117,13 @@ class TestImage:
                 assert im.mode == "RGB"
                 assert im.size == (128, 128)
 
+    def test_open_verbose_failure(self) -> None:
+        im = io.BytesIO(b"")
+        with pytest.warns(UserWarning):
+            with pytest.raises(UnidentifiedImageError):
+                with Image.open(im, warn_possible_formats=True):
+                    pass
+
     def test_width_height(self) -> None:
         im = Image.new("RGB", (1, 2))
         assert im.width == 1


### PR DESCRIPTION
Resolves #7993

If a user tries to open the image from that issue
```python
from PIL import Image
Image.open("bug.png")
```
they will see
```
Traceback (most recent call last):
  File "demo.py", line 2, in <module>
    Image.open("bug.png")
  File "PIL/Image.py", line 3380, in open
    raise UnidentifiedImageError(msg)
PIL.UnidentifiedImageError: cannot identify image file 'bug.png'
```

If the user would like to investigate further, this PR adds "warn_possible_formats". It will show any errors raised during the checking of the formats as warnings.
```python
from PIL import Image
Image.open("bug.png", warn_possible_formats=True)
```
giving
```
PIL/Image.py:3378: UserWarning: PNG opening failed. broken PNG file (bad header checksum in b'pHYs')
  warnings.warn(message)
PIL/Image.py:3378: UserWarning: IM opening failed. Syntax error in IM header: �PNG
  warnings.warn(message)
PIL/Image.py:3378: UserWarning: IMT opening failed. not identified by this driver
  warnings.warn(message)
PIL/Image.py:3378: UserWarning: IPTC opening failed. invalid IPTC/NAA file
  warnings.warn(message)
PIL/Image.py:3378: UserWarning: MPEG opening failed. not an MPEG file
  warnings.warn(message)
PIL/Image.py:3378: UserWarning: PCD opening failed. not a PCD file
  warnings.warn(message)
PIL/Image.py:3378: UserWarning: SPIDER opening failed. not a valid Spider file
  warnings.warn(message)
PIL/Image.py:3378: UserWarning: TGA opening failed. not a TGA file
  warnings.warn(message)
Traceback (most recent call last):
  File "demo.py", line 3, in <module>
    Image.open("bug.png", warn_possible_formats=True)
  File "PIL/Image.py", line 3380, in open
    raise UnidentifiedImageError(msg)
PIL.UnidentifiedImageError: cannot identify image file 'bug.png'
```