### PR TITLE
Check test type hints

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -353,7 +353,7 @@ def test_palette_434(tmp_path: Path) -> None:
 
     def roundtrip(im: Image.Image, **kwargs: bool) -> Image.Image:
         out = str(tmp_path / "temp.gif")
-        im.copy().save(out, **kwargs)
+        im.copy().save(out, "GIF", **kwargs)
         reloaded = Image.open(out)
 
         return reloaded

--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -118,7 +118,7 @@ def test_dpi(params: dict[str, int | tuple[int, int]], tmp_path: Path) -> None:
     im = hopper()
 
     outfile = str(tmp_path / "temp.pdf")
-    im.save(outfile, **params)
+    im.save(outfile, "PDF", **params)
 
     with open(outfile, "rb") as fp:
         contents = fp.read()

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -78,6 +78,7 @@ class TestFileTiff:
 
     def test_seek_after_close(self) -> None:
         im = Image.open("Tests/images/multipage.tiff")
+        assert isinstance(im, TiffImagePlugin.TiffImageFile)
         im.close()
 
         with pytest.raises(ValueError):
@@ -424,13 +425,13 @@ class TestFileTiff:
     def test_load_float(self) -> None:
         ifd = TiffImagePlugin.ImageFileDirectory_v2()
         data = b"abcdabcd"
-        ret = ifd.load_float(data, False)
+        ret = getattr(ifd, "load_float")(data, False)
         assert ret == (1.6777999408082104e22, 1.6777999408082104e22)
 
     def test_load_double(self) -> None:
         ifd = TiffImagePlugin.ImageFileDirectory_v2()
         data = b"abcdefghabcdefgh"
-        ret = ifd.load_double(data, False)
+        ret = getattr(ifd, "load_double")(data, False)
         assert ret == (8.540883223036124e194, 8.540883223036124e194)
 
     def test_ifd_tag_type(self) -> None:
@@ -599,7 +600,7 @@ class TestFileTiff:
     def test_with_underscores(self, tmp_path: Path) -> None:
         kwargs = {"resolution_unit": "inch", "x_resolution": 72, "y_resolution": 36}
         filename = str(tmp_path / "temp.tif")
-        hopper("RGB").save(filename, **kwargs)
+        hopper("RGB").save(filename, "TIFF", **kwargs)
         with Image.open(filename) as im:
             # legacy interface
             assert im.tag[X_RESOLUTION][0][0] == 72
@@ -624,14 +625,17 @@ class TestFileTiff:
     def test_iptc(self, tmp_path: Path) -> None:
         # Do not preserve IPTC_NAA_CHUNK by default if type is LONG
         outfile = str(tmp_path / "temp.tif")
-        im = hopper()
-        ifd = TiffImagePlugin.ImageFileDirectory_v2()
-        ifd[33723] = 1
-        ifd.tagtype[33723] = 4
-        im.tag_v2 = ifd
-        im.save(outfile)
+        with Image.open("Tests/images/hopper.tif") as im:
+            im.load()
+            assert isinstance(im, TiffImagePlugin.TiffImageFile)
+            ifd = TiffImagePlugin.ImageFileDirectory_v2()
+            ifd[33723] = 1
+            ifd.tagtype[33723] = 4
+            im.tag_v2 = ifd
+            im.save(outfile)
 
         with Image.open(outfile) as im:
+            assert isinstance(im, TiffImagePlugin.TiffImageFile)
             assert 33723 not in im.tag_v2
 
     def test_rowsperstrip(self, tmp_path: Path) -> None:

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -704,7 +704,7 @@ class TestImage:
             else:
                 assert new_image.palette is None
 
-        _make_new(im, im_p, ImagePalette.ImagePalette(list(range(256)) * 3))
+        _make_new(im, im_p, ImagePalette.ImagePalette("RGB"))
         _make_new(im_p, im, None)
         _make_new(im, blank_p, ImagePalette.ImagePalette())
         _make_new(im, blank_pa, ImagePalette.ImagePalette())

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -60,6 +60,8 @@ class TestImageGrab:
     def test_grabclipboard(self) -> None:
         if sys.platform == "darwin":
             subprocess.call(["screencapture", "-cx"])
+
+            ImageGrab.grabclipboard()
         elif sys.platform == "win32":
             p = subprocess.Popen(["powershell", "-command", "-"], stdin=subprocess.PIPE)
             p.stdin.write(
@@ -69,6 +71,8 @@ $bmp = New-Object Drawing.Bitmap 200, 200
 [Windows.Forms.Clipboard]::SetImage($bmp)"""
             )
             p.communicate()
+
+            ImageGrab.grabclipboard()
         else:
             if not shutil.which("wl-paste") and not shutil.which("xclip"):
                 with pytest.raises(
@@ -77,9 +81,6 @@ $bmp = New-Object Drawing.Bitmap 200, 200
                     r" ImageGrab.grabclipboard\(\) on Linux",
                 ):
                     ImageGrab.grabclipboard()
-            return
-
-        ImageGrab.grabclipboard()
 
     @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
     def test_grabclipboard_file(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,3 +155,11 @@ follow_imports = "silent"
 warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_ignores = true
+exclude = [
+  '^Tests/oss-fuzz/fuzz_font.py$',
+  '^Tests/oss-fuzz/fuzz_pillow.py$',
+  '^Tests/test_qt_image_qapplication.py$',
+  '^Tests/test_font_pcf_charsets.py$',
+  '^Tests/test_font_pcf.py$',
+  '^Tests/test_file_tar.py$',
+]

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1886,7 +1886,7 @@ class Image:
 
     def point(
         self,
-        lut: Sequence[float] | Callable[[int], float] | ImagePointHandler,
+        lut: Sequence[float] | NumpyArray | Callable[[int], float] | ImagePointHandler,
         mode: str | None = None,
     ) -> Image:
         """
@@ -1996,7 +1996,7 @@ class Image:
 
     def putdata(
         self,
-        data: Sequence[float] | Sequence[Sequence[int]],
+        data: Sequence[float] | Sequence[Sequence[int]] | NumpyArray,
         scale: float = 1.0,
         offset: float = 0.0,
     ) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -38,9 +38,11 @@ deps =
     ipython
     numpy
     packaging
+    pytest
     types-defusedxml
     types-olefile
+    types-setuptools
 extras =
     typing
 commands =
-    mypy src {posargs}
+    mypy src Tests {posargs}


### PR DESCRIPTION
After the changes in this PR, there are only half a dozen files left in Tests that do not pass mypy. So I've updated tox to also check Tests, and excluded those left with errors.

By running mypy over Tests, it better ensures that Pillow's main type hints are correct, as the test suite provides example input and handles output.