### PR TITLE
Added Image.WARN_POSSIBLE_FORMATS

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -116,16 +116,14 @@ class TestImage:
                 assert im.mode == "RGB"
                 assert im.size == (128, 128)
 
-    def test_open_verbose_failure(self) -> None:
+    def test_open_verbose_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(Image, "WARN_POSSIBLE_FORMATS", True)
+
         im = io.BytesIO(b"")
-        Image.WARN_POSSIBLE_FORMATS = True
-        try:
-            with pytest.warns(UserWarning):
-                with pytest.raises(UnidentifiedImageError):
-                    with Image.open(im):
-                        pass
-        finally:
-            Image.WARN_POSSIBLE_FORMATS = False
+        with pytest.warns(UserWarning):
+            with pytest.raises(UnidentifiedImageError):
+                with Image.open(im):
+                    pass
 
     def test_width_height(self) -> None:
         im = Image.new("RGB", (1, 2))

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -116,6 +116,17 @@ class TestImage:
                 assert im.mode == "RGB"
                 assert im.size == (128, 128)
 
+    def test_open_verbose_failure(self) -> None:
+        im = io.BytesIO(b"")
+        Image.WARN_POSSIBLE_FORMATS = True
+        try:
+            with pytest.warns(UserWarning):
+                with pytest.raises(UnidentifiedImageError):
+                    with Image.open(im):
+                        pass
+        finally:
+            Image.WARN_POSSIBLE_FORMATS = False
+
     def test_width_height(self) -> None:
         im = Image.new("RGB", (1, 2))
         assert im.width == 1

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -374,6 +374,11 @@ Constants
     Set to 89,478,485, approximately 0.25GB for a 24-bit (3 bpp) image.
     See :py:meth:`~PIL.Image.open` for more information about how this is used.
 
+.. data:: WARN_POSSIBLE_FORMATS
+
+    Set to false. If true, when an image cannot be identified, warnings will be raised
+    from formats that attempted to read the data.
+
 Transpose methods
 ^^^^^^^^^^^^^^^^^
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3371,7 +3371,6 @@ def open(
             except (SyntaxError, IndexError, TypeError, struct.error) as e:
                 if WARN_POSSIBLE_FORMATS:
                     warning_messages.append(i + " opening failed. " + str(e))
-                continue
             except BaseException:
                 if exclusive_fp:
                     fp.close()


### PR DESCRIPTION
Resolves #7993. Alternative to #8033

If a user tries to open the image from that issue
```python
from PIL import Image
Image.open("bug.png")
```
they will see
```pytb
Traceback (most recent call last):
  File "demo.py", line 2, in <module>
    Image.open("bug.png")
  File "PIL/Image.py", line 3380, in open
    raise UnidentifiedImageError(msg)
PIL.UnidentifiedImageError: cannot identify image file 'bug.png'
```

If the user would like to investigate further, this PR adds "warn_possible_formats". It will show any errors raised during the checking of the formats as warnings.
```python
from PIL import Image
Image.WARN_POSSIBLE_FORMATS = True
Image.open("bug.png")
```
giving
```pytb
PIL/Image.py:3378: UserWarning: PNG opening failed. broken PNG file (bad header checksum in b'pHYs')
  warnings.warn(message)
PIL/Image.py:3378: UserWarning: IM opening failed. Syntax error in IM header: �PNG
  warnings.warn(message)
PIL/Image.py:3378: UserWarning: IMT opening failed. not identified by this driver
  warnings.warn(message)
PIL/Image.py:3378: UserWarning: IPTC opening failed. invalid IPTC/NAA file
  warnings.warn(message)
PIL/Image.py:3378: UserWarning: PCD opening failed. not a PCD file
  warnings.warn(message)
PIL/Image.py:3378: UserWarning: SPIDER opening failed. not a valid Spider file
  warnings.warn(message)
PIL/Image.py:3378: UserWarning: TGA opening failed. not a TGA file
  warnings.warn(message)
Traceback (most recent call last):
  File "demo.py", line 3, in <module>
    Image.open("bug.png", warn_possible_formats=True)
  File "PIL/Image.py", line 3380, in open
    raise UnidentifiedImageError(msg)
PIL.UnidentifiedImageError: cannot identify image file 'bug.png'
```