### PR TITLE
Prevent extra EPS header validations

### DIFF
--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -231,9 +231,9 @@ class EpsImageFile(ImageFile.ImageFile):
 
         def check_required_header_comments() -> None:
             """
-            The EPS spec requires that some headers exist.
-            This should be checked after all headers have been read,
-            or at the end of the file if that comes first.
+            The EPS specification requires that some headers exist.
+            This should be checked when the header comments formally end,
+            when image data starts, or when the file ends, whichever comes first.
             """
             if "PS-Adobe" not in self.info:
                 msg = 'EPS header missing "%!PS-Adobe" comment'

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -230,6 +230,11 @@ class EpsImageFile(ImageFile.ImageFile):
         trailer_reached = False
 
         def check_required_header_comments() -> None:
+            """
+            The EPS spec requires that some headers exist.
+            This should be checked after all headers have been read,
+            or at the end of the file if that comes first.
+            """
             if "PS-Adobe" not in self.info:
                 msg = 'EPS header missing "%!PS-Adobe" comment'
                 raise SyntaxError(msg)
@@ -270,6 +275,8 @@ class EpsImageFile(ImageFile.ImageFile):
             if byte == b"":
                 # if we didn't read a byte we must be at the end of the file
                 if bytes_read == 0:
+                    if reading_header_comments:
+                        check_required_header_comments()
                     break
             elif byte in b"\r\n":
                 # if we read a line ending character, ignore it and parse what
@@ -364,8 +371,6 @@ class EpsImageFile(ImageFile.ImageFile):
             elif bytes_mv[:9] == b"%%Trailer":
                 trailer_reached = True
             bytes_read = 0
-
-        check_required_header_comments()
 
         if not self._size:
             msg = "cannot determine EPS bounding box"


### PR DESCRIPTION
This is the only return statement in this function, and it appears to be unnecessary since breaking from the loop at this location accomplishes the same thing, and matches what the rest of this loop does.

The only change is that `check_required_header_comments()` is called at the end of the function. This was being skipped before due to the early return, but it will be called now that it's just breaking from the loop.

Before 8f75cc2bbf9cb274a7167f895ab0d437ddca1c07 this return was inside a nested loop, so breaking wouldn't have worked, but now it does. Also, `check_required_header_comments()` didn't exist at that time, so the early return wasn't skipping anything.