### PR TITLE
Parse _version contents instead of using exec()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,7 @@ from setuptools.command.build_ext import build_ext
 def get_version():
     version_file = "src/PIL/_version.py"
     with open(version_file, encoding="utf-8") as f:
-        exec(compile(f.read(), version_file, "exec"))
-    return locals()["__version__"]
+        return f.read().split('"')[1]
 
 
 configuration = {}


### PR DESCRIPTION
Our Python 3.13 jobs have started failing in GitHub Actions - https://github.com/python-pillow/Pillow/actions/runs/9032048835/job/24819485997#step:9:46
```pytb
    File "/private/var/folders/3m/p59k4qdj0f17st0gn2cmj3640000gn/T/pip-build-env-v125k6ei/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 311, in run_setup
      exec(code, locals())
      ~~~~^^^^^^^^^^^^^^^^
    File "<string>", line 33, in <module>
    File "<string>", line 27, in get_version
  KeyError: '__version__'
```
This is referring to https://github.com/python-pillow/Pillow/blob/0cad346fc960bc07cde9d1d9135421978e2f28e8/setup.py#L23-L27

Python 3.13 is failing to populate the local variables from `exec()` - https://github.com/python/cpython/issues/118888

We have various options at this point.
1. Presuming the bug report is accepted and fixed, the next beta will be out in about three weeks. We could just deal with these failing jobs until then.
2. We could disable these jobs until then.
3. We could stop using `exec()` for this (originally added in #2517), and instead just simply parse the version string out of `_version.py` after reading the file contents.

This PR suggests Option 3. I don't mind if this is declined, it merely seems like a straightforward solution with no obvious downsides - if `_version.py` ever changes in the future so that this parsing code doesn't work, `get_version()` can be changed again.