### PR TITLE
Improve ImageDraw2 shape methods

### DIFF
--- a/Tests/test_imagedraw2.py
+++ b/Tests/test_imagedraw2.py
@@ -66,6 +66,36 @@ def test_mode() -> None:
 
 
 @pytest.mark.parametrize("bbox", BBOX)
+@pytest.mark.parametrize("start, end", ((0, 180), (0.5, 180.4)))
+def test_arc(bbox: Coords, start: float, end: float) -> None:
+    # Arrange
+    im = Image.new("RGB", (W, H))
+    draw = ImageDraw2.Draw(im)
+    pen = ImageDraw2.Pen("white", width=1)
+
+    # Act
+    draw.arc(bbox, pen, start, end)
+
+    # Assert
+    assert_image_similar_tofile(im, "Tests/images/imagedraw_arc.png", 1)
+
+
+@pytest.mark.parametrize("bbox", BBOX)
+def test_chord(bbox: Coords) -> None:
+    # Arrange
+    im = Image.new("RGB", (W, H))
+    draw = ImageDraw2.Draw(im)
+    pen = ImageDraw2.Pen("yellow")
+    brush = ImageDraw2.Brush("red")
+
+    # Act
+    draw.chord(bbox, pen, 0, 180, brush)
+
+    # Assert
+    assert_image_similar_tofile(im, "Tests/images/imagedraw_chord_RGB.png", 1)
+
+
+@pytest.mark.parametrize("bbox", BBOX)
 def test_ellipse(bbox: Coords) -> None:
     # Arrange
     im = Image.new("RGB", (W, H))
@@ -121,6 +151,22 @@ def test_line_pen_as_brush(points: Coords) -> None:
 
     # Assert
     assert_image_equal_tofile(im, "Tests/images/imagedraw_line.png")
+
+
+@pytest.mark.parametrize("bbox", BBOX)
+@pytest.mark.parametrize("start, end", ((-92, 46), (-92.2, 46.2)))
+def test_pieslice(bbox: Coords, start: float, end: float) -> None:
+    # Arrange
+    im = Image.new("RGB", (W, H))
+    draw = ImageDraw2.Draw(im)
+    pen = ImageDraw2.Pen("blue")
+    brush = ImageDraw2.Brush("white")
+
+    # Act
+    draw.pieslice(bbox, pen, start, end, brush)
+
+    # Assert
+    assert_image_similar_tofile(im, "Tests/images/imagedraw_pieslice.png", 1)
 
 
 @pytest.mark.parametrize("points", POINTS)

--- a/src/PIL/ImageDraw2.py
+++ b/src/PIL/ImageDraw2.py
@@ -80,7 +80,12 @@ class Draw:
         return self.image
 
     def render(
-        self, op: str, xy: Coords, pen: Pen | Brush | None, brush: Brush | Pen | None = None
+        self,
+        op: str,
+        xy: Coords,
+        pen: Pen | Brush | None,
+        brush: Brush | Pen | None = None,
+        **kwargs: Any,
     ) -> None:
         # handle color arguments
         outline = fill = None
@@ -101,35 +106,51 @@ class Draw:
             path.transform(self.transform)
             xy = path
         # render the item
-        if op == "arc":
-            self.draw.arc(xy, fill=outline)
-        elif op == "line":
-            self.draw.line(xy, fill=outline, width=width)
+        if op in ("arc", "line"):
+            kwargs.setdefault("fill", outline)
         else:
-            getattr(self.draw, op)(xy, fill=fill, outline=outline)
+            kwargs.setdefault("fill", fill)
+            kwargs.setdefault("outline", outline)
+        if op == "line":
+            kwargs.setdefault("width", width)
+        getattr(self.draw, op)(xy, **kwargs)
 
     def settransform(self, offset: tuple[float, float]) -> None:
         """Sets a transformation offset."""
         (xoffset, yoffset) = offset
         self.transform = (1, 0, xoffset, 0, 1, yoffset)
 
-    def arc(self, xy: Coords, pen: Pen | Brush | None, start, end, *options: Any) -> None:
+    def arc(
+        self,
+        xy: Coords,
+        pen: Pen | Brush | None,
+        start: float,
+        end: float,
+        *options: Any,
+    ) -> None:
         """
         Draws an arc (a portion of a circle outline) between the start and end
         angles, inside the given bounding box.
 
         .. seealso:: :py:meth:`PIL.ImageDraw.ImageDraw.arc`
         """
-        self.render("arc", xy, pen, start, end, *options)
+        self.render("arc", xy, pen, *options, start=start, end=end)
 
-    def chord(self, xy: Coords, pen: Pen | Brush | None, start, end, *options: Any) -> None:
+    def chord(
+        self,
+        xy: Coords,
+        pen: Pen | Brush | None,
+        start: float,
+        end: float,
+        *options: Any,
+    ) -> None:
         """
         Same as :py:meth:`~PIL.ImageDraw2.Draw.arc`, but connects the end points
         with a straight line.
 
         .. seealso:: :py:meth:`PIL.ImageDraw.ImageDraw.chord`
         """
-        self.render("chord", xy, pen, start, end, *options)
+        self.render("chord", xy, pen, *options, start=start, end=end)
 
     def ellipse(self, xy: Coords, pen: Pen | Brush | None, *options: Any) -> None:
         """
@@ -147,14 +168,21 @@ class Draw:
         """
         self.render("line", xy, pen, *options)
 
-    def pieslice(self, xy: Coords, pen: Pen | Brush | None, start, end, *options: Any) -> None:
+    def pieslice(
+        self,
+        xy: Coords,
+        pen: Pen | Brush | None,
+        start: float,
+        end: float,
+        *options: Any,
+    ) -> None:
         """
         Same as arc, but also draws straight lines between the end points and the
         center of the bounding box.
 
         .. seealso:: :py:meth:`PIL.ImageDraw.ImageDraw.pieslice`
         """
-        self.render("pieslice", xy, pen, start, end, *options)
+        self.render("pieslice", xy, pen, *options, start=start, end=end)
 
     def polygon(self, xy: Coords, pen: Pen | Brush | None, *options: Any) -> None:
         """

--- a/src/PIL/ImageDraw2.py
+++ b/src/PIL/ImageDraw2.py
@@ -101,7 +101,9 @@ class Draw:
             path.transform(self.transform)
             xy = path
         # render the item
-        if op == "line":
+        if op == "arc":
+            self.draw.arc(xy, fill=outline)
+        elif op == "line":
             self.draw.line(xy, fill=outline, width=width)
         else:
             getattr(self.draw, op)(xy, fill=fill, outline=outline)

--- a/src/PIL/ImageDraw2.py
+++ b/src/PIL/ImageDraw2.py
@@ -80,7 +80,7 @@ class Draw:
         return self.image
 
     def render(
-        self, op: str, xy: Coords, pen: Pen | Brush, brush: Brush | Pen | None = None
+        self, op: str, xy: Coords, pen: Pen | Brush | None, brush: Brush | Pen | None = None
     ) -> None:
         # handle color arguments
         outline = fill = None
@@ -111,50 +111,50 @@ class Draw:
         (xoffset, yoffset) = offset
         self.transform = (1, 0, xoffset, 0, 1, yoffset)
 
-    def arc(self, xy: Coords, start, end, *options: Any) -> None:
+    def arc(self, xy: Coords, pen: Pen | Brush | None, start, end, *options: Any) -> None:
         """
         Draws an arc (a portion of a circle outline) between the start and end
         angles, inside the given bounding box.
 
         .. seealso:: :py:meth:`PIL.ImageDraw.ImageDraw.arc`
         """
-        self.render("arc", xy, start, end, *options)
+        self.render("arc", xy, pen, start, end, *options)
 
-    def chord(self, xy: Coords, start, end, *options: Any) -> None:
+    def chord(self, xy: Coords, pen: Pen | Brush | None, start, end, *options: Any) -> None:
         """
         Same as :py:meth:`~PIL.ImageDraw2.Draw.arc`, but connects the end points
         with a straight line.
 
         .. seealso:: :py:meth:`PIL.ImageDraw.ImageDraw.chord`
         """
-        self.render("chord", xy, start, end, *options)
+        self.render("chord", xy, pen, start, end, *options)
 
-    def ellipse(self, xy: Coords, *options: Any) -> None:
+    def ellipse(self, xy: Coords, pen: Pen | Brush | None, *options: Any) -> None:
         """
         Draws an ellipse inside the given bounding box.
 
         .. seealso:: :py:meth:`PIL.ImageDraw.ImageDraw.ellipse`
         """
-        self.render("ellipse", xy, *options)
+        self.render("ellipse", xy, pen, *options)
 
-    def line(self, xy: Coords, *options: Any) -> None:
+    def line(self, xy: Coords, pen: Pen | Brush | None, *options: Any) -> None:
         """
         Draws a line between the coordinates in the ``xy`` list.
 
         .. seealso:: :py:meth:`PIL.ImageDraw.ImageDraw.line`
         """
-        self.render("line", xy, *options)
+        self.render("line", xy, pen, *options)
 
-    def pieslice(self, xy: Coords, start, end, *options: Any) -> None:
+    def pieslice(self, xy: Coords, pen: Pen | Brush | None, start, end, *options: Any) -> None:
         """
         Same as arc, but also draws straight lines between the end points and the
         center of the bounding box.
 
         .. seealso:: :py:meth:`PIL.ImageDraw.ImageDraw.pieslice`
         """
-        self.render("pieslice", xy, start, end, *options)
+        self.render("pieslice", xy, pen, start, end, *options)
 
-    def polygon(self, xy: Coords, *options: Any) -> None:
+    def polygon(self, xy: Coords, pen: Pen | Brush | None, *options: Any) -> None:
         """
         Draws a polygon.
 
@@ -165,15 +165,15 @@ class Draw:
 
         .. seealso:: :py:meth:`PIL.ImageDraw.ImageDraw.polygon`
         """
-        self.render("polygon", xy, *options)
+        self.render("polygon", xy, pen, *options)
 
-    def rectangle(self, xy: Coords, *options: Any) -> None:
+    def rectangle(self, xy: Coords, pen: Pen | Brush | None, *options: Any) -> None:
         """
         Draws a rectangle.
 
         .. seealso:: :py:meth:`PIL.ImageDraw.ImageDraw.rectangle`
         """
-        self.render("rectangle", xy, *options)
+        self.render("rectangle", xy, pen, *options)
 
     def text(self, xy: tuple[float, float], text: AnyStr, font: Font) -> None:
         """


### PR DESCRIPTION
Some improvements to ImageDraw2.

1. You might think that ImageDraw2 `ellipse()` only requires `xy`,

https://github.com/python-pillow/Pillow/blob/8f62fbdf440b99cc087c19b58725ff266b76758d/src/PIL/ImageDraw2.py#L132

but that is not the case.

```python
from PIL import Image, ImageDraw2
im = Image.new("RGB", (100, 100))
d = ImageDraw2.Draw(im)
d.ellipse((0, 0, 100, 100))
```
gives
```pytb
Traceback (most recent call last):
  File "demo.py", line 4, in <module>
    d.ellipse((0, 0, 100, 100))
  File "PIL/ImageDraw2.py", line 138, in ellipse
    self.render("ellipse", xy, *options)
TypeError: render() missing 1 required positional argument: 'pen'
```

So I've made a change to add `pen` as a required argument to `arc()` and other methods.

Some of our test code does pass through `pen` as `None`, and uses the `brush` argument for the `Pen` instead.

https://github.com/python-pillow/Pillow/blob/8f62fbdf440b99cc087c19b58725ff266b76758d/Tests/test_imagedraw2.py#L115-L120

But even if `pen` is `None`, the fact that `brush` needs to come afterwards means that a value for `pen` is still required.

2. At the moment, ImageDraw2 `arc()` does not work.

https://github.com/python-pillow/Pillow/blob/8f62fbdf440b99cc087c19b58725ff266b76758d/src/PIL/ImageDraw2.py#L114

```pytb
>>> from PIL import Image, ImageDraw2
>>> im = Image.new("RGB", (1, 1))
>>> d = ImageDraw2.Draw(im)
>>> d.arc((0, 0), 0, 180)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/PIL/ImageDraw2.py", line 121, in arc
    self.render("arc", xy, start, end, *options)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/PIL/ImageDraw2.py", line 107, in render
    getattr(self.draw, op)(xy, fill=fill, outline=outline)
TypeError: arc() got an unexpected keyword argument 'outline'
```

This is because ImageDraw2 `render()` passes `outline` to every method except for `line()`, but ImageDraw `arc()` doesn't accept that.

https://github.com/python-pillow/Pillow/blob/8f62fbdf440b99cc087c19b58725ff266b76758d/src/PIL/ImageDraw2.py#L104-L107

https://github.com/python-pillow/Pillow/blob/8f62fbdf440b99cc087c19b58725ff266b76758d/src/PIL/ImageDraw.py#L174-L181

I've made a change for that.

3. You will also notice in the above code that the required `start` and `end` parameters aren't passed through to ImageDraw. I've added `**kwargs` to `render()` to allow them to be added.