### PR TITLE
Lint: Run PT016

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1086,22 +1086,17 @@ class TestImage:
         valgrind pytest -qq Tests/test_image.py::TestImage::test_overrun | grep decode.c
         """
         with Image.open(os.path.join("Tests/images", path)) as im:
-            try:
+            with pytest.raises(OSError) as e:
                 im.load()
-                pytest.fail()
-            except OSError as e:
-                buffer_overrun = str(e) == "buffer overrun when reading image file"
-                truncated = "image file is truncated" in str(e)
+        buffer_overrun = str(e.value) == "buffer overrun when reading image file"
+        truncated = "image file is truncated" in str(e.value)
 
-                assert buffer_overrun or truncated
+        assert buffer_overrun or truncated
 
     def test_fli_overrun2(self) -> None:
         with Image.open("Tests/images/fli_overrun2.bin") as im:
-            try:
+            with pytest.raises(OSError, match="buffer overrun when reading image file"):
                 im.seek(1)
-                pytest.fail()
-            except OSError as e:
-                assert str(e) == "buffer overrun when reading image file"
 
     def test_exit_fp(self) -> None:
         with Image.new("L", (1, 1)) as im:

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -115,7 +115,7 @@ def test_ipythonviewer() -> None:
             test_viewer = viewer
             break
     else:
-        pytest.fail()
+        pytest.fail("IPythonViewer not found")
 
     im = hopper()
     assert test_viewer.show(im) == 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,6 @@ lint.ignore = [
   "PT007",  # pytest-parametrize-values-wrong-type
   "PT011",  # pytest-raises-too-broad
   "PT012",  # pytest-raises-with-multiple-statements
-  "PT016",  # pytest-fail-without-message
   "PT017",  # pytest-assert-in-except
   "PYI026", # flake8-pyi: typing.TypeAlias added in Python 3.10
   "PYI034", # flake8-pyi: typing.Self added in Python 3.11


### PR DESCRIPTION
Sequel to #8309

Enables https://docs.astral.sh/ruff/rules/pytest-fail-without-message