### PR TITLE
Improve `ImageFont.freetype` support for XDG directories on Linux

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -564,7 +564,7 @@ def test_find_font(
     # catching syntax like errors
     monkeypatch.setattr(sys, "platform", platform)
     if platform == "linux":
-        monkeypatch.setenv("XDG_DATA_HOME", "/home/__pillow__/.local/share")
+        monkeypatch.setenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share"))
         monkeypatch.setenv("XDG_DATA_DIRS", "/usr/share/:/usr/local/share/")
 
     def fake_walker(path: str) -> list[tuple[str, list[str], list[str]]]:

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -564,6 +564,7 @@ def test_find_font(
     # catching syntax like errors
     monkeypatch.setattr(sys, "platform", platform)
     if platform == "linux":
+        monkeypatch.setenv("XDG_DATA_HOME", "/home/__pillow__/.local/share")
         monkeypatch.setenv("XDG_DATA_DIRS", "/usr/share/:/usr/local/share/")
 
     def fake_walker(path: str) -> list[tuple[str, list[str], list[str]]]:

--- a/docs/releasenotes/10.4.0.rst
+++ b/docs/releasenotes/10.4.0.rst
@@ -46,7 +46,7 @@ ImageFont.truetype
 ^^^^^^^^^^^^^^^^^^
 
 :py:func:`~PIL.ImageFont.truetype` now searches for fonts in the directory indicated
-by the ``XDG_DATA_HOME`` envirnorment variable in addition to those specified in
+by the ``XDG_DATA_HOME`` environment variable in addition to those specified in
 ``XDG_DATA_DIRS``.  Additionally, the default for ``XDG_DATA_DIRS`` has been updated
 to match the freedesktop spec.
 

--- a/docs/releasenotes/10.4.0.rst
+++ b/docs/releasenotes/10.4.0.rst
@@ -45,10 +45,10 @@ API Changes
 ImageFont.truetype
 ^^^^^^^^^^^^^^^^^^
 
-:py:func:`~PIL.ImageFont.truetype` now searches for fonts in the directory
-indicated by the ``XDG_DATA_HOME`` in addition to those specified in ``XDG_DATA_DIRS``.
-Additionally, the default for ``XDG_DATA_DIRS`` has been updated to match the
-freedesktop spec.
+:py:func:`~PIL.ImageFont.truetype` now searches for fonts in the directory indicated
+by the ``XDG_DATA_HOME`` envirnorment variable in addition to those specified in
+``XDG_DATA_DIRS``.  Additionally, the default for ``XDG_DATA_DIRS`` has been updated
+to match the freedesktop spec.
 
 TODO
 ^^^^

--- a/docs/releasenotes/10.4.0.rst
+++ b/docs/releasenotes/10.4.0.rst
@@ -45,7 +45,7 @@ API Changes
 ImageFont.truetype
 ^^^^^^^^^^^^^^^^^^
 
-:py:function:`~PIL.ImageFont.truetype` now searches for fonts in the directory
+:py:func:`~PIL.ImageFont.truetype` now searches for fonts in the directory
 indicated by the ``XDG_DATA_HOME`` in addition to those specified in ``XDG_DATA_DIRS``.
 Additionally, the default for ``XDG_DATA_DIRS`` has been updated to match the
 freedesktop spec.

--- a/docs/releasenotes/10.4.0.rst
+++ b/docs/releasenotes/10.4.0.rst
@@ -42,14 +42,6 @@ The ``hints`` parameter in :py:meth:`~PIL.ImageDraw.getdraw()` has been deprecat
 API Changes
 ===========
 
-ImageFont.truetype
-^^^^^^^^^^^^^^^^^^
-
-:py:func:`~PIL.ImageFont.truetype` now searches for fonts in the directory indicated
-by the ``XDG_DATA_HOME`` environment variable in addition to those specified in
-``XDG_DATA_DIRS``.  Additionally, the default for ``XDG_DATA_DIRS`` has been updated
-to match the freedesktop spec.
-
 TODO
 ^^^^
 

--- a/docs/releasenotes/10.4.0.rst
+++ b/docs/releasenotes/10.4.0.rst
@@ -42,6 +42,14 @@ The ``hints`` parameter in :py:meth:`~PIL.ImageDraw.getdraw()` has been deprecat
 API Changes
 ===========
 
+ImageFont.truetype
+^^^^^^^^^^^^^^^^^^
+
+:py:function:`~PIL.ImageFont.truetype` now searches for fonts in the directory
+indicated by the ``XDG_DATA_HOME`` in addition to those specified in ``XDG_DATA_DIRS``.
+Additionally, the default for ``XDG_DATA_DIRS`` has been updated to match the
+freedesktop spec.
+
 TODO
 ^^^^
 

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -775,10 +775,15 @@ def truetype(
 
     :param font: A filename or file-like object containing a TrueType font.
                  If the file is not found in this filename, the loader may also
-                 search in other directories, such as the :file:`fonts/`
-                 directory on Windows or :file:`/Library/Fonts/`,
-                 :file:`/System/Library/Fonts/` and :file:`~/Library/Fonts/` on
-                 macOS.
+                 search in other directories, such as:
+
+                 * The :file:`fonts/` directory on Windows,
+                 * :file:`/Library/Fonts/`, :file:`/System/Library/Fonts/`
+                   and :file:`~/Library/Fonts/` on macOS.
+                 * :file:`~/.local/share/fonts`, :file:`/usr/local/share/fonts`,
+                   and :file:`/usr/share/fonts` on Linux; or those specified by
+                   the ``XDG_DATA_HOME`` and ``XDG_DATA_DIRS`` environment variables
+                   for user-installed and system-wide fonts, respectively.
 
     :param size: The requested size, in pixels.
     :param index: Which font face to load (default is first available face).

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -837,12 +837,19 @@ def truetype(
             if windir:
                 dirs.append(os.path.join(windir, "fonts"))
         elif sys.platform in ("linux", "linux2"):
-            lindirs = os.environ.get("XDG_DATA_DIRS")
-            if not lindirs:
-                # According to the freedesktop spec, XDG_DATA_DIRS should
-                # default to /usr/share
-                lindirs = "/usr/share"
-            dirs += [os.path.join(lindir, "fonts") for lindir in lindirs.split(":")]
+            data_home = os.environ.get("XDG_DATA_HOME")
+            if not data_home:
+                # The freedesktop spec defines the following default directory for
+                # when XDG_DATA_HOME is unset or empty. This user-level directory
+                # takes precedence over system-level directories.
+                data_home = os.path.expanduser("~/.local/share")
+            dirs.append(os.path.join(data_home, "fonts"))
+
+            data_dirs = os.environ.get("XDG_DATA_DIRS")
+            if not data_dirs:
+                # Similarly, defaults are defined for the system-level directories
+                data_dirs = "/usr/local/share:/usr/share"
+            dirs += [os.path.join(ddir, "fonts") for ddir in data_dirs.split(":")]
         elif sys.platform == "darwin":
             dirs += [
                 "/Library/Fonts",


### PR DESCRIPTION
Changes proposed in this pull request:

For `ImageFont.freetype`:

* Add support for searching fonts in the user data directory indicated by `XDG_DATA_HOME` or its default, before searching in system-wide directories.
* Update the default value for `XDG_DATA_DIRS` to include the directory for system-local fonts in `/usr/local/share/fonts`.

These changes allow searching for both user-installed fonts, and fonts that aren't managed by the system package manager, such as when Microsoft fonts are installed by `mscorefonts-installer` into `/usr/local`.

Reference: [version 0.8 of the freedesktop base directory spec](https://specifications.freedesktop.org/basedir-spec/0.8/)