### PR TITLE
Added byte support to FreeTypeFont

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -1096,6 +1096,23 @@ def test_too_many_characters(font: ImageFont.FreeTypeFont) -> None:
         imagefont.getmask("A" * 1_000_001)
 
 
+def test_bytes(font: ImageFont.FreeTypeFont) -> None:
+    assert font.getlength(b"test") == font.getlength("test")
+
+    assert font.getbbox(b"test") == font.getbbox("test")
+
+    assert_image_equal(
+        Image.Image()._new(font.getmask(b"test")),
+        Image.Image()._new(font.getmask("test")),
+    )
+
+    assert_image_equal(
+        Image.Image()._new(font.getmask2(b"test")[0]),
+        Image.Image()._new(font.getmask2("test")[0]),
+    )
+    assert font.getmask2(b"test")[1] == font.getmask2("test")[1]
+
+
 @pytest.mark.parametrize(
     "test_file",
     [

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -279,7 +279,7 @@ class FreeTypeFont:
         return self.font.ascent, self.font.descent
 
     def getlength(
-        self, text: str, mode="", direction=None, features=None, language=None
+        self, text: str | bytes, mode="", direction=None, features=None, language=None
     ) -> float:
         """
         Returns length (in pixels with 1/64 precision) of given text when rendered
@@ -354,7 +354,7 @@ class FreeTypeFont:
 
     def getbbox(
         self,
-        text: str,
+        text: str | bytes,
         mode: str = "",
         direction: str | None = None,
         features: list[str] | None = None,
@@ -511,7 +511,7 @@ class FreeTypeFont:
 
     def getmask2(
         self,
-        text: str,
+        text: str | bytes,
         mode="",
         direction=None,
         features=None,
@@ -730,7 +730,7 @@ class TransposedFont:
             return 0, 0, height, width
         return 0, 0, width, height
 
-    def getlength(self, text: str, *args, **kwargs) -> float:
+    def getlength(self, text: str | bytes, *args, **kwargs) -> float:
         if self.orientation in (Image.Transpose.ROTATE_90, Image.Transpose.ROTATE_270):
             msg = "text length is undefined for text rotated by 90 or 270 degrees"
             raise ValueError(msg)

--- a/src/PIL/_imagingft.pyi
+++ b/src/PIL/_imagingft.pyi
@@ -27,7 +27,7 @@ class Font:
     def glyphs(self) -> int: ...
     def render(
         self,
-        string: str,
+        string: str | bytes,
         fill,
         mode=...,
         dir=...,
@@ -51,7 +51,7 @@ class Font:
         /,
     ) -> tuple[tuple[int, int], tuple[int, int]]: ...
     def getlength(
-        self, string: str, mode=..., dir=..., features=..., lang=..., /
+        self, string: str | bytes, mode=..., dir=..., features=..., lang=..., /
     ) -> float: ...
     def getvarnames(self) -> list[bytes]: ...
     def getvaraxes(self) -> list[_Axis] | None: ...


### PR DESCRIPTION
Currently, `FreeTypeFont` doesn't support bytes, while the less-used `ImageFont` does.
```pycon
>>> from PIL import ImageFont
>>> font = ImageFont.load_default()
>>> font
<PIL.ImageFont.FreeTypeFont object at 0x102bbac10>
>>> font.getlength("test")
16.0
>>> font.getlength(b"test")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/ImageFont.py", line 353, in getlength
    return self.font.getlength(text, mode, direction, features, language) / 64
TypeError: expected string
>>> from PIL import _util
>>> ImageFont.core = _util.DeferredError(ImportError)
>>> font = ImageFont.load_default()
>>> font
<PIL.ImageFont.ImageFont object at 0x102d23910>
>>> font.getlength("test")
24
>>> font.getlength(b"test")
24
```

This adds byte support to FreeTypeFont.