### PR TITLE
Move auxiliary mypy requirements to a requirements file

### DIFF
--- a/.ci/requirements-mypy.txt
+++ b/.ci/requirements-mypy.txt
@@ -1,1 +1,10 @@
 mypy==1.11.1
+IceSpringPySideStubs-PyQt6
+IceSpringPySideStubs-PySide6
+ipython
+numpy
+packaging
+pytest
+types-defusedxml
+types-olefile
+types-setuptools

--- a/tox.ini
+++ b/tox.ini
@@ -33,15 +33,6 @@ commands =
 skip_install = true
 deps =
     -r .ci/requirements-mypy.txt
-    IceSpringPySideStubs-PyQt6
-    IceSpringPySideStubs-PySide6
-    ipython
-    numpy
-    packaging
-    pytest
-    types-defusedxml
-    types-olefile
-    types-setuptools
 extras =
     typing
 commands =


### PR DESCRIPTION
For easier installation of those requirements outside tox.