### PR TITLE
Removed unused ImagePath variable

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -44,7 +44,6 @@ PyImaging_GetBuffer(PyObject *buffer, Py_buffer *view);
 typedef struct {
     PyObject_HEAD Py_ssize_t count;
     double *xy;
-    int index; /* temporary use, e.g. in decimate */
 } PyPathObject;
 
 static PyTypeObject PyPathType;


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/c9eb14e1043f04aa0463725060cde24e2c7bea8b/src/path.c#L44-L48

`index` has been unused since PIL. I have no idea what 'decimate' is.