### PR TITLE
Improved handling of RGBA palettes when saving GIF images

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1429,3 +1429,21 @@ def test_saving_rgba(tmp_path: Path) -> None:
     with Image.open(out) as reloaded:
         reloaded_rgba = reloaded.convert("RGBA")
         assert reloaded_rgba.load()[0, 0][3] == 0
+
+
+def test_optimizing_p_rgba(tmp_path: Path) -> None:
+    out = str(tmp_path / "temp.gif")
+
+    im1 = Image.new("P", (100, 100))
+    d = ImageDraw.Draw(im1)
+    d.ellipse([(40, 40), (60, 60)], fill=1)
+    data = [0, 0, 0, 0, 0, 0, 0, 255] + [0, 0, 0, 0] * 254
+    im1.putpalette(data, "RGBA")
+
+    im2 = Image.new("P", (100, 100))
+    im2.putpalette(data, "RGBA")
+
+    im1.save(out, save_all=True, append_images=[im2])
+
+    with Image.open(out) as reloaded:
+        assert reloaded.n_frames == 2

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1066,7 +1066,7 @@ class Image:
                     trns_im = new(self.mode, (1, 1))
                     if self.mode == "P":
                         assert self.palette is not None
-                        trns_im.putpalette(self.palette)
+                        trns_im.putpalette(self.palette, self.palette.mode)
                         if isinstance(t, tuple):
                             err = "Couldn't allocate a palette color for transparency"
                             assert trns_im.palette is not None
@@ -2182,6 +2182,9 @@ class Image:
                 source_palette = self.im.getpalette(palette_mode, palette_mode)
             else:  # L-mode
                 source_palette = bytearray(i // 3 for i in range(768))
+        elif len(source_palette) > 768:
+            bands = 4
+            palette_mode = "RGBA"
 
         palette_bytes = b""
         new_positions = [0] * 256


### PR DESCRIPTION
Resolves #8222

In the issue, two RGBA images are saved together in the GIF format. However, the transparent background is (0, 0, 0, 0) and (0, 0, 0) is also re-used at different opacities within the image. When GifImagePlugin tries to optimise the image by utilising `remap_palette()` to group multiple colours together, [it doesn't consider the A channel](https://github.com/python-pillow/Pillow/blob/22c333289e3009f8dd5f345e3328220daf11d929/src/PIL/GifImagePlugin.py#L556), and so an unexpected result occurs, where the colour information for the bottom line of the second image is lost, and then cropped out.

By improving the detection of RGBA palettes, this is fixed.