### PR TITLE
Do not run scheduled wheel jobs on forks

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -97,6 +97,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   build-2-native-wheels:
+    if: github.event_name != 'schedule' || github.repository_owner == 'python-pillow'
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -150,6 +151,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   windows:
+    if: github.event_name != 'schedule' || github.repository_owner == 'python-pillow'
     name: Windows ${{ matrix.cibw_arch }}
     runs-on: windows-latest
     strategy:
@@ -256,7 +258,7 @@ jobs:
         path: dist/*.tar.gz
 
   scientific-python-nightly-wheels-publish:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.repository_owner == 'python-pillow' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     needs: [build-2-native-wheels, windows]
     runs-on: ubuntu-latest
     name: Upload wheels to scientific-python-nightly-wheels
@@ -273,7 +275,7 @@ jobs:
           anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
 
   pypi-publish:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    if: github.repository_owner == 'python-pillow' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     needs: [build-1-QEMU-emulated-wheels, build-2-native-wheels, windows, sdist]
     runs-on: ubuntu-latest
     name: Upload release to PyPI


### PR DESCRIPTION
Skip two more wheel builds on schedule, and only run the publish jobs in the main repository.

Fixes #8253. 