### PR TITLE
Removed unused TiffImagePlugin IFD_LEGACY_API

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -142,6 +142,13 @@ Removed features
 Deprecated features are only removed in major releases after an appropriate
 period of deprecation has passed.
 
+TiffImagePlugin IFD_LEGACY_API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionremoved:: 11.0.0
+
+``TiffImagePlugin.IFD_LEGACY_API`` was removed, as it was an unused setting.
+
 PSFile
 ~~~~~~
 

--- a/docs/releasenotes/11.0.0.rst
+++ b/docs/releasenotes/11.0.0.rst
@@ -40,6 +40,11 @@ removed. Pillow's C API will now be used on PyPy instead.
 ``Image.USE_CFFI_ACCESS``, for switching from the C API to PyAccess, was
 similarly removed.
 
+TiffImagePlugin IFD_LEGACY_API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An unused setting, ``TiffImagePlugin.IFD_LEGACY_API``, has been removed.
+
 Deprecations
 ============
 

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -69,7 +69,6 @@ logger = logging.getLogger(__name__)
 # Set these to true to force use of libtiff for reading or writing.
 READ_LIBTIFF = False
 WRITE_LIBTIFF = False
-IFD_LEGACY_API = True
 STRIP_SIZE = 65536
 
 II = b"II"  # little-endian (Intel style)
@@ -1125,7 +1124,7 @@ class ImageFileDirectory_v1(ImageFileDirectory_v2):
         return val
 
 
-# undone -- switch this pointer when IFD_LEGACY_API == False
+# undone -- switch this pointer
 ImageFileDirectory = ImageFileDirectory_v1
 
 


### PR DESCRIPTION
This value is not used anywhere.

https://github.com/python-pillow/Pillow/blob/6377321625b93f5241305a7b301026cbbcd21e96/src/PIL/TiffImagePlugin.py#L72