### PR TITLE
Lint fixes

### DIFF
--- a/src/libImaging/Dib.c
+++ b/src/libImaging/Dib.c
@@ -94,8 +94,8 @@ ImagingNewDIB(const char *mode, int xsize, int ysize) {
         return (ImagingDIB)ImagingError_MemoryError();
     }
 
-    dib->bitmap =
-        CreateDIBSection(dib->dc, dib->info, DIB_RGB_COLORS, (void **)&dib->bits, NULL, 0);
+    dib->bitmap = CreateDIBSection(
+        dib->dc, dib->info, DIB_RGB_COLORS, (void **)&dib->bits, NULL, 0);
     if (!dib->bitmap) {
         free(dib->info);
         free(dib);

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -1005,7 +1005,8 @@ ImagingLibTiffEncode(Imaging im, ImagingCodecState state, UINT8 *buffer, int byt
     }
 
     if (state->state == 1 && !clientstate->fp) {
-        int read = (int)_tiffReadProc((thandle_t)clientstate, (tdata_t)buffer, (tsize_t)bytes);
+        int read =
+            (int)_tiffReadProc((thandle_t)clientstate, (tdata_t)buffer, (tsize_t)bytes);
         TRACE(
             ("Buffer: %p: %c%c%c%c\n",
              buffer,


### PR DESCRIPTION
After merging #8015, the Lint job is [failing](https://github.com/python-pillow/Pillow/actions/runs/9145658534/job/25144864620), because its run of pre-commit did not include #8064