### PR TITLE
Updated CVE URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -338,7 +338,7 @@ linkcheck_allowed_redirects = {
 # https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html
 _repo = "https://github.com/python-pillow/Pillow/"
 extlinks = {
-    "cve": ("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-%s", "CVE-%s"),
+    "cve": ("https://www.cve.org/CVERecord?id=CVE-%s", "CVE-%s"),
     "cwe": ("https://cwe.mitre.org/data/definitions/%s.html", "CWE-%s"),
     "issue": (_repo + "issues/%s", "#%s"),
     "pr": (_repo + "pull/%s", "#%s"),


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-28219
> NOTICE: Transition to the all-new CVE website at [WWW.CVE.ORG](https://www.cve.org/) and [CVE Record Format JSON](https://www.cve.org/Media/News/item/blog/2022/10/06/CVE-Records-Are-Now-Displayed) are underway.

This PR updates the URL for CVEs in our documentation.