### PR TITLE
Return early from BoxBlur if either width or height is zero

### DIFF
--- a/Tests/test_box_blur.py
+++ b/Tests/test_box_blur.py
@@ -71,6 +71,11 @@ def test_color_modes() -> None:
         box_blur(sample.convert("YCbCr"))
 
 
+@pytest.mark.parametrize("size", ((0, 1), (1, 0)))
+def test_zero_dimension(size: tuple[int, int]) -> None:
+    assert box_blur(Image.new("L", size)).size == size
+
+
 def test_radius_0() -> None:
     assert_blur(
         sample,

--- a/src/libImaging/BoxBlur.c
+++ b/src/libImaging/BoxBlur.c
@@ -238,6 +238,9 @@ ImagingBoxBlur(Imaging imOut, Imaging imIn, float xradius, float yradius, int n)
     int i;
     Imaging imTransposed;
 
+    if (imOut->xsize == 0 || imOut->ysize == 0) {
+        return imOut;
+    }
     if (n < 1) {
         return ImagingError_ValueError("number of passes must be greater than zero");
     }


### PR DESCRIPTION
Resolves #8346

If the resulting image has either a zero width or zero height, then the Box Blur will clearly have no effect on the output, and the empty image can be returned early.