### PR TITLE
Removed support for Qt 5

### DIFF
--- a/Tests/test_imageqt.py
+++ b/Tests/test_imageqt.py
@@ -41,18 +41,13 @@ def test_rgb() -> None:
     checkrgb(0, 0, 255)
 
 
-def test_image() -> None:
-    modes = ["1", "RGB", "RGBA", "L", "P"]
-    qt_format = ImageQt.QImage.Format if ImageQt.qt_version == "6" else ImageQt.QImage
-    if hasattr(qt_format, "Format_Grayscale16"):  # Qt 5.13+
-        modes.append("I;16")
-
-    for mode in modes:
-        im = hopper(mode)
-        roundtripped_im = ImageQt.fromqimage(ImageQt.ImageQt(im))
-        if mode not in ("RGB", "RGBA"):
-            im = im.convert("RGB")
-        assert_image_similar(roundtripped_im, im, 1)
+@pytest.mark.parametrize("mode", ("1", "RGB", "RGBA", "L", "P", "I;16"))
+def test_image(mode: str) -> None:
+    im = hopper(mode)
+    roundtripped_im = ImageQt.fromqimage(ImageQt.ImageQt(im))
+    if mode not in ("RGB", "RGBA"):
+        im = im.convert("RGB")
+    assert_image_similar(roundtripped_im, im, 1)
 
 
 def test_closed_file() -> None:

--- a/src/PIL/ImageQt.py
+++ b/src/PIL/ImageQt.py
@@ -152,7 +152,7 @@ def _toqclass_helper(im):
     elif im.mode == "RGBA":
         data = im.tobytes("raw", "BGRA")
         format = qt_format.Format_ARGB32
-    elif im.mode == "I;16" and hasattr(qt_format, "Format_Grayscale16"):  # Qt 5.13+
+    elif im.mode == "I;16":
         im = im.point(lambda i: i * 256)
 
         format = qt_format.Format_Grayscale16


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/4b258be3bbedbdd54ef65140a14982b086d10c7b/src/PIL/ImageQt.py#L155
https://github.com/python-pillow/Pillow/blob/4b258be3bbedbdd54ef65140a14982b086d10c7b/Tests/test_imageqt.py#L46-L48

Support for Qt 5 was [removed in Pillow 10.0.0](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#pyqt5-and-pyside2), so this code can be simplified.