### PR TITLE
Catch defusedxml warnings

### DIFF
--- a/Tests/test_file_webp_metadata.py
+++ b/Tests/test_file_webp_metadata.py
@@ -116,7 +116,15 @@ def test_read_no_exif() -> None:
 def test_getxmp() -> None:
     with Image.open("Tests/images/flower.webp") as im:
         assert "xmp" not in im.info
-        assert im.getxmp() == {}
+        if ElementTree is None:
+            with pytest.warns(
+                UserWarning,
+                match="XMP data cannot be read without defusedxml dependency",
+            ):
+                xmp = im.getxmp()
+        else:
+            xmp = im.getxmp()
+        assert xmp == {}
 
     with Image.open("Tests/images/flower2.webp") as im:
         if ElementTree is None:

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -938,7 +938,15 @@ class TestImage:
 
     def test_empty_xmp(self) -> None:
         with Image.open("Tests/images/hopper.gif") as im:
-            assert im.getxmp() == {}
+            if ElementTree is None:
+                with pytest.warns(
+                    UserWarning,
+                    match="XMP data cannot be read without defusedxml dependency",
+                ):
+                    xmp = im.getxmp()
+            else:
+                xmp = im.getxmp()
+            assert xmp == {}
 
     def test_getxmp_padded(self) -> None:
         im = Image.new("RGB", (1, 1))


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/10500106794/job/29087976482#step:6:5386

> Tests/test_file_webp_metadata.py::test_getxmp
> Tests/test_image.py::TestImage::test_empty_xmp
>   /vpy3/lib64/python3.12/site-packages/PIL/Image.py:1491: UserWarning: XMP data cannot be read without defusedxml dependency
>     warnings.warn("XMP data cannot be read without defusedxml dependency")