### PR TITLE
Parametrize some color_lut tests for DRYness

### DIFF
--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -106,39 +106,39 @@ class TestColorLut3DCoreAPI:
             im.im.color_lut_3d("RGB", Image.Resampling.BILINEAR, 3, 2, 2, 2, 16)
 
     @pytest.mark.parametrize(
-        "lut_mode, table_size",
+        "lut_mode, table_channels, table_size",
         [
-            ("RGB", (3, 3)),
-            ("CMYK", (4, 3)),
-            ("RGB", (3, (2, 3, 3))),
-            ("RGB", (3, (65, 3, 3))),
-            ("RGB", (3, (3, 65, 3))),
-            ("RGB", (3, (3, 3, 65))),
+            ("RGB", 3, 3),
+            ("CMYK", 4, 3),
+            ("RGB", 3, (2, 3, 3)),
+            ("RGB", 3, (65, 3, 3)),
+            ("RGB", 3, (3, 65, 3)),
+            ("RGB", 3, (2, 3, 65)),
         ],
     )
     def test_correct_args(
-        self, lut_mode: str, table_size: tuple[int, int | tuple[int, int, int]]
+        self, lut_mode: str, table_channels: int, table_size: int | tuple[int, int, int]
     ) -> None:
         im = Image.new("RGB", (10, 10), 0)
         assert im.im is not None
         im.im.color_lut_3d(
             lut_mode,
             Image.Resampling.BILINEAR,
-            *self.generate_identity_table(*table_size),
+            *self.generate_identity_table(table_channels, table_size),
         )
 
     @pytest.mark.parametrize(
-        "image_mode, lut_mode, table_size",
+        "image_mode, lut_mode, table_channels, table_size",
         [
-            ("L", "RGB", (3, 3)),
-            ("RGB", "L", (3, 3)),
-            ("L", "L", (3, 3)),
-            ("RGB", "RGBA", (3, 3)),
-            ("RGB", "RGB", (4, 3)),
+            ("L", "RGB", 3, 3),
+            ("RGB", "L", 3, 3),
+            ("L", "L", 3, 3),
+            ("RGB", "RGBA", 3, 3),
+            ("RGB", "RGB", 4, 3),
         ],
     )
     def test_wrong_mode(
-        self, image_mode: str, lut_mode: str, table_size: tuple[int, int]
+        self, image_mode: str, lut_mode: str, table_channels: int, table_size: int
     ) -> None:
         with pytest.raises(ValueError, match="wrong mode"):
             im = Image.new(image_mode, (10, 10), 0)
@@ -146,27 +146,27 @@ class TestColorLut3DCoreAPI:
             im.im.color_lut_3d(
                 lut_mode,
                 Image.Resampling.BILINEAR,
-                *self.generate_identity_table(*table_size),
+                *self.generate_identity_table(table_channels, table_size),
             )
 
     @pytest.mark.parametrize(
-        "image_mode, lut_mode, table_size",
+        "image_mode, lut_mode, table_channels, table_size",
         [
-            ("RGBA", "RGBA", (3, 3)),
-            ("RGBA", "RGBA", (4, 3)),
-            ("RGB", "HSV", (3, 3)),
-            ("RGB", "RGBA", (4, 3)),
+            ("RGBA", "RGBA", 3, 3),
+            ("RGBA", "RGBA", 4, 3),
+            ("RGB", "HSV", 3, 3),
+            ("RGB", "RGBA", 4, 3),
         ],
     )
     def test_correct_mode(
-        self, image_mode: str, lut_mode: str, table_size: tuple[int, int]
+        self, image_mode: str, lut_mode: str, table_channels: int, table_size: int
     ) -> None:
         im = Image.new(image_mode, (10, 10), 0)
         assert im.im is not None
         im.im.color_lut_3d(
             lut_mode,
             Image.Resampling.BILINEAR,
-            *self.generate_identity_table(*table_size),
+            *self.generate_identity_table(table_channels, table_size),
         )
 
     def test_identities(self) -> None:

--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -106,7 +106,7 @@ class TestColorLut3DCoreAPI:
             im.im.color_lut_3d("RGB", Image.Resampling.BILINEAR, 3, 2, 2, 2, 16)
 
     @pytest.mark.parametrize(
-        ("lut_mode", "table_size"),
+        "lut_mode, table_size",
         [
             ("RGB", (3, 3)),
             ("CMYK", (4, 3)),
@@ -128,7 +128,7 @@ class TestColorLut3DCoreAPI:
         )
 
     @pytest.mark.parametrize(
-        ("image_mode", "lut_mode", "table_size"),
+        "image_mode, lut_mode, table_size",
         [
             ("L", "RGB", (3, 3)),
             ("RGB", "L", (3, 3)),
@@ -150,7 +150,7 @@ class TestColorLut3DCoreAPI:
             )
 
     @pytest.mark.parametrize(
-        ("image_mode", "lut_mode", "table_size"),
+        "image_mode, lut_mode, table_size",
         [
             ("RGBA", "RGBA", (3, 3)),
             ("RGBA", "RGBA", (4, 3)),

--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -152,7 +152,7 @@ class TestColorLut3DCoreAPI:
     @pytest.mark.parametrize(
         ("image_mode", "lut_mode", "table_size"),
         [
-            ("RGBA", "RGB", (3, 3)),
+            ("RGBA", "RGBA", (3, 3)),
             ("RGBA", "RGBA", (4, 3)),
             ("RGB", "HSV", (3, 3)),
             ("RGB", "RGBA", (4, 3)),

--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -105,91 +105,68 @@ class TestColorLut3DCoreAPI:
         with pytest.raises(TypeError):
             im.im.color_lut_3d("RGB", Image.Resampling.BILINEAR, 3, 2, 2, 2, 16)
 
-    def test_correct_args(self) -> None:
+    @pytest.mark.parametrize(
+        ("lut_mode", "table_size"),
+        [
+            ("RGB", (3, 3)),
+            ("CMYK", (4, 3)),
+            ("RGB", (3, (2, 3, 3))),
+            ("RGB", (3, (65, 3, 3))),
+            ("RGB", (3, (3, 65, 3))),
+            ("RGB", (3, (3, 3, 65))),
+        ],
+    )
+    def test_correct_args(
+        self, lut_mode: str, table_size: tuple[int, int | tuple[int, int, int]]
+    ) -> None:
         im = Image.new("RGB", (10, 10), 0)
-
+        assert im.im is not None
         im.im.color_lut_3d(
-            "RGB", Image.Resampling.BILINEAR, *self.generate_identity_table(3, 3)
-        )
-
-        im.im.color_lut_3d(
-            "CMYK", Image.Resampling.BILINEAR, *self.generate_identity_table(4, 3)
-        )
-
-        im.im.color_lut_3d(
-            "RGB",
+            lut_mode,
             Image.Resampling.BILINEAR,
-            *self.generate_identity_table(3, (2, 3, 3)),
+            *self.generate_identity_table(*table_size),
         )
 
+    @pytest.mark.parametrize(
+        ("image_mode", "lut_mode", "table_size"),
+        [
+            ("L", "RGB", (3, 3)),
+            ("RGB", "L", (3, 3)),
+            ("L", "L", (3, 3)),
+            ("RGB", "RGBA", (3, 3)),
+            ("RGB", "RGB", (4, 3)),
+        ],
+    )
+    def test_wrong_mode(
+        self, image_mode: str, lut_mode: str, table_size: tuple[int, int]
+    ) -> None:
+        with pytest.raises(ValueError, match="wrong mode"):
+            im = Image.new(image_mode, (10, 10), 0)
+            assert im.im is not None
+            im.im.color_lut_3d(
+                lut_mode,
+                Image.Resampling.BILINEAR,
+                *self.generate_identity_table(*table_size),
+            )
+
+    @pytest.mark.parametrize(
+        ("image_mode", "lut_mode", "table_size"),
+        [
+            ("RGBA", "RGB", (3, 3)),
+            ("RGBA", "RGBA", (4, 3)),
+            ("RGB", "HSV", (3, 3)),
+            ("RGB", "RGBA", (4, 3)),
+        ],
+    )
+    def test_correct_mode(
+        self, image_mode: str, lut_mode: str, table_size: tuple[int, int]
+    ) -> None:
+        im = Image.new(image_mode, (10, 10), 0)
+        assert im.im is not None
         im.im.color_lut_3d(
-            "RGB",
+            lut_mode,
             Image.Resampling.BILINEAR,
-            *self.generate_identity_table(3, (65, 3, 3)),
-        )
-
-        im.im.color_lut_3d(
-            "RGB",
-            Image.Resampling.BILINEAR,
-            *self.generate_identity_table(3, (3, 65, 3)),
-        )
-
-        im.im.color_lut_3d(
-            "RGB",
-            Image.Resampling.BILINEAR,
-            *self.generate_identity_table(3, (3, 3, 65)),
-        )
-
-    def test_wrong_mode(self) -> None:
-        with pytest.raises(ValueError, match="wrong mode"):
-            im = Image.new("L", (10, 10), 0)
-            im.im.color_lut_3d(
-                "RGB", Image.Resampling.BILINEAR, *self.generate_identity_table(3, 3)
-            )
-
-        with pytest.raises(ValueError, match="wrong mode"):
-            im = Image.new("RGB", (10, 10), 0)
-            im.im.color_lut_3d(
-                "L", Image.Resampling.BILINEAR, *self.generate_identity_table(3, 3)
-            )
-
-        with pytest.raises(ValueError, match="wrong mode"):
-            im = Image.new("L", (10, 10), 0)
-            im.im.color_lut_3d(
-                "L", Image.Resampling.BILINEAR, *self.generate_identity_table(3, 3)
-            )
-
-        with pytest.raises(ValueError, match="wrong mode"):
-            im = Image.new("RGB", (10, 10), 0)
-            im.im.color_lut_3d(
-                "RGBA", Image.Resampling.BILINEAR, *self.generate_identity_table(3, 3)
-            )
-
-        with pytest.raises(ValueError, match="wrong mode"):
-            im = Image.new("RGB", (10, 10), 0)
-            im.im.color_lut_3d(
-                "RGB", Image.Resampling.BILINEAR, *self.generate_identity_table(4, 3)
-            )
-
-    def test_correct_mode(self) -> None:
-        im = Image.new("RGBA", (10, 10), 0)
-        im.im.color_lut_3d(
-            "RGBA", Image.Resampling.BILINEAR, *self.generate_identity_table(3, 3)
-        )
-
-        im = Image.new("RGBA", (10, 10), 0)
-        im.im.color_lut_3d(
-            "RGBA", Image.Resampling.BILINEAR, *self.generate_identity_table(4, 3)
-        )
-
-        im = Image.new("RGB", (10, 10), 0)
-        im.im.color_lut_3d(
-            "HSV", Image.Resampling.BILINEAR, *self.generate_identity_table(3, 3)
-        )
-
-        im = Image.new("RGB", (10, 10), 0)
-        im.im.color_lut_3d(
-            "RGBA", Image.Resampling.BILINEAR, *self.generate_identity_table(4, 3)
+            *self.generate_identity_table(*table_size),
         )
 
     def test_identities(self) -> None:


### PR DESCRIPTION
Refs #8279.

These tests were doing the same repeated call with slightly differing arguments, so might as well use `parametrize` for less repetition (and so #8279 wouldn't need as many `assert`s).

I can rebase this afterwards if #8279 should get merged first :)