### PR TITLE
Added type hints to ImageFile.__init__()

### DIFF
--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -238,7 +238,9 @@ class MockImageFile(ImageFile.ImageFile):
         self.rawmode = "RGBA"
         self._mode = "RGBA"
         self._size = (200, 200)
-        self.tile = [("MOCK", (xoff, yoff, xoff + xsize, yoff + ysize), 32, None)]
+        self.tile = [
+            ImageFile._Tile("MOCK", (xoff, yoff, xoff + xsize, yoff + ysize), 32, None)
+        ]
 
 
 class CodecsTest:
@@ -268,7 +270,7 @@ class TestPyDecoder(CodecsTest):
         buf = BytesIO(b"\x00" * 255)
 
         im = MockImageFile(buf)
-        im.tile = [("MOCK", None, 32, None)]
+        im.tile = [ImageFile._Tile("MOCK", None, 32, None)]
 
         im.load()
 
@@ -281,12 +283,12 @@ class TestPyDecoder(CodecsTest):
         buf = BytesIO(b"\x00" * 255)
 
         im = MockImageFile(buf)
-        im.tile = [("MOCK", (xoff, yoff, -10, yoff + ysize), 32, None)]
+        im.tile = [ImageFile._Tile("MOCK", (xoff, yoff, -10, yoff + ysize), 32, None)]
 
         with pytest.raises(ValueError):
             im.load()
 
-        im.tile = [("MOCK", (xoff, yoff, xoff + xsize, -10), 32, None)]
+        im.tile = [ImageFile._Tile("MOCK", (xoff, yoff, xoff + xsize, -10), 32, None)]
         with pytest.raises(ValueError):
             im.load()
 
@@ -294,12 +296,20 @@ class TestPyDecoder(CodecsTest):
         buf = BytesIO(b"\x00" * 255)
 
         im = MockImageFile(buf)
-        im.tile = [("MOCK", (xoff, yoff, xoff + xsize + 100, yoff + ysize), 32, None)]
+        im.tile = [
+            ImageFile._Tile(
+                "MOCK", (xoff, yoff, xoff + xsize + 100, yoff + ysize), 32, None
+            )
+        ]
 
         with pytest.raises(ValueError):
             im.load()
 
-        im.tile = [("MOCK", (xoff, yoff, xoff + xsize, yoff + ysize + 100), 32, None)]
+        im.tile = [
+            ImageFile._Tile(
+                "MOCK", (xoff, yoff, xoff + xsize, yoff + ysize + 100), 32, None
+            )
+        ]
         with pytest.raises(ValueError):
             im.load()
 
@@ -336,7 +346,7 @@ class TestPyEncoder(CodecsTest):
         buf = BytesIO(b"\x00" * 255)
 
         im = MockImageFile(buf)
-        im.tile = [("MOCK", None, 32, None)]
+        im.tile = [ImageFile._Tile("MOCK", None, 32, None)]
 
         fp = BytesIO()
         ImageFile._save(im, fp, [ImageFile._Tile("MOCK", None, 0, "RGB")])

--- a/docs/example/DdsImagePlugin.py
+++ b/docs/example/DdsImagePlugin.py
@@ -246,7 +246,9 @@ class DdsImageFile(ImageFile.ImageFile):
             msg = f"Unimplemented pixel format {repr(fourcc)}"
             raise NotImplementedError(msg)
 
-        self.tile = [(self.decoder, (0, 0) + self.size, 0, (self.mode, 0, 1))]
+        self.tile = [
+            ImageFile._Tile(self.decoder, (0, 0) + self.size, 0, (self.mode, 0, 1))
+        ]
 
     def load_seek(self, pos: int) -> None:
         pass

--- a/src/PIL/BlpImagePlugin.py
+++ b/src/PIL/BlpImagePlugin.py
@@ -273,7 +273,7 @@ class BlpImageFile(ImageFile.ImageFile):
             raise BLPFormatError(msg)
 
         self._mode = "RGBA" if self._blp_alpha_depth else "RGB"
-        self.tile = [(decoder, (0, 0) + self.size, 0, (self.mode, 0, 1))]
+        self.tile = [ImageFile._Tile(decoder, (0, 0) + self.size, 0, (self.mode, 0, 1))]
 
 
 class _BLPBaseDecoder(ImageFile.PyDecoder):
@@ -372,7 +372,10 @@ class BLP1Decoder(_BLPBaseDecoder):
         Image._decompression_bomb_check(image.size)
         if image.mode == "CMYK":
             decoder_name, extents, offset, args = image.tile[0]
-            image.tile = [(decoder_name, extents, offset, (args[0], "CMYK"))]
+            assert isinstance(args, tuple)
+            image.tile = [
+                ImageFile._Tile(decoder_name, extents, offset, (args[0], "CMYK"))
+            ]
         r, g, b = image.convert("RGB").split()
         reversed_image = Image.merge("RGB", (b, g, r))
         self.set_as_raw(reversed_image.tobytes())

--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -296,7 +296,7 @@ class BmpImageFile(ImageFile.ImageFile):
             args.append(((file_info["width"] * file_info["bits"] + 31) >> 3) & (~3))
         args.append(file_info["direction"])
         self.tile = [
-            (
+            ImageFile._Tile(
                 decoder_name,
                 (0, 0, file_info["width"], file_info["height"]),
                 offset or self.fp.tell(),

--- a/src/PIL/CurImagePlugin.py
+++ b/src/PIL/CurImagePlugin.py
@@ -17,7 +17,7 @@
 #
 from __future__ import annotations
 
-from . import BmpImagePlugin, Image
+from . import BmpImagePlugin, Image, ImageFile
 from ._binary import i16le as i16
 from ._binary import i32le as i32
 
@@ -64,7 +64,7 @@ class CurImageFile(BmpImagePlugin.BmpImageFile):
         # patch up the bitmap height
         self._size = self.size[0], self.size[1] // 2
         d, e, o, a = self.tile[0]
-        self.tile[0] = d, (0, 0) + self.size, o, a
+        self.tile[0] = ImageFile._Tile(d, (0, 0) + self.size, o, a)
 
 
 #

--- a/src/PIL/DdsImagePlugin.py
+++ b/src/PIL/DdsImagePlugin.py
@@ -367,7 +367,7 @@ class DdsImageFile(ImageFile.ImageFile):
                 mask_count = 3
 
             masks = struct.unpack(f"<{mask_count}I", header.read(mask_count * 4))
-            self.tile = [("dds_rgb", extents, 0, (bitcount, masks))]
+            self.tile = [ImageFile._Tile("dds_rgb", extents, 0, (bitcount, masks))]
             return
         elif pfflags & DDPF.LUMINANCE:
             if bitcount == 8:

--- a/src/PIL/FitsImagePlugin.py
+++ b/src/PIL/FitsImagePlugin.py
@@ -67,7 +67,7 @@ class FitsImageFile(ImageFile.ImageFile):
             raise ValueError(msg)
 
         offset += self.fp.tell() - 80
-        self.tile = [(decoder_name, (0, 0) + self.size, offset, args)]
+        self.tile = [ImageFile._Tile(decoder_name, (0, 0) + self.size, offset, args)]
 
     def _get_size(
         self, headers: dict[bytes, bytes], prefix: bytes

--- a/src/PIL/FliImagePlugin.py
+++ b/src/PIL/FliImagePlugin.py
@@ -159,7 +159,7 @@ class FliImageFile(ImageFile.ImageFile):
         framesize = i32(s)
 
         self.decodermaxblock = framesize
-        self.tile = [("fli", (0, 0) + self.size, self.__offset, None)]
+        self.tile = [ImageFile._Tile("fli", (0, 0) + self.size, self.__offset, None)]
 
         self.__offset += framesize
 

--- a/src/PIL/FpxImagePlugin.py
+++ b/src/PIL/FpxImagePlugin.py
@@ -166,7 +166,7 @@ class FpxImageFile(ImageFile.ImageFile):
 
             if compression == 0:
                 self.tile.append(
-                    (
+                    ImageFile._Tile(
                         "raw",
                         (x, y, x1, y1),
                         i32(s, i) + 28,
@@ -177,7 +177,7 @@ class FpxImageFile(ImageFile.ImageFile):
             elif compression == 1:
                 # FIXME: the fill decoder is not implemented
                 self.tile.append(
-                    (
+                    ImageFile._Tile(
                         "fill",
                         (x, y, x1, y1),
                         i32(s, i) + 28,
@@ -205,7 +205,7 @@ class FpxImageFile(ImageFile.ImageFile):
                     jpegmode = rawmode
 
                 self.tile.append(
-                    (
+                    ImageFile._Tile(
                         "jpeg",
                         (x, y, x1, y1),
                         i32(s, i) + 28,

--- a/src/PIL/FtexImagePlugin.py
+++ b/src/PIL/FtexImagePlugin.py
@@ -93,9 +93,9 @@ class FtexImageFile(ImageFile.ImageFile):
 
         if format == Format.DXT1:
             self._mode = "RGBA"
-            self.tile = [("bcn", (0, 0) + self.size, 0, 1)]
+            self.tile = [ImageFile._Tile("bcn", (0, 0) + self.size, 0, (1,))]
         elif format == Format.UNCOMPRESSED:
-            self.tile = [("raw", (0, 0) + self.size, 0, ("RGB", 0, 1))]
+            self.tile = [ImageFile._Tile("raw", (0, 0) + self.size, 0, ("RGB", 0, 1))]
         else:
             msg = f"Invalid texture compression format: {repr(format)}"
             raise ValueError(msg)

--- a/src/PIL/GdImageFile.py
+++ b/src/PIL/GdImageFile.py
@@ -72,7 +72,7 @@ class GdImageFile(ImageFile.ImageFile):
         )
 
         self.tile = [
-            (
+            ImageFile._Tile(
                 "raw",
                 (0, 0) + self.size,
                 7 + true_color_offset + 4 + 256 * 4,

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -407,7 +407,7 @@ class GifImageFile(ImageFile.ImageFile):
                 elif self.mode not in ("RGB", "RGBA"):
                     transparency = frame_transparency
             self.tile = [
-                (
+                ImageFile._Tile(
                     "gif",
                     (x0, y0, x1, y1),
                     self.__offset,

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -228,7 +228,7 @@ class IcoFile:
             # change tile dimension to only encompass XOR image
             im._size = (im.size[0], int(im.size[1] / 2))
             d, e, o, a = im.tile[0]
-            im.tile[0] = d, (0, 0) + im.size, o, a
+            im.tile[0] = ImageFile._Tile(d, (0, 0) + im.size, o, a)
 
             # figure out where AND mask image starts
             if header.bpp == 32:

--- a/src/PIL/ImImagePlugin.py
+++ b/src/PIL/ImImagePlugin.py
@@ -253,7 +253,11 @@ class ImImageFile(ImageFile.ImageFile):
                 # use bit decoder (if necessary)
                 bits = int(self.rawmode[2:])
                 if bits not in [8, 16, 32]:
-                    self.tile = [("bit", (0, 0) + self.size, offs, (bits, 8, 3, 0, -1))]
+                    self.tile = [
+                        ImageFile._Tile(
+                            "bit", (0, 0) + self.size, offs, (bits, 8, 3, 0, -1)
+                        )
+                    ]
                     return
             except ValueError:
                 pass
@@ -263,13 +267,17 @@ class ImImageFile(ImageFile.ImageFile):
             # ever stumbled upon such a file ;-)
             size = self.size[0] * self.size[1]
             self.tile = [
-                ("raw", (0, 0) + self.size, offs, ("G", 0, -1)),
-                ("raw", (0, 0) + self.size, offs + size, ("R", 0, -1)),
-                ("raw", (0, 0) + self.size, offs + 2 * size, ("B", 0, -1)),
+                ImageFile._Tile("raw", (0, 0) + self.size, offs, ("G", 0, -1)),
+                ImageFile._Tile("raw", (0, 0) + self.size, offs + size, ("R", 0, -1)),
+                ImageFile._Tile(
+                    "raw", (0, 0) + self.size, offs + 2 * size, ("B", 0, -1)
+                ),
             ]
         else:
             # LabEye/IFUNC files
-            self.tile = [("raw", (0, 0) + self.size, offs, (self.rawmode, 0, -1))]
+            self.tile = [
+                ImageFile._Tile("raw", (0, 0) + self.size, offs, (self.rawmode, 0, -1))
+            ]
 
     @property
     def n_frames(self) -> int:
@@ -295,7 +303,9 @@ class ImImageFile(ImageFile.ImageFile):
 
         self.fp = self._fp
 
-        self.tile = [("raw", (0, 0) + self.size, offs, (self.rawmode, 0, -1))]
+        self.tile = [
+            ImageFile._Tile("raw", (0, 0) + self.size, offs, (self.rawmode, 0, -1))
+        ]
 
     def tell(self) -> int:
         return self.frame

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3641,7 +3641,10 @@ def merge(mode: str, bands: Sequence[Image]) -> Image:
 
 def register_open(
     id: str,
-    factory: Callable[[IO[bytes], str | bytes], ImageFile.ImageFile],
+    factory: (
+        Callable[[IO[bytes], str | bytes], ImageFile.ImageFile]
+        | type[ImageFile.ImageFile]
+    ),
     accept: Callable[[bytes], bool | str] | None = None,
 ) -> None:
     """

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -34,7 +34,7 @@ import itertools
 import os
 import struct
 import sys
-from typing import IO, TYPE_CHECKING, Any, NamedTuple
+from typing import IO, TYPE_CHECKING, Any, NamedTuple, cast
 
 from . import Image
 from ._deprecate import deprecate
@@ -111,7 +111,7 @@ class ImageFile(Image.Image):
     """Base class for image file format handlers."""
 
     def __init__(
-        self, fp: StrOrBytesPath | IO[bytes] | None = None, filename: str | bytes | None = None
+        self, fp: StrOrBytesPath | IO[bytes], filename: str | bytes | None = None
     ) -> None:
         super().__init__()
 
@@ -134,7 +134,7 @@ class ImageFile(Image.Image):
             self._exclusive_fp = True
         else:
             # stream
-            self.fp = fp
+            self.fp = cast(IO[bytes], fp)
             self.filename = filename if filename is not None else ""
             # can be overridden
             self._exclusive_fp = False

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -34,11 +34,14 @@ import itertools
 import os
 import struct
 import sys
-from typing import IO, Any, NamedTuple
+from typing import IO, TYPE_CHECKING, Any, NamedTuple
 
 from . import Image
 from ._deprecate import deprecate
 from ._util import is_path
+
+if TYPE_CHECKING:
+    from ._typing import StrOrBytesPath
 
 MAXBLOCK = 65536
 
@@ -107,32 +110,34 @@ class _Tile(NamedTuple):
 class ImageFile(Image.Image):
     """Base class for image file format handlers."""
 
-    def __init__(self, fp=None, filename=None):
+    def __init__(
+        self, fp: StrOrBytesPath | IO[bytes] | None = None, filename: str | bytes | None = None
+    ) -> None:
         super().__init__()
 
         self._min_frame = 0
 
-        self.custom_mimetype = None
+        self.custom_mimetype: str | None = None
 
-        self.tile = None
+        self.tile: list[_Tile] = []
         """ A list of tile descriptors, or ``None`` """
 
         self.readonly = 1  # until we know better
 
-        self.decoderconfig = ()
+        self.decoderconfig: tuple[Any, ...] = ()
         self.decodermaxblock = MAXBLOCK
 
         if is_path(fp):
             # filename
             self.fp = open(fp, "rb")
-            self.filename = fp
+            self.filename = os.path.realpath(os.fspath(fp))
             self._exclusive_fp = True
         else:
             # stream
             self.fp = fp
-            self.filename = filename
+            self.filename = filename if filename is not None else ""
             # can be overridden
-            self._exclusive_fp = None
+            self._exclusive_fp = False
 
         try:
             try:
@@ -154,6 +159,9 @@ class ImageFile(Image.Image):
             if self._exclusive_fp:
                 self.fp.close()
             raise
+
+    def _open(self) -> None:
+        pass
 
     def get_format_mimetype(self) -> str | None:
         if self.custom_mimetype:
@@ -178,7 +186,7 @@ class ImageFile(Image.Image):
     def load(self) -> Image.core.PixelAccess | None:
         """Load image data based on tile list"""
 
-        if self.tile is None:
+        if not self.tile and self._im is None:
             msg = "cannot load this image"
             raise OSError(msg)
 
@@ -214,6 +222,7 @@ class ImageFile(Image.Image):
                 args = (args, 0, 1)
             if (
                 decoder_name == "raw"
+                and isinstance(args, tuple)
                 and len(args) >= 3
                 and args[0] == self.mode
                 and args[0] in Image._MAPMODES

--- a/src/PIL/ImtImagePlugin.py
+++ b/src/PIL/ImtImagePlugin.py
@@ -58,7 +58,7 @@ class ImtImageFile(ImageFile.ImageFile):
             if s == b"\x0C":
                 # image data begins
                 self.tile = [
-                    (
+                    ImageFile._Tile(
                         "raw",
                         (0, 0) + self.size,
                         self.fp.tell() - len(buffer),

--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -147,7 +147,9 @@ class IptcImageFile(ImageFile.ImageFile):
 
         # tile
         if tag == (8, 10):
-            self.tile = [("iptc", (0, 0) + self.size, offset, compression)]
+            self.tile = [
+                ImageFile._Tile("iptc", (0, 0) + self.size, offset, compression)
+            ]
 
     def load(self) -> Image.core.PixelAccess | None:
         if len(self.tile) != 1 or self.tile[0][0] != "iptc":

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -286,7 +286,7 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
                 length = -1
 
         self.tile = [
-            (
+            ImageFile._Tile(
                 "jpeg2k",
                 (0, 0) + self.size,
                 0,
@@ -338,8 +338,9 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
 
             # Update the reduce and layers settings
             t = self.tile[0]
+            assert isinstance(t[3], tuple)
             t3 = (t[3][0], self._reduce, self.layers, t[3][3], t[3][4])
-            self.tile = [(t[0], (0, 0) + self.size, t[2], t3)]
+            self.tile = [ImageFile._Tile(t[0], (0, 0) + self.size, t[2], t3)]
 
         return ImageFile.ImageFile.load(self)
 

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -848,7 +848,7 @@ def _save_cjpeg(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
 ##
 # Factory for making JPEG and MPO instances
 def jpeg_factory(
-    fp: IO[bytes] | None = None, filename: str | bytes | None = None
+    fp: IO[bytes], filename: str | bytes | None = None
 ) -> JpegImageFile | MpoImageFile:
     im = JpegImageFile(fp, filename)
     try:

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -372,7 +372,9 @@ class JpegImageFile(ImageFile.ImageFile):
                     rawmode = self.mode
                     if self.mode == "CMYK":
                         rawmode = "CMYK;I"  # assume adobe conventions
-                    self.tile = [("jpeg", (0, 0) + self.size, 0, (rawmode, ""))]
+                    self.tile = [
+                        ImageFile._Tile("jpeg", (0, 0) + self.size, 0, (rawmode, ""))
+                    ]
                     # self.__offset = self.fp.tell()
                     break
                 s = self.fp.read(1)
@@ -423,6 +425,7 @@ class JpegImageFile(ImageFile.ImageFile):
         scale = 1
         original_size = self.size
 
+        assert isinstance(a, tuple)
         if a[0] == "RGB" and mode in ["L", "YCbCr"]:
             self._mode = mode
             a = mode, ""
@@ -432,6 +435,7 @@ class JpegImageFile(ImageFile.ImageFile):
             for s in [8, 4, 2, 1]:
                 if scale >= s:
                     break
+            assert e is not None
             e = (
                 e[0],
                 e[1],
@@ -441,7 +445,7 @@ class JpegImageFile(ImageFile.ImageFile):
             self._size = ((self.size[0] + s - 1) // s, (self.size[1] + s - 1) // s)
             scale = s
 
-        self.tile = [(d, e, o, a)]
+        self.tile = [ImageFile._Tile(d, e, o, a)]
         self.decoderconfig = (scale, 0)
 
         box = (0, 0, original_size[0] / scale, original_size[1] / scale)

--- a/src/PIL/McIdasImagePlugin.py
+++ b/src/PIL/McIdasImagePlugin.py
@@ -67,7 +67,9 @@ class McIdasImageFile(ImageFile.ImageFile):
         offset = w[34] + w[15]
         stride = w[15] + w[10] * w[11] * w[14]
 
-        self.tile = [("raw", (0, 0) + self.size, offset, (rawmode, stride, 1))]
+        self.tile = [
+            ImageFile._Tile("raw", (0, 0) + self.size, offset, (rawmode, stride, 1))
+        ]
 
 
 # --------------------------------------------------------------------

--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -26,6 +26,7 @@ from typing import IO, Any, cast
 
 from . import (
     Image,
+    ImageFile,
     ImageSequence,
     JpegImagePlugin,
     TiffImagePlugin,
@@ -145,7 +146,9 @@ class MpoImageFile(JpegImagePlugin.JpegImageFile):
         if self.info.get("exif") != original_exif:
             self._reload_exif()
 
-        self.tile = [("jpeg", (0, 0) + self.size, self.offset, self.tile[0][-1])]
+        self.tile = [
+            ImageFile._Tile("jpeg", (0, 0) + self.size, self.offset, self.tile[0][-1])
+        ]
         self.__frame = frame
 
     def tell(self) -> int:

--- a/src/PIL/MspImagePlugin.py
+++ b/src/PIL/MspImagePlugin.py
@@ -70,9 +70,9 @@ class MspImageFile(ImageFile.ImageFile):
         self._size = i16(s, 4), i16(s, 6)
 
         if s[:4] == b"DanM":
-            self.tile = [("raw", (0, 0) + self.size, 32, ("1", 0, 1))]
+            self.tile = [ImageFile._Tile("raw", (0, 0) + self.size, 32, ("1", 0, 1))]
         else:
-            self.tile = [("MSP", (0, 0) + self.size, 32, None)]
+            self.tile = [ImageFile._Tile("MSP", (0, 0) + self.size, 32, None)]
 
 
 class MspDecoder(ImageFile.PyDecoder):

--- a/src/PIL/PcdImagePlugin.py
+++ b/src/PIL/PcdImagePlugin.py
@@ -47,7 +47,7 @@ class PcdImageFile(ImageFile.ImageFile):
 
         self._mode = "RGB"
         self._size = 768, 512  # FIXME: not correct for rotated images!
-        self.tile = [("pcd", (0, 0) + self.size, 96 * 2048, None)]
+        self.tile = [ImageFile._Tile("pcd", (0, 0) + self.size, 96 * 2048, None)]
 
     def load_end(self) -> None:
         if self.tile_post_rotate:

--- a/src/PIL/PcxImagePlugin.py
+++ b/src/PIL/PcxImagePlugin.py
@@ -128,7 +128,9 @@ class PcxImageFile(ImageFile.ImageFile):
         bbox = (0, 0) + self.size
         logger.debug("size: %sx%s", *self.size)
 
-        self.tile = [("pcx", bbox, self.fp.tell(), (rawmode, planes * stride))]
+        self.tile = [
+            ImageFile._Tile("pcx", bbox, self.fp.tell(), (rawmode, planes * stride))
+        ]
 
 
 # --------------------------------------------------------------------

--- a/src/PIL/PixarImagePlugin.py
+++ b/src/PIL/PixarImagePlugin.py
@@ -61,7 +61,9 @@ class PixarImageFile(ImageFile.ImageFile):
         # FIXME: to be continued...
 
         # create tile descriptor (assuming "dumped")
-        self.tile = [("raw", (0, 0) + self.size, 1024, (self.mode, 0, 1))]
+        self.tile = [
+            ImageFile._Tile("raw", (0, 0) + self.size, 1024, (self.mode, 0, 1))
+        ]
 
 
 #

--- a/src/PIL/PpmImagePlugin.py
+++ b/src/PIL/PpmImagePlugin.py
@@ -151,7 +151,9 @@ class PpmImageFile(ImageFile.ImageFile):
                     decoder_name = "ppm"
 
             args = rawmode if decoder_name == "raw" else (rawmode, maxval)
-        self.tile = [(decoder_name, (0, 0) + self.size, self.fp.tell(), args)]
+        self.tile = [
+            ImageFile._Tile(decoder_name, (0, 0) + self.size, self.fp.tell(), args)
+        ]
 
 
 #

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -277,8 +277,8 @@ def _layerinfo(
 
 def _maketile(
     file: IO[bytes], mode: str, bbox: tuple[int, int, int, int], channels: int
-) -> list[ImageFile._Tile] | None:
-    tiles = None
+) -> list[ImageFile._Tile]:
+    tiles = []
     read = file.read
 
     compression = i16(read(2))
@@ -291,7 +291,6 @@ def _maketile(
     if compression == 0:
         #
         # raw compression
-        tiles = []
         for channel in range(channels):
             layer = mode[channel]
             if mode == "CMYK":
@@ -303,7 +302,6 @@ def _maketile(
         #
         # packbits compression
         i = 0
-        tiles = []
         bytecount = read(channels * ysize * 2)
         offset = file.tell()
         for channel in range(channels):

--- a/src/PIL/QoiImagePlugin.py
+++ b/src/PIL/QoiImagePlugin.py
@@ -32,7 +32,7 @@ class QoiImageFile(ImageFile.ImageFile):
         self._mode = "RGB" if channels == 3 else "RGBA"
 
         self.fp.seek(1, os.SEEK_CUR)  # colorspace
-        self.tile = [("qoi", (0, 0) + self._size, self.fp.tell(), None)]
+        self.tile = [ImageFile._Tile("qoi", (0, 0) + self._size, self.fp.tell(), None)]
 
 
 class QoiDecoder(ImageFile.PyDecoder):

--- a/src/PIL/SgiImagePlugin.py
+++ b/src/PIL/SgiImagePlugin.py
@@ -109,19 +109,28 @@ class SgiImageFile(ImageFile.ImageFile):
             pagesize = xsize * ysize * bpc
             if bpc == 2:
                 self.tile = [
-                    ("SGI16", (0, 0) + self.size, headlen, (self.mode, 0, orientation))
+                    ImageFile._Tile(
+                        "SGI16",
+                        (0, 0) + self.size,
+                        headlen,
+                        (self.mode, 0, orientation),
+                    )
                 ]
             else:
                 self.tile = []
                 offset = headlen
                 for layer in self.mode:
                     self.tile.append(
-                        ("raw", (0, 0) + self.size, offset, (layer, 0, orientation))
+                        ImageFile._Tile(
+                            "raw", (0, 0) + self.size, offset, (layer, 0, orientation)
+                        )
                     )
                     offset += pagesize
         elif compression == 1:
             self.tile = [
-                ("sgi_rle", (0, 0) + self.size, headlen, (rawmode, orientation, bpc))
+                ImageFile._Tile(
+                    "sgi_rle", (0, 0) + self.size, headlen, (rawmode, orientation, bpc)
+                )
             ]
 
 

--- a/src/PIL/SpiderImagePlugin.py
+++ b/src/PIL/SpiderImagePlugin.py
@@ -154,7 +154,9 @@ class SpiderImageFile(ImageFile.ImageFile):
             self.rawmode = "F;32F"
         self._mode = "F"
 
-        self.tile = [("raw", (0, 0) + self.size, offset, (self.rawmode, 0, 1))]
+        self.tile = [
+            ImageFile._Tile("raw", (0, 0) + self.size, offset, (self.rawmode, 0, 1))
+        ]
         self._fp = self.fp  # FIXME: hack
 
     @property

--- a/src/PIL/SunImagePlugin.py
+++ b/src/PIL/SunImagePlugin.py
@@ -124,9 +124,13 @@ class SunImageFile(ImageFile.ImageFile):
         # (https://www.fileformat.info/format/sunraster/egff.htm)
 
         if file_type in (0, 1, 3, 4, 5):
-            self.tile = [("raw", (0, 0) + self.size, offset, (rawmode, stride))]
+            self.tile = [
+                ImageFile._Tile("raw", (0, 0) + self.size, offset, (rawmode, stride))
+            ]
         elif file_type == 2:
-            self.tile = [("sun_rle", (0, 0) + self.size, offset, rawmode)]
+            self.tile = [
+                ImageFile._Tile("sun_rle", (0, 0) + self.size, offset, rawmode)
+            ]
         else:
             msg = "Unsupported Sun Raster file type"
             raise SyntaxError(msg)

--- a/src/PIL/TgaImagePlugin.py
+++ b/src/PIL/TgaImagePlugin.py
@@ -137,7 +137,7 @@ class TgaImageFile(ImageFile.ImageFile):
             if imagetype & 8:
                 # compressed
                 self.tile = [
-                    (
+                    ImageFile._Tile(
                         "tga_rle",
                         (0, 0) + self.size,
                         self.fp.tell(),
@@ -146,7 +146,7 @@ class TgaImageFile(ImageFile.ImageFile):
                 ]
             else:
                 self.tile = [
-                    (
+                    ImageFile._Tile(
                         "raw",
                         (0, 0) + self.size,
                         self.fp.tell(),

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1126,7 +1126,7 @@ class TiffImageFile(ImageFile.ImageFile):
 
     def __init__(
         self,
-        fp: StrOrBytesPath | IO[bytes] | None = None,
+        fp: StrOrBytesPath | IO[bytes],
         filename: str | bytes | None = None,
     ) -> None:
         self.tag_v2: ImageFileDirectory_v2

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -142,7 +142,7 @@ class WebPImageFile(ImageFile.ImageFile):
             if self.fp and self._exclusive_fp:
                 self.fp.close()
             self.fp = BytesIO(data)
-            self.tile = [("raw", (0, 0) + self.size, 0, self.rawmode)]
+            self.tile = [ImageFile._Tile("raw", (0, 0) + self.size, 0, self.rawmode)]
 
         return super().load()
 

--- a/src/PIL/XVThumbImagePlugin.py
+++ b/src/PIL/XVThumbImagePlugin.py
@@ -73,7 +73,11 @@ class XVThumbImageFile(ImageFile.ImageFile):
 
         self.palette = ImagePalette.raw("RGB", PALETTE)
 
-        self.tile = [("raw", (0, 0) + self.size, self.fp.tell(), (self.mode, 0, 1))]
+        self.tile = [
+            ImageFile._Tile(
+                "raw", (0, 0) + self.size, self.fp.tell(), (self.mode, 0, 1)
+            )
+        ]
 
 
 # --------------------------------------------------------------------

--- a/src/PIL/XbmImagePlugin.py
+++ b/src/PIL/XbmImagePlugin.py
@@ -67,7 +67,7 @@ class XbmImageFile(ImageFile.ImageFile):
         self._mode = "1"
         self._size = xsize, ysize
 
-        self.tile = [("xbm", (0, 0) + self.size, m.end(), None)]
+        self.tile = [ImageFile._Tile("xbm", (0, 0) + self.size, m.end(), None)]
 
 
 def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:

--- a/src/PIL/XpmImagePlugin.py
+++ b/src/PIL/XpmImagePlugin.py
@@ -101,7 +101,9 @@ class XpmImageFile(ImageFile.ImageFile):
         self._mode = "P"
         self.palette = ImagePalette.raw("RGB", b"".join(palette))
 
-        self.tile = [("raw", (0, 0) + self.size, self.fp.tell(), ("P", 0, 1))]
+        self.tile = [
+            ImageFile._Tile("raw", (0, 0) + self.size, self.fp.tell(), ("P", 0, 1))
+        ]
 
     def load_read(self, read_bytes: int) -> bytes:
         #


### PR DESCRIPTION
Aside from the obvious type hinting, this has two changes.

1. Require `fp` in
https://github.com/python-pillow/Pillow/blob/44c2ff3f0b1b0773064cd2e3746a8dcc89f5c3b4/src/PIL/ImageFile.py#L107-L110
It will [become the stream](https://github.com/python-pillow/Pillow/blob/44c2ff3f0b1b0773064cd2e3746a8dcc89f5c3b4/src/PIL/ImageFile.py#L125-L139) that is [used by plugins](https://github.com/python-pillow/Pillow/blob/44c2ff3f0b1b0773064cd2e3746a8dcc89f5c3b4/src/PIL/QoiImagePlugin.py#L24-L29), so there's no reason for it to be `None`.

2. Rather than allowing `im.tile` to be `None`
https://github.com/python-pillow/Pillow/blob/44c2ff3f0b1b0773064cd2e3746a8dcc89f5c3b4/src/PIL/ImageFile.py#L117
https://github.com/python-pillow/Pillow/blob/44c2ff3f0b1b0773064cd2e3746a8dcc89f5c3b4/src/PIL/ImageFile.py#L178-L185
I have changed the check to
https://github.com/python-pillow/Pillow/blob/d00f3656a684825569152ea1d6e74526ffa5d14b/src/PIL/ImageFile.py#L189
as it seems simpler from a type hinting perspective. If there is no tile to load, and no core image object already loaded, then this image cannot be loaded.