### PR TITLE
Remove warning if NumPy failed to raise an error during conversion

### DIFF
--- a/Tests/test_image_array.py
+++ b/Tests/test_image_array.py
@@ -47,7 +47,7 @@ def test_toarray() -> None:
             with pytest.raises(OSError):
                 numpy.array(im_truncated)
         else:
-            with pytest.warns(UserWarning):
+            with pytest.warns(DeprecationWarning):
                 numpy.array(im_truncated)
 
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -724,24 +724,12 @@ class Image:
     def __array_interface__(self) -> dict[str, str | bytes | int | tuple[int, ...]]:
         # numpy array interface support
         new: dict[str, str | bytes | int | tuple[int, ...]] = {"version": 3}
-        try:
-            if self.mode == "1":
-                # Binary images need to be extended from bits to bytes
-                # See: https://github.com/python-pillow/Pillow/issues/350
-                new["data"] = self.tobytes("raw", "L")
-            else:
-                new["data"] = self.tobytes()
-        except Exception as e:
-            if not isinstance(e, (MemoryError, RecursionError)):
-                try:
-                    import numpy
-                    from packaging.version import parse as parse_version
-                except ImportError:
-                    pass
-                else:
-                    if parse_version(numpy.__version__) < parse_version("1.23"):
-                        warnings.warn(str(e))
-            raise
+        if self.mode == "1":
+            # Binary images need to be extended from bits to bytes
+            # See: https://github.com/python-pillow/Pillow/issues/350
+            new["data"] = self.tobytes("raw", "L")
+        else:
+            new["data"] = self.tobytes()
         new["shape"], new["typestr"] = _conv_type_shape(self)
         return new
 


### PR DESCRIPTION
If an error is raised when converting an image to a NumPy array, NumPy < 1.23 doesn't raise an error. So #6594 added a warning for that scenario.
https://github.com/python-pillow/Pillow/blob/d6cfebd016db25549d05a9c5caa2ef3b53cff5c5/src/PIL/Image.py#L742-L743

NumPy < 1.23 is [EOL](https://endoflife.date/numpy), so this explicit warning can be removed.

A caveat to this is that [Ubuntu 22.04 still has NumPy 1.21 packaged](https://packages.ubuntu.com/jammy/python3-numpy). However, that version carries its own warning - https://github.com/python-pillow/Pillow/actions/runs/10500106794/job/29087976733#step:6:5394
>   /Pillow/Tests/test_image_array.py:51: DeprecationWarning: An exception was ignored while fetching the attribute `__array_interface__` from an object of type 'JpegImageFile'.  With the exception of `AttributeError` NumPy will always raise this exception in the future.  Raise this deprecation warning to see the original exception. (Warning added NumPy 1.21)

So it is also ok for our custom warning to be removed for that scenario.