### PR TITLE
Use more specific error

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -337,7 +337,7 @@ def test_issue_6194() -> None:
 
 def test_unbound_local() -> None:
     # prepatch, a malformed jp2 file could cause an UnboundLocalError exception.
-    with pytest.raises(OSError):
+    with pytest.raises(UnidentifiedImageError):
         with Image.open("Tests/images/unbound_variable.jp2"):
             pass
 


### PR DESCRIPTION
I was just looking at
https://github.com/python-pillow/Pillow/blob/e7c1da3cc8a26b821e0a4ec2d4651d62271f00c5/Tests/test_file_jpeg2k.py#L338-L342
which triggers a SyntaxError
https://github.com/python-pillow/Pillow/blob/e7c1da3cc8a26b821e0a4ec2d4651d62271f00c5/src/PIL/Jpeg2KImagePlugin.py#L205-L207
and wondering why that didn't [lead to an UnidentifiedImageError.](https://github.com/python-pillow/Pillow/blob/e7c1da3cc8a26b821e0a4ec2d4651d62271f00c5/src/PIL/Image.py#L3463-L3504)

The answer was that it did, but `UnidentifiedImageError` inherits from `OSError`, so the test passed without a problem.
https://github.com/python-pillow/Pillow/blob/e7c1da3cc8a26b821e0a4ec2d4651d62271f00c5/src/PIL/__init__.py#L77

This PR just updated the test to check for `UnidentifiedImageError`, to be clearer.