### PR TITLE
Remove comments

### DIFF
--- a/src/encode.c
+++ b/src/encode.c
@@ -1411,10 +1411,3 @@ PyImaging_Jpeg2KEncoderNew(PyObject *self, PyObject *args) {
 }
 
 #endif
-
-/*
- * Local Variables:
- * c-basic-offset: 4
- * End:
- *
- */

--- a/src/libImaging/Jpeg2K.h
+++ b/src/libImaging/Jpeg2K.h
@@ -104,10 +104,3 @@ typedef struct {
     int plt;
 
 } JPEG2KENCODESTATE;
-
-/*
- * Local Variables:
- * c-basic-offset: 4
- * End:
- *
- */

--- a/src/libImaging/Jpeg2KDecode.c
+++ b/src/libImaging/Jpeg2KDecode.c
@@ -979,10 +979,3 @@ ImagingJpeg2KVersion(void) {
 }
 
 #endif /* HAVE_OPENJPEG */
-
-/*
- * Local Variables:
- * c-basic-offset: 4
- * End:
- *
- */

--- a/src/libImaging/Jpeg2KEncode.c
+++ b/src/libImaging/Jpeg2KEncode.c
@@ -652,10 +652,3 @@ ImagingJpeg2KEncodeCleanup(ImagingCodecState state) {
 }
 
 #endif /* HAVE_OPENJPEG */
-
-/*
- * Local Variables:
- * c-basic-offset: 4
- * End:
- *
- */


### PR DESCRIPTION
Cherry-picking a commit from @homm's #8340 that is unrelated to the rest of the draft PR, and so can be included by itself.

The following comment appears in a few C files.
https://github.com/python-pillow/Pillow/blob/cb2a0c40f3760411423d09defada95c54564317a/src/encode.c#L1414-L1420

It appears to be [setting indentation for Emacs](https://www.gnu.org/software/emacs/manual/html_node/ccmode/Customizing-Indentation.html). These can be removed, if for no other reason than #4770 set the indentation instead with ClangFormat.