### PR TITLE
Allow using SIMD intrinsics for SSE2, SSE4, AVX2 and NEON code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,15 +52,19 @@ jobs:
         include:
         - { python-version: "3.11", PYTHONOPTIMIZE: 1, REVERSE: "--reverse" }
         - { python-version: "3.10", PYTHONOPTIMIZE: 2 }
+        # SIMD-accelerated builds for x86
+        - { os: "ubuntu-latest", python-version: "3.9", acceleration: "sse4"}
+        - { os: "ubuntu-latest", python-version: "3.12", acceleration: "avx2"}
         # Free-threaded
         - { os: "ubuntu-latest", python-version: "3.13-dev", disable-gil: true }
         # M1 only available for 3.10+
         - { os: "macos-13", python-version: "3.9" }
+        - { os: "macos-13", python-version: "3.9", acceleration: "avx2"}
         exclude:
         - { os: "macos-14", python-version: "3.9" }
 
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }} Python ${{ matrix.python-version }} ${{ matrix.disable-gil && 'free-threaded' || '' }}
+    name: ${{ matrix.os }} Python ${{ matrix.python-version }} ${{ matrix.acceleration }} ${{ matrix.disable-gil && 'free-threaded' || '' }}
 
     steps:
     - uses: actions/checkout@v4
@@ -108,7 +112,7 @@ jobs:
         GHA_LIBIMAGEQUANT_CACHE_HIT: ${{ steps.cache-libimagequant.outputs.cache-hit }}
 
     - name: Install macOS dependencies
-      if: startsWith(matrix.os, 'macOS')
+      if: startsWith(matrix.os, 'macos')
       run: |
         .github/workflows/macos-install.sh
       env:
@@ -117,6 +121,11 @@ jobs:
     - name: Register gcc problem matcher
       if: "matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'"
       run: echo "::add-matcher::.github/problem-matchers/gcc.json"
+
+    - name: Set compiler options for optimization
+      if: ${{ matrix.acceleration }}
+      run: |
+        echo "CC=cc -m${{ matrix.acceleration }}" >> $GITHUB_ENV
 
     - name: Build
       run: |

--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -36,7 +36,9 @@ def test_version() -> None:
             assert version is None
         else:
             assert function(name) == version
-            if name != "PIL":
+            if name == "acceleration":
+                assert version in ("avx2", "sse4", "sse2", "neon", None)
+            elif name != "PIL":
                 if name == "zlib" and version is not None:
                     version = re.sub(".zlib-ng$", "", version)
                 elif name == "libtiff" and version is not None:

--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -128,6 +128,7 @@ features = {
     "libjpeg_turbo": ("PIL._imaging", "HAVE_LIBJPEGTURBO", "libjpeg_turbo_version"),
     "libimagequant": ("PIL._imaging", "HAVE_LIBIMAGEQUANT", "imagequant_version"),
     "xcb": ("PIL._imaging", "HAVE_XCB", None),
+    "acceleration": ("PIL._imaging", "acceleration", "acceleration"),
 }
 
 
@@ -267,6 +268,7 @@ def pilinfo(out: IO[str] | None = None, supported_formats: bool = True) -> None:
 
     for name, feature in [
         ("pil", "PIL CORE"),
+        ("acceleration", "Acceleration"),
         ("tkinter", "TKINTER"),
         ("freetype2", "FREETYPE2"),
         ("littlecms2", "LITTLECMS2"),
@@ -291,7 +293,7 @@ def pilinfo(out: IO[str] | None = None, supported_formats: bool = True) -> None:
             if v is None:
                 v = version(name)
             if v is not None:
-                version_static = name in ("pil", "jpg")
+                version_static = name in ("pil", "jpg", "acceleration")
                 if name == "littlecms2":
                     # this check is also in src/_imagingcms.c:setup_module()
                     version_static = tuple(int(x) for x in v.split(".")) < (2, 7)

--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -128,7 +128,7 @@ features = {
     "libjpeg_turbo": ("PIL._imaging", "HAVE_LIBJPEGTURBO", "libjpeg_turbo_version"),
     "libimagequant": ("PIL._imaging", "HAVE_LIBIMAGEQUANT", "imagequant_version"),
     "xcb": ("PIL._imaging", "HAVE_XCB", None),
-    "acceleration": ("PIL._imaging", "acceleration", "acceleration"),
+    "acceleration": ("PIL._imaging", "HAVE_ACCELERATION", "acceleration"),
 }
 
 

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -4407,6 +4407,7 @@ setup_module(PyObject *m) {
     Py_INCREF(have_xcb);
     PyModule_AddObject(m, "HAVE_XCB", have_xcb);
 
+    PyObject *have_acceleration = Py_True;
 #ifdef __AVX2__
     PyModule_AddStringConstant(m, "acceleration", "avx2");
 #elif defined(__SSE4__)
@@ -4418,7 +4419,11 @@ setup_module(PyObject *m) {
 #else
     Py_INCREF(Py_False);
     PyModule_AddObject(m, "acceleration", Py_False);
+
+    have_acceleration = Py_False;
 #endif
+    Py_INCREF(have_acceleration);
+    PyModule_AddObject(m, "HAVE_ACCELERATION", have_acceleration);
 
     PyObject *pillow_version = PyUnicode_FromString(version);
     PyDict_SetItemString(

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -4417,8 +4417,8 @@ setup_module(PyObject *m) {
 #elif defined(__NEON__)
     PyModule_AddStringConstant(m, "acceleration", "neon");
 #else
-    Py_INCREF(Py_False);
-    PyModule_AddObject(m, "acceleration", Py_False);
+    Py_INCREF(Py_None);
+    PyModule_AddObject(m, "acceleration", Py_None);
 
     have_acceleration = Py_False;
 #endif

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -4407,6 +4407,19 @@ setup_module(PyObject *m) {
     Py_INCREF(have_xcb);
     PyModule_AddObject(m, "HAVE_XCB", have_xcb);
 
+#ifdef __AVX2__
+    PyModule_AddStringConstant(m, "acceleration", "avx2");
+#elif defined(__SSE4__)
+    PyModule_AddStringConstant(m, "acceleration", "sse4");
+#elif defined(__SSE2__)
+    PyModule_AddStringConstant(m, "acceleration", "sse2");
+#elif defined(__NEON__)
+    PyModule_AddStringConstant(m, "acceleration", "neon");
+#else
+    Py_INCREF(Py_False);
+    PyModule_AddObject(m, "acceleration", Py_False);
+#endif
+
     PyObject *pillow_version = PyUnicode_FromString(version);
     PyDict_SetItemString(
         d, "PILLOW_VERSION", pillow_version ? pillow_version : Py_None

--- a/src/libImaging/Bands.c
+++ b/src/libImaging/Bands.c
@@ -66,7 +66,8 @@ ImagingGetBand(Imaging imIn, int band) {
         12 + band,
         8 + band,
         4 + band,
-        0 + band);
+        0 + band
+    );
 #endif
 
     /* Extract band from image */
@@ -132,7 +133,8 @@ ImagingSplit(Imaging imIn, Imaging bands[4]) {
                 __m128i source = _mm_loadu_si128((__m128i *)in);
                 source = _mm_shuffle_epi8(
                     source,
-                    _mm_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0));
+                    _mm_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0)
+                );
                 *((UINT32 *)(out0 + x)) = _mm_cvtsi128_si32(source);
                 *((UINT32 *)(out1 + x)) = _mm_cvtsi128_si32(_mm_srli_si128(source, 12));
 #else
@@ -161,7 +163,8 @@ ImagingSplit(Imaging imIn, Imaging bands[4]) {
                 __m128i source = _mm_loadu_si128((__m128i *)in);
                 source = _mm_shuffle_epi8(
                     source,
-                    _mm_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0));
+                    _mm_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0)
+                );
                 *((UINT32 *)(out0 + x)) = _mm_cvtsi128_si32(source);
                 *((UINT32 *)(out1 + x)) = _mm_cvtsi128_si32(_mm_srli_si128(source, 4));
                 *((UINT32 *)(out2 + x)) = _mm_cvtsi128_si32(_mm_srli_si128(source, 8));
@@ -195,7 +198,8 @@ ImagingSplit(Imaging imIn, Imaging bands[4]) {
                 __m128i source = _mm_loadu_si128((__m128i *)in);
                 source = _mm_shuffle_epi8(
                     source,
-                    _mm_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0));
+                    _mm_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0)
+                );
                 *((UINT32 *)(out0 + x)) = _mm_cvtsi128_si32(source);
                 *((UINT32 *)(out1 + x)) = _mm_cvtsi128_si32(_mm_srli_si128(source, 4));
                 *((UINT32 *)(out2 + x)) = _mm_cvtsi128_si32(_mm_srli_si128(source, 8));

--- a/src/libImaging/Bands.c
+++ b/src/libImaging/Bands.c
@@ -21,6 +21,9 @@ Imaging
 ImagingGetBand(Imaging imIn, int band) {
     Imaging imOut;
     int x, y;
+#ifdef __SSE4__
+    __m128i shuffle_mask;
+#endif
 
     /* Check arguments */
     if (!imIn || imIn->type != IMAGING_TYPE_UINT8) {
@@ -46,14 +49,25 @@ ImagingGetBand(Imaging imIn, int band) {
         return NULL;
     }
 
+#ifdef __SSE4__
+    shuffle_mask = _mm_set_epi8(
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, 12+band,8+band,4+band,0+band);
+#endif
+
     /* Extract band from image */
     for (y = 0; y < imIn->ysize; y++) {
         UINT8 *in = (UINT8 *)imIn->image[y] + band;
         UINT8 *out = imOut->image8[y];
         x = 0;
         for (; x < imIn->xsize - 3; x += 4) {
+#ifdef __SSE4__
+            __m128i source = _mm_loadu_si128((__m128i *)(in - band));
+            *((UINT32 *)(out + x)) = _mm_cvtsi128_si32(
+                _mm_shuffle_epi8(source, shuffle_mask));
+#else
             UINT32 v = MAKE_UINT32(in[0], in[4], in[8], in[12]);
             memcpy(out + x, &v, sizeof(v));
+#endif
             in += 16;
         }
         for (; x < imIn->xsize; x++) {
@@ -99,10 +113,18 @@ ImagingSplit(Imaging imIn, Imaging bands[4]) {
             UINT8 *out1 = bands[1]->image8[y];
             x = 0;
             for (; x < imIn->xsize - 3; x += 4) {
+#ifdef __SSE4__
+                __m128i source = _mm_loadu_si128((__m128i *)in);
+                source = _mm_shuffle_epi8(source, _mm_set_epi8(
+                    15,11,7,3, 14,10,6,2, 13,9,5,1, 12,8,4,0));
+                *((UINT32 *)(out0 + x)) = _mm_cvtsi128_si32(source);
+                *((UINT32 *)(out1 + x)) = _mm_cvtsi128_si32(_mm_srli_si128(source, 12));
+#else
                 UINT32 v = MAKE_UINT32(in[0], in[4], in[8], in[12]);
                 memcpy(out0 + x, &v, sizeof(v));
                 v = MAKE_UINT32(in[0 + 3], in[4 + 3], in[8 + 3], in[12 + 3]);
                 memcpy(out1 + x, &v, sizeof(v));
+#endif
                 in += 16;
             }
             for (; x < imIn->xsize; x++) {
@@ -119,12 +141,21 @@ ImagingSplit(Imaging imIn, Imaging bands[4]) {
             UINT8 *out2 = bands[2]->image8[y];
             x = 0;
             for (; x < imIn->xsize - 3; x += 4) {
+#ifdef __SSE4__
+                __m128i source = _mm_loadu_si128((__m128i *)in);
+                source = _mm_shuffle_epi8(source, _mm_set_epi8(
+                    15,11,7,3, 14,10,6,2, 13,9,5,1, 12,8,4,0));
+                *((UINT32 *)(out0 + x)) = _mm_cvtsi128_si32(source);
+                *((UINT32 *)(out1 + x)) = _mm_cvtsi128_si32(_mm_srli_si128(source, 4));
+                *((UINT32 *)(out2 + x)) = _mm_cvtsi128_si32(_mm_srli_si128(source, 8));
+#else
                 UINT32 v = MAKE_UINT32(in[0], in[4], in[8], in[12]);
                 memcpy(out0 + x, &v, sizeof(v));
                 v = MAKE_UINT32(in[0 + 1], in[4 + 1], in[8 + 1], in[12 + 1]);
                 memcpy(out1 + x, &v, sizeof(v));
                 v = MAKE_UINT32(in[0 + 2], in[4 + 2], in[8 + 2], in[12 + 2]);
                 memcpy(out2 + x, &v, sizeof(v));
+#endif
                 in += 16;
             }
             for (; x < imIn->xsize; x++) {
@@ -143,6 +174,15 @@ ImagingSplit(Imaging imIn, Imaging bands[4]) {
             UINT8 *out3 = bands[3]->image8[y];
             x = 0;
             for (; x < imIn->xsize - 3; x += 4) {
+#ifdef __SSE4__
+                __m128i source = _mm_loadu_si128((__m128i *)in);
+                source = _mm_shuffle_epi8(source, _mm_set_epi8(
+                    15,11,7,3, 14,10,6,2, 13,9,5,1, 12,8,4,0));
+                *((UINT32 *)(out0 + x)) = _mm_cvtsi128_si32(source);
+                *((UINT32 *)(out1 + x)) = _mm_cvtsi128_si32(_mm_srli_si128(source, 4));
+                *((UINT32 *)(out2 + x)) = _mm_cvtsi128_si32(_mm_srli_si128(source, 8));
+                *((UINT32 *)(out3 + x)) = _mm_cvtsi128_si32(_mm_srli_si128(source, 12));
+#else
                 UINT32 v = MAKE_UINT32(in[0], in[4], in[8], in[12]);
                 memcpy(out0 + x, &v, sizeof(v));
                 v = MAKE_UINT32(in[0 + 1], in[4 + 1], in[8 + 1], in[12 + 1]);
@@ -151,6 +191,7 @@ ImagingSplit(Imaging imIn, Imaging bands[4]) {
                 memcpy(out2 + x, &v, sizeof(v));
                 v = MAKE_UINT32(in[0 + 3], in[4 + 3], in[8 + 3], in[12 + 3]);
                 memcpy(out3 + x, &v, sizeof(v));
+#endif
                 in += 16;
             }
             for (; x < imIn->xsize; x++) {

--- a/src/libImaging/Bands.c
+++ b/src/libImaging/Bands.c
@@ -51,7 +51,22 @@ ImagingGetBand(Imaging imIn, int band) {
 
 #ifdef __SSE4__
     shuffle_mask = _mm_set_epi8(
-        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, 12+band,8+band,4+band,0+band);
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+        12 + band,
+        8 + band,
+        4 + band,
+        0 + band);
 #endif
 
     /* Extract band from image */
@@ -62,8 +77,8 @@ ImagingGetBand(Imaging imIn, int band) {
         for (; x < imIn->xsize - 3; x += 4) {
 #ifdef __SSE4__
             __m128i source = _mm_loadu_si128((__m128i *)(in - band));
-            *((UINT32 *)(out + x)) = _mm_cvtsi128_si32(
-                _mm_shuffle_epi8(source, shuffle_mask));
+            *((UINT32 *)(out + x)) =
+                _mm_cvtsi128_si32(_mm_shuffle_epi8(source, shuffle_mask));
 #else
             UINT32 v = MAKE_UINT32(in[0], in[4], in[8], in[12]);
             memcpy(out + x, &v, sizeof(v));
@@ -115,8 +130,9 @@ ImagingSplit(Imaging imIn, Imaging bands[4]) {
             for (; x < imIn->xsize - 3; x += 4) {
 #ifdef __SSE4__
                 __m128i source = _mm_loadu_si128((__m128i *)in);
-                source = _mm_shuffle_epi8(source, _mm_set_epi8(
-                    15,11,7,3, 14,10,6,2, 13,9,5,1, 12,8,4,0));
+                source = _mm_shuffle_epi8(
+                    source,
+                    _mm_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0));
                 *((UINT32 *)(out0 + x)) = _mm_cvtsi128_si32(source);
                 *((UINT32 *)(out1 + x)) = _mm_cvtsi128_si32(_mm_srli_si128(source, 12));
 #else
@@ -143,8 +159,9 @@ ImagingSplit(Imaging imIn, Imaging bands[4]) {
             for (; x < imIn->xsize - 3; x += 4) {
 #ifdef __SSE4__
                 __m128i source = _mm_loadu_si128((__m128i *)in);
-                source = _mm_shuffle_epi8(source, _mm_set_epi8(
-                    15,11,7,3, 14,10,6,2, 13,9,5,1, 12,8,4,0));
+                source = _mm_shuffle_epi8(
+                    source,
+                    _mm_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0));
                 *((UINT32 *)(out0 + x)) = _mm_cvtsi128_si32(source);
                 *((UINT32 *)(out1 + x)) = _mm_cvtsi128_si32(_mm_srli_si128(source, 4));
                 *((UINT32 *)(out2 + x)) = _mm_cvtsi128_si32(_mm_srli_si128(source, 8));
@@ -176,8 +193,9 @@ ImagingSplit(Imaging imIn, Imaging bands[4]) {
             for (; x < imIn->xsize - 3; x += 4) {
 #ifdef __SSE4__
                 __m128i source = _mm_loadu_si128((__m128i *)in);
-                source = _mm_shuffle_epi8(source, _mm_set_epi8(
-                    15,11,7,3, 14,10,6,2, 13,9,5,1, 12,8,4,0));
+                source = _mm_shuffle_epi8(
+                    source,
+                    _mm_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0));
                 *((UINT32 *)(out0 + x)) = _mm_cvtsi128_si32(source);
                 *((UINT32 *)(out1 + x)) = _mm_cvtsi128_si32(_mm_srli_si128(source, 4));
                 *((UINT32 *)(out2 + x)) = _mm_cvtsi128_si32(_mm_srli_si128(source, 8));

--- a/src/libImaging/ImPlatform.h
+++ b/src/libImaging/ImPlatform.h
@@ -96,3 +96,5 @@ typedef signed __int64 int64_t;
 #ifdef __GNUC__
 #define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #endif
+
+#include "ImagingSIMD.h"

--- a/src/libImaging/ImagingSIMD.h
+++ b/src/libImaging/ImagingSIMD.h
@@ -1,0 +1,41 @@
+/* Microsoft compiler doesn't limit intrinsics for an architecture.
+   This macro is set only on x86 and means SSE2 and above including AVX2. */
+#if defined(_M_X64) || _M_IX86_FP == 2
+    #define __SSE2__
+#endif
+
+#ifdef __SSE4_2__
+    #define __SSE4__
+#endif
+
+#ifdef __SSE2__
+    #include <mmintrin.h>  // MMX
+    #include <xmmintrin.h>  // SSE
+    #include <emmintrin.h>  // SSE2
+#endif
+#ifdef __SSE4__
+    #include <pmmintrin.h>  // SSE3
+    #include <tmmintrin.h>  // SSSE3
+    #include <smmintrin.h>  // SSE4.1
+    #include <nmmintrin.h>  // SSE4.2
+#endif
+#ifdef __AVX2__
+    #include <immintrin.h>  // AVX, AVX2
+#endif
+#ifdef __aarch64__
+    #include <arm_neon.h>  // ARM NEON
+#endif
+
+#ifdef __SSE4__
+static __m128i inline
+mm_cvtepu8_epi32(void *ptr) {
+    return _mm_cvtepu8_epi32(_mm_cvtsi32_si128(*(INT32 *) ptr));
+}
+#endif
+
+#ifdef __AVX2__
+static __m256i inline
+mm256_cvtepu8_epi32(void *ptr) {
+    return _mm256_cvtepu8_epi32(_mm_loadl_epi64((__m128i *) ptr));
+}
+#endif

--- a/src/libImaging/ImagingSIMD.h
+++ b/src/libImaging/ImagingSIMD.h
@@ -1,46 +1,46 @@
 /* Microsoft compiler doesn't limit intrinsics for an architecture.
    This macro is set only on x86 and means SSE2 and above including AVX2. */
 #if defined(_M_X64) || _M_IX86_FP == 2
-    #define __SSE2__
-    /* However, Microsoft compiler set __AVX2__ if /arch:AVX2 option is set */
-    #ifdef __AVX2__
-        #define __SSE4_2__
-    #endif
+#define __SSE2__
+/* However, Microsoft compiler set __AVX2__ if /arch:AVX2 option is set */
+#ifdef __AVX2__
+#define __SSE4_2__
+#endif
 #endif
 
 /* For better readability */
 #ifdef __SSE4_2__
-    #define __SSE4__
+#define __SSE4__
 #endif
 
 #ifdef __SSE2__
-    #include <mmintrin.h>  // MMX
-    #include <xmmintrin.h>  // SSE
-    #include <emmintrin.h>  // SSE2
+#include <mmintrin.h>   // MMX
+#include <xmmintrin.h>  // SSE
+#include <emmintrin.h>  // SSE2
 #endif
 #ifdef __SSE4__
-    #include <pmmintrin.h>  // SSE3
-    #include <tmmintrin.h>  // SSSE3
-    #include <smmintrin.h>  // SSE4.1
-    #include <nmmintrin.h>  // SSE4.2
+#include <pmmintrin.h>  // SSE3
+#include <tmmintrin.h>  // SSSE3
+#include <smmintrin.h>  // SSE4.1
+#include <nmmintrin.h>  // SSE4.2
 #endif
 #ifdef __AVX2__
-    #include <immintrin.h>  // AVX, AVX2
+#include <immintrin.h>  // AVX, AVX2
 #endif
 #ifdef __aarch64__
-    #include <arm_neon.h>  // ARM NEON
+#include <arm_neon.h>  // ARM NEON
 #endif
 
 #ifdef __SSE4__
-static __m128i inline
+static inline __m128i
 mm_cvtepu8_epi32(void *ptr) {
-    return _mm_cvtepu8_epi32(_mm_cvtsi32_si128(*(INT32 *) ptr));
+    return _mm_cvtepu8_epi32(_mm_cvtsi32_si128(*(INT32 *)ptr));
 }
 #endif
 
 #ifdef __AVX2__
-static __m256i inline
+static inline __m256i
 mm256_cvtepu8_epi32(void *ptr) {
-    return _mm256_cvtepu8_epi32(_mm_loadl_epi64((__m128i *) ptr));
+    return _mm256_cvtepu8_epi32(_mm_loadl_epi64((__m128i *)ptr));
 }
 #endif

--- a/src/libImaging/ImagingSIMD.h
+++ b/src/libImaging/ImagingSIMD.h
@@ -12,6 +12,9 @@
 #ifdef __SSE4_2__
 #define __SSE4__
 #endif
+#ifdef __aarch64__
+#define __NEON__
+#endif
 
 #ifdef __SSE2__
 #include <mmintrin.h>   // MMX
@@ -27,7 +30,7 @@
 #ifdef __AVX2__
 #include <immintrin.h>  // AVX, AVX2
 #endif
-#ifdef __aarch64__
+#ifdef __NEON__
 #include <arm_neon.h>  // ARM NEON
 #endif
 

--- a/src/libImaging/ImagingSIMD.h
+++ b/src/libImaging/ImagingSIMD.h
@@ -2,8 +2,13 @@
    This macro is set only on x86 and means SSE2 and above including AVX2. */
 #if defined(_M_X64) || _M_IX86_FP == 2
     #define __SSE2__
+    /* However, Microsoft compiler set __AVX2__ if /arch:AVX2 option is set */
+    #ifdef __AVX2__
+        #define __SSE4_2__
+    #endif
 #endif
 
+/* For better readability */
 #ifdef __SSE4_2__
     #define __SSE4__
 #endif


### PR DESCRIPTION
## Current SIMD state

There is a separate [Pillow-SIMD](https://pypi.org/project/Pillow-SIMD/) package on PyPI with modified Pillow code, which includes some rewritten routines using SSE4 and AVX2 compiler intrinsics. Any version of Pillow-SIMD has strictly the same functionality, behavior, and bugs as the corresponding Pillow version. There are many problems with this approach, including:

1. Pillow-SIMD versions are often outdated. This is because any Pillow-SIMD release requires some work to merge SIMD-accelerated code into every Pillow version, which involves resolving potential conflicts and testing all implementations.
2. SIMD-accelerated code is unconditionally platform-specific. Pillow-SIMD can be compiled and run only on x86. This means that it is very hard to add Pillow-SIMD as a dependency in cross-platform applications.
3. Pillow-SIMD is a different package, although it shares the same namespace (PIL), which means only one package (Pillow or Pillow-SIMD) should be installed at a time in one environment. It can be tricky to avoid Pillow installation if it is a dependency for some third-party libraries.
4. Pillow-SIMD itself can't be a dependency for third-party libraries, since it's not cross-platform.
5. Pillow-SIMD doesn't provide precompiled binaries since there are two types of SIMD-acceleration implemented: SSE4 and AVX2. Pillow-SIMD compiled with AVX2 is a bit faster, but can't be run on non-AVX2 CPUs (including Rosetta 2 on Apple silicon).

## Proposal 

I'd like to move SIMD-accelerated code to the upstream with some enhancements for cross-platform compilation. How it affects described problems:

1. Every released Pillow version will contain SIMD-accelerated code, so no additional actions will be required.
2. Pillow can be compiled on any platform, with or without SIMD-acceleration, if available. No separate package will be required.
3. Like the previous point, no separate package will be required.
3. Like the previous point, no separate package will be required.
5. Default precompiled binaries for Pillow will be provided with minimal available SIMD-acceleration for every platform: SSE2 for x86_64 and NEON for ARM aarch64 (please note, currently there is no SSE2 or NEON accelerated code). For advanced users who want acceleration, compilation documentation will be provided.

## Challenges

### Testing

The main challenge is testing. If some code is contributed to the upstream, it should be run during tests. There could be the following versions of the code:

* Native code: Will be tested on platforms without acceleration support: 32-bit x86, s390x, and ppc64le. Are there any tests for any of these platforms?
* SSE2: The most common, since it is the default for x86_64.
* SSE4: Not currently tested. Should be added explicitly.
* AVX2: Not currently tested. Should be added explicitly.
* NEON: Mandatory extension for ARM aarch64, so it will be tested in many ARM configurations.

### Detecting Current Acceleration

There should be a way to detect the current acceleration implementation. I think some property for the core object should be enough.

## Criticism

The proposed solution doesn't provide first-class SIMD-acceleration for Pillow. When you are using any application or installing other libraries, like NumPy, there is only one compiled version available for a platform, and it contains all types of available acceleration. The right accelerated functions are dynamically called at runtime instead of recompiling for particular CPU capabilities during installation. However, such an approach requires much more effort, and this is not the aim of the current proposal.