### PR TITLE
Install NumPy from PyPI for free threaded job

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -38,12 +38,7 @@ python3 -m pip install -U pytest-timeout
 python3 -m pip install pyroma
 
 if [[ $(uname) != CYGWIN* ]]; then
-    # TODO Update condition when NumPy supports free-threading
-    if [[ "$PYTHON_GIL" == "0" ]]; then
-        python3 -m pip install numpy --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-    else
-        python3 -m pip install numpy
-    fi
+    python3 -m pip install numpy
 
     # PyQt6 doesn't support PyPy3
     if [[ $GHA_PYTHON_VERSION == 3.* ]]; then


### PR DESCRIPTION
https://pypi.org/project/numpy/#files now offers 313t wheels, and so we can start installing NumPy from PyPI for the free threaded job, rather than using Scientific Python Nightly Wheels.