### PR TITLE
Corrected AppVeyor Ghostscript path

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ install:
 - curl -fsSL -o nasm-win64.zip https://raw.githubusercontent.com/python-pillow/pillow-depends/main/nasm-2.16.03-win64.zip
 - 7z x nasm-win64.zip -oc:\
 - choco install ghostscript --version=10.3.1
-- path c:\nasm-2.16.03;C:\Program Files\gs\gs10.00.0\bin;%PATH%
+- path c:\nasm-2.16.03;C:\Program Files\gs\gs10.03.1\bin;%PATH%
 - cd c:\pillow\winbuild\
 - ps: |
         c:\python38\python.exe c:\pillow\winbuild\build_prepare.py -v --depends=C:\pillow-depends\


### PR DESCRIPTION
Ghostscript is not currently detected on AppVeyor - https://ci.appveyor.com/project/Python-pillow/pillow/builds/50010618/job/q3r9wd89bu5xt9l5?fullLog=true#L3964

This fixes it by correcting the Ghostscript path.