### PR TITLE
Test 3.13 free-threaded build on CI

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -38,7 +38,11 @@ python3 -m pip install pyroma
 
 if [[ $(uname) != CYGWIN* ]]; then
     # TODO Update condition when NumPy supports free-threading
-    if ! [[ "$GHA_PYTHON_VERSION" == "3.13-dev" ]]; then python3 -m pip install numpy ; fi
+    if [[ "$GHA_PYTHON_VERSION" == "3.13-dev" ]]; then
+        python3 -m pip install numpy --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    else
+        python3 -m pip install numpy
+    fi
 
     # PyQt6 doesn't support PyPy3
     if [[ $GHA_PYTHON_VERSION == 3.* ]]; then

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -37,12 +37,14 @@ python3 -m pip install -U pytest-timeout
 python3 -m pip install pyroma
 
 if [[ $(uname) != CYGWIN* ]]; then
-    python3 -m pip install numpy
+    # TODO Update condition when NumPy supports free-threading
+    if ! [[ "$GHA_PYTHON_VERSION" == "3.13-dev" ]]; then python3 -m pip install numpy ; fi
 
     # PyQt6 doesn't support PyPy3
     if [[ $GHA_PYTHON_VERSION == 3.* ]]; then
         sudo apt-get -qq install libegl1 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxkbcommon-x11-0
-        python3 -m pip install pyqt6
+        # TODO Update condition when pyqt6 supports free-threading
+        if ! [[ "$GHA_PYTHON_VERSION" == "3.13-dev" ]]; then python3 -m pip install pyqt6 ; fi
     fi
 
     # Pyroma uses non-isolated build and fails with old setuptools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
         nogil: ${{ matrix.disable-gil }}
 
+    - name: Set PYTHON_GIL
+      if: "${{ matrix.disable-gil }}"
+      run: |
+        echo "PYTHON_GIL=0" >> $GITHUB_ENV
+
     - name: Build system information
       run: python3 .github/workflows/system-info.py
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,19 +50,14 @@ jobs:
           "3.9",
         ]
         include:
-        - python-version: "3.11"
-          PYTHONOPTIMIZE: 1
-          REVERSE: "--reverse"
-        - python-version: "3.10"
-          PYTHONOPTIMIZE: 2
+        - { python-version: "3.11", PYTHONOPTIMIZE: 1, REVERSE: "--reverse" }
+        - { python-version: "3.10", PYTHONOPTIMIZE: 2 }
         # Free-threaded
         - { os: "ubuntu-latest", python-version: "3.13-dev", disable-gil: true }
         # M1 only available for 3.10+
-        - os: "macos-13"
-          python-version: "3.9"
+        - { os: "macos-13", python-version: "3.9" }
         exclude:
-        - os: "macos-14"
-          python-version: "3.9"
+        - { os: "macos-14", python-version: "3.9" }
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         - { os: "macos-14", python-version: "3.9" }
 
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }} Python ${{ matrix.python-version }}
+    name: ${{ matrix.os }} Python ${{ matrix.python-version }} ${{ matrix.disable-gil && 'free-threaded' || '' }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,8 @@ jobs:
           REVERSE: "--reverse"
         - python-version: "3.10"
           PYTHONOPTIMIZE: 2
+        # Free-threaded
+        - { os: "ubuntu-latest", python-version: "3.13-dev", disable-gil: true }
         # M1 only available for 3.10+
         - os: "macos-13"
           python-version: "3.9"
@@ -70,6 +72,7 @@ jobs:
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
+      if: "!endsWith(matrix.python-version, '-dev')"
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -77,6 +80,13 @@ jobs:
         cache-dependency-path: |
           ".ci/*.sh"
           "pyproject.toml"
+
+    - name: Set up Python ${{ matrix.python-version }} (free-threaded)
+      uses: deadsnakes/action@v3.1.0
+      if: endsWith(matrix.python-version, '-dev')
+      with:
+        python-version: ${{ matrix.python-version }}
+        nogil: ${{ matrix.disable-gil }}
 
     - name: Build system information
       run: python3 .github/workflows/system-info.py


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/8199.

Currently GitHub's `actions/setup-python` does not yet support free-threading but it has been requested: https://github.com/actions/setup-python/issues/771 (give it a 👍)

However, it is available via `deadsnakes/action`:

* https://github.com/deadsnakes/action
* https://dev.to/hugovk/help-us-test-free-threaded-python-without-the-gil-1hgf

This PR adds an Ubuntu `3.13-dev` job to the matrix, to run tests with a free-threaded build.

The build actually _runs_ with the GIL enabled, we'll need to explicitly indicate in the extensions that they should run with it disabled. This will be changed in a follow-up PR.

We can check if Python is built with free-threaded mode by looking for "experimental free-threading build" in `python --version --version`. On the CI we can see it under "Build system information":

```
sys.version		 ['3.13.0b2+ experimental free-threading build (main, Jun 27 2024, 08:49:18) [GCC 11.4.0]']
```

https://github.com/python-pillow/Pillow/actions/runs/9794942077/job/27045976814#step:5:10

Compared to the regular build:

```
sys.version		 ['3.13.0b3 (main, Jun 28 2024, 13:42:44) [GCC 11.4.0]']
```

https://github.com/python-pillow/Pillow/actions/runs/9794942077/job/27045975199#step:5:16