### PR TITLE
Fixed sign comparison warning

### DIFF
--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -1243,7 +1243,7 @@ font_getvarnames(FontObject *self) {
         return PyErr_NoMemory();
     }
 
-    for (int i = 0; i < num_namedstyles; i++) {
+    for (unsigned int i = 0; i < num_namedstyles; i++) {
         list_names_filled[i] = 0;
     }
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/10280498668/job/28447977337#step:11:240

>   src/_imagingft.c:1246:23: warning: comparison of integers of different signs: 'int' and 'FT_UInt' (aka 'unsigned int') [-Wsign-compare]
>       for (int i = 0; i < num_namedstyles; i++) {
>                       ~ ^ ~~~~~~~~~~~~~~~
>   1 warning generated.
>   src/_imagingft.c:1246:23: warning: comparison of integers of different signs: 'int' and 'FT_UInt' (aka 'unsigned int') [-Wsign-compare]
>       for (int i = 0; i < num_namedstyles; i++) {
>                       ~ ^ ~~~~~~~~~~~~~~~