### PR TITLE
Enforce CSV names style for `pytest.mark.parametrize`

### DIFF
--- a/Tests/test_file_dds.py
+++ b/Tests/test_file_dds.py
@@ -152,7 +152,7 @@ def test_sanity_ati2_bc5u(image_path: str) -> None:
 
 
 @pytest.mark.parametrize(
-    ("image_path", "expected_path"),
+    "image_path, expected_path",
     (
         # hexeditted to be typeless
         (TEST_FILE_DX10_BC5_TYPELESS, TEST_FILE_DX10_BC5_UNORM),
@@ -248,7 +248,7 @@ def test_dx10_r8g8b8a8_unorm_srgb() -> None:
 
 
 @pytest.mark.parametrize(
-    ("mode", "size", "test_file"),
+    "mode, size, test_file",
     [
         ("L", (128, 128), TEST_FILE_UNCOMPRESSED_L),
         ("LA", (128, 128), TEST_FILE_UNCOMPRESSED_L_WITH_ALPHA),
@@ -373,7 +373,7 @@ def test_save_unsupported_mode(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    ("mode", "test_file"),
+    "mode, test_file",
     [
         ("L", "Tests/images/linear_gradient.png"),
         ("LA", "Tests/images/uncompressed_la.png"),

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -80,9 +80,7 @@ simple_eps_file_with_long_binary_data = (
 
 
 @pytest.mark.skipif(not HAS_GHOSTSCRIPT, reason="Ghostscript not available")
-@pytest.mark.parametrize(
-    ("filename", "size"), ((FILE1, (460, 352)), (FILE2, (360, 252)))
-)
+@pytest.mark.parametrize("filename, size", ((FILE1, (460, 352)), (FILE2, (360, 252))))
 @pytest.mark.parametrize("scale", (1, 2))
 def test_sanity(filename: str, size: tuple[int, int], scale: int) -> None:
     expected_size = tuple(s * scale for s in size)

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -230,7 +230,7 @@ class TestImagePutPixelError:
                 im.putpixel((0, 0), v)  # type: ignore[arg-type]
 
     @pytest.mark.parametrize(
-        ("mode", "band_numbers", "match"),
+        "mode, band_numbers, match",
         (
             ("L", (0, 2), "color must be int or single-element tuple"),
             ("LA", (0, 3), "color must be int, or tuple of one or two elements"),

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -46,7 +46,7 @@ def helper_pickle_string(protocol: int, test_file: str, mode: str | None) -> Non
 
 
 @pytest.mark.parametrize(
-    ("test_file", "test_mode"),
+    "test_file, test_mode",
     [
         ("Tests/images/hopper.jpg", None),
         ("Tests/images/hopper.jpg", "L"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,6 @@ lint.per-file-ignores."Tests/oss-fuzz/fuzz_pillow.py" = [
   "I002",
 ]
 lint.flake8-pytest-style.parametrize-names-type = "csv"
-
 lint.isort.known-first-party = [
   "PIL",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ lint.select = [
   "ISC",    # flake8-implicit-str-concat
   "LOG",    # flake8-logging
   "PGH",    # pygrep-hooks
+  "PT006",  # pytest-parametrize-names-wrong-type
   "PYI",    # flake8-pyi
   "RUF100", # unused noqa (yesqa)
   "UP",     # pyupgrade
@@ -129,6 +130,8 @@ lint.per-file-ignores."Tests/oss-fuzz/fuzz_font.py" = [
 lint.per-file-ignores."Tests/oss-fuzz/fuzz_pillow.py" = [
   "I002",
 ]
+lint.flake8-pytest-style.parametrize-names-type = "csv"
+
 lint.isort.known-first-party = [
   "PIL",
 ]


### PR DESCRIPTION
As mentioned by @radarhere in 
https://github.com/akx/Pillow/pull/7, Pillow's `pytest.mark.parametrize` house style is `csv` – this configures Ruff to enforce that and fixes the stray tuples.

* Ruff rule reference: https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/