### PR TITLE
Get IPTC info from tag_v2

### DIFF
--- a/Tests/test_file_iptc.py
+++ b/Tests/test_file_iptc.py
@@ -77,6 +77,16 @@ def test_getiptcinfo_zero_padding() -> None:
     assert len(iptc) == 3
 
 
+def test_getiptcinfo_tiff() -> None:
+    # Arrange
+    with Image.open("Tests/images/hopper.Lab.tif") as im:
+        # Act
+        iptc = IptcImagePlugin.getiptcinfo(im)
+
+    # Assert
+    assert iptc == {(1, 90): b"\x1b%G", (2, 0): b"\xcf\xc0"}
+
+
 def test_getiptcinfo_tiff_none() -> None:
     # Arrange
     with Image.open("Tests/images/hopper.tif") as im:

--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -213,7 +213,7 @@ def getiptcinfo(
         # get raw data from the IPTC/NAA tag (PhotoShop tags the data
         # as 4-byte integers, so we cannot use the get method...)
         try:
-            data = im.tag.tagdata[TiffImagePlugin.IPTC_NAA_CHUNK]
+            data = im.tag_v2[TiffImagePlugin.IPTC_NAA_CHUNK]
         except (AttributeError, KeyError):
             pass
 


### PR DESCRIPTION
Move from the legacy `tag` to the more recent  `tag_v2` when accessing TIFF data in IptcImagePlugin.

I've also added a test, that passes with or without this change.