### PR TITLE
Removed helper.py modes

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -29,33 +29,6 @@ elif "GITHUB_ACTIONS" in os.environ:
     uploader = "github_actions"
 
 
-modes = (
-    "1",
-    "L",
-    "LA",
-    "La",
-    "P",
-    "PA",
-    "F",
-    "I",
-    "I;16",
-    "I;16L",
-    "I;16B",
-    "I;16N",
-    "RGB",
-    "RGBA",
-    "RGBa",
-    "RGBX",
-    "BGR;15",
-    "BGR;16",
-    "BGR;24",
-    "CMYK",
-    "YCbCr",
-    "HSV",
-    "LAB",
-)
-
-
 def upload(a: Image.Image, b: Image.Image) -> str | None:
     if uploader == "show":
         # local img.show for errors.

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -31,7 +31,6 @@ from .helper import (
     is_big_endian,
     is_win32,
     mark_if_feature_version,
-    modes,
     skip_unless_feature,
 )
 
@@ -46,7 +45,7 @@ def helper_image_new(mode: str, size: tuple[int, int]) -> Image.Image:
 
 
 class TestImage:
-    @pytest.mark.parametrize("mode", modes)
+    @pytest.mark.parametrize("mode", Image.MODES + ["BGR;15", "BGR;16", "BGR;24"])
     def test_image_modes_success(self, mode: str) -> None:
         helper_image_new(mode, (1, 1))
 
@@ -1027,7 +1026,7 @@ class TestImage:
 
 
 class TestImageBytes:
-    @pytest.mark.parametrize("mode", modes)
+    @pytest.mark.parametrize("mode", Image.MODES + ["BGR;15", "BGR;16", "BGR;24"])
     def test_roundtrip_bytes_constructor(self, mode: str) -> None:
         im = hopper(mode)
         source_bytes = im.tobytes()
@@ -1039,7 +1038,7 @@ class TestImageBytes:
             reloaded = Image.frombytes(mode, im.size, source_bytes)
         assert reloaded.tobytes() == source_bytes
 
-    @pytest.mark.parametrize("mode", modes)
+    @pytest.mark.parametrize("mode", Image.MODES + ["BGR;15", "BGR;16", "BGR;24"])
     def test_roundtrip_bytes_method(self, mode: str) -> None:
         im = hopper(mode)
         source_bytes = im.tobytes()
@@ -1048,7 +1047,7 @@ class TestImageBytes:
         reloaded.frombytes(source_bytes)
         assert reloaded.tobytes() == source_bytes
 
-    @pytest.mark.parametrize("mode", modes)
+    @pytest.mark.parametrize("mode", Image.MODES + ["BGR;15", "BGR;16", "BGR;24"])
     def test_getdata_putdata(self, mode: str) -> None:
         if is_big_endian() and mode == "BGR;15":
             pytest.xfail("Known failure of BGR;15 on big-endian")

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -10,7 +10,7 @@ import pytest
 
 from PIL import Image
 
-from .helper import assert_image_equal, hopper, is_win32, modes
+from .helper import assert_image_equal, hopper, is_win32
 
 # CFFI imports pycparser which doesn't support PYTHONOPTIMIZE=2
 # https://github.com/eliben/pycparser/pull/198#issuecomment-317001670
@@ -205,12 +205,13 @@ class TestImageGetPixel(AccessTest):
         with pytest.raises(error):
             im.getpixel((-1, -1))
 
-    @pytest.mark.parametrize("mode", modes)
+    @pytest.mark.parametrize("mode", Image.MODES)
     def test_basic(self, mode: str) -> None:
-        if mode.startswith("BGR;"):
-            with pytest.warns(DeprecationWarning):
-                self.check(mode)
-        else:
+        self.check(mode)
+
+    @pytest.mark.parametrize("mode", ("BGR;15", "BGR;16", "BGR;24"))
+    def test_deprecated(self, mode: str) -> None:
+        with pytest.warns(DeprecationWarning):
             self.check(mode)
 
     def test_list(self) -> None:


### PR DESCRIPTION
Now that `Image.MODES` is populated with all non-deprecated modes, it seems simpler to me to remove Tests/helper.py's `modes`.

Alternatively, this can be closed, and `modes` can live on in helper.py until the deprecated modes are removed completely in Pillow 12.