### PR TITLE
FIX: in py3.13 exec does not implicitly update locals()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,9 @@ from setuptools.command.build_ext import build_ext
 def get_version():
     version_file = "src/PIL/_version.py"
     with open(version_file, encoding="utf-8") as f:
-        exec(compile(f.read(), version_file, "exec"))
-    return locals()["__version__"]
+        lcl = {}
+        exec(compile(f.read(), version_file, "exec"), lcl)
+    return lcl["__version__"]
 
 
 configuration = {}


### PR DESCRIPTION
Alternative to #8050