### PR TITLE
Use BreakBeforeBraces: Linux for clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,7 +6,7 @@ AllowShortIfStatementsOnASingleLine: false
 AlignAfterOpenBracket: AlwaysBreak
 BinPackArguments: false
 BinPackParameters: false
-BreakBeforeBraces: Attach
+BreakBeforeBraces: Linux
 ColumnLimit: 88
 DerivePointerAlignment: false
 IndentGotoLabels: false

--- a/src/Tk/tkImaging.c
+++ b/src/Tk/tkImaging.c
@@ -55,7 +55,8 @@ static Tk_PhotoGetImage_t TK_PHOTO_GET_IMAGE;
 static Tk_PhotoPutBlock_t TK_PHOTO_PUT_BLOCK;
 
 static Imaging
-ImagingFind(const char *name) {
+ImagingFind(const char *name)
+{
     Py_ssize_t id;
 
     /* FIXME: use CObject instead? */
@@ -73,7 +74,8 @@ ImagingFind(const char *name) {
 
 static int
 PyImagingPhotoPut(
-    ClientData clientdata, Tcl_Interp *interp, int argc, const char **argv) {
+    ClientData clientdata, Tcl_Interp *interp, int argc, const char **argv)
+{
     Imaging im;
     Tk_PhotoHandle photo;
     Tk_PhotoImageBlock block;
@@ -135,7 +137,8 @@ PyImagingPhotoPut(
 
 static int
 PyImagingPhotoGet(
-    ClientData clientdata, Tcl_Interp *interp, int argc, const char **argv) {
+    ClientData clientdata, Tcl_Interp *interp, int argc, const char **argv)
+{
     Imaging im;
     Tk_PhotoHandle photo;
     Tk_PhotoImageBlock block;
@@ -177,7 +180,8 @@ PyImagingPhotoGet(
 }
 
 void
-TkImaging_Init(Tcl_Interp *interp) {
+TkImaging_Init(Tcl_Interp *interp)
+{
     TCL_CREATE_COMMAND(
         interp,
         "PyImagingPhoto",
@@ -215,7 +219,8 @@ TkImaging_Init(Tcl_Interp *interp) {
 #define TKINTER_PKG "tkinter"
 
 FARPROC
-_dfunc(HMODULE lib_handle, const char *func_name) {
+_dfunc(HMODULE lib_handle, const char *func_name)
+{
     /*
      * Load function `func_name` from `lib_handle`.
      * Set Python exception if we can't find `func_name` in `lib_handle`.
@@ -233,7 +238,8 @@ _dfunc(HMODULE lib_handle, const char *func_name) {
 }
 
 int
-get_tcl(HMODULE hMod) {
+get_tcl(HMODULE hMod)
+{
     /*
      * Try to fill Tcl global vars with function pointers. Return 0 for no
      * functions found, 1 for all functions found, -1 for some but not all
@@ -251,7 +257,8 @@ get_tcl(HMODULE hMod) {
 }
 
 int
-get_tk(HMODULE hMod) {
+get_tk(HMODULE hMod)
+{
     /*
      * Try to fill Tk global vars with function pointers. Return 0 for no
      * functions found, 1 for all functions found, -1 for some but not all
@@ -274,7 +281,8 @@ get_tk(HMODULE hMod) {
 }
 
 int
-load_tkinter_funcs(void) {
+load_tkinter_funcs(void)
+{
     /*
      * Load Tcl and Tk functions by searching all modules in current process.
      * Return 0 for success, non-zero for failure.
@@ -352,7 +360,8 @@ load_tkinter_funcs(void) {
 #include <dlfcn.h>
 
 void *
-_dfunc(void *lib_handle, const char *func_name) {
+_dfunc(void *lib_handle, const char *func_name)
+{
     /*
      * Load function `func_name` from `lib_handle`.
      * Set Python exception if we can't find `func_name` in `lib_handle`.
@@ -371,7 +380,8 @@ _dfunc(void *lib_handle, const char *func_name) {
 }
 
 int
-_func_loader(void *lib) {
+_func_loader(void *lib)
+{
     /*
      * Fill global function pointers from dynamic lib.
      * Return 1 if any pointer is NULL, 0 otherwise.
@@ -398,7 +408,8 @@ _func_loader(void *lib) {
 }
 
 int
-load_tkinter_funcs(void) {
+load_tkinter_funcs(void)
+{
     /*
      * Load tkinter global funcs from tkinter compiled module.
      * Return 0 for success, non-zero for failure.

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -161,7 +161,8 @@ typedef struct {
 static PyTypeObject PixelAccess_Type;
 
 PyObject *
-PyImagingNew(Imaging imOut) {
+PyImagingNew(Imaging imOut)
+{
     ImagingObject *imagep;
 
     if (!imOut) {
@@ -185,7 +186,8 @@ PyImagingNew(Imaging imOut) {
 }
 
 static void
-_dealloc(ImagingObject *imagep) {
+_dealloc(ImagingObject *imagep)
+{
 #ifdef VERBOSE
     printf("imaging %p deleted\n", imagep);
 #endif
@@ -200,7 +202,8 @@ _dealloc(ImagingObject *imagep) {
 #define PyImaging_Check(op) (Py_TYPE(op) == &Imaging_Type)
 
 Imaging
-PyImaging_AsImaging(PyObject *op) {
+PyImaging_AsImaging(PyObject *op)
+{
     if (!PyImaging_Check(op)) {
         PyErr_BadInternalCall();
         return NULL;
@@ -214,14 +217,16 @@ PyImaging_AsImaging(PyObject *op) {
 /* -------------------------------------------------------------------- */
 
 void
-ImagingSectionEnter(ImagingSectionCookie *cookie) {
+ImagingSectionEnter(ImagingSectionCookie *cookie)
+{
 #ifdef WITH_THREADING
     *cookie = (PyThreadState *)PyEval_SaveThread();
 #endif
 }
 
 void
-ImagingSectionLeave(ImagingSectionCookie *cookie) {
+ImagingSectionLeave(ImagingSectionCookie *cookie)
+{
 #ifdef WITH_THREADING
     PyEval_RestoreThread((PyThreadState *)*cookie);
 #endif
@@ -233,12 +238,14 @@ ImagingSectionLeave(ImagingSectionCookie *cookie) {
 /* Python compatibility API */
 
 int
-PyImaging_CheckBuffer(PyObject *buffer) {
+PyImaging_CheckBuffer(PyObject *buffer)
+{
     return PyObject_CheckBuffer(buffer);
 }
 
 int
-PyImaging_GetBuffer(PyObject *buffer, Py_buffer *view) {
+PyImaging_GetBuffer(PyObject *buffer, Py_buffer *view)
+{
     /* must call check_buffer first! */
     return PyObject_GetBuffer(buffer, view, PyBUF_SIMPLE);
 }
@@ -265,37 +272,43 @@ static const char *readonly = "image is readonly";
 /* static const char* no_content = "image has no content"; */
 
 void *
-ImagingError_OSError(void) {
+ImagingError_OSError(void)
+{
     PyErr_SetString(PyExc_OSError, "error when accessing file");
     return NULL;
 }
 
 void *
-ImagingError_MemoryError(void) {
+ImagingError_MemoryError(void)
+{
     return PyErr_NoMemory();
 }
 
 void *
-ImagingError_Mismatch(void) {
+ImagingError_Mismatch(void)
+{
     PyErr_SetString(PyExc_ValueError, "images do not match");
     return NULL;
 }
 
 void *
-ImagingError_ModeError(void) {
+ImagingError_ModeError(void)
+{
     PyErr_SetString(PyExc_ValueError, "image has wrong mode");
     return NULL;
 }
 
 void *
-ImagingError_ValueError(const char *message) {
+ImagingError_ValueError(const char *message)
+{
     PyErr_SetString(
         PyExc_ValueError, (message) ? (char *)message : "unrecognized argument value");
     return NULL;
 }
 
 void
-ImagingError_Clear(void) {
+ImagingError_Clear(void)
+{
     PyErr_Clear();
 }
 
@@ -304,7 +317,8 @@ ImagingError_Clear(void) {
 /* -------------------------------------------------------------------- */
 
 static int
-getbands(const char *mode) {
+getbands(const char *mode)
+{
     Imaging im;
     int bands;
 
@@ -328,7 +342,8 @@ getbands(const char *mode) {
 #define TYPE_DOUBLE (0x400 | sizeof(double))
 
 static void *
-getlist(PyObject *arg, Py_ssize_t *length, const char *wrong_length, int type) {
+getlist(PyObject *arg, Py_ssize_t *length, const char *wrong_length, int type)
+{
     /* - allocates and returns a c array of the items in the
           python sequence arg.
        - the size of the returned array is in length
@@ -410,7 +425,8 @@ getlist(PyObject *arg, Py_ssize_t *length, const char *wrong_length, int type) {
 }
 
 FLOAT32
-float16tofloat32(const FLOAT16 in) {
+float16tofloat32(const FLOAT16 in)
+{
     UINT32 t1;
     UINT32 t2;
     UINT32 t3;
@@ -434,7 +450,8 @@ float16tofloat32(const FLOAT16 in) {
 }
 
 static inline PyObject *
-getpixel(Imaging im, ImagingAccess access, int x, int y) {
+getpixel(Imaging im, ImagingAccess access, int x, int y)
+{
     union {
         UINT8 b[4];
         UINT16 h;
@@ -489,7 +506,8 @@ getpixel(Imaging im, ImagingAccess access, int x, int y) {
 }
 
 static char *
-getink(PyObject *color, Imaging im, char *ink) {
+getink(PyObject *color, Imaging im, char *ink)
+{
     int g = 0, b = 0, a = 0;
     double f = 0;
     /* Windows 64 bit longs are 32 bits, and 0xFFFFFFFF (white) is a
@@ -649,7 +667,8 @@ getink(PyObject *color, Imaging im, char *ink) {
 /* -------------------------------------------------------------------- */
 
 static PyObject *
-_fill(PyObject *self, PyObject *args) {
+_fill(PyObject *self, PyObject *args)
+{
     char *mode;
     int xsize, ysize;
     PyObject *color;
@@ -682,7 +701,8 @@ _fill(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-_new(PyObject *self, PyObject *args) {
+_new(PyObject *self, PyObject *args)
+{
     char *mode;
     int xsize, ysize;
 
@@ -694,7 +714,8 @@ _new(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-_new_block(PyObject *self, PyObject *args) {
+_new_block(PyObject *self, PyObject *args)
+{
     char *mode;
     int xsize, ysize;
 
@@ -706,7 +727,8 @@ _new_block(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-_linear_gradient(PyObject *self, PyObject *args) {
+_linear_gradient(PyObject *self, PyObject *args)
+{
     char *mode;
 
     if (!PyArg_ParseTuple(args, "s", &mode)) {
@@ -717,7 +739,8 @@ _linear_gradient(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-_radial_gradient(PyObject *self, PyObject *args) {
+_radial_gradient(PyObject *self, PyObject *args)
+{
     char *mode;
 
     if (!PyArg_ParseTuple(args, "s", &mode)) {
@@ -728,7 +751,8 @@ _radial_gradient(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-_alpha_composite(ImagingObject *self, PyObject *args) {
+_alpha_composite(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep1;
     ImagingObject *imagep2;
 
@@ -741,7 +765,8 @@ _alpha_composite(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_blend(ImagingObject *self, PyObject *args) {
+_blend(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep1;
     ImagingObject *imagep2;
     double alpha;
@@ -760,7 +785,8 @@ _blend(ImagingObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 static INT16 *
-_prepare_lut_table(PyObject *table, Py_ssize_t table_size) {
+_prepare_lut_table(PyObject *table, Py_ssize_t table_size)
+{
     int i;
     Py_buffer buffer_info;
     INT32 data_type = TYPE_FLOAT32;
@@ -859,7 +885,8 @@ _prepare_lut_table(PyObject *table, Py_ssize_t table_size) {
 }
 
 static PyObject *
-_color_lut_3d(ImagingObject *self, PyObject *args) {
+_color_lut_3d(ImagingObject *self, PyObject *args)
+{
     char *mode;
     int filter;
     int table_channels;
@@ -931,7 +958,8 @@ _color_lut_3d(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_convert(ImagingObject *self, PyObject *args) {
+_convert(ImagingObject *self, PyObject *args)
+{
     char *mode;
     int dither = 0;
     ImagingObject *paletteimage = NULL;
@@ -957,7 +985,8 @@ _convert(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_convert2(ImagingObject *self, PyObject *args) {
+_convert2(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep1;
     ImagingObject *imagep2;
     if (!PyArg_ParseTuple(
@@ -974,7 +1003,8 @@ _convert2(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_convert_matrix(ImagingObject *self, PyObject *args) {
+_convert_matrix(ImagingObject *self, PyObject *args)
+{
     char *mode;
     float m[12];
     if (!PyArg_ParseTuple(args, "s(ffff)", &mode, m + 0, m + 1, m + 2, m + 3)) {
@@ -1003,7 +1033,8 @@ _convert_matrix(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_convert_transparent(ImagingObject *self, PyObject *args) {
+_convert_transparent(ImagingObject *self, PyObject *args)
+{
     char *mode;
     int r, g, b;
     if (PyArg_ParseTuple(args, "s(iii)", &mode, &r, &g, &b)) {
@@ -1017,7 +1048,8 @@ _convert_transparent(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_copy(ImagingObject *self, PyObject *args) {
+_copy(ImagingObject *self, PyObject *args)
+{
     if (!PyArg_ParseTuple(args, "")) {
         return NULL;
     }
@@ -1026,7 +1058,8 @@ _copy(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_crop(ImagingObject *self, PyObject *args) {
+_crop(ImagingObject *self, PyObject *args)
+{
     int x0, y0, x1, y1;
     if (!PyArg_ParseTuple(args, "(iiii)", &x0, &y0, &x1, &y1)) {
         return NULL;
@@ -1036,7 +1069,8 @@ _crop(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_expand_image(ImagingObject *self, PyObject *args) {
+_expand_image(ImagingObject *self, PyObject *args)
+{
     int x, y;
     if (!PyArg_ParseTuple(args, "ii", &x, &y)) {
         return NULL;
@@ -1046,7 +1080,8 @@ _expand_image(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_filter(ImagingObject *self, PyObject *args) {
+_filter(ImagingObject *self, PyObject *args)
+{
     PyObject *imOut;
     Py_ssize_t kernelsize;
     FLOAT32 *kerneldata;
@@ -1082,7 +1117,8 @@ _filter(ImagingObject *self, PyObject *args) {
 
 #ifdef WITH_UNSHARPMASK
 static PyObject *
-_gaussian_blur(ImagingObject *self, PyObject *args) {
+_gaussian_blur(ImagingObject *self, PyObject *args)
+{
     Imaging imIn;
     Imaging imOut;
 
@@ -1108,7 +1144,8 @@ _gaussian_blur(ImagingObject *self, PyObject *args) {
 #endif
 
 static PyObject *
-_getpalette(ImagingObject *self, PyObject *args) {
+_getpalette(ImagingObject *self, PyObject *args)
+{
     PyObject *palette;
     int palettesize;
     int bits;
@@ -1144,7 +1181,8 @@ _getpalette(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_getpalettemode(ImagingObject *self) {
+_getpalettemode(ImagingObject *self)
+{
     if (!self->image->palette) {
         PyErr_SetString(PyExc_ValueError, no_palette);
         return NULL;
@@ -1154,7 +1192,8 @@ _getpalettemode(ImagingObject *self) {
 }
 
 static inline int
-_getxy(PyObject *xy, int *x, int *y) {
+_getxy(PyObject *xy, int *x, int *y)
+{
     PyObject *value;
 
     if (!PyTuple_Check(xy) || PyTuple_GET_SIZE(xy) != 2) {
@@ -1201,7 +1240,8 @@ badval:
 }
 
 static PyObject *
-_getpixel(ImagingObject *self, PyObject *args) {
+_getpixel(ImagingObject *self, PyObject *args)
+{
     PyObject *xy;
     int x, y;
 
@@ -1232,7 +1272,8 @@ union hist_extrema {
 
 static union hist_extrema *
 parse_histogram_extremap(
-    ImagingObject *self, PyObject *extremap, union hist_extrema *ep) {
+    ImagingObject *self, PyObject *extremap, union hist_extrema *ep)
+{
     int i0, i1;
     double f0, f1;
 
@@ -1269,7 +1310,8 @@ parse_histogram_extremap(
 }
 
 static PyObject *
-_histogram(ImagingObject *self, PyObject *args) {
+_histogram(ImagingObject *self, PyObject *args)
+{
     ImagingHistogram h;
     PyObject *list;
     int i;
@@ -1314,7 +1356,8 @@ _histogram(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_entropy(ImagingObject *self, PyObject *args) {
+_entropy(ImagingObject *self, PyObject *args)
+{
     ImagingHistogram h;
     int idx, length;
     long sum;
@@ -1363,7 +1406,8 @@ _entropy(ImagingObject *self, PyObject *args) {
 
 #ifdef WITH_MODEFILTER
 static PyObject *
-_modefilter(ImagingObject *self, PyObject *args) {
+_modefilter(ImagingObject *self, PyObject *args)
+{
     int size;
     if (!PyArg_ParseTuple(args, "i", &size)) {
         return NULL;
@@ -1374,7 +1418,8 @@ _modefilter(ImagingObject *self, PyObject *args) {
 #endif
 
 static PyObject *
-_offset(ImagingObject *self, PyObject *args) {
+_offset(ImagingObject *self, PyObject *args)
+{
     int xoffset, yoffset;
     if (!PyArg_ParseTuple(args, "ii", &xoffset, &yoffset)) {
         return NULL;
@@ -1384,7 +1429,8 @@ _offset(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_paste(ImagingObject *self, PyObject *args) {
+_paste(ImagingObject *self, PyObject *args)
+{
     int status;
     char ink[4];
 
@@ -1423,7 +1469,8 @@ _paste(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_point(ImagingObject *self, PyObject *args) {
+_point(ImagingObject *self, PyObject *args)
+{
     static const char *wrong_number = "wrong number of lut entries";
 
     Py_ssize_t n;
@@ -1507,7 +1554,8 @@ _point(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_point_transform(ImagingObject *self, PyObject *args) {
+_point_transform(ImagingObject *self, PyObject *args)
+{
     double scale = 1.0;
     double offset = 0.0;
     if (!PyArg_ParseTuple(args, "|dd", &scale, &offset)) {
@@ -1518,7 +1566,8 @@ _point_transform(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_putdata(ImagingObject *self, PyObject *args) {
+_putdata(ImagingObject *self, PyObject *args)
+{
     Imaging image;
     // i & n are # pixels, require py_ssize_t. x can be as large as n. y, just because.
     Py_ssize_t n, i, x, y;
@@ -1703,7 +1752,8 @@ _putdata(ImagingObject *self, PyObject *args) {
 #ifdef WITH_QUANTIZE
 
 static PyObject *
-_quantize(ImagingObject *self, PyObject *args) {
+_quantize(ImagingObject *self, PyObject *args)
+{
     int colours = 256;
     int method = 0;
     int kmeans = 0;
@@ -1721,7 +1771,8 @@ _quantize(ImagingObject *self, PyObject *args) {
 #endif
 
 static PyObject *
-_putpalette(ImagingObject *self, PyObject *args) {
+_putpalette(ImagingObject *self, PyObject *args)
+{
     ImagingShuffler unpack;
     int bits;
 
@@ -1764,7 +1815,8 @@ _putpalette(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_putpalettealpha(ImagingObject *self, PyObject *args) {
+_putpalettealpha(ImagingObject *self, PyObject *args)
+{
     int index;
     int alpha = 0;
     if (!PyArg_ParseTuple(args, "i|i", &index, &alpha)) {
@@ -1789,7 +1841,8 @@ _putpalettealpha(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_putpalettealphas(ImagingObject *self, PyObject *args) {
+_putpalettealphas(ImagingObject *self, PyObject *args)
+{
     int i;
     UINT8 *values;
     Py_ssize_t length;
@@ -1817,7 +1870,8 @@ _putpalettealphas(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_putpixel(ImagingObject *self, PyObject *args) {
+_putpixel(ImagingObject *self, PyObject *args)
+{
     Imaging im;
     char ink[4];
 
@@ -1855,7 +1909,8 @@ _putpixel(ImagingObject *self, PyObject *args) {
 
 #ifdef WITH_RANKFILTER
 static PyObject *
-_rankfilter(ImagingObject *self, PyObject *args) {
+_rankfilter(ImagingObject *self, PyObject *args)
+{
     int size, rank;
     if (!PyArg_ParseTuple(args, "ii", &size, &rank)) {
         return NULL;
@@ -1866,7 +1921,8 @@ _rankfilter(ImagingObject *self, PyObject *args) {
 #endif
 
 static PyObject *
-_resize(ImagingObject *self, PyObject *args) {
+_resize(ImagingObject *self, PyObject *args)
+{
     Imaging imIn;
     Imaging imOut;
 
@@ -1932,7 +1988,8 @@ _resize(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_reduce(ImagingObject *self, PyObject *args) {
+_reduce(ImagingObject *self, PyObject *args)
+{
     Imaging imIn;
     Imaging imOut;
 
@@ -1987,7 +2044,8 @@ _reduce(ImagingObject *self, PyObject *args) {
     (!strcmp(mode, "RGB") || !strcmp(mode, "RGBA") || !strcmp(mode, "RGBX"))
 
 static PyObject *
-im_setmode(ImagingObject *self, PyObject *args) {
+im_setmode(ImagingObject *self, PyObject *args)
+{
     /* attempt to modify the mode of an image in place */
 
     Imaging im;
@@ -2028,7 +2086,8 @@ im_setmode(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_transform(ImagingObject *self, PyObject *args) {
+_transform(ImagingObject *self, PyObject *args)
+{
     static const char *wrong_number = "wrong number of matrix entries";
 
     Imaging imOut;
@@ -2090,7 +2149,8 @@ _transform(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_transpose(ImagingObject *self, PyObject *args) {
+_transpose(ImagingObject *self, PyObject *args)
+{
     Imaging imIn;
     Imaging imOut;
 
@@ -2149,7 +2209,8 @@ _transpose(ImagingObject *self, PyObject *args) {
 
 #ifdef WITH_UNSHARPMASK
 static PyObject *
-_unsharp_mask(ImagingObject *self, PyObject *args) {
+_unsharp_mask(ImagingObject *self, PyObject *args)
+{
     Imaging imIn;
     Imaging imOut;
 
@@ -2174,7 +2235,8 @@ _unsharp_mask(ImagingObject *self, PyObject *args) {
 #endif
 
 static PyObject *
-_box_blur(ImagingObject *self, PyObject *args) {
+_box_blur(ImagingObject *self, PyObject *args)
+{
     Imaging imIn;
     Imaging imOut;
 
@@ -2201,12 +2263,14 @@ _box_blur(ImagingObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 static PyObject *
-_isblock(ImagingObject *self) {
+_isblock(ImagingObject *self)
+{
     return PyBool_FromLong(self->image->block != NULL);
 }
 
 static PyObject *
-_getbbox(ImagingObject *self, PyObject *args) {
+_getbbox(ImagingObject *self, PyObject *args)
+{
     int bbox[4];
 
     int alpha_only = 1;
@@ -2223,7 +2287,8 @@ _getbbox(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_getcolors(ImagingObject *self, PyObject *args) {
+_getcolors(ImagingObject *self, PyObject *args)
+{
     ImagingColorItem *items;
     int i, colors;
     PyObject *out;
@@ -2261,7 +2326,8 @@ _getcolors(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_getextrema(ImagingObject *self) {
+_getextrema(ImagingObject *self)
+{
     union {
         UINT8 u[2];
         INT32 i[2];
@@ -2295,7 +2361,8 @@ _getextrema(ImagingObject *self) {
 }
 
 static PyObject *
-_getprojection(ImagingObject *self) {
+_getprojection(ImagingObject *self)
+{
     unsigned char *xprofile;
     unsigned char *yprofile;
     PyObject *result;
@@ -2329,7 +2396,8 @@ _getprojection(ImagingObject *self) {
 /* -------------------------------------------------------------------- */
 
 static PyObject *
-_getband(ImagingObject *self, PyObject *args) {
+_getband(ImagingObject *self, PyObject *args)
+{
     int band;
 
     if (!PyArg_ParseTuple(args, "i", &band)) {
@@ -2340,7 +2408,8 @@ _getband(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_fillband(ImagingObject *self, PyObject *args) {
+_fillband(ImagingObject *self, PyObject *args)
+{
     int band;
     int color;
 
@@ -2357,7 +2426,8 @@ _fillband(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_putband(ImagingObject *self, PyObject *args) {
+_putband(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep;
     int band;
     if (!PyArg_ParseTuple(args, "O!i", &Imaging_Type, &imagep, &band)) {
@@ -2373,7 +2443,8 @@ _putband(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_merge(PyObject *self, PyObject *args) {
+_merge(PyObject *self, PyObject *args)
+{
     char *mode;
     ImagingObject *band0 = NULL;
     ImagingObject *band1 = NULL;
@@ -2413,7 +2484,8 @@ _merge(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-_split(ImagingObject *self) {
+_split(ImagingObject *self)
+{
     int fails = 0;
     Py_ssize_t i;
     PyObject *list;
@@ -2444,12 +2516,14 @@ _split(ImagingObject *self) {
 #ifdef WITH_IMAGECHOPS
 
 static PyObject *
-_chop_invert(ImagingObject *self) {
+_chop_invert(ImagingObject *self)
+{
     return PyImagingNew(ImagingNegative(self->image));
 }
 
 static PyObject *
-_chop_lighter(ImagingObject *self, PyObject *args) {
+_chop_lighter(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep;
 
     if (!PyArg_ParseTuple(args, "O!", &Imaging_Type, &imagep)) {
@@ -2460,7 +2534,8 @@ _chop_lighter(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_chop_darker(ImagingObject *self, PyObject *args) {
+_chop_darker(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep;
 
     if (!PyArg_ParseTuple(args, "O!", &Imaging_Type, &imagep)) {
@@ -2471,7 +2546,8 @@ _chop_darker(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_chop_difference(ImagingObject *self, PyObject *args) {
+_chop_difference(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep;
 
     if (!PyArg_ParseTuple(args, "O!", &Imaging_Type, &imagep)) {
@@ -2482,7 +2558,8 @@ _chop_difference(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_chop_multiply(ImagingObject *self, PyObject *args) {
+_chop_multiply(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep;
 
     if (!PyArg_ParseTuple(args, "O!", &Imaging_Type, &imagep)) {
@@ -2493,7 +2570,8 @@ _chop_multiply(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_chop_screen(ImagingObject *self, PyObject *args) {
+_chop_screen(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep;
 
     if (!PyArg_ParseTuple(args, "O!", &Imaging_Type, &imagep)) {
@@ -2504,7 +2582,8 @@ _chop_screen(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_chop_add(ImagingObject *self, PyObject *args) {
+_chop_add(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep;
     float scale;
     int offset;
@@ -2520,7 +2599,8 @@ _chop_add(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_chop_subtract(ImagingObject *self, PyObject *args) {
+_chop_subtract(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep;
     float scale;
     int offset;
@@ -2536,7 +2616,8 @@ _chop_subtract(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_chop_and(ImagingObject *self, PyObject *args) {
+_chop_and(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep;
 
     if (!PyArg_ParseTuple(args, "O!", &Imaging_Type, &imagep)) {
@@ -2547,7 +2628,8 @@ _chop_and(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_chop_or(ImagingObject *self, PyObject *args) {
+_chop_or(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep;
 
     if (!PyArg_ParseTuple(args, "O!", &Imaging_Type, &imagep)) {
@@ -2558,7 +2640,8 @@ _chop_or(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_chop_xor(ImagingObject *self, PyObject *args) {
+_chop_xor(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep;
 
     if (!PyArg_ParseTuple(args, "O!", &Imaging_Type, &imagep)) {
@@ -2569,7 +2652,8 @@ _chop_xor(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_chop_add_modulo(ImagingObject *self, PyObject *args) {
+_chop_add_modulo(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep;
 
     if (!PyArg_ParseTuple(args, "O!", &Imaging_Type, &imagep)) {
@@ -2580,7 +2664,8 @@ _chop_add_modulo(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_chop_subtract_modulo(ImagingObject *self, PyObject *args) {
+_chop_subtract_modulo(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep;
 
     if (!PyArg_ParseTuple(args, "O!", &Imaging_Type, &imagep)) {
@@ -2591,7 +2676,8 @@ _chop_subtract_modulo(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_chop_soft_light(ImagingObject *self, PyObject *args) {
+_chop_soft_light(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep;
 
     if (!PyArg_ParseTuple(args, "O!", &Imaging_Type, &imagep)) {
@@ -2602,7 +2688,8 @@ _chop_soft_light(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_chop_hard_light(ImagingObject *self, PyObject *args) {
+_chop_hard_light(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep;
 
     if (!PyArg_ParseTuple(args, "O!", &Imaging_Type, &imagep)) {
@@ -2613,7 +2700,8 @@ _chop_hard_light(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_chop_overlay(ImagingObject *self, PyObject *args) {
+_chop_overlay(ImagingObject *self, PyObject *args)
+{
     ImagingObject *imagep;
 
     if (!PyArg_ParseTuple(args, "O!", &Imaging_Type, &imagep)) {
@@ -2629,7 +2717,8 @@ _chop_overlay(ImagingObject *self, PyObject *args) {
 #ifdef WITH_IMAGEDRAW
 
 static PyObject *
-_font_new(PyObject *self_, PyObject *args) {
+_font_new(PyObject *self_, PyObject *args)
+{
     ImagingFontObject *self;
     int i, y0, y1;
     static const char *wrong_length = "descriptor table has wrong size";
@@ -2709,13 +2798,15 @@ _font_new(PyObject *self_, PyObject *args) {
 }
 
 static void
-_font_dealloc(ImagingFontObject *self) {
+_font_dealloc(ImagingFontObject *self)
+{
     Py_XDECREF(self->ref);
     PyObject_Del(self);
 }
 
 static inline int
-textwidth(ImagingFontObject *self, const unsigned char *text) {
+textwidth(ImagingFontObject *self, const unsigned char *text)
+{
     int xsize;
 
     for (xsize = 0; *text; text++) {
@@ -2726,7 +2817,8 @@ textwidth(ImagingFontObject *self, const unsigned char *text) {
 }
 
 void
-_font_text_asBytes(PyObject *encoded_string, unsigned char **text) {
+_font_text_asBytes(PyObject *encoded_string, unsigned char **text)
+{
     /* Allocates *text, returns a 'new reference'. Caller is required to free */
 
     PyObject *bytes = NULL;
@@ -2759,7 +2851,8 @@ _font_text_asBytes(PyObject *encoded_string, unsigned char **text) {
 }
 
 static PyObject *
-_font_getmask(ImagingFontObject *self, PyObject *args) {
+_font_getmask(ImagingFontObject *self, PyObject *args)
+{
     Imaging im;
     Imaging bitmap = NULL;
     int x, b;
@@ -2827,7 +2920,8 @@ failed:
 }
 
 static PyObject *
-_font_getsize(ImagingFontObject *self, PyObject *args) {
+_font_getsize(ImagingFontObject *self, PyObject *args)
+{
     unsigned char *text;
     PyObject *encoded_string;
     PyObject *val;
@@ -2855,7 +2949,8 @@ static struct PyMethodDef _font_methods[] = {
 /* -------------------------------------------------------------------- */
 
 static PyObject *
-_draw_new(PyObject *self_, PyObject *args) {
+_draw_new(PyObject *self_, PyObject *args)
+{
     ImagingDrawObject *self;
 
     ImagingObject *imagep;
@@ -2881,7 +2976,8 @@ _draw_new(PyObject *self_, PyObject *args) {
 }
 
 static void
-_draw_dealloc(ImagingDrawObject *self) {
+_draw_dealloc(ImagingDrawObject *self)
+{
     Py_XDECREF(self->image);
     PyObject_Del(self);
 }
@@ -2890,7 +2986,8 @@ extern Py_ssize_t
 PyPath_Flatten(PyObject *data, double **xy);
 
 static PyObject *
-_draw_ink(ImagingDrawObject *self, PyObject *args) {
+_draw_ink(ImagingDrawObject *self, PyObject *args)
+{
     INT32 ink = 0;
     PyObject *color;
     if (!PyArg_ParseTuple(args, "O", &color)) {
@@ -2905,7 +3002,8 @@ _draw_ink(ImagingDrawObject *self, PyObject *args) {
 }
 
 static PyObject *
-_draw_arc(ImagingDrawObject *self, PyObject *args) {
+_draw_arc(ImagingDrawObject *self, PyObject *args)
+{
     double *xy;
     Py_ssize_t n;
 
@@ -2960,7 +3058,8 @@ _draw_arc(ImagingDrawObject *self, PyObject *args) {
 }
 
 static PyObject *
-_draw_bitmap(ImagingDrawObject *self, PyObject *args) {
+_draw_bitmap(ImagingDrawObject *self, PyObject *args)
+{
     double *xy;
     Py_ssize_t n;
 
@@ -2996,7 +3095,8 @@ _draw_bitmap(ImagingDrawObject *self, PyObject *args) {
 }
 
 static PyObject *
-_draw_chord(ImagingDrawObject *self, PyObject *args) {
+_draw_chord(ImagingDrawObject *self, PyObject *args)
+{
     double *xy;
     Py_ssize_t n;
 
@@ -3052,7 +3152,8 @@ _draw_chord(ImagingDrawObject *self, PyObject *args) {
 }
 
 static PyObject *
-_draw_ellipse(ImagingDrawObject *self, PyObject *args) {
+_draw_ellipse(ImagingDrawObject *self, PyObject *args)
+{
     double *xy;
     Py_ssize_t n;
 
@@ -3106,7 +3207,8 @@ _draw_ellipse(ImagingDrawObject *self, PyObject *args) {
 }
 
 static PyObject *
-_draw_lines(ImagingDrawObject *self, PyObject *args) {
+_draw_lines(ImagingDrawObject *self, PyObject *args)
+{
     double *xy;
     Py_ssize_t i, n;
 
@@ -3167,7 +3269,8 @@ _draw_lines(ImagingDrawObject *self, PyObject *args) {
 }
 
 static PyObject *
-_draw_points(ImagingDrawObject *self, PyObject *args) {
+_draw_points(ImagingDrawObject *self, PyObject *args)
+{
     double *xy;
     Py_ssize_t i, n;
 
@@ -3204,7 +3307,8 @@ extern ImagingOutline
 PyOutline_AsOutline(PyObject *outline);
 
 static PyObject *
-_draw_outline(ImagingDrawObject *self, PyObject *args) {
+_draw_outline(ImagingDrawObject *self, PyObject *args)
+{
     ImagingOutline outline;
 
     PyObject *outline_;
@@ -3231,7 +3335,8 @@ _draw_outline(ImagingDrawObject *self, PyObject *args) {
 #endif
 
 static PyObject *
-_draw_pieslice(ImagingDrawObject *self, PyObject *args) {
+_draw_pieslice(ImagingDrawObject *self, PyObject *args)
+{
     double *xy;
     Py_ssize_t n;
 
@@ -3287,7 +3392,8 @@ _draw_pieslice(ImagingDrawObject *self, PyObject *args) {
 }
 
 static PyObject *
-_draw_polygon(ImagingDrawObject *self, PyObject *args) {
+_draw_polygon(ImagingDrawObject *self, PyObject *args)
+{
     double *xy;
     int *ixy;
     Py_ssize_t n, i;
@@ -3338,7 +3444,8 @@ _draw_polygon(ImagingDrawObject *self, PyObject *args) {
 }
 
 static PyObject *
-_draw_rectangle(ImagingDrawObject *self, PyObject *args) {
+_draw_rectangle(ImagingDrawObject *self, PyObject *args)
+{
     double *xy;
     Py_ssize_t n;
 
@@ -3414,7 +3521,8 @@ static struct PyMethodDef _draw_methods[] = {
 #endif
 
 static PyObject *
-pixel_access_new(ImagingObject *imagep, PyObject *args) {
+pixel_access_new(ImagingObject *imagep, PyObject *args)
+{
     PixelAccessObject *self;
 
     int readonly = 0;
@@ -3437,13 +3545,15 @@ pixel_access_new(ImagingObject *imagep, PyObject *args) {
 }
 
 static void
-pixel_access_dealloc(PixelAccessObject *self) {
+pixel_access_dealloc(PixelAccessObject *self)
+{
     Py_XDECREF(self->image);
     PyObject_Del(self);
 }
 
 static PyObject *
-pixel_access_getitem(PixelAccessObject *self, PyObject *xy) {
+pixel_access_getitem(PixelAccessObject *self, PyObject *xy)
+{
     int x, y;
     if (_getxy(xy, &x, &y)) {
         return NULL;
@@ -3453,7 +3563,8 @@ pixel_access_getitem(PixelAccessObject *self, PyObject *xy) {
 }
 
 static int
-pixel_access_setitem(PixelAccessObject *self, PyObject *xy, PyObject *color) {
+pixel_access_setitem(PixelAccessObject *self, PyObject *xy, PyObject *color)
+{
     Imaging im = self->image->image;
     char ink[4];
     int x, y;
@@ -3499,7 +3610,8 @@ pixel_access_setitem(PixelAccessObject *self, PyObject *xy, PyObject *color) {
 #ifdef WITH_EFFECTS
 
 static PyObject *
-_effect_mandelbrot(ImagingObject *self, PyObject *args) {
+_effect_mandelbrot(ImagingObject *self, PyObject *args)
+{
     int xsize = 512;
     int ysize = 512;
     double extent[4];
@@ -3527,7 +3639,8 @@ _effect_mandelbrot(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_effect_noise(ImagingObject *self, PyObject *args) {
+_effect_noise(ImagingObject *self, PyObject *args)
+{
     int xsize, ysize;
     float sigma = 128;
     if (!PyArg_ParseTuple(args, "(ii)|f", &xsize, &ysize, &sigma)) {
@@ -3538,7 +3651,8 @@ _effect_noise(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_effect_spread(ImagingObject *self, PyObject *args) {
+_effect_spread(ImagingObject *self, PyObject *args)
+{
     int dist;
 
     if (!PyArg_ParseTuple(args, "i", &dist)) {
@@ -3555,7 +3669,8 @@ _effect_spread(ImagingObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 static PyObject *
-_getcodecstatus(PyObject *self, PyObject *args) {
+_getcodecstatus(PyObject *self, PyObject *args)
+{
     int status;
     char *msg;
 
@@ -3591,7 +3706,8 @@ _getcodecstatus(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 static PyObject *
-_save_ppm(ImagingObject *self, PyObject *args) {
+_save_ppm(ImagingObject *self, PyObject *args)
+{
     char *filename;
 
     if (!PyArg_ParseTuple(args, "s", &filename)) {
@@ -3714,32 +3830,38 @@ static struct PyMethodDef methods[] = {
 /* attributes */
 
 static PyObject *
-_getattr_mode(ImagingObject *self, void *closure) {
+_getattr_mode(ImagingObject *self, void *closure)
+{
     return PyUnicode_FromString(self->image->mode);
 }
 
 static PyObject *
-_getattr_size(ImagingObject *self, void *closure) {
+_getattr_size(ImagingObject *self, void *closure)
+{
     return Py_BuildValue("ii", self->image->xsize, self->image->ysize);
 }
 
 static PyObject *
-_getattr_bands(ImagingObject *self, void *closure) {
+_getattr_bands(ImagingObject *self, void *closure)
+{
     return PyLong_FromLong(self->image->bands);
 }
 
 static PyObject *
-_getattr_id(ImagingObject *self, void *closure) {
+_getattr_id(ImagingObject *self, void *closure)
+{
     return PyLong_FromSsize_t((Py_ssize_t)self->image);
 }
 
 static PyObject *
-_getattr_ptr(ImagingObject *self, void *closure) {
+_getattr_ptr(ImagingObject *self, void *closure)
+{
     return PyCapsule_New(self->image, IMAGING_MAGIC, NULL);
 }
 
 static PyObject *
-_getattr_unsafe_ptrs(ImagingObject *self, void *closure) {
+_getattr_unsafe_ptrs(ImagingObject *self, void *closure)
+{
     return Py_BuildValue(
         "(sn)(sn)(sn)",
         "image8",
@@ -3762,14 +3884,16 @@ static struct PyGetSetDef getsetters[] = {
 /* basic sequence semantics */
 
 static Py_ssize_t
-image_length(ImagingObject *self) {
+image_length(ImagingObject *self)
+{
     Imaging im = self->image;
 
     return (Py_ssize_t)im->xsize * im->ysize;
 }
 
 static PyObject *
-image_item(ImagingObject *self, Py_ssize_t i) {
+image_item(ImagingObject *self, Py_ssize_t i)
+{
     int x, y;
     Imaging im = self->image;
 
@@ -3926,7 +4050,8 @@ static PyTypeObject PixelAccess_Type = {
 /* -------------------------------------------------------------------- */
 
 static PyObject *
-_get_stats(PyObject *self, PyObject *args) {
+_get_stats(PyObject *self, PyObject *args)
+{
     PyObject *d;
     PyObject *v;
     ImagingMemoryArena arena = &ImagingDefaultArena;
@@ -3966,7 +4091,8 @@ _get_stats(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-_reset_stats(PyObject *self, PyObject *args) {
+_reset_stats(PyObject *self, PyObject *args)
+{
     ImagingMemoryArena arena = &ImagingDefaultArena;
 
     if (!PyArg_ParseTuple(args, ":reset_stats")) {
@@ -3984,7 +4110,8 @@ _reset_stats(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-_get_alignment(PyObject *self, PyObject *args) {
+_get_alignment(PyObject *self, PyObject *args)
+{
     if (!PyArg_ParseTuple(args, ":get_alignment")) {
         return NULL;
     }
@@ -3993,7 +4120,8 @@ _get_alignment(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-_get_block_size(PyObject *self, PyObject *args) {
+_get_block_size(PyObject *self, PyObject *args)
+{
     if (!PyArg_ParseTuple(args, ":get_block_size")) {
         return NULL;
     }
@@ -4002,7 +4130,8 @@ _get_block_size(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-_get_blocks_max(PyObject *self, PyObject *args) {
+_get_blocks_max(PyObject *self, PyObject *args)
+{
     if (!PyArg_ParseTuple(args, ":get_blocks_max")) {
         return NULL;
     }
@@ -4011,7 +4140,8 @@ _get_blocks_max(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-_set_alignment(PyObject *self, PyObject *args) {
+_set_alignment(PyObject *self, PyObject *args)
+{
     int alignment;
     if (!PyArg_ParseTuple(args, "i:set_alignment", &alignment)) {
         return NULL;
@@ -4034,7 +4164,8 @@ _set_alignment(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-_set_block_size(PyObject *self, PyObject *args) {
+_set_block_size(PyObject *self, PyObject *args)
+{
     int block_size;
     if (!PyArg_ParseTuple(args, "i:set_block_size", &block_size)) {
         return NULL;
@@ -4057,7 +4188,8 @@ _set_block_size(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-_set_blocks_max(PyObject *self, PyObject *args) {
+_set_blocks_max(PyObject *self, PyObject *args)
+{
     int blocks_max;
     if (!PyArg_ParseTuple(args, "i:set_blocks_max", &blocks_max)) {
         return NULL;
@@ -4082,7 +4214,8 @@ _set_blocks_max(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-_clear_cache(PyObject *self, PyObject *args) {
+_clear_cache(PyObject *self, PyObject *args)
+{
     int i = 0;
 
     if (!PyArg_ParseTuple(args, "|i:clear_cache", &i)) {
@@ -4303,7 +4436,8 @@ static PyMethodDef functions[] = {
 };
 
 static int
-setup_module(PyObject *m) {
+setup_module(PyObject *m)
+{
     PyObject *d = PyModule_GetDict(m);
     const char *version = (char *)PILLOW_VERSION;
 
@@ -4430,7 +4564,8 @@ setup_module(PyObject *m) {
 }
 
 PyMODINIT_FUNC
-PyInit__imaging(void) {
+PyInit__imaging(void)
+{
     PyObject *m;
 
     static PyModuleDef module_def = {

--- a/src/_imagingcms.c
+++ b/src/_imagingcms.c
@@ -84,7 +84,8 @@ static PyTypeObject CmsProfile_Type;
 #define CmsProfile_Check(op) (Py_TYPE(op) == &CmsProfile_Type)
 
 static PyObject *
-cms_profile_new(cmsHPROFILE profile) {
+cms_profile_new(cmsHPROFILE profile)
+{
     CmsProfileObject *self;
 
     self = PyObject_New(CmsProfileObject, &CmsProfile_Type);
@@ -98,7 +99,8 @@ cms_profile_new(cmsHPROFILE profile) {
 }
 
 static PyObject *
-cms_profile_open(PyObject *self, PyObject *args) {
+cms_profile_open(PyObject *self, PyObject *args)
+{
     cmsHPROFILE hProfile;
 
     char *sProfile;
@@ -116,7 +118,8 @@ cms_profile_open(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-cms_profile_frombytes(PyObject *self, PyObject *args) {
+cms_profile_frombytes(PyObject *self, PyObject *args)
+{
     cmsHPROFILE hProfile;
 
     char *pProfile;
@@ -135,7 +138,8 @@ cms_profile_frombytes(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-cms_profile_tobytes(PyObject *self, PyObject *args) {
+cms_profile_tobytes(PyObject *self, PyObject *args)
+{
     char *pProfile = NULL;
     cmsUInt32Number nProfile;
     PyObject *CmsProfile;
@@ -173,7 +177,8 @@ cms_profile_tobytes(PyObject *self, PyObject *args) {
 }
 
 static void
-cms_profile_dealloc(CmsProfileObject *self) {
+cms_profile_dealloc(CmsProfileObject *self)
+{
     (void)cmsCloseProfile(self->profile);
     PyObject_Del(self);
 }
@@ -189,7 +194,8 @@ static PyTypeObject CmsTransform_Type;
 #define CmsTransform_Check(op) (Py_TYPE(op) == &CmsTransform_Type)
 
 static PyObject *
-cms_transform_new(cmsHTRANSFORM transform) {
+cms_transform_new(cmsHTRANSFORM transform)
+{
     CmsTransformObject *self;
 
     self = PyObject_New(CmsTransformObject, &CmsTransform_Type);
@@ -203,7 +209,8 @@ cms_transform_new(cmsHTRANSFORM transform) {
 }
 
 static void
-cms_transform_dealloc(CmsTransformObject *self) {
+cms_transform_dealloc(CmsTransformObject *self)
+{
     cmsDeleteTransform(self->transform);
     PyObject_Del(self);
 }
@@ -212,7 +219,8 @@ cms_transform_dealloc(CmsTransformObject *self) {
 /* internal functions */
 
 static cmsUInt32Number
-findLCMStype(char *PILmode) {
+findLCMStype(char *PILmode)
+{
     if (strcmp(PILmode, "RGB") == 0 || strcmp(PILmode, "RGBA") == 0 ||
         strcmp(PILmode, "RGBX") == 0) {
         return TYPE_RGBA_8;
@@ -245,7 +253,8 @@ findLCMStype(char *PILmode) {
 #define Cms_Min(a, b) ((a) < (b) ? (a) : (b))
 
 static int
-pyCMSgetAuxChannelChannel(cmsUInt32Number format, int auxChannelNdx) {
+pyCMSgetAuxChannelChannel(cmsUInt32Number format, int auxChannelNdx)
+{
     int numColors = T_CHANNELS(format);
     int numExtras = T_EXTRA(format);
 
@@ -273,7 +282,8 @@ pyCMSgetAuxChannelChannel(cmsUInt32Number format, int auxChannelNdx) {
 }
 
 static void
-pyCMScopyAux(cmsHTRANSFORM hTransform, Imaging imDst, const Imaging imSrc) {
+pyCMScopyAux(cmsHTRANSFORM hTransform, Imaging imDst, const Imaging imSrc)
+{
     cmsUInt32Number dstLCMSFormat;
     cmsUInt32Number srcLCMSFormat;
     int numSrcExtras;
@@ -338,7 +348,8 @@ pyCMScopyAux(cmsHTRANSFORM hTransform, Imaging imDst, const Imaging imSrc) {
 }
 
 static int
-pyCMSdoTransform(Imaging im, Imaging imOut, cmsHTRANSFORM hTransform) {
+pyCMSdoTransform(Imaging im, Imaging imOut, cmsHTRANSFORM hTransform)
+{
     int i;
 
     if (im->xsize > imOut->xsize || im->ysize > imOut->ysize) {
@@ -348,7 +359,8 @@ pyCMSdoTransform(Imaging im, Imaging imOut, cmsHTRANSFORM hTransform) {
     Py_BEGIN_ALLOW_THREADS
 
         // transform color channels only
-        for (i = 0; i < im->ysize; i++) {
+        for (i = 0; i < im->ysize; i++)
+    {
         cmsDoTransform(hTransform, im->image[i], imOut->image[i], im->xsize);
     }
 
@@ -373,7 +385,8 @@ _buildTransform(
     char *sInMode,
     char *sOutMode,
     int iRenderingIntent,
-    cmsUInt32Number cmsFLAGS) {
+    cmsUInt32Number cmsFLAGS)
+{
     cmsHTRANSFORM hTransform;
 
     Py_BEGIN_ALLOW_THREADS
@@ -405,7 +418,8 @@ _buildProofTransform(
     char *sOutMode,
     int iRenderingIntent,
     int iProofIntent,
-    cmsUInt32Number cmsFLAGS) {
+    cmsUInt32Number cmsFLAGS)
+{
     cmsHTRANSFORM hTransform;
 
     Py_BEGIN_ALLOW_THREADS
@@ -434,7 +448,8 @@ _buildProofTransform(
 /* Python callable functions */
 
 static PyObject *
-buildTransform(PyObject *self, PyObject *args) {
+buildTransform(PyObject *self, PyObject *args)
+{
     CmsProfileObject *pInputProfile;
     CmsProfileObject *pOutputProfile;
     char *sInMode;
@@ -474,7 +489,8 @@ buildTransform(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-buildProofTransform(PyObject *self, PyObject *args) {
+buildProofTransform(PyObject *self, PyObject *args)
+{
     CmsProfileObject *pInputProfile;
     CmsProfileObject *pOutputProfile;
     CmsProfileObject *pProofProfile;
@@ -521,7 +537,8 @@ buildProofTransform(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-cms_transform_apply(CmsTransformObject *self, PyObject *args) {
+cms_transform_apply(CmsTransformObject *self, PyObject *args)
+{
     Py_ssize_t idIn;
     Py_ssize_t idOut;
     Imaging im;
@@ -545,7 +562,8 @@ cms_transform_apply(CmsTransformObject *self, PyObject *args) {
 /* Python-Callable On-The-Fly profile creation functions */
 
 static PyObject *
-createProfile(PyObject *self, PyObject *args) {
+createProfile(PyObject *self, PyObject *args)
+{
     char *sColorSpace;
     cmsHPROFILE hProfile;
     cmsFloat64Number dColorTemp = 0.0;
@@ -590,7 +608,8 @@ createProfile(PyObject *self, PyObject *args) {
 /* profile methods */
 
 static PyObject *
-cms_profile_is_intent_supported(CmsProfileObject *self, PyObject *args) {
+cms_profile_is_intent_supported(CmsProfileObject *self, PyObject *args)
+{
     cmsBool result;
 
     int intent;
@@ -616,7 +635,8 @@ cms_profile_is_intent_supported(CmsProfileObject *self, PyObject *args) {
 #endif
 
 static PyObject *
-cms_get_display_profile_win32(PyObject *self, PyObject *args) {
+cms_get_display_profile_win32(PyObject *self, PyObject *args)
+{
     char filename[MAX_PATH];
     DWORD filename_size;
     BOOL ok;
@@ -651,7 +671,8 @@ cms_get_display_profile_win32(PyObject *self, PyObject *args) {
 /* Helper functions.  */
 
 static PyObject *
-_profile_read_mlu(CmsProfileObject *self, cmsTagSignature info) {
+_profile_read_mlu(CmsProfileObject *self, cmsTagSignature info)
+{
     PyObject *uni;
     char *lc = "en";
     char *cc = cmsNoCountry;
@@ -693,7 +714,8 @@ _profile_read_mlu(CmsProfileObject *self, cmsTagSignature info) {
 }
 
 static PyObject *
-_profile_read_int_as_string(cmsUInt32Number nr) {
+_profile_read_int_as_string(cmsUInt32Number nr)
+{
     PyObject *ret;
     char buf[5];
     buf[0] = (char)((nr >> 24) & 0xff);
@@ -707,7 +729,8 @@ _profile_read_int_as_string(cmsUInt32Number nr) {
 }
 
 static PyObject *
-_profile_read_signature(CmsProfileObject *self, cmsTagSignature info) {
+_profile_read_signature(CmsProfileObject *self, cmsTagSignature info)
+{
     unsigned int *sig;
 
     if (!cmsIsTag(self->profile, info)) {
@@ -725,7 +748,8 @@ _profile_read_signature(CmsProfileObject *self, cmsTagSignature info) {
 }
 
 static PyObject *
-_xyz_py(cmsCIEXYZ *XYZ) {
+_xyz_py(cmsCIEXYZ *XYZ)
+{
     cmsCIExyY xyY;
     cmsXYZ2xyY(&xyY, XYZ);
     return Py_BuildValue(
@@ -733,7 +757,8 @@ _xyz_py(cmsCIEXYZ *XYZ) {
 }
 
 static PyObject *
-_xyz3_py(cmsCIEXYZ *XYZ) {
+_xyz3_py(cmsCIEXYZ *XYZ)
+{
     cmsCIExyY xyY[3];
     cmsXYZ2xyY(&xyY[0], &XYZ[0]);
     cmsXYZ2xyY(&xyY[1], &XYZ[1]);
@@ -762,7 +787,8 @@ _xyz3_py(cmsCIEXYZ *XYZ) {
 }
 
 static PyObject *
-_profile_read_ciexyz(CmsProfileObject *self, cmsTagSignature info, int multi) {
+_profile_read_ciexyz(CmsProfileObject *self, cmsTagSignature info, int multi)
+{
     cmsCIEXYZ *XYZ;
 
     if (!cmsIsTag(self->profile, info)) {
@@ -783,7 +809,8 @@ _profile_read_ciexyz(CmsProfileObject *self, cmsTagSignature info, int multi) {
 }
 
 static PyObject *
-_profile_read_ciexyy_triple(CmsProfileObject *self, cmsTagSignature info) {
+_profile_read_ciexyy_triple(CmsProfileObject *self, cmsTagSignature info)
+{
     cmsCIExyYTRIPLE *triple;
 
     if (!cmsIsTag(self->profile, info)) {
@@ -813,7 +840,8 @@ _profile_read_ciexyy_triple(CmsProfileObject *self, cmsTagSignature info) {
 }
 
 static PyObject *
-_profile_read_named_color_list(CmsProfileObject *self, cmsTagSignature info) {
+_profile_read_named_color_list(CmsProfileObject *self, cmsTagSignature info)
+{
     cmsNAMEDCOLORLIST *ncl;
     int i, n;
     char name[cmsMAX_PATH];
@@ -853,7 +881,8 @@ _profile_read_named_color_list(CmsProfileObject *self, cmsTagSignature info) {
 }
 
 static cmsBool
-_calculate_rgb_primaries(CmsProfileObject *self, cmsCIEXYZTRIPLE *result) {
+_calculate_rgb_primaries(CmsProfileObject *self, cmsCIEXYZTRIPLE *result)
+{
     double input[3][3] = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
     cmsHPROFILE hXYZ;
     cmsHTRANSFORM hTransform;
@@ -889,7 +918,8 @@ _check_intent(
     int clut,
     cmsHPROFILE hProfile,
     cmsUInt32Number Intent,
-    cmsUInt32Number UsedDirection) {
+    cmsUInt32Number UsedDirection)
+{
     if (clut) {
         return cmsIsCLUT(hProfile, Intent, UsedDirection);
     } else {
@@ -900,7 +930,8 @@ _check_intent(
 #define INTENTS 200
 
 static PyObject *
-_is_intent_supported(CmsProfileObject *self, int clut) {
+_is_intent_supported(CmsProfileObject *self, int clut)
+{
     PyObject *result;
     int n;
     int i;
@@ -976,48 +1007,57 @@ static struct PyMethodDef cms_profile_methods[] = {
 };
 
 static PyObject *
-cms_profile_getattr_rendering_intent(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_rendering_intent(CmsProfileObject *self, void *closure)
+{
     return PyLong_FromLong(cmsGetHeaderRenderingIntent(self->profile));
 }
 
 /* New-style unicode interfaces.  */
 static PyObject *
-cms_profile_getattr_copyright(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_copyright(CmsProfileObject *self, void *closure)
+{
     return _profile_read_mlu(self, cmsSigCopyrightTag);
 }
 
 static PyObject *
-cms_profile_getattr_target(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_target(CmsProfileObject *self, void *closure)
+{
     return _profile_read_mlu(self, cmsSigCharTargetTag);
 }
 
 static PyObject *
-cms_profile_getattr_manufacturer(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_manufacturer(CmsProfileObject *self, void *closure)
+{
     return _profile_read_mlu(self, cmsSigDeviceMfgDescTag);
 }
 
 static PyObject *
-cms_profile_getattr_model(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_model(CmsProfileObject *self, void *closure)
+{
     return _profile_read_mlu(self, cmsSigDeviceModelDescTag);
 }
 
 static PyObject *
-cms_profile_getattr_profile_description(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_profile_description(CmsProfileObject *self, void *closure)
+{
     return _profile_read_mlu(self, cmsSigProfileDescriptionTag);
 }
 
 static PyObject *
-cms_profile_getattr_screening_description(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_screening_description(CmsProfileObject *self, void *closure)
+{
     return _profile_read_mlu(self, cmsSigScreeningDescTag);
 }
 
 static PyObject *
-cms_profile_getattr_viewing_condition(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_viewing_condition(CmsProfileObject *self, void *closure)
+{
     return _profile_read_mlu(self, cmsSigViewingCondDescTag);
 }
 
 static PyObject *
-cms_profile_getattr_creation_date(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_creation_date(CmsProfileObject *self, void *closure)
+{
     cmsBool result;
     struct tm ct;
 
@@ -1032,18 +1072,21 @@ cms_profile_getattr_creation_date(CmsProfileObject *self, void *closure) {
 }
 
 static PyObject *
-cms_profile_getattr_version(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_version(CmsProfileObject *self, void *closure)
+{
     cmsFloat64Number version = cmsGetProfileVersion(self->profile);
     return PyFloat_FromDouble(version);
 }
 
 static PyObject *
-cms_profile_getattr_icc_version(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_icc_version(CmsProfileObject *self, void *closure)
+{
     return PyLong_FromLong((long)cmsGetEncodedICCversion(self->profile));
 }
 
 static PyObject *
-cms_profile_getattr_attributes(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_attributes(CmsProfileObject *self, void *closure)
+{
     cmsUInt64Number attr;
     cmsGetHeaderAttributes(self->profile, &attr);
     /* This works just as well on Windows (LLP64), 32-bit Linux
@@ -1052,72 +1095,85 @@ cms_profile_getattr_attributes(CmsProfileObject *self, void *closure) {
 }
 
 static PyObject *
-cms_profile_getattr_header_flags(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_header_flags(CmsProfileObject *self, void *closure)
+{
     cmsUInt32Number flags = cmsGetHeaderFlags(self->profile);
     return PyLong_FromLong(flags);
 }
 
 static PyObject *
-cms_profile_getattr_header_manufacturer(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_header_manufacturer(CmsProfileObject *self, void *closure)
+{
     return _profile_read_int_as_string(cmsGetHeaderManufacturer(self->profile));
 }
 
 static PyObject *
-cms_profile_getattr_header_model(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_header_model(CmsProfileObject *self, void *closure)
+{
     return _profile_read_int_as_string(cmsGetHeaderModel(self->profile));
 }
 
 static PyObject *
-cms_profile_getattr_device_class(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_device_class(CmsProfileObject *self, void *closure)
+{
     return _profile_read_int_as_string(cmsGetDeviceClass(self->profile));
 }
 
 static PyObject *
-cms_profile_getattr_connection_space(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_connection_space(CmsProfileObject *self, void *closure)
+{
     return _profile_read_int_as_string(cmsGetPCS(self->profile));
 }
 
 static PyObject *
-cms_profile_getattr_xcolor_space(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_xcolor_space(CmsProfileObject *self, void *closure)
+{
     return _profile_read_int_as_string(cmsGetColorSpace(self->profile));
 }
 
 static PyObject *
-cms_profile_getattr_profile_id(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_profile_id(CmsProfileObject *self, void *closure)
+{
     cmsUInt8Number id[16];
     cmsGetHeaderProfileID(self->profile, id);
     return PyBytes_FromStringAndSize((char *)id, 16);
 }
 
 static PyObject *
-cms_profile_getattr_is_matrix_shaper(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_is_matrix_shaper(CmsProfileObject *self, void *closure)
+{
     return PyBool_FromLong((long)cmsIsMatrixShaper(self->profile));
 }
 
 static PyObject *
-cms_profile_getattr_technology(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_technology(CmsProfileObject *self, void *closure)
+{
     return _profile_read_signature(self, cmsSigTechnologyTag);
 }
 
 static PyObject *
-cms_profile_getattr_colorimetric_intent(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_colorimetric_intent(CmsProfileObject *self, void *closure)
+{
     return _profile_read_signature(self, cmsSigColorimetricIntentImageStateTag);
 }
 
 static PyObject *
 cms_profile_getattr_perceptual_rendering_intent_gamut(
-    CmsProfileObject *self, void *closure) {
+    CmsProfileObject *self, void *closure)
+{
     return _profile_read_signature(self, cmsSigPerceptualRenderingIntentGamutTag);
 }
 
 static PyObject *
 cms_profile_getattr_saturation_rendering_intent_gamut(
-    CmsProfileObject *self, void *closure) {
+    CmsProfileObject *self, void *closure)
+{
     return _profile_read_signature(self, cmsSigSaturationRenderingIntentGamutTag);
 }
 
 static PyObject *
-cms_profile_getattr_red_colorant(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_red_colorant(CmsProfileObject *self, void *closure)
+{
     if (!cmsIsMatrixShaper(self->profile)) {
         Py_INCREF(Py_None);
         return Py_None;
@@ -1126,7 +1182,8 @@ cms_profile_getattr_red_colorant(CmsProfileObject *self, void *closure) {
 }
 
 static PyObject *
-cms_profile_getattr_green_colorant(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_green_colorant(CmsProfileObject *self, void *closure)
+{
     if (!cmsIsMatrixShaper(self->profile)) {
         Py_INCREF(Py_None);
         return Py_None;
@@ -1135,7 +1192,8 @@ cms_profile_getattr_green_colorant(CmsProfileObject *self, void *closure) {
 }
 
 static PyObject *
-cms_profile_getattr_blue_colorant(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_blue_colorant(CmsProfileObject *self, void *closure)
+{
     if (!cmsIsMatrixShaper(self->profile)) {
         Py_INCREF(Py_None);
         return Py_None;
@@ -1144,8 +1202,8 @@ cms_profile_getattr_blue_colorant(CmsProfileObject *self, void *closure) {
 }
 
 static PyObject *
-cms_profile_getattr_media_white_point_temperature(
-    CmsProfileObject *self, void *closure) {
+cms_profile_getattr_media_white_point_temperature(CmsProfileObject *self, void *closure)
+{
     cmsCIEXYZ *XYZ;
     cmsCIExyY xyY;
     cmsFloat64Number tempK;
@@ -1173,32 +1231,38 @@ cms_profile_getattr_media_white_point_temperature(
 }
 
 static PyObject *
-cms_profile_getattr_media_white_point(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_media_white_point(CmsProfileObject *self, void *closure)
+{
     return _profile_read_ciexyz(self, cmsSigMediaWhitePointTag, 0);
 }
 
 static PyObject *
-cms_profile_getattr_media_black_point(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_media_black_point(CmsProfileObject *self, void *closure)
+{
     return _profile_read_ciexyz(self, cmsSigMediaBlackPointTag, 0);
 }
 
 static PyObject *
-cms_profile_getattr_luminance(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_luminance(CmsProfileObject *self, void *closure)
+{
     return _profile_read_ciexyz(self, cmsSigLuminanceTag, 0);
 }
 
 static PyObject *
-cms_profile_getattr_chromatic_adaptation(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_chromatic_adaptation(CmsProfileObject *self, void *closure)
+{
     return _profile_read_ciexyz(self, cmsSigChromaticAdaptationTag, 1);
 }
 
 static PyObject *
-cms_profile_getattr_chromaticity(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_chromaticity(CmsProfileObject *self, void *closure)
+{
     return _profile_read_ciexyy_triple(self, cmsSigChromaticityTag);
 }
 
 static PyObject *
-cms_profile_getattr_red_primary(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_red_primary(CmsProfileObject *self, void *closure)
+{
     cmsBool result = 0;
     cmsCIEXYZTRIPLE primaries;
 
@@ -1214,7 +1278,8 @@ cms_profile_getattr_red_primary(CmsProfileObject *self, void *closure) {
 }
 
 static PyObject *
-cms_profile_getattr_green_primary(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_green_primary(CmsProfileObject *self, void *closure)
+{
     cmsBool result = 0;
     cmsCIEXYZTRIPLE primaries;
 
@@ -1230,7 +1295,8 @@ cms_profile_getattr_green_primary(CmsProfileObject *self, void *closure) {
 }
 
 static PyObject *
-cms_profile_getattr_blue_primary(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_blue_primary(CmsProfileObject *self, void *closure)
+{
     cmsBool result = 0;
     cmsCIEXYZTRIPLE primaries;
 
@@ -1246,27 +1312,32 @@ cms_profile_getattr_blue_primary(CmsProfileObject *self, void *closure) {
 }
 
 static PyObject *
-cms_profile_getattr_colorant_table(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_colorant_table(CmsProfileObject *self, void *closure)
+{
     return _profile_read_named_color_list(self, cmsSigColorantTableTag);
 }
 
 static PyObject *
-cms_profile_getattr_colorant_table_out(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_colorant_table_out(CmsProfileObject *self, void *closure)
+{
     return _profile_read_named_color_list(self, cmsSigColorantTableOutTag);
 }
 
 static PyObject *
-cms_profile_getattr_is_intent_supported(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_is_intent_supported(CmsProfileObject *self, void *closure)
+{
     return _is_intent_supported(self, 0);
 }
 
 static PyObject *
-cms_profile_getattr_is_clut(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_is_clut(CmsProfileObject *self, void *closure)
+{
     return _is_intent_supported(self, 1);
 }
 
 static const char *
-_illu_map(int i) {
+_illu_map(int i)
+{
     switch (i) {
         case 0:
             return "unknown";
@@ -1292,7 +1363,8 @@ _illu_map(int i) {
 }
 
 static PyObject *
-cms_profile_getattr_icc_measurement_condition(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_icc_measurement_condition(CmsProfileObject *self, void *closure)
+{
     cmsICCMeasurementConditions *mc;
     cmsTagSignature info = cmsSigMeasurementTag;
     const char *geo;
@@ -1333,7 +1405,8 @@ cms_profile_getattr_icc_measurement_condition(CmsProfileObject *self, void *clos
 }
 
 static PyObject *
-cms_profile_getattr_icc_viewing_condition(CmsProfileObject *self, void *closure) {
+cms_profile_getattr_icc_viewing_condition(CmsProfileObject *self, void *closure)
+{
     cmsICCViewingConditions *vc;
     cmsTagSignature info = cmsSigViewingConditionsTag;
 
@@ -1484,7 +1557,8 @@ static PyTypeObject CmsTransform_Type = {
 };
 
 static int
-setup_module(PyObject *m) {
+setup_module(PyObject *m)
+{
     PyObject *d;
     PyObject *v;
     int vn;
@@ -1519,7 +1593,8 @@ setup_module(PyObject *m) {
 }
 
 PyMODINIT_FUNC
-PyInit__imagingcms(void) {
+PyInit__imagingcms(void)
+{
     PyObject *m;
 
     static PyModuleDef module_def = {

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -42,7 +42,9 @@
 #define FT_ERRORDEF(e, v, s) {e, s},
 #define FT_ERROR_START_LIST {
 #define FT_ERROR_END_LIST \
-    { 0, 0 }              \
+    {                     \
+        0, 0              \
+    }                     \
     }                     \
     ;
 
@@ -94,7 +96,8 @@ static PyTypeObject Font_Type;
 #define PIXEL(x) ((((x) + 32) & -64) >> 6)
 
 static PyObject *
-geterror(int code) {
+geterror(int code)
+{
     int i;
 
     for (i = 0; ft_errors[i].message; i++) {
@@ -109,7 +112,8 @@ geterror(int code) {
 }
 
 static PyObject *
-getfont(PyObject *self_, PyObject *args, PyObject *kw) {
+getfont(PyObject *self_, PyObject *args, PyObject *kw)
+{
     /* create a font object from a file name and a size (in pixels) */
 
     FontObject *self;
@@ -242,7 +246,8 @@ text_layout_raqm(
     const char *dir,
     PyObject *features,
     const char *lang,
-    GlyphInfo **glyph_info) {
+    GlyphInfo **glyph_info)
+{
     size_t i = 0, count = 0, start = 0;
     raqm_t *rq;
     raqm_glyph_t *glyphs = NULL;
@@ -398,7 +403,8 @@ text_layout_fallback(
     const char *lang,
     GlyphInfo **glyph_info,
     int mask,
-    int color) {
+    int color)
+{
     int error, load_flags, i;
     char *buffer = NULL;
     FT_ULong ch;
@@ -482,7 +488,8 @@ text_layout(
     const char *lang,
     GlyphInfo **glyph_info,
     int mask,
-    int color) {
+    int color)
+{
     size_t count;
 #ifdef HAVE_RAQM
     if (have_raqm && self->layout_engine == LAYOUT_RAQM) {
@@ -497,7 +504,8 @@ text_layout(
 }
 
 static PyObject *
-font_getlength(FontObject *self, PyObject *args) {
+font_getlength(FontObject *self, PyObject *args)
+{
     int length;                   /* length along primary axis, in 26.6 precision */
     GlyphInfo *glyph_info = NULL; /* computed text layout */
     size_t i, count;              /* glyph_info index and length */
@@ -555,7 +563,8 @@ bounding_box_and_anchors(
     int *width,
     int *height,
     int *x_offset,
-    int *y_offset) {
+    int *y_offset)
+{
     int position; /* pen position along primary axis, in 26.6 precision */
     int advanced; /* pen position along primary axis, in pixels */
     int px, py;   /* position of current glyph, in pixels */
@@ -721,7 +730,8 @@ bad_anchor:
 }
 
 static PyObject *
-font_getsize(FontObject *self, PyObject *args) {
+font_getsize(FontObject *self, PyObject *args)
+{
     int width, height, x_offset, y_offset;
     int load_flags; /* FreeType load_flags parameter */
     int error;
@@ -785,7 +795,8 @@ font_getsize(FontObject *self, PyObject *args) {
 }
 
 static PyObject *
-font_render(FontObject *self, PyObject *args) {
+font_render(FontObject *self, PyObject *args)
+{
     int x, y;         /* pen position, in 26.6 precision */
     int px, py;       /* position of current glyph, in pixels */
     int x_min, y_max; /* text offset in 26.6 precision */
@@ -1190,7 +1201,8 @@ glyph_error:
 #if FREETYPE_MAJOR > 2 || (FREETYPE_MAJOR == 2 && FREETYPE_MINOR > 9) || \
     (FREETYPE_MAJOR == 2 && FREETYPE_MINOR == 9 && FREETYPE_PATCH == 1)
 static PyObject *
-font_getvarnames(FontObject *self) {
+font_getvarnames(FontObject *self)
+{
     int error;
     FT_UInt i, j, num_namedstyles, name_count;
     FT_MM_Var *master;
@@ -1237,7 +1249,8 @@ font_getvarnames(FontObject *self) {
 }
 
 static PyObject *
-font_getvaraxes(FontObject *self) {
+font_getvaraxes(FontObject *self)
+{
     int error;
     FT_UInt i, j, num_axis, name_count;
     FT_MM_Var *master;
@@ -1305,7 +1318,8 @@ font_getvaraxes(FontObject *self) {
 }
 
 static PyObject *
-font_setvarname(FontObject *self, PyObject *args) {
+font_setvarname(FontObject *self, PyObject *args)
+{
     int error;
 
     int instance_index;
@@ -1323,7 +1337,8 @@ font_setvarname(FontObject *self, PyObject *args) {
 }
 
 static PyObject *
-font_setvaraxes(FontObject *self, PyObject *args) {
+font_setvaraxes(FontObject *self, PyObject *args)
+{
     int error;
 
     PyObject *axes, *item;
@@ -1372,7 +1387,8 @@ font_setvaraxes(FontObject *self, PyObject *args) {
 #endif
 
 static void
-font_dealloc(FontObject *self) {
+font_dealloc(FontObject *self)
+{
     if (self->face) {
         FT_Done_Face(self->face);
     }
@@ -1396,7 +1412,8 @@ static PyMethodDef font_methods[] = {
     {NULL, NULL}};
 
 static PyObject *
-font_getattr_family(FontObject *self, void *closure) {
+font_getattr_family(FontObject *self, void *closure)
+{
     if (self->face->family_name) {
         return PyUnicode_FromString(self->face->family_name);
     }
@@ -1404,7 +1421,8 @@ font_getattr_family(FontObject *self, void *closure) {
 }
 
 static PyObject *
-font_getattr_style(FontObject *self, void *closure) {
+font_getattr_style(FontObject *self, void *closure)
+{
     if (self->face->style_name) {
         return PyUnicode_FromString(self->face->style_name);
     }
@@ -1412,32 +1430,38 @@ font_getattr_style(FontObject *self, void *closure) {
 }
 
 static PyObject *
-font_getattr_ascent(FontObject *self, void *closure) {
+font_getattr_ascent(FontObject *self, void *closure)
+{
     return PyLong_FromLong(PIXEL(self->face->size->metrics.ascender));
 }
 
 static PyObject *
-font_getattr_descent(FontObject *self, void *closure) {
+font_getattr_descent(FontObject *self, void *closure)
+{
     return PyLong_FromLong(-PIXEL(self->face->size->metrics.descender));
 }
 
 static PyObject *
-font_getattr_height(FontObject *self, void *closure) {
+font_getattr_height(FontObject *self, void *closure)
+{
     return PyLong_FromLong(PIXEL(self->face->size->metrics.height));
 }
 
 static PyObject *
-font_getattr_x_ppem(FontObject *self, void *closure) {
+font_getattr_x_ppem(FontObject *self, void *closure)
+{
     return PyLong_FromLong(self->face->size->metrics.x_ppem);
 }
 
 static PyObject *
-font_getattr_y_ppem(FontObject *self, void *closure) {
+font_getattr_y_ppem(FontObject *self, void *closure)
+{
     return PyLong_FromLong(self->face->size->metrics.y_ppem);
 }
 
 static PyObject *
-font_getattr_glyphs(FontObject *self, void *closure) {
+font_getattr_glyphs(FontObject *self, void *closure)
+{
     return PyLong_FromLong(self->face->num_glyphs);
 }
 
@@ -1489,7 +1513,8 @@ static PyMethodDef _functions[] = {
     {"getfont", (PyCFunction)getfont, METH_VARARGS | METH_KEYWORDS}, {NULL, NULL}};
 
 static int
-setup_module(PyObject *m) {
+setup_module(PyObject *m)
+{
     PyObject *d;
     PyObject *v;
     int major, minor, patch;
@@ -1559,7 +1584,8 @@ setup_module(PyObject *m) {
 }
 
 PyMODINIT_FUNC
-PyInit__imagingft(void) {
+PyInit__imagingft(void)
+{
     PyObject *m;
 
     static PyModuleDef module_def = {

--- a/src/_imagingmath.c
+++ b/src/_imagingmath.c
@@ -24,7 +24,8 @@
 #define MIN_INT32 -2147483648.0
 
 #define UNOP(name, op, type)                   \
-    void name(Imaging out, Imaging im1) {      \
+    void name(Imaging out, Imaging im1)        \
+    {                                          \
         int x, y;                              \
         for (y = 0; y < out->ysize; y++) {     \
             type *p0 = (type *)out->image[y];  \
@@ -37,20 +38,21 @@
         }                                      \
     }
 
-#define BINOP(name, op, type)                          \
-    void name(Imaging out, Imaging im1, Imaging im2) { \
-        int x, y;                                      \
-        for (y = 0; y < out->ysize; y++) {             \
-            type *p0 = (type *)out->image[y];          \
-            type *p1 = (type *)im1->image[y];          \
-            type *p2 = (type *)im2->image[y];          \
-            for (x = 0; x < out->xsize; x++) {         \
-                *p0 = op(type, *p1, *p2);              \
-                p0++;                                  \
-                p1++;                                  \
-                p2++;                                  \
-            }                                          \
-        }                                              \
+#define BINOP(name, op, type)                        \
+    void name(Imaging out, Imaging im1, Imaging im2) \
+    {                                                \
+        int x, y;                                    \
+        for (y = 0; y < out->ysize; y++) {           \
+            type *p0 = (type *)out->image[y];        \
+            type *p1 = (type *)im1->image[y];        \
+            type *p2 = (type *)im2->image[y];        \
+            for (x = 0; x < out->xsize; x++) {       \
+                *p0 = op(type, *p1, *p2);            \
+                p0++;                                \
+                p1++;                                \
+                p2++;                                \
+            }                                        \
+        }                                            \
     }
 
 #define NEG(type, v1) -(v1)
@@ -87,7 +89,8 @@
 #define MOD_F(type, v1, v2) ((v2) != 0.0F) ? fmod((v1), (v2)) : 0.0F
 
 static int
-powi(int x, int y) {
+powi(int x, int y)
+{
     double v = pow(x, y) + 0.5;
     if (errno == EDOM) {
         return 0;
@@ -163,7 +166,8 @@ BINOP(gt_F, GT, FLOAT32)
 BINOP(ge_F, GE, FLOAT32)
 
 static PyObject *
-_unop(PyObject *self, PyObject *args) {
+_unop(PyObject *self, PyObject *args)
+{
     Imaging out;
     Imaging im1;
     void (*unop)(Imaging, Imaging);
@@ -185,7 +189,8 @@ _unop(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-_binop(PyObject *self, PyObject *args) {
+_binop(PyObject *self, PyObject *args)
+{
     Imaging out;
     Imaging im1;
     Imaging im2;
@@ -212,7 +217,8 @@ static PyMethodDef _functions[] = {
     {"unop", _unop, 1}, {"binop", _binop, 1}, {NULL, NULL}};
 
 static void
-install(PyObject *d, char *name, void *value) {
+install(PyObject *d, char *name, void *value)
+{
     PyObject *v = PyLong_FromSsize_t((Py_ssize_t)value);
     if (!v || PyDict_SetItemString(d, name, v)) {
         PyErr_Clear();
@@ -221,7 +227,8 @@ install(PyObject *d, char *name, void *value) {
 }
 
 static int
-setup_module(PyObject *m) {
+setup_module(PyObject *m)
+{
     PyObject *d = PyModule_GetDict(m);
 
     install(d, "abs_I", abs_I);
@@ -273,7 +280,8 @@ setup_module(PyObject *m) {
 }
 
 PyMODINIT_FUNC
-PyInit__imagingmath(void) {
+PyInit__imagingmath(void)
+{
     PyObject *m;
 
     static PyModuleDef module_def = {

--- a/src/_imagingmorph.c
+++ b/src/_imagingmorph.c
@@ -28,7 +28,8 @@
    Returns number of changed pixels.
 */
 static PyObject *
-apply(PyObject *self, PyObject *args) {
+apply(PyObject *self, PyObject *args)
+{
     const char *lut;
     PyObject *py_lut;
     Py_ssize_t lut_len, i0, i1;
@@ -127,7 +128,8 @@ apply(PyObject *self, PyObject *args) {
    Returns list of matching pixels.
 */
 static PyObject *
-match(PyObject *self, PyObject *args) {
+match(PyObject *self, PyObject *args)
+{
     const char *lut;
     PyObject *py_lut;
     Py_ssize_t lut_len, i0;
@@ -214,7 +216,8 @@ match(PyObject *self, PyObject *args) {
    This is faster than match as only 1x1 lookup is made.
 */
 static PyObject *
-get_on_pixels(PyObject *self, PyObject *args) {
+get_on_pixels(PyObject *self, PyObject *args)
+{
     Py_ssize_t i0;
     Imaging img;
     UINT8 **rows;
@@ -256,7 +259,8 @@ static PyMethodDef functions[] = {
     {NULL, NULL, 0, NULL}};
 
 PyMODINIT_FUNC
-PyInit__imagingmorph(void) {
+PyInit__imagingmorph(void)
+{
     PyObject *m;
 
     static PyModuleDef module_def = {

--- a/src/_imagingtk.c
+++ b/src/_imagingtk.c
@@ -24,7 +24,8 @@ extern int
 load_tkinter_funcs(void);
 
 static PyObject *
-_tkinit(PyObject *self, PyObject *args) {
+_tkinit(PyObject *self, PyObject *args)
+{
     Tcl_Interp *interp;
 
     PyObject *arg;
@@ -48,7 +49,8 @@ static PyMethodDef functions[] = {
 };
 
 PyMODINIT_FUNC
-PyInit__imagingtk(void) {
+PyInit__imagingtk(void)
+{
     static PyModuleDef module_def = {
         PyModuleDef_HEAD_INIT,
         "_imagingtk", /* m_name */

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -22,12 +22,14 @@
 #endif
 
 void
-ImagingSectionEnter(ImagingSectionCookie *cookie) {
+ImagingSectionEnter(ImagingSectionCookie *cookie)
+{
     *cookie = (PyThreadState *)PyEval_SaveThread();
 }
 
 void
-ImagingSectionLeave(ImagingSectionCookie *cookie) {
+ImagingSectionLeave(ImagingSectionCookie *cookie)
+{
     PyEval_RestoreThread((PyThreadState *)*cookie);
 }
 
@@ -45,7 +47,8 @@ static const char *const kErrorMessages[-WEBP_MUX_NOT_ENOUGH_DATA + 1] = {
     "WEBP_MUX_NOT_ENOUGH_DATA"};
 
 PyObject *
-HandleMuxError(WebPMuxError err, char *chunk) {
+HandleMuxError(WebPMuxError err, char *chunk)
+{
     char message[100];
     int message_len;
     assert(err <= WEBP_MUX_NOT_FOUND && err >= WEBP_MUX_NOT_ENOUGH_DATA);
@@ -115,7 +118,8 @@ static PyTypeObject WebPAnimDecoder_Type;
 
 // Encoder functions
 PyObject *
-_anim_encoder_new(PyObject *self, PyObject *args) {
+_anim_encoder_new(PyObject *self, PyObject *args)
+{
     int width, height;
     uint32_t bgcolor;
     int loop_count;
@@ -179,14 +183,16 @@ _anim_encoder_new(PyObject *self, PyObject *args) {
 }
 
 void
-_anim_encoder_dealloc(PyObject *self) {
+_anim_encoder_dealloc(PyObject *self)
+{
     WebPAnimEncoderObject *encp = (WebPAnimEncoderObject *)self;
     WebPPictureFree(&(encp->frame));
     WebPAnimEncoderDelete(encp->enc);
 }
 
 PyObject *
-_anim_encoder_add(PyObject *self, PyObject *args) {
+_anim_encoder_add(PyObject *self, PyObject *args)
+{
     uint8_t *rgb;
     Py_ssize_t size;
     int timestamp;
@@ -262,7 +268,8 @@ _anim_encoder_add(PyObject *self, PyObject *args) {
 }
 
 PyObject *
-_anim_encoder_assemble(PyObject *self, PyObject *args) {
+_anim_encoder_assemble(PyObject *self, PyObject *args)
+{
     uint8_t *icc_bytes;
     uint8_t *exif_bytes;
     uint8_t *xmp_bytes;
@@ -357,7 +364,8 @@ _anim_encoder_assemble(PyObject *self, PyObject *args) {
 
 // Decoder functions
 PyObject *
-_anim_decoder_new(PyObject *self, PyObject *args) {
+_anim_decoder_new(PyObject *self, PyObject *args)
+{
     PyBytesObject *webp_string;
     const uint8_t *webp;
     Py_ssize_t size;
@@ -403,14 +411,16 @@ _anim_decoder_new(PyObject *self, PyObject *args) {
 }
 
 void
-_anim_decoder_dealloc(PyObject *self) {
+_anim_decoder_dealloc(PyObject *self)
+{
     WebPAnimDecoderObject *decp = (WebPAnimDecoderObject *)self;
     WebPDataClear(&(decp->data));
     WebPAnimDecoderDelete(decp->dec);
 }
 
 PyObject *
-_anim_decoder_get_info(PyObject *self) {
+_anim_decoder_get_info(PyObject *self)
+{
     WebPAnimDecoderObject *decp = (WebPAnimDecoderObject *)self;
     WebPAnimInfo *info = &(decp->info);
 
@@ -425,7 +435,8 @@ _anim_decoder_get_info(PyObject *self) {
 }
 
 PyObject *
-_anim_decoder_get_chunk(PyObject *self, PyObject *args) {
+_anim_decoder_get_chunk(PyObject *self, PyObject *args)
+{
     char *mode;
     WebPAnimDecoderObject *decp = (WebPAnimDecoderObject *)self;
     const WebPDemuxer *demux;
@@ -448,7 +459,8 @@ _anim_decoder_get_chunk(PyObject *self, PyObject *args) {
 }
 
 PyObject *
-_anim_decoder_get_next(PyObject *self) {
+_anim_decoder_get_next(PyObject *self)
+{
     uint8_t *buf;
     int timestamp;
     int ok;
@@ -475,7 +487,8 @@ _anim_decoder_get_next(PyObject *self) {
 }
 
 PyObject *
-_anim_decoder_reset(PyObject *self) {
+_anim_decoder_reset(PyObject *self)
+{
     WebPAnimDecoderObject *decp = (WebPAnimDecoderObject *)self;
     WebPAnimDecoderReset(decp->dec);
     Py_RETURN_NONE;
@@ -576,7 +589,8 @@ static PyTypeObject WebPAnimDecoder_Type = {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-WebPEncode_wrapper(PyObject *self, PyObject *args) {
+WebPEncode_wrapper(PyObject *self, PyObject *args)
+{
     int width;
     int height;
     int lossless;
@@ -772,7 +786,8 @@ WebPEncode_wrapper(PyObject *self, PyObject *args) {
 }
 
 PyObject *
-WebPDecode_wrapper(PyObject *self, PyObject *args) {
+WebPDecode_wrapper(PyObject *self, PyObject *args)
+{
     PyBytesObject *webp_string;
     const uint8_t *webp;
     Py_ssize_t size;
@@ -884,13 +899,15 @@ end:
 // Return the decoder's version number, packed in hexadecimal using 8bits for
 // each of major/minor/revision. E.g: v2.5.7 is 0x020507.
 PyObject *
-WebPDecoderVersion_wrapper() {
+WebPDecoderVersion_wrapper()
+{
     return Py_BuildValue("i", WebPGetDecoderVersion());
 }
 
 // Version as string
 const char *
-WebPDecoderVersion_str(void) {
+WebPDecoderVersion_str(void)
+{
     static char version[20];
     int version_number = WebPGetDecoderVersion();
     sprintf(
@@ -907,12 +924,14 @@ WebPDecoderVersion_str(void) {
  * Files that are valid with 0.3 are reported as being invalid.
  */
 int
-WebPDecoderBuggyAlpha(void) {
+WebPDecoderBuggyAlpha(void)
+{
     return WebPGetDecoderVersion() == 0x0103;
 }
 
 PyObject *
-WebPDecoderBuggyAlpha_wrapper() {
+WebPDecoderBuggyAlpha_wrapper()
+{
     return Py_BuildValue("i", WebPDecoderBuggyAlpha());
 }
 
@@ -935,7 +954,8 @@ static PyMethodDef webpMethods[] = {
     {NULL, NULL}};
 
 void
-addMuxFlagToModule(PyObject *m) {
+addMuxFlagToModule(PyObject *m)
+{
     PyObject *have_webpmux;
 #ifdef HAVE_WEBPMUX
     have_webpmux = Py_True;
@@ -947,7 +967,8 @@ addMuxFlagToModule(PyObject *m) {
 }
 
 void
-addAnimFlagToModule(PyObject *m) {
+addAnimFlagToModule(PyObject *m)
+{
     PyObject *have_webpanim;
 #ifdef HAVE_WEBPANIM
     have_webpanim = Py_True;
@@ -959,7 +980,8 @@ addAnimFlagToModule(PyObject *m) {
 }
 
 void
-addTransparencyFlagToModule(PyObject *m) {
+addTransparencyFlagToModule(PyObject *m)
+{
     PyObject *have_transparency = PyBool_FromLong(!WebPDecoderBuggyAlpha());
     if (PyModule_AddObject(m, "HAVE_TRANSPARENCY", have_transparency)) {
         Py_DECREF(have_transparency);
@@ -967,7 +989,8 @@ addTransparencyFlagToModule(PyObject *m) {
 }
 
 static int
-setup_module(PyObject *m) {
+setup_module(PyObject *m)
+{
 #ifdef HAVE_WEBPANIM
     /* Ready object types */
     if (PyType_Ready(&WebPAnimDecoder_Type) < 0 ||
@@ -988,7 +1011,8 @@ setup_module(PyObject *m) {
 }
 
 PyMODINIT_FUNC
-PyInit__webp(void) {
+PyInit__webp(void)
+{
     PyObject *m;
 
     static PyModuleDef module_def = {

--- a/src/decode.c
+++ b/src/decode.c
@@ -57,7 +57,8 @@ typedef struct {
 static PyTypeObject ImagingDecoderType;
 
 static ImagingDecoderObject *
-PyImaging_DecoderNew(int contextsize) {
+PyImaging_DecoderNew(int contextsize)
+{
     ImagingDecoderObject *decoder;
     void *context;
 
@@ -103,7 +104,8 @@ PyImaging_DecoderNew(int contextsize) {
 }
 
 static void
-_dealloc(ImagingDecoderObject *decoder) {
+_dealloc(ImagingDecoderObject *decoder)
+{
     if (decoder->cleanup) {
         decoder->cleanup(&decoder->state);
     }
@@ -115,7 +117,8 @@ _dealloc(ImagingDecoderObject *decoder) {
 }
 
 static PyObject *
-_decode(ImagingDecoderObject *decoder, PyObject *args) {
+_decode(ImagingDecoderObject *decoder, PyObject *args)
+{
     Py_buffer buffer;
     int status;
     ImagingSectionCookie cookie;
@@ -139,7 +142,8 @@ _decode(ImagingDecoderObject *decoder, PyObject *args) {
 }
 
 static PyObject *
-_decode_cleanup(ImagingDecoderObject *decoder, PyObject *args) {
+_decode_cleanup(ImagingDecoderObject *decoder, PyObject *args)
+{
     int status = 0;
 
     if (decoder->cleanup) {
@@ -153,7 +157,8 @@ extern Imaging
 PyImaging_AsImaging(PyObject *op);
 
 static PyObject *
-_setimage(ImagingDecoderObject *decoder, PyObject *args) {
+_setimage(ImagingDecoderObject *decoder, PyObject *args)
+{
     PyObject *op;
     Imaging im;
     ImagingCodecState state;
@@ -217,7 +222,8 @@ _setimage(ImagingDecoderObject *decoder, PyObject *args) {
 }
 
 static PyObject *
-_setfd(ImagingDecoderObject *decoder, PyObject *args) {
+_setfd(ImagingDecoderObject *decoder, PyObject *args)
+{
     PyObject *fd;
     ImagingCodecState state;
 
@@ -235,7 +241,8 @@ _setfd(ImagingDecoderObject *decoder, PyObject *args) {
 }
 
 static PyObject *
-_get_pulls_fd(ImagingDecoderObject *decoder, void *closure) {
+_get_pulls_fd(ImagingDecoderObject *decoder, void *closure)
+{
     return PyBool_FromLong(decoder->pulls_fd);
 }
 
@@ -292,7 +299,8 @@ static PyTypeObject ImagingDecoderType = {
 /* -------------------------------------------------------------------- */
 
 int
-get_unpacker(ImagingDecoderObject *decoder, const char *mode, const char *rawmode) {
+get_unpacker(ImagingDecoderObject *decoder, const char *mode, const char *rawmode)
+{
     int bits;
     ImagingShuffler unpack;
 
@@ -314,7 +322,8 @@ get_unpacker(ImagingDecoderObject *decoder, const char *mode, const char *rawmod
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_BitDecoderNew(PyObject *self, PyObject *args) {
+PyImaging_BitDecoderNew(PyObject *self, PyObject *args)
+{
     ImagingDecoderObject *decoder;
 
     char *mode;
@@ -354,7 +363,8 @@ PyImaging_BitDecoderNew(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_BcnDecoderNew(PyObject *self, PyObject *args) {
+PyImaging_BcnDecoderNew(PyObject *self, PyObject *args)
+{
     ImagingDecoderObject *decoder;
 
     char *mode;
@@ -406,7 +416,8 @@ PyImaging_BcnDecoderNew(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_FliDecoderNew(PyObject *self, PyObject *args) {
+PyImaging_FliDecoderNew(PyObject *self, PyObject *args)
+{
     ImagingDecoderObject *decoder;
 
     decoder = PyImaging_DecoderNew(0);
@@ -424,7 +435,8 @@ PyImaging_FliDecoderNew(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_GifDecoderNew(PyObject *self, PyObject *args) {
+PyImaging_GifDecoderNew(PyObject *self, PyObject *args)
+{
     ImagingDecoderObject *decoder;
 
     char *mode;
@@ -459,7 +471,8 @@ PyImaging_GifDecoderNew(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_HexDecoderNew(PyObject *self, PyObject *args) {
+PyImaging_HexDecoderNew(PyObject *self, PyObject *args)
+{
     ImagingDecoderObject *decoder;
 
     char *mode;
@@ -493,7 +506,8 @@ PyImaging_HexDecoderNew(PyObject *self, PyObject *args) {
 #include <string.h>
 
 PyObject *
-PyImaging_LibTiffDecoderNew(PyObject *self, PyObject *args) {
+PyImaging_LibTiffDecoderNew(PyObject *self, PyObject *args)
+{
     ImagingDecoderObject *decoder;
     char *mode;
     char *rawmode;
@@ -534,7 +548,8 @@ PyImaging_LibTiffDecoderNew(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_PackbitsDecoderNew(PyObject *self, PyObject *args) {
+PyImaging_PackbitsDecoderNew(PyObject *self, PyObject *args)
+{
     ImagingDecoderObject *decoder;
 
     char *mode;
@@ -562,7 +577,8 @@ PyImaging_PackbitsDecoderNew(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_PcdDecoderNew(PyObject *self, PyObject *args) {
+PyImaging_PcdDecoderNew(PyObject *self, PyObject *args)
+{
     ImagingDecoderObject *decoder;
 
     decoder = PyImaging_DecoderNew(0);
@@ -585,7 +601,8 @@ PyImaging_PcdDecoderNew(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_PcxDecoderNew(PyObject *self, PyObject *args) {
+PyImaging_PcxDecoderNew(PyObject *self, PyObject *args)
+{
     ImagingDecoderObject *decoder;
 
     char *mode;
@@ -616,7 +633,8 @@ PyImaging_PcxDecoderNew(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_RawDecoderNew(PyObject *self, PyObject *args) {
+PyImaging_RawDecoderNew(PyObject *self, PyObject *args)
+{
     ImagingDecoderObject *decoder;
 
     char *mode;
@@ -650,7 +668,8 @@ PyImaging_RawDecoderNew(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_SgiRleDecoderNew(PyObject *self, PyObject *args) {
+PyImaging_SgiRleDecoderNew(PyObject *self, PyObject *args)
+{
     ImagingDecoderObject *decoder;
 
     char *mode;
@@ -684,7 +703,8 @@ PyImaging_SgiRleDecoderNew(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_SunRleDecoderNew(PyObject *self, PyObject *args) {
+PyImaging_SunRleDecoderNew(PyObject *self, PyObject *args)
+{
     ImagingDecoderObject *decoder;
 
     char *mode;
@@ -712,7 +732,8 @@ PyImaging_SunRleDecoderNew(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_TgaRleDecoderNew(PyObject *self, PyObject *args) {
+PyImaging_TgaRleDecoderNew(PyObject *self, PyObject *args)
+{
     ImagingDecoderObject *decoder;
 
     char *mode;
@@ -745,7 +766,8 @@ PyImaging_TgaRleDecoderNew(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_XbmDecoderNew(PyObject *self, PyObject *args) {
+PyImaging_XbmDecoderNew(PyObject *self, PyObject *args)
+{
     ImagingDecoderObject *decoder;
 
     decoder = PyImaging_DecoderNew(0);
@@ -771,7 +793,8 @@ PyImaging_XbmDecoderNew(PyObject *self, PyObject *args) {
 #include "libImaging/ZipCodecs.h"
 
 PyObject *
-PyImaging_ZipDecoderNew(PyObject *self, PyObject *args) {
+PyImaging_ZipDecoderNew(PyObject *self, PyObject *args)
+{
     ImagingDecoderObject *decoder;
 
     char *mode;
@@ -821,7 +844,8 @@ PyImaging_ZipDecoderNew(PyObject *self, PyObject *args) {
 #include "libImaging/Jpeg.h"
 
 PyObject *
-PyImaging_JpegDecoderNew(PyObject *self, PyObject *args) {
+PyImaging_JpegDecoderNew(PyObject *self, PyObject *args)
+{
     ImagingDecoderObject *decoder;
 
     char *mode;
@@ -876,7 +900,8 @@ PyImaging_JpegDecoderNew(PyObject *self, PyObject *args) {
 #include "libImaging/Jpeg2K.h"
 
 PyObject *
-PyImaging_Jpeg2KDecoderNew(PyObject *self, PyObject *args) {
+PyImaging_Jpeg2KDecoderNew(PyObject *self, PyObject *args)
+{
     ImagingDecoderObject *decoder;
     JPEG2KDECODESTATE *context;
 

--- a/src/display.c
+++ b/src/display.c
@@ -47,7 +47,8 @@ typedef struct {
 static PyTypeObject ImagingDisplayType;
 
 static ImagingDisplayObject *
-_new(const char *mode, int xsize, int ysize) {
+_new(const char *mode, int xsize, int ysize)
+{
     ImagingDisplayObject *display;
 
     if (PyType_Ready(&ImagingDisplayType) < 0) {
@@ -69,7 +70,8 @@ _new(const char *mode, int xsize, int ysize) {
 }
 
 static void
-_delete(ImagingDisplayObject *display) {
+_delete(ImagingDisplayObject *display)
+{
     if (display->dib) {
         ImagingDeleteDIB(display->dib);
     }
@@ -77,7 +79,8 @@ _delete(ImagingDisplayObject *display) {
 }
 
 static PyObject *
-_expose(ImagingDisplayObject *display, PyObject *args) {
+_expose(ImagingDisplayObject *display, PyObject *args)
+{
     HDC hdc;
     if (!PyArg_ParseTuple(args, F_HANDLE, &hdc)) {
         return NULL;
@@ -90,7 +93,8 @@ _expose(ImagingDisplayObject *display, PyObject *args) {
 }
 
 static PyObject *
-_draw(ImagingDisplayObject *display, PyObject *args) {
+_draw(ImagingDisplayObject *display, PyObject *args)
+{
     HDC hdc;
     int dst[4];
     int src[4];
@@ -119,7 +123,8 @@ extern Imaging
 PyImaging_AsImaging(PyObject *op);
 
 static PyObject *
-_paste(ImagingDisplayObject *display, PyObject *args) {
+_paste(ImagingDisplayObject *display, PyObject *args)
+{
     Imaging im;
 
     PyObject *op;
@@ -147,7 +152,8 @@ _paste(ImagingDisplayObject *display, PyObject *args) {
 }
 
 static PyObject *
-_query_palette(ImagingDisplayObject *display, PyObject *args) {
+_query_palette(ImagingDisplayObject *display, PyObject *args)
+{
     HDC hdc;
     int status;
 
@@ -161,7 +167,8 @@ _query_palette(ImagingDisplayObject *display, PyObject *args) {
 }
 
 static PyObject *
-_getdc(ImagingDisplayObject *display, PyObject *args) {
+_getdc(ImagingDisplayObject *display, PyObject *args)
+{
     HWND window;
     HDC dc;
 
@@ -179,7 +186,8 @@ _getdc(ImagingDisplayObject *display, PyObject *args) {
 }
 
 static PyObject *
-_releasedc(ImagingDisplayObject *display, PyObject *args) {
+_releasedc(ImagingDisplayObject *display, PyObject *args)
+{
     HWND window;
     HDC dc;
 
@@ -194,7 +202,8 @@ _releasedc(ImagingDisplayObject *display, PyObject *args) {
 }
 
 static PyObject *
-_frombytes(ImagingDisplayObject *display, PyObject *args) {
+_frombytes(ImagingDisplayObject *display, PyObject *args)
+{
     Py_buffer buffer;
 
     if (!PyArg_ParseTuple(args, "y*:frombytes", &buffer)) {
@@ -215,7 +224,8 @@ _frombytes(ImagingDisplayObject *display, PyObject *args) {
 }
 
 static PyObject *
-_tobytes(ImagingDisplayObject *display, PyObject *args) {
+_tobytes(ImagingDisplayObject *display, PyObject *args)
+{
     if (!PyArg_ParseTuple(args, ":tobytes")) {
         return NULL;
     }
@@ -237,12 +247,14 @@ static struct PyMethodDef methods[] = {
 };
 
 static PyObject *
-_getattr_mode(ImagingDisplayObject *self, void *closure) {
+_getattr_mode(ImagingDisplayObject *self, void *closure)
+{
     return Py_BuildValue("s", self->dib->mode);
 }
 
 static PyObject *
-_getattr_size(ImagingDisplayObject *self, void *closure) {
+_getattr_size(ImagingDisplayObject *self, void *closure)
+{
     return Py_BuildValue("ii", self->dib->xsize, self->dib->ysize);
 }
 
@@ -283,7 +295,8 @@ static PyTypeObject ImagingDisplayType = {
 };
 
 PyObject *
-PyImaging_DisplayWin32(PyObject *self, PyObject *args) {
+PyImaging_DisplayWin32(PyObject *self, PyObject *args)
+{
     ImagingDisplayObject *display;
     char *mode;
     int xsize, ysize;
@@ -301,7 +314,8 @@ PyImaging_DisplayWin32(PyObject *self, PyObject *args) {
 }
 
 PyObject *
-PyImaging_DisplayModeWin32(PyObject *self, PyObject *args) {
+PyImaging_DisplayModeWin32(PyObject *self, PyObject *args)
+{
     char *mode;
     int size[2];
 
@@ -316,7 +330,8 @@ PyImaging_DisplayModeWin32(PyObject *self, PyObject *args) {
 typedef HANDLE(__stdcall *Func_SetThreadDpiAwarenessContext)(HANDLE);
 
 PyObject *
-PyImaging_GrabScreenWin32(PyObject *self, PyObject *args) {
+PyImaging_GrabScreenWin32(PyObject *self, PyObject *args)
+{
     int x = 0, y = 0, width, height;
     int includeLayeredWindows = 0, all_screens = 0;
     HBITMAP bitmap;
@@ -426,7 +441,8 @@ error:
 /* Windows clipboard grabber */
 
 PyObject *
-PyImaging_GrabClipboardWin32(PyObject *self, PyObject *args) {
+PyImaging_GrabClipboardWin32(PyObject *self, PyObject *args)
+{
     HANDLE handle = NULL;
     int size;
     void *data;
@@ -484,7 +500,8 @@ PyImaging_GrabClipboardWin32(PyObject *self, PyObject *args) {
 static int mainloop = 0;
 
 static void
-callback_error(const char *handler) {
+callback_error(const char *handler)
+{
     PyObject *sys_stderr;
 
     sys_stderr = PySys_GetObject("stderr");
@@ -500,7 +517,8 @@ callback_error(const char *handler) {
 }
 
 static LRESULT CALLBACK
-windowCallback(HWND wnd, UINT message, WPARAM wParam, LPARAM lParam) {
+windowCallback(HWND wnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
     PAINTSTRUCT ps;
     PyObject *callback = NULL;
     PyObject *result;
@@ -625,7 +643,8 @@ windowCallback(HWND wnd, UINT message, WPARAM wParam, LPARAM lParam) {
 }
 
 PyObject *
-PyImaging_CreateWindowWin32(PyObject *self, PyObject *args) {
+PyImaging_CreateWindowWin32(PyObject *self, PyObject *args)
+{
     HWND wnd;
     WNDCLASS windowClass;
 
@@ -690,10 +709,12 @@ PyImaging_CreateWindowWin32(PyObject *self, PyObject *args) {
 }
 
 PyObject *
-PyImaging_EventLoopWin32(PyObject *self, PyObject *args) {
+PyImaging_EventLoopWin32(PyObject *self, PyObject *args)
+{
     MSG msg;
 
-    Py_BEGIN_ALLOW_THREADS while (mainloop && GetMessage(&msg, NULL, 0, 0)) {
+    Py_BEGIN_ALLOW_THREADS while (mainloop && GetMessage(&msg, NULL, 0, 0))
+    {
         TranslateMessage(&msg);
         DispatchMessage(&msg);
     }
@@ -709,7 +730,8 @@ PyImaging_EventLoopWin32(PyObject *self, PyObject *args) {
 #define GET32(p, o) ((DWORD *)(p + o))[0]
 
 PyObject *
-PyImaging_DrawWmf(PyObject *self, PyObject *args) {
+PyImaging_DrawWmf(PyObject *self, PyObject *args)
+{
     HBITMAP bitmap;
     HENHMETAFILE meta;
     BITMAPCOREHEADER core;
@@ -822,7 +844,8 @@ error:
 /* X11 screen grabber */
 
 PyObject *
-PyImaging_GrabScreenX11(PyObject *self, PyObject *args) {
+PyImaging_GrabScreenX11(PyObject *self, PyObject *args)
+{
     int width, height;
     char *display_name;
     xcb_connection_t *connection;

--- a/src/encode.c
+++ b/src/encode.c
@@ -49,7 +49,8 @@ typedef struct {
 static PyTypeObject ImagingEncoderType;
 
 static ImagingEncoderObject *
-PyImaging_EncoderNew(int contextsize) {
+PyImaging_EncoderNew(int contextsize)
+{
     ImagingEncoderObject *encoder;
     void *context;
 
@@ -92,7 +93,8 @@ PyImaging_EncoderNew(int contextsize) {
 }
 
 static void
-_dealloc(ImagingEncoderObject *encoder) {
+_dealloc(ImagingEncoderObject *encoder)
+{
     if (encoder->cleanup) {
         encoder->cleanup(&encoder->state);
     }
@@ -104,7 +106,8 @@ _dealloc(ImagingEncoderObject *encoder) {
 }
 
 static PyObject *
-_encode_cleanup(ImagingEncoderObject *encoder, PyObject *args) {
+_encode_cleanup(ImagingEncoderObject *encoder, PyObject *args)
+{
     int status = 0;
 
     if (encoder->cleanup) {
@@ -115,7 +118,8 @@ _encode_cleanup(ImagingEncoderObject *encoder, PyObject *args) {
 }
 
 static PyObject *
-_encode(ImagingEncoderObject *encoder, PyObject *args) {
+_encode(ImagingEncoderObject *encoder, PyObject *args)
+{
     PyObject *buf;
     PyObject *result;
     int status;
@@ -149,7 +153,8 @@ _encode(ImagingEncoderObject *encoder, PyObject *args) {
 }
 
 static PyObject *
-_encode_to_pyfd(ImagingEncoderObject *encoder) {
+_encode_to_pyfd(ImagingEncoderObject *encoder)
+{
     PyObject *result;
     int status;
 
@@ -167,7 +172,8 @@ _encode_to_pyfd(ImagingEncoderObject *encoder) {
 }
 
 static PyObject *
-_encode_to_file(ImagingEncoderObject *encoder, PyObject *args) {
+_encode_to_file(ImagingEncoderObject *encoder, PyObject *args)
+{
     UINT8 *buf;
     int status;
     ImagingSectionCookie cookie;
@@ -217,7 +223,8 @@ extern Imaging
 PyImaging_AsImaging(PyObject *op);
 
 static PyObject *
-_setimage(ImagingEncoderObject *encoder, PyObject *args) {
+_setimage(ImagingEncoderObject *encoder, PyObject *args)
+{
     PyObject *op;
     Imaging im;
     ImagingCodecState state;
@@ -280,7 +287,8 @@ _setimage(ImagingEncoderObject *encoder, PyObject *args) {
 }
 
 static PyObject *
-_setfd(ImagingEncoderObject *encoder, PyObject *args) {
+_setfd(ImagingEncoderObject *encoder, PyObject *args)
+{
     PyObject *fd;
     ImagingCodecState state;
 
@@ -298,7 +306,8 @@ _setfd(ImagingEncoderObject *encoder, PyObject *args) {
 }
 
 static PyObject *
-_get_pushes_fd(ImagingEncoderObject *encoder, void *closure) {
+_get_pushes_fd(ImagingEncoderObject *encoder, void *closure)
+{
     return PyBool_FromLong(encoder->pushes_fd);
 }
 
@@ -357,7 +366,8 @@ static PyTypeObject ImagingEncoderType = {
 /* -------------------------------------------------------------------- */
 
 int
-get_packer(ImagingEncoderObject *encoder, const char *mode, const char *rawmode) {
+get_packer(ImagingEncoderObject *encoder, const char *mode, const char *rawmode)
+{
     int bits;
     ImagingShuffler pack;
 
@@ -379,7 +389,8 @@ get_packer(ImagingEncoderObject *encoder, const char *mode, const char *rawmode)
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_EpsEncoderNew(PyObject *self, PyObject *args) {
+PyImaging_EpsEncoderNew(PyObject *self, PyObject *args)
+{
     ImagingEncoderObject *encoder;
 
     encoder = PyImaging_EncoderNew(0);
@@ -397,7 +408,8 @@ PyImaging_EpsEncoderNew(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_GifEncoderNew(PyObject *self, PyObject *args) {
+PyImaging_GifEncoderNew(PyObject *self, PyObject *args)
+{
     ImagingEncoderObject *encoder;
 
     char *mode;
@@ -430,7 +442,8 @@ PyImaging_GifEncoderNew(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_PcxEncoderNew(PyObject *self, PyObject *args) {
+PyImaging_PcxEncoderNew(PyObject *self, PyObject *args)
+{
     ImagingEncoderObject *encoder;
 
     char *mode;
@@ -460,7 +473,8 @@ PyImaging_PcxEncoderNew(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_RawEncoderNew(PyObject *self, PyObject *args) {
+PyImaging_RawEncoderNew(PyObject *self, PyObject *args)
+{
     ImagingEncoderObject *encoder;
 
     char *mode;
@@ -494,7 +508,8 @@ PyImaging_RawEncoderNew(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_TgaRleEncoderNew(PyObject *self, PyObject *args) {
+PyImaging_TgaRleEncoderNew(PyObject *self, PyObject *args)
+{
     ImagingEncoderObject *encoder;
 
     char *mode;
@@ -526,7 +541,8 @@ PyImaging_TgaRleEncoderNew(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyImaging_XbmEncoderNew(PyObject *self, PyObject *args) {
+PyImaging_XbmEncoderNew(PyObject *self, PyObject *args)
+{
     ImagingEncoderObject *encoder;
 
     encoder = PyImaging_EncoderNew(0);
@@ -552,7 +568,8 @@ PyImaging_XbmEncoderNew(PyObject *self, PyObject *args) {
 #include "libImaging/ZipCodecs.h"
 
 PyObject *
-PyImaging_ZipEncoderNew(PyObject *self, PyObject *args) {
+PyImaging_ZipEncoderNew(PyObject *self, PyObject *args)
+{
     ImagingEncoderObject *encoder;
 
     char *mode;
@@ -628,7 +645,8 @@ PyImaging_ZipEncoderNew(PyObject *self, PyObject *args) {
 #include <string.h>
 
 PyObject *
-PyImaging_LibTiffEncoderNew(PyObject *self, PyObject *args) {
+PyImaging_LibTiffEncoderNew(PyObject *self, PyObject *args)
+{
     ImagingEncoderObject *encoder;
 
     char *mode;
@@ -970,7 +988,8 @@ PyImaging_LibTiffEncoderNew(PyObject *self, PyObject *args) {
 #include "libImaging/Jpeg.h"
 
 static unsigned int *
-get_qtables_arrays(PyObject *qtables, int *qtablesLen) {
+get_qtables_arrays(PyObject *qtables, int *qtablesLen)
+{
     PyObject *tables;
     PyObject *table;
     PyObject *table_data;
@@ -1033,7 +1052,8 @@ JPEG_QTABLES_ERR:
 }
 
 PyObject *
-PyImaging_JpegEncoderNew(PyObject *self, PyObject *args) {
+PyImaging_JpegEncoderNew(PyObject *self, PyObject *args)
+{
     ImagingEncoderObject *encoder;
 
     char *mode;
@@ -1188,7 +1208,8 @@ PyImaging_JpegEncoderNew(PyObject *self, PyObject *args) {
 #include "libImaging/Jpeg2K.h"
 
 static void
-j2k_decode_coord_tuple(PyObject *tuple, int *x, int *y) {
+j2k_decode_coord_tuple(PyObject *tuple, int *x, int *y)
+{
     *x = *y = 0;
 
     if (tuple && PyTuple_Check(tuple) && PyTuple_GET_SIZE(tuple) == 2) {
@@ -1205,7 +1226,8 @@ j2k_decode_coord_tuple(PyObject *tuple, int *x, int *y) {
 }
 
 PyObject *
-PyImaging_Jpeg2KEncoderNew(PyObject *self, PyObject *args) {
+PyImaging_Jpeg2KEncoderNew(PyObject *self, PyObject *args)
+{
     ImagingEncoderObject *encoder;
     JPEG2KENCODESTATE *context;
 

--- a/src/libImaging/Access.c
+++ b/src/libImaging/Access.c
@@ -18,7 +18,8 @@
 static struct ImagingAccessInstance access_table[ACCESS_TABLE_SIZE];
 
 static inline UINT32
-hash(const char *mode) {
+hash(const char *mode)
+{
     UINT32 i = ACCESS_TABLE_HASH;
     while (*mode) {
         i = ((i << 5) + i) ^ (UINT8)*mode++;
@@ -27,7 +28,8 @@ hash(const char *mode) {
 }
 
 static ImagingAccess
-add_item(const char *mode) {
+add_item(const char *mode)
+{
     UINT32 i = hash(mode);
     /* printf("hash %s => %d\n", mode, i); */
     if (access_table[i].mode && strcmp(access_table[i].mode, mode) != 0) {
@@ -46,7 +48,8 @@ add_item(const char *mode) {
 /* fetch individual pixel */
 
 static void
-get_pixel_32_2bands(Imaging im, int x, int y, void *color) {
+get_pixel_32_2bands(Imaging im, int x, int y, void *color)
+{
     char *out = color;
     UINT8 *p = (UINT8 *)&im->image32[y][x];
     out[0] = p[0];
@@ -54,13 +57,15 @@ get_pixel_32_2bands(Imaging im, int x, int y, void *color) {
 }
 
 static void
-get_pixel_8(Imaging im, int x, int y, void *color) {
+get_pixel_8(Imaging im, int x, int y, void *color)
+{
     char *out = color;
     out[0] = im->image8[y][x];
 }
 
 static void
-get_pixel_16L(Imaging im, int x, int y, void *color) {
+get_pixel_16L(Imaging im, int x, int y, void *color)
+{
     UINT8 *in = (UINT8 *)&im->image[y][x + x];
 #ifdef WORDS_BIGENDIAN
     UINT16 out = in[0] + (in[1] << 8);
@@ -71,7 +76,8 @@ get_pixel_16L(Imaging im, int x, int y, void *color) {
 }
 
 static void
-get_pixel_16B(Imaging im, int x, int y, void *color) {
+get_pixel_16B(Imaging im, int x, int y, void *color)
+{
     UINT8 *in = (UINT8 *)&im->image[y][x + x];
 #ifdef WORDS_BIGENDIAN
     memcpy(color, in, sizeof(UINT16));
@@ -82,7 +88,8 @@ get_pixel_16B(Imaging im, int x, int y, void *color) {
 }
 
 static void
-get_pixel_BGR15(Imaging im, int x, int y, void *color) {
+get_pixel_BGR15(Imaging im, int x, int y, void *color)
+{
     UINT8 *in = (UINT8 *)&im->image8[y][x * 2];
     UINT16 pixel = in[0] + (in[1] << 8);
     char *out = color;
@@ -92,7 +99,8 @@ get_pixel_BGR15(Imaging im, int x, int y, void *color) {
 }
 
 static void
-get_pixel_BGR16(Imaging im, int x, int y, void *color) {
+get_pixel_BGR16(Imaging im, int x, int y, void *color)
+{
     UINT8 *in = (UINT8 *)&im->image8[y][x * 2];
     UINT16 pixel = in[0] + (in[1] << 8);
     char *out = color;
@@ -102,17 +110,20 @@ get_pixel_BGR16(Imaging im, int x, int y, void *color) {
 }
 
 static void
-get_pixel_BGR24(Imaging im, int x, int y, void *color) {
+get_pixel_BGR24(Imaging im, int x, int y, void *color)
+{
     memcpy(color, &im->image8[y][x * 3], sizeof(UINT8) * 3);
 }
 
 static void
-get_pixel_32(Imaging im, int x, int y, void *color) {
+get_pixel_32(Imaging im, int x, int y, void *color)
+{
     memcpy(color, &im->image32[y][x], sizeof(INT32));
 }
 
 static void
-get_pixel_32L(Imaging im, int x, int y, void *color) {
+get_pixel_32L(Imaging im, int x, int y, void *color)
+{
     UINT8 *in = (UINT8 *)&im->image[y][x * 4];
 #ifdef WORDS_BIGENDIAN
     INT32 out = in[0] + (in[1] << 8) + (in[2] << 16) + (in[3] << 24);
@@ -123,7 +134,8 @@ get_pixel_32L(Imaging im, int x, int y, void *color) {
 }
 
 static void
-get_pixel_32B(Imaging im, int x, int y, void *color) {
+get_pixel_32B(Imaging im, int x, int y, void *color)
+{
     UINT8 *in = (UINT8 *)&im->image[y][x * 4];
 #ifdef WORDS_BIGENDIAN
     memcpy(color, in, sizeof(INT32));
@@ -136,17 +148,20 @@ get_pixel_32B(Imaging im, int x, int y, void *color) {
 /* store individual pixel */
 
 static void
-put_pixel_8(Imaging im, int x, int y, const void *color) {
+put_pixel_8(Imaging im, int x, int y, const void *color)
+{
     im->image8[y][x] = *((UINT8 *)color);
 }
 
 static void
-put_pixel_16L(Imaging im, int x, int y, const void *color) {
+put_pixel_16L(Imaging im, int x, int y, const void *color)
+{
     memcpy(&im->image8[y][x + x], color, 2);
 }
 
 static void
-put_pixel_16B(Imaging im, int x, int y, const void *color) {
+put_pixel_16B(Imaging im, int x, int y, const void *color)
+{
     const char *in = color;
     UINT8 *out = (UINT8 *)&im->image8[y][x + x];
     out[0] = in[1];
@@ -154,22 +169,26 @@ put_pixel_16B(Imaging im, int x, int y, const void *color) {
 }
 
 static void
-put_pixel_BGR1516(Imaging im, int x, int y, const void *color) {
+put_pixel_BGR1516(Imaging im, int x, int y, const void *color)
+{
     memcpy(&im->image8[y][x * 2], color, 2);
 }
 
 static void
-put_pixel_BGR24(Imaging im, int x, int y, const void *color) {
+put_pixel_BGR24(Imaging im, int x, int y, const void *color)
+{
     memcpy(&im->image8[y][x * 3], color, 3);
 }
 
 static void
-put_pixel_32L(Imaging im, int x, int y, const void *color) {
+put_pixel_32L(Imaging im, int x, int y, const void *color)
+{
     memcpy(&im->image8[y][x * 4], color, 4);
 }
 
 static void
-put_pixel_32B(Imaging im, int x, int y, const void *color) {
+put_pixel_32B(Imaging im, int x, int y, const void *color)
+{
     const char *in = color;
     UINT8 *out = (UINT8 *)&im->image8[y][x * 4];
     out[0] = in[3];
@@ -179,12 +198,14 @@ put_pixel_32B(Imaging im, int x, int y, const void *color) {
 }
 
 static void
-put_pixel_32(Imaging im, int x, int y, const void *color) {
+put_pixel_32(Imaging im, int x, int y, const void *color)
+{
     memcpy(&im->image32[y][x], color, sizeof(INT32));
 }
 
 void
-ImagingAccessInit() {
+ImagingAccessInit()
+{
 #define ADD(mode_, get_pixel_, put_pixel_)      \
     {                                           \
         ImagingAccess access = add_item(mode_); \
@@ -225,7 +246,8 @@ ImagingAccessInit() {
 }
 
 ImagingAccess
-ImagingAccessNew(Imaging im) {
+ImagingAccessNew(Imaging im)
+{
     ImagingAccess access = &access_table[hash(im->mode)];
     if (im->mode[0] != access->mode[0] || strcmp(im->mode, access->mode) != 0) {
         return NULL;
@@ -234,4 +256,6 @@ ImagingAccessNew(Imaging im) {
 }
 
 void
-_ImagingAccessDelete(Imaging im, ImagingAccess access) {}
+_ImagingAccessDelete(Imaging im, ImagingAccess access)
+{
+}

--- a/src/libImaging/AlphaComposite.c
+++ b/src/libImaging/AlphaComposite.c
@@ -20,7 +20,8 @@ typedef struct {
 } rgba8;
 
 Imaging
-ImagingAlphaComposite(Imaging imDst, Imaging imSrc) {
+ImagingAlphaComposite(Imaging imDst, Imaging imSrc)
+{
     Imaging imOut;
     int x, y;
 

--- a/src/libImaging/Bands.c
+++ b/src/libImaging/Bands.c
@@ -18,7 +18,8 @@
 #include "Imaging.h"
 
 Imaging
-ImagingGetBand(Imaging imIn, int band) {
+ImagingGetBand(Imaging imIn, int band)
+{
     Imaging imOut;
     int x, y;
 
@@ -66,7 +67,8 @@ ImagingGetBand(Imaging imIn, int band) {
 }
 
 int
-ImagingSplit(Imaging imIn, Imaging bands[4]) {
+ImagingSplit(Imaging imIn, Imaging bands[4])
+{
     int i, j, x, y;
 
     /* Check arguments */
@@ -167,7 +169,8 @@ ImagingSplit(Imaging imIn, Imaging bands[4]) {
 }
 
 Imaging
-ImagingPutBand(Imaging imOut, Imaging imIn, int band) {
+ImagingPutBand(Imaging imOut, Imaging imIn, int band)
+{
     int x, y;
 
     /* Check arguments */
@@ -208,7 +211,8 @@ ImagingPutBand(Imaging imOut, Imaging imIn, int band) {
 }
 
 Imaging
-ImagingFillBand(Imaging imOut, int band, int color) {
+ImagingFillBand(Imaging imOut, int band, int color)
+{
     int x, y;
 
     /* Check arguments */
@@ -240,7 +244,8 @@ ImagingFillBand(Imaging imOut, int band, int color) {
 }
 
 Imaging
-ImagingMerge(const char *mode, Imaging bands[4]) {
+ImagingMerge(const char *mode, Imaging bands[4])
+{
     int i, x, y;
     int bandsCount = 0;
     Imaging imOut;

--- a/src/libImaging/BcnDecode.c
+++ b/src/libImaging/BcnDecode.c
@@ -43,14 +43,16 @@ typedef struct {
 #define LOAD32(p) (p)[0] | ((p)[1] << 8) | ((p)[2] << 16) | ((p)[3] << 24)
 
 static void
-bc1_color_load(bc1_color *dst, const UINT8 *src) {
+bc1_color_load(bc1_color *dst, const UINT8 *src)
+{
     dst->c0 = LOAD16(src);
     dst->c1 = LOAD16(src + 2);
     dst->lut = LOAD32(src + 4);
 }
 
 static rgba
-decode_565(UINT16 x) {
+decode_565(UINT16 x)
+{
     rgba c;
     int r, g, b;
     r = (x & 0xf800) >> 8;
@@ -67,7 +69,8 @@ decode_565(UINT16 x) {
 }
 
 static void
-decode_bc1_color(rgba *dst, const UINT8 *src, int separate_alpha) {
+decode_bc1_color(rgba *dst, const UINT8 *src, int separate_alpha)
+{
     bc1_color col;
     rgba p[4];
     int n, cw;
@@ -110,7 +113,8 @@ decode_bc1_color(rgba *dst, const UINT8 *src, int separate_alpha) {
 }
 
 static void
-decode_bc3_alpha(char *dst, const UINT8 *src, int stride, int o, int sign) {
+decode_bc3_alpha(char *dst, const UINT8 *src, int stride, int o, int sign)
+{
     UINT16 a0, a1;
     UINT8 a[8];
     int n, lut1, lut2, aw;
@@ -158,12 +162,14 @@ decode_bc3_alpha(char *dst, const UINT8 *src, int stride, int o, int sign) {
 }
 
 static void
-decode_bc1_block(rgba *col, const UINT8 *src) {
+decode_bc1_block(rgba *col, const UINT8 *src)
+{
     decode_bc1_color(col, src, 0);
 }
 
 static void
-decode_bc2_block(rgba *col, const UINT8 *src) {
+decode_bc2_block(rgba *col, const UINT8 *src)
+{
     int n, bitI, byI, av;
     decode_bc1_color(col, src + 8, 1);
     for (n = 0; n < 16; n++) {
@@ -176,18 +182,21 @@ decode_bc2_block(rgba *col, const UINT8 *src) {
 }
 
 static void
-decode_bc3_block(rgba *col, const UINT8 *src) {
+decode_bc3_block(rgba *col, const UINT8 *src)
+{
     decode_bc1_color(col, src + 8, 1);
     decode_bc3_alpha((char *)col, src, sizeof(col[0]), 3, 0);
 }
 
 static void
-decode_bc4_block(lum *col, const UINT8 *src) {
+decode_bc4_block(lum *col, const UINT8 *src)
+{
     decode_bc3_alpha((char *)col, src, sizeof(col[0]), 0, 0);
 }
 
 static void
-decode_bc5_block(rgba *col, const UINT8 *src, int sign) {
+decode_bc5_block(rgba *col, const UINT8 *src, int sign)
+{
     decode_bc3_alpha((char *)col, src, sizeof(col[0]), 0, sign);
     decode_bc3_alpha((char *)col, src + 8, sizeof(col[0]), 1, sign);
 }
@@ -197,14 +206,16 @@ decode_bc5_block(rgba *col, const UINT8 *src, int sign) {
  */
 
 static UINT8
-get_bit(const UINT8 *src, int bit) {
+get_bit(const UINT8 *src, int bit)
+{
     int by = bit >> 3;
     bit &= 7;
     return (src[by] >> bit) & 1;
 }
 
 static UINT8
-get_bits(const UINT8 *src, int bit, int count) {
+get_bits(const UINT8 *src, int bit, int count)
+{
     UINT8 v;
     int x;
     int by = bit >> 3;
@@ -296,7 +307,8 @@ static const char bc7_weights4[] = {
     0, 4, 9, 13, 17, 21, 26, 30, 34, 38, 43, 47, 51, 55, 60, 64};
 
 static const char *
-bc7_get_weights(int n) {
+bc7_get_weights(int n)
+{
     if (n == 2) {
         return bc7_weights2;
     }
@@ -307,7 +319,8 @@ bc7_get_weights(int n) {
 }
 
 static int
-bc7_get_subset(int ns, int partition, int n) {
+bc7_get_subset(int ns, int partition, int n)
+{
     if (ns == 2) {
         return 1 & (bc7_si2[partition] >> n);
     }
@@ -318,13 +331,15 @@ bc7_get_subset(int ns, int partition, int n) {
 }
 
 static UINT8
-expand_quantized(UINT8 v, int bits) {
+expand_quantized(UINT8 v, int bits)
+{
     v = v << (8 - bits);
     return v | (v >> bits);
 }
 
 static void
-bc7_lerp(rgba *dst, const rgba *e, int s0, int s1) {
+bc7_lerp(rgba *dst, const rgba *e, int s0, int s1)
+{
     int t0 = 64 - s0;
     int t1 = 64 - s1;
     dst->r = (UINT8)((t0 * e[0].r + s0 * e[1].r + 32) >> 6);
@@ -334,7 +349,8 @@ bc7_lerp(rgba *dst, const rgba *e, int s0, int s1) {
 }
 
 static void
-decode_bc7_block(rgba *col, const UINT8 *src) {
+decode_bc7_block(rgba *col, const UINT8 *src)
+{
     rgba endpoints[6];
     int bit = 0, cibit, aibit;
     int mode = src[0];
@@ -594,7 +610,8 @@ static const UINT8 bc6_bit_packings[][75] = {
      64, 65, 66, 67, 31, 30, 29, 28, 27, 26, 80, 81, 82, 83, 47, 46, 45, 44, 43, 42}};
 
 static void
-bc6_sign_extend(UINT16 *v, int prec) {
+bc6_sign_extend(UINT16 *v, int prec)
+{
     int x = *v;
     if (x & (1 << (prec - 1))) {
         x |= -1 << prec;
@@ -603,7 +620,8 @@ bc6_sign_extend(UINT16 *v, int prec) {
 }
 
 static int
-bc6_unquantize(UINT16 v, int prec, int sign) {
+bc6_unquantize(UINT16 v, int prec, int sign)
+{
     int s = 0;
     int x;
     if (!sign) {
@@ -644,7 +662,8 @@ bc6_unquantize(UINT16 v, int prec, int sign) {
 }
 
 static float
-half_to_float(UINT16 h) {
+half_to_float(UINT16 h)
+{
     /* https://gist.github.com/rygorous/2144712 */
     union {
         UINT32 u;
@@ -662,7 +681,8 @@ half_to_float(UINT16 h) {
 }
 
 static float
-bc6_finalize(int v, int sign) {
+bc6_finalize(int v, int sign)
+{
     if (sign) {
         if (v < 0) {
             v = ((-v) * 31) / 32;
@@ -676,7 +696,8 @@ bc6_finalize(int v, int sign) {
 }
 
 static UINT8
-bc6_clamp(float value) {
+bc6_clamp(float value)
+{
     if (value < 0.0f) {
         return 0;
     } else if (value > 1.0f) {
@@ -687,7 +708,8 @@ bc6_clamp(float value) {
 }
 
 static void
-bc6_lerp(rgba *col, int *e0, int *e1, int s, int sign) {
+bc6_lerp(rgba *col, int *e0, int *e1, int s, int sign)
+{
     int r, g, b;
     int t = 64 - s;
     r = (e0[0] * t + e1[0] * s) >> 6;
@@ -699,7 +721,8 @@ bc6_lerp(rgba *col, int *e0, int *e1, int s, int sign) {
 }
 
 static void
-decode_bc6_block(rgba *col, const UINT8 *src, int sign) {
+decode_bc6_block(rgba *col, const UINT8 *src, int sign)
+{
     UINT16 endpoints[12]; /* storage for r0, g0, b0, r1, ... */
     int ueps[12];
     int i, i0, ib2, di, dw, mask, numep, s;
@@ -782,7 +805,8 @@ decode_bc6_block(rgba *col, const UINT8 *src, int sign) {
 }
 
 static void
-put_block(Imaging im, ImagingCodecState state, const char *col, int sz, int C) {
+put_block(Imaging im, ImagingCodecState state, const char *col, int sz, int C)
+{
     int width = state->xsize;
     int height = state->ysize;
     int xmax = width + state->xoff;
@@ -830,7 +854,8 @@ decode_bcn(
     int bytes,
     int N,
     int C,
-    char *pixel_format) {
+    char *pixel_format)
+{
     int ymax = state->ysize + state->yoff;
     const UINT8 *ptr = src;
     switch (N) {
@@ -889,7 +914,8 @@ decode_bcn(
 }
 
 int
-ImagingBcnDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes) {
+ImagingBcnDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes)
+{
     int N = state->state & 0xf;
     int width = state->xsize;
     int height = state->ysize;

--- a/src/libImaging/BitDecode.c
+++ b/src/libImaging/BitDecode.c
@@ -18,7 +18,8 @@
 #include "Bit.h"
 
 int
-ImagingBitDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes) {
+ImagingBitDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes)
+{
     BITSTATE *bitstate = state->context;
     UINT8 *ptr;
 

--- a/src/libImaging/Blend.c
+++ b/src/libImaging/Blend.c
@@ -18,7 +18,8 @@
 #include "Imaging.h"
 
 Imaging
-ImagingBlend(Imaging imIn1, Imaging imIn2, float alpha) {
+ImagingBlend(Imaging imIn1, Imaging imIn2, float alpha)
+{
     Imaging imOut;
     int x, y;
 

--- a/src/libImaging/BoxBlur.c
+++ b/src/libImaging/BoxBlur.c
@@ -13,7 +13,8 @@ void static inline ImagingLineBoxBlur32(
     int edgeA,
     int edgeB,
     UINT32 ww,
-    UINT32 fw) {
+    UINT32 fw)
+{
     int x;
     UINT32 acc[4];
     UINT32 bulk[4];
@@ -109,7 +110,8 @@ void static inline ImagingLineBoxBlur8(
     int edgeA,
     int edgeB,
     UINT32 ww,
-    UINT32 fw) {
+    UINT32 fw)
+{
     int x;
     UINT32 acc;
     UINT32 bulk;
@@ -167,7 +169,8 @@ void static inline ImagingLineBoxBlur8(
 }
 
 Imaging
-ImagingHorizontalBoxBlur(Imaging imOut, Imaging imIn, float floatRadius) {
+ImagingHorizontalBoxBlur(Imaging imOut, Imaging imIn, float floatRadius)
+{
     ImagingSectionCookie cookie;
 
     int y;
@@ -230,7 +233,8 @@ ImagingHorizontalBoxBlur(Imaging imOut, Imaging imIn, float floatRadius) {
 }
 
 Imaging
-ImagingBoxBlur(Imaging imOut, Imaging imIn, float xradius, float yradius, int n) {
+ImagingBoxBlur(Imaging imOut, Imaging imIn, float xradius, float yradius, int n)
+{
     int i;
     Imaging imTransposed;
 
@@ -296,7 +300,8 @@ ImagingBoxBlur(Imaging imOut, Imaging imIn, float xradius, float yradius, int n)
 }
 
 static float
-_gaussian_blur_radius(float radius, int passes) {
+_gaussian_blur_radius(float radius, int passes)
+{
     float sigma2, L, l, a;
 
     sigma2 = radius * radius / passes;
@@ -314,7 +319,8 @@ _gaussian_blur_radius(float radius, int passes) {
 
 Imaging
 ImagingGaussianBlur(
-    Imaging imOut, Imaging imIn, float xradius, float yradius, int passes) {
+    Imaging imOut, Imaging imIn, float xradius, float yradius, int passes)
+{
     return ImagingBoxBlur(
         imOut,
         imIn,

--- a/src/libImaging/Chops.c
+++ b/src/libImaging/Chops.c
@@ -60,7 +60,8 @@
     return imOut;
 
 static Imaging
-create(Imaging im1, Imaging im2, char *mode) {
+create(Imaging im1, Imaging im2, char *mode)
+{
     int xsize, ysize;
 
     if (!im1 || !im2 || im1->type != IMAGING_TYPE_UINT8 ||
@@ -78,67 +79,80 @@ create(Imaging im1, Imaging im2, char *mode) {
 }
 
 Imaging
-ImagingChopLighter(Imaging imIn1, Imaging imIn2) {
+ImagingChopLighter(Imaging imIn1, Imaging imIn2)
+{
     CHOP((in1[x] > in2[x]) ? in1[x] : in2[x]);
 }
 
 Imaging
-ImagingChopDarker(Imaging imIn1, Imaging imIn2) {
+ImagingChopDarker(Imaging imIn1, Imaging imIn2)
+{
     CHOP((in1[x] < in2[x]) ? in1[x] : in2[x]);
 }
 
 Imaging
-ImagingChopDifference(Imaging imIn1, Imaging imIn2) {
+ImagingChopDifference(Imaging imIn1, Imaging imIn2)
+{
     CHOP(abs((int)in1[x] - (int)in2[x]));
 }
 
 Imaging
-ImagingChopMultiply(Imaging imIn1, Imaging imIn2) {
+ImagingChopMultiply(Imaging imIn1, Imaging imIn2)
+{
     CHOP((int)in1[x] * (int)in2[x] / 255);
 }
 
 Imaging
-ImagingChopScreen(Imaging imIn1, Imaging imIn2) {
+ImagingChopScreen(Imaging imIn1, Imaging imIn2)
+{
     CHOP(255 - ((int)(255 - in1[x]) * (int)(255 - in2[x])) / 255);
 }
 
 Imaging
-ImagingChopAdd(Imaging imIn1, Imaging imIn2, float scale, int offset) {
+ImagingChopAdd(Imaging imIn1, Imaging imIn2, float scale, int offset)
+{
     CHOP(((int)in1[x] + (int)in2[x]) / scale + offset);
 }
 
 Imaging
-ImagingChopSubtract(Imaging imIn1, Imaging imIn2, float scale, int offset) {
+ImagingChopSubtract(Imaging imIn1, Imaging imIn2, float scale, int offset)
+{
     CHOP(((int)in1[x] - (int)in2[x]) / scale + offset);
 }
 
 Imaging
-ImagingChopAnd(Imaging imIn1, Imaging imIn2) {
+ImagingChopAnd(Imaging imIn1, Imaging imIn2)
+{
     CHOP2((in1[x] && in2[x]) ? 255 : 0, "1");
 }
 
 Imaging
-ImagingChopOr(Imaging imIn1, Imaging imIn2) {
+ImagingChopOr(Imaging imIn1, Imaging imIn2)
+{
     CHOP2((in1[x] || in2[x]) ? 255 : 0, "1");
 }
 
 Imaging
-ImagingChopXor(Imaging imIn1, Imaging imIn2) {
+ImagingChopXor(Imaging imIn1, Imaging imIn2)
+{
     CHOP2(((in1[x] != 0) ^ (in2[x] != 0)) ? 255 : 0, "1");
 }
 
 Imaging
-ImagingChopAddModulo(Imaging imIn1, Imaging imIn2) {
+ImagingChopAddModulo(Imaging imIn1, Imaging imIn2)
+{
     CHOP2(in1[x] + in2[x], NULL);
 }
 
 Imaging
-ImagingChopSubtractModulo(Imaging imIn1, Imaging imIn2) {
+ImagingChopSubtractModulo(Imaging imIn1, Imaging imIn2)
+{
     CHOP2(in1[x] - in2[x], NULL);
 }
 
 Imaging
-ImagingChopSoftLight(Imaging imIn1, Imaging imIn2) {
+ImagingChopSoftLight(Imaging imIn1, Imaging imIn2)
+{
     CHOP2(
         (((255 - in1[x]) * (in1[x] * in2[x])) / 65536) +
             (in1[x] * (255 - ((255 - in1[x]) * (255 - in2[x]) / 255))) / 255,
@@ -146,7 +160,8 @@ ImagingChopSoftLight(Imaging imIn1, Imaging imIn2) {
 }
 
 Imaging
-ImagingChopHardLight(Imaging imIn1, Imaging imIn2) {
+ImagingChopHardLight(Imaging imIn1, Imaging imIn2)
+{
     CHOP2(
         (in2[x] < 128) ? ((in1[x] * in2[x]) / 127)
                        : 255 - (((255 - in2[x]) * (255 - in1[x])) / 127),
@@ -154,7 +169,8 @@ ImagingChopHardLight(Imaging imIn1, Imaging imIn2) {
 }
 
 Imaging
-ImagingOverlay(Imaging imIn1, Imaging imIn2) {
+ImagingOverlay(Imaging imIn1, Imaging imIn2)
+{
     CHOP2(
         (in1[x] < 128) ? ((in1[x] * in2[x]) / 127)
                        : 255 - (((255 - in1[x]) * (255 - in2[x])) / 127),

--- a/src/libImaging/ColorLUT.c
+++ b/src/libImaging/ColorLUT.c
@@ -16,19 +16,22 @@
 #define SHIFT_BITS (16 - 1)
 
 static inline UINT8
-clip8(int in) {
+clip8(int in)
+{
     return clip8_lookups[(in + PRECISION_ROUNDING) >> PRECISION_BITS];
 }
 
 static inline void
-interpolate3(INT16 out[3], const INT16 a[3], const INT16 b[3], INT16 shift) {
+interpolate3(INT16 out[3], const INT16 a[3], const INT16 b[3], INT16 shift)
+{
     out[0] = (a[0] * ((1 << SHIFT_BITS) - shift) + b[0] * shift) >> SHIFT_BITS;
     out[1] = (a[1] * ((1 << SHIFT_BITS) - shift) + b[1] * shift) >> SHIFT_BITS;
     out[2] = (a[2] * ((1 << SHIFT_BITS) - shift) + b[2] * shift) >> SHIFT_BITS;
 }
 
 static inline void
-interpolate4(INT16 out[4], const INT16 a[4], const INT16 b[4], INT16 shift) {
+interpolate4(INT16 out[4], const INT16 a[4], const INT16 b[4], INT16 shift)
+{
     out[0] = (a[0] * ((1 << SHIFT_BITS) - shift) + b[0] * shift) >> SHIFT_BITS;
     out[1] = (a[1] * ((1 << SHIFT_BITS) - shift) + b[1] * shift) >> SHIFT_BITS;
     out[2] = (a[2] * ((1 << SHIFT_BITS) - shift) + b[2] * shift) >> SHIFT_BITS;
@@ -36,7 +39,8 @@ interpolate4(INT16 out[4], const INT16 a[4], const INT16 b[4], INT16 shift) {
 }
 
 static inline int
-table_index3D(int index1D, int index2D, int index3D, int size1D, int size1D_2D) {
+table_index3D(int index1D, int index2D, int index3D, int size1D, int size1D_2D)
+{
     return index1D + index2D * size1D + index3D * size1D_2D;
 }
 
@@ -63,7 +67,8 @@ ImagingColorLUT3D_linear(
     int size1D,
     int size2D,
     int size3D,
-    INT16 *table) {
+    INT16 *table)
+{
     /* This float to int conversion doesn't have rounding
        error compensation (+0.5) for two reasons:
        1. As we don't hit the highest value,

--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -48,13 +48,15 @@
 /* ------------------- */
 
 static void
-bit2l(UINT8 *out, const UINT8 *in, int xsize) {
+bit2l(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++) *out++ = (*in++ != 0) ? 255 : 0;
 }
 
 static void
-bit2rgb(UINT8 *out, const UINT8 *in, int xsize) {
+bit2rgb(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++) {
         UINT8 v = (*in++ != 0) ? 255 : 0;
@@ -66,7 +68,8 @@ bit2rgb(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-bit2cmyk(UINT8 *out, const UINT8 *in, int xsize) {
+bit2cmyk(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++) {
         *out++ = 0;
@@ -77,7 +80,8 @@ bit2cmyk(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-bit2ycbcr(UINT8 *out, const UINT8 *in, int xsize) {
+bit2ycbcr(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++) {
         *out++ = (*in++ != 0) ? 255 : 0;
@@ -88,7 +92,8 @@ bit2ycbcr(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-bit2hsv(UINT8 *out, const UINT8 *in, int xsize) {
+bit2hsv(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, out += 4) {
         UINT8 v = (*in++ != 0) ? 255 : 0;
@@ -104,7 +109,8 @@ bit2hsv(UINT8 *out, const UINT8 *in, int xsize) {
 /* ----------------- */
 
 static void
-l2bit(UINT8 *out, const UINT8 *in, int xsize) {
+l2bit(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++) {
         *out++ = (*in++ >= 128) ? 255 : 0;
@@ -112,7 +118,8 @@ l2bit(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-lA2la(UINT8 *out, const UINT8 *in, int xsize) {
+lA2la(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     unsigned int alpha, pixel, tmp;
     for (x = 0; x < xsize; x++, in += 4) {
@@ -128,7 +135,8 @@ lA2la(UINT8 *out, const UINT8 *in, int xsize) {
 /* RGBa -> RGBA conversion to remove premultiplication
    Needed for correct transforms/resizing on RGBA images */
 static void
-la2lA(UINT8 *out, const UINT8 *in, int xsize) {
+la2lA(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     unsigned int alpha, pixel;
     for (x = 0; x < xsize; x++, in += 4) {
@@ -146,7 +154,8 @@ la2lA(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-l2la(UINT8 *out, const UINT8 *in, int xsize) {
+l2la(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++) {
         UINT8 v = *in++;
@@ -158,7 +167,8 @@ l2la(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-l2rgb(UINT8 *out, const UINT8 *in, int xsize) {
+l2rgb(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++) {
         UINT8 v = *in++;
@@ -170,7 +180,8 @@ l2rgb(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-l2hsv(UINT8 *out, const UINT8 *in, int xsize) {
+l2hsv(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, out += 4) {
         UINT8 v = *in++;
@@ -182,7 +193,8 @@ l2hsv(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-la2l(UINT8 *out, const UINT8 *in, int xsize) {
+la2l(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4) {
         *out++ = in[0];
@@ -190,7 +202,8 @@ la2l(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-la2rgb(UINT8 *out, const UINT8 *in, int xsize) {
+la2rgb(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4) {
         UINT8 v = in[0];
@@ -202,7 +215,8 @@ la2rgb(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-la2hsv(UINT8 *out, const UINT8 *in, int xsize) {
+la2hsv(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4, out += 4) {
         UINT8 v = in[0];
@@ -214,7 +228,8 @@ la2hsv(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-rgb2bit(UINT8 *out, const UINT8 *in, int xsize) {
+rgb2bit(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4) {
         /* ITU-R Recommendation 601-2 (assuming nonlinear RGB) */
@@ -223,7 +238,8 @@ rgb2bit(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-rgb2l(UINT8 *out, const UINT8 *in, int xsize) {
+rgb2l(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4) {
         /* ITU-R Recommendation 601-2 (assuming nonlinear RGB) */
@@ -232,7 +248,8 @@ rgb2l(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-rgb2la(UINT8 *out, const UINT8 *in, int xsize) {
+rgb2la(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4, out += 4) {
         /* ITU-R Recommendation 601-2 (assuming nonlinear RGB) */
@@ -242,7 +259,8 @@ rgb2la(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-rgb2i(UINT8 *out_, const UINT8 *in, int xsize) {
+rgb2i(UINT8 *out_, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4, out_ += 4) {
         INT32 v = L24(in) >> 16;
@@ -251,7 +269,8 @@ rgb2i(UINT8 *out_, const UINT8 *in, int xsize) {
 }
 
 static void
-rgb2i16l(UINT8 *out_, const UINT8 *in, int xsize) {
+rgb2i16l(UINT8 *out_, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4) {
         *out_++ = L24(in) >> 16;
@@ -260,7 +279,8 @@ rgb2i16l(UINT8 *out_, const UINT8 *in, int xsize) {
 }
 
 static void
-rgb2i16b(UINT8 *out_, const UINT8 *in, int xsize) {
+rgb2i16b(UINT8 *out_, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4) {
         *out_++ = 0;
@@ -269,7 +289,8 @@ rgb2i16b(UINT8 *out_, const UINT8 *in, int xsize) {
 }
 
 static void
-rgb2f(UINT8 *out_, const UINT8 *in, int xsize) {
+rgb2f(UINT8 *out_, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4, out_ += 4) {
         FLOAT32 v = (float)L(in) / 1000.0F;
@@ -278,7 +299,8 @@ rgb2f(UINT8 *out_, const UINT8 *in, int xsize) {
 }
 
 static void
-rgb2bgr15(UINT8 *out_, const UINT8 *in, int xsize) {
+rgb2bgr15(UINT8 *out_, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4, out_ += 2) {
         UINT16 v = ((((UINT16)in[0]) << 7) & 0x7c00) +
@@ -289,7 +311,8 @@ rgb2bgr15(UINT8 *out_, const UINT8 *in, int xsize) {
 }
 
 static void
-rgb2bgr16(UINT8 *out_, const UINT8 *in, int xsize) {
+rgb2bgr16(UINT8 *out_, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4, out_ += 2) {
         UINT16 v = ((((UINT16)in[0]) << 8) & 0xf800) +
@@ -300,7 +323,8 @@ rgb2bgr16(UINT8 *out_, const UINT8 *in, int xsize) {
 }
 
 static void
-rgb2bgr24(UINT8 *out, const UINT8 *in, int xsize) {
+rgb2bgr24(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4) {
         *out++ = in[2];
@@ -310,7 +334,8 @@ rgb2bgr24(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-rgb2hsv_row(UINT8 *out, const UINT8 *in) {  // following colorsys.py
+rgb2hsv_row(UINT8 *out, const UINT8 *in)
+{  // following colorsys.py
     float h, s, rc, gc, bc, cr;
     UINT8 maxc, minc;
     UINT8 r, g, b;
@@ -350,7 +375,8 @@ rgb2hsv_row(UINT8 *out, const UINT8 *in) {  // following colorsys.py
 }
 
 static void
-rgb2hsv(UINT8 *out, const UINT8 *in, int xsize) {
+rgb2hsv(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4, out += 4) {
         rgb2hsv_row(out, in);
@@ -359,7 +385,8 @@ rgb2hsv(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-hsv2rgb(UINT8 *out, const UINT8 *in, int xsize) {  // following colorsys.py
+hsv2rgb(UINT8 *out, const UINT8 *in, int xsize)
+{  // following colorsys.py
 
     int p, q, t;
     UINT8 up, uq, ut;
@@ -430,7 +457,8 @@ hsv2rgb(UINT8 *out, const UINT8 *in, int xsize) {  // following colorsys.py
 /* ---------------- */
 
 static void
-rgb2rgba(UINT8 *out, const UINT8 *in, int xsize) {
+rgb2rgba(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++) {
         *out++ = *in++;
@@ -442,7 +470,8 @@ rgb2rgba(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-rgba2la(UINT8 *out, const UINT8 *in, int xsize) {
+rgba2la(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4, out += 4) {
         /* ITU-R Recommendation 601-2 (assuming nonlinear RGB) */
@@ -452,7 +481,8 @@ rgba2la(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-rgba2rgb(UINT8 *out, const UINT8 *in, int xsize) {
+rgba2rgb(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++) {
         *out++ = *in++;
@@ -464,7 +494,8 @@ rgba2rgb(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-rgbA2rgba(UINT8 *out, const UINT8 *in, int xsize) {
+rgbA2rgba(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     unsigned int alpha, tmp;
     for (x = 0; x < xsize; x++) {
@@ -479,7 +510,8 @@ rgbA2rgba(UINT8 *out, const UINT8 *in, int xsize) {
 /* RGBa -> RGBA conversion to remove premultiplication
    Needed for correct transforms/resizing on RGBA images */
 static void
-rgba2rgbA(UINT8 *out, const UINT8 *in, int xsize) {
+rgba2rgbA(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     unsigned int alpha;
     for (x = 0; x < xsize; x++, in += 4) {
@@ -498,7 +530,8 @@ rgba2rgbA(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-rgba2rgb_(UINT8 *out, const UINT8 *in, int xsize) {
+rgba2rgb_(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     unsigned int alpha;
     for (x = 0; x < xsize; x++, in += 4) {
@@ -523,7 +556,8 @@ rgba2rgb_(UINT8 *out, const UINT8 *in, int xsize) {
  */
 
 static void
-rgbT2a(UINT8 *out, UINT8 *in, int xsize, int r, int g, int b, int premultiplied) {
+rgbT2a(UINT8 *out, UINT8 *in, int xsize, int r, int g, int b, int premultiplied)
+{
 #ifdef WORDS_BIGENDIAN
     UINT32 trns = ((r & 0xff) << 24) | ((g & 0xff) << 16) | ((b & 0xff) << 8) | 0xff;
     UINT32 repl = premultiplied ? 0 : (trns & 0xffffff00);
@@ -549,7 +583,8 @@ rgbT2a(UINT8 *out, UINT8 *in, int xsize, int r, int g, int b, int premultiplied)
 /* ---------------- */
 
 static void
-l2cmyk(UINT8 *out, const UINT8 *in, int xsize) {
+l2cmyk(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++) {
         *out++ = 0;
@@ -560,7 +595,8 @@ l2cmyk(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-la2cmyk(UINT8 *out, const UINT8 *in, int xsize) {
+la2cmyk(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4) {
         *out++ = 0;
@@ -571,7 +607,8 @@ la2cmyk(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-rgb2cmyk(UINT8 *out, const UINT8 *in, int xsize) {
+rgb2cmyk(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++) {
         /* Note: no undercolour removal */
@@ -584,7 +621,8 @@ rgb2cmyk(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 void
-cmyk2rgb(UINT8 *out, const UINT8 *in, int xsize) {
+cmyk2rgb(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x, nk, tmp;
     for (x = 0; x < xsize; x++) {
         nk = 255 - in[3];
@@ -598,7 +636,8 @@ cmyk2rgb(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-cmyk2hsv(UINT8 *out, const UINT8 *in, int xsize) {
+cmyk2hsv(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x, nk, tmp;
     for (x = 0; x < xsize; x++) {
         nk = 255 - in[3];
@@ -617,7 +656,8 @@ cmyk2hsv(UINT8 *out, const UINT8 *in, int xsize) {
 /* ------------- */
 
 static void
-bit2i(UINT8 *out_, const UINT8 *in, int xsize) {
+bit2i(UINT8 *out_, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, out_ += 4) {
         INT32 v = (*in++ != 0) ? 255 : 0;
@@ -626,7 +666,8 @@ bit2i(UINT8 *out_, const UINT8 *in, int xsize) {
 }
 
 static void
-l2i(UINT8 *out_, const UINT8 *in, int xsize) {
+l2i(UINT8 *out_, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, out_ += 4) {
         INT32 v = *in++;
@@ -635,7 +676,8 @@ l2i(UINT8 *out_, const UINT8 *in, int xsize) {
 }
 
 static void
-i2l(UINT8 *out, const UINT8 *in_, int xsize) {
+i2l(UINT8 *out, const UINT8 *in_, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, out++, in_ += 4) {
         INT32 v;
@@ -651,7 +693,8 @@ i2l(UINT8 *out, const UINT8 *in_, int xsize) {
 }
 
 static void
-i2f(UINT8 *out_, const UINT8 *in_, int xsize) {
+i2f(UINT8 *out_, const UINT8 *in_, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in_ += 4, out_ += 4) {
         INT32 i;
@@ -663,7 +706,8 @@ i2f(UINT8 *out_, const UINT8 *in_, int xsize) {
 }
 
 static void
-i2rgb(UINT8 *out, const UINT8 *in_, int xsize) {
+i2rgb(UINT8 *out, const UINT8 *in_, int xsize)
+{
     int x;
     INT32 *in = (INT32 *)in_;
     for (x = 0; x < xsize; x++, in++, out += 4) {
@@ -679,7 +723,8 @@ i2rgb(UINT8 *out, const UINT8 *in_, int xsize) {
 }
 
 static void
-i2hsv(UINT8 *out, const UINT8 *in_, int xsize) {
+i2hsv(UINT8 *out, const UINT8 *in_, int xsize)
+{
     int x;
     INT32 *in = (INT32 *)in_;
     for (x = 0; x < xsize; x++, in++, out += 4) {
@@ -701,7 +746,8 @@ i2hsv(UINT8 *out, const UINT8 *in_, int xsize) {
 /* ------------- */
 
 static void
-bit2f(UINT8 *out_, const UINT8 *in, int xsize) {
+bit2f(UINT8 *out_, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, out_ += 4) {
         FLOAT32 f = (*in++ != 0) ? 255.0F : 0.0F;
@@ -710,7 +756,8 @@ bit2f(UINT8 *out_, const UINT8 *in, int xsize) {
 }
 
 static void
-l2f(UINT8 *out_, const UINT8 *in, int xsize) {
+l2f(UINT8 *out_, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, out_ += 4) {
         FLOAT32 f = (FLOAT32)*in++;
@@ -719,7 +766,8 @@ l2f(UINT8 *out_, const UINT8 *in, int xsize) {
 }
 
 static void
-f2l(UINT8 *out, const UINT8 *in_, int xsize) {
+f2l(UINT8 *out, const UINT8 *in_, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, out++, in_ += 4) {
         FLOAT32 v;
@@ -735,7 +783,8 @@ f2l(UINT8 *out, const UINT8 *in_, int xsize) {
 }
 
 static void
-f2i(UINT8 *out_, const UINT8 *in_, int xsize) {
+f2i(UINT8 *out_, const UINT8 *in_, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in_ += 4, out_ += 4) {
         FLOAT32 f;
@@ -753,7 +802,8 @@ f2i(UINT8 *out_, const UINT8 *in_, int xsize) {
 /* See ConvertYCbCr.c for RGB/YCbCr tables */
 
 static void
-l2ycbcr(UINT8 *out, const UINT8 *in, int xsize) {
+l2ycbcr(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++) {
         *out++ = *in++;
@@ -764,7 +814,8 @@ l2ycbcr(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-la2ycbcr(UINT8 *out, const UINT8 *in, int xsize) {
+la2ycbcr(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4) {
         *out++ = in[0];
@@ -775,7 +826,8 @@ la2ycbcr(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-ycbcr2l(UINT8 *out, const UINT8 *in, int xsize) {
+ycbcr2l(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4) {
         *out++ = in[0];
@@ -783,7 +835,8 @@ ycbcr2l(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-ycbcr2la(UINT8 *out, const UINT8 *in, int xsize) {
+ycbcr2la(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4, out += 4) {
         out[0] = out[1] = out[2] = in[0];
@@ -796,7 +849,8 @@ ycbcr2la(UINT8 *out, const UINT8 *in, int xsize) {
 /* ------------------------- */
 
 static void
-I_I16L(UINT8 *out, const UINT8 *in_, int xsize) {
+I_I16L(UINT8 *out, const UINT8 *in_, int xsize)
+{
     int x, v;
     for (x = 0; x < xsize; x++, in_ += 4) {
         INT32 i;
@@ -808,7 +862,8 @@ I_I16L(UINT8 *out, const UINT8 *in_, int xsize) {
 }
 
 static void
-I_I16B(UINT8 *out, const UINT8 *in_, int xsize) {
+I_I16B(UINT8 *out, const UINT8 *in_, int xsize)
+{
     int x, v;
     for (x = 0; x < xsize; x++, in_ += 4) {
         INT32 i;
@@ -820,7 +875,8 @@ I_I16B(UINT8 *out, const UINT8 *in_, int xsize) {
 }
 
 static void
-I16L_I(UINT8 *out_, const UINT8 *in, int xsize) {
+I16L_I(UINT8 *out_, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 2, out_ += 4) {
         INT32 v = in[0] + ((int)in[1] << 8);
@@ -829,7 +885,8 @@ I16L_I(UINT8 *out_, const UINT8 *in, int xsize) {
 }
 
 static void
-I16B_I(UINT8 *out_, const UINT8 *in, int xsize) {
+I16B_I(UINT8 *out_, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 2, out_ += 4) {
         INT32 v = in[1] + ((int)in[0] << 8);
@@ -838,7 +895,8 @@ I16B_I(UINT8 *out_, const UINT8 *in, int xsize) {
 }
 
 static void
-I16L_F(UINT8 *out_, const UINT8 *in, int xsize) {
+I16L_F(UINT8 *out_, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 2, out_ += 4) {
         FLOAT32 v = in[0] + ((int)in[1] << 8);
@@ -847,7 +905,8 @@ I16L_F(UINT8 *out_, const UINT8 *in, int xsize) {
 }
 
 static void
-I16B_F(UINT8 *out_, const UINT8 *in, int xsize) {
+I16B_F(UINT8 *out_, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 2, out_ += 4) {
         FLOAT32 v = in[1] + ((int)in[0] << 8);
@@ -856,7 +915,8 @@ I16B_F(UINT8 *out_, const UINT8 *in, int xsize) {
 }
 
 static void
-L_I16L(UINT8 *out, const UINT8 *in, int xsize) {
+L_I16L(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in++) {
         *out++ = *in;
@@ -865,7 +925,8 @@ L_I16L(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-L_I16B(UINT8 *out, const UINT8 *in, int xsize) {
+L_I16B(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in++) {
         *out++ = 0;
@@ -874,7 +935,8 @@ L_I16B(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-I16L_L(UINT8 *out, const UINT8 *in, int xsize) {
+I16L_L(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 2) {
         if (in[1] != 0) {
@@ -886,7 +948,8 @@ I16L_L(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-I16B_L(UINT8 *out, const UINT8 *in, int xsize) {
+I16B_L(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 2) {
         if (in[0] != 0) {
@@ -898,7 +961,8 @@ I16B_L(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-I16_RGB(UINT8 *out, const UINT8 *in, int xsize) {
+I16_RGB(UINT8 *out, const UINT8 *in, int xsize)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 2) {
         UINT8 v = in[1] == 0 ? in[0] : 255;
@@ -1053,7 +1117,8 @@ static struct {
 /* ------------------- */
 
 static void
-p2bit(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+p2bit(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     /* FIXME: precalculate grayscale palette? */
     for (x = 0; x < xsize; x++) {
@@ -1062,7 +1127,8 @@ p2bit(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-pa2bit(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+pa2bit(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     /* FIXME: precalculate grayscale palette? */
     for (x = 0; x < xsize; x++, in += 4) {
@@ -1071,7 +1137,8 @@ pa2bit(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-p2l(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+p2l(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     /* FIXME: precalculate grayscale palette? */
     for (x = 0; x < xsize; x++) {
@@ -1080,7 +1147,8 @@ p2l(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-pa2l(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+pa2l(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     /* FIXME: precalculate grayscale palette? */
     for (x = 0; x < xsize; x++, in += 4) {
@@ -1089,7 +1157,8 @@ pa2l(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-pa2p(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+pa2p(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4) {
         *out++ = in[0];
@@ -1097,7 +1166,8 @@ pa2p(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-p2pa(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+p2pa(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     int rgb = strcmp(palette->mode, "RGB");
     for (x = 0; x < xsize; x++, in++) {
@@ -1110,7 +1180,8 @@ p2pa(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-p2la(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+p2la(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     /* FIXME: precalculate grayscale palette? */
     for (x = 0; x < xsize; x++, out += 4) {
@@ -1121,7 +1192,8 @@ p2la(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-pa2la(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+pa2la(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     /* FIXME: precalculate grayscale palette? */
     for (x = 0; x < xsize; x++, in += 4, out += 4) {
@@ -1131,7 +1203,8 @@ pa2la(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-p2i(UINT8 *out_, const UINT8 *in, int xsize, ImagingPalette palette) {
+p2i(UINT8 *out_, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     for (x = 0; x < xsize; x++, out_ += 4) {
         INT32 v = L24(&palette->palette[in[x] * 4]) >> 16;
@@ -1140,7 +1213,8 @@ p2i(UINT8 *out_, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-pa2i(UINT8 *out_, const UINT8 *in, int xsize, ImagingPalette palette) {
+pa2i(UINT8 *out_, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     INT32 *out = (INT32 *)out_;
     for (x = 0; x < xsize; x++, in += 4) {
@@ -1149,7 +1223,8 @@ pa2i(UINT8 *out_, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-p2f(UINT8 *out_, const UINT8 *in, int xsize, ImagingPalette palette) {
+p2f(UINT8 *out_, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     for (x = 0; x < xsize; x++, out_ += 4) {
         FLOAT32 v = L(&palette->palette[in[x] * 4]) / 1000.0F;
@@ -1158,7 +1233,8 @@ p2f(UINT8 *out_, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-pa2f(UINT8 *out_, const UINT8 *in, int xsize, ImagingPalette palette) {
+pa2f(UINT8 *out_, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     FLOAT32 *out = (FLOAT32 *)out_;
     for (x = 0; x < xsize; x++, in += 4) {
@@ -1167,7 +1243,8 @@ pa2f(UINT8 *out_, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-p2rgb(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+p2rgb(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     for (x = 0; x < xsize; x++) {
         const UINT8 *rgb = &palette->palette[*in++ * 4];
@@ -1179,7 +1256,8 @@ p2rgb(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-pa2rgb(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+pa2rgb(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4) {
         const UINT8 *rgb = &palette->palette[in[0] * 4];
@@ -1191,7 +1269,8 @@ pa2rgb(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-p2hsv(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+p2hsv(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     for (x = 0; x < xsize; x++, out += 4) {
         const UINT8 *rgb = &palette->palette[*in++ * 4];
@@ -1201,7 +1280,8 @@ p2hsv(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-pa2hsv(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+pa2hsv(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4, out += 4) {
         const UINT8 *rgb = &palette->palette[in[0] * 4];
@@ -1211,7 +1291,8 @@ pa2hsv(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-p2rgba(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+p2rgba(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     for (x = 0; x < xsize; x++) {
         const UINT8 *rgba = &palette->palette[*in++ * 4];
@@ -1223,7 +1304,8 @@ p2rgba(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-pa2rgba(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+pa2rgba(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     int x;
     for (x = 0; x < xsize; x++, in += 4) {
         const UINT8 *rgb = &palette->palette[in[0] * 4];
@@ -1235,31 +1317,36 @@ pa2rgba(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
 }
 
 static void
-p2cmyk(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+p2cmyk(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     p2rgb(out, in, xsize, palette);
     rgb2cmyk(out, out, xsize);
 }
 
 static void
-pa2cmyk(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+pa2cmyk(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     pa2rgb(out, in, xsize, palette);
     rgb2cmyk(out, out, xsize);
 }
 
 static void
-p2ycbcr(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+p2ycbcr(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     p2rgb(out, in, xsize, palette);
     ImagingConvertRGB2YCbCr(out, out, xsize);
 }
 
 static void
-pa2ycbcr(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette) {
+pa2ycbcr(UINT8 *out, const UINT8 *in, int xsize, ImagingPalette palette)
+{
     pa2rgb(out, in, xsize, palette);
     ImagingConvertRGB2YCbCr(out, out, xsize);
 }
 
 static Imaging
-frompalette(Imaging imOut, Imaging imIn, const char *mode) {
+frompalette(Imaging imOut, Imaging imIn, const char *mode)
+{
     ImagingSectionCookie cookie;
     int alpha;
     int y;
@@ -1328,11 +1415,8 @@ frompalette(Imaging imOut, Imaging imIn, const char *mode) {
 #endif
 static Imaging
 topalette(
-    Imaging imOut,
-    Imaging imIn,
-    const char *mode,
-    ImagingPalette inpalette,
-    int dither) {
+    Imaging imOut, Imaging imIn, const char *mode, ImagingPalette inpalette, int dither)
+{
     ImagingSectionCookie cookie;
     int alpha;
     int x, y;
@@ -1529,7 +1613,8 @@ topalette(
 }
 
 static Imaging
-tobilevel(Imaging imOut, Imaging imIn) {
+tobilevel(Imaging imOut, Imaging imIn)
+{
     ImagingSectionCookie cookie;
     int x, y;
     int *errors;
@@ -1623,7 +1708,8 @@ tobilevel(Imaging imOut, Imaging imIn) {
 
 static Imaging
 convert(
-    Imaging imOut, Imaging imIn, const char *mode, ImagingPalette palette, int dither) {
+    Imaging imOut, Imaging imIn, const char *mode, ImagingPalette palette, int dither)
+{
     ImagingSectionCookie cookie;
     ImagingShuffler convert;
     int y;
@@ -1697,17 +1783,20 @@ convert(
 }
 
 Imaging
-ImagingConvert(Imaging imIn, const char *mode, ImagingPalette palette, int dither) {
+ImagingConvert(Imaging imIn, const char *mode, ImagingPalette palette, int dither)
+{
     return convert(NULL, imIn, mode, palette, dither);
 }
 
 Imaging
-ImagingConvert2(Imaging imOut, Imaging imIn) {
+ImagingConvert2(Imaging imOut, Imaging imIn)
+{
     return convert(imOut, imIn, imOut->mode, NULL, 0);
 }
 
 Imaging
-ImagingConvertTransparent(Imaging imIn, const char *mode, int r, int g, int b) {
+ImagingConvertTransparent(Imaging imIn, const char *mode, int r, int g, int b)
+{
     ImagingSectionCookie cookie;
     ImagingShuffler convert;
     Imaging imOut = NULL;
@@ -1778,7 +1867,8 @@ ImagingConvertTransparent(Imaging imIn, const char *mode, int r, int g, int b) {
 }
 
 Imaging
-ImagingConvertInPlace(Imaging imIn, const char *mode) {
+ImagingConvertInPlace(Imaging imIn, const char *mode)
+{
     ImagingSectionCookie cookie;
     ImagingShuffler convert;
     int y;

--- a/src/libImaging/ConvertYCbCr.c
+++ b/src/libImaging/ConvertYCbCr.c
@@ -315,7 +315,8 @@ static INT16 B_Cb[] = {
     13836,  13949,  14063,  14176,  14289,  14403};
 
 void
-ImagingConvertRGB2YCbCr(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingConvertRGB2YCbCr(UINT8 *out, const UINT8 *in, int pixels)
+{
     int x;
     UINT8 a;
     int r, g, b;
@@ -339,7 +340,8 @@ ImagingConvertRGB2YCbCr(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingConvertYCbCr2RGB(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingConvertYCbCr2RGB(UINT8 *out, const UINT8 *in, int pixels)
+{
     int x;
     UINT8 a;
     int r, g, b;

--- a/src/libImaging/Copy.c
+++ b/src/libImaging/Copy.c
@@ -18,7 +18,8 @@
 #include "Imaging.h"
 
 static Imaging
-_copy(Imaging imOut, Imaging imIn) {
+_copy(Imaging imOut, Imaging imIn)
+{
     ImagingSectionCookie cookie;
     int y;
 
@@ -47,11 +48,13 @@ _copy(Imaging imOut, Imaging imIn) {
 }
 
 Imaging
-ImagingCopy(Imaging imIn) {
+ImagingCopy(Imaging imIn)
+{
     return _copy(NULL, imIn);
 }
 
 Imaging
-ImagingCopy2(Imaging imOut, Imaging imIn) {
+ImagingCopy2(Imaging imOut, Imaging imIn)
+{
     return _copy(imOut, imIn);
 }

--- a/src/libImaging/Crop.c
+++ b/src/libImaging/Crop.c
@@ -18,7 +18,8 @@
 #include "Imaging.h"
 
 Imaging
-ImagingCrop(Imaging imIn, int sx0, int sy0, int sx1, int sy1) {
+ImagingCrop(Imaging imIn, int sx0, int sy0, int sx1, int sy1)
+{
     Imaging imOut;
     int xsize, ysize;
     int dx0, dy0, dx1, dy1;

--- a/src/libImaging/Dib.c
+++ b/src/libImaging/Dib.c
@@ -26,7 +26,8 @@
 #include "ImDib.h"
 
 char *
-ImagingGetModeDIB(int size_out[2]) {
+ImagingGetModeDIB(int size_out[2])
+{
     /* Get device characteristics */
 
     HDC dc;
@@ -53,7 +54,8 @@ ImagingGetModeDIB(int size_out[2]) {
 }
 
 ImagingDIB
-ImagingNewDIB(const char *mode, int xsize, int ysize) {
+ImagingNewDIB(const char *mode, int xsize, int ysize)
+{
     /* Create a Windows bitmap */
 
     ImagingDIB dib;
@@ -207,7 +209,8 @@ ImagingNewDIB(const char *mode, int xsize, int ysize) {
 }
 
 void
-ImagingPasteDIB(ImagingDIB dib, Imaging im, int xy[4]) {
+ImagingPasteDIB(ImagingDIB dib, Imaging im, int xy[4])
+{
     /* Paste image data into a bitmap */
 
     /* FIXME: check size! */
@@ -223,7 +226,8 @@ ImagingPasteDIB(ImagingDIB dib, Imaging im, int xy[4]) {
 }
 
 void
-ImagingExposeDIB(ImagingDIB dib, void *dc) {
+ImagingExposeDIB(ImagingDIB dib, void *dc)
+{
     /* Copy bitmap to display */
 
     if (dib->palette != 0) {
@@ -233,7 +237,8 @@ ImagingExposeDIB(ImagingDIB dib, void *dc) {
 }
 
 void
-ImagingDrawDIB(ImagingDIB dib, void *dc, int dst[4], int src[4]) {
+ImagingDrawDIB(ImagingDIB dib, void *dc, int dst[4], int src[4])
+{
     /* Copy bitmap to printer/display */
 
     if (GetDeviceCaps((HDC)dc, RASTERCAPS) & RC_STRETCHDIB) {
@@ -273,7 +278,8 @@ ImagingDrawDIB(ImagingDIB dib, void *dc, int dst[4], int src[4]) {
 }
 
 int
-ImagingQueryPaletteDIB(ImagingDIB dib, void *dc) {
+ImagingQueryPaletteDIB(ImagingDIB dib, void *dc)
+{
     /* Install bitmap palette */
 
     int n;
@@ -294,7 +300,8 @@ ImagingQueryPaletteDIB(ImagingDIB dib, void *dc) {
 }
 
 void
-ImagingDeleteDIB(ImagingDIB dib) {
+ImagingDeleteDIB(ImagingDIB dib)
+{
     /* Clean up */
 
     if (dib->palette) {

--- a/src/libImaging/Draw.c
+++ b/src/libImaging/Draw.c
@@ -66,7 +66,8 @@ typedef struct {
 typedef void (*hline_handler)(Imaging, int, int, int, int);
 
 static inline void
-point8(Imaging im, int x, int y, int ink) {
+point8(Imaging im, int x, int y, int ink)
+{
     if (x >= 0 && x < im->xsize && y >= 0 && y < im->ysize) {
         if (strncmp(im->mode, "I;16", 4) == 0) {
 #ifdef WORDS_BIGENDIAN
@@ -83,14 +84,16 @@ point8(Imaging im, int x, int y, int ink) {
 }
 
 static inline void
-point32(Imaging im, int x, int y, int ink) {
+point32(Imaging im, int x, int y, int ink)
+{
     if (x >= 0 && x < im->xsize && y >= 0 && y < im->ysize) {
         im->image32[y][x] = ink;
     }
 }
 
 static inline void
-point32rgba(Imaging im, int x, int y, int ink) {
+point32rgba(Imaging im, int x, int y, int ink)
+{
     unsigned int tmp;
 
     if (x >= 0 && x < im->xsize && y >= 0 && y < im->ysize) {
@@ -103,7 +106,8 @@ point32rgba(Imaging im, int x, int y, int ink) {
 }
 
 static inline void
-hline8(Imaging im, int x0, int y0, int x1, int ink) {
+hline8(Imaging im, int x0, int y0, int x1, int ink)
+{
     int pixelwidth;
 
     if (y0 >= 0 && y0 < im->ysize) {
@@ -128,7 +132,8 @@ hline8(Imaging im, int x0, int y0, int x1, int ink) {
 }
 
 static inline void
-hline32(Imaging im, int x0, int y0, int x1, int ink) {
+hline32(Imaging im, int x0, int y0, int x1, int ink)
+{
     INT32 *p;
 
     if (y0 >= 0 && y0 < im->ysize) {
@@ -150,7 +155,8 @@ hline32(Imaging im, int x0, int y0, int x1, int ink) {
 }
 
 static inline void
-hline32rgba(Imaging im, int x0, int y0, int x1, int ink) {
+hline32rgba(Imaging im, int x0, int y0, int x1, int ink)
+{
     unsigned int tmp;
 
     if (y0 >= 0 && y0 < im->ysize) {
@@ -179,7 +185,8 @@ hline32rgba(Imaging im, int x0, int y0, int x1, int ink) {
 }
 
 static inline void
-line8(Imaging im, int x0, int y0, int x1, int y1, int ink) {
+line8(Imaging im, int x0, int y0, int x1, int y1, int ink)
+{
     int i, n, e;
     int dx, dy;
     int xs, ys;
@@ -251,7 +258,8 @@ line8(Imaging im, int x0, int y0, int x1, int y1, int ink) {
 }
 
 static inline void
-line32(Imaging im, int x0, int y0, int x1, int y1, int ink) {
+line32(Imaging im, int x0, int y0, int x1, int y1, int ink)
+{
     int i, n, e;
     int dx, dy;
     int xs, ys;
@@ -323,7 +331,8 @@ line32(Imaging im, int x0, int y0, int x1, int y1, int ink) {
 }
 
 static inline void
-line32rgba(Imaging im, int x0, int y0, int x1, int y1, int ink) {
+line32rgba(Imaging im, int x0, int y0, int x1, int y1, int ink)
+{
     int i, n, e;
     int dx, dy;
     int xs, ys;
@@ -395,7 +404,8 @@ line32rgba(Imaging im, int x0, int y0, int x1, int y1, int ink) {
 }
 
 static int
-x_cmp(const void *x0, const void *x1) {
+x_cmp(const void *x0, const void *x1)
+{
     float diff = *((float *)x0) - *((float *)x1);
     if (diff < 0) {
         return -1;
@@ -408,7 +418,8 @@ x_cmp(const void *x0, const void *x1) {
 
 static void
 draw_horizontal_lines(
-    Imaging im, int n, Edge *e, int ink, int *x_pos, int y, hline_handler hline) {
+    Imaging im, int n, Edge *e, int ink, int *x_pos, int y, hline_handler hline)
+{
     int i;
     for (i = 0; i < n; i++) {
         if (e[i].ymin == y && e[i].ymin == e[i].ymax) {
@@ -440,13 +451,8 @@ draw_horizontal_lines(
  */
 static inline int
 polygon_generic(
-    Imaging im,
-    int n,
-    Edge *e,
-    int ink,
-    int eofill,
-    hline_handler hline,
-    int hasAlpha) {
+    Imaging im, int n, Edge *e, int ink, int eofill, hline_handler hline, int hasAlpha)
+{
     Edge **edge_table;
     float *xx;
     int edge_count = 0;
@@ -599,22 +605,26 @@ polygon_generic(
 }
 
 static inline int
-polygon8(Imaging im, int n, Edge *e, int ink, int eofill) {
+polygon8(Imaging im, int n, Edge *e, int ink, int eofill)
+{
     return polygon_generic(im, n, e, ink, eofill, hline8, 0);
 }
 
 static inline int
-polygon32(Imaging im, int n, Edge *e, int ink, int eofill) {
+polygon32(Imaging im, int n, Edge *e, int ink, int eofill)
+{
     return polygon_generic(im, n, e, ink, eofill, hline32, 0);
 }
 
 static inline int
-polygon32rgba(Imaging im, int n, Edge *e, int ink, int eofill) {
+polygon32rgba(Imaging im, int n, Edge *e, int ink, int eofill)
+{
     return polygon_generic(im, n, e, ink, eofill, hline32rgba, 1);
 }
 
 static inline void
-add_edge(Edge *e, int x0, int y0, int x1, int y1) {
+add_edge(Edge *e, int x0, int y0, int x1, int y1)
+{
     /* printf("edge %d %d %d %d\n", x0, y0, x1, y1); */
 
     if (x0 <= x1) {
@@ -674,7 +684,8 @@ DRAW draw32rgba = {point32rgba, hline32rgba, line32rgba, polygon32rgba};
     }
 
 int
-ImagingDrawPoint(Imaging im, int x0, int y0, const void *ink_, int op) {
+ImagingDrawPoint(Imaging im, int x0, int y0, const void *ink_, int op)
+{
     DRAW *draw;
     INT32 ink;
 
@@ -686,7 +697,8 @@ ImagingDrawPoint(Imaging im, int x0, int y0, const void *ink_, int op) {
 }
 
 int
-ImagingDrawLine(Imaging im, int x0, int y0, int x1, int y1, const void *ink_, int op) {
+ImagingDrawLine(Imaging im, int x0, int y0, int x1, int y1, const void *ink_, int op)
+{
     DRAW *draw;
     INT32 ink;
 
@@ -699,7 +711,8 @@ ImagingDrawLine(Imaging im, int x0, int y0, int x1, int y1, const void *ink_, in
 
 int
 ImagingDrawWideLine(
-    Imaging im, int x0, int y0, int x1, int y1, const void *ink_, int width, int op) {
+    Imaging im, int x0, int y0, int x1, int y1, const void *ink_, int width, int op)
+{
     DRAW *draw;
     INT32 ink;
     int dx, dy;
@@ -752,7 +765,8 @@ ImagingDrawRectangle(
     const void *ink_,
     int fill,
     int width,
-    int op) {
+    int op)
+{
     int i;
     int y;
     int tmp;
@@ -800,7 +814,8 @@ ImagingDrawRectangle(
 
 int
 ImagingDrawPolygon(
-    Imaging im, int count, int *xy, const void *ink_, int fill, int width, int op) {
+    Imaging im, int count, int *xy, const void *ink_, int fill, int width, int op)
+{
     int i, n, x0, y0, x1, y1;
     DRAW *draw;
     INT32 ink;
@@ -875,7 +890,8 @@ ImagingDrawPolygon(
 }
 
 int
-ImagingDrawBitmap(Imaging im, int x0, int y0, Imaging bitmap, const void *ink, int op) {
+ImagingDrawBitmap(Imaging im, int x0, int y0, Imaging bitmap, const void *ink, int op)
+{
     return ImagingFill2(
         im, ink, bitmap, x0, y0, x0 + bitmap->xsize, y0 + bitmap->ysize);
 }
@@ -895,7 +911,8 @@ typedef struct {
 } quarter_state;
 
 void
-quarter_init(quarter_state *s, int32_t a, int32_t b) {
+quarter_init(quarter_state *s, int32_t a, int32_t b)
+{
     if (a < 0 || b < 0) {
         s->finished = 1;
     } else {
@@ -915,12 +932,14 @@ quarter_init(quarter_state *s, int32_t a, int32_t b) {
 // deviation of the point from ellipse curve, basically a substitution
 // of the point into the ellipse equation
 int64_t
-quarter_delta(quarter_state *s, int64_t x, int64_t y) {
+quarter_delta(quarter_state *s, int64_t x, int64_t y)
+{
     return llabs(s->a2 * y * y + s->b2 * x * x - s->a2b2);
 }
 
 int8_t
-quarter_next(quarter_state *s, int32_t *ret_x, int32_t *ret_y) {
+quarter_next(quarter_state *s, int32_t *ret_x, int32_t *ret_y)
+{
     if (s->finished) {
         return -1;
     }
@@ -971,7 +990,8 @@ typedef struct {
 } ellipse_state;
 
 void
-ellipse_init(ellipse_state *s, int32_t a, int32_t b, int32_t w) {
+ellipse_init(ellipse_state *s, int32_t a, int32_t b, int32_t w)
+{
     s->bufcnt = 0;
     s->leftmost = a % 2;
     quarter_init(&s->st_o, a, b);
@@ -985,7 +1005,8 @@ ellipse_init(ellipse_state *s, int32_t a, int32_t b, int32_t w) {
 }
 
 int8_t
-ellipse_next(ellipse_state *s, int32_t *ret_x0, int32_t *ret_y, int32_t *ret_x1) {
+ellipse_next(ellipse_state *s, int32_t *ret_x0, int32_t *ret_y, int32_t *ret_x1)
+{
     if (s->bufcnt == 0) {
         if (s->finished) {
             return -1;
@@ -1068,7 +1089,8 @@ typedef struct event_list {
 
 // Mirrors all the clipping nodes of the tree relative to the y = x line.
 void
-clip_tree_transpose(clip_node *root) {
+clip_tree_transpose(clip_node *root)
+{
     if (root != NULL) {
         if (root->type == CT_CLIP) {
             double t = root->a;
@@ -1085,8 +1107,8 @@ clip_tree_transpose(clip_node *root) {
 // Combining nodes (AND, OR) may also accept sequences for intersecting
 // segments, i.e. something like correct bracket sequences.
 int
-clip_tree_do_clip(
-    clip_node *root, int32_t x0, int32_t y, int32_t x1, event_list **ret) {
+clip_tree_do_clip(clip_node *root, int32_t x0, int32_t y, int32_t x1, event_list **ret)
+{
     if (root == NULL) {
         event_list *start = malloc(sizeof(event_list));
         if (!start) {
@@ -1226,7 +1248,8 @@ typedef void (*clip_ellipse_init)(
     clip_ellipse_state *, int32_t, int32_t, int32_t, float, float);
 
 void
-debug_clip_tree(clip_node *root, int space) {
+debug_clip_tree(clip_node *root, int space)
+{
     if (root == NULL) {
         return;
     }
@@ -1252,7 +1275,8 @@ debug_clip_tree(clip_node *root, int space) {
 
 // Resulting angles will satisfy 0 <= al < 360, al <= ar <= al + 360
 void
-normalize_angles(float *al, float *ar) {
+normalize_angles(float *al, float *ar)
+{
     if (*ar - *al >= 360) {
         *al = 0;
         *ar = 360;
@@ -1264,7 +1288,8 @@ normalize_angles(float *al, float *ar) {
 
 // An arc with caps orthogonal to the ellipse curve.
 void
-arc_init(clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float ar) {
+arc_init(clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float ar)
+{
     if (a < b) {
         // transpose the coordinate system
         arc_init(s, b, a, w, 90 - ar, 90 - al);
@@ -1335,7 +1360,8 @@ arc_init(clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float
 // A chord line.
 void
 chord_line_init(
-    clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float ar) {
+    clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float ar)
+{
     ellipse_init(&s->st, a, b, a + b + 1);
 
     s->head = NULL;
@@ -1361,8 +1387,8 @@ chord_line_init(
 
 // Pie side.
 void
-pie_side_init(
-    clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float _) {
+pie_side_init(clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float _)
+{
     ellipse_init(&s->st, a, b, a + b + 1);
 
     s->head = NULL;
@@ -1405,7 +1431,8 @@ pie_side_init(
 
 // A chord.
 void
-chord_init(clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float ar) {
+chord_init(clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float ar)
+{
     ellipse_init(&s->st, a, b, w);
 
     s->head = NULL;
@@ -1424,7 +1451,8 @@ chord_init(clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, flo
 
 // A pie. Can also be used to draw an arc with ugly sharp caps.
 void
-pie_init(clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float ar) {
+pie_init(clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float ar)
+{
     ellipse_init(&s->st, a, b, w);
 
     s->head = NULL;
@@ -1468,7 +1496,8 @@ pie_init(clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float
 }
 
 void
-clip_ellipse_free(clip_ellipse_state *s) {
+clip_ellipse_free(clip_ellipse_state *s)
+{
     while (s->head != NULL) {
         event_list *t = s->head;
         s->head = s->head->next;
@@ -1478,7 +1507,8 @@ clip_ellipse_free(clip_ellipse_state *s) {
 
 int8_t
 clip_ellipse_next(
-    clip_ellipse_state *s, int32_t *ret_x0, int32_t *ret_y, int32_t *ret_x1) {
+    clip_ellipse_state *s, int32_t *ret_x0, int32_t *ret_y, int32_t *ret_x1)
+{
     int32_t x0, y, x1;
     while (s->head == NULL && ellipse_next(&s->st, &x0, &y, &x1) >= 0) {
         if (clip_tree_do_clip(s->root, x0, y, x1, &s->head) < 0) {
@@ -1512,7 +1542,8 @@ ellipseNew(
     const void *ink_,
     int fill,
     int width,
-    int op) {
+    int op)
+{
     DRAW *draw;
     INT32 ink;
     DRAWINIT();
@@ -1547,7 +1578,8 @@ clipEllipseNew(
     const void *ink_,
     int width,
     int op,
-    clip_ellipse_init init) {
+    clip_ellipse_init init)
+{
     DRAW *draw;
     INT32 ink;
     DRAWINIT();
@@ -1580,7 +1612,8 @@ arcNew(
     float end,
     const void *ink_,
     int width,
-    int op) {
+    int op)
+{
     return clipEllipseNew(im, x0, y0, x1, y1, start, end, ink_, width, op, arc_init);
 }
 
@@ -1595,7 +1628,8 @@ chordNew(
     float end,
     const void *ink_,
     int width,
-    int op) {
+    int op)
+{
     return clipEllipseNew(im, x0, y0, x1, y1, start, end, ink_, width, op, chord_init);
 }
 
@@ -1610,7 +1644,8 @@ chordLineNew(
     float end,
     const void *ink_,
     int width,
-    int op) {
+    int op)
+{
     return clipEllipseNew(
         im, x0, y0, x1, y1, start, end, ink_, width, op, chord_line_init);
 }
@@ -1626,7 +1661,8 @@ pieNew(
     float end,
     const void *ink_,
     int width,
-    int op) {
+    int op)
+{
     return clipEllipseNew(im, x0, y0, x1, y1, start, end, ink_, width, op, pie_init);
 }
 
@@ -1640,7 +1676,8 @@ pieSideNew(
     float start,
     const void *ink_,
     int width,
-    int op) {
+    int op)
+{
     return clipEllipseNew(im, x0, y0, x1, y1, start, 0, ink_, width, op, pie_side_init);
 }
 
@@ -1654,7 +1691,8 @@ ImagingDrawEllipse(
     const void *ink,
     int fill,
     int width,
-    int op) {
+    int op)
+{
     return ellipseNew(im, x0, y0, x1, y1, ink, fill, width, op);
 }
 
@@ -1669,7 +1707,8 @@ ImagingDrawArc(
     float end,
     const void *ink,
     int width,
-    int op) {
+    int op)
+{
     normalize_angles(&start, &end);
     if (start + 360 == end) {
         return ImagingDrawEllipse(im, x0, y0, x1, y1, ink, 0, width, op);
@@ -1692,7 +1731,8 @@ ImagingDrawChord(
     const void *ink,
     int fill,
     int width,
-    int op) {
+    int op)
+{
     normalize_angles(&start, &end);
     if (start + 360 == end) {
         return ImagingDrawEllipse(im, x0, y0, x1, y1, ink, fill, width, op);
@@ -1722,7 +1762,8 @@ ImagingDrawPieslice(
     const void *ink,
     int fill,
     int width,
-    int op) {
+    int op)
+{
     normalize_angles(&start, &end);
     if (start + 360 == end) {
         return ellipseNew(im, x0, y0, x1, y1, ink, fill, width, op);
@@ -1764,7 +1805,8 @@ struct ImagingOutlineInstance {
 };
 
 ImagingOutline
-ImagingOutlineNew(void) {
+ImagingOutlineNew(void)
+{
     ImagingOutline outline;
 
     outline = calloc(1, sizeof(struct ImagingOutlineInstance));
@@ -1781,7 +1823,8 @@ ImagingOutlineNew(void) {
 }
 
 void
-ImagingOutlineDelete(ImagingOutline outline) {
+ImagingOutlineDelete(ImagingOutline outline)
+{
     if (!outline) {
         return;
     }
@@ -1794,7 +1837,8 @@ ImagingOutlineDelete(ImagingOutline outline) {
 }
 
 static Edge *
-allocate(ImagingOutline outline, int extra) {
+allocate(ImagingOutline outline, int extra)
+{
     Edge *e;
 
     if (outline->count + extra > outline->size) {
@@ -1824,7 +1868,8 @@ allocate(ImagingOutline outline, int extra) {
 }
 
 int
-ImagingOutlineMove(ImagingOutline outline, float x0, float y0) {
+ImagingOutlineMove(ImagingOutline outline, float x0, float y0)
+{
     outline->x = outline->x0 = x0;
     outline->y = outline->y0 = y0;
 
@@ -1832,7 +1877,8 @@ ImagingOutlineMove(ImagingOutline outline, float x0, float y0) {
 }
 
 int
-ImagingOutlineLine(ImagingOutline outline, float x1, float y1) {
+ImagingOutlineLine(ImagingOutline outline, float x1, float y1)
+{
     Edge *e;
 
     e = allocate(outline, 1);
@@ -1850,13 +1896,8 @@ ImagingOutlineLine(ImagingOutline outline, float x1, float y1) {
 
 int
 ImagingOutlineCurve(
-    ImagingOutline outline,
-    float x1,
-    float y1,
-    float x2,
-    float y2,
-    float x3,
-    float y3) {
+    ImagingOutline outline, float x1, float y1, float x2, float y2, float x3, float y3)
+{
     Edge *e;
     int i;
     float xo, yo;
@@ -1897,7 +1938,8 @@ ImagingOutlineCurve(
 }
 
 int
-ImagingOutlineClose(ImagingOutline outline) {
+ImagingOutlineClose(ImagingOutline outline)
+{
     if (outline->x == outline->x0 && outline->y == outline->y0) {
         return 0;
     }
@@ -1905,7 +1947,8 @@ ImagingOutlineClose(ImagingOutline outline) {
 }
 
 int
-ImagingOutlineTransform(ImagingOutline outline, double a[6]) {
+ImagingOutlineTransform(ImagingOutline outline, double a[6])
+{
     Edge *eIn;
     Edge *eOut;
     int i, n;
@@ -1970,7 +2013,8 @@ ImagingOutlineTransform(ImagingOutline outline, double a[6]) {
 
 int
 ImagingDrawOutline(
-    Imaging im, ImagingOutline outline, const void *ink_, int fill, int op) {
+    Imaging im, ImagingOutline outline, const void *ink_, int fill, int op)
+{
     DRAW *draw;
     INT32 ink;
 

--- a/src/libImaging/Effects.c
+++ b/src/libImaging/Effects.c
@@ -20,7 +20,8 @@
 #include <math.h>
 
 Imaging
-ImagingEffectMandelbrot(int xsize, int ysize, double extent[4], int quality) {
+ImagingEffectMandelbrot(int xsize, int ysize, double extent[4], int quality)
+{
     /* Generate a Mandelbrot set covering the given extent */
 
     Imaging im;
@@ -72,7 +73,8 @@ ImagingEffectMandelbrot(int xsize, int ysize, double extent[4], int quality) {
 }
 
 Imaging
-ImagingEffectNoise(int xsize, int ysize, float sigma) {
+ImagingEffectNoise(int xsize, int ysize, float sigma)
+{
     /* Generate Gaussian noise centered around 128 */
 
     Imaging imOut;
@@ -114,7 +116,8 @@ ImagingEffectNoise(int xsize, int ysize, float sigma) {
 }
 
 Imaging
-ImagingEffectSpread(Imaging imIn, int distance) {
+ImagingEffectSpread(Imaging imIn, int distance)
+{
     /* Randomly spread pixels in an image */
 
     Imaging imOut;

--- a/src/libImaging/EpsEncode.c
+++ b/src/libImaging/EpsEncode.c
@@ -20,7 +20,8 @@
 #include "Imaging.h"
 
 int
-ImagingEpsEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
+ImagingEpsEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes)
+{
     enum { HEXBYTE = 1, NEWLINE };
     const char *hex = "0123456789abcdef";
 

--- a/src/libImaging/Except.c
+++ b/src/libImaging/Except.c
@@ -24,29 +24,34 @@
 /* exception state */
 
 void *
-ImagingError_OSError(void) {
+ImagingError_OSError(void)
+{
     fprintf(stderr, "*** exception: file access error\n");
     return NULL;
 }
 
 void *
-ImagingError_MemoryError(void) {
+ImagingError_MemoryError(void)
+{
     fprintf(stderr, "*** exception: out of memory\n");
     return NULL;
 }
 
 void *
-ImagingError_ModeError(void) {
+ImagingError_ModeError(void)
+{
     return ImagingError_ValueError("bad image mode");
 }
 
 void *
-ImagingError_Mismatch(void) {
+ImagingError_Mismatch(void)
+{
     return ImagingError_ValueError("images don't match");
 }
 
 void *
-ImagingError_ValueError(const char *message) {
+ImagingError_ValueError(const char *message)
+{
     if (!message) {
         message = "exception: bad argument to function";
     }
@@ -55,18 +60,21 @@ ImagingError_ValueError(const char *message) {
 }
 
 void
-ImagingError_Clear(void) {
+ImagingError_Clear(void)
+{
     /* nop */;
 }
 
 /* thread state */
 
 void
-ImagingSectionEnter(ImagingSectionCookie *cookie) {
+ImagingSectionEnter(ImagingSectionCookie *cookie)
+{
     /* pass */
 }
 
 void
-ImagingSectionLeave(ImagingSectionCookie *cookie) {
+ImagingSectionLeave(ImagingSectionCookie *cookie)
+{
     /* pass */
 }

--- a/src/libImaging/File.c
+++ b/src/libImaging/File.c
@@ -20,7 +20,8 @@
 #include <ctype.h>
 
 int
-ImagingSaveRaw(Imaging im, FILE *fp) {
+ImagingSaveRaw(Imaging im, FILE *fp)
+{
     int x, y, i;
 
     if (strcmp(im->mode, "1") == 0 || strcmp(im->mode, "L") == 0) {
@@ -44,7 +45,8 @@ ImagingSaveRaw(Imaging im, FILE *fp) {
 }
 
 int
-ImagingSavePPM(Imaging im, const char *outfile) {
+ImagingSavePPM(Imaging im, const char *outfile)
+{
     FILE *fp;
 
     if (!im) {

--- a/src/libImaging/Fill.c
+++ b/src/libImaging/Fill.c
@@ -20,7 +20,8 @@
 #include "math.h"
 
 Imaging
-ImagingFill(Imaging im, const void *colour) {
+ImagingFill(Imaging im, const void *colour)
+{
     int x, y;
     ImagingSectionCookie cookie;
 
@@ -68,7 +69,8 @@ ImagingFill(Imaging im, const void *colour) {
 }
 
 Imaging
-ImagingFillLinearGradient(const char *mode) {
+ImagingFillLinearGradient(const char *mode)
+{
     Imaging im;
     int y;
 
@@ -102,7 +104,8 @@ ImagingFillLinearGradient(const char *mode) {
 }
 
 Imaging
-ImagingFillRadialGradient(const char *mode) {
+ImagingFillRadialGradient(const char *mode)
+{
     Imaging im;
     int x, y;
     int d;

--- a/src/libImaging/Filter.c
+++ b/src/libImaging/Filter.c
@@ -27,7 +27,8 @@
 #include "Imaging.h"
 
 static inline UINT8
-clip8(float in) {
+clip8(float in)
+{
     if (in <= 0.0) {
         return 0;
     }
@@ -38,7 +39,8 @@ clip8(float in) {
 }
 
 static inline INT32
-clip32(float in) {
+clip32(float in)
+{
     if (in <= 0.0) {
         return 0;
     }
@@ -49,7 +51,8 @@ clip32(float in) {
 }
 
 Imaging
-ImagingExpand(Imaging imIn, int xmargin, int ymargin) {
+ImagingExpand(Imaging imIn, int xmargin, int ymargin)
+{
     Imaging imOut;
     int x, y;
     ImagingSectionCookie cookie;
@@ -105,7 +108,8 @@ ImagingExpand(Imaging imIn, int xmargin, int ymargin) {
 }
 
 void
-ImagingFilter3x3(Imaging imOut, Imaging im, const float *kernel, float offset) {
+ImagingFilter3x3(Imaging imOut, Imaging im, const float *kernel, float offset)
+{
 #define KERNEL1x3(in0, x, kernel, d)                               \
     (_i2f(in0[x - d]) * (kernel)[0] + _i2f(in0[x]) * (kernel)[1] + \
      _i2f(in0[x + d]) * (kernel)[2])
@@ -223,7 +227,8 @@ ImagingFilter3x3(Imaging imOut, Imaging im, const float *kernel, float offset) {
 }
 
 void
-ImagingFilter5x5(Imaging imOut, Imaging im, const float *kernel, float offset) {
+ImagingFilter5x5(Imaging imOut, Imaging im, const float *kernel, float offset)
+{
 #define KERNEL1x5(in0, x, kernel, d)                                       \
     (_i2f(in0[x - d - d]) * (kernel)[0] + _i2f(in0[x - d]) * (kernel)[1] + \
      _i2f(in0[x]) * (kernel)[2] + _i2f(in0[x + d]) * (kernel)[3] +         \
@@ -377,7 +382,8 @@ ImagingFilter5x5(Imaging imOut, Imaging im, const float *kernel, float offset) {
 }
 
 Imaging
-ImagingFilter(Imaging im, int xsize, int ysize, const FLOAT32 *kernel, FLOAT32 offset) {
+ImagingFilter(Imaging im, int xsize, int ysize, const FLOAT32 *kernel, FLOAT32 offset)
+{
     Imaging imOut;
     ImagingSectionCookie cookie;
 

--- a/src/libImaging/FliDecode.c
+++ b/src/libImaging/FliDecode.c
@@ -27,7 +27,8 @@
     }
 
 int
-ImagingFliDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes) {
+ImagingFliDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes)
+{
     UINT8 *ptr;
     int framesize;
     int c, chunks, advance;

--- a/src/libImaging/Geometry.c
+++ b/src/libImaging/Geometry.c
@@ -15,7 +15,8 @@
 /* Transpose operations                                                 */
 
 Imaging
-ImagingFlipLeftRight(Imaging imOut, Imaging imIn) {
+ImagingFlipLeftRight(Imaging imOut, Imaging imIn)
+{
     ImagingSectionCookie cookie;
     int x, y, xr;
 
@@ -58,7 +59,8 @@ ImagingFlipLeftRight(Imaging imOut, Imaging imIn) {
 }
 
 Imaging
-ImagingFlipTopBottom(Imaging imOut, Imaging imIn) {
+ImagingFlipTopBottom(Imaging imOut, Imaging imIn)
+{
     ImagingSectionCookie cookie;
     int y, yr;
 
@@ -84,7 +86,8 @@ ImagingFlipTopBottom(Imaging imOut, Imaging imIn) {
 }
 
 Imaging
-ImagingRotate90(Imaging imOut, Imaging imIn) {
+ImagingRotate90(Imaging imOut, Imaging imIn)
+{
     ImagingSectionCookie cookie;
     int x, y, xx, yy, xr, xxsize, yysize;
     int xxx, yyy, xxxsize, yyysize;
@@ -144,7 +147,8 @@ ImagingRotate90(Imaging imOut, Imaging imIn) {
 }
 
 Imaging
-ImagingTranspose(Imaging imOut, Imaging imIn) {
+ImagingTranspose(Imaging imOut, Imaging imIn)
+{
     ImagingSectionCookie cookie;
     int x, y, xx, yy, xxsize, yysize;
     int xxx, yyy, xxxsize, yyysize;
@@ -203,7 +207,8 @@ ImagingTranspose(Imaging imOut, Imaging imIn) {
 }
 
 Imaging
-ImagingTransverse(Imaging imOut, Imaging imIn) {
+ImagingTransverse(Imaging imOut, Imaging imIn)
+{
     ImagingSectionCookie cookie;
     int x, y, xr, yr, xx, yy, xxsize, yysize;
     int xxx, yyy, xxxsize, yyysize;
@@ -264,7 +269,8 @@ ImagingTransverse(Imaging imOut, Imaging imIn) {
 }
 
 Imaging
-ImagingRotate180(Imaging imOut, Imaging imIn) {
+ImagingRotate180(Imaging imOut, Imaging imIn)
+{
     ImagingSectionCookie cookie;
     int x, y, xr, yr;
 
@@ -308,7 +314,8 @@ ImagingRotate180(Imaging imOut, Imaging imIn) {
 }
 
 Imaging
-ImagingRotate270(Imaging imOut, Imaging imIn) {
+ImagingRotate270(Imaging imOut, Imaging imIn)
+{
     ImagingSectionCookie cookie;
     int x, y, xx, yy, yr, xxsize, yysize;
     int xxx, yyy, xxxsize, yyysize;
@@ -373,7 +380,8 @@ ImagingRotate270(Imaging imOut, Imaging imIn) {
 /* transform primitives (ImagingTransformMap) */
 
 static int
-affine_transform(double *xout, double *yout, int x, int y, void *data) {
+affine_transform(double *xout, double *yout, int x, int y, void *data)
+{
     /* full moon tonight.  your compiler will generate bogus code
        for simple expressions, unless you reorganize the code, or
        install Service Pack 3 */
@@ -396,7 +404,8 @@ affine_transform(double *xout, double *yout, int x, int y, void *data) {
 }
 
 static int
-perspective_transform(double *xout, double *yout, int x, int y, void *data) {
+perspective_transform(double *xout, double *yout, int x, int y, void *data)
+{
     double *a = (double *)data;
     double a0 = a[0];
     double a1 = a[1];
@@ -417,7 +426,8 @@ perspective_transform(double *xout, double *yout, int x, int y, void *data) {
 }
 
 static int
-quad_transform(double *xout, double *yout, int x, int y, void *data) {
+quad_transform(double *xout, double *yout, int x, int y, void *data)
+{
     /* quad warp: map quadrilateral to rectangle */
 
     double *a = (double *)data;
@@ -442,7 +452,8 @@ quad_transform(double *xout, double *yout, int x, int y, void *data) {
 /* transform filters (ImagingTransformFilter) */
 
 static int
-nearest_filter8(void *out, Imaging im, double xin, double yin) {
+nearest_filter8(void *out, Imaging im, double xin, double yin)
+{
     int x = COORD(xin);
     int y = COORD(yin);
     if (x < 0 || x >= im->xsize || y < 0 || y >= im->ysize) {
@@ -453,7 +464,8 @@ nearest_filter8(void *out, Imaging im, double xin, double yin) {
 }
 
 static int
-nearest_filter16(void *out, Imaging im, double xin, double yin) {
+nearest_filter16(void *out, Imaging im, double xin, double yin)
+{
     int x = COORD(xin);
     int y = COORD(yin);
     if (x < 0 || x >= im->xsize || y < 0 || y >= im->ysize) {
@@ -464,7 +476,8 @@ nearest_filter16(void *out, Imaging im, double xin, double yin) {
 }
 
 static int
-nearest_filter32(void *out, Imaging im, double xin, double yin) {
+nearest_filter32(void *out, Imaging im, double xin, double yin)
+{
     int x = COORD(xin);
     int y = COORD(yin);
     if (x < 0 || x >= im->xsize || y < 0 || y >= im->ysize) {
@@ -511,7 +524,8 @@ nearest_filter32(void *out, Imaging im, double xin, double yin) {
     }
 
 static int
-bilinear_filter8(void *out, Imaging im, double xin, double yin) {
+bilinear_filter8(void *out, Imaging im, double xin, double yin)
+{
     BILINEAR_HEAD(UINT8);
     BILINEAR_BODY(UINT8, im->image8, 1, 0);
     ((UINT8 *)out)[0] = (UINT8)v1;
@@ -519,7 +533,8 @@ bilinear_filter8(void *out, Imaging im, double xin, double yin) {
 }
 
 static int
-bilinear_filter32I(void *out, Imaging im, double xin, double yin) {
+bilinear_filter32I(void *out, Imaging im, double xin, double yin)
+{
     INT32 k;
     BILINEAR_HEAD(INT32);
     BILINEAR_BODY(INT32, im->image32, 1, 0);
@@ -529,7 +544,8 @@ bilinear_filter32I(void *out, Imaging im, double xin, double yin) {
 }
 
 static int
-bilinear_filter32F(void *out, Imaging im, double xin, double yin) {
+bilinear_filter32F(void *out, Imaging im, double xin, double yin)
+{
     FLOAT32 k;
     BILINEAR_HEAD(FLOAT32);
     BILINEAR_BODY(FLOAT32, im->image32, 1, 0);
@@ -539,7 +555,8 @@ bilinear_filter32F(void *out, Imaging im, double xin, double yin) {
 }
 
 static int
-bilinear_filter32LA(void *out, Imaging im, double xin, double yin) {
+bilinear_filter32LA(void *out, Imaging im, double xin, double yin)
+{
     BILINEAR_HEAD(UINT8);
     BILINEAR_BODY(UINT8, im->image, 4, 0);
     ((UINT8 *)out)[0] = (UINT8)v1;
@@ -551,7 +568,8 @@ bilinear_filter32LA(void *out, Imaging im, double xin, double yin) {
 }
 
 static int
-bilinear_filter32RGB(void *out, Imaging im, double xin, double yin) {
+bilinear_filter32RGB(void *out, Imaging im, double xin, double yin)
+{
     int b;
     BILINEAR_HEAD(UINT8);
     for (b = 0; b < im->bands; b++) {
@@ -623,7 +641,8 @@ bilinear_filter32RGB(void *out, Imaging im, double xin, double yin) {
     }
 
 static int
-bicubic_filter8(void *out, Imaging im, double xin, double yin) {
+bicubic_filter8(void *out, Imaging im, double xin, double yin)
+{
     BICUBIC_HEAD(UINT8);
     BICUBIC_BODY(UINT8, im->image8, 1, 0);
     if (v1 <= 0.0) {
@@ -637,7 +656,8 @@ bicubic_filter8(void *out, Imaging im, double xin, double yin) {
 }
 
 static int
-bicubic_filter32I(void *out, Imaging im, double xin, double yin) {
+bicubic_filter32I(void *out, Imaging im, double xin, double yin)
+{
     INT32 k;
     BICUBIC_HEAD(INT32);
     BICUBIC_BODY(INT32, im->image32, 1, 0);
@@ -647,7 +667,8 @@ bicubic_filter32I(void *out, Imaging im, double xin, double yin) {
 }
 
 static int
-bicubic_filter32F(void *out, Imaging im, double xin, double yin) {
+bicubic_filter32F(void *out, Imaging im, double xin, double yin)
+{
     FLOAT32 k;
     BICUBIC_HEAD(FLOAT32);
     BICUBIC_BODY(FLOAT32, im->image32, 1, 0);
@@ -657,7 +678,8 @@ bicubic_filter32F(void *out, Imaging im, double xin, double yin) {
 }
 
 static int
-bicubic_filter32LA(void *out, Imaging im, double xin, double yin) {
+bicubic_filter32LA(void *out, Imaging im, double xin, double yin)
+{
     BICUBIC_HEAD(UINT8);
     BICUBIC_BODY(UINT8, im->image, 4, 0);
     if (v1 <= 0.0) {
@@ -685,7 +707,8 @@ bicubic_filter32LA(void *out, Imaging im, double xin, double yin) {
 }
 
 static int
-bicubic_filter32RGB(void *out, Imaging im, double xin, double yin) {
+bicubic_filter32RGB(void *out, Imaging im, double xin, double yin)
+{
     int b;
     BICUBIC_HEAD(UINT8);
     for (b = 0; b < im->bands; b++) {
@@ -706,7 +729,8 @@ bicubic_filter32RGB(void *out, Imaging im, double xin, double yin) {
 #undef BICUBIC_BODY
 
 static ImagingTransformFilter
-getfilter(Imaging im, int filterid) {
+getfilter(Imaging im, int filterid)
+{
     switch (filterid) {
         case IMAGING_TRANSFORM_NEAREST:
             if (im->image8) {
@@ -781,7 +805,8 @@ ImagingGenericTransform(
     ImagingTransformMap transform,
     void *transform_data,
     int filterid,
-    int fill) {
+    int fill)
+{
     /* slow generic transformation.  use ImagingTransformAffine or
        ImagingScaleAffine where possible. */
 
@@ -836,14 +861,8 @@ ImagingGenericTransform(
 
 static Imaging
 ImagingScaleAffine(
-    Imaging imOut,
-    Imaging imIn,
-    int x0,
-    int y0,
-    int x1,
-    int y1,
-    double a[6],
-    int fill) {
+    Imaging imOut, Imaging imIn, int x0, int y0, int x1, int y1, double a[6], int fill)
+{
     /* scale, nearest neighbour resampling */
 
     ImagingSectionCookie cookie;
@@ -933,7 +952,8 @@ ImagingScaleAffine(
 }
 
 static inline int
-check_fixed(double a[6], int x, int y) {
+check_fixed(double a[6], int x, int y)
+{
     return (
         fabs(x * a[0] + y * a[1] + a[2]) < 32768.0 &&
         fabs(x * a[3] + y * a[4] + a[5]) < 32768.0);
@@ -949,7 +969,8 @@ affine_fixed(
     int y1,
     double a[6],
     int filterid,
-    int fill) {
+    int fill)
+{
     /* affine transform, nearest neighbour resampling, fixed point
        arithmetics */
 
@@ -1026,7 +1047,8 @@ ImagingTransformAffine(
     int y1,
     double a[6],
     int filterid,
-    int fill) {
+    int fill)
+{
     /* affine transform, nearest neighbour resampling, floating point
        arithmetics*/
 
@@ -1134,7 +1156,8 @@ ImagingTransform(
     int y1,
     double a[8],
     int filterid,
-    int fill) {
+    int fill)
+{
     ImagingTransformMap transform;
 
     switch (method) {

--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -19,7 +19,8 @@
 #include "Imaging.h"
 
 int
-ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
+ImagingGetBBox(Imaging im, int bbox[4], int alpha_only)
+{
     /* Get the bounding box for any non-zero data in the image.*/
 
     int x, y;
@@ -81,7 +82,8 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
 }
 
 int
-ImagingGetProjection(Imaging im, UINT8 *xproj, UINT8 *yproj) {
+ImagingGetProjection(Imaging im, UINT8 *xproj, UINT8 *yproj)
+{
     /* Get projection arrays for non-zero data in the image.*/
 
     int x, y;
@@ -119,7 +121,8 @@ ImagingGetProjection(Imaging im, UINT8 *xproj, UINT8 *yproj) {
 }
 
 int
-ImagingGetExtrema(Imaging im, void *extrema) {
+ImagingGetExtrema(Imaging im, void *extrema)
+{
     int x, y;
     INT32 imin, imax;
     FLOAT32 fmin, fmax;
@@ -223,13 +226,15 @@ static ImagingColorItem *
 getcolors32(Imaging im, int maxcolors, int *size);
 
 ImagingColorItem *
-ImagingGetColors(Imaging im, int maxcolors, int *size) {
+ImagingGetColors(Imaging im, int maxcolors, int *size)
+{
     /* FIXME: add support for 8-bit images */
     return getcolors32(im, maxcolors, size);
 }
 
 static ImagingColorItem *
-getcolors32(Imaging im, int maxcolors, int *size) {
+getcolors32(Imaging im, int maxcolors, int *size)
+{
     unsigned int h;
     unsigned int i, incr;
     int colors;

--- a/src/libImaging/GifDecode.c
+++ b/src/libImaging/GifDecode.c
@@ -56,7 +56,8 @@
     }
 
 int
-ImagingGifDecode(Imaging im, ImagingCodecState state, UINT8 *buffer, Py_ssize_t bytes) {
+ImagingGifDecode(Imaging im, ImagingCodecState state, UINT8 *buffer, Py_ssize_t bytes)
+{
     UINT8 *p;
     UINT8 *out;
     int c, i;

--- a/src/libImaging/GifEncode.c
+++ b/src/libImaging/GifEncode.c
@@ -55,7 +55,8 @@ enum {
 enum { PUT_HEAD, PUT_INIT_CLEAR, PUT_CLEAR, PUT_LAST_HEAD, PUT_END };
 
 static void
-glzwe_reset(GIFENCODERSTATE *st) {
+glzwe_reset(GIFENCODERSTATE *st)
+{
     st->next_code = st->end_code + 1;
     st->max_code = 2 * st->clear_code - 1;
     st->code_width = st->bits + 1;
@@ -63,7 +64,8 @@ glzwe_reset(GIFENCODERSTATE *st) {
 }
 
 static void
-glzwe_init(GIFENCODERSTATE *st) {
+glzwe_init(GIFENCODERSTATE *st)
+{
     st->clear_code = 1 << st->bits;
     st->end_code = st->clear_code + 1;
     glzwe_reset(st);
@@ -79,7 +81,8 @@ glzwe(
     UINT8 *out_ptr,
     UINT32 *in_avail,
     UINT32 *out_avail,
-    UINT32 end_of_data) {
+    UINT32 end_of_data)
+{
     switch (st->entry_state) {
         case LZW_TRY_IN1:
 get_first_byte:
@@ -217,7 +220,8 @@ flush_code_buffer: /* jump here after put_code */
 /* -END- GIF LZW encoder. */
 
 int
-ImagingGifEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
+ImagingGifEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes)
+{
     UINT8 *ptr;
     UINT8 *sub_block_ptr;
     UINT8 *sub_block_limit;

--- a/src/libImaging/HexDecode.c
+++ b/src/libImaging/HexDecode.c
@@ -22,7 +22,8 @@
                               : -1)
 
 int
-ImagingHexDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes) {
+ImagingHexDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes)
+{
     UINT8 *ptr;
     int a, b;
 

--- a/src/libImaging/Histo.c
+++ b/src/libImaging/Histo.c
@@ -25,7 +25,8 @@
  */
 
 void
-ImagingHistogramDelete(ImagingHistogram h) {
+ImagingHistogramDelete(ImagingHistogram h)
+{
     if (h) {
         if (h->histogram) {
             free(h->histogram);
@@ -35,7 +36,8 @@ ImagingHistogramDelete(ImagingHistogram h) {
 }
 
 ImagingHistogram
-ImagingHistogramNew(Imaging im) {
+ImagingHistogramNew(Imaging im)
+{
     ImagingHistogram h;
 
     /* Create histogram descriptor */
@@ -57,7 +59,8 @@ ImagingHistogramNew(Imaging im) {
 }
 
 ImagingHistogram
-ImagingGetHistogram(Imaging im, Imaging imMask, void *minmax) {
+ImagingGetHistogram(Imaging im, Imaging imMask, void *minmax)
+{
     ImagingSectionCookie cookie;
     int x, y, i;
     ImagingHistogram h;

--- a/src/libImaging/ImagingUtils.h
+++ b/src/libImaging/ImagingUtils.h
@@ -32,7 +32,8 @@
    See: https://stackoverflow.com/a/26588074/253146 */
 #if defined(__x86_64__) && defined(__SSE__) && !defined(__NO_INLINE__) && \
     !defined(__clang__) && defined(GCC_VERSION) && (GCC_VERSION < 40900)
-static float __attribute__((always_inline)) inline _i2f(int v) {
+static float __attribute__((always_inline)) inline _i2f(int v)
+{
     float x;
     __asm__("xorps %0, %0; cvtsi2ss %1, %0" : "=x"(x) : "r"(v));
     return x;

--- a/src/libImaging/Jpeg2KDecode.c
+++ b/src/libImaging/Jpeg2KDecode.c
@@ -32,7 +32,8 @@ typedef struct {
 /* -------------------------------------------------------------------- */
 
 static void
-j2k_error(const char *msg, void *client_data) {
+j2k_error(const char *msg, void *client_data)
+{
     JPEG2KDECODESTATE *state = (JPEG2KDECODESTATE *)client_data;
     free((void *)state->error_msg);
     state->error_msg = strdup(msg);
@@ -43,7 +44,8 @@ j2k_error(const char *msg, void *client_data) {
 /* -------------------------------------------------------------------- */
 
 static OPJ_SIZE_T
-j2k_read(void *p_buffer, OPJ_SIZE_T p_nb_bytes, void *p_user_data) {
+j2k_read(void *p_buffer, OPJ_SIZE_T p_nb_bytes, void *p_user_data)
+{
     ImagingCodecState state = (ImagingCodecState)p_user_data;
 
     size_t len = _imaging_read_pyFd(state->fd, p_buffer, p_nb_bytes);
@@ -52,7 +54,8 @@ j2k_read(void *p_buffer, OPJ_SIZE_T p_nb_bytes, void *p_user_data) {
 }
 
 static OPJ_OFF_T
-j2k_skip(OPJ_OFF_T p_nb_bytes, void *p_user_data) {
+j2k_skip(OPJ_OFF_T p_nb_bytes, void *p_user_data)
+{
     off_t pos;
     ImagingCodecState state = (ImagingCodecState)p_user_data;
 
@@ -79,7 +82,8 @@ struct j2k_decode_unpacker {
 };
 
 static inline unsigned
-j2ku_shift(unsigned x, int n) {
+j2ku_shift(unsigned x, int n)
+{
     if (n < 0) {
         return x >> -n;
     } else {
@@ -89,10 +93,8 @@ j2ku_shift(unsigned x, int n) {
 
 static void
 j2ku_gray_l(
-    opj_image_t *in,
-    const JPEG2KTILEINFO *tileinfo,
-    const UINT8 *tiledata,
-    Imaging im) {
+    opj_image_t *in, const JPEG2KTILEINFO *tileinfo, const UINT8 *tiledata, Imaging im)
+{
     unsigned x0 = tileinfo->x0 - in->x0, y0 = tileinfo->y0 - in->y0;
     unsigned w = tileinfo->x1 - tileinfo->x0;
     unsigned h = tileinfo->y1 - tileinfo->y0;
@@ -145,10 +147,8 @@ j2ku_gray_l(
 
 static void
 j2ku_gray_i(
-    opj_image_t *in,
-    const JPEG2KTILEINFO *tileinfo,
-    const UINT8 *tiledata,
-    Imaging im) {
+    opj_image_t *in, const JPEG2KTILEINFO *tileinfo, const UINT8 *tiledata, Imaging im)
+{
     unsigned x0 = tileinfo->x0 - in->x0, y0 = tileinfo->y0 - in->y0;
     unsigned w = tileinfo->x1 - tileinfo->x0;
     unsigned h = tileinfo->y1 - tileinfo->y0;
@@ -204,10 +204,8 @@ j2ku_gray_i(
 
 static void
 j2ku_gray_rgb(
-    opj_image_t *in,
-    const JPEG2KTILEINFO *tileinfo,
-    const UINT8 *tiledata,
-    Imaging im) {
+    opj_image_t *in, const JPEG2KTILEINFO *tileinfo, const UINT8 *tiledata, Imaging im)
+{
     unsigned x0 = tileinfo->x0 - in->x0, y0 = tileinfo->y0 - in->y0;
     unsigned w = tileinfo->x1 - tileinfo->x0;
     unsigned h = tileinfo->y1 - tileinfo->y0;
@@ -268,10 +266,8 @@ j2ku_gray_rgb(
 
 static void
 j2ku_graya_la(
-    opj_image_t *in,
-    const JPEG2KTILEINFO *tileinfo,
-    const UINT8 *tiledata,
-    Imaging im) {
+    opj_image_t *in, const JPEG2KTILEINFO *tileinfo, const UINT8 *tiledata, Imaging im)
+{
     unsigned x0 = tileinfo->x0 - in->x0, y0 = tileinfo->y0 - in->y0;
     unsigned w = tileinfo->x1 - tileinfo->x0;
     unsigned h = tileinfo->y1 - tileinfo->y0;
@@ -347,10 +343,8 @@ j2ku_graya_la(
 
 static void
 j2ku_srgb_rgb(
-    opj_image_t *in,
-    const JPEG2KTILEINFO *tileinfo,
-    const UINT8 *tiledata,
-    Imaging im) {
+    opj_image_t *in, const JPEG2KTILEINFO *tileinfo, const UINT8 *tiledata, Imaging im)
+{
     unsigned x0 = tileinfo->x0 - in->x0, y0 = tileinfo->y0 - in->y0;
     unsigned w = tileinfo->x1 - tileinfo->x0;
     unsigned h = tileinfo->y1 - tileinfo->y0;
@@ -413,10 +407,8 @@ j2ku_srgb_rgb(
 
 static void
 j2ku_sycc_rgb(
-    opj_image_t *in,
-    const JPEG2KTILEINFO *tileinfo,
-    const UINT8 *tiledata,
-    Imaging im) {
+    opj_image_t *in, const JPEG2KTILEINFO *tileinfo, const UINT8 *tiledata, Imaging im)
+{
     unsigned x0 = tileinfo->x0 - in->x0, y0 = tileinfo->y0 - in->y0;
     unsigned w = tileinfo->x1 - tileinfo->x0;
     unsigned h = tileinfo->y1 - tileinfo->y0;
@@ -482,10 +474,8 @@ j2ku_sycc_rgb(
 
 static void
 j2ku_srgba_rgba(
-    opj_image_t *in,
-    const JPEG2KTILEINFO *tileinfo,
-    const UINT8 *tiledata,
-    Imaging im) {
+    opj_image_t *in, const JPEG2KTILEINFO *tileinfo, const UINT8 *tiledata, Imaging im)
+{
     unsigned x0 = tileinfo->x0 - in->x0, y0 = tileinfo->y0 - in->y0;
     unsigned w = tileinfo->x1 - tileinfo->x0;
     unsigned h = tileinfo->y1 - tileinfo->y0;
@@ -547,10 +537,8 @@ j2ku_srgba_rgba(
 
 static void
 j2ku_sycca_rgba(
-    opj_image_t *in,
-    const JPEG2KTILEINFO *tileinfo,
-    const UINT8 *tiledata,
-    Imaging im) {
+    opj_image_t *in, const JPEG2KTILEINFO *tileinfo, const UINT8 *tiledata, Imaging im)
+{
     unsigned x0 = tileinfo->x0 - in->x0, y0 = tileinfo->y0 - in->y0;
     unsigned w = tileinfo->x1 - tileinfo->x0;
     unsigned h = tileinfo->y1 - tileinfo->y0;
@@ -647,7 +635,8 @@ enum {
 };
 
 static int
-j2k_decode_entry(Imaging im, ImagingCodecState state) {
+j2k_decode_entry(Imaging im, ImagingCodecState state)
+{
     JPEG2KDECODESTATE *context = (JPEG2KDECODESTATE *)state->context;
     opj_stream_t *stream = NULL;
     opj_image_t *image = NULL;
@@ -945,7 +934,8 @@ quick_exit:
 }
 
 int
-ImagingJpeg2KDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes) {
+ImagingJpeg2KDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes)
+{
     if (bytes) {
         state->errcode = IMAGING_CODEC_BROKEN;
         state->state = J2K_STATE_FAILED;
@@ -975,7 +965,8 @@ ImagingJpeg2KDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t 
 /* -------------------------------------------------------------------- */
 
 int
-ImagingJpeg2KDecodeCleanup(ImagingCodecState state) {
+ImagingJpeg2KDecodeCleanup(ImagingCodecState state)
+{
     JPEG2KDECODESTATE *context = (JPEG2KDECODESTATE *)state->context;
 
     if (context->error_msg) {
@@ -988,7 +979,8 @@ ImagingJpeg2KDecodeCleanup(ImagingCodecState state) {
 }
 
 const char *
-ImagingJpeg2KVersion(void) {
+ImagingJpeg2KVersion(void)
+{
     return opj_version();
 }
 

--- a/src/libImaging/Jpeg2KEncode.c
+++ b/src/libImaging/Jpeg2KEncode.c
@@ -29,14 +29,16 @@
 /* -------------------------------------------------------------------- */
 
 static void
-j2k_error(const char *msg, void *client_data) {
+j2k_error(const char *msg, void *client_data)
+{
     JPEG2KENCODESTATE *state = (JPEG2KENCODESTATE *)client_data;
     free((void *)state->error_msg);
     state->error_msg = strdup(msg);
 }
 
 static void
-j2k_warn(const char *msg, void *client_data) {
+j2k_warn(const char *msg, void *client_data)
+{
     // Null handler
 }
 
@@ -45,7 +47,8 @@ j2k_warn(const char *msg, void *client_data) {
 /* -------------------------------------------------------------------- */
 
 static OPJ_SIZE_T
-j2k_write(void *p_buffer, OPJ_SIZE_T p_nb_bytes, void *p_user_data) {
+j2k_write(void *p_buffer, OPJ_SIZE_T p_nb_bytes, void *p_user_data)
+{
     ImagingCodecState state = (ImagingCodecState)p_user_data;
     unsigned int result;
 
@@ -55,7 +58,8 @@ j2k_write(void *p_buffer, OPJ_SIZE_T p_nb_bytes, void *p_user_data) {
 }
 
 static OPJ_OFF_T
-j2k_skip(OPJ_OFF_T p_nb_bytes, void *p_user_data) {
+j2k_skip(OPJ_OFF_T p_nb_bytes, void *p_user_data)
+{
     ImagingCodecState state = (ImagingCodecState)p_user_data;
     char *buffer;
     int result;
@@ -74,7 +78,8 @@ j2k_skip(OPJ_OFF_T p_nb_bytes, void *p_user_data) {
 }
 
 static OPJ_BOOL
-j2k_seek(OPJ_OFF_T p_nb_bytes, void *p_user_data) {
+j2k_seek(OPJ_OFF_T p_nb_bytes, void *p_user_data)
+{
     ImagingCodecState state = (ImagingCodecState)p_user_data;
     off_t pos = 0;
 
@@ -92,7 +97,8 @@ typedef void (*j2k_pack_tile_t)(
     Imaging im, UINT8 *buf, unsigned x0, unsigned y0, unsigned w, unsigned h);
 
 static void
-j2k_pack_l(Imaging im, UINT8 *buf, unsigned x0, unsigned y0, unsigned w, unsigned h) {
+j2k_pack_l(Imaging im, UINT8 *buf, unsigned x0, unsigned y0, unsigned w, unsigned h)
+{
     UINT8 *ptr = buf;
     unsigned x, y;
     for (y = 0; y < h; ++y) {
@@ -104,7 +110,8 @@ j2k_pack_l(Imaging im, UINT8 *buf, unsigned x0, unsigned y0, unsigned w, unsigne
 }
 
 static void
-j2k_pack_i16(Imaging im, UINT8 *buf, unsigned x0, unsigned y0, unsigned w, unsigned h) {
+j2k_pack_i16(Imaging im, UINT8 *buf, unsigned x0, unsigned y0, unsigned w, unsigned h)
+{
     UINT8 *ptr = buf;
     unsigned x, y;
     for (y = 0; y < h; ++y) {
@@ -124,7 +131,8 @@ j2k_pack_i16(Imaging im, UINT8 *buf, unsigned x0, unsigned y0, unsigned w, unsig
 }
 
 static void
-j2k_pack_la(Imaging im, UINT8 *buf, unsigned x0, unsigned y0, unsigned w, unsigned h) {
+j2k_pack_la(Imaging im, UINT8 *buf, unsigned x0, unsigned y0, unsigned w, unsigned h)
+{
     UINT8 *ptr = buf;
     UINT8 *ptra = buf + w * h;
     unsigned x, y;
@@ -139,7 +147,8 @@ j2k_pack_la(Imaging im, UINT8 *buf, unsigned x0, unsigned y0, unsigned w, unsign
 }
 
 static void
-j2k_pack_rgb(Imaging im, UINT8 *buf, unsigned x0, unsigned y0, unsigned w, unsigned h) {
+j2k_pack_rgb(Imaging im, UINT8 *buf, unsigned x0, unsigned y0, unsigned w, unsigned h)
+{
     UINT8 *pr = buf;
     UINT8 *pg = pr + w * h;
     UINT8 *pb = pg + w * h;
@@ -156,8 +165,8 @@ j2k_pack_rgb(Imaging im, UINT8 *buf, unsigned x0, unsigned y0, unsigned w, unsig
 }
 
 static void
-j2k_pack_rgba(
-    Imaging im, UINT8 *buf, unsigned x0, unsigned y0, unsigned w, unsigned h) {
+j2k_pack_rgba(Imaging im, UINT8 *buf, unsigned x0, unsigned y0, unsigned w, unsigned h)
+{
     UINT8 *pr = buf;
     UINT8 *pg = pr + w * h;
     UINT8 *pb = pg + w * h;
@@ -182,7 +191,8 @@ enum {
 };
 
 static void
-j2k_set_cinema_params(Imaging im, int components, opj_cparameters_t *params) {
+j2k_set_cinema_params(Imaging im, int components, opj_cparameters_t *params)
+{
     float rate;
     int n;
 
@@ -263,7 +273,8 @@ j2k_set_cinema_params(Imaging im, int components, opj_cparameters_t *params) {
 }
 
 static int
-j2k_encode_entry(Imaging im, ImagingCodecState state) {
+j2k_encode_entry(Imaging im, ImagingCodecState state)
+{
     JPEG2KENCODESTATE *context = (JPEG2KENCODESTATE *)state->context;
     opj_stream_t *stream = NULL;
     opj_image_t *image = NULL;
@@ -608,7 +619,8 @@ quick_exit:
 }
 
 int
-ImagingJpeg2KEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
+ImagingJpeg2KEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes)
+{
     if (state->state == J2K_STATE_FAILED) {
         return -1;
     }
@@ -627,7 +639,8 @@ ImagingJpeg2KEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) 
 /* -------------------------------------------------------------------- */
 
 int
-ImagingJpeg2KEncodeCleanup(ImagingCodecState state) {
+ImagingJpeg2KEncodeCleanup(ImagingCodecState state)
+{
     JPEG2KENCODESTATE *context = (JPEG2KENCODESTATE *)state->context;
 
     if (context->quality_layers) {

--- a/src/libImaging/JpegDecode.c
+++ b/src/libImaging/JpegDecode.c
@@ -48,7 +48,8 @@ char *libjpeg_turbo_version = NULL;
 #endif
 
 int
-ImagingJpegUseJCSExtensions() {
+ImagingJpegUseJCSExtensions()
+{
     int use_jcs_extensions = 0;
 #ifdef JCS_EXTENSIONS
 #if defined(LIBJPEG_TURBO_VERSION_NUMBER)
@@ -72,13 +73,15 @@ METHODDEF(void)
 stub(j_decompress_ptr cinfo) { /* empty */ }
 
 METHODDEF(boolean)
-fill_input_buffer(j_decompress_ptr cinfo) {
+fill_input_buffer(j_decompress_ptr cinfo)
+{
     /* Suspension */
     return FALSE;
 }
 
 METHODDEF(void)
-skip_input_data(j_decompress_ptr cinfo, long num_bytes) {
+skip_input_data(j_decompress_ptr cinfo, long num_bytes)
+{
     JPEGSOURCE *source = (JPEGSOURCE *)cinfo->src;
 
     if (num_bytes > (long)source->pub.bytes_in_buffer) {
@@ -96,7 +99,8 @@ skip_input_data(j_decompress_ptr cinfo, long num_bytes) {
 }
 
 GLOBAL(void)
-jpeg_buffer_src(j_decompress_ptr cinfo, JPEGSOURCE *source) {
+jpeg_buffer_src(j_decompress_ptr cinfo, JPEGSOURCE *source)
+{
     cinfo->src = (void *)source;
 
     /* Prepare for suspending reader */
@@ -115,7 +119,8 @@ jpeg_buffer_src(j_decompress_ptr cinfo, JPEGSOURCE *source) {
 /* -------------------------------------------------------------------- */
 
 METHODDEF(void)
-error(j_common_ptr cinfo) {
+error(j_common_ptr cinfo)
+{
     JPEGERROR *error;
     error = (JPEGERROR *)cinfo->err;
     longjmp(error->setjmp_buffer, 1);
@@ -129,7 +134,8 @@ output(j_common_ptr cinfo) { /* nothing */ }
 /* -------------------------------------------------------------------- */
 
 int
-ImagingJpegDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes) {
+ImagingJpegDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes)
+{
     JPEGSTATE *context = (JPEGSTATE *)state->context;
     int ok;
 
@@ -290,7 +296,8 @@ ImagingJpegDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t by
 /* -------------------------------------------------------------------- */
 
 int
-ImagingJpegDecodeCleanup(ImagingCodecState state) {
+ImagingJpegDecodeCleanup(ImagingCodecState state)
+{
     /* called to free the decompression engine when the decode terminates
        due to a corrupt or truncated image
     */

--- a/src/libImaging/JpegEncode.c
+++ b/src/libImaging/JpegEncode.c
@@ -42,13 +42,15 @@ METHODDEF(void)
 stub(j_compress_ptr cinfo) { /* empty */ }
 
 METHODDEF(boolean)
-empty_output_buffer(j_compress_ptr cinfo) {
+empty_output_buffer(j_compress_ptr cinfo)
+{
     /* Suspension */
     return FALSE;
 }
 
 GLOBAL(void)
-jpeg_buffer_dest(j_compress_ptr cinfo, JPEGDESTINATION *destination) {
+jpeg_buffer_dest(j_compress_ptr cinfo, JPEGDESTINATION *destination)
+{
     cinfo->dest = (void *)destination;
 
     destination->pub.init_destination = stub;
@@ -61,7 +63,8 @@ jpeg_buffer_dest(j_compress_ptr cinfo, JPEGDESTINATION *destination) {
 /* -------------------------------------------------------------------- */
 
 METHODDEF(void)
-error(j_common_ptr cinfo) {
+error(j_common_ptr cinfo)
+{
     JPEGERROR *error;
     error = (JPEGERROR *)cinfo->err;
     (*cinfo->err->output_message)(cinfo);
@@ -73,7 +76,8 @@ error(j_common_ptr cinfo) {
 /* -------------------------------------------------------------------- */
 
 int
-ImagingJpegEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
+ImagingJpegEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes)
+{
     JPEGENCODERSTATE *context = (JPEGENCODERSTATE *)state->context;
     int ok;
 
@@ -376,7 +380,8 @@ cleanup:
 }
 
 const char *
-ImagingJpegVersion(void) {
+ImagingJpegVersion(void)
+{
     static char version[20];
     sprintf(version, "%d.%d", JPEG_LIB_VERSION / 10, JPEG_LIB_VERSION % 10);
     return version;

--- a/src/libImaging/Matrix.c
+++ b/src/libImaging/Matrix.c
@@ -18,7 +18,8 @@
 #define CLIPF(v) ((v <= 0.0) ? 0 : (v >= 255.0F) ? 255 : (UINT8)v)
 
 Imaging
-ImagingConvertMatrix(Imaging im, const char *mode, float m[]) {
+ImagingConvertMatrix(Imaging im, const char *mode, float m[])
+{
     Imaging imOut;
     int x, y;
     ImagingSectionCookie cookie;

--- a/src/libImaging/ModeFilter.c
+++ b/src/libImaging/ModeFilter.c
@@ -16,7 +16,8 @@
 #include "Imaging.h"
 
 Imaging
-ImagingModeFilter(Imaging im, int size) {
+ImagingModeFilter(Imaging im, int size)
+{
     Imaging imOut;
     int x, y, i;
     int xx, yy;

--- a/src/libImaging/Negative.c
+++ b/src/libImaging/Negative.c
@@ -19,7 +19,8 @@
 #include "Imaging.h"
 
 Imaging
-ImagingNegative(Imaging im) {
+ImagingNegative(Imaging im)
+{
     Imaging imOut;
     int x, y;
 

--- a/src/libImaging/Offset.c
+++ b/src/libImaging/Offset.c
@@ -17,7 +17,8 @@
 #include "Imaging.h"
 
 Imaging
-ImagingOffset(Imaging im, int xoffset, int yoffset) {
+ImagingOffset(Imaging im, int xoffset, int yoffset)
+{
     int x, y;
     Imaging imOut;
 

--- a/src/libImaging/Pack.c
+++ b/src/libImaging/Pack.c
@@ -80,7 +80,8 @@
 #endif
 
 static void
-pack1(UINT8 *out, const UINT8 *in, int pixels) {
+pack1(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i, m, b;
     /* bilevel (black is 0) */
     b = 0;
@@ -102,7 +103,8 @@ pack1(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-pack1I(UINT8 *out, const UINT8 *in, int pixels) {
+pack1I(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i, m, b;
     /* bilevel (black is 1) */
     b = 0;
@@ -124,7 +126,8 @@ pack1I(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-pack1R(UINT8 *out, const UINT8 *in, int pixels) {
+pack1R(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i, m, b;
     /* bilevel, lsb first (black is 0) */
     b = 0;
@@ -146,7 +149,8 @@ pack1R(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-pack1IR(UINT8 *out, const UINT8 *in, int pixels) {
+pack1IR(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i, m, b;
     /* bilevel, lsb first (black is 1) */
     b = 0;
@@ -168,7 +172,8 @@ pack1IR(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-pack1L(UINT8 *out, const UINT8 *in, int pixels) {
+pack1L(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* bilevel, stored as bytes */
     for (i = 0; i < pixels; i++) {
@@ -177,7 +182,8 @@ pack1L(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-packP4(UINT8 *out, const UINT8 *in, int pixels) {
+packP4(UINT8 *out, const UINT8 *in, int pixels)
+{
     while (pixels >= 2) {
         *out++ = (in[0] << 4) | (in[1] & 15);
         in += 2;
@@ -190,7 +196,8 @@ packP4(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-packP2(UINT8 *out, const UINT8 *in, int pixels) {
+packP2(UINT8 *out, const UINT8 *in, int pixels)
+{
     while (pixels >= 4) {
         *out++ = (in[0] << 6) | ((in[1] & 3) << 4) | ((in[2] & 3) << 2) | (in[3] & 3);
         in += 4;
@@ -210,7 +217,8 @@ packP2(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-packL16(UINT8 *out, const UINT8 *in, int pixels) {
+packL16(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* L -> L;16, e.g: \xff77 -> \x00\xff\x00\x77 */
     for (i = 0; i < pixels; i++) {
@@ -221,7 +229,8 @@ packL16(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-packL16B(UINT8 *out, const UINT8 *in, int pixels) {
+packL16B(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* L -> L;16B, e.g: \xff77 -> \xff\x00\x77\x00 */
     for (i = 0; i < pixels; i++) {
@@ -232,7 +241,8 @@ packL16B(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-packLA(UINT8 *out, const UINT8 *in, int pixels) {
+packLA(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* LA, pixel interleaved */
     for (i = 0; i < pixels; i++) {
@@ -244,7 +254,8 @@ packLA(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-packLAL(UINT8 *out, const UINT8 *in, int pixels) {
+packLAL(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* LA, line interleaved */
     for (i = 0; i < pixels; i++) {
@@ -255,7 +266,8 @@ packLAL(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingPackRGB(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingPackRGB(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i = 0;
     /* RGB triplets */
 #ifdef __sparc
@@ -282,7 +294,8 @@ ImagingPackRGB(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingPackXRGB(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingPackXRGB(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* XRGB, triplets with left padding */
     for (i = 0; i < pixels; i++) {
@@ -296,7 +309,8 @@ ImagingPackXRGB(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingPackBGR(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingPackBGR(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* RGB, reversed bytes */
     for (i = 0; i < pixels; i++) {
@@ -309,7 +323,8 @@ ImagingPackBGR(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingPackBGRX(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingPackBGRX(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* BGRX, reversed bytes with right padding */
     for (i = 0; i < pixels; i++) {
@@ -323,7 +338,8 @@ ImagingPackBGRX(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingPackXBGR(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingPackXBGR(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* XBGR, reversed bytes with left padding */
     for (i = 0; i < pixels; i++) {
@@ -337,7 +353,8 @@ ImagingPackXBGR(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingPackBGRA(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingPackBGRA(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* BGRA, reversed bytes with right alpha */
     for (i = 0; i < pixels; i++) {
@@ -351,7 +368,8 @@ ImagingPackBGRA(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingPackABGR(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingPackABGR(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* ABGR, reversed bytes with left alpha */
     for (i = 0; i < pixels; i++) {
@@ -365,7 +383,8 @@ ImagingPackABGR(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingPackBGRa(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingPackBGRa(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* BGRa, reversed bytes with premultiplied alpha */
     for (i = 0; i < pixels; i++) {
@@ -380,7 +399,8 @@ ImagingPackBGRa(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-packRGBL(UINT8 *out, const UINT8 *in, int pixels) {
+packRGBL(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* RGB, line interleaved */
     for (i = 0; i < pixels; i++) {
@@ -392,7 +412,8 @@ packRGBL(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-packRGBXL(UINT8 *out, const UINT8 *in, int pixels) {
+packRGBXL(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* RGBX, line interleaved */
     for (i = 0; i < pixels; i++) {
@@ -405,7 +426,8 @@ packRGBXL(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-packI16B(UINT8 *out, const UINT8 *in_, int pixels) {
+packI16B(UINT8 *out, const UINT8 *in_, int pixels)
+{
     int i;
     UINT16 tmp_;
     UINT8 *tmp = (UINT8 *)&tmp_;
@@ -426,7 +448,8 @@ packI16B(UINT8 *out, const UINT8 *in_, int pixels) {
 }
 
 static void
-packI16N_I16B(UINT8 *out, const UINT8 *in, int pixels) {
+packI16N_I16B(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     UINT8 *tmp = (UINT8 *)in;
     for (i = 0; i < pixels; i++) {
@@ -436,7 +459,8 @@ packI16N_I16B(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 static void
-packI16N_I16(UINT8 *out, const UINT8 *in, int pixels) {
+packI16N_I16(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     UINT8 *tmp = (UINT8 *)in;
     for (i = 0; i < pixels; i++) {
@@ -447,7 +471,8 @@ packI16N_I16(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-packI32S(UINT8 *out, const UINT8 *in, int pixels) {
+packI32S(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     UINT8 *tmp = (UINT8 *)in;
     for (i = 0; i < pixels; i++) {
@@ -458,7 +483,8 @@ packI32S(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingPackLAB(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingPackLAB(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* LAB triplets */
     for (i = 0; i < pixels; i++) {
@@ -471,31 +497,36 @@ ImagingPackLAB(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-copy1(UINT8 *out, const UINT8 *in, int pixels) {
+copy1(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* L, P */
     memcpy(out, in, pixels);
 }
 
 static void
-copy2(UINT8 *out, const UINT8 *in, int pixels) {
+copy2(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* I;16, etc */
     memcpy(out, in, pixels * 2);
 }
 
 static void
-copy3(UINT8 *out, const UINT8 *in, int pixels) {
+copy3(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* BGR;24, etc */
     memcpy(out, in, pixels * 3);
 }
 
 static void
-copy4(UINT8 *out, const UINT8 *in, int pixels) {
+copy4(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* RGBA, CMYK quadruples */
     memcpy(out, in, 4 * pixels);
 }
 
 static void
-copy4I(UINT8 *out, const UINT8 *in, int pixels) {
+copy4I(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* RGBA, CMYK quadruples, inverted */
     int i;
     for (i = 0; i < pixels * 4; i++) {
@@ -504,7 +535,8 @@ copy4I(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band0(UINT8 *out, const UINT8 *in, int pixels) {
+band0(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     for (i = 0; i < pixels; i++, in += 4) {
         out[i] = in[0];
@@ -512,7 +544,8 @@ band0(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band1(UINT8 *out, const UINT8 *in, int pixels) {
+band1(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     for (i = 0; i < pixels; i++, in += 4) {
         out[i] = in[1];
@@ -520,7 +553,8 @@ band1(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band2(UINT8 *out, const UINT8 *in, int pixels) {
+band2(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     for (i = 0; i < pixels; i++, in += 4) {
         out[i] = in[2];
@@ -528,7 +562,8 @@ band2(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band3(UINT8 *out, const UINT8 *in, int pixels) {
+band3(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     for (i = 0; i < pixels; i++, in += 4) {
         out[i] = in[3];
@@ -676,7 +711,8 @@ static struct {
 };
 
 ImagingShuffler
-ImagingFindPacker(const char *mode, const char *rawmode, int *bits_out) {
+ImagingFindPacker(const char *mode, const char *rawmode, int *bits_out)
+{
     int i;
 
     /* find a suitable pixel packer */

--- a/src/libImaging/PackDecode.c
+++ b/src/libImaging/PackDecode.c
@@ -16,8 +16,8 @@
 #include "Imaging.h"
 
 int
-ImagingPackbitsDecode(
-    Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes) {
+ImagingPackbitsDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes)
+{
     UINT8 n;
     UINT8 *ptr;
     int i;

--- a/src/libImaging/Palette.c
+++ b/src/libImaging/Palette.c
@@ -21,7 +21,8 @@
 #include <math.h>
 
 ImagingPalette
-ImagingPaletteNew(const char *mode) {
+ImagingPaletteNew(const char *mode)
+{
     /* Create a palette object */
 
     int i;
@@ -48,7 +49,8 @@ ImagingPaletteNew(const char *mode) {
 }
 
 ImagingPalette
-ImagingPaletteNewBrowser(void) {
+ImagingPaletteNewBrowser(void)
+{
     /* Create a standard "browser" palette object */
 
     int i, r, g, b;
@@ -81,7 +83,8 @@ ImagingPaletteNewBrowser(void) {
 }
 
 ImagingPalette
-ImagingPaletteDuplicate(ImagingPalette palette) {
+ImagingPaletteDuplicate(ImagingPalette palette)
+{
     /* Duplicate palette descriptor */
 
     ImagingPalette new_palette;
@@ -104,7 +107,8 @@ ImagingPaletteDuplicate(ImagingPalette palette) {
 }
 
 void
-ImagingPaletteDelete(ImagingPalette palette) {
+ImagingPaletteDelete(ImagingPalette palette)
+{
     /* Destroy palette object */
 
     if (palette) {
@@ -151,7 +155,8 @@ ImagingPaletteDelete(ImagingPalette palette) {
 #define BOXVOLUME BOX *BOX *BOX
 
 void
-ImagingPaletteCacheUpdate(ImagingPalette palette, int r, int g, int b) {
+ImagingPaletteCacheUpdate(ImagingPalette palette, int r, int g, int b)
+{
     int i, j;
     unsigned int dmin[256], dmax;
     int r0, g0, b0;
@@ -270,7 +275,8 @@ ImagingPaletteCacheUpdate(ImagingPalette palette, int r, int g, int b) {
 }
 
 int
-ImagingPaletteCachePrepare(ImagingPalette palette) {
+ImagingPaletteCachePrepare(ImagingPalette palette)
+{
     /* Add a colour cache to a palette */
 
     int i;
@@ -297,7 +303,8 @@ ImagingPaletteCachePrepare(ImagingPalette palette) {
 }
 
 void
-ImagingPaletteCacheDelete(ImagingPalette palette) {
+ImagingPaletteCacheDelete(ImagingPalette palette)
+{
     /* Release the colour cache, if any */
 
     if (palette && palette->cache) {

--- a/src/libImaging/Paste.c
+++ b/src/libImaging/Paste.c
@@ -33,7 +33,8 @@ paste(
     int sy,
     int xsize,
     int ysize,
-    int pixelsize) {
+    int pixelsize)
+{
     /* paste opaque region */
 
     int y;
@@ -59,7 +60,8 @@ paste_mask_1(
     int sy,
     int xsize,
     int ysize,
-    int pixelsize) {
+    int pixelsize)
+{
     /* paste with mode "1" mask */
 
     int x, y;
@@ -120,7 +122,8 @@ paste_mask_L(
     int sy,
     int xsize,
     int ysize,
-    int pixelsize) {
+    int pixelsize)
+{
     /* paste with mode "L" matte */
 
     int x, y;
@@ -167,7 +170,8 @@ paste_mask_RGBA(
     int sy,
     int xsize,
     int ysize,
-    int pixelsize) {
+    int pixelsize)
+{
     /* paste with mode "RGBA" matte */
 
     int x, y;
@@ -214,7 +218,8 @@ paste_mask_RGBa(
     int sy,
     int xsize,
     int ysize,
-    int pixelsize) {
+    int pixelsize)
+{
     /* paste with mode "RGBa" matte */
 
     int x, y;
@@ -252,7 +257,8 @@ paste_mask_RGBa(
 
 int
 ImagingPaste(
-    Imaging imOut, Imaging imIn, Imaging imMask, int dx0, int dy0, int dx1, int dy1) {
+    Imaging imOut, Imaging imIn, Imaging imMask, int dx0, int dy0, int dx1, int dy1)
+{
     int xsize, ysize;
     int pixelsize;
     int sx0, sy0;
@@ -340,7 +346,8 @@ fill(
     int dy,
     int xsize,
     int ysize,
-    int pixelsize) {
+    int pixelsize)
+{
     /* fill opaque region */
 
     int x, y;
@@ -378,7 +385,8 @@ fill_mask_1(
     int sy,
     int xsize,
     int ysize,
-    int pixelsize) {
+    int pixelsize)
+{
     /* fill with mode "1" mask */
 
     int x, y;
@@ -425,7 +433,8 @@ fill_mask_L(
     int sy,
     int xsize,
     int ysize,
-    int pixelsize) {
+    int pixelsize)
+{
     /* fill with mode "L" matte */
 
     int x, y, i;
@@ -484,7 +493,8 @@ fill_mask_RGBA(
     int sy,
     int xsize,
     int ysize,
-    int pixelsize) {
+    int pixelsize)
+{
     /* fill with mode "RGBA" matte */
 
     int x, y, i;
@@ -529,7 +539,8 @@ fill_mask_RGBa(
     int sy,
     int xsize,
     int ysize,
-    int pixelsize) {
+    int pixelsize)
+{
     /* fill with mode "RGBa" matte */
 
     int x, y, i;
@@ -565,13 +576,8 @@ fill_mask_RGBa(
 
 int
 ImagingFill2(
-    Imaging imOut,
-    const void *ink,
-    Imaging imMask,
-    int dx0,
-    int dy0,
-    int dx1,
-    int dy1) {
+    Imaging imOut, const void *ink, Imaging imMask, int dx0, int dy0, int dx1, int dy1)
+{
     ImagingSectionCookie cookie;
     int xsize, ysize;
     int pixelsize;

--- a/src/libImaging/PcdDecode.c
+++ b/src/libImaging/PcdDecode.c
@@ -22,7 +22,8 @@
 #include "Imaging.h"
 
 int
-ImagingPcdDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes) {
+ImagingPcdDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes)
+{
     int x;
     int chunk;
     UINT8 *out;

--- a/src/libImaging/PcxDecode.c
+++ b/src/libImaging/PcxDecode.c
@@ -16,7 +16,8 @@
 #include "Imaging.h"
 
 int
-ImagingPcxDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes) {
+ImagingPcxDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes)
+{
     UINT8 n;
     UINT8 *ptr;
 

--- a/src/libImaging/PcxEncode.c
+++ b/src/libImaging/PcxEncode.c
@@ -21,7 +21,8 @@ enum { INIT, FETCH, ENCODE };
 #define LAST ystep
 
 int
-ImagingPcxEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
+ImagingPcxEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes)
+{
     UINT8 *ptr;
     int this;
     int bytes_per_line = 0;

--- a/src/libImaging/Point.c
+++ b/src/libImaging/Point.c
@@ -26,7 +26,8 @@ typedef struct {
 } im_point_context;
 
 static void
-im_point_8_8(Imaging imOut, Imaging imIn, im_point_context *context) {
+im_point_8_8(Imaging imOut, Imaging imIn, im_point_context *context)
+{
     int x, y;
     /* 8-bit source, 8-bit destination */
     UINT8 *table = (UINT8 *)context->table;
@@ -40,7 +41,8 @@ im_point_8_8(Imaging imOut, Imaging imIn, im_point_context *context) {
 }
 
 static void
-im_point_2x8_2x8(Imaging imOut, Imaging imIn, im_point_context *context) {
+im_point_2x8_2x8(Imaging imOut, Imaging imIn, im_point_context *context)
+{
     int x, y;
     /* 2x8-bit source, 2x8-bit destination */
     UINT8 *table = (UINT8 *)context->table;
@@ -57,7 +59,8 @@ im_point_2x8_2x8(Imaging imOut, Imaging imIn, im_point_context *context) {
 }
 
 static void
-im_point_3x8_3x8(Imaging imOut, Imaging imIn, im_point_context *context) {
+im_point_3x8_3x8(Imaging imOut, Imaging imIn, im_point_context *context)
+{
     int x, y;
     /* 3x8-bit source, 3x8-bit destination */
     UINT8 *table = (UINT8 *)context->table;
@@ -75,7 +78,8 @@ im_point_3x8_3x8(Imaging imOut, Imaging imIn, im_point_context *context) {
 }
 
 static void
-im_point_4x8_4x8(Imaging imOut, Imaging imIn, im_point_context *context) {
+im_point_4x8_4x8(Imaging imOut, Imaging imIn, im_point_context *context)
+{
     int x, y;
     /* 4x8-bit source, 4x8-bit destination */
     UINT8 *table = (UINT8 *)context->table;
@@ -94,7 +98,8 @@ im_point_4x8_4x8(Imaging imOut, Imaging imIn, im_point_context *context) {
 }
 
 static void
-im_point_8_32(Imaging imOut, Imaging imIn, im_point_context *context) {
+im_point_8_32(Imaging imOut, Imaging imIn, im_point_context *context)
+{
     int x, y;
     /* 8-bit source, 32-bit destination */
     char *table = (char *)context->table;
@@ -108,7 +113,8 @@ im_point_8_32(Imaging imOut, Imaging imIn, im_point_context *context) {
 }
 
 static void
-im_point_32_8(Imaging imOut, Imaging imIn, im_point_context *context) {
+im_point_32_8(Imaging imOut, Imaging imIn, im_point_context *context)
+{
     int x, y;
     /* 32-bit source, 8-bit destination */
     UINT8 *table = (UINT8 *)context->table;
@@ -128,7 +134,8 @@ im_point_32_8(Imaging imOut, Imaging imIn, im_point_context *context) {
 }
 
 Imaging
-ImagingPoint(Imaging imIn, const char *mode, const void *table) {
+ImagingPoint(Imaging imIn, const char *mode, const void *table)
+{
     /* lookup table transform */
 
     ImagingSectionCookie cookie;
@@ -202,7 +209,8 @@ mode_mismatch:
 }
 
 Imaging
-ImagingPointTransform(Imaging imIn, double scale, double offset) {
+ImagingPointTransform(Imaging imIn, double scale, double offset)
+{
     /* scale/offset transform */
 
     ImagingSectionCookie cookie;

--- a/src/libImaging/Quant.c
+++ b/src/libImaging/Quant.c
@@ -78,12 +78,14 @@ typedef struct _BoxNode {
         ((q)->c.b = (p)->c.b >> (s))
 
 static uint32_t
-unshifted_pixel_hash(const HashTable *h, const Pixel pixel) {
+unshifted_pixel_hash(const HashTable *h, const Pixel pixel)
+{
     return PIXEL_HASH(pixel.c.r, pixel.c.g, pixel.c.b);
 }
 
 static int
-unshifted_pixel_cmp(const HashTable *h, const Pixel pixel1, const Pixel pixel2) {
+unshifted_pixel_cmp(const HashTable *h, const Pixel pixel1, const Pixel pixel2)
+{
     if (pixel1.c.r == pixel2.c.r) {
         if (pixel1.c.g == pixel2.c.g) {
             if (pixel1.c.b == pixel2.c.b) {
@@ -100,14 +102,16 @@ unshifted_pixel_cmp(const HashTable *h, const Pixel pixel1, const Pixel pixel2) 
 }
 
 static uint32_t
-pixel_hash(const HashTable *h, const Pixel pixel) {
+pixel_hash(const HashTable *h, const Pixel pixel)
+{
     PixelHashData *d = (PixelHashData *)hashtable_get_user_data(h);
     return PIXEL_HASH(
         pixel.c.r >> d->scale, pixel.c.g >> d->scale, pixel.c.b >> d->scale);
 }
 
 static int
-pixel_cmp(const HashTable *h, const Pixel pixel1, const Pixel pixel2) {
+pixel_cmp(const HashTable *h, const Pixel pixel1, const Pixel pixel2)
+{
     PixelHashData *d = (PixelHashData *)hashtable_get_user_data(h);
     uint32_t A, B;
     A = PIXEL_HASH(
@@ -118,25 +122,29 @@ pixel_cmp(const HashTable *h, const Pixel pixel1, const Pixel pixel2) {
 }
 
 static void
-exists_count_func(const HashTable *h, const Pixel key, uint32_t *val) {
+exists_count_func(const HashTable *h, const Pixel key, uint32_t *val)
+{
     *val += 1;
 }
 
 static void
-new_count_func(const HashTable *h, const Pixel key, uint32_t *val) {
+new_count_func(const HashTable *h, const Pixel key, uint32_t *val)
+{
     *val = 1;
 }
 
 static void
 rehash_collide(
-    const HashTable *h, Pixel *keyp, uint32_t *valp, Pixel newkey, uint32_t newval) {
+    const HashTable *h, Pixel *keyp, uint32_t *valp, Pixel newkey, uint32_t newval)
+{
     *valp += newval;
 }
 
 /* %% */
 
 static HashTable *
-create_pixel_hash(Pixel *pixelData, uint32_t nPixels) {
+create_pixel_hash(Pixel *pixelData, uint32_t nPixels)
+{
     PixelHashData *d;
     HashTable *hash;
     uint32_t i;
@@ -184,7 +192,8 @@ create_pixel_hash(Pixel *pixelData, uint32_t nPixels) {
 }
 
 static void
-destroy_pixel_hash(HashTable *hash) {
+destroy_pixel_hash(HashTable *hash)
+{
     PixelHashData *d = (PixelHashData *)hashtable_get_user_data(hash);
     if (d) {
         free(d);
@@ -201,7 +210,8 @@ destroy_pixel_hash(HashTable *hash) {
 /* 7. map each pixel to nearest average.                                      */
 
 static int
-compute_box_volume(BoxNode *b) {
+compute_box_volume(BoxNode *b)
+{
     unsigned char rl, rh, gl, gh, bl, bh;
     if (b->volume >= 0) {
         return b->volume;
@@ -221,7 +231,8 @@ compute_box_volume(BoxNode *b) {
 }
 
 static void
-hash_to_list(const HashTable *h, const Pixel pixel, const uint32_t count, void *u) {
+hash_to_list(const HashTable *h, const Pixel pixel, const uint32_t count, void *u)
+{
     PixelHashData *d = (PixelHashData *)hashtable_get_user_data(h);
     PixelList **pl = (PixelList **)u;
     PixelList *p;
@@ -250,7 +261,8 @@ hash_to_list(const HashTable *h, const Pixel pixel, const uint32_t count, void *
 }
 
 static PixelList *
-mergesort_pixels(PixelList *head, int i) {
+mergesort_pixels(PixelList *head, int i)
+{
     PixelList *c, *t, *a, *b, *p;
     if (!head || !head->next[i]) {
         if (head) {
@@ -301,7 +313,8 @@ mergesort_pixels(PixelList *head, int i) {
 
 #if defined(TEST_MERGESORT) || defined(TEST_SORTED)
 static int
-test_sorted(PixelList *pl[3]) {
+test_sorted(PixelList *pl[3])
+{
     int i, n, l;
     PixelList *t;
 
@@ -319,7 +332,8 @@ test_sorted(PixelList *pl[3]) {
 #endif
 
 static int
-box_heap_cmp(const Heap *h, const void *A, const void *B) {
+box_heap_cmp(const Heap *h, const void *A, const void *B)
+{
     BoxNode *a = (BoxNode *)A;
     BoxNode *b = (BoxNode *)B;
     return (int)a->pixelCount - (int)b->pixelCount;
@@ -335,7 +349,8 @@ splitlists(
     PixelList *nt[2][3],
     uint32_t nCount[2],
     int axis,
-    uint32_t pixelCount) {
+    uint32_t pixelCount)
+{
     uint32_t left;
 
     PixelList *l, *r, *c, *n;
@@ -488,7 +503,8 @@ splitlists(
 }
 
 static int
-split(BoxNode *node) {
+split(BoxNode *node)
+{
     unsigned char rl, rh, gl, gh, bl, bh;
     int f[3];
     int best, axis;
@@ -644,7 +660,8 @@ split(BoxNode *node) {
 }
 
 static BoxNode *
-median_cut(PixelList *hl[3], uint32_t imPixelCount, int nPixels) {
+median_cut(PixelList *hl[3], uint32_t imPixelCount, int nPixels)
+{
     PixelList *tl[3];
     int i;
     BoxNode *root;
@@ -690,7 +707,8 @@ done:
 }
 
 static void
-free_box_tree(BoxNode *n) {
+free_box_tree(BoxNode *n)
+{
     PixelList *p, *pp;
     if (n->l) {
         free_box_tree(n->l);
@@ -707,7 +725,8 @@ free_box_tree(BoxNode *n) {
 
 #ifdef TEST_SPLIT_INTEGRITY
 static int
-checkContained(BoxNode *n, Pixel *pp) {
+checkContained(BoxNode *n, Pixel *pp)
+{
     if (n->l && n->r) {
         return checkContained(n->l, pp) + checkContained(n->r, pp);
     }
@@ -727,7 +746,8 @@ checkContained(BoxNode *n, Pixel *pp) {
 #endif
 
 static int
-annotate_hash_table(BoxNode *n, HashTable *h, uint32_t *box) {
+annotate_hash_table(BoxNode *n, HashTable *h, uint32_t *box)
+{
     PixelList *p;
     PixelHashData *d = (PixelHashData *)hashtable_get_user_data(h);
     Pixel q;
@@ -761,7 +781,8 @@ typedef struct {
 } DistanceWithIndex;
 
 static int
-_distance_index_cmp(const void *a, const void *b) {
+_distance_index_cmp(const void *a, const void *b)
+{
     DistanceWithIndex *A = (DistanceWithIndex *)a;
     DistanceWithIndex *B = (DistanceWithIndex *)b;
     if (*A->distance == *B->distance) {
@@ -772,7 +793,8 @@ _distance_index_cmp(const void *a, const void *b) {
 
 static int
 resort_distance_tables(
-    uint32_t *avgDist, uint32_t **avgDistSortKey, Pixel *p, uint32_t nEntries) {
+    uint32_t *avgDist, uint32_t **avgDistSortKey, Pixel *p, uint32_t nEntries)
+{
     uint32_t i, j, k;
     uint32_t **skRow;
     uint32_t *skElt;
@@ -801,7 +823,8 @@ resort_distance_tables(
 
 static int
 build_distance_tables(
-    uint32_t *avgDist, uint32_t **avgDistSortKey, Pixel *p, uint32_t nEntries) {
+    uint32_t *avgDist, uint32_t **avgDistSortKey, Pixel *p, uint32_t nEntries)
+{
     uint32_t i, j;
     DistanceWithIndex *dwi;
 
@@ -841,7 +864,8 @@ map_image_pixels(
     uint32_t nPaletteEntries,
     uint32_t *avgDist,
     uint32_t **avgDistSortKey,
-    uint32_t *pixelArray) {
+    uint32_t *pixelArray)
+{
     uint32_t *aD, **aDSK;
     uint32_t idx;
     uint32_t i, j;
@@ -888,7 +912,8 @@ map_image_pixels_from_quantized_pixels(
     uint32_t **avgDistSortKey,
     uint32_t *pixelArray,
     uint32_t *avg[3],
-    uint32_t *count) {
+    uint32_t *count)
+{
     uint32_t *aD, **aDSK;
     uint32_t idx;
     uint32_t i, j;
@@ -946,7 +971,8 @@ map_image_pixels_from_median_box(
     HashTable *medianBoxHash,
     uint32_t *avgDist,
     uint32_t **avgDistSortKey,
-    uint32_t *pixelArray) {
+    uint32_t *pixelArray)
+{
     uint32_t *aD, **aDSK;
     uint32_t idx;
     uint32_t i, j;
@@ -998,7 +1024,8 @@ compute_palette_from_median_cut(
     uint32_t nPixels,
     HashTable *medianBoxHash,
     Pixel **palette,
-    uint32_t nPaletteEntries) {
+    uint32_t nPaletteEntries)
+{
     uint32_t i;
     uint32_t paletteEntry;
     Pixel *p;
@@ -1092,7 +1119,8 @@ compute_palette_from_median_cut(
 
 static int
 recompute_palette_from_averages(
-    Pixel *palette, uint32_t nPaletteEntries, uint32_t *avg[3], uint32_t *count) {
+    Pixel *palette, uint32_t nPaletteEntries, uint32_t *avg[3], uint32_t *count)
+{
     uint32_t i;
 
     for (i = 0; i < nPaletteEntries; i++) {
@@ -1111,7 +1139,8 @@ compute_palette_from_quantized_pixels(
     uint32_t nPaletteEntries,
     uint32_t *avg[3],
     uint32_t *count,
-    uint32_t *qp) {
+    uint32_t *qp)
+{
     uint32_t i;
 
     memset(count, 0, sizeof(uint32_t) * nPaletteEntries);
@@ -1145,7 +1174,8 @@ k_means(
     Pixel *paletteData,
     uint32_t nPaletteEntries,
     uint32_t *qp,
-    int threshold) {
+    int threshold)
+{
     uint32_t *avg[3];
     uint32_t *count;
     uint32_t i;
@@ -1273,7 +1303,8 @@ quantize(
     Pixel **palette,
     uint32_t *paletteLength,
     uint32_t **quantizedPixels,
-    int kmeans) {
+    int kmeans)
+{
     PixelList *hl[3];
     HashTable *h;
     BoxNode *root;
@@ -1522,7 +1553,8 @@ typedef struct {
 } DistanceData;
 
 static void
-compute_distances(const HashTable *h, const Pixel pixel, uint32_t *dist, void *u) {
+compute_distances(const HashTable *h, const Pixel pixel, uint32_t *dist, void *u)
+{
     DistanceData *data = (DistanceData *)u;
     uint32_t oldDist = *dist;
     uint32_t newDist;
@@ -1545,7 +1577,8 @@ quantize2(
     Pixel **palette,
     uint32_t *paletteLength,
     uint32_t **quantizedPixels,
-    int kmeans) {
+    int kmeans)
+{
     HashTable *h;
     uint32_t i;
     uint32_t mean[3];
@@ -1635,7 +1668,8 @@ error_1:
 }
 
 Imaging
-ImagingQuantize(Imaging im, int colors, int mode, int kmeans) {
+ImagingQuantize(Imaging im, int colors, int mode, int kmeans)
+{
     int i, j;
     int x, y, v;
     UINT8 *pp;

--- a/src/libImaging/QuantHash.c
+++ b/src/libImaging/QuantHash.c
@@ -45,7 +45,8 @@ static int
 _hashtable_insert_node(HashTable *, HashNode *, int, int, CollisionFunc);
 
 HashTable *
-hashtable_new(HashFunc hf, HashCmpFunc cf) {
+hashtable_new(HashFunc hf, HashCmpFunc cf)
+{
     HashTable *h;
     h = malloc(sizeof(HashTable));
     if (!h) {
@@ -66,7 +67,8 @@ hashtable_new(HashFunc hf, HashCmpFunc cf) {
 }
 
 static uint32_t
-_findPrime(uint32_t start, int dir) {
+_findPrime(uint32_t start, int dir)
+{
     static int unit[] = {0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0};
     uint32_t t;
     while (start > 1) {
@@ -88,7 +90,8 @@ _findPrime(uint32_t start, int dir) {
 }
 
 static void
-_hashtable_rehash(HashTable *h, CollisionFunc cf, uint32_t newSize) {
+_hashtable_rehash(HashTable *h, CollisionFunc cf, uint32_t newSize)
+{
     HashNode **oldTable = h->table;
     uint32_t i;
     HashNode *n, *nn;
@@ -112,7 +115,8 @@ _hashtable_rehash(HashTable *h, CollisionFunc cf, uint32_t newSize) {
 }
 
 static void
-_hashtable_resize(HashTable *h) {
+_hashtable_resize(HashTable *h)
+{
     uint32_t newSize;
     uint32_t oldSize;
     oldSize = h->length;
@@ -132,7 +136,8 @@ _hashtable_resize(HashTable *h) {
 
 static int
 _hashtable_insert_node(
-    HashTable *h, HashNode *node, int resize, int update, CollisionFunc cf) {
+    HashTable *h, HashNode *node, int resize, int update, CollisionFunc cf)
+{
     uint32_t hash = h->hashFunc(h, node->key) % h->length;
     HashNode **n, *nv;
     int i;
@@ -170,7 +175,8 @@ _hashtable_insert_node(
 }
 
 static int
-_hashtable_insert(HashTable *h, HashKey_t key, HashVal_t val, int resize, int update) {
+_hashtable_insert(HashTable *h, HashKey_t key, HashVal_t val, int resize, int update)
+{
     HashNode **n, *nv;
     HashNode *t;
     int i;
@@ -207,7 +213,8 @@ _hashtable_insert(HashTable *h, HashKey_t key, HashVal_t val, int resize, int up
 
 int
 hashtable_insert_or_update_computed(
-    HashTable *h, HashKey_t key, ComputeFunc newFunc, ComputeFunc existsFunc) {
+    HashTable *h, HashKey_t key, ComputeFunc newFunc, ComputeFunc existsFunc)
+{
     HashNode **n, *nv;
     HashNode *t;
     int i;
@@ -246,12 +253,14 @@ hashtable_insert_or_update_computed(
 }
 
 int
-hashtable_insert(HashTable *h, HashKey_t key, HashVal_t val) {
+hashtable_insert(HashTable *h, HashKey_t key, HashVal_t val)
+{
     return _hashtable_insert(h, key, val, 1, 0);
 }
 
 void
-hashtable_foreach_update(HashTable *h, IteratorUpdateFunc i, void *u) {
+hashtable_foreach_update(HashTable *h, IteratorUpdateFunc i, void *u)
+{
     HashNode *n;
     uint32_t x;
 
@@ -265,7 +274,8 @@ hashtable_foreach_update(HashTable *h, IteratorUpdateFunc i, void *u) {
 }
 
 void
-hashtable_foreach(HashTable *h, IteratorFunc i, void *u) {
+hashtable_foreach(HashTable *h, IteratorFunc i, void *u)
+{
     HashNode *n;
     uint32_t x;
 
@@ -279,7 +289,8 @@ hashtable_foreach(HashTable *h, IteratorFunc i, void *u) {
 }
 
 void
-hashtable_free(HashTable *h) {
+hashtable_free(HashTable *h)
+{
     HashNode *n, *nn;
     uint32_t i;
 
@@ -296,12 +307,14 @@ hashtable_free(HashTable *h) {
 }
 
 void
-hashtable_rehash_compute(HashTable *h, CollisionFunc cf) {
+hashtable_rehash_compute(HashTable *h, CollisionFunc cf)
+{
     _hashtable_rehash(h, cf, h->length);
 }
 
 int
-hashtable_lookup(const HashTable *h, const HashKey_t key, HashVal_t *valp) {
+hashtable_lookup(const HashTable *h, const HashKey_t key, HashVal_t *valp)
+{
     uint32_t hash = h->hashFunc(h, key) % h->length;
     HashNode *n;
     int i;
@@ -319,17 +332,20 @@ hashtable_lookup(const HashTable *h, const HashKey_t key, HashVal_t *valp) {
 }
 
 uint32_t
-hashtable_get_count(const HashTable *h) {
+hashtable_get_count(const HashTable *h)
+{
     return h->count;
 }
 
 void *
-hashtable_get_user_data(const HashTable *h) {
+hashtable_get_user_data(const HashTable *h)
+{
     return h->userData;
 }
 
 void *
-hashtable_set_user_data(HashTable *h, void *data) {
+hashtable_set_user_data(HashTable *h, void *data)
+{
     void *r = h->userData;
     h->userData = data;
     return r;

--- a/src/libImaging/QuantHeap.c
+++ b/src/libImaging/QuantHeap.c
@@ -41,13 +41,15 @@ _heap_test(Heap *);
 #endif
 
 void
-ImagingQuantHeapFree(Heap *h) {
+ImagingQuantHeapFree(Heap *h)
+{
     free(h->heap);
     free(h);
 }
 
 static int
-_heap_grow(Heap *h, unsigned int newsize) {
+_heap_grow(Heap *h, unsigned int newsize)
+{
     void *newheap;
     if (!newsize) {
         newsize = h->heapsize << 1;
@@ -73,7 +75,8 @@ _heap_grow(Heap *h, unsigned int newsize) {
 
 #ifdef DEBUG
 static int
-_heap_test(Heap *h) {
+_heap_test(Heap *h)
+{
     unsigned int k;
     for (k = 1; k * 2 <= h->heapcount; k++) {
         if (h->cf(h, h->heap[k], h->heap[k * 2]) < 0) {
@@ -90,7 +93,8 @@ _heap_test(Heap *h) {
 #endif
 
 int
-ImagingQuantHeapRemove(Heap *h, void **r) {
+ImagingQuantHeapRemove(Heap *h, void **r)
+{
     unsigned int k, l;
     void *v;
 
@@ -122,7 +126,8 @@ ImagingQuantHeapRemove(Heap *h, void **r) {
 }
 
 int
-ImagingQuantHeapAdd(Heap *h, void *val) {
+ImagingQuantHeapAdd(Heap *h, void *val)
+{
     int k;
     if (h->heapcount == h->heapsize - 1) {
         _heap_grow(h, 0);
@@ -146,7 +151,8 @@ ImagingQuantHeapAdd(Heap *h, void *val) {
 }
 
 int
-ImagingQuantHeapTop(Heap *h, void **r) {
+ImagingQuantHeapTop(Heap *h, void **r)
+{
     if (!h->heapcount) {
         return 0;
     }
@@ -155,7 +161,8 @@ ImagingQuantHeapTop(Heap *h, void **r) {
 }
 
 Heap *
-ImagingQuantHeapNew(HeapCmpFunc cf) {
+ImagingQuantHeapNew(HeapCmpFunc cf)
+{
     Heap *h;
 
     /* malloc check ok, small constant allocation */

--- a/src/libImaging/QuantOctree.c
+++ b/src/libImaging/QuantOctree.c
@@ -52,7 +52,8 @@ typedef struct _ColorCube {
 #define MAX(a, b) (a) > (b) ? (a) : (b)
 
 static ColorCube
-new_color_cube(int r, int g, int b, int a) {
+new_color_cube(int r, int g, int b, int a)
+{
     ColorCube cube;
 
     /* malloc check ok, small constant allocation */
@@ -98,7 +99,8 @@ new_color_cube(int r, int g, int b, int a) {
 }
 
 static void
-free_color_cube(ColorCube cube) {
+free_color_cube(ColorCube cube)
+{
     if (cube != NULL) {
         free(cube->buckets);
         free(cube);
@@ -111,13 +113,15 @@ color_bucket_offset_pos(
     unsigned int r,
     unsigned int g,
     unsigned int b,
-    unsigned int a) {
+    unsigned int a)
+{
     return r << cube->rOffset | g << cube->gOffset | b << cube->bOffset |
            a << cube->aOffset;
 }
 
 static long
-color_bucket_offset(const ColorCube cube, const Pixel *p) {
+color_bucket_offset(const ColorCube cube, const Pixel *p)
+{
     unsigned int r = p->c.r >> (8 - cube->rBits);
     unsigned int g = p->c.g >> (8 - cube->gBits);
     unsigned int b = p->c.b >> (8 - cube->bBits);
@@ -126,13 +130,15 @@ color_bucket_offset(const ColorCube cube, const Pixel *p) {
 }
 
 static ColorBucket
-color_bucket_from_cube(const ColorCube cube, const Pixel *p) {
+color_bucket_from_cube(const ColorCube cube, const Pixel *p)
+{
     unsigned int offset = color_bucket_offset(cube, p);
     return &cube->buckets[offset];
 }
 
 static void
-add_color_to_color_cube(const ColorCube cube, const Pixel *p) {
+add_color_to_color_cube(const ColorCube cube, const Pixel *p)
+{
     ColorBucket bucket = color_bucket_from_cube(cube, p);
     bucket->count += 1;
     bucket->r += p->c.r;
@@ -142,7 +148,8 @@ add_color_to_color_cube(const ColorCube cube, const Pixel *p) {
 }
 
 static unsigned long
-count_used_color_buckets(const ColorCube cube) {
+count_used_color_buckets(const ColorCube cube)
+{
     unsigned long usedBuckets = 0;
     unsigned long i;
     for (i = 0; i < cube->size; i++) {
@@ -154,7 +161,8 @@ count_used_color_buckets(const ColorCube cube) {
 }
 
 static void
-avg_color_from_color_bucket(const ColorBucket bucket, Pixel *dst) {
+avg_color_from_color_bucket(const ColorBucket bucket, Pixel *dst)
+{
     float count = bucket->count;
     if (count != 0) {
         dst->c.r = CLIP8((int)(bucket->r / count));
@@ -170,12 +178,14 @@ avg_color_from_color_bucket(const ColorBucket bucket, Pixel *dst) {
 }
 
 static int
-compare_bucket_count(const ColorBucket a, const ColorBucket b) {
+compare_bucket_count(const ColorBucket a, const ColorBucket b)
+{
     return b->count - a->count;
 }
 
 static ColorBucket
-create_sorted_color_palette(const ColorCube cube) {
+create_sorted_color_palette(const ColorCube cube)
+{
     ColorBucket buckets;
     if (cube->size > LONG_MAX / sizeof(struct _ColorBucket)) {
         return NULL;
@@ -197,7 +207,8 @@ create_sorted_color_palette(const ColorCube cube) {
 }
 
 void
-add_bucket_values(ColorBucket src, ColorBucket dst) {
+add_bucket_values(ColorBucket src, ColorBucket dst)
+{
     dst->count += src->count;
     dst->r += src->r;
     dst->g += src->g;
@@ -212,7 +223,8 @@ copy_color_cube(
     unsigned int rBits,
     unsigned int gBits,
     unsigned int bBits,
-    unsigned int aBits) {
+    unsigned int aBits)
+{
     unsigned int r, g, b, a;
     long src_pos, dst_pos;
     unsigned int src_reduce[4] = {0}, dst_reduce[4] = {0};
@@ -279,7 +291,8 @@ copy_color_cube(
 }
 
 void
-subtract_color_buckets(ColorCube cube, ColorBucket buckets, long nBuckets) {
+subtract_color_buckets(ColorCube cube, ColorBucket buckets, long nBuckets)
+{
     ColorBucket minuend, subtrahend;
     long i;
     Pixel p;
@@ -302,19 +315,22 @@ subtract_color_buckets(ColorCube cube, ColorBucket buckets, long nBuckets) {
 }
 
 static void
-set_lookup_value(const ColorCube cube, const Pixel *p, long value) {
+set_lookup_value(const ColorCube cube, const Pixel *p, long value)
+{
     ColorBucket bucket = color_bucket_from_cube(cube, p);
     bucket->count = value;
 }
 
 uint64_t
-lookup_color(const ColorCube cube, const Pixel *p) {
+lookup_color(const ColorCube cube, const Pixel *p)
+{
     ColorBucket bucket = color_bucket_from_cube(cube, p);
     return bucket->count;
 }
 
 void
-add_lookup_buckets(ColorCube cube, ColorBucket palette, long nColors, long offset) {
+add_lookup_buckets(ColorCube cube, ColorBucket palette, long nColors, long offset)
+{
     long i;
     Pixel p;
     for (i = offset + nColors - 1; i >= offset; i--) {
@@ -328,7 +344,8 @@ combined_palette(
     ColorBucket bucketsA,
     unsigned long nBucketsA,
     ColorBucket bucketsB,
-    unsigned long nBucketsB) {
+    unsigned long nBucketsB)
+{
     ColorBucket result;
     if (nBucketsA > LONG_MAX - nBucketsB ||
         (nBucketsA + nBucketsB) > LONG_MAX / sizeof(struct _ColorBucket)) {
@@ -345,7 +362,8 @@ combined_palette(
 }
 
 static Pixel *
-create_palette_array(const ColorBucket palette, unsigned int paletteLength) {
+create_palette_array(const ColorBucket palette, unsigned int paletteLength)
+{
     Pixel *paletteArray;
     unsigned int i;
 
@@ -366,7 +384,8 @@ map_image_pixels(
     const Pixel *pixelData,
     uint32_t nPixels,
     const ColorCube lookupCube,
-    uint32_t *pixelArray) {
+    uint32_t *pixelArray)
+{
     long i;
     for (i = 0; i < nPixels; i++) {
         pixelArray[i] = lookup_color(lookupCube, &pixelData[i]);
@@ -384,7 +403,8 @@ quantize_octree(
     Pixel **palette,
     uint32_t *paletteLength,
     uint32_t **quantizedPixels,
-    int withAlpha) {
+    int withAlpha)
+{
     ColorCube fineCube = NULL;
     ColorCube coarseCube = NULL;
     ColorCube lookupCube = NULL;

--- a/src/libImaging/QuantPngQuant.c
+++ b/src/libImaging/QuantPngQuant.c
@@ -26,7 +26,8 @@ quantize_pngquant(
     Pixel **palette,
     uint32_t *paletteLength,
     uint32_t **quantizedPixels,
-    int withAlpha) {
+    int withAlpha)
+{
     int result = 0;
     liq_image *image = NULL;
     liq_attr *attr = NULL;
@@ -122,7 +123,8 @@ err:
 }
 
 const char *
-ImagingImageQuantVersion(void) {
+ImagingImageQuantVersion(void)
+{
     static char version[20];
     int number = liq_version();
     sprintf(version, "%d.%d.%d", number / 10000, (number / 100) % 100, number % 100);

--- a/src/libImaging/RankFilter.c
+++ b/src/libImaging/RankFilter.c
@@ -24,42 +24,44 @@
         (b) = t;               \
     }
 
-#define MakeRankFunction(type)                       \
-    static type Rank##type(type a[], int n, int k) { \
-        register int i, j, l, m;                     \
-        register type x;                             \
-        l = 0;                                       \
-        m = n - 1;                                   \
-        while (l < m) {                              \
-            x = a[k];                                \
-            i = l;                                   \
-            j = m;                                   \
-            do {                                     \
-                while (a[i] < x) {                   \
-                    i++;                             \
-                }                                    \
-                while (x < a[j]) {                   \
-                    j--;                             \
-                }                                    \
-                if (i <= j) {                        \
-                    SWAP(type, a[i], a[j]);          \
-                    i++;                             \
-                    j--;                             \
-                }                                    \
-            } while (i <= j);                        \
-            if (j < k) {                             \
-                l = i;                               \
-            }                                        \
-            if (k < i) {                             \
-                m = j;                               \
-            }                                        \
-        }                                            \
-        return a[k];                                 \
+#define MakeRankFunction(type)                     \
+    static type Rank##type(type a[], int n, int k) \
+    {                                              \
+        register int i, j, l, m;                   \
+        register type x;                           \
+        l = 0;                                     \
+        m = n - 1;                                 \
+        while (l < m) {                            \
+            x = a[k];                              \
+            i = l;                                 \
+            j = m;                                 \
+            do {                                   \
+                while (a[i] < x) {                 \
+                    i++;                           \
+                }                                  \
+                while (x < a[j]) {                 \
+                    j--;                           \
+                }                                  \
+                if (i <= j) {                      \
+                    SWAP(type, a[i], a[j]);        \
+                    i++;                           \
+                    j--;                           \
+                }                                  \
+            } while (i <= j);                      \
+            if (j < k) {                           \
+                l = i;                             \
+            }                                      \
+            if (k < i) {                           \
+                m = j;                             \
+            }                                      \
+        }                                          \
+        return a[k];                               \
     }
 
 MakeRankFunction(UINT8) MakeRankFunction(INT32) MakeRankFunction(FLOAT32)
 
-    Imaging ImagingRankFilter(Imaging im, int size, int rank) {
+    Imaging ImagingRankFilter(Imaging im, int size, int rank)
+{
     Imaging imOut = NULL;
     int x, y;
     int i, margin, size2;

--- a/src/libImaging/RawDecode.c
+++ b/src/libImaging/RawDecode.c
@@ -18,7 +18,8 @@
 #include "Raw.h"
 
 int
-ImagingRawDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes) {
+ImagingRawDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes)
+{
     enum { LINE = 1, SKIP };
     RAWSTATE *rawstate = state->context;
 

--- a/src/libImaging/RawEncode.c
+++ b/src/libImaging/RawEncode.c
@@ -20,7 +20,8 @@
 #include "Imaging.h"
 
 int
-ImagingRawEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
+ImagingRawEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes)
+{
     UINT8 *ptr;
 
     if (!state->state) {

--- a/src/libImaging/Reduce.c
+++ b/src/libImaging/Reduce.c
@@ -5,14 +5,16 @@
 #define ROUND_UP(f) ((int)((f) >= 0.0 ? (f) + 0.5F : (f) - 0.5F))
 
 UINT32
-division_UINT32(int divider, int result_bits) {
+division_UINT32(int divider, int result_bits)
+{
     UINT32 max_dividend = (1 << result_bits) * divider;
     float max_int = (1 << 30) * 4.0;
     return (UINT32)(max_int / max_dividend);
 }
 
 void
-ImagingReduceNxN(Imaging imOut, Imaging imIn, int box[4], int xscale, int yscale) {
+ImagingReduceNxN(Imaging imOut, Imaging imIn, int box[4], int xscale, int yscale)
+{
     /* The most general implementation for any xscale and yscale
      */
     int x, y, xx, yy;
@@ -180,7 +182,8 @@ ImagingReduceNxN(Imaging imOut, Imaging imIn, int box[4], int xscale, int yscale
 }
 
 void
-ImagingReduce1xN(Imaging imOut, Imaging imIn, int box[4], int yscale) {
+ImagingReduce1xN(Imaging imOut, Imaging imIn, int box[4], int yscale)
+{
     /* Optimized implementation for xscale = 1.
      */
     int x, y, yy;
@@ -287,7 +290,8 @@ ImagingReduce1xN(Imaging imOut, Imaging imIn, int box[4], int yscale) {
 }
 
 void
-ImagingReduceNx1(Imaging imOut, Imaging imIn, int box[4], int xscale) {
+ImagingReduceNx1(Imaging imOut, Imaging imIn, int box[4], int xscale)
+{
     /* Optimized implementation for yscale = 1.
      */
     int x, y, xx;
@@ -384,7 +388,8 @@ ImagingReduceNx1(Imaging imOut, Imaging imIn, int box[4], int xscale) {
 }
 
 void
-ImagingReduce1x2(Imaging imOut, Imaging imIn, int box[4]) {
+ImagingReduce1x2(Imaging imOut, Imaging imIn, int box[4])
+{
     /* Optimized implementation for xscale = 1 and yscale = 2.
      */
     int xscale = 1, yscale = 2;
@@ -449,7 +454,8 @@ ImagingReduce1x2(Imaging imOut, Imaging imIn, int box[4]) {
 }
 
 void
-ImagingReduce2x1(Imaging imOut, Imaging imIn, int box[4]) {
+ImagingReduce2x1(Imaging imOut, Imaging imIn, int box[4])
+{
     /* Optimized implementation for xscale = 2 and yscale = 1.
      */
     int xscale = 2, yscale = 1;
@@ -512,7 +518,8 @@ ImagingReduce2x1(Imaging imOut, Imaging imIn, int box[4]) {
 }
 
 void
-ImagingReduce2x2(Imaging imOut, Imaging imIn, int box[4]) {
+ImagingReduce2x2(Imaging imOut, Imaging imIn, int box[4])
+{
     /* Optimized implementation for xscale = 2 and yscale = 2.
      */
     int xscale = 2, yscale = 2;
@@ -586,7 +593,8 @@ ImagingReduce2x2(Imaging imOut, Imaging imIn, int box[4]) {
 }
 
 void
-ImagingReduce1x3(Imaging imOut, Imaging imIn, int box[4]) {
+ImagingReduce1x3(Imaging imOut, Imaging imIn, int box[4])
+{
     /* Optimized implementation for xscale = 1 and yscale = 3.
      */
     int xscale = 1, yscale = 3;
@@ -661,7 +669,8 @@ ImagingReduce1x3(Imaging imOut, Imaging imIn, int box[4]) {
 }
 
 void
-ImagingReduce3x1(Imaging imOut, Imaging imIn, int box[4]) {
+ImagingReduce3x1(Imaging imOut, Imaging imIn, int box[4])
+{
     /* Optimized implementation for xscale = 3 and yscale = 1.
      */
     int xscale = 3, yscale = 1;
@@ -732,7 +741,8 @@ ImagingReduce3x1(Imaging imOut, Imaging imIn, int box[4]) {
 }
 
 void
-ImagingReduce3x3(Imaging imOut, Imaging imIn, int box[4]) {
+ImagingReduce3x3(Imaging imOut, Imaging imIn, int box[4])
+{
     /* Optimized implementation for xscale = 3 and yscale = 3.
      */
     int xscale = 3, yscale = 3;
@@ -827,7 +837,8 @@ ImagingReduce3x3(Imaging imOut, Imaging imIn, int box[4]) {
 }
 
 void
-ImagingReduce4x4(Imaging imOut, Imaging imIn, int box[4]) {
+ImagingReduce4x4(Imaging imOut, Imaging imIn, int box[4])
+{
     /* Optimized implementation for xscale = 4 and yscale = 4.
      */
     int xscale = 4, yscale = 4;
@@ -944,7 +955,8 @@ ImagingReduce4x4(Imaging imOut, Imaging imIn, int box[4]) {
 }
 
 void
-ImagingReduce5x5(Imaging imOut, Imaging imIn, int box[4]) {
+ImagingReduce5x5(Imaging imOut, Imaging imIn, int box[4])
+{
     /* Fast special case for xscale = 5 and yscale = 5.
      */
     int xscale = 5, yscale = 5;
@@ -1101,7 +1113,8 @@ ImagingReduce5x5(Imaging imOut, Imaging imIn, int box[4]) {
 }
 
 void
-ImagingReduceCorners(Imaging imOut, Imaging imIn, int box[4], int xscale, int yscale) {
+ImagingReduceCorners(Imaging imOut, Imaging imIn, int box[4], int xscale, int yscale)
+{
     /* Fill the last row and the last column for any xscale and yscale.
      */
     int x, y, xx, yy;
@@ -1239,8 +1252,8 @@ ImagingReduceCorners(Imaging imOut, Imaging imIn, int box[4], int xscale, int ys
 }
 
 void
-ImagingReduceNxN_32bpc(
-    Imaging imOut, Imaging imIn, int box[4], int xscale, int yscale) {
+ImagingReduceNxN_32bpc(Imaging imOut, Imaging imIn, int box[4], int xscale, int yscale)
+{
     /* The most general implementation for any xscale and yscale
      */
     int x, y, xx, yy;
@@ -1313,7 +1326,8 @@ ImagingReduceNxN_32bpc(
 
 void
 ImagingReduceCorners_32bpc(
-    Imaging imOut, Imaging imIn, int box[4], int xscale, int yscale) {
+    Imaging imOut, Imaging imIn, int box[4], int xscale, int yscale)
+{
     /* Fill the last row and the last column for any xscale and yscale.
      */
     int x, y, xx, yy;
@@ -1414,7 +1428,8 @@ ImagingReduceCorners_32bpc(
 }
 
 Imaging
-ImagingReduce(Imaging imIn, int xscale, int yscale, int box[4]) {
+ImagingReduce(Imaging imIn, int xscale, int yscale, int box[4])
+{
     ImagingSectionCookie cookie;
     Imaging imOut = NULL;
 

--- a/src/libImaging/Resample.c
+++ b/src/libImaging/Resample.c
@@ -10,7 +10,8 @@ struct filter {
 };
 
 static inline double
-box_filter(double x) {
+box_filter(double x)
+{
     if (x > -0.5 && x <= 0.5) {
         return 1.0;
     }
@@ -18,7 +19,8 @@ box_filter(double x) {
 }
 
 static inline double
-bilinear_filter(double x) {
+bilinear_filter(double x)
+{
     if (x < 0.0) {
         x = -x;
     }
@@ -29,7 +31,8 @@ bilinear_filter(double x) {
 }
 
 static inline double
-hamming_filter(double x) {
+hamming_filter(double x)
+{
     if (x < 0.0) {
         x = -x;
     }
@@ -44,7 +47,8 @@ hamming_filter(double x) {
 }
 
 static inline double
-bicubic_filter(double x) {
+bicubic_filter(double x)
+{
     /* https://en.wikipedia.org/wiki/Bicubic_interpolation#Bicubic_convolution_algorithm
      */
 #define a -0.5
@@ -62,7 +66,8 @@ bicubic_filter(double x) {
 }
 
 static inline double
-sinc_filter(double x) {
+sinc_filter(double x)
+{
     if (x == 0.0) {
         return 1.0;
     }
@@ -71,7 +76,8 @@ sinc_filter(double x) {
 }
 
 static inline double
-lanczos_filter(double x) {
+lanczos_filter(double x)
+{
     /* truncated sinc */
     if (-3.0 <= x && x < 3.0) {
         return sinc_filter(x) * sinc_filter(x / 3);
@@ -174,7 +180,8 @@ UINT8 _clip8_lookups[1280] = {
 UINT8 *clip8_lookups = &_clip8_lookups[640];
 
 static inline UINT8
-clip8(int in) {
+clip8(int in)
+{
     return clip8_lookups[in >> PRECISION_BITS];
 }
 
@@ -186,7 +193,8 @@ precompute_coeffs(
     int outSize,
     struct filter *filterp,
     int **boundsp,
-    double **kkp) {
+    double **kkp)
+{
     double support, scale, filterscale;
     double center, ww, ss;
     int xx, x, ksize, xmin, xmax;
@@ -266,7 +274,8 @@ precompute_coeffs(
 }
 
 void
-normalize_coeffs_8bpc(int outSize, int ksize, double *prekk) {
+normalize_coeffs_8bpc(int outSize, int ksize, double *prekk)
+{
     int x;
     INT32 *kk;
 
@@ -284,7 +293,8 @@ normalize_coeffs_8bpc(int outSize, int ksize, double *prekk) {
 
 void
 ImagingResampleHorizontal_8bpc(
-    Imaging imOut, Imaging imIn, int offset, int ksize, int *bounds, double *prekk) {
+    Imaging imOut, Imaging imIn, int offset, int ksize, int *bounds, double *prekk)
+{
     ImagingSectionCookie cookie;
     int ss0, ss1, ss2, ss3;
     int xx, yy, x, xmin, xmax;
@@ -376,7 +386,8 @@ ImagingResampleHorizontal_8bpc(
 
 void
 ImagingResampleVertical_8bpc(
-    Imaging imOut, Imaging imIn, int offset, int ksize, int *bounds, double *prekk) {
+    Imaging imOut, Imaging imIn, int offset, int ksize, int *bounds, double *prekk)
+{
     ImagingSectionCookie cookie;
     int ss0, ss1, ss2, ss3;
     int xx, yy, y, ymin, ymax;
@@ -459,7 +470,8 @@ ImagingResampleVertical_8bpc(
 
 void
 ImagingResampleHorizontal_32bpc(
-    Imaging imOut, Imaging imIn, int offset, int ksize, int *bounds, double *kk) {
+    Imaging imOut, Imaging imIn, int offset, int ksize, int *bounds, double *kk)
+{
     ImagingSectionCookie cookie;
     double ss;
     int xx, yy, x, xmin, xmax;
@@ -502,7 +514,8 @@ ImagingResampleHorizontal_32bpc(
 
 void
 ImagingResampleVertical_32bpc(
-    Imaging imOut, Imaging imIn, int offset, int ksize, int *bounds, double *kk) {
+    Imaging imOut, Imaging imIn, int offset, int ksize, int *bounds, double *kk)
+{
     ImagingSectionCookie cookie;
     double ss;
     int xx, yy, y, ymin, ymax;
@@ -557,7 +570,8 @@ ImagingResampleInner(
     ResampleFunction ResampleVertical);
 
 Imaging
-ImagingResample(Imaging imIn, int xsize, int ysize, int filter, float box[4]) {
+ImagingResample(Imaging imIn, int xsize, int ysize, int filter, float box[4])
+{
     struct filter *filterp;
     ResampleFunction ResampleHorizontal;
     ResampleFunction ResampleVertical;
@@ -620,7 +634,8 @@ ImagingResampleInner(
     struct filter *filterp,
     float box[4],
     ResampleFunction ResampleHorizontal,
-    ResampleFunction ResampleVertical) {
+    ResampleFunction ResampleVertical)
+{
     Imaging imTemp = NULL;
     Imaging imOut = NULL;
 

--- a/src/libImaging/SgiRleDecode.c
+++ b/src/libImaging/SgiRleDecode.c
@@ -21,7 +21,8 @@
 #define RLE_MAX_RUN 0x7f
 
 static void
-read4B(UINT32 *dest, UINT8 *buf) {
+read4B(UINT32 *dest, UINT8 *buf)
+{
     *dest = (UINT32)((buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3]);
 }
 
@@ -61,7 +62,8 @@ read4B(UINT32 *dest, UINT8 *buf) {
 
  */
 static int
-expandrow(UINT8 *dest, UINT8 *src, int n, int z, int xsize, UINT8 *end_of_buffer) {
+expandrow(UINT8 *dest, UINT8 *src, int n, int z, int xsize, UINT8 *end_of_buffer)
+{
     /*
      * n here is the number of rlechunks
      * z is the number of channels, for calculating the interleave
@@ -113,8 +115,8 @@ expandrow(UINT8 *dest, UINT8 *src, int n, int z, int xsize, UINT8 *end_of_buffer
 }
 
 static int
-expandrow2(
-    UINT8 *dest, const UINT8 *src, int n, int z, int xsize, UINT8 *end_of_buffer) {
+expandrow2(UINT8 *dest, const UINT8 *src, int n, int z, int xsize, UINT8 *end_of_buffer)
+{
     UINT8 pixel, count;
     int x = 0;
 
@@ -159,7 +161,8 @@ expandrow2(
 }
 
 int
-ImagingSgiRleDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes) {
+ImagingSgiRleDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes)
+{
     UINT8 *ptr;
     SGISTATE *c;
     int err = 0;

--- a/src/libImaging/Storage.c
+++ b/src/libImaging/Storage.c
@@ -42,7 +42,8 @@
  */
 
 Imaging
-ImagingNewPrologueSubtype(const char *mode, int xsize, int ysize, int size) {
+ImagingNewPrologueSubtype(const char *mode, int xsize, int ysize, int size)
+{
     Imaging im;
 
     /* linesize overflow check, roughly the current largest space req'd */
@@ -225,13 +226,15 @@ ImagingNewPrologueSubtype(const char *mode, int xsize, int ysize, int size) {
 }
 
 Imaging
-ImagingNewPrologue(const char *mode, int xsize, int ysize) {
+ImagingNewPrologue(const char *mode, int xsize, int ysize)
+{
     return ImagingNewPrologueSubtype(
         mode, xsize, ysize, sizeof(struct ImagingMemoryInstance));
 }
 
 void
-ImagingDelete(Imaging im) {
+ImagingDelete(Imaging im)
+{
     if (!im) {
         return;
     }
@@ -271,7 +274,8 @@ struct ImagingMemoryArena ImagingDefaultArena = {
 };
 
 int
-ImagingMemorySetBlocksMax(ImagingMemoryArena arena, int blocks_max) {
+ImagingMemorySetBlocksMax(ImagingMemoryArena arena, int blocks_max)
+{
     void *p;
     /* Free already cached blocks */
     ImagingMemoryClearCache(arena, blocks_max);
@@ -298,7 +302,8 @@ ImagingMemorySetBlocksMax(ImagingMemoryArena arena, int blocks_max) {
 }
 
 void
-ImagingMemoryClearCache(ImagingMemoryArena arena, int new_size) {
+ImagingMemoryClearCache(ImagingMemoryArena arena, int new_size)
+{
     while (arena->blocks_cached > new_size) {
         arena->blocks_cached -= 1;
         free(arena->blocks_pool[arena->blocks_cached].ptr);
@@ -307,7 +312,8 @@ ImagingMemoryClearCache(ImagingMemoryArena arena, int new_size) {
 }
 
 ImagingMemoryBlock
-memory_get_block(ImagingMemoryArena arena, int requested_size, int dirty) {
+memory_get_block(ImagingMemoryArena arena, int requested_size, int dirty)
+{
     ImagingMemoryBlock block = {NULL, 0};
 
     if (arena->blocks_cached > 0) {
@@ -344,7 +350,8 @@ memory_get_block(ImagingMemoryArena arena, int requested_size, int dirty) {
 }
 
 void
-memory_return_block(ImagingMemoryArena arena, ImagingMemoryBlock block) {
+memory_return_block(ImagingMemoryArena arena, ImagingMemoryBlock block)
+{
     if (arena->blocks_cached < arena->blocks_max) {
         // Reduce block size
         if (block.size > arena->block_size) {
@@ -360,7 +367,8 @@ memory_return_block(ImagingMemoryArena arena, ImagingMemoryBlock block) {
 }
 
 static void
-ImagingDestroyArray(Imaging im) {
+ImagingDestroyArray(Imaging im)
+{
     int y = 0;
 
     if (im->blocks) {
@@ -373,7 +381,8 @@ ImagingDestroyArray(Imaging im) {
 }
 
 Imaging
-ImagingAllocateArray(Imaging im, int dirty, int block_size) {
+ImagingAllocateArray(Imaging im, int dirty, int block_size)
+{
     int y, line_in_block, current_block;
     ImagingMemoryArena arena = &ImagingDefaultArena;
     ImagingMemoryBlock block = {NULL, 0};
@@ -442,14 +451,16 @@ ImagingAllocateArray(Imaging im, int dirty, int block_size) {
 /* Allocate image as a single block. */
 
 static void
-ImagingDestroyBlock(Imaging im) {
+ImagingDestroyBlock(Imaging im)
+{
     if (im->block) {
         free(im->block);
     }
 }
 
 Imaging
-ImagingAllocateBlock(Imaging im) {
+ImagingAllocateBlock(Imaging im)
+{
     Py_ssize_t y, i;
 
     /* overflow check for malloc */
@@ -486,7 +497,8 @@ ImagingAllocateBlock(Imaging im) {
  */
 
 Imaging
-ImagingNewInternal(const char *mode, int xsize, int ysize, int dirty) {
+ImagingNewInternal(const char *mode, int xsize, int ysize, int dirty)
+{
     Imaging im;
 
     if (xsize < 0 || ysize < 0) {
@@ -514,17 +526,20 @@ ImagingNewInternal(const char *mode, int xsize, int ysize, int dirty) {
 }
 
 Imaging
-ImagingNew(const char *mode, int xsize, int ysize) {
+ImagingNew(const char *mode, int xsize, int ysize)
+{
     return ImagingNewInternal(mode, xsize, ysize, 0);
 }
 
 Imaging
-ImagingNewDirty(const char *mode, int xsize, int ysize) {
+ImagingNewDirty(const char *mode, int xsize, int ysize)
+{
     return ImagingNewInternal(mode, xsize, ysize, 1);
 }
 
 Imaging
-ImagingNewBlock(const char *mode, int xsize, int ysize) {
+ImagingNewBlock(const char *mode, int xsize, int ysize)
+{
     Imaging im;
 
     if (xsize < 0 || ysize < 0) {
@@ -545,7 +560,8 @@ ImagingNewBlock(const char *mode, int xsize, int ysize) {
 }
 
 Imaging
-ImagingNew2Dirty(const char *mode, Imaging imOut, Imaging imIn) {
+ImagingNew2Dirty(const char *mode, Imaging imOut, Imaging imIn)
+{
     /* allocate or validate output image */
 
     if (imOut) {
@@ -566,7 +582,8 @@ ImagingNew2Dirty(const char *mode, Imaging imOut, Imaging imIn) {
 }
 
 void
-ImagingCopyPalette(Imaging destination, Imaging source) {
+ImagingCopyPalette(Imaging destination, Imaging source)
+{
     if (source->palette) {
         if (destination->palette) {
             ImagingPaletteDelete(destination->palette);

--- a/src/libImaging/SunRleDecode.c
+++ b/src/libImaging/SunRleDecode.c
@@ -18,7 +18,8 @@
 #include "Imaging.h"
 
 int
-ImagingSunRleDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes) {
+ImagingSunRleDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes)
+{
     int n;
     UINT8 *ptr;
     UINT8 extra_data = 0;

--- a/src/libImaging/TgaRleDecode.c
+++ b/src/libImaging/TgaRleDecode.c
@@ -17,7 +17,8 @@
 #include "Imaging.h"
 
 int
-ImagingTgaRleDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes) {
+ImagingTgaRleDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes)
+{
     int n, depth;
     UINT8 *ptr;
     int extra_bytes = 0;

--- a/src/libImaging/TgaRleEncode.c
+++ b/src/libImaging/TgaRleEncode.c
@@ -5,13 +5,15 @@
 #include <string.h>
 
 static int
-comparePixels(const UINT8 *buf, int x, int bytesPerPixel) {
+comparePixels(const UINT8 *buf, int x, int bytesPerPixel)
+{
     buf += x * bytesPerPixel;
     return memcmp(buf, buf + bytesPerPixel, bytesPerPixel) == 0;
 }
 
 int
-ImagingTgaRleEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
+ImagingTgaRleEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes)
+{
     UINT8 *dst;
     int bytesPerPixel;
 

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -37,7 +37,8 @@
 #endif
 
 void
-dump_state(const TIFFSTATE *state) {
+dump_state(const TIFFSTATE *state)
+{
     TRACE(
         ("State: Location %u size %d eof %d data: %p ifd: %d\n",
          (uint)state->loc,
@@ -52,7 +53,8 @@ dump_state(const TIFFSTATE *state) {
 */
 
 tsize_t
-_tiffReadProc(thandle_t hdata, tdata_t buf, tsize_t size) {
+_tiffReadProc(thandle_t hdata, tdata_t buf, tsize_t size)
+{
     TIFFSTATE *state = (TIFFSTATE *)hdata;
     tsize_t to_read;
 
@@ -78,7 +80,8 @@ _tiffReadProc(thandle_t hdata, tdata_t buf, tsize_t size) {
 }
 
 tsize_t
-_tiffWriteProc(thandle_t hdata, tdata_t buf, tsize_t size) {
+_tiffWriteProc(thandle_t hdata, tdata_t buf, tsize_t size)
+{
     TIFFSTATE *state = (TIFFSTATE *)hdata;
     tsize_t to_write;
 
@@ -119,7 +122,8 @@ _tiffWriteProc(thandle_t hdata, tdata_t buf, tsize_t size) {
 }
 
 toff_t
-_tiffSeekProc(thandle_t hdata, toff_t off, int whence) {
+_tiffSeekProc(thandle_t hdata, toff_t off, int whence)
+{
     TIFFSTATE *state = (TIFFSTATE *)hdata;
 
     TRACE(("_tiffSeekProc: off: %u whence: %d \n", (uint)off, whence));
@@ -140,7 +144,8 @@ _tiffSeekProc(thandle_t hdata, toff_t off, int whence) {
 }
 
 int
-_tiffCloseProc(thandle_t hdata) {
+_tiffCloseProc(thandle_t hdata)
+{
     TIFFSTATE *state = (TIFFSTATE *)hdata;
 
     TRACE(("_tiffCloseProc \n"));
@@ -150,7 +155,8 @@ _tiffCloseProc(thandle_t hdata) {
 }
 
 toff_t
-_tiffSizeProc(thandle_t hdata) {
+_tiffSizeProc(thandle_t hdata)
+{
     TIFFSTATE *state = (TIFFSTATE *)hdata;
 
     TRACE(("_tiffSizeProc \n"));
@@ -160,7 +166,8 @@ _tiffSizeProc(thandle_t hdata) {
 }
 
 int
-_tiffMapProc(thandle_t hdata, tdata_t *pbase, toff_t *psize) {
+_tiffMapProc(thandle_t hdata, tdata_t *pbase, toff_t *psize)
+{
     TIFFSTATE *state = (TIFFSTATE *)hdata;
 
     TRACE(("_tiffMapProc input size: %u, data: %p\n", (uint)*psize, *pbase));
@@ -173,7 +180,8 @@ _tiffMapProc(thandle_t hdata, tdata_t *pbase, toff_t *psize) {
 }
 
 int
-_tiffNullMapProc(thandle_t hdata, tdata_t *pbase, toff_t *psize) {
+_tiffNullMapProc(thandle_t hdata, tdata_t *pbase, toff_t *psize)
+{
     (void)hdata;
     (void)pbase;
     (void)psize;
@@ -181,7 +189,8 @@ _tiffNullMapProc(thandle_t hdata, tdata_t *pbase, toff_t *psize) {
 }
 
 void
-_tiffUnmapProc(thandle_t hdata, tdata_t base, toff_t size) {
+_tiffUnmapProc(thandle_t hdata, tdata_t base, toff_t size)
+{
     TRACE(("_tiffUnMapProc\n"));
     (void)hdata;
     (void)base;
@@ -189,7 +198,8 @@ _tiffUnmapProc(thandle_t hdata, tdata_t base, toff_t size) {
 }
 
 int
-ImagingLibTiffInit(ImagingCodecState state, int fp, uint32_t offset) {
+ImagingLibTiffInit(ImagingCodecState state, int fp, uint32_t offset)
+{
     TIFFSTATE *clientstate = (TIFFSTATE *)state->context;
 
     TRACE(("initing libtiff\n"));
@@ -226,7 +236,8 @@ _pickUnpackers(
     ImagingCodecState state,
     TIFF *tiff,
     uint16_t planarconfig,
-    ImagingShuffler *unpackers) {
+    ImagingShuffler *unpackers)
+{
     // if number of bands is 1, there is no difference with contig case
     if (planarconfig == PLANARCONFIG_SEPARATE && im->bands > 1) {
         uint16_t bits_per_sample = 8;
@@ -259,7 +270,8 @@ _pickUnpackers(
 }
 
 int
-_decodeAsRGBA(Imaging im, ImagingCodecState state, TIFF *tiff) {
+_decodeAsRGBA(Imaging im, ImagingCodecState state, TIFF *tiff)
+{
     // To avoid dealing with YCbCr subsampling and other complications, let libtiff
     // handle it Use a TIFFRGBAImage wrapping the tiff image, and let libtiff handle all
     // of the conversion. Metadata read from the TIFFRGBAImage could be different from
@@ -374,7 +386,8 @@ _decodeTile(
     ImagingCodecState state,
     TIFF *tiff,
     int planes,
-    ImagingShuffler *unpackers) {
+    ImagingShuffler *unpackers)
+{
     INT32 x, y, tile_y, current_tile_length, current_tile_width;
     UINT32 tile_width, tile_length;
     tsize_t tile_bytes_size, row_byte_size;
@@ -477,7 +490,8 @@ _decodeStrip(
     ImagingCodecState state,
     TIFF *tiff,
     int planes,
-    ImagingShuffler *unpackers) {
+    ImagingShuffler *unpackers)
+{
     INT32 strip_row = 0;
     UINT8 *new_data;
     UINT32 rows_per_strip;
@@ -577,7 +591,8 @@ _decodeStrip(
 
 int
 ImagingLibTiffDecode(
-    Imaging im, ImagingCodecState state, UINT8 *buffer, Py_ssize_t bytes) {
+    Imaging im, ImagingCodecState state, UINT8 *buffer, Py_ssize_t bytes)
+{
     TIFFSTATE *clientstate = (TIFFSTATE *)state->context;
     char *filename = "tempfile.tif";
     char *mode = "rC";
@@ -773,7 +788,8 @@ decode_err:
 }
 
 int
-ImagingLibTiffEncodeInit(ImagingCodecState state, char *filename, int fp) {
+ImagingLibTiffEncodeInit(ImagingCodecState state, char *filename, int fp)
+{
     // Open the FD or the pointer as a tiff file, for writing.
     // We may have to do some monkeying around to make this really work.
     // If we have a fp, then we're good.
@@ -852,7 +868,8 @@ ImagingLibTiffEncodeInit(ImagingCodecState state, char *filename, int fp) {
 
 int
 ImagingLibTiffMergeFieldInfo(
-    ImagingCodecState state, TIFFDataType field_type, int key, int is_var_length) {
+    ImagingCodecState state, TIFFDataType field_type, int key, int is_var_length)
+{
     // Refer to libtiff docs (http://www.simplesystems.org/libtiff/addingtags.html)
     TIFFSTATE *clientstate = (TIFFSTATE *)state->context;
     uint32_t n;
@@ -889,7 +906,8 @@ ImagingLibTiffMergeFieldInfo(
 }
 
 int
-ImagingLibTiffSetField(ImagingCodecState state, ttag_t tag, ...) {
+ImagingLibTiffSetField(ImagingCodecState state, ttag_t tag, ...)
+{
     // after tif_dir.c->TIFFSetField.
     TIFFSTATE *clientstate = (TIFFSTATE *)state->context;
     va_list ap;
@@ -902,7 +920,8 @@ ImagingLibTiffSetField(ImagingCodecState state, ttag_t tag, ...) {
 }
 
 int
-ImagingLibTiffEncode(Imaging im, ImagingCodecState state, UINT8 *buffer, int bytes) {
+ImagingLibTiffEncode(Imaging im, ImagingCodecState state, UINT8 *buffer, int bytes)
+{
     /* One shot encoder. Encode everything to the tiff in the clientstate.
        If we're running off of a FD, then run once, we're good, everything
        ends up in the file, we close and we're done.
@@ -1027,7 +1046,8 @@ ImagingLibTiffEncode(Imaging im, ImagingCodecState state, UINT8 *buffer, int byt
 }
 
 const char *
-ImagingTiffVersion(void) {
+ImagingTiffVersion(void)
+{
     return TIFFGetVersion();
 }
 

--- a/src/libImaging/Unpack.c
+++ b/src/libImaging/Unpack.c
@@ -109,7 +109,8 @@ static UINT8 BITFLIP[] = {
 /* Unpack to "1" image */
 
 static void
-unpack1(UINT8 *out, const UINT8 *in, int pixels) {
+unpack1(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* bits (msb first, white is non-zero) */
     while (pixels > 0) {
         UINT8 byte = *in++;
@@ -143,7 +144,8 @@ unpack1(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpack1I(UINT8 *out, const UINT8 *in, int pixels) {
+unpack1I(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* bits (msb first, white is zero) */
     while (pixels > 0) {
         UINT8 byte = *in++;
@@ -177,7 +179,8 @@ unpack1I(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpack1R(UINT8 *out, const UINT8 *in, int pixels) {
+unpack1R(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* bits (lsb first, white is non-zero) */
     while (pixels > 0) {
         UINT8 byte = *in++;
@@ -211,7 +214,8 @@ unpack1R(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpack1IR(UINT8 *out, const UINT8 *in, int pixels) {
+unpack1IR(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* bits (lsb first, white is zero) */
     while (pixels > 0) {
         UINT8 byte = *in++;
@@ -245,7 +249,8 @@ unpack1IR(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpack18(UINT8 *out, const UINT8 *in, int pixels) {
+unpack18(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* Unpack a '|b1' image, which is a numpy boolean.
        1 == true, 0==false, in bytes */
 
@@ -258,7 +263,8 @@ unpack18(UINT8 *out, const UINT8 *in, int pixels) {
 /* Unpack to "L" image */
 
 static void
-unpackL2(UINT8 *out, const UINT8 *in, int pixels) {
+unpackL2(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* nibbles (msb first, white is non-zero) */
     while (pixels > 0) {
         UINT8 byte = *in++;
@@ -280,7 +286,8 @@ unpackL2(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackL2I(UINT8 *out, const UINT8 *in, int pixels) {
+unpackL2I(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* nibbles (msb first, white is zero) */
     while (pixels > 0) {
         UINT8 byte = *in++;
@@ -302,7 +309,8 @@ unpackL2I(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackL2R(UINT8 *out, const UINT8 *in, int pixels) {
+unpackL2R(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* nibbles (bit order reversed, white is non-zero) */
     while (pixels > 0) {
         UINT8 byte = *in++;
@@ -325,7 +333,8 @@ unpackL2R(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackL2IR(UINT8 *out, const UINT8 *in, int pixels) {
+unpackL2IR(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* nibbles (bit order reversed, white is zero) */
     while (pixels > 0) {
         UINT8 byte = *in++;
@@ -348,7 +357,8 @@ unpackL2IR(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackL4(UINT8 *out, const UINT8 *in, int pixels) {
+unpackL4(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* nibbles (msb first, white is non-zero) */
     while (pixels > 0) {
         UINT8 byte = *in++;
@@ -364,7 +374,8 @@ unpackL4(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackL4I(UINT8 *out, const UINT8 *in, int pixels) {
+unpackL4I(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* nibbles (msb first, white is zero) */
     while (pixels > 0) {
         UINT8 byte = *in++;
@@ -380,7 +391,8 @@ unpackL4I(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackL4R(UINT8 *out, const UINT8 *in, int pixels) {
+unpackL4R(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* nibbles (bit order reversed, white is non-zero) */
     while (pixels > 0) {
         UINT8 byte = *in++;
@@ -397,7 +409,8 @@ unpackL4R(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackL4IR(UINT8 *out, const UINT8 *in, int pixels) {
+unpackL4IR(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* nibbles (bit order reversed, white is zero) */
     while (pixels > 0) {
         UINT8 byte = *in++;
@@ -414,7 +427,8 @@ unpackL4IR(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackLA(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackLA(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* LA, pixel interleaved */
     for (i = 0; i < pixels; i++) {
@@ -426,7 +440,8 @@ unpackLA(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackLAL(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackLAL(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* LA, line interleaved */
     for (i = 0; i < pixels; i++, _out += 4) {
@@ -436,7 +451,8 @@ unpackLAL(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackLI(UINT8 *out, const UINT8 *in, int pixels) {
+unpackLI(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* negative */
     int i;
     for (i = 0; i < pixels; i++) {
@@ -445,7 +461,8 @@ unpackLI(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackLR(UINT8 *out, const UINT8 *in, int pixels) {
+unpackLR(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* RGB, bit reversed */
     for (i = 0; i < pixels; i++) {
@@ -454,7 +471,8 @@ unpackLR(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackL16(UINT8 *out, const UINT8 *in, int pixels) {
+unpackL16(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* int16 (upper byte, little endian) */
     int i;
     for (i = 0; i < pixels; i++) {
@@ -464,7 +482,8 @@ unpackL16(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackL16B(UINT8 *out, const UINT8 *in, int pixels) {
+unpackL16B(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* int16 (upper byte, big endian) */
     for (i = 0; i < pixels; i++) {
@@ -476,7 +495,8 @@ unpackL16B(UINT8 *out, const UINT8 *in, int pixels) {
 /* Unpack to "P" image */
 
 static void
-unpackP1(UINT8 *out, const UINT8 *in, int pixels) {
+unpackP1(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* bits */
     while (pixels > 0) {
         UINT8 byte = *in++;
@@ -510,7 +530,8 @@ unpackP1(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackP2(UINT8 *out, const UINT8 *in, int pixels) {
+unpackP2(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* bit pairs */
     while (pixels > 0) {
         UINT8 byte = *in++;
@@ -532,7 +553,8 @@ unpackP2(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackP4(UINT8 *out, const UINT8 *in, int pixels) {
+unpackP4(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* nibbles */
     while (pixels > 0) {
         UINT8 byte = *in++;
@@ -548,7 +570,8 @@ unpackP4(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackP2L(UINT8 *out, const UINT8 *in, int pixels) {
+unpackP2L(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i, j, m, s;
     /* bit layers */
     m = 128;
@@ -563,7 +586,8 @@ unpackP2L(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackP4L(UINT8 *out, const UINT8 *in, int pixels) {
+unpackP4L(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i, j, m, s;
     /* bit layers (trust the optimizer ;-) */
     m = 128;
@@ -581,7 +605,8 @@ unpackP4L(UINT8 *out, const UINT8 *in, int pixels) {
 /* Unpack to "RGB" image */
 
 void
-ImagingUnpackRGB(UINT8 *_out, const UINT8 *in, int pixels) {
+ImagingUnpackRGB(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i = 0;
     /* RGB triplets */
     for (; i < pixels - 1; i++) {
@@ -601,7 +626,8 @@ ImagingUnpackRGB(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 void
-unpackRGB16L(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackRGB16L(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* 16-bit RGB triplets, little-endian order */
     for (i = 0; i < pixels; i++) {
@@ -613,7 +639,8 @@ unpackRGB16L(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 void
-unpackRGB16B(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackRGB16B(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* 16-bit RGB triplets, big-endian order */
     for (i = 0; i < pixels; i++) {
@@ -625,7 +652,8 @@ unpackRGB16B(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackRGBL(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackRGBL(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* RGB, line interleaved */
     for (i = 0; i < pixels; i++, _out += 4) {
@@ -635,7 +663,8 @@ unpackRGBL(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackRGBR(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackRGBR(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* RGB, bit reversed */
     for (i = 0; i < pixels; i++) {
@@ -647,7 +676,8 @@ unpackRGBR(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingUnpackBGR(UINT8 *_out, const UINT8 *in, int pixels) {
+ImagingUnpackBGR(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* RGB, reversed bytes */
     for (i = 0; i < pixels; i++) {
@@ -659,7 +689,8 @@ ImagingUnpackBGR(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingUnpackRGB15(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingUnpackRGB15(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i, pixel;
     /* RGB, 5 bits per pixel */
     for (i = 0; i < pixels; i++) {
@@ -674,7 +705,8 @@ ImagingUnpackRGB15(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingUnpackRGBA15(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingUnpackRGBA15(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i, pixel;
     /* RGB, 5/5/5/1 bits per pixel */
     for (i = 0; i < pixels; i++) {
@@ -689,7 +721,8 @@ ImagingUnpackRGBA15(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingUnpackBGR15(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingUnpackBGR15(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i, pixel;
     /* RGB, reversed bytes, 5 bits per pixel */
     for (i = 0; i < pixels; i++) {
@@ -704,7 +737,8 @@ ImagingUnpackBGR15(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingUnpackBGRA15(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingUnpackBGRA15(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i, pixel;
     /* RGB, rearranged channels, 5/5/5/1 bits per pixel */
     for (i = 0; i < pixels; i++) {
@@ -719,7 +753,8 @@ ImagingUnpackBGRA15(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingUnpackBGRA15Z(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingUnpackBGRA15Z(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i, pixel;
     /* RGB, rearranged channels, 5/5/5/1 bits per pixel, inverted alpha */
     for (i = 0; i < pixels; i++) {
@@ -734,7 +769,8 @@ ImagingUnpackBGRA15Z(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingUnpackRGB16(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingUnpackRGB16(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i, pixel;
     /* RGB, 5/6/5 bits per pixel */
     for (i = 0; i < pixels; i++) {
@@ -749,7 +785,8 @@ ImagingUnpackRGB16(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingUnpackBGR16(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingUnpackBGR16(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i, pixel;
     /* RGB, reversed bytes, 5/6/5 bits per pixel */
     for (i = 0; i < pixels; i++) {
@@ -764,7 +801,8 @@ ImagingUnpackBGR16(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingUnpackRGB4B(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingUnpackRGB4B(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i, pixel;
     /* RGB, 4 bits per pixel */
     for (i = 0; i < pixels; i++) {
@@ -779,7 +817,8 @@ ImagingUnpackRGB4B(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingUnpackRGBA4B(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingUnpackRGBA4B(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i, pixel;
     /* RGBA, 4 bits per pixel */
     for (i = 0; i < pixels; i++) {
@@ -794,7 +833,8 @@ ImagingUnpackRGBA4B(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-ImagingUnpackBGRX(UINT8 *_out, const UINT8 *in, int pixels) {
+ImagingUnpackBGRX(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* RGB, reversed bytes with padding */
     for (i = 0; i < pixels; i++) {
@@ -806,7 +846,8 @@ ImagingUnpackBGRX(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-ImagingUnpackBGXR(UINT8 *_out, const UINT8 *in, int pixels) {
+ImagingUnpackBGXR(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     for (i = 0; i < pixels; i++) {
         UINT32 iv = MAKE_UINT32(in[3], in[1], in[0], 255);
@@ -817,7 +858,8 @@ ImagingUnpackBGXR(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-ImagingUnpackXRGB(UINT8 *_out, const UINT8 *in, int pixels) {
+ImagingUnpackXRGB(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* RGB, leading pad */
     for (i = 0; i < pixels; i++) {
@@ -829,7 +871,8 @@ ImagingUnpackXRGB(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-ImagingUnpackXBGR(UINT8 *_out, const UINT8 *in, int pixels) {
+ImagingUnpackXBGR(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* RGB, reversed bytes, leading pad */
     for (i = 0; i < pixels; i++) {
@@ -843,7 +886,8 @@ ImagingUnpackXBGR(UINT8 *_out, const UINT8 *in, int pixels) {
 /* Unpack to "RGBA" image */
 
 static void
-unpackRGBALA(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackRGBALA(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* grayscale with alpha */
     for (i = 0; i < pixels; i++) {
@@ -855,7 +899,8 @@ unpackRGBALA(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackRGBALA16B(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackRGBALA16B(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* 16-bit grayscale with alpha, big-endian */
     for (i = 0; i < pixels; i++) {
@@ -867,7 +912,8 @@ unpackRGBALA16B(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackRGBa16L(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackRGBa16L(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* premultiplied 16-bit RGBA, little-endian */
     for (i = 0; i < pixels; i++) {
@@ -891,7 +937,8 @@ unpackRGBa16L(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackRGBa16B(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackRGBa16B(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* premultiplied 16-bit RGBA, big-endian */
     for (i = 0; i < pixels; i++) {
@@ -915,7 +962,8 @@ unpackRGBa16B(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackRGBa(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackRGBa(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* premultiplied RGBA */
     for (i = 0; i < pixels; i++) {
@@ -939,7 +987,8 @@ unpackRGBa(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackRGBaskip1(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackRGBaskip1(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     UINT32 *out = (UINT32 *)_out;
     /* premultiplied RGBA */
@@ -961,7 +1010,8 @@ unpackRGBaskip1(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackRGBaskip2(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackRGBaskip2(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     UINT32 *out = (UINT32 *)_out;
     /* premultiplied RGBA */
@@ -983,7 +1033,8 @@ unpackRGBaskip2(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackBGRa(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackBGRa(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* premultiplied BGRA */
     for (i = 0; i < pixels; i++) {
@@ -1007,7 +1058,8 @@ unpackBGRa(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackRGBAI(UINT8 *out, const UINT8 *in, int pixels) {
+unpackRGBAI(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* RGBA, inverted RGB bytes (FlashPix) */
     for (i = 0; i < pixels; i++) {
@@ -1021,7 +1073,8 @@ unpackRGBAI(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackRGBAL(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackRGBAL(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* RGBA, line interleaved */
     for (i = 0; i < pixels; i++, _out += 4) {
@@ -1035,7 +1088,8 @@ unpackRGBAL(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 void
-unpackRGBA16L(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackRGBA16L(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* 16-bit RGBA, little-endian order */
     for (i = 0; i < pixels; i++, _out += 4) {
@@ -1046,7 +1100,8 @@ unpackRGBA16L(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 void
-unpackRGBA16B(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackRGBA16B(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* 16-bit RGBA, big-endian order */
     for (i = 0; i < pixels; i++, _out += 4) {
@@ -1057,7 +1112,8 @@ unpackRGBA16B(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackARGB(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackARGB(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* RGBA, leading pad */
     for (i = 0; i < pixels; i++) {
@@ -1069,7 +1125,8 @@ unpackARGB(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackABGR(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackABGR(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* RGBA, reversed bytes */
     for (i = 0; i < pixels; i++) {
@@ -1081,7 +1138,8 @@ unpackABGR(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackBGRA(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackBGRA(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* RGBA, rearranged channels */
     for (i = 0; i < pixels; i++) {
@@ -1093,7 +1151,8 @@ unpackBGRA(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackBGRA16L(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackBGRA16L(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* 16-bit RGBA, little-endian order, rearranged channels */
     for (i = 0; i < pixels; i++) {
@@ -1105,7 +1164,8 @@ unpackBGRA16L(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackBGRA16B(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackBGRA16B(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* 16-bit RGBA, big-endian order, rearranged channels */
     for (i = 0; i < pixels; i++) {
@@ -1117,7 +1177,8 @@ unpackBGRA16B(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackBGAR(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackBGAR(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     for (i = 0; i < pixels; i++) {
         UINT32 iv = MAKE_UINT32(in[3], in[1], in[0], in[2]);
@@ -1130,7 +1191,8 @@ unpackBGAR(UINT8 *_out, const UINT8 *in, int pixels) {
 /* Unpack to "CMYK" image */
 
 static void
-unpackCMYKI(UINT8 *_out, const UINT8 *in, int pixels) {
+unpackCMYKI(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     /* CMYK, inverted bytes (Photoshop 2.5) */
     for (i = 0; i < pixels; i++) {
@@ -1153,7 +1215,8 @@ unpackCMYKI(UINT8 *_out, const UINT8 *in, int pixels) {
    internally, and we'll unshift for saving and whatnot.
 */
 void
-ImagingUnpackLAB(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingUnpackLAB(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* LAB triplets */
     for (i = 0; i < pixels; i++) {
@@ -1167,7 +1230,8 @@ ImagingUnpackLAB(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackI16N_I16B(UINT8 *out, const UINT8 *in, int pixels) {
+unpackI16N_I16B(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     UINT8 *tmp = (UINT8 *)out;
     for (i = 0; i < pixels; i++) {
@@ -1177,7 +1241,8 @@ unpackI16N_I16B(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 static void
-unpackI16N_I16(UINT8 *out, const UINT8 *in, int pixels) {
+unpackI16N_I16(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     UINT8 *tmp = (UINT8 *)out;
     for (i = 0; i < pixels; i++) {
@@ -1187,7 +1252,8 @@ unpackI16N_I16(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 static void
-unpackI16B_I16(UINT8 *out, const UINT8 *in, int pixels) {
+unpackI16B_I16(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     for (i = 0; i < pixels; i++) {
         out[0] = in[1];
@@ -1197,7 +1263,8 @@ unpackI16B_I16(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 static void
-unpackI16R_I16(UINT8 *out, const UINT8 *in, int pixels) {
+unpackI16R_I16(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     for (i = 0; i < pixels; i++) {
         out[0] = BITFLIP[in[0]];
@@ -1208,7 +1275,8 @@ unpackI16R_I16(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-unpackI12_I16(UINT8 *out, const UINT8 *in, int pixels) {
+unpackI12_I16(UINT8 *out, const UINT8 *in, int pixels)
+{
     /*  Fillorder 1/MSB -> LittleEndian, for 12bit integer grayscale tiffs.
 
         According to the TIFF spec:
@@ -1265,31 +1333,36 @@ unpackI12_I16(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-copy1(UINT8 *out, const UINT8 *in, int pixels) {
+copy1(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* L, P */
     memcpy(out, in, pixels);
 }
 
 static void
-copy2(UINT8 *out, const UINT8 *in, int pixels) {
+copy2(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* I;16 */
     memcpy(out, in, pixels * 2);
 }
 
 static void
-copy3(UINT8 *out, const UINT8 *in, int pixels) {
+copy3(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* BGR;24 */
     memcpy(out, in, pixels * 3);
 }
 
 static void
-copy4(UINT8 *out, const UINT8 *in, int pixels) {
+copy4(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* RGBA, CMYK quadruples */
     memcpy(out, in, 4 * pixels);
 }
 
 static void
-copy4skip1(UINT8 *_out, const UINT8 *in, int pixels) {
+copy4skip1(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     for (i = 0; i < pixels; i++) {
         memcpy(_out, in, 4);
@@ -1299,7 +1372,8 @@ copy4skip1(UINT8 *_out, const UINT8 *in, int pixels) {
 }
 
 static void
-copy4skip2(UINT8 *_out, const UINT8 *in, int pixels) {
+copy4skip2(UINT8 *_out, const UINT8 *in, int pixels)
+{
     int i;
     for (i = 0; i < pixels; i++) {
         memcpy(_out, in, 4);
@@ -1310,25 +1384,27 @@ copy4skip2(UINT8 *_out, const UINT8 *in, int pixels) {
 
 /* Unpack to "I" and "F" images */
 
-#define UNPACK_RAW(NAME, GET, INTYPE, OUTTYPE)                   \
-    static void NAME(UINT8 *out_, const UINT8 *in, int pixels) { \
-        int i;                                                   \
-        OUTTYPE *out = (OUTTYPE *)out_;                          \
-        for (i = 0; i < pixels; i++, in += sizeof(INTYPE)) {     \
-            out[i] = (OUTTYPE)((INTYPE)GET);                     \
-        }                                                        \
+#define UNPACK_RAW(NAME, GET, INTYPE, OUTTYPE)                 \
+    static void NAME(UINT8 *out_, const UINT8 *in, int pixels) \
+    {                                                          \
+        int i;                                                 \
+        OUTTYPE *out = (OUTTYPE *)out_;                        \
+        for (i = 0; i < pixels; i++, in += sizeof(INTYPE)) {   \
+            out[i] = (OUTTYPE)((INTYPE)GET);                   \
+        }                                                      \
     }
 
-#define UNPACK(NAME, COPY, INTYPE, OUTTYPE)                      \
-    static void NAME(UINT8 *out_, const UINT8 *in, int pixels) { \
-        int i;                                                   \
-        OUTTYPE *out = (OUTTYPE *)out_;                          \
-        INTYPE tmp_;                                             \
-        UINT8 *tmp = (UINT8 *)&tmp_;                             \
-        for (i = 0; i < pixels; i++, in += sizeof(INTYPE)) {     \
-            COPY;                                                \
-            out[i] = (OUTTYPE)tmp_;                              \
-        }                                                        \
+#define UNPACK(NAME, COPY, INTYPE, OUTTYPE)                    \
+    static void NAME(UINT8 *out_, const UINT8 *in, int pixels) \
+    {                                                          \
+        int i;                                                 \
+        OUTTYPE *out = (OUTTYPE *)out_;                        \
+        INTYPE tmp_;                                           \
+        UINT8 *tmp = (UINT8 *)&tmp_;                           \
+        for (i = 0; i < pixels; i++, in += sizeof(INTYPE)) {   \
+            COPY;                                              \
+            out[i] = (OUTTYPE)tmp_;                            \
+        }                                                      \
     }
 
 UNPACK_RAW(unpackI8, in[0], UINT8, INT32)
@@ -1372,7 +1448,8 @@ UNPACK(unpackF64NF, C64N, FLOAT64, FLOAT32)
 /* Misc. unpackers */
 
 static void
-band0(UINT8 *out, const UINT8 *in, int pixels) {
+band0(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* band 0 only */
     for (i = 0; i < pixels; i++) {
@@ -1382,7 +1459,8 @@ band0(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band1(UINT8 *out, const UINT8 *in, int pixels) {
+band1(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* band 1 only */
     for (i = 0; i < pixels; i++) {
@@ -1392,7 +1470,8 @@ band1(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band2(UINT8 *out, const UINT8 *in, int pixels) {
+band2(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* band 2 only */
     for (i = 0; i < pixels; i++) {
@@ -1402,7 +1481,8 @@ band2(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band3(UINT8 *out, const UINT8 *in, int pixels) {
+band3(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* band 3 only */
     int i;
     for (i = 0; i < pixels; i++) {
@@ -1412,7 +1492,8 @@ band3(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band0I(UINT8 *out, const UINT8 *in, int pixels) {
+band0I(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* band 0 only */
     for (i = 0; i < pixels; i++) {
@@ -1422,7 +1503,8 @@ band0I(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band1I(UINT8 *out, const UINT8 *in, int pixels) {
+band1I(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* band 1 only */
     for (i = 0; i < pixels; i++) {
@@ -1432,7 +1514,8 @@ band1I(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band2I(UINT8 *out, const UINT8 *in, int pixels) {
+band2I(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* band 2 only */
     for (i = 0; i < pixels; i++) {
@@ -1442,7 +1525,8 @@ band2I(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band3I(UINT8 *out, const UINT8 *in, int pixels) {
+band3I(UINT8 *out, const UINT8 *in, int pixels)
+{
     /* band 3 only */
     int i;
     for (i = 0; i < pixels; i++) {
@@ -1452,7 +1536,8 @@ band3I(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band016B(UINT8 *out, const UINT8 *in, int pixels) {
+band016B(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* band 0 only, big endian */
     for (i = 0; i < pixels; i++) {
@@ -1463,7 +1548,8 @@ band016B(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band116B(UINT8 *out, const UINT8 *in, int pixels) {
+band116B(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* band 1 only, big endian */
     for (i = 0; i < pixels; i++) {
@@ -1474,7 +1560,8 @@ band116B(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band216B(UINT8 *out, const UINT8 *in, int pixels) {
+band216B(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* band 2 only, big endian */
     for (i = 0; i < pixels; i++) {
@@ -1485,7 +1572,8 @@ band216B(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band316B(UINT8 *out, const UINT8 *in, int pixels) {
+band316B(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* band 3 only, big endian */
     for (i = 0; i < pixels; i++) {
@@ -1496,7 +1584,8 @@ band316B(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band016L(UINT8 *out, const UINT8 *in, int pixels) {
+band016L(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* band 0 only, little endian */
     for (i = 0; i < pixels; i++) {
@@ -1507,7 +1596,8 @@ band016L(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band116L(UINT8 *out, const UINT8 *in, int pixels) {
+band116L(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* band 1 only, little endian */
     for (i = 0; i < pixels; i++) {
@@ -1518,7 +1608,8 @@ band116L(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band216L(UINT8 *out, const UINT8 *in, int pixels) {
+band216L(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* band 2 only, little endian */
     for (i = 0; i < pixels; i++) {
@@ -1529,7 +1620,8 @@ band216L(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 static void
-band316L(UINT8 *out, const UINT8 *in, int pixels) {
+band316L(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* band 3 only, little endian */
     for (i = 0; i < pixels; i++) {
@@ -1845,7 +1937,8 @@ static struct {
 };
 
 ImagingShuffler
-ImagingFindUnpacker(const char *mode, const char *rawmode, int *bits_out) {
+ImagingFindUnpacker(const char *mode, const char *rawmode, int *bits_out)
+{
     int i;
 
     /* find a suitable pixel unpacker */

--- a/src/libImaging/UnpackYCC.c
+++ b/src/libImaging/UnpackYCC.c
@@ -133,7 +133,8 @@ static INT16 GR[] = {
     }
 
 void
-ImagingUnpackYCC(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingUnpackYCC(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* PhotoYCC triplets */
     for (i = 0; i < pixels; i++) {
@@ -145,7 +146,8 @@ ImagingUnpackYCC(UINT8 *out, const UINT8 *in, int pixels) {
 }
 
 void
-ImagingUnpackYCCA(UINT8 *out, const UINT8 *in, int pixels) {
+ImagingUnpackYCCA(UINT8 *out, const UINT8 *in, int pixels)
+{
     int i;
     /* PhotoYCC triplets plus premultiplied alpha */
     for (i = 0; i < pixels; i++) {

--- a/src/libImaging/UnsharpMask.c
+++ b/src/libImaging/UnsharpMask.c
@@ -11,7 +11,8 @@
 typedef UINT8 pixel[4];
 
 static inline UINT8
-clip8(int in) {
+clip8(int in)
+{
     if (in >= 255) {
         return 255;
     }
@@ -23,7 +24,8 @@ clip8(int in) {
 
 Imaging
 ImagingUnsharpMask(
-    Imaging imOut, Imaging imIn, float radius, int percent, int threshold) {
+    Imaging imOut, Imaging imIn, float radius, int percent, int threshold)
+{
     ImagingSectionCookie cookie;
     Imaging result;
 

--- a/src/libImaging/XbmDecode.c
+++ b/src/libImaging/XbmDecode.c
@@ -22,7 +22,8 @@
                               : 0)
 
 int
-ImagingXbmDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes) {
+ImagingXbmDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes)
+{
     enum { BYTE = 1, SKIP };
 
     UINT8 *ptr;

--- a/src/libImaging/XbmEncode.c
+++ b/src/libImaging/XbmEncode.c
@@ -16,7 +16,8 @@
 #include "Imaging.h"
 
 int
-ImagingXbmEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
+ImagingXbmEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes)
+{
     const char *hex = "0123456789abcdef";
 
     UINT8 *ptr = buf;

--- a/src/libImaging/ZipDecode.c
+++ b/src/libImaging/ZipDecode.c
@@ -30,7 +30,8 @@ static const int ROW_INCREMENT[] = {8, 8, 8, 4, 4, 2, 2};
 /* Get the length in bytes of a scanline in the pass specified,
  * for interlaced images */
 static int
-get_row_len(ImagingCodecState state, int pass) {
+get_row_len(ImagingCodecState state, int pass)
+{
     int row_len = (state->xsize + OFFSET[pass]) / COL_INCREMENT[pass];
     return ((row_len * state->bits) + 7) / 8;
 }
@@ -40,7 +41,8 @@ get_row_len(ImagingCodecState state, int pass) {
 /* -------------------------------------------------------------------- */
 
 int
-ImagingZipDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes) {
+ImagingZipDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t bytes)
+{
     ZIPSTATE *context = (ZIPSTATE *)state->context;
     int err;
     int n;
@@ -281,7 +283,8 @@ ImagingZipDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t byt
 }
 
 int
-ImagingZipDecodeCleanup(ImagingCodecState state) {
+ImagingZipDecodeCleanup(ImagingCodecState state)
+{
     /* called to free the decompression engine when the decode terminates
        due to a corrupt or truncated image
     */

--- a/src/libImaging/ZipEncode.c
+++ b/src/libImaging/ZipEncode.c
@@ -21,7 +21,8 @@
 #include "ZipCodecs.h"
 
 int
-ImagingZipEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
+ImagingZipEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes)
+{
     ZIPSTATE *context = (ZIPSTATE *)state->context;
     int err;
     int compress_level, compress_type;
@@ -348,7 +349,8 @@ ImagingZipEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
 /* -------------------------------------------------------------------- */
 
 int
-ImagingZipEncodeCleanup(ImagingCodecState state) {
+ImagingZipEncodeCleanup(ImagingCodecState state)
+{
     ZIPSTATE *context = (ZIPSTATE *)state->context;
 
     if (context->dictionary) {
@@ -360,7 +362,8 @@ ImagingZipEncodeCleanup(ImagingCodecState state) {
 }
 
 const char *
-ImagingZipVersion(void) {
+ImagingZipVersion(void)
+{
     return zlibVersion();
 }
 

--- a/src/libImaging/codec_fd.c
+++ b/src/libImaging/codec_fd.c
@@ -2,7 +2,8 @@
 #include "Imaging.h"
 
 Py_ssize_t
-_imaging_read_pyFd(PyObject *fd, char *dest, Py_ssize_t bytes) {
+_imaging_read_pyFd(PyObject *fd, char *dest, Py_ssize_t bytes)
+{
     /* dest should be a buffer bytes long, returns length of read
        -1 on error */
 
@@ -33,7 +34,8 @@ err:
 }
 
 Py_ssize_t
-_imaging_write_pyFd(PyObject *fd, char *src, Py_ssize_t bytes) {
+_imaging_write_pyFd(PyObject *fd, char *src, Py_ssize_t bytes)
+{
     PyObject *result;
     PyObject *byteObj;
 
@@ -47,7 +49,8 @@ _imaging_write_pyFd(PyObject *fd, char *src, Py_ssize_t bytes) {
 }
 
 int
-_imaging_seek_pyFd(PyObject *fd, Py_ssize_t offset, int whence) {
+_imaging_seek_pyFd(PyObject *fd, Py_ssize_t offset, int whence)
+{
     PyObject *result;
 
     result = PyObject_CallMethod(fd, "seek", "ni", offset, whence);
@@ -57,7 +60,8 @@ _imaging_seek_pyFd(PyObject *fd, Py_ssize_t offset, int whence) {
 }
 
 Py_ssize_t
-_imaging_tell_pyFd(PyObject *fd) {
+_imaging_tell_pyFd(PyObject *fd)
+{
     PyObject *result;
     Py_ssize_t location;
 

--- a/src/map.c
+++ b/src/map.c
@@ -41,7 +41,8 @@ typedef struct ImagingBufferInstance {
 } ImagingBufferInstance;
 
 static void
-mapping_destroy_buffer(Imaging im) {
+mapping_destroy_buffer(Imaging im)
+{
     ImagingBufferInstance *buffer = (ImagingBufferInstance *)im;
 
     PyBuffer_Release(&buffer->view);
@@ -49,7 +50,8 @@ mapping_destroy_buffer(Imaging im) {
 }
 
 PyObject *
-PyImaging_MapBuffer(PyObject *self, PyObject *args) {
+PyImaging_MapBuffer(PyObject *self, PyObject *args)
+{
     Py_ssize_t y, size;
     Imaging im;
 

--- a/src/outline.c
+++ b/src/outline.c
@@ -33,7 +33,8 @@ static PyTypeObject OutlineType;
 #define PyOutline_Check(op) (Py_TYPE(op) == &OutlineType)
 
 static OutlineObject *
-_outline_new(void) {
+_outline_new(void)
+{
     OutlineObject *self;
 
     if (PyType_Ready(&OutlineType) < 0) {
@@ -51,13 +52,15 @@ _outline_new(void) {
 }
 
 static void
-_outline_dealloc(OutlineObject *self) {
+_outline_dealloc(OutlineObject *self)
+{
     ImagingOutlineDelete(self->outline);
     PyObject_Del(self);
 }
 
 ImagingOutline
-PyOutline_AsOutline(PyObject *outline) {
+PyOutline_AsOutline(PyObject *outline)
+{
     if (PyOutline_Check(outline)) {
         return ((OutlineObject *)outline)->outline;
     }
@@ -69,7 +72,8 @@ PyOutline_AsOutline(PyObject *outline) {
 /* Factories                                                            */
 
 PyObject *
-PyOutline_Create(PyObject *self, PyObject *args) {
+PyOutline_Create(PyObject *self, PyObject *args)
+{
     if (!PyArg_ParseTuple(args, ":outline")) {
         return NULL;
     }
@@ -81,7 +85,8 @@ PyOutline_Create(PyObject *self, PyObject *args) {
 /* Methods                                                              */
 
 static PyObject *
-_outline_move(OutlineObject *self, PyObject *args) {
+_outline_move(OutlineObject *self, PyObject *args)
+{
     float x0, y0;
     if (!PyArg_ParseTuple(args, "ff", &x0, &y0)) {
         return NULL;
@@ -94,7 +99,8 @@ _outline_move(OutlineObject *self, PyObject *args) {
 }
 
 static PyObject *
-_outline_line(OutlineObject *self, PyObject *args) {
+_outline_line(OutlineObject *self, PyObject *args)
+{
     float x1, y1;
     if (!PyArg_ParseTuple(args, "ff", &x1, &y1)) {
         return NULL;
@@ -107,7 +113,8 @@ _outline_line(OutlineObject *self, PyObject *args) {
 }
 
 static PyObject *
-_outline_curve(OutlineObject *self, PyObject *args) {
+_outline_curve(OutlineObject *self, PyObject *args)
+{
     float x1, y1, x2, y2, x3, y3;
     if (!PyArg_ParseTuple(args, "ffffff", &x1, &y1, &x2, &y2, &x3, &y3)) {
         return NULL;
@@ -120,7 +127,8 @@ _outline_curve(OutlineObject *self, PyObject *args) {
 }
 
 static PyObject *
-_outline_close(OutlineObject *self, PyObject *args) {
+_outline_close(OutlineObject *self, PyObject *args)
+{
     if (!PyArg_ParseTuple(args, ":close")) {
         return NULL;
     }
@@ -132,7 +140,8 @@ _outline_close(OutlineObject *self, PyObject *args) {
 }
 
 static PyObject *
-_outline_transform(OutlineObject *self, PyObject *args) {
+_outline_transform(OutlineObject *self, PyObject *args)
+{
     double a[6];
     if (!PyArg_ParseTuple(args, "(dddddd)", a + 0, a + 1, a + 2, a + 3, a + 4, a + 5)) {
         return NULL;

--- a/src/path.c
+++ b/src/path.c
@@ -49,7 +49,8 @@ typedef struct {
 static PyTypeObject PyPathType;
 
 static double *
-alloc_array(Py_ssize_t count) {
+alloc_array(Py_ssize_t count)
+{
     double *xy;
     if (count < 0) {
         return ImagingError_MemoryError();
@@ -65,7 +66,8 @@ alloc_array(Py_ssize_t count) {
 }
 
 static PyPathObject *
-path_new(Py_ssize_t count, double *xy, int duplicate) {
+path_new(Py_ssize_t count, double *xy, int duplicate)
+{
     PyPathObject *path;
 
     if (duplicate) {
@@ -96,7 +98,8 @@ path_new(Py_ssize_t count, double *xy, int duplicate) {
 }
 
 static void
-path_dealloc(PyPathObject *path) {
+path_dealloc(PyPathObject *path)
+{
     free(path->xy);
     PyObject_Del(path);
 }
@@ -108,7 +111,8 @@ path_dealloc(PyPathObject *path) {
 #define PyPath_Check(op) (Py_TYPE(op) == &PyPathType)
 
 Py_ssize_t
-PyPath_Flatten(PyObject *data, double **pxy) {
+PyPath_Flatten(PyObject *data, double **pxy)
+{
     Py_ssize_t i, j, n;
     double *xy;
 
@@ -228,7 +232,8 @@ PyPath_Flatten(PyObject *data, double **pxy) {
 /* -------------------------------------------------------------------- */
 
 PyObject *
-PyPath_Create(PyObject *self, PyObject *args) {
+PyPath_Create(PyObject *self, PyObject *args)
+{
     PyObject *data;
     Py_ssize_t count;
     double *xy;
@@ -261,7 +266,8 @@ PyPath_Create(PyObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 static PyObject *
-path_compact(PyPathObject *self, PyObject *args) {
+path_compact(PyPathObject *self, PyObject *args)
+{
     /* Simple-minded method to shorten path.  A point is removed if
        the city block distance to the previous point is less than the
        given distance */
@@ -297,7 +303,8 @@ path_compact(PyPathObject *self, PyObject *args) {
 }
 
 static PyObject *
-path_getbbox(PyPathObject *self, PyObject *args) {
+path_getbbox(PyPathObject *self, PyObject *args)
+{
     /* Find bounding box */
     Py_ssize_t i;
     double *xy;
@@ -336,7 +343,8 @@ path_getbbox(PyPathObject *self, PyObject *args) {
 }
 
 static PyObject *
-path_getitem(PyPathObject *self, Py_ssize_t i) {
+path_getitem(PyPathObject *self, Py_ssize_t i)
+{
     if (i < 0) {
         i = self->count + i;
     }
@@ -349,7 +357,8 @@ path_getitem(PyPathObject *self, Py_ssize_t i) {
 }
 
 static PyObject *
-path_getslice(PyPathObject *self, Py_ssize_t ilow, Py_ssize_t ihigh) {
+path_getslice(PyPathObject *self, Py_ssize_t ilow, Py_ssize_t ihigh)
+{
     /* adjust arguments */
     if (ilow < 0) {
         ilow = 0;
@@ -369,12 +378,14 @@ path_getslice(PyPathObject *self, Py_ssize_t ilow, Py_ssize_t ihigh) {
 }
 
 static Py_ssize_t
-path_len(PyPathObject *self) {
+path_len(PyPathObject *self)
+{
     return self->count;
 }
 
 static PyObject *
-path_map(PyPathObject *self, PyObject *args) {
+path_map(PyPathObject *self, PyObject *args)
+{
     /* Map coordinate set through function */
     Py_ssize_t i;
     double *xy;
@@ -405,7 +416,8 @@ path_map(PyPathObject *self, PyObject *args) {
 }
 
 static int
-path_setitem(PyPathObject *self, Py_ssize_t i, PyObject *op) {
+path_setitem(PyPathObject *self, Py_ssize_t i, PyObject *op)
+{
     double *xy;
 
     if (i < 0 || i >= self->count) {
@@ -428,7 +440,8 @@ path_setitem(PyPathObject *self, Py_ssize_t i, PyObject *op) {
 }
 
 static PyObject *
-path_tolist(PyPathObject *self, PyObject *args) {
+path_tolist(PyPathObject *self, PyObject *args)
+{
     PyObject *list;
     Py_ssize_t i;
 
@@ -473,7 +486,8 @@ error:
 }
 
 static PyObject *
-path_transform(PyPathObject *self, PyObject *args) {
+path_transform(PyPathObject *self, PyObject *args)
+{
     /* Apply affine transform to coordinate set */
     Py_ssize_t i;
     double *xy;
@@ -526,14 +540,16 @@ static struct PyMethodDef methods[] = {
 };
 
 static PyObject *
-path_getattr_id(PyPathObject *self, void *closure) {
+path_getattr_id(PyPathObject *self, void *closure)
+{
     return Py_BuildValue("n", (Py_ssize_t)self->xy);
 }
 
 static struct PyGetSetDef getsetters[] = {{"id", (getter)path_getattr_id}, {NULL}};
 
 static PyObject *
-path_subscript(PyPathObject *self, PyObject *item) {
+path_subscript(PyPathObject *self, PyObject *item)
+{
     if (PyIndex_Check(item)) {
         Py_ssize_t i;
         i = PyNumber_AsSsize_t(item, PyExc_IndexError);


### PR DESCRIPTION
## Rationale

It's extremely hard to distinguish function arguments from local variables:

```c
void static inline ImagingLineBoxBlur32(
    pixel *lineOut,
    pixel *lineIn,
    int lastx,
    int radius,
    int edgeA,
    int edgeB,
    UINT32 ww,
    UINT32 fw) {
    int x;
    UINT32 acc[4];
    UINT32 bulk[4];
```

```c
static union hist_extrema *
parse_histogram_extremap(
    ImagingObject *self, PyObject *extremap, union hist_extrema *ep) {
    int i0, i1;
    double f0, f1;
```

After proposition:

```c
void static inline ImagingLineBoxBlur32(
    pixel *lineOut,
    pixel *lineIn,
    int lastx,
    int radius,
    int edgeA,
    int edgeB,
    UINT32 ww,
    UINT32 fw)
{
    int x;
    UINT32 acc[4];
    UINT32 bulk[4];
```

```c
static union hist_extrema *
parse_histogram_extremap(
    ImagingObject *self, PyObject *extremap, union hist_extrema *ep)
{
    int i0, i1;
    double f0, f1;
```
