### PR TITLE
Change macos-14 to macos-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-          "macos-14",
+          "macos-latest",
           "ubuntu-latest",
         ]
         python-version: [
@@ -56,7 +56,7 @@ jobs:
         # M1 only available for 3.10+
         - { os: "macos-13", python-version: "3.9" }
         exclude:
-        - { os: "macos-14", python-version: "3.9" }
+        - { os: "macos-latest", python-version: "3.9" }
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} Python ${{ matrix.python-version }} ${{ matrix.disable-gil && 'free-threaded' || '' }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -107,7 +107,7 @@ jobs:
             cibw_arch: x86_64
             macosx_deployment_target: "10.10"
           - name: "macOS arm64"
-            os: macos-14
+            os: macos-latest
             cibw_arch: arm64
             macosx_deployment_target: "11.0"
           - name: "manylinux2014 and musllinux x86_64"


### PR DESCRIPTION
#7766 added macos-14 to our GitHub Actions, since macos-latest didn't point to it [at the time.](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/)

macos-latest now does point to it, so we can change back to that, for future automatic upgrades.