### PR TITLE
Restore original thread state

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -618,7 +618,7 @@ windowCallback(HWND wnd, UINT message, WPARAM wParam, LPARAM lParam) {
     if (callback) {
         /* restore thread state */
         PyEval_SaveThread();
-        PyThreadState_Swap(threadstate);
+        PyThreadState_Swap(current_threadstate);
     }
 
     return status;


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/9108593264/job/25039692144#step:5:225
>   src/display.c: In function 'windowCallback':
>   src/display.c:508:20: warning: variable 'current_threadstate' set but not used [-Wunused-but-set-variable]
>     508 |     PyThreadState *current_threadstate;
>         |                    ^~~~~~~~~~~~~~~~~~~

Looking at [`windowCallback()`](https://github.com/python-pillow/Pillow/blob/0da83a1164c6663075bd313d258e671de30710b5/src/display.c#L503), I think this should be used at the end of the function to restore the original thread state.