### PR TITLE
Accept 't' suffix for libtiff version

### DIFF
--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -38,7 +38,9 @@ def test_version() -> None:
             assert function(name) == version
             if name != "PIL":
                 if name == "zlib" and version is not None:
-                    version = version.replace(".zlib-ng", "")
+                    version = re.sub(".zlib-ng$", "", version)
+                elif name == "libtiff" and version is not None:
+                    version = re.sub("t$", "", version)
                 assert version is None or re.search(r"\d+(\.\d+)*$", version)
 
     for module in features.modules:


### PR DESCRIPTION
The docker-images alpine build has started failing - https://github.com/python-pillow/docker-images/actions/runs/9444260430/job/26009462397
> FAILED Tests/test_features.py::test_version - AssertionError: assert ('4.6.0t' is None or None)

This is because the libtiff version on alpine has been changed to 4.6.0t - https://git.alpinelinux.org/aports/commit/?id=7f743c559b40c7e47561f032b2cae50681e362fc

So, like #8009, let's update the tests to allow for the suffix.