### PR TITLE
Ignore brew dependencies for libraqm on macOS 13

### DIFF
--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -7,11 +7,15 @@ brew install \
     ghostscript \
     libimagequant \
     libjpeg \
-    libraqm \
     libtiff \
     little-cms2 \
     openjpeg \
     webp
+if [[ "$ImageOS" == "macos13" ]]; then
+    brew install --ignore-dependencies libraqm
+else
+    brew install libraqm
+fi
 export PKG_CONFIG_PATH="/usr/local/opt/openblas/lib/pkgconfig"
 
 # TODO Update condition when cffi supports 3.13


### PR DESCRIPTION
The macOS 13 GitHub Actions jobs have started failing - https://github.com/python-pillow/Pillow/actions/runs/9524124798/job/26256604583#step:7:150

> ==> Pouring libraqm--0.10.1.ventura.bottle.tar.gz
> 🍺  /usr/local/Cellar/libraqm/0.10.1: 12 files, 104KB
> ==> Caveats
> ==> jpeg
> jpeg is keg-only, which means it was not symlinked into /usr/local,
> because it conflicts with `jpeg-turbo`.
> 
> If you need to have jpeg first in your PATH, run:
>   echo 'export PATH="/usr/local/opt/jpeg/bin:$PATH"' >> /Users/runner/.bash_profile
> 
> For compilers to find jpeg you may need to set:
>   export LDFLAGS="-L/usr/local/opt/jpeg/lib"
>   export CPPFLAGS="-I/usr/local/opt/jpeg/include"
> 
> For pkg-config to find jpeg you may need to set:
>   export PKG_CONFIG_PATH="/usr/local/opt/jpeg/lib/pkgconfig"
> Error: Process completed with exit code 1.

Ignoring the dependencies when installing libraqm resolves the error.