### PR TITLE
Deprecate JpegImageFile huffman_ac and huffman_dc

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -1045,6 +1045,13 @@ class TestFileJpeg:
 
         assert im._repr_jpeg_() is None
 
+    def test_deprecation(self) -> None:
+        with Image.open(TEST_FILE) as im:
+            with pytest.warns(DeprecationWarning):
+                assert im.huffman_ac == {}
+            with pytest.warns(DeprecationWarning):
+                assert im.huffman_dc == {}
+
 
 @pytest.mark.skipif(not is_win32(), reason="Windows only")
 @skip_unless_feature("jpg")

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -118,6 +118,14 @@ The ``options`` parameter in :py:meth:`~PIL.ImageMath.lambda_eval()` and
 :py:meth:`~PIL.ImageMath.unsafe_eval()` has been deprecated. One or more keyword
 arguments can be used instead.
 
+JpegImageFile.huffman_ac and JpegImageFile.huffman_dc
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. deprecated:: 11.0.0
+
+The ``huffman_ac`` and ``huffman_dc`` dictionaries on JPEG images were unused, and have
+been deprecated.
+
 Removed features
 ----------------
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -123,8 +123,8 @@ JpegImageFile.huffman_ac and JpegImageFile.huffman_dc
 
 .. deprecated:: 11.0.0
 
-The ``huffman_ac`` and ``huffman_dc`` dictionaries on JPEG images were unused, and have
-been deprecated.
+The ``huffman_ac`` and ``huffman_dc`` dictionaries on JPEG images were unused. They
+have been deprecated, and will be removed in Pillow 12 (2025-10-15).
 
 Removed features
 ----------------

--- a/docs/releasenotes/11.0.0.rst
+++ b/docs/releasenotes/11.0.0.rst
@@ -50,6 +50,14 @@ The ``options`` parameter in :py:meth:`~PIL.ImageMath.lambda_eval()` and
 :py:meth:`~PIL.ImageMath.unsafe_eval()` has been deprecated. One or more
 keyword arguments can be used instead.
 
+JpegImageFile.huffman_ac and JpegImageFile.huffman_dc
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. deprecated:: 11.0.0
+
+The ``huffman_ac`` and ``huffman_dc`` dictionaries on JPEG images were unused, and have
+been deprecated.
+
 API Changes
 ===========
 

--- a/docs/releasenotes/11.0.0.rst
+++ b/docs/releasenotes/11.0.0.rst
@@ -55,8 +55,8 @@ JpegImageFile.huffman_ac and JpegImageFile.huffman_dc
 
 .. deprecated:: 11.0.0
 
-The ``huffman_ac`` and ``huffman_dc`` dictionaries on JPEG images were unused, and have
-been deprecated.
+The ``huffman_ac`` and ``huffman_dc`` dictionaries on JPEG images were unused. They
+have been deprecated, and will be removed in Pillow 12 (2025-10-15).
 
 API Changes
 ===========

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -49,6 +49,7 @@ from ._binary import i16be as i16
 from ._binary import i32be as i32
 from ._binary import o8
 from ._binary import o16be as o16
+from ._deprecate import deprecate
 from .JpegPresets import presets
 
 if TYPE_CHECKING:
@@ -346,8 +347,8 @@ class JpegImageFile(ImageFile.ImageFile):
 
         # JPEG specifics (internal)
         self.layer: list[tuple[int, int, int, int]] = []
-        self.huffman_dc: dict[Any, Any] = {}
-        self.huffman_ac: dict[Any, Any] = {}
+        self._huffman_dc: dict[Any, Any] = {}
+        self._huffman_ac: dict[Any, Any] = {}
         self.quantization: dict[int, list[int]] = {}
         self.app: dict[str, bytes] = {}  # compatibility
         self.applist: list[tuple[str, bytes]] = []
@@ -385,6 +386,12 @@ class JpegImageFile(ImageFile.ImageFile):
                 raise SyntaxError(msg)
 
         self._read_dpi_from_exif()
+
+    def __getattr__(self, name: str) -> Any:
+        if name in ("huffman_ac", "huffman_dc"):
+            deprecate(name, 12)
+            return getattr(self, "_" + name)
+        raise AttributeError(name)
 
     def load_read(self, read_bytes: int) -> bytes:
         """


### PR DESCRIPTION
These dictionaries have been unused since PIL, so let's deprecate them.

https://github.com/python-pillow/Pillow/blob/4df4df2a18ded44811be786703a43c3460cb3bc9/src/PIL/JpegImagePlugin.py#L349-L350