### PR TITLE
Updated macOS deployment target for Python >= 3.12 on Intel to 10.13

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -102,10 +102,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "macOS x86_64"
+          - name: "macOS 10.10 x86_64"
             os: macos-13
             cibw_arch: x86_64
+            build: "pp310* cp3{9,10,11}*"
             macosx_deployment_target: "10.10"
+          - name: "macOS 10.13 x86_64"
+            os: macos-13
+            cibw_arch: x86_64
+            build: "cp3{12,13}*"
+            macosx_deployment_target: "10.13"
           - name: "macOS arm64"
             os: macos-latest
             cibw_arch: arm64
@@ -145,7 +151,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: dist-${{ matrix.os }}-${{ matrix.cibw_arch }}${{ matrix.manylinux && format('-{0}', matrix.manylinux) }}
+          name: dist-${{ matrix.os }}${{ matrix.macosx_deployment_target && format('-{0}', matrix.macosx_deployment_target) }}-${{ matrix.cibw_arch }}${{ matrix.manylinux && format('-{0}', matrix.manylinux) }}
           path: ./wheelhouse/*.whl
 
   windows:


### PR DESCRIPTION
cibuildwheel 2.21.0 has just been released - https://github.com/pypa/cibuildwheel#changelog
> Update CPython 3.12 to 3.12.6, which changes the macOS minimum deployment target on CPython 3.12 from macOS 10.9 to macOS 10.13

This is not just a cibuildwheel restriction - https://www.python.org/downloads/release/python-3126
> this release drops support for macOS versions 10.9 through 10.12. Versions of macOS older than 10.13 haven't been supported by Apple since 2019, and maintaining support for them has become too difficult. (All versions of Python 3.13 have already dropped support for them.)

So this PR splits our macOS Intel job into two - one for Python < 3.12 with a deployment target of macOS 10.10, and one for Python >= 3.12 with a deployment target of 10.13.

Our M1 builds already have a deployment target of macOS 11.0.