### PR TITLE
Updated error message when saving WebP with invalid width or height

### DIFF
--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -164,7 +164,7 @@ class TestFileWebp:
         with pytest.raises(ValueError) as e:
             im.save(temp_file)
         assert (
-            str(e.value) == "encoding error 5: Image size exceeds WebP limit of 16383"
+            str(e.value) == "encoding error 5: Image size exceeds WebP limit of 16383 pixels"
         )
 
     def test_WebPEncode_with_invalid_args(self) -> None:

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -163,7 +163,9 @@ class TestFileWebp:
         im = Image.new("L", (16384, 16384))
         with pytest.raises(ValueError) as e:
             im.save(temp_file)
-        assert str(e.value) == "encoding error 5: Image size exceeds WebP limit"
+        assert (
+            str(e.value) == "encoding error 5: Image size exceeds WebP limit of 16383"
+        )
 
     def test_WebPEncode_with_invalid_args(self) -> None:
         """

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -164,7 +164,8 @@ class TestFileWebp:
         with pytest.raises(ValueError) as e:
             im.save(temp_file)
         assert (
-            str(e.value) == "encoding error 5: Image size exceeds WebP limit of 16383 pixels"
+            str(e.value)
+            == "encoding error 5: Image size exceeds WebP limit of 16383 pixels"
         )
 
     def test_WebPEncode_with_invalid_args(self) -> None:

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -157,6 +157,14 @@ class TestFileWebp:
             im.save(temp_file, method=0)
         assert str(e.value) == "encoding error 6"
 
+    @pytest.mark.skipif(sys.maxsize <= 2**32, reason="Requires 64-bit system")
+    def test_write_encoding_error_bad_dimension(self, tmp_path: Path) -> None:
+        temp_file = str(tmp_path / "temp.webp")
+        im = Image.new("L", (16384, 16384))
+        with pytest.raises(ValueError) as e:
+            im.save(temp_file)
+        assert str(e.value) == "encoding error 5: Image size exceeds WebP limit"
+
     def test_WebPEncode_with_invalid_args(self) -> None:
         """
         Calling encoder functions with no arguments should result in an error.

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -673,9 +673,11 @@ WebPEncode_wrapper(PyObject *self, PyObject *args) {
     WebPPictureFree(&pic);
     if (!ok) {
         int error_code = (&pic)->error_code;
-        const char *message = "";
+        char message[50] = "";
         if (error_code == VP8_ENC_ERROR_BAD_DIMENSION) {
-            message = ": Image size exceeds WebP limit";
+            sprintf(
+                message, ": Image size exceeds WebP limit of %d", WEBP_MAX_DIMENSION
+            );
         }
         PyErr_Format(PyExc_ValueError, "encoding error %d%s", error_code, message);
         return NULL;

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -672,7 +672,12 @@ WebPEncode_wrapper(PyObject *self, PyObject *args) {
 
     WebPPictureFree(&pic);
     if (!ok) {
-        PyErr_Format(PyExc_ValueError, "encoding error %d", (&pic)->error_code);
+        int error_code = (&pic)->error_code;
+        const char *message = "";
+        if (error_code == VP8_ENC_ERROR_BAD_DIMENSION) {
+            message = ": Image size exceeds WebP limit";
+        }
+        PyErr_Format(PyExc_ValueError, "encoding error %d%s", error_code, message);
         return NULL;
     }
     output = writer.mem;

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -676,7 +676,9 @@ WebPEncode_wrapper(PyObject *self, PyObject *args) {
         char message[50] = "";
         if (error_code == VP8_ENC_ERROR_BAD_DIMENSION) {
             sprintf(
-                message, ": Image size exceeds WebP limit of %d pixels", WEBP_MAX_DIMENSION
+                message,
+                ": Image size exceeds WebP limit of %d pixels",
+                WEBP_MAX_DIMENSION
             );
         }
         PyErr_Format(PyExc_ValueError, "encoding error %d%s", error_code, message);

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -676,7 +676,7 @@ WebPEncode_wrapper(PyObject *self, PyObject *args) {
         char message[50] = "";
         if (error_code == VP8_ENC_ERROR_BAD_DIMENSION) {
             sprintf(
-                message, ": Image size exceeds WebP limit of %d", WEBP_MAX_DIMENSION
+                message, ": Image size exceeds WebP limit of %d pixels", WEBP_MAX_DIMENSION
             );
         }
         PyErr_Format(PyExc_ValueError, "encoding error %d%s", error_code, message);


### PR DESCRIPTION
Resolves #8321

There is a limit on the size of WebP images.

https://developers.google.com/speed/webp/faq
> The maximum pixel dimensions of a WebP image is 16383 x 16383.

When that limit is hit, this PR changes the error message from
"encoding error 5"
to
"encoding error 5: Image size exceeds WebP limit"
