### PR TITLE
Check text is either string or bytes

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -1113,6 +1113,9 @@ def test_bytes(font: ImageFont.FreeTypeFont) -> None:
     )
     assert font.getmask2(b"test")[1] == font.getmask2("test")[1]
 
+    with pytest.raises(TypeError):
+        font.getlength((0, 0))  # type: ignore[arg-type]
+
 
 @pytest.mark.parametrize(
     "test_file",

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -272,7 +272,7 @@ text_layout_raqm(
         }
         set_text = raqm_set_text(rq, text, size);
         PyMem_Free(text);
-    } else {
+    } else if (PyBytes_Check(string)) {
         char *buffer;
         PyBytes_AsStringAndSize(string, &buffer, &size);
         if (!buffer || !size) {
@@ -281,6 +281,9 @@ text_layout_raqm(
             goto failed;
         }
         set_text = raqm_set_text_utf8(rq, buffer, size);
+    } else {
+        PyErr_SetString(PyExc_TypeError, "expected string or bytes");
+        goto failed;
     }
     if (!set_text) {
         PyErr_SetString(PyExc_ValueError, "raqm_set_text() failed");
@@ -425,8 +428,11 @@ text_layout_fallback(
 
     if (PyUnicode_Check(string)) {
         count = PyUnicode_GET_LENGTH(string);
-    } else {
+    } else if (PyBytes_Check(string)) {
         PyBytes_AsStringAndSize(string, &buffer, &count);
+    } else {
+        PyErr_SetString(PyExc_TypeError, "expected string or bytes");
+        return 0;
     }
     if (count == 0) {
         return 0;


### PR DESCRIPTION
Resolves #8307

When #8141 added support for bytes in FreeTypeFont, it presumed that the text would be either a string or bytes.

This raises an error if neither are the case.