### PR TITLE
Deprecate ImageDraw.getdraw hints parameter

### DIFF
--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -1624,3 +1624,8 @@ def test_incorrectly_ordered_coordinates(xy: tuple[int, int, int, int]) -> None:
         draw.rectangle(xy)
     with pytest.raises(ValueError):
         draw.rounded_rectangle(xy)
+
+
+def test_getdraw():
+    with pytest.warns(DeprecationWarning):
+        ImageDraw.getdraw(None, [])

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -115,6 +115,13 @@ Support for LibTIFF earlier than 4
 Support for LibTIFF earlier than version 4 has been deprecated.
 Upgrade to a newer version of LibTIFF instead.
 
+ImageDraw.getdraw hints argument
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. deprecated:: 10.4.0
+
+The ``hints`` argument in :py:meth:`~PIL.ImageDraw.getdraw()` has been deprecated.
+
 Removed features
 ----------------
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -115,12 +115,12 @@ Support for LibTIFF earlier than 4
 Support for LibTIFF earlier than version 4 has been deprecated.
 Upgrade to a newer version of LibTIFF instead.
 
-ImageDraw.getdraw hints argument
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ImageDraw.getdraw hints parameter
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. deprecated:: 10.4.0
 
-The ``hints`` argument in :py:meth:`~PIL.ImageDraw.getdraw()` has been deprecated.
+The ``hints`` parameter in :py:meth:`~PIL.ImageDraw.getdraw()` has been deprecated.
 
 Removed features
 ----------------

--- a/docs/releasenotes/10.4.0.rst
+++ b/docs/releasenotes/10.4.0.rst
@@ -34,10 +34,10 @@ Support for LibTIFF earlier than 4
 Support for LibTIFF earlier than version 4 has been deprecated.
 Upgrade to a newer version of LibTIFF instead.
 
-ImageDraw.getdraw hints argument
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ImageDraw.getdraw hints parameter
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``hints`` argument in :py:meth:`~PIL.ImageDraw.getdraw()` has been deprecated.
+The ``hints`` parameter in :py:meth:`~PIL.ImageDraw.getdraw()` has been deprecated.
 
 API Changes
 ===========

--- a/docs/releasenotes/10.4.0.rst
+++ b/docs/releasenotes/10.4.0.rst
@@ -34,6 +34,11 @@ Support for LibTIFF earlier than 4
 Support for LibTIFF earlier than version 4 has been deprecated.
 Upgrade to a newer version of LibTIFF instead.
 
+ImageDraw.getdraw hints argument
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``hints`` argument in :py:meth:`~PIL.ImageDraw.getdraw()` has been deprecated.
+
 API Changes
 ===========
 

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -908,7 +908,7 @@ def getdraw(im=None, hints=None):
     :returns: A (drawing context, drawing resource factory) tuple.
     """
     if hints is not None:
-        deprecate("'hints' argument", 12)
+        deprecate("'hints' parameter", 12)
     from . import ImageDraw2
 
     if im:

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -37,6 +37,7 @@ import struct
 from typing import TYPE_CHECKING, AnyStr, Sequence, cast
 
 from . import Image, ImageColor
+from ._deprecate import deprecate
 from ._typing import Coords
 
 """
@@ -902,26 +903,17 @@ except AttributeError:
 
 def getdraw(im=None, hints=None):
     """
-    (Experimental) A more advanced 2D drawing interface for PIL images,
-    based on the WCK interface.
-
     :param im: The image to draw in.
-    :param hints: An optional list of hints.
+    :param hints: An optional list of hints. Deprecated.
     :returns: A (drawing context, drawing resource factory) tuple.
     """
-    # FIXME: this needs more work!
-    # FIXME: come up with a better 'hints' scheme.
-    handler = None
-    if not hints or "nicest" in hints:
-        try:
-            from . import _imagingagg as handler
-        except ImportError:
-            pass
-    if handler is None:
-        from . import ImageDraw2 as handler
+    if hints is not None:
+        deprecate("'hints' argument", 12)
+    from . import ImageDraw2
+
     if im:
-        im = handler.Draw(im)
-    return im, handler
+        im = ImageDraw2.Draw(im)
+    return im, ImageDraw2
 
 
 def floodfill(


### PR DESCRIPTION
`ImageDraw.getdraw()` has a `hints` argument. Its purpose is to indicate whether or not `_imagingagg` should be used instead of `ImageDraw2`.

However, `_imagingagg` doesn't exist, so I suggest deprecating the `hints` argument.