### PR TITLE
Test NumPy with musllinux wheels

### DIFF
--- a/.github/workflows/wheels-test.sh
+++ b/.github/workflows/wheels-test.sh
@@ -13,9 +13,7 @@ else
     yum install -y fribidi
 fi
 
-if [ "${AUDITWHEEL_POLICY::9}" != "musllinux" ]; then
-  python3 -m pip install numpy
-fi
+python3 -m pip install numpy
 
 if [ ! -d "test-images-main" ]; then
     curl -fsSL -o pillow-test-images.zip https://github.com/python-pillow/test-images/archive/main.zip


### PR DESCRIPTION
NumPy now provides musllinux wheels on PyPi - see https://pypi.org/project/numpy/#files (and https://pypi.org/project/numpy/2.0.2/#files for Python 3.9).

So our musllinux wheels can use it for testing.