### PR TITLE
Add support for Python 3.13

### DIFF
--- a/docs/installation/newer-versions.csv
+++ b/docs/installation/newer-versions.csv
@@ -1,8 +1,9 @@
-﻿Python,3.12,3.11,3.10,3.9,3.8,3.7,3.6,3.5
-Pillow >= 10.1,Yes,Yes,Yes,Yes,Yes,,,
-Pillow 10.0,,Yes,Yes,Yes,Yes,,,
-Pillow 9.3 - 9.5,,Yes,Yes,Yes,Yes,Yes,,
-Pillow 9.0 - 9.2,,,Yes,Yes,Yes,Yes,,
-Pillow 8.3.2 - 8.4,,,Yes,Yes,Yes,Yes,Yes,
-Pillow 8.0 - 8.3.1,,,,Yes,Yes,Yes,Yes,
-Pillow 7.0 - 7.2,,,,,Yes,Yes,Yes,Yes
+﻿Python,3.13,3.12,3.11,3.10,3.9,3.8,3.7,3.6,3.5
+Pillow >= 11,Yes,Yes,Yes,Yes,Yes,Yes,,,
+Pillow >= 10.1,,Yes,Yes,Yes,Yes,Yes,,,
+Pillow 10.0,,,Yes,Yes,Yes,Yes,,,
+Pillow 9.3 - 9.5,,,Yes,Yes,Yes,Yes,Yes,,
+Pillow 9.0 - 9.2,,,,Yes,Yes,Yes,Yes,,
+Pillow 8.3.2 - 8.4,,,,Yes,Yes,Yes,Yes,Yes,
+Pillow 8.0 - 8.3.1,,,,,Yes,Yes,Yes,Yes,
+Pillow 7.0 - 7.2,,,,,,Yes,Yes,Yes,Yes

--- a/docs/installation/newer-versions.csv
+++ b/docs/installation/newer-versions.csv
@@ -1,6 +1,6 @@
 ﻿Python,3.13,3.12,3.11,3.10,3.9,3.8,3.7,3.6,3.5
 Pillow >= 11,Yes,Yes,Yes,Yes,Yes,Yes,,,
-Pillow >= 10.1,,Yes,Yes,Yes,Yes,Yes,,,
+Pillow 10.1 - 10.4,,Yes,Yes,Yes,Yes,Yes,,,
 Pillow 10.0,,,Yes,Yes,Yes,Yes,,,
 Pillow 9.3 - 9.5,,,Yes,Yes,Yes,Yes,Yes,,
 Pillow 9.0 - 9.2,,,,Yes,Yes,Yes,Yes,,

--- a/docs/releasenotes/11.0.0.rst
+++ b/docs/releasenotes/11.0.0.rst
@@ -61,7 +61,11 @@ TODO
 Other Changes
 =============
 
-TODO
-^^^^
+Python 3.13
+^^^^^^^^^^^
 
-TODO
+Pillow 10.4.0 had wheels built against Python 3.13 beta, available as a preview to help
+others prepare for 3.13, and to ensure Pillow could be used immediately at the release
+of 3.13.0 final (2024-10-01, :pep:`719`).
+
+Pillow 11.0.0 now officially supports Python 3.13.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Multimedia :: Graphics",
@@ -135,6 +136,9 @@ lint.isort.known-first-party = [
 lint.isort.required-imports = [
   "from __future__ import annotations",
 ]
+
+[tool.pyproject-fmt]
+max_supported_python = "3.13"
 
 [tool.pytest.ini_options]
 addopts = "-ra --color=yes"

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ WEBP_ROOT = None
 ZLIB_ROOT = None
 FUZZING_BUILD = "LIB_FUZZING_ENGINE" in os.environ
 
-if sys.platform == "win32" and sys.version_info >= (3, 13):
+if sys.platform == "win32" and sys.version_info >= (3, 14):
     import atexit
 
     atexit.register(

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
     tox>=4.2
 env_list =
     lint
-    py{py3, 312, 311, 310, 39, 38}
+    py{py3, 313, 312, 311, 310, 39, 38}
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.13.0 final is planned for 2024-10-01:

* https://peps.python.org/pep-0719/

Pillow 11.0.0 is planned for 2024-10-15 and will officially support Python 3.13: 

* https://github.com/python-pillow/Pillow/milestone/48

We've already released wheels for the beta, but this adds official support and the Trove classifier.