### PR TITLE
Group aarch64 wheel jobs

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -41,11 +41,8 @@ jobs:
         python-version:
           - pp39
           - pp310
-          - cp39
-          - cp310
-          - cp311
-          - cp312
-          - cp313
+          - cp3{9,10,11}
+          - cp3{12,13}
         spec:
           - manylinux2014
           - manylinux_2_28


### PR DESCRIPTION
When [building wheels for Pillow 10.4.0](https://github.com/python-pillow/Pillow/actions/runs/9738988796), the longest job was [aarch64 pp310 manylinux_2_28](https://github.com/python-pillow/Pillow/actions/runs/9738988796/job/26873432211) at 2h 16m.

However, since there were 27 wheel building jobs, and we are limited to 20 concurrent runners, it takes longer than any single job. With the recent removal of Python 3.8, things are a bit better, but with [free-threaded wheels](https://github.com/python-pillow/Pillow/issues/8199) on the horizon, there will be more again.

It is the dependency installation that takes most of the time in the jobs, so this PR suggests grouping the aarch64 CPythons together - rather than a job per CPython version, have one job for 3.9, 3.10 and 3.11, and one job for 3.12 and 3.13. I've kept it as two jobs to try and avoid extending the maximum time for a single job.

The overall number of wheel building jobs is thus reduced to 17, less than our limit of concurrent runners.