### PR TITLE
Drop support for EOL PyPy3.9

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -53,10 +53,7 @@ if [[ $(uname) != CYGWIN* ]]; then
     fi
 
     # Pyroma uses non-isolated build and fails with old setuptools
-    if [[
-        $GHA_PYTHON_VERSION == pypy3.9
-        || $GHA_PYTHON_VERSION == 3.9
-    ]]; then
+    if [[ $GHA_PYTHON_VERSION == 3.9 ]]; then
         # To match pyproject.toml
         python3 -m pip install "setuptools>=67.8"
     fi

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.10", "pypy3.9", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["pypy3.10", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     timeout-minutes: 30
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,6 @@ jobs:
         ]
         python-version: [
           "pypy3.10",
-          "pypy3.9",
           "3.13",
           "3.12",
           "3.11",

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,7 +48,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - pp39
           - pp310
           - cp3{9,10,11}
           - cp3{12,13}
@@ -57,7 +56,6 @@ jobs:
           - manylinux_2_28
           - musllinux
         exclude:
-          - { python-version: pp39, spec: musllinux }
           - { python-version: pp310, spec: musllinux }
 
     steps:


### PR DESCRIPTION
PyPy 7.3.17 is out, including PyPy3.10 and dropping PyPy3.9:

> The keen-eyed will have noticed no mention of Python version 3.9 in the releases above. Typically we will maintain only one version of Python3, but due to PyPy3.9 support on conda-forge we maintained multiple versions from the first release of PyPy3.10 in PyPy v7.3.12 (Dec 2022). Conda-forge is [sunsetting its PyPy support](https://pypy.org/posts/2024/08/conda-forge-proposes-dropping-support-for-pypy.html), which means we can drop PyPy3.9.

https://pypy.org/posts/2024/08/pypy-v7317-release.html#pypy-versions-and-speed-pypy-org