### PR TITLE
Updated ImageCms.createProfile colorTemp default and docstring

### DIFF
--- a/src/PIL/ImageCms.py
+++ b/src/PIL/ImageCms.py
@@ -777,7 +777,7 @@ def createProfile(
     :param colorSpace: String, the color space of the profile you wish to
         create.
         Currently only "LAB", "XYZ", and "sRGB" are supported.
-    :param colorTemp: Positive integer for the white point for the profile, in
+    :param colorTemp: Positive number for the white point for the profile, in
         degrees Kelvin (i.e. 5000, 6500, 9600, etc.).  The default is for D50
         illuminant if omitted (5000k).  colorTemp is ONLY applied to LAB
         profiles, and is ignored for XYZ and sRGB.

--- a/src/PIL/ImageCms.py
+++ b/src/PIL/ImageCms.py
@@ -754,7 +754,7 @@ def applyTransform(
 
 
 def createProfile(
-    colorSpace: Literal["LAB", "XYZ", "sRGB"], colorTemp: SupportsFloat = -1
+    colorSpace: Literal["LAB", "XYZ", "sRGB"], colorTemp: SupportsFloat = 0
 ) -> core.CmsProfile:
     """
     (pyCMS) Creates a profile.


### PR DESCRIPTION
`colorTemp` is hinted as a float,
https://github.com/python-pillow/Pillow/blob/4f4b0bc74816ac7ea7a47127905a5cba3f6067b8/src/PIL/ImageCms.py#L756-L758
but described in the docstring as an integer.
https://github.com/python-pillow/Pillow/blob/4f4b0bc74816ac7ea7a47127905a5cba3f6067b8/src/PIL/ImageCms.py#L780

I've updated the docstring to say 'float' instead. 

I've also changed the default from -1 to 0. This has [no effect](https://github.com/python-pillow/Pillow/blob/4f4b0bc74816ac7ea7a47127905a5cba3f6067b8/src/_imagingcms.c#L549-L559), it just seems simpler to me. It also matches the default in the C layer.