### PR TITLE
Added writing XMP bytes to JPEG

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -995,11 +995,13 @@ class TestFileJpeg:
         f = str(tmp_path / "temp.jpg")
         im = hopper()
         im.save(f, xmp=b"XMP test")
-
         with Image.open(f) as reloaded:
             assert reloaded.info["xmp"] == b"XMP test"
 
-        im.save(f, xmp=b"1" * 65504)
+        im.info["xmp"] = b"1" * 65504
+        im.save(f)
+        with Image.open(f) as reloaded:
+            assert reloaded.info["xmp"] == b"1" * 65504
 
         with pytest.raises(ValueError):
             im.save(f, xmp=b"1" * 65505)

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -991,6 +991,13 @@ class TestFileJpeg:
             else:
                 assert im.getxmp() == {"xmpmeta": None}
 
+    def test_save_xmp(self, tmp_path: Path) -> None:
+        f = str(tmp_path / "temp.jpg")
+        hopper().save(f, xmp=b"XMP test")
+
+        with Image.open(f) as reloaded:
+            assert reloaded.info["xmp"] == b"XMP test"
+
     @pytest.mark.timeout(timeout=1)
     def test_eof(self) -> None:
         # Even though this decoder never says that it is finished

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -993,10 +993,16 @@ class TestFileJpeg:
 
     def test_save_xmp(self, tmp_path: Path) -> None:
         f = str(tmp_path / "temp.jpg")
-        hopper().save(f, xmp=b"XMP test")
+        im = hopper()
+        im.save(f, xmp=b"XMP test")
 
         with Image.open(f) as reloaded:
             assert reloaded.info["xmp"] == b"XMP test"
+
+        im.save(f, xmp=b"1" * 65504)
+
+        with pytest.raises(ValueError):
+            im.save(f, xmp=b"1" * 65505)
 
     @pytest.mark.timeout(timeout=1)
     def test_eof(self) -> None:

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -747,7 +747,7 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
     extra = info.get("extra", b"")
 
     MAX_BYTES_IN_MARKER = 65533
-    xmp = info.get("xmp")
+    xmp = info.get("xmp", im.info.get("xmp"))
     if xmp:
         overhead_len = 29  # b"http://ns.adobe.com/xap/1.0/\x00"
         max_data_bytes_in_marker = MAX_BYTES_IN_MARKER - overhead_len

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -746,23 +746,28 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
 
     extra = info.get("extra", b"")
 
+    MAX_BYTES_IN_MARKER = 65533
     xmp = info.get("xmp")
     if xmp:
-        size = o16(31 + len(xmp))
+        overhead_len = 29
+        max_data_bytes_in_marker = MAX_BYTES_IN_MARKER - overhead_len
+        if len(xmp) > max_data_bytes_in_marker:
+            msg = "XMP data is too long"
+            raise ValueError(msg)
+        size = o16(2 + overhead_len + len(xmp))
         extra += b"\xFF\xE1" + size + b"http://ns.adobe.com/xap/1.0/\x00" + xmp
 
-    MAX_BYTES_IN_MARKER = 65533
     icc_profile = info.get("icc_profile")
     if icc_profile:
-        ICC_OVERHEAD_LEN = 14
-        MAX_DATA_BYTES_IN_MARKER = MAX_BYTES_IN_MARKER - ICC_OVERHEAD_LEN
+        overhead_len = 14
+        max_data_bytes_in_marker = MAX_BYTES_IN_MARKER - overhead_len
         markers = []
         while icc_profile:
-            markers.append(icc_profile[:MAX_DATA_BYTES_IN_MARKER])
-            icc_profile = icc_profile[MAX_DATA_BYTES_IN_MARKER:]
+            markers.append(icc_profile[:max_data_bytes_in_marker])
+            icc_profile = icc_profile[max_data_bytes_in_marker:]
         i = 1
         for marker in markers:
-            size = o16(2 + ICC_OVERHEAD_LEN + len(marker))
+            size = o16(2 + overhead_len + len(marker))
             extra += (
                 b"\xFF\xE2"
                 + size

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -749,7 +749,7 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
     MAX_BYTES_IN_MARKER = 65533
     xmp = info.get("xmp")
     if xmp:
-        overhead_len = 29
+        overhead_len = 29  # b"http://ns.adobe.com/xap/1.0/\x00"
         max_data_bytes_in_marker = MAX_BYTES_IN_MARKER - overhead_len
         if len(xmp) > max_data_bytes_in_marker:
             msg = "XMP data is too long"
@@ -759,7 +759,7 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
 
     icc_profile = info.get("icc_profile")
     if icc_profile:
-        overhead_len = 14
+        overhead_len = 14  # b"ICC_PROFILE\0" + o8(i) + o8(len(markers))
         max_data_bytes_in_marker = MAX_BYTES_IN_MARKER - overhead_len
         markers = []
         while icc_profile:

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -746,6 +746,11 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
 
     extra = info.get("extra", b"")
 
+    xmp = info.get("xmp")
+    if xmp:
+        size = o16(31 + len(xmp))
+        extra += b"\xFF\xE1" + size + b"http://ns.adobe.com/xap/1.0/\x00" + xmp
+
     MAX_BYTES_IN_MARKER = 65533
     icc_profile = info.get("icc_profile")
     if icc_profile:


### PR DESCRIPTION
Resolves #8283, allowing XMP data to be saved to JPEG files, either by
```python
im.save("out.jpg", xmp=b"test")
```
or
```python
im.info["xmp"] = b"test"
im.save("out.jpg")
```