### PR TITLE
Do not use percent format in strings

### DIFF
--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -336,9 +336,7 @@ def test_readline_psfile(tmp_path: Path) -> None:
     strings = ["something", "else", "baz", "bif"]
 
     def _test_readline(t: EpsImagePlugin.PSFile, ending: str) -> None:
-        ending = "Failure with line ending: %s" % (
-            "".join("%s" % ord(s) for s in ending)
-        )
+        ending = f"Failure with line ending: {''.join(str(ord(s)) for s in ending)}"
         assert t.readline().strip("\r\n") == "something", ending
         assert t.readline().strip("\r\n") == "else", ending
         assert t.readline().strip("\r\n") == "baz", ending

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -409,15 +409,14 @@ class TestEmbeddable:
         from setuptools.command import build_ext
 
         with open("embed_pil.c", "w", encoding="utf-8") as fh:
+            home = sys.prefix.replace("\\", "\\\\")
             fh.write(
-                """
+                f"""
 #include "Python.h"
 
 int main(int argc, char* argv[])
-{
-    char *home = \""""
-                + sys.prefix.replace("\\", "\\\\")
-                + """\";
+{{
+    char *home = "{home}";
     wchar_t *whome = Py_DecodeLocale(home, NULL);
     Py_SetPythonHome(whome);
 
@@ -432,7 +431,7 @@ int main(int argc, char* argv[])
     PyMem_RawFree(whome);
 
     return 0;
-}
+}}
         """
             )
 

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -415,7 +415,9 @@ class TestEmbeddable:
 
 int main(int argc, char* argv[])
 {
-    char *home = "%s";
+    char *home = \""""
+                + sys.prefix.replace("\\", "\\\\")
+                + """\";
     wchar_t *whome = Py_DecodeLocale(home, NULL);
     Py_SetPythonHome(whome);
 
@@ -432,7 +434,6 @@ int main(int argc, char* argv[])
     return 0;
 }
         """
-                % sys.prefix.replace("\\", "\\\\")
             )
 
         compiler = getattr(build_ext, "new_compiler")()

--- a/selftest.py
+++ b/selftest.py
@@ -165,9 +165,9 @@ if __name__ == "__main__":
     print("Running selftest:")
     status = doctest.testmod(sys.modules[__name__])
     if status[0]:
-        print("*** %s tests of %d failed." % status)
+        print(f"*** {status[0]} tests of {status[1]} failed.")
         exit_status = 1
     else:
-        print("--- %s tests passed." % status[1])
+        print(f"--- {status[1]} tests passed.")
 
     sys.exit(exit_status)

--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -57,7 +57,7 @@ def dump(c: Sequence[int | bytes]) -> None:
     """.. deprecated:: 10.2.0"""
     deprecate("IptcImagePlugin.dump", 12)
     for i in c:
-        print("%02x" % _i8(i), end=" ")
+        print(f"{_i8(i):02x}", end=" ")
     print()
 
 

--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -823,12 +823,10 @@ class PdfParser:
             m = cls.re_stream_start.match(data, offset)
             if m:
                 try:
-                    stream_len = int(result[b"Length"])
-                except (TypeError, KeyError, ValueError) as e:
-                    msg = (
-                        "bad or missing Length in stream dict "
-                        f"({result.get(b'Length')})"
-                    )
+                    stream_len_str = result.get(b"Length")
+                    stream_len = int(stream_len_str)
+                except (TypeError, ValueError) as e:
+                    msg = f"bad or missing Length in stream dict ({stream_len_str})"
                     raise PdfFormatError(msg) from e
                 stream_data = data[m.end() : m.end() + stream_len]
                 m = cls.re_stream_end.match(data, m.end() + stream_len)

--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -825,8 +825,9 @@ class PdfParser:
                 try:
                     stream_len = int(result[b"Length"])
                 except (TypeError, KeyError, ValueError) as e:
-                    msg = "bad or missing Length in stream dict (%r)" % result.get(
-                        b"Length", None
+                    msg = (
+                        "bad or missing Length in stream dict "
+                        f"({result.get(b'Length')})"
                     )
                     raise PdfFormatError(msg) from e
                 stream_data = data[m.end() : m.end() + stream_len]


### PR DESCRIPTION
Fixes the failures in https://github.com/python-pillow/Pillow/pull/8044

Converts several percent format strings to f-strings.

There is also a percent format inside a multiline string - I think the neatest solution is just to break the multiline string.