### PR TITLE
Uninstall gradle and maven on macOS 13

### DIFF
--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+if [[ "$ImageOS" == "macos13" ]]; then
+    brew uninstall gradle maven
+fi
 brew install \
     freetype \
     ghostscript \


### PR DESCRIPTION
Our macOS 13 job has started failing in main - https://github.com/python-pillow/Pillow/actions/runs/10451246000/job/28937272389

It is trying to install Python 3.12, when there is already a copy of Python present, leading to an error.

The new Python dependency is not for any packages we have requested though, but instead for gradle and maven, when brew tries to update versions already installed.

Perhaps the simplest solution is just to uninstall gradle and maven.