### PR TITLE
Optimize getbbox() and getextrema() routines

### DIFF
--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -53,6 +53,8 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
         for (x = 0; x < im->xsize; x++)                      \
             if (im->image[y][x] & mask) {                    \
                 has_data = 1;                                \
+                if (x < bbox[0])                             \
+                    bbox[0] = x;                             \
                 bbox[3] = y + 1;                             \
                 break;                                       \
             }                                                \

--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -31,7 +31,7 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
     bbox[2] = bbox[3] = 0;
 
 #define GETBBOX(image, mask)                                 \
-    /* first stage: looking for any px from top */           \
+    /* first stage: looking for any pixels from top */       \
     for (y = 0; y < im->ysize; y++) {                        \
         has_data = 0;                                        \
         for (x = 0; x < im->xsize; x++) {                    \
@@ -46,11 +46,11 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
             break;                                           \
         }                                                    \
     }                                                        \
-    /* Check that we got a box */                            \
+    /* Check that we have a box */                           \
     if (bbox[1] < 0) {                                       \
         return 0; /* no data */                              \
     }                                                        \
-    /* second stage: looking for any px from bottom */       \
+    /* second stage: looking for any pixels from bottom */   \
     for (y = im->ysize - 1; y >= bbox[1]; y--) {             \
         has_data = 0;                                        \
         for (x = 0; x < im->xsize; x++) {                    \

--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -30,26 +30,45 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
     bbox[1] = -1;
     bbox[2] = bbox[3] = 0;
 
-#define GETBBOX(image, mask)              \
-    for (y = 0; y < im->ysize; y++) {     \
-        has_data = 0;                     \
-        for (x = 0; x < im->xsize; x++) { \
-            if (im->image[y][x] & mask) { \
-                has_data = 1;             \
-                if (x < bbox[0]) {        \
-                    bbox[0] = x;          \
-                }                         \
-                if (x >= bbox[2]) {       \
-                    bbox[2] = x + 1;      \
-                }                         \
-            }                             \
-        }                                 \
-        if (has_data) {                   \
-            if (bbox[1] < 0) {            \
-                bbox[1] = y;              \
-            }                             \
-            bbox[3] = y + 1;              \
-        }                                 \
+#define	GETBBOX(image, mask)                                 \
+    /* first stage: looking for any px from top */           \
+    for (y = 0; y < im->ysize; y++) {                        \
+        has_data = 0;                                        \
+        for (x = 0; x < im->xsize; x++)                      \
+            if (im->image[y][x] & mask) {                    \
+                has_data = 1;                                \
+                bbox[0] = x;                                 \
+                bbox[1] = y;                                 \
+                break;                                       \
+            }                                                \
+        if (has_data) break;                                 \
+    }                                                        \
+    /* Check that we got a box */                            \
+    if (bbox[1] < 0)                                         \
+        return 0; /* no data */                              \
+    /* second stage: looking for any px from bottom */       \
+    for (y = im->ysize - 1; y >= bbox[1]; y--) {             \
+        has_data = 0;                                        \
+        for (x = 0; x < im->xsize; x++)                      \
+            if (im->image[y][x] & mask) {                    \
+                has_data = 1;                                \
+                bbox[3] = y + 1;                             \
+                break;                                       \
+            }                                                \
+        if (has_data) break;                                 \
+    }                                                        \
+    /* third stage: looking for left and right boundaries */ \
+    for (y = bbox[1]; y < bbox[3]; y++) {                    \
+        for (x = 0; x < bbox[0]; x++)                        \
+            if (im->image[y][x] & mask) {                    \
+                bbox[0] = x;                                 \
+                break;                                       \
+            }                                                \
+        for (x = im->xsize - 1; x >= bbox[2]; x--)           \
+            if (im->image[y][x] & mask) {                    \
+                bbox[2] = x + 1;                             \
+                break;                                       \
+            }                                                \
     }
 
     if (im->image8) {
@@ -143,6 +162,9 @@ ImagingGetExtrema(Imaging im, void *extrema) {
                     } else if (imax < in[x]) {
                         imax = in[x];
                     }
+                }
+                if (imin == 0 && imax == 255) {
+                    break;
                 }
             }
             ((UINT8 *)extrema)[0] = (UINT8)imin;

--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -34,45 +34,53 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
     /* first stage: looking for any px from top */           \
     for (y = 0; y < im->ysize; y++) {                        \
         has_data = 0;                                        \
-        for (x = 0; x < im->xsize; x++)                      \
+        for (x = 0; x < im->xsize; x++) {                    \
             if (im->image[y][x] & mask) {                    \
                 has_data = 1;                                \
                 bbox[0] = x;                                 \
                 bbox[1] = y;                                 \
                 break;                                       \
             }                                                \
-        if (has_data)                                        \
+        }                                                    \
+        if (has_data) {                                      \
             break;                                           \
+        }                                                    \
     }                                                        \
     /* Check that we got a box */                            \
-    if (bbox[1] < 0)                                         \
+    if (bbox[1] < 0) {                                       \
         return 0; /* no data */                              \
+    }                                                        \
     /* second stage: looking for any px from bottom */       \
     for (y = im->ysize - 1; y >= bbox[1]; y--) {             \
         has_data = 0;                                        \
-        for (x = 0; x < im->xsize; x++)                      \
+        for (x = 0; x < im->xsize; x++) {                    \
             if (im->image[y][x] & mask) {                    \
                 has_data = 1;                                \
-                if (x < bbox[0])                             \
+                if (x < bbox[0]) {                           \
                     bbox[0] = x;                             \
+                }                                            \
                 bbox[3] = y + 1;                             \
                 break;                                       \
             }                                                \
-        if (has_data)                                        \
+        }                                                    \
+        if (has_data) {                                      \
             break;                                           \
+        }                                                    \
     }                                                        \
     /* third stage: looking for left and right boundaries */ \
     for (y = bbox[1]; y < bbox[3]; y++) {                    \
-        for (x = 0; x < bbox[0]; x++)                        \
+        for (x = 0; x < bbox[0]; x++) {                      \
             if (im->image[y][x] & mask) {                    \
                 bbox[0] = x;                                 \
                 break;                                       \
             }                                                \
-        for (x = im->xsize - 1; x >= bbox[2]; x--)           \
+        }                                                    \
+        for (x = im->xsize - 1; x >= bbox[2]; x--) {         \
             if (im->image[y][x] & mask) {                    \
                 bbox[2] = x + 1;                             \
                 break;                                       \
             }                                                \
+        }                                                    \
     }
 
     if (im->image8) {

--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -30,7 +30,7 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
     bbox[1] = -1;
     bbox[2] = bbox[3] = 0;
 
-#define	GETBBOX(image, mask)                                 \
+#define GETBBOX(image, mask)                                 \
     /* first stage: looking for any px from top */           \
     for (y = 0; y < im->ysize; y++) {                        \
         has_data = 0;                                        \
@@ -41,7 +41,8 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
                 bbox[1] = y;                                 \
                 break;                                       \
             }                                                \
-        if (has_data) break;                                 \
+        if (has_data)                                        \
+            break;                                           \
     }                                                        \
     /* Check that we got a box */                            \
     if (bbox[1] < 0)                                         \
@@ -55,7 +56,8 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
                 bbox[3] = y + 1;                             \
                 break;                                       \
             }                                                \
-        if (has_data) break;                                 \
+        if (has_data)                                        \
+            break;                                           \
     }                                                        \
     /* third stage: looking for left and right boundaries */ \
     for (y = bbox[1]; y < bbox[3]; y++) {                    \

--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -92,11 +92,6 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
         GETBBOX(image32, mask);
     }
 
-    /* Check that we got a box */
-    if (bbox[1] < 0) {
-        return 0; /* no data */
-    }
-
     return 1; /* ok */
 }
 


### PR DESCRIPTION
Code for ipython:

```python
from PIL import Image
im = Image.new('L', (2048, 2048), 0)
print('Worst case:', im.getbbox())
%timeit im.getbbox()
im = Image.open('tests/images/face1.png').resize((2048, 2048))
print('Normal case:', im.getbbox())
%timeit im.getbbox()
im = Image.open('tests/images/dices.png').resize((2048, 2048))
print('Normal case:', im.getbbox())
%timeit im.getbbox()
im = im.convert('RGB').convert('RGBA')
print('Best case:', im.getbbox())
%timeit im.getbbox()
im = im.convert('L')
print('Extrema:', im.getextrema())
%timeit im.getextrema()
```

## `main` branch

```python
Worst case: None
2.31 ms ± 3.29 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
Normal case: (150, 474, 1802, 2048)
3.97 ms ± 519 ns per loop (mean ± std. dev. of 7 runs, 100 loops each)
Normal case: (286, 70, 1724, 1797)
3.86 ms ± 461 ns per loop (mean ± std. dev. of 7 runs, 100 loops each)
Best case: (0, 0, 2048, 2048)
4.6 ms ± 464 ns per loop (mean ± std. dev. of 7 runs, 100 loops each)
Extrema: (0, 255)
2.3 ms ± 468 ns per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

## `optimize-getbbox` branch

```python
Worst case: None
1.16 ms ± 1.65 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
Normal case: (150, 474, 1802, 2048)
722 μs ± 161 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
Normal case: (286, 70, 1724, 1797)
874 μs ± 260 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
Best case: (0, 0, 2048, 2048)
2.51 μs ± 18.1 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
Extrema: (0, 255)
97.6 μs ± 5.74 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

```
Worst case: 1.99x speedup
Normal case: 5.5x speedup
Normal case: 4.4x speedup
Best case: 1833x speedup
Extrema: 23.5x speedup
```

## `dices.png` test image

![dices](https://github.com/python-pillow/Pillow/assets/128982/0d6321e8-6194-4a5d-bf22-9cb99c68a133)

## `face1.png` test image

![face1](https://github.com/user-attachments/assets/66e411c2-63a7-4d8c-a7e3-898fb8d3aec3)
