### PR TITLE
Support JPEG2000 RGBA palettes

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -391,6 +391,13 @@ def test_pclr() -> None:
         assert len(im.palette.colors) == 256
         assert im.palette.colors[(255, 255, 255)] == 0
 
+    with Image.open(
+        f"{EXTRA_DIR}/147af3f1083de4393666b7d99b01b58b_signal_sigsegv_130c531_6155_5136.jp2"
+    ) as im:
+        assert im.mode == "P"
+        assert len(im.palette.colors) == 139
+        assert im.palette.colors[(0, 0, 0, 0)] == 0
+
 
 def test_comment() -> None:
     with Image.open("Tests/images/comment.jp2") as im:

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -205,7 +205,7 @@ def _parse_jp2_header(
                 if bitdepth > max_bitdepth:
                     max_bitdepth = bitdepth
             if max_bitdepth <= 8:
-                palette = ImagePalette.ImagePalette()
+                palette = ImagePalette.ImagePalette("RGBA" if npc == 4 else "RGB")
                 for i in range(ne):
                     color: list[int] = []
                     for value in header.read_fields(">" + ("B" * npc)):


### PR DESCRIPTION
Resolves #8255

Page 7 of https://cdn.standards.iteh.ai/samples/36628/10393e6ddb5c4dbc9513ae89230d97f9/ISO-IEC-15444-1-2000-Cor-2-2002.pdf explains that `npc` is
> Number of components created by the application of the palette

When there are four components, this PR changes the palette to be RGBA.

Requires a test image from https://github.com/python-pillow/test-images/pull/5