### PR TITLE
Removed libffi-dev

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -21,7 +21,7 @@ set -e
 
 if [[ $(uname) != CYGWIN* ]]; then
     sudo apt-get -qq install libfreetype6-dev liblcms2-dev python3-tk\
-                             ghostscript libffi-dev libjpeg-turbo-progs libopenjp2-7-dev\
+                             ghostscript libjpeg-turbo-progs libopenjp2-7-dev\
                              cmake meson imagemagick libharfbuzz-dev libfribidi-dev\
                              sway wl-clipboard libopenblas-dev
 fi


### PR DESCRIPTION
Since #8182, cffi is no longer used, so its dependency, libffi-dev, no longer needs to be installed.