### PR TITLE
Lint: run more flake8-pytest-style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.6
+    rev: v0.6.0
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
 
@@ -67,7 +67,7 @@ repos:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.18
+    rev: v0.19
     hooks:
       - id: validate-pyproject
 

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -1019,13 +1019,16 @@ class TestFileJpeg:
 
         # SOI, EOI
         for marker in b"\xff\xd8", b"\xff\xd9":
-            assert marker in data[1] and marker in data[2]
+            assert marker in data[1]
+            assert marker in data[2]
         # DHT, DQT
         for marker in b"\xff\xc4", b"\xff\xdb":
-            assert marker in data[1] and marker not in data[2]
+            assert marker in data[1]
+            assert marker not in data[2]
         # SOF0, SOS, APP0 (JFIF header)
         for marker in b"\xff\xc0", b"\xff\xda", b"\xff\xe0":
-            assert marker not in data[1] and marker in data[2]
+            assert marker not in data[1]
+            assert marker in data[2]
 
         with Image.open(BytesIO(data[0])) as interchange_im:
             with Image.open(BytesIO(data[1] + data[2])) as combined_im:

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -233,7 +233,7 @@ def test_layers() -> None:
         ("foo.jp2", {"no_jp2": True}, 0, b"\xff\x4f"),
         ("foo.j2k", {"no_jp2": False}, 0, b"\xff\x4f"),
         ("foo.jp2", {"no_jp2": False}, 4, b"jP"),
-        ("foo.jp2", {"no_jp2": False}, 4, b"jP"),
+        (None, {"no_jp2": False}, 4, b"jP"),
     ),
 )
 def test_no_jp2(name: str, args: dict[str, bool], offset: int, data: bytes) -> None:

--- a/Tests/test_imagechops.py
+++ b/Tests/test_imagechops.py
@@ -398,7 +398,8 @@ def test_logical() -> None:
             for y in (a, b):
                 imy = Image.new("1", (1, 1), y)
                 value = op(imx, imy).getpixel((0, 0))
-                assert not isinstance(value, tuple) and value is not None
+                assert not isinstance(value, tuple)
+                assert value is not None
                 out.append(value)
         return out
 

--- a/Tests/test_imagemorph.py
+++ b/Tests/test_imagemorph.py
@@ -46,7 +46,8 @@ def img_to_string(im: Image.Image) -> str:
         line = ""
         for c in range(im.width):
             value = im.getpixel((c, r))
-            assert not isinstance(value, tuple) and value is not None
+            assert not isinstance(value, tuple)
+            assert value is not None
             line += chars[value > 0]
         result.append(line)
     return "\n".join(result)

--- a/Tests/test_tiff_ifdrational.py
+++ b/Tests/test_tiff_ifdrational.py
@@ -54,8 +54,8 @@ def test_nonetype() -> None:
     assert xres.denominator is not None
     assert yres._val is not None
 
-    assert xres and 1
-    assert xres and yres
+    assert xres
+    assert yres
 
 
 @pytest.mark.parametrize(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,6 @@ lint.ignore = [
   "PT012",  # pytest-raises-with-multiple-statements
   "PT016",  # pytest-fail-without-message
   "PT017",  # pytest-assert-in-except
-  "PT018",  # pytest-composite-assertion
   "PYI026", # flake8-pyi: typing.TypeAlias added in Python 3.10
   "PYI034", # flake8-pyi: typing.Self added in Python 3.11
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,6 @@ lint.ignore = [
   "PT007",  # pytest-parametrize-values-wrong-type
   "PT011",  # pytest-raises-too-broad
   "PT012",  # pytest-raises-with-multiple-statements
-  "PT014",  # pytest-duplicate-parametrize-test-cases
   "PT016",  # pytest-fail-without-message
   "PT017",  # pytest-assert-in-except
   "PT018",  # pytest-composite-assertion

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ lint.select = [
   "ISC",    # flake8-implicit-str-concat
   "LOG",    # flake8-logging
   "PGH",    # pygrep-hooks
-  "PT006",  # pytest-parametrize-names-wrong-type
+  "PT",     # flake8-pytest-style
   "PYI",    # flake8-pyi
   "RUF100", # unused noqa (yesqa)
   "UP",     # pyupgrade
@@ -121,6 +121,14 @@ lint.ignore = [
   "E221",   # Multiple spaces before operator
   "E226",   # Missing whitespace around arithmetic operator
   "E241",   # Multiple spaces after ','
+  "PT001",  # pytest-fixture-incorrect-parentheses-style
+  "PT007",  # pytest-parametrize-values-wrong-type
+  "PT011",  # pytest-raises-too-broad
+  "PT012",  # pytest-raises-with-multiple-statements
+  "PT014",  # pytest-duplicate-parametrize-test-cases
+  "PT016",  # pytest-fail-without-message
+  "PT017",  # pytest-assert-in-except
+  "PT018",  # pytest-composite-assertion
   "PYI026", # flake8-pyi: typing.TypeAlias added in Python 3.10
   "PYI034", # flake8-pyi: typing.Self added in Python 3.11
 ]


### PR DESCRIPTION
Expand from PT006 to all of PT:

https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt

Fix warnings for PT001, PT014 and PT018.

Exclude these which have warnings:

*  PT007 pytest-parametrize-values-wrong-type
*  PT011 pytest-raises-too-broad
*  PT012 pytest-raises-with-multiple-statements
*  PT016 pytest-fail-without-message
*  PT017 pytest-assert-in-except

I'm fine if someone wants to tackle those in another PR.