### PR TITLE
Handle duplicate EXIF header

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -775,6 +775,14 @@ class TestImage:
         exif.load(b"Exif\x00\x00")
         assert not dict(exif)
 
+    def test_duplicate_exif_header(self) -> None:
+        with Image.open("Tests/images/exif.png") as im:
+            im.load()
+            im.info["exif"] = b"Exif\x00\x00" + im.info["exif"]
+
+            exif = im.getexif()
+        assert exif[274] == 1
+
     def test_empty_get_ifd(self) -> None:
         exif = Image.Exif()
         ifd = exif.get_ifd(0x8769)

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3968,7 +3968,7 @@ class Exif(_ExifBase):
         self._data.clear()
         self._hidden_data.clear()
         self._ifds.clear()
-        if data and data.startswith(b"Exif\x00\x00"):
+        while data and data.startswith(b"Exif\x00\x00"):
             data = data[6:]
         if not data:
             self._info = None


### PR DESCRIPTION
Fixes #8348 

Changes proposed in this pull request:

 * Explicitly check for double exif info and drop it
