### PR TITLE
Updated oss-fuzz to Python 3.10

### DIFF
--- a/Tests/oss-fuzz/python.supp
+++ b/Tests/oss-fuzz/python.supp
@@ -1,5 +1,5 @@
 {
-   <py3_8_encode_current_locale>
+   <py3_10_encode_current_locale>
    Memcheck:Cond
    ...
    fun:encode_current_locale


### PR DESCRIPTION
While we have [dropped support for Python 3.8](https://github.com/python-pillow/Pillow/pull/8183), the[ cifuzz base image is still using it](https://github.com/google/oss-fuzz/pull/11401#issuecomment-1872050104).

https://github.com/google/oss-fuzz/issues/11419 suggests upgrading their Python version to 3.10.

This PR updates a reference in our oss-fuzz code to use Python 3.10.