### PR TITLE
Simplified code

### DIFF
--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -1315,8 +1315,7 @@ font_getvaraxes(FontObject *self) {
                     FT_Done_MM_Var(library, master);
                     return NULL;
                 }
-                PyDict_SetItemString(
-                    list_axis, "name", axis_name ? axis_name : Py_None);
+                PyDict_SetItemString(list_axis, "name", axis_name);
                 Py_DECREF(axis_name);
                 break;
             }


### PR DESCRIPTION
#8216 has changed the code to return early if `axis_name` is `NULL`.

https://github.com/python-pillow/Pillow/blob/6944e9e1831c621db296e4ba708b38e5be378995/src/_imagingft.c#L1311-L1319

So the ternary condition can be removed.