### PR TITLE
Deprecate isImageType

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1117,6 +1117,10 @@ class TestImage:
             assert len(caplog.records) == 0
             assert im.fp is None
 
+    def test_deprecation(self) -> None:
+        with pytest.warns(DeprecationWarning):
+            assert not Image.isImageType(None)
+
 
 class TestImageBytes:
     @pytest.mark.parametrize("mode", Image.MODES + ["BGR;15", "BGR;16", "BGR;24"])

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -122,6 +122,14 @@ vulnerability introduced in FreeType 2.6 (:cve:`2020-15999`).
 
 .. _2.10.4: https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/
 
+Image isImageType()
+^^^^^^^^^^^^^^^^^^^
+
+.. deprecated:: 11.0.0
+
+``Image.isImageType(im)`` has been deprecated. Use ``isinstance(im, Image.Image)``
+instead.
+
 ImageMath.lambda_eval and ImageMath.unsafe_eval options parameter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/releasenotes/11.0.0.rst
+++ b/docs/releasenotes/11.0.0.rst
@@ -61,6 +61,14 @@ vulnerability introduced in FreeType 2.6 (:cve:`2020-15999`).
 
 .. _2.10.4: https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/
 
+Image isImageType()
+^^^^^^^^^^^^^^^^^^^
+
+.. deprecated:: 11.0.0
+
+``Image.isImageType(im)`` has been deprecated. Use ``isinstance(im, Image.Image)``
+instead.
+
 ImageMath.lambda_eval and ImageMath.unsafe_eval options parameter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -133,6 +133,7 @@ def isImageType(t: Any) -> TypeGuard[Image]:
     :param t: object to check if it's an image
     :returns: True if the object is an image
     """
+    deprecate("Image.isImageType(im)", 12, "isinstance(im, Image.Image)")
     return hasattr(t, "im")
 
 
@@ -1823,23 +1824,22 @@ class Image:
         :param mask: An optional mask image.
         """
 
-        if isImageType(box):
+        if isinstance(box, Image):
             if mask is not None:
                 msg = "If using second argument as mask, third argument must be None"
                 raise ValueError(msg)
             # abbreviated paste(im, mask) syntax
             mask = box
             box = None
-        assert not isinstance(box, Image)
 
         if box is None:
             box = (0, 0)
 
         if len(box) == 2:
             # upper left corner given; get size from image or mask
-            if isImageType(im):
+            if isinstance(im, Image):
                 size = im.size
-            elif isImageType(mask):
+            elif isinstance(mask, Image):
                 size = mask.size
             else:
                 # FIXME: use self.size here?
@@ -1852,17 +1852,15 @@ class Image:
             from . import ImageColor
 
             source = ImageColor.getcolor(im, self.mode)
-        elif isImageType(im):
+        elif isinstance(im, Image):
             im.load()
             if self.mode != im.mode:
                 if self.mode != "RGB" or im.mode not in ("LA", "RGBA", "RGBa"):
                     # should use an adapter for this!
                     im = im.convert(self.mode)
             source = im.im
-        elif isinstance(im, tuple):
-            source = im
         else:
-            source = cast(float, im)
+            source = im
 
         self._ensure_mutable()
 
@@ -2023,7 +2021,7 @@ class Image:
         else:
             band = 3
 
-        if isImageType(alpha):
+        if isinstance(alpha, Image):
             # alpha layer
             if alpha.mode not in ("1", "L"):
                 msg = "illegal image mode"
@@ -2033,7 +2031,6 @@ class Image:
                 alpha = alpha.convert("L")
         else:
             # constant alpha
-            alpha = cast(int, alpha)  # see python/typing#1013
             try:
                 self.im.fillband(band, alpha)
             except (AttributeError, ValueError):

--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -268,7 +268,7 @@ def lambda_eval(
     args.update(options)
     args.update(kw)
     for k, v in args.items():
-        if hasattr(v, "im"):
+        if isinstance(v, Image.Image):
             args[k] = _Operand(v)
 
     out = expression(args)
@@ -319,7 +319,7 @@ def unsafe_eval(
     args.update(options)
     args.update(kw)
     for k, v in args.items():
-        if hasattr(v, "im"):
+        if isinstance(v, Image.Image):
             args[k] = _Operand(v)
 
     compiled_code = compile(expression, "<string>", "eval")


### PR DESCRIPTION
Removes `isImageType()`, which relies on `hasattr(t, "im")`,
https://github.com/python-pillow/Pillow/blob/be01d536c652f2224351ad0803c92067394db1bb/src/PIL/Image.py#L125-L136
and instead uses `isinstance(im, Image)`.

I've also made a similar change in ImageMath, replacing `hasattr(v, "im")` with `isinstance(v, Image.Image)`.