### PR TITLE
Use DCTDecode and SMask when saving LA and RGBA PDF images

### DIFF
--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -12,7 +12,7 @@ import pytest
 
 from PIL import Image, PdfParser, features
 
-from .helper import hopper, mark_if_feature_version, skip_unless_feature
+from .helper import hopper, mark_if_feature_version
 
 
 def helper_save_as_pdf(tmp_path: Path, mode: str, **kwargs: Any) -> str:
@@ -41,14 +41,8 @@ def helper_save_as_pdf(tmp_path: Path, mode: str, **kwargs: Any) -> str:
     return outfile
 
 
-@pytest.mark.parametrize("mode", ("L", "P", "RGB", "CMYK"))
+@pytest.mark.parametrize("mode", ("L", "LA", "P", "RGB", "RGBA", "CMYK"))
 def test_save(tmp_path: Path, mode: str) -> None:
-    helper_save_as_pdf(tmp_path, mode)
-
-
-@skip_unless_feature("jpg_2000")
-@pytest.mark.parametrize("mode", ("LA", "RGBA"))
-def test_save_alpha(tmp_path: Path, mode: str) -> None:
     helper_save_as_pdf(tmp_path, mode)
 
 

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1585,9 +1585,8 @@ files. Different encoding methods are used, depending on the image mode.
 
 * 1 mode images are saved using TIFF encoding, or JPEG encoding if libtiff support is
   unavailable
-* L, RGB and CMYK mode images use JPEG encoding
+* L, LA, RGB, RGBA and CMYK mode images use JPEG encoding
 * P mode images use HEX encoding
-* LA and RGBA mode images use JPEG2000 encoding
 
 .. _pdf-saving:
 


### PR DESCRIPTION
Resolves #8074

Discussion in the issue revealed that JPXDecode PDFs are not displayed correctly in Firefox. This is the filter that Pillow uses to save [LA](https://github.com/python-pillow/Pillow/pull/7299) and [RGBA](https://github.com/python-pillow/Pillow/pull/6925) images. There is an [open issue about the Firefox problem](https://github.com/mozilla/pdf.js/issues/16782), but in the meantime, there was a [suggestion that we could use SMasks instead](https://github.com/python-pillow/Pillow/issues/8074#issuecomment-2143739314).