### PR TITLE
Corrected type hint

### DIFF
--- a/src/PIL/ImageCms.py
+++ b/src/PIL/ImageCms.py
@@ -1089,7 +1089,7 @@ def isIntentSupported(
         raise PyCMSError(v) from v
 
 
-def versions() -> tuple[str, str, str, str]:
+def versions() -> tuple[str, str | None, str, str]:
     """
     (pyCMS) Fetches versions.
     """

--- a/src/PIL/_imagingcms.pyi
+++ b/src/PIL/_imagingcms.pyi
@@ -2,7 +2,7 @@ import datetime
 import sys
 from typing import Literal, SupportsFloat, TypedDict
 
-littlecms_version: str
+littlecms_version: str | None
 
 _Tuple3f = tuple[float, float, float]
 _Tuple2x3f = tuple[_Tuple3f, _Tuple3f]


### PR DESCRIPTION
`littlecms_version` may be none, as seen here.

https://github.com/python-pillow/Pillow/blob/eeb1eeab209ac395427d269a7aecfd76d525bdc4/src/_imagingcms.c#L1513