### PR TITLE
Do not read layers immediately when opening PSD images

### DIFF
--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -4,7 +4,7 @@ import warnings
 
 import pytest
 
-from PIL import Image, PsdImagePlugin, UnidentifiedImageError
+from PIL import Image, PsdImagePlugin
 
 from .helper import assert_image_equal_tofile, assert_image_similar, hopper, is_pypy
 
@@ -150,14 +150,6 @@ def test_combined_larger_than_size() -> None:
 @pytest.mark.parametrize(
     "test_file,raises",
     [
-        (
-            "Tests/images/timeout-1ee28a249896e05b83840ae8140622de8e648ba9.psd",
-            UnidentifiedImageError,
-        ),
-        (
-            "Tests/images/timeout-598843abc37fc080ec36a2699ebbd44f795d3a6f.psd",
-            UnidentifiedImageError,
-        ),
         ("Tests/images/timeout-c8efc3fded6426986ba867a399791bae544f59bc.psd", OSError),
         ("Tests/images/timeout-dedc7a4ebd856d79b4359bbcc79e8ef231ce38f6.psd", OSError),
     ],
@@ -167,3 +159,17 @@ def test_crashes(test_file: str, raises) -> None:
         with pytest.raises(raises):
             with Image.open(f):
                 pass
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "Tests/images/timeout-1ee28a249896e05b83840ae8140622de8e648ba9.psd",
+        "Tests/images/timeout-598843abc37fc080ec36a2699ebbd44f795d3a6f.psd",
+    ],
+)
+def test_layer_crashes(test_file: str) -> None:
+    with open(test_file, "rb") as f:
+        with Image.open(f) as im:
+            with pytest.raises(SyntaxError):
+                im.layers


### PR DESCRIPTION
When opening a PSD image, this PR skips reading and parsing the PSD layers until the user calls `im.layers`, `im.n_frames` or `im.is_animated`.

This will improve performance, and also allow users who just want to `open()` an image without seeking to workaround any errors that might be raised when parsing layers, such as in #8034