### PR TITLE
Require font parameter in FreeTypeFont and truetype()

### DIFF
--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -203,7 +203,7 @@ class FreeTypeFont:
 
     def __init__(
         self,
-        font: StrOrBytesPath | BinaryIO | None = None,
+        font: StrOrBytesPath | BinaryIO,
         size: float = 10,
         index: int = 0,
         encoding: str = "",

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -756,7 +756,7 @@ def load(filename: str) -> ImageFont:
 
 
 def truetype(
-    font: StrOrBytesPath | BinaryIO | None = None,
+    font: StrOrBytesPath | BinaryIO,
     size: float = 10,
     index: int = 0,
     encoding: str = "",
@@ -827,7 +827,7 @@ def truetype(
     :exception ValueError: If the font size is not greater than zero.
     """
 
-    def freetype(font: StrOrBytesPath | BinaryIO | None) -> FreeTypeFont:
+    def freetype(font: StrOrBytesPath | BinaryIO) -> FreeTypeFont:
         return FreeTypeFont(font, size, index, encoding, layout_engine)
 
     try:


### PR DESCRIPTION
Currently, `font` is an optional parameter for `FreeTypeFont` and `truetype()`.

https://github.com/python-pillow/Pillow/blob/6dd4b3c826512b6e50f7343951bcb3650087119b/src/PIL/ImageFont.py#L198-L211

https://github.com/python-pillow/Pillow/blob/6dd4b3c826512b6e50f7343951bcb3650087119b/src/PIL/ImageFont.py#L758-L764

However, if it is `None`, then an error is raised.
```pytb
>>> from PIL import ImageFont
>>> ImageFont.FreeTypeFont()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/ImageFont.py", line 261, in __init__
    load_from_bytes(font)
  File "PIL/ImageFont.py", line 240, in load_from_bytes
    self.font_bytes = f.read()
AttributeError: 'NoneType' object has no attribute 'read'
```
```pytb
>>> from PIL import ImageFont
>>> ImageFont.truetype()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/ImageFont.py", line 834, in truetype
    return freetype(font)
  File "PIL/ImageFont.py", line 831, in freetype
    return FreeTypeFont(font, size, index, encoding, layout_engine)
  File "PIL/ImageFont.py", line 261, in __init__
    load_from_bytes(font)
  File "PIL/ImageFont.py", line 240, in load_from_bytes
    self.font_bytes = f.read()
AttributeError: 'NoneType' object has no attribute 'read'
```

This PR removes the defaults to make it required instead.