### PR TITLE
Removed documentation of unused argument

### DIFF
--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -160,10 +160,6 @@ class ImageFont:
         .. versionadded:: 9.2.0
 
         :param text: Text to render.
-        :param mode: Used by some graphics drivers to indicate what mode the
-                     driver prefers; if empty, the renderer may return either
-                     mode. Note that the mode is always a string, to simplify
-                     C-level implementations.
 
         :return: ``(left, top, right, bottom)`` bounding box
         """


### PR DESCRIPTION
I see no reason to mention `mode` in the following docstring
https://github.com/python-pillow/Pillow/blob/3c2d36e11379a69d6bcff0ed9a02cf54deda8b19/src/PIL/ImageFont.py#L156-L172