### PR TITLE
Fix incompatibility with NumPy 1.20 

### DIFF
--- a/src/PIL/_typing.py
+++ b/src/PIL/_typing.py
@@ -7,8 +7,8 @@ from typing import Any, Protocol, Sequence, TypeVar, Union
 try:
     import numpy.typing as npt
 
-    NumpyArray = npt.NDArray[Any]
-except ImportError:
+    NumpyArray = npt.NDArray[Any]  # requires numpy>=1.21
+except (ImportError, AttributeError):
     pass
 
 if sys.version_info >= (3, 10):


### PR DESCRIPTION
Fixes an incompatibility encountered in the wild when importing `Pillow==10.4.0` with `numpy==1.20.x` installed.
