### PR TITLE
Cast Dib handle to int

### DIFF
--- a/Tests/test_imagewin.py
+++ b/Tests/test_imagewin.py
@@ -60,6 +60,18 @@ class TestImageWinDib:
         with pytest.raises(ValueError):
             ImageWin.Dib(mode)
 
+    def test_dib_hwnd(self) -> None:
+        mode = "RGBA"
+        size = (128, 128)
+        wnd = 0
+
+        dib = ImageWin.Dib(mode, size)
+        hwnd = ImageWin.HWND(wnd)
+
+        dib.expose(hwnd)
+        dib.draw(hwnd, (0, 0) + size)
+        assert isinstance(dib.query_palette(hwnd), int)
+
     def test_dib_paste(self) -> None:
         # Arrange
         im = hopper()

--- a/src/PIL/ImageWin.py
+++ b/src/PIL/ImageWin.py
@@ -98,14 +98,15 @@ class Dib:
                        HDC or HWND instance.  In PythonWin, you can use
                        ``CDC.GetHandleAttrib()`` to get a suitable handle.
         """
+        handle_int = int(handle)
         if isinstance(handle, HWND):
-            dc = self.image.getdc(handle)
+            dc = self.image.getdc(handle_int)
             try:
                 self.image.expose(dc)
             finally:
-                self.image.releasedc(handle, dc)
+                self.image.releasedc(handle_int, dc)
         else:
-            self.image.expose(handle)
+            self.image.expose(handle_int)
 
     def draw(
         self,
@@ -124,14 +125,15 @@ class Dib:
         """
         if src is None:
             src = (0, 0) + self.size
+        handle_int = int(handle)
         if isinstance(handle, HWND):
-            dc = self.image.getdc(handle)
+            dc = self.image.getdc(handle_int)
             try:
                 self.image.draw(dc, dst, src)
             finally:
-                self.image.releasedc(handle, dc)
+                self.image.releasedc(handle_int, dc)
         else:
-            self.image.draw(handle, dst, src)
+            self.image.draw(handle_int, dst, src)
 
     def query_palette(self, handle: int | HDC | HWND) -> int:
         """
@@ -148,14 +150,15 @@ class Dib:
         :return: The number of entries that were changed (if one or more entries,
                  this indicates that the image should be redrawn).
         """
+        handle_int = int(handle)
         if isinstance(handle, HWND):
-            handle = self.image.getdc(handle)
+            handle = self.image.getdc(handle_int)
             try:
                 result = self.image.query_palette(handle)
             finally:
                 self.image.releasedc(handle, handle)
         else:
-            result = self.image.query_palette(handle)
+            result = self.image.query_palette(handle_int)
         return result
 
     def paste(


### PR DESCRIPTION
Resolves #8383

The `Dib` class passes `handle` to core method `getdc()` in `expose()`
https://github.com/python-pillow/Pillow/blob/b67f018c00841601d8b11a1be722b0ebffc62f54/src/PIL/ImageWin.py#L101-L102
but despite what our Python logic would lead you to expect, [it must be an integer.](https://github.com/radarhere/Pillow/actions/runs/10871220422/job/30164766681#step:27:3403) See the following code and https://docs.python.org/3/c-api/arg.html#numbers
https://github.com/python-pillow/Pillow/blob/b67f018c00841601d8b11a1be722b0ebffc62f54/src/display.c#L37-L41
https://github.com/python-pillow/Pillow/blob/b67f018c00841601d8b11a1be722b0ebffc62f54/src/display.c#L165-L169

So this PR casts it to an integer in Python first. The same logic also applies to `draw()` and `query_palette()`.