### PR TITLE
Deprecate ImageMath lambda_eval and unsafe_eval options argument

### DIFF
--- a/Tests/test_imagemath_lambda_eval.py
+++ b/Tests/test_imagemath_lambda_eval.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from typing import Any
+
+import pytest
+
 from PIL import Image, ImageMath
 
 
@@ -19,7 +23,7 @@ I = Image.new("I", (1, 1), 4)  # noqa: E741
 A2 = A.resize((2, 2))
 B2 = B.resize((2, 2))
 
-images = {"A": A, "B": B, "F": F, "I": I}
+images: dict[str, Any] = {"A": A, "B": B, "F": F, "I": I}
 
 
 def test_sanity() -> None:
@@ -30,13 +34,13 @@ def test_sanity() -> None:
         == "I 3"
     )
     assert (
-        pixel(ImageMath.lambda_eval(lambda args: args["A"] + args["B"], images))
+        pixel(ImageMath.lambda_eval(lambda args: args["A"] + args["B"], **images))
         == "I 3"
     )
     assert (
         pixel(
             ImageMath.lambda_eval(
-                lambda args: args["float"](args["A"]) + args["B"], images
+                lambda args: args["float"](args["A"]) + args["B"], **images
             )
         )
         == "F 3.0"
@@ -44,42 +48,47 @@ def test_sanity() -> None:
     assert (
         pixel(
             ImageMath.lambda_eval(
-                lambda args: args["int"](args["float"](args["A"]) + args["B"]), images
+                lambda args: args["int"](args["float"](args["A"]) + args["B"]), **images
             )
         )
         == "I 3"
     )
 
 
+def test_options_deprecated() -> None:
+    with pytest.warns(DeprecationWarning):
+        assert ImageMath.lambda_eval(lambda args: 1, images) == 1
+
+
 def test_ops() -> None:
-    assert pixel(ImageMath.lambda_eval(lambda args: args["A"] * -1, images)) == "I -1"
+    assert pixel(ImageMath.lambda_eval(lambda args: args["A"] * -1, **images)) == "I -1"
 
     assert (
-        pixel(ImageMath.lambda_eval(lambda args: args["A"] + args["B"], images))
+        pixel(ImageMath.lambda_eval(lambda args: args["A"] + args["B"], **images))
         == "I 3"
     )
     assert (
-        pixel(ImageMath.lambda_eval(lambda args: args["A"] - args["B"], images))
+        pixel(ImageMath.lambda_eval(lambda args: args["A"] - args["B"], **images))
         == "I -1"
     )
     assert (
-        pixel(ImageMath.lambda_eval(lambda args: args["A"] * args["B"], images))
+        pixel(ImageMath.lambda_eval(lambda args: args["A"] * args["B"], **images))
         == "I 2"
     )
     assert (
-        pixel(ImageMath.lambda_eval(lambda args: args["A"] / args["B"], images))
+        pixel(ImageMath.lambda_eval(lambda args: args["A"] / args["B"], **images))
         == "I 0"
     )
-    assert pixel(ImageMath.lambda_eval(lambda args: args["B"] ** 2, images)) == "I 4"
+    assert pixel(ImageMath.lambda_eval(lambda args: args["B"] ** 2, **images)) == "I 4"
     assert (
-        pixel(ImageMath.lambda_eval(lambda args: args["B"] ** 33, images))
+        pixel(ImageMath.lambda_eval(lambda args: args["B"] ** 33, **images))
         == "I 2147483647"
     )
 
     assert (
         pixel(
             ImageMath.lambda_eval(
-                lambda args: args["float"](args["A"]) + args["B"], images
+                lambda args: args["float"](args["A"]) + args["B"], **images
             )
         )
         == "F 3.0"
@@ -87,7 +96,7 @@ def test_ops() -> None:
     assert (
         pixel(
             ImageMath.lambda_eval(
-                lambda args: args["float"](args["A"]) - args["B"], images
+                lambda args: args["float"](args["A"]) - args["B"], **images
             )
         )
         == "F -1.0"
@@ -95,7 +104,7 @@ def test_ops() -> None:
     assert (
         pixel(
             ImageMath.lambda_eval(
-                lambda args: args["float"](args["A"]) * args["B"], images
+                lambda args: args["float"](args["A"]) * args["B"], **images
             )
         )
         == "F 2.0"
@@ -103,31 +112,33 @@ def test_ops() -> None:
     assert (
         pixel(
             ImageMath.lambda_eval(
-                lambda args: args["float"](args["A"]) / args["B"], images
+                lambda args: args["float"](args["A"]) / args["B"], **images
             )
         )
         == "F 0.5"
     )
     assert (
-        pixel(ImageMath.lambda_eval(lambda args: args["float"](args["B"]) ** 2, images))
+        pixel(
+            ImageMath.lambda_eval(lambda args: args["float"](args["B"]) ** 2, **images)
+        )
         == "F 4.0"
     )
     assert (
         pixel(
-            ImageMath.lambda_eval(lambda args: args["float"](args["B"]) ** 33, images)
+            ImageMath.lambda_eval(lambda args: args["float"](args["B"]) ** 33, **images)
         )
         == "F 8589934592.0"
     )
 
 
 def test_logical() -> None:
-    assert pixel(ImageMath.lambda_eval(lambda args: not args["A"], images)) == 0
+    assert pixel(ImageMath.lambda_eval(lambda args: not args["A"], **images)) == 0
     assert (
-        pixel(ImageMath.lambda_eval(lambda args: args["A"] and args["B"], images))
+        pixel(ImageMath.lambda_eval(lambda args: args["A"] and args["B"], **images))
         == "L 2"
     )
     assert (
-        pixel(ImageMath.lambda_eval(lambda args: args["A"] or args["B"], images))
+        pixel(ImageMath.lambda_eval(lambda args: args["A"] or args["B"], **images))
         == "L 1"
     )
 
@@ -136,7 +147,7 @@ def test_convert() -> None:
     assert (
         pixel(
             ImageMath.lambda_eval(
-                lambda args: args["convert"](args["A"] + args["B"], "L"), images
+                lambda args: args["convert"](args["A"] + args["B"], "L"), **images
             )
         )
         == "L 3"
@@ -144,7 +155,7 @@ def test_convert() -> None:
     assert (
         pixel(
             ImageMath.lambda_eval(
-                lambda args: args["convert"](args["A"] + args["B"], "1"), images
+                lambda args: args["convert"](args["A"] + args["B"], "1"), **images
             )
         )
         == "1 0"
@@ -152,7 +163,7 @@ def test_convert() -> None:
     assert (
         pixel(
             ImageMath.lambda_eval(
-                lambda args: args["convert"](args["A"] + args["B"], "RGB"), images
+                lambda args: args["convert"](args["A"] + args["B"], "RGB"), **images
             )
         )
         == "RGB (3, 3, 3)"
@@ -163,7 +174,7 @@ def test_compare() -> None:
     assert (
         pixel(
             ImageMath.lambda_eval(
-                lambda args: args["min"](args["A"], args["B"]), images
+                lambda args: args["min"](args["A"], args["B"]), **images
             )
         )
         == "I 1"
@@ -171,13 +182,13 @@ def test_compare() -> None:
     assert (
         pixel(
             ImageMath.lambda_eval(
-                lambda args: args["max"](args["A"], args["B"]), images
+                lambda args: args["max"](args["A"], args["B"]), **images
             )
         )
         == "I 2"
     )
-    assert pixel(ImageMath.lambda_eval(lambda args: args["A"] == 1, images)) == "I 1"
-    assert pixel(ImageMath.lambda_eval(lambda args: args["A"] == 2, images)) == "I 0"
+    assert pixel(ImageMath.lambda_eval(lambda args: args["A"] == 1, **images)) == "I 1"
+    assert pixel(ImageMath.lambda_eval(lambda args: args["A"] == 2, **images)) == "I 0"
 
 
 def test_one_image_larger() -> None:

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -109,6 +109,15 @@ ImageDraw.getdraw hints parameter
 
 The ``hints`` parameter in :py:meth:`~PIL.ImageDraw.getdraw()` has been deprecated.
 
+ImageMath.lambda_eval and ImageMath.unsafe_eval options parameter
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. deprecated:: 11.0.0
+
+The ``options`` parameter in :py:meth:`~PIL.ImageMath.lambda_eval()` and
+:py:meth:`~PIL.ImageMath.unsafe_eval()` has been deprecated. One or more keyword
+arguments can be used instead.
+
 Removed features
 ----------------
 

--- a/docs/reference/ImageMath.rst
+++ b/docs/reference/ImageMath.rst
@@ -37,10 +37,10 @@ Example: Using the :py:mod:`~PIL.ImageMath` module
 
     :param expression: A function that receives a dictionary.
     :param options: Values to add to the function's dictionary, mapping image
-                    names to Image instances. You can use one or more keyword
-                    arguments instead of a dictionary, as shown in the above
-                    example. Note that the names must be valid Python
-                    identifiers.
+                    names to Image instances. Deprecated.
+                    You can instead use one or more keyword arguments, as
+                    shown in the above example. Note that the names must be
+                    valid Python identifiers.
     :return: An image, an integer value, a floating point value,
              or a pixel tuple, depending on the expression.
 
@@ -62,10 +62,10 @@ Example: Using the :py:mod:`~PIL.ImageMath` module
                        syntax. In addition to the standard operators, you can
                        also use the functions described below.
     :param options: Values to add to the function's dictionary, mapping image
-                    names to Image instances. You can use one or more keyword
-                    arguments instead of a dictionary, as shown in the above
-                    example. Note that the names must be valid Python
-                    identifiers.
+                    names to Image instances. Deprecated.
+                    You can instead use one or more keyword arguments, as
+                    shown in the above example. Note that the names must be
+                    valid Python identifiers.
     :return: An image, an integer value, a floating point value,
              or a pixel tuple, depending on the expression.
 

--- a/docs/reference/ImageMath.rst
+++ b/docs/reference/ImageMath.rst
@@ -31,20 +31,21 @@ Example: Using the :py:mod:`~PIL.ImageMath` module
               b=im2
             )
 
-.. py:function:: lambda_eval(expression, options)
+.. py:function:: lambda_eval(expression, options, **kw)
 
     Returns the result of an image function.
 
     :param expression: A function that receives a dictionary.
-    :param options: Values to add to the function's dictionary, mapping image
-                    names to Image instances. Deprecated.
+    :param options: Values to add to the function's dictionary. Note that the names
+                    must be valid Python identifiers. Deprecated.
                     You can instead use one or more keyword arguments, as
-                    shown in the above example. Note that the names must be
-                    valid Python identifiers.
+                    shown in the above example.
+    :param \**kw: Values to add to the function's dictionary, mapping image names to
+                 Image instances.
     :return: An image, an integer value, a floating point value,
              or a pixel tuple, depending on the expression.
 
-.. py:function:: unsafe_eval(expression, options)
+.. py:function:: unsafe_eval(expression, options, **kw)
 
     Evaluates an image expression.
 
@@ -61,11 +62,12 @@ Example: Using the :py:mod:`~PIL.ImageMath` module
     :param expression: A string which uses the standard Python expression
                        syntax. In addition to the standard operators, you can
                        also use the functions described below.
-    :param options: Values to add to the function's dictionary, mapping image
-                    names to Image instances. Deprecated.
+    :param options: Values to add to the evaluation context. Note that the names must
+                    be valid Python identifiers. Deprecated.
                     You can instead use one or more keyword arguments, as
-                    shown in the above example. Note that the names must be
-                    valid Python identifiers.
+                    shown in the above example.
+    :param \**kw: Values to add to the evaluation context, mapping image names to Image
+                 instances.
     :return: An image, an integer value, a floating point value,
              or a pixel tuple, depending on the expression.
 

--- a/docs/releasenotes/11.0.0.rst
+++ b/docs/releasenotes/11.0.0.rst
@@ -43,10 +43,12 @@ similarly removed.
 Deprecations
 ============
 
-TODO
-^^^^
+ImageMath.lambda_eval and ImageMath.unsafe_eval options parameter
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-TODO
+The ``options`` parameter in :py:meth:`~PIL.ImageMath.lambda_eval()` and
+:py:meth:`~PIL.ImageMath.unsafe_eval()` has been deprecated. One or more
+keyword arguments can be used instead.
 
 API Changes
 ===========

--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -249,13 +249,19 @@ def lambda_eval(
     :py:func:`~PIL.Image.merge` function.
 
     :param expression: A function that receives a dictionary.
-    :param options: Values to add to the function's dictionary. You
-                    can either use a dictionary, or one or more keyword
-                    arguments.
+    :param options: Values to add to the function's dictionary. Deprecated.
+                    You can instead use one or more keyword arguments.
     :return: The expression result. This is usually an image object, but can
              also be an integer, a floating point value, or a pixel tuple,
              depending on the expression.
     """
+
+    if options:
+        deprecate(
+            "ImageMath.lambda_eval options",
+            12,
+            "ImageMath.lambda_eval keyword arguments",
+        )
 
     args: dict[str, Any] = ops.copy()
     args.update(options)
@@ -287,13 +293,19 @@ def unsafe_eval(
     :py:func:`~PIL.Image.merge` function.
 
     :param expression: A string containing a Python-style expression.
-    :param options: Values to add to the evaluation context.  You
-                    can either use a dictionary, or one or more keyword
-                    arguments.
+    :param options: Values to add to the evaluation context. Deprecated.
+                    You can instead use one or more keyword arguments.
     :return: The evaluated expression. This is usually an image object, but can
              also be an integer, a floating point value, or a pixel tuple,
              depending on the expression.
     """
+
+    if options:
+        deprecate(
+            "ImageMath.unsafe_eval options",
+            12,
+            "ImageMath.unsafe_eval keyword arguments",
+        )
 
     # build execution namespace
     args: dict[str, Any] = ops.copy()

--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -251,6 +251,7 @@ def lambda_eval(
     :param expression: A function that receives a dictionary.
     :param options: Values to add to the function's dictionary. Deprecated.
                     You can instead use one or more keyword arguments.
+    :param **kw: Values to add to the function's dictionary.
     :return: The expression result. This is usually an image object, but can
              also be an integer, a floating point value, or a pixel tuple,
              depending on the expression.
@@ -295,6 +296,7 @@ def unsafe_eval(
     :param expression: A string containing a Python-style expression.
     :param options: Values to add to the evaluation context. Deprecated.
                     You can instead use one or more keyword arguments.
+    :param **kw: Values to add to the evaluation context.
     :return: The evaluated expression. This is usually an image object, but can
              also be an integer, a floating point value, or a pixel tuple,
              depending on the expression.


### PR DESCRIPTION
Suggested in https://github.com/python-pillow/Pillow/pull/8227#discussion_r1677553779

Deprecate ImageMath lambda_eval and unsafe_eval `options` argument, in favour of providing arguments through individual keywords instead.