### PR TITLE
Deprecate support for FreeType 2.9.0

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -1154,7 +1154,7 @@ def test_invalid_truetype_sizes_raise_valueerror(
 
 def test_freetype_deprecation(monkeypatch: pytest.MonkeyPatch) -> None:
     # Arrange: mock features.version_module to return fake FreeType version
-    def fake_version_module(module):
+    def fake_version_module(module: str) -> str:
         return "2.9.0"
 
     monkeypatch.setattr(features, "version_module", fake_version_module)

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -1150,3 +1150,15 @@ def test_invalid_truetype_sizes_raise_valueerror(
 ) -> None:
     with pytest.raises(ValueError):
         ImageFont.truetype(FONT_PATH, size, layout_engine=layout_engine)
+
+
+def test_freetype_deprecation(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: mock features.version_module to return fake FreeType version
+    def fake_version_module(module):
+        return "2.9.0"
+
+    monkeypatch.setattr(features, "version_module", fake_version_module)
+
+    # Act / Assert
+    with pytest.warns(DeprecationWarning):
+        ImageFont.truetype(FONT_PATH, FONT_SIZE)

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -12,6 +12,19 @@ Deprecated features
 Below are features which are considered deprecated. Where appropriate,
 a :py:exc:`DeprecationWarning` is issued.
 
+FreeType 2.9.0
+~~~~~~~~~~~~~~
+
+.. deprecated:: 11.0.0
+
+Support for FreeType 2.9.0 is deprecated and will be removed in Pillow 12.0.0
+(2025-10-15), when FreeType 2.9.1 will be the minimum supported.
+
+We recommend upgrading to at least FreeType `2.10.4`_, which fixed a severe
+vulnerability introduced in FreeType 2.6 (:cve:`CVE-2020-15999`).
+
+.. _2.10.4: https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/
+
 ImageFile.raise_oserror
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -21,7 +21,7 @@ Support for FreeType 2.9.0 is deprecated and will be removed in Pillow 12.0.0
 (2025-10-15), when FreeType 2.9.1 will be the minimum supported.
 
 We recommend upgrading to at least FreeType `2.10.4`_, which fixed a severe
-vulnerability introduced in FreeType 2.6 (:cve:`CVE-2020-15999`).
+vulnerability introduced in FreeType 2.6 (:cve:`2020-15999`).
 
 .. _2.10.4: https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -110,7 +110,7 @@ ImageDraw.getdraw hints parameter
 The ``hints`` parameter in :py:meth:`~PIL.ImageDraw.getdraw()` has been deprecated.
 
 FreeType 2.9.0
-~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^
 
 .. deprecated:: 11.0.0
 

--- a/docs/releasenotes/11.0.0.rst
+++ b/docs/releasenotes/11.0.0.rst
@@ -52,7 +52,7 @@ Support for FreeType 2.9.0 is deprecated and will be removed in Pillow 12.0.0
 (2025-10-15), when FreeType 2.9.1 will be the minimum supported.
 
 We recommend upgrading to at least FreeType `2.10.4`_, which fixed a severe
-vulnerability introduced in FreeType 2.6 (:cve:`CVE-2020-15999`).
+vulnerability introduced in FreeType 2.6 (:cve:`2020-15999`).
 
 .. _2.10.4: https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/
 

--- a/docs/releasenotes/11.0.0.rst
+++ b/docs/releasenotes/11.0.0.rst
@@ -43,6 +43,19 @@ similarly removed.
 Deprecations
 ============
 
+FreeType 2.9.0
+^^^^^^^^^^^^^^
+
+.. deprecated:: 11.0.0
+
+Support for FreeType 2.9.0 is deprecated and will be removed in Pillow 12.0.0
+(2025-10-15), when FreeType 2.9.1 will be the minimum supported.
+
+We recommend upgrading to at least FreeType `2.10.4`_, which fixed a severe
+vulnerability introduced in FreeType 2.6 (:cve:`CVE-2020-15999`).
+
+.. _2.10.4: https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/
+
 ImageMath.lambda_eval and ImageMath.unsafe_eval options parameter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -36,7 +36,7 @@ from io import BytesIO
 from types import ModuleType
 from typing import IO, TYPE_CHECKING, Any, BinaryIO, TypedDict, cast
 
-from . import Image
+from . import Image, features
 from ._typing import StrOrBytesPath
 from ._util import DeferredError, is_path
 
@@ -231,6 +231,21 @@ class FreeTypeFont:
         self.size = size
         self.index = index
         self.encoding = encoding
+
+        try:
+            from packaging.version import parse as parse_version
+        except ImportError:
+            pass
+        else:
+            if freetype_version := features.version_module("freetype2"):
+                if parse_version(freetype_version) < parse_version("2.9.1"):
+                    warnings.warn(
+                        "Support for FreeType 2.9.0 is deprecated and will be removed "
+                        "in Pillow 12 (2025-10-15). Please upgrade to FreeType 2.9.1 "
+                        "or newer, preferably FreeType 2.10.4 which fixes "
+                        "CVE-2020-15999.",
+                        DeprecationWarning,
+                    )
 
         if layout_engine not in (Layout.BASIC, Layout.RAQM):
             layout_engine = Layout.BASIC


### PR DESCRIPTION
We need FreeType >= 2.9.1 in some places in Pillow 10.4.0.

FreeType 2.9.1 was released on 2018-05-02.

FreeType 2.10.4 fixes a severe vulnerability: "All users should update immediately".

If deprecated in Pillow 11.0.0 (2024-10), it can be removed in Pillow 12.0.0 (2025-10).

Checking some distros from https://repology.org/project/freetype/versions:

| distro | FreeType |
| - | - |
| Alpine 3.17 | 2.12.1 |
| Alpine 3.18 | 2.12.1 |
| Alpine 3.19 | 2.12.1 |
| Alpine 3.20 | 2.12.1 |
| Amazon Linux 2 | 2.8 / 2.4.11 |
| Arch | 2.13.3 |
| CentOS Stream 9 | 2.10.4 |
| Debian 11 Bullseye | 2.10.4 |
| Debian 12 Bookworm | 2.12.1 |
| Fedora 39 | 2.13.1 |
| Fedora 40 | 2.13.2 |
| Ubuntu 20.04 Focal | 2.10.1 |
| Ubuntu 22.04 Jammy | 2.11.1 |
| Ubuntu 24.04 Noble | 2.13.2 |

Removing those distros which will be EOL before 2025-10 and sorting by FreeType version:

| distro | FreeType |
| - | - |
| CentOS Stream 9 | 2.10.4 |
| Debian 11 Bullseye | 2.10.4 |
| Ubuntu 22.04 Jammy | 2.11.1 |
| Alpine 3.19 | 2.12.1 |
| Alpine 3.20 | 2.12.1 |
| Debian 12 Bookworm | 2.12.1 |
| Ubuntu 24.04 Noble | 2.13.2 |
| Arch | 2.13.3 |

All of these are newer than 2.9.1.

---

For reference, we deprecated support for FreeType 2.7 in Pillow 8.1.0 (issue https://github.com/python-pillow/Pillow/issues/5075, PR https://github.com/python-pillow/Pillow/pull/5098), and removed it in 9.0.0 (https://github.com/python-pillow/Pillow/pull/5777).
