### PR TITLE
Build free-threaded wheels

### DIFF
--- a/.github/workflows/wheels-test.sh
+++ b/.github/workflows/wheels-test.sh
@@ -12,8 +12,14 @@ elif [ "${AUDITWHEEL_POLICY::9}" == "musllinux" ]; then
 else
     yum install -y fribidi
 fi
+
 if [ "${AUDITWHEEL_POLICY::9}" != "musllinux" ]; then
+  # TODO Update condition when NumPy supports free-threading
+  if [ $(python3 -c "import sysconfig;print(sysconfig.get_config_var('Py_GIL_DISABLED'))") == "1" ]; then
+    python3 -m pip install numpy --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+  else
     python3 -m pip install numpy
+  fi
 fi
 
 if [ ! -d "test-images-main" ]; then

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -129,6 +129,7 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
           CIBW_BUILD: ${{ matrix.build }}
+          CIBW_FREE_THREADED_SUPPORT: True
           CIBW_MANYLINUX_PYPY_X86_64_IMAGE: ${{ matrix.manylinux }}
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux }}
           CIBW_PRERELEASE_PYTHONS: True
@@ -201,6 +202,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
           CIBW_BEFORE_ALL: "{package}\\winbuild\\build\\build_dep_all.cmd"
           CIBW_CACHE_PATH: "C:\\cibw"
+          CIBW_FREE_THREADED_SUPPORT: True
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_TEST_SKIP: "*-win_arm64"
           CIBW_TEST_COMMAND: 'docker run --rm


### PR DESCRIPTION
Helps #8199

Does not build free-threaded wheels for aarch64. I guess that isn't supported yet by cibuildwheel.