### PR TITLE
Log value from tag_v2 instead of tag

### DIFF
--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1393,7 +1393,7 @@ class TiffImageFile(ImageFile.ImageFile):
         logger.debug("- photometric_interpretation: %s", photo)
         logger.debug("- planar_configuration: %s", self._planar_configuration)
         logger.debug("- fill_order: %s", fillorder)
-        logger.debug("- YCbCr subsampling: %s", self.tag.get(YCBCRSUBSAMPLING))
+        logger.debug("- YCbCr subsampling: %s", self.tag_v2.get(YCBCRSUBSAMPLING))
 
         # size
         xsize = int(self.tag_v2.get(IMAGEWIDTH))


### PR DESCRIPTION
Move from the legacy `tag` to the more recent  `tag_v2` in a logging statement in TiffImagePlugin.