### PR TITLE
Temporarily disable cifuzz

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -24,6 +24,8 @@ concurrency:
 
 jobs:
   Fuzzing:
+    # Disabled until google/oss-fuzz#11419 upgrades Python to 3.9+
+    if: false
     runs-on: ubuntu-latest
     steps:
     - name: Build Fuzzers


### PR DESCRIPTION
While we have [dropped support for Python 3.8](https://github.com/python-pillow/Pillow/pull/8183), the[ cifuzz base image is still using it](https://github.com/google/oss-fuzz/pull/11401#issuecomment-1872050104).

Until https://github.com/google/oss-fuzz/issues/11419 is resolved by upgrading the Python version, this skips the cifuzz job.