### PR TITLE
Fixed writing multiple StripOffsets to TIFF

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -108,7 +108,8 @@ class TestFileTiff:
             assert_image_equal_tofile(im, "Tests/images/hopper.tif")
 
         with Image.open("Tests/images/hopper_bigtiff.tif") as im:
-            # multistrip support not yet implemented
+            # The data type of this file's StripOffsets tag is LONG8,
+            # which is not yet supported for offset data when saving multiple frames.
             del im.tag_v2[273]
 
             outfile = str(tmp_path / "temp.tif")

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -191,14 +191,15 @@ def test_save_multiple_stripoffsets() -> None:
         # number of tags == 1
         b"\x01\x00"
         # tag id (2 bytes), type (2 bytes), count (4 bytes), value (4 bytes)
-        # == 273, 4, 2, 18
-        # == TiffImagePlugin.STRIPOFFSETS, TiffTags.LONG, 2, 18
-        # the value is the index of the tag data
+        # TiffImagePlugin.STRIPOFFSETS, TiffTags.LONG, 2, 18
+        # where STRIPOFFSETS is 273, LONG is 4
+        # and 18 is the offset of the tag data
         b"\x11\x01\x04\x00\x02\x00\x00\x00\x12\x00\x00\x00"
-        # end of tags marker
+        # end of entries
         b"\x00\x00\x00\x00"
-        # tag data == (149, 482) == (123 + 26, 456 + 26)
-        # 26 is the number of bytes before this data
+        # 26 is the total number of bytes output,
+        # the offset for any auxiliary strip data that will then be appended
+        # (123 + 26, 456 + 26) == (149, 482)
         b"\x95\x00\x00\x00\xe2\x01\x00\x00"
     )
 

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -991,9 +991,11 @@ class ImageFileDirectory_v2(_IFDv2Base):
         if stripoffsets is not None:
             tag, typ, count, value, data = entries[stripoffsets]
             if data:
-                msg = "multistrip support not yet implemented"
-                raise NotImplementedError(msg)
-            value = self._pack("L", self._unpack("L", value)[0] + offset)
+                size, handler = self._load_dispatch[typ]
+                values = [val + offset for val in handler(self, data, self.legacy_api)]
+                data = self._write_dispatch[typ](self, *values)
+            else:
+                value = self._pack("L", self._unpack("L", value)[0] + offset)
             entries[stripoffsets] = tag, typ, count, value, data
 
         # pass 2: write entries to file


### PR DESCRIPTION
The StripOffsets values don't really mean anything without associated image data, so I just did the same thing as when this tag only has one value and added the IFD offset to the values.

StripOffsets is overwritten with correct values when writing TIFF images, so this only matters when writing a non-TIFF image, where StripOffsets doesn't mean anything. The main benefit of this change is that it won't raise an exception now when saving a non-TIFF image with EXIF data copied from a TIFF image that has more than one strip.