### PR TITLE
Clarify ImageDraw2 error message when size is missing

### DIFF
--- a/Tests/test_imagedraw2.py
+++ b/Tests/test_imagedraw2.py
@@ -57,6 +57,14 @@ def test_sanity() -> None:
     draw2.line(list(range(10)), pen)
 
 
+def test_mode() -> None:
+    draw = ImageDraw2.Draw("L", (1, 1))
+    assert draw.image.mode == "L"
+
+    with pytest.raises(ValueError):
+        ImageDraw2.Draw("L")
+
+
 @pytest.mark.parametrize("bbox", BBOX)
 def test_ellipse(bbox: Coords) -> None:
     # Arrange

--- a/src/PIL/ImageDraw2.py
+++ b/src/PIL/ImageDraw2.py
@@ -56,8 +56,16 @@ class Draw:
     (Experimental) WCK-style drawing interface
     """
 
-    def __init__(self, image, size=None, color=None):
-        if not hasattr(image, "im"):
+    def __init__(
+        self,
+        image: Image.Image | str,
+        size: tuple[int, int] | list[int] | None = None,
+        color: float | tuple[float, ...] | str | None = None,
+    ) -> None:
+        if isinstance(image, str):
+            if size is None:
+                msg = "If image argument is mode string, size must be a list or tuple"
+                raise ValueError(msg)
             image = Image.new(image, size, color)
         self.draw = ImageDraw.Draw(image)
         self.image = image


### PR DESCRIPTION
When creating an `ImageDraw2.Draw` instance, `image` can be either an image or a mode string.

https://github.com/python-pillow/Pillow/blob/920698eea7693012d945300b2b87a16ae8f0706a/src/PIL/ImageDraw2.py#L59-L62

If you provide a mode string without a size, you get an error saying that size must be a list or a tuple.
```pytb
>>> from PIL import ImageDraw2
>>> ImageDraw2.Draw("RGB", size=None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/ImageDraw2.py", line 61, in __init__
    image = Image.new(image, size, color)
  File "PIL/Image.py", line 3061, in new
    _check_size(size)
  File "PIL/Image.py", line 3029, in _check_size
    raise ValueError(msg)
ValueError: Size must be a list or tuple
```
Except, if you provided an image as the first argument, then `size` can be `None` without a problem.

```pycon
>>> from PIL import Image
>>> im = Image.new("RGB", (1, 1))
>>> ImageDraw2.Draw(im, size=None)
<PIL.ImageDraw2.Draw object at 0x10084cdf0>
```

This is conceivably confusing, so this PR clarifies the situation, by changing the error to
> If image argument is mode string, size must be a list or tuple