### PR TITLE
Treat unknown JPEG2000 colorspace as unspecified

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -182,6 +182,15 @@ def test_restricted_icc_profile() -> None:
         ImageFile.LOAD_TRUNCATED_IMAGES = False
 
 
+@pytest.mark.skipif(
+    not os.path.exists(EXTRA_DIR), reason="Extra image files not installed"
+)
+def test_unknown_colorspace() -> None:
+    with Image.open(f"{EXTRA_DIR}/file8.jp2") as im:
+        im.load()
+        assert im.mode == "L"
+
+
 def test_header_errors() -> None:
     for path in (
         "Tests/images/invalid_header_length.jp2",

--- a/src/libImaging/Jpeg2KDecode.c
+++ b/src/libImaging/Jpeg2KDecode.c
@@ -698,8 +698,7 @@ j2k_decode_entry(Imaging im, ImagingCodecState state) {
     }
 
     /* Check that this image is something we can handle */
-    if (image->numcomps < 1 || image->numcomps > 4 ||
-        image->color_space == OPJ_CLRSPC_UNKNOWN) {
+    if (image->numcomps < 1 || image->numcomps > 4) {
         state->errcode = IMAGING_CODEC_BROKEN;
         state->state = J2K_STATE_FAILED;
         goto quick_exit;
@@ -744,7 +743,7 @@ j2k_decode_entry(Imaging im, ImagingCodecState state) {
     /* Find the correct unpacker */
     color_space = image->color_space;
 
-    if (color_space == OPJ_CLRSPC_UNSPECIFIED) {
+    if (color_space == OPJ_CLRSPC_UNKNOWN || color_space == OPJ_CLRSPC_UNSPECIFIED) {
         switch (image->numcomps) {
             case 1:
             case 2:


### PR DESCRIPTION
Resolves #8327

Requires https://github.com/python-pillow/test-images/pull/6