### PR TITLE
Remove zero-byte end padding when parsing any XMP data

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1511,7 +1511,7 @@ class Image:
             return {}
         if "xmp" not in self.info:
             return {}
-        root = ElementTree.fromstring(self.info["xmp"])
+        root = ElementTree.fromstring(self.info["xmp"].rstrip(b"\x00"))
         return {get_name(root.tag): get_value(root)}
 
     def getexif(self) -> Exif:

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -96,7 +96,7 @@ def APP(self, marker):
             self.info["exif"] = s
             self._exif_offset = self.fp.tell() - n + 6
     elif marker == 0xFFE1 and s[:29] == b"http://ns.adobe.com/xap/1.0/\x00":
-        self.info["xmp"] = s.split(b"\x00")[1]
+        self.info["xmp"] = s.split(b"\x00", 1)[1]
     elif marker == 0xFFE2 and s[:5] == b"FPXR\0":
         # extract FlashPix information (incomplete)
         self.info["flashpix"] = s  # FIXME: value will change


### PR DESCRIPTION
Last year, we received a report of a JPEG image where [XMP data was zero-padded at the end](https://github.com/python-pillow/Pillow/issues/7273). I created a fix for that [by adjusting JpegImagePlugin.](https://github.com/python-pillow/Pillow/pull/7274/commits/2488167f33b7e357315c7052273b973fe2cad8e8)

Now https://github.com/python-pillow/Pillow/pull/8069#issuecomment-2186382029 reports that XMP data might also be zero-padded for another format.

So this PR removes zero-byte end padding from XMP data for all formats, not just JPEG.