### PR TITLE
Do not presume "xmp" info simply because "XML:com.adobe.xmp" info exists

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -432,6 +432,16 @@ def test_exif_transpose() -> None:
     assert 0x0112 not in transposed_im.getexif()
 
 
+def test_exif_transpose_xml_without_xmp() -> None:
+    with Image.open("Tests/images/xmp_tags_orientation.png") as im:
+        assert im.getexif()[0x0112] == 3
+        assert "XML:com.adobe.xmp" in im.info
+
+        del im.info["xmp"]
+        transposed_im = ImageOps.exif_transpose(im)
+        assert 0x0112 not in transposed_im.getexif()
+
+
 def test_exif_transpose_in_place() -> None:
     with Image.open("Tests/images/orientation_rectangle.jpg") as im:
         assert im.size == (2, 1)

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -709,17 +709,18 @@ def exif_transpose(image: Image.Image, *, in_place: bool = False) -> Image.Image
                 exif_image.info["exif"] = exif.tobytes()
             elif "Raw profile type exif" in exif_image.info:
                 exif_image.info["Raw profile type exif"] = exif.tobytes().hex()
-            elif "XML:com.adobe.xmp" in exif_image.info:
-                for pattern in (
-                    r'tiff:Orientation="([0-9])"',
-                    r"<tiff:Orientation>([0-9])</tiff:Orientation>",
-                ):
-                    exif_image.info["XML:com.adobe.xmp"] = re.sub(
-                        pattern, "", exif_image.info["XML:com.adobe.xmp"]
-                    )
-                    exif_image.info["xmp"] = re.sub(
-                        pattern.encode(), b"", exif_image.info["xmp"]
-                    )
+            for key in ("XML:com.adobe.xmp", "xmp"):
+                if key in exif_image.info:
+                    for pattern in (
+                        r'tiff:Orientation="([0-9])"',
+                        r"<tiff:Orientation>([0-9])</tiff:Orientation>",
+                    ):
+                        value = exif_image.info[key]
+                        exif_image.info[key] = (
+                            re.sub(pattern, "", value)
+                            if isinstance(value, str)
+                            else re.sub(pattern.encode(), b"", value)
+                        )
         if not in_place:
             return transposed_image
     elif not in_place:


### PR DESCRIPTION
#8069 changed `ImageOps.exif_transpose()` so that when updating a PNG image's `im.info["XML:com.adobe.xmp"]`, it would update the newly added `im.info["xmp"]` as well.

However, https://github.com/python-pillow/Pillow/pull/8171#issuecomment-2191625500 has pointed out that our code shouldn't presume that the user didn't manually set `im.info["XML:com.adobe.xmp"]` themselves, in which case `im.info["xmp"]` might be absent.