### PR TITLE
Use Capsule for WEBP saving

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog (Pillow)
 11.0.0 (unreleased)
 -------------------
 
+- Removed unused TiffImagePlugin IFD_LEGACY_API #8355
+  [radarhere]
+
 - Handle duplicate EXIF header #8350
   [zakajd, radarhere]
 

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -72,7 +72,7 @@ class TestFileWebp:
     def _roundtrip(
         self, tmp_path: Path, mode: str, epsilon: float, args: dict[str, Any] = {}
     ) -> None:
-        temp_file = str(tmp_path / "temp.webp")
+        temp_file = tmp_path / "temp.webp"
 
         hopper(mode).save(temp_file, **args)
         with Image.open(temp_file) as image:
@@ -116,7 +116,7 @@ class TestFileWebp:
         assert buffer_no_args.getbuffer() != buffer_method.getbuffer()
 
     def test_save_all(self, tmp_path: Path) -> None:
-        temp_file = str(tmp_path / "temp.webp")
+        temp_file = tmp_path / "temp.webp"
         im = Image.new("RGB", (1, 1))
         im2 = Image.new("RGB", (1, 1), "#f00")
         im.save(temp_file, save_all=True, append_images=[im2])
@@ -151,18 +151,16 @@ class TestFileWebp:
 
     @pytest.mark.skipif(sys.maxsize <= 2**32, reason="Requires 64-bit system")
     def test_write_encoding_error_message(self, tmp_path: Path) -> None:
-        temp_file = str(tmp_path / "temp.webp")
         im = Image.new("RGB", (15000, 15000))
         with pytest.raises(ValueError) as e:
-            im.save(temp_file, method=0)
+            im.save(tmp_path / "temp.webp", method=0)
         assert str(e.value) == "encoding error 6"
 
     @pytest.mark.skipif(sys.maxsize <= 2**32, reason="Requires 64-bit system")
     def test_write_encoding_error_bad_dimension(self, tmp_path: Path) -> None:
-        temp_file = str(tmp_path / "temp.webp")
         im = Image.new("L", (16384, 16384))
         with pytest.raises(ValueError) as e:
-            im.save(temp_file)
+            im.save(tmp_path / "temp.webp")
         assert (
             str(e.value)
             == "encoding error 5: Image size exceeds WebP limit of 16383 pixels"
@@ -187,9 +185,8 @@ class TestFileWebp:
     def test_no_resource_warning(self, tmp_path: Path) -> None:
         file_path = "Tests/images/hopper.webp"
         with Image.open(file_path) as image:
-            temp_file = str(tmp_path / "temp.webp")
             with warnings.catch_warnings():
-                image.save(temp_file)
+                image.save(tmp_path / "temp.webp")
 
     def test_file_pointer_could_be_reused(self) -> None:
         file_path = "Tests/images/hopper.webp"
@@ -204,15 +201,16 @@ class TestFileWebp:
     def test_invalid_background(
         self, background: int | tuple[int, ...], tmp_path: Path
     ) -> None:
-        temp_file = str(tmp_path / "temp.webp")
+        temp_file = tmp_path / "temp.webp"
         im = hopper()
         with pytest.raises(OSError):
             im.save(temp_file, save_all=True, append_images=[im], background=background)
 
     def test_background_from_gif(self, tmp_path: Path) -> None:
+        out_webp = tmp_path / "temp.webp"
+        
         # Save L mode GIF with background
         with Image.open("Tests/images/no_palette_with_background.gif") as im:
-            out_webp = str(tmp_path / "temp.webp")
             im.save(out_webp, save_all=True)
 
         # Save P mode GIF with background
@@ -220,11 +218,10 @@ class TestFileWebp:
             original_value = im.convert("RGB").getpixel((1, 1))
 
             # Save as WEBP
-            out_webp = str(tmp_path / "temp.webp")
             im.save(out_webp, save_all=True)
 
         # Save as GIF
-        out_gif = str(tmp_path / "temp.gif")
+        out_gif = tmp_path / "temp.gif"
         with Image.open(out_webp) as im:
             im.save(out_gif)
 
@@ -234,10 +231,10 @@ class TestFileWebp:
         assert difference < 5
 
     def test_duration(self, tmp_path: Path) -> None:
+        out_webp = tmp_path / "temp.webp"
+
         with Image.open("Tests/images/dispose_bgnd.gif") as im:
             assert im.info["duration"] == 1000
-
-            out_webp = str(tmp_path / "temp.webp")
             im.save(out_webp, save_all=True)
 
         with Image.open(out_webp) as reloaded:
@@ -245,7 +242,7 @@ class TestFileWebp:
             assert reloaded.info["duration"] == 1000
 
     def test_roundtrip_rgba_palette(self, tmp_path: Path) -> None:
-        temp_file = str(tmp_path / "temp.webp")
+        temp_file = tmp_path / "temp.webp"
         im = Image.new("RGBA", (1, 1)).convert("P")
         assert im.mode == "P"
         assert im.palette is not None

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -208,7 +208,7 @@ class TestFileWebp:
 
     def test_background_from_gif(self, tmp_path: Path) -> None:
         out_webp = tmp_path / "temp.webp"
-        
+
         # Save L mode GIF with background
         with Image.open("Tests/images/no_palette_with_background.gif") as im:
             im.save(out_webp, save_all=True)

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -248,11 +248,8 @@ def _save_all(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
 
                 # Append the frame to the animation encoder
                 enc.add(
-                    frame.tobytes(),
+                    frame.im.ptr,
                     round(timestamp),
-                    frame.size[0],
-                    frame.size[1],
-                    frame.mode,
                     lossless,
                     quality,
                     alpha_quality,
@@ -270,7 +267,7 @@ def _save_all(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
         im.seek(cur_idx)
 
     # Force encoder to flush frames
-    enc.add(None, round(timestamp), 0, 0, "", lossless, quality, alpha_quality, 0)
+    enc.add(None, round(timestamp), lossless, quality, alpha_quality, 0)
 
     # Get the final output from the encoder
     data = enc.assemble(icc_profile, exif, xmp)

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -239,7 +239,6 @@ def _save_all(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
 
             for idx in range(nfr):
                 ims.seek(idx)
-                ims.load()
 
                 # Make sure image mode is supported
                 frame = ims
@@ -248,7 +247,7 @@ def _save_all(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
 
                 # Append the frame to the animation encoder
                 enc.add(
-                    frame.im.ptr,
+                    frame.getim(),
                     round(timestamp),
                     lossless,
                     quality,
@@ -296,7 +295,7 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
         im = im.convert("RGBA" if im.has_transparency_data else "RGB")
 
     data = _webp.WebPEncode(
-        im.im.ptr,
+        im.getim(),
         lossless,
         float(quality),
         float(alpha_quality),

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -295,17 +295,14 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
     method = im.encoderinfo.get("method", 4)
     exact = 1 if im.encoderinfo.get("exact") else 0
 
-    if im.mode not in ("RGB", "RGBA"):
+    if im.mode not in ("RGBX", "RGBA", "RGB"):
         im = im.convert("RGBA" if im.has_transparency_data else "RGB")
 
     data = _webp.WebPEncode(
-        im.tobytes(),
-        im.size[0],
-        im.size[1],
+        im.im.ptr,
         lossless,
         float(quality),
         float(alpha_quality),
-        im.mode,
         icc_profile,
         method,
         exact,

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -243,7 +243,9 @@ def _save_all(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
                 # Make sure image mode is supported
                 frame = ims
                 if frame.mode not in ("RGBX", "RGBA", "RGB"):
-                    frame = frame.convert("RGBA" if im.has_transparency_data else "RGB")
+                    frame = frame.convert(
+                        "RGBA" if frame.has_transparency_data else "RGB"
+                    )
 
                 # Append the frame to the animation encoder
                 enc.add(

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -149,6 +149,13 @@ class WebPImageFile(ImageFile.ImageFile):
         return self.__logical_frame
 
 
+def _convert_frame(im: Image.Image) -> Image.Image:
+    # Make sure image mode is supported
+    if im.mode not in ("RGBX", "RGBA", "RGB"):
+        im = im.convert("RGBA" if im.has_transparency_data else "RGB")
+    return im
+
+
 def _save_all(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
     encoderinfo = im.encoderinfo.copy()
     append_images = list(encoderinfo.get("append_images", []))
@@ -240,12 +247,7 @@ def _save_all(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
             for idx in range(nfr):
                 ims.seek(idx)
 
-                # Make sure image mode is supported
-                frame = ims
-                if frame.mode not in ("RGBX", "RGBA", "RGB"):
-                    frame = frame.convert(
-                        "RGBA" if frame.has_transparency_data else "RGB"
-                    )
+                frame = _convert_frame(ims)
 
                 # Append the frame to the animation encoder
                 enc.add(
@@ -293,8 +295,7 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
     method = im.encoderinfo.get("method", 4)
     exact = 1 if im.encoderinfo.get("exact") else 0
 
-    if im.mode not in ("RGBX", "RGBA", "RGB"):
-        im = im.convert("RGBA" if im.has_transparency_data else "RGB")
+    im = _convert_frame(im)
 
     data = _webp.WebPEncode(
         im.getim(),

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -190,6 +190,7 @@ _anim_encoder_add(PyObject *self, PyObject *args) {
     float quality_factor;
     float alpha_quality_factor;
     int method;
+    ImagingSectionCookie cookie;
     WebPConfig config;
     WebPAnimEncoderObject *encp = (WebPAnimEncoderObject *)self;
     WebPAnimEncoder *enc = encp->enc;
@@ -246,8 +247,11 @@ _anim_encoder_add(PyObject *self, PyObject *args) {
         WebPPictureImportRGB(frame, rgb, 3 * width);
     }
 
-    // Add the frame to the encoder
-    if (!WebPAnimEncoderAdd(enc, frame, timestamp, &config)) {
+    ImagingSectionEnter(&cookie);
+    int ok = WebPAnimEncoderAdd(enc, frame, timestamp, &config);
+    ImagingSectionLeave(&cookie);
+
+    if (!ok) {
         PyErr_SetString(PyExc_RuntimeError, WebPAnimEncoderGetError(enc));
         return NULL;
     }

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -89,16 +89,12 @@ HandleMuxError(WebPMuxError err, char *chunk) {
 
 static int
 import_frame_libwebp(WebPPicture *frame, Imaging im) {
-    UINT32 mask = 0;
+    int drop_alpha = strcmp(im->mode, "RGBA");
 
     if (strcmp(im->mode, "RGBA") && strcmp(im->mode, "RGB") &&
         strcmp(im->mode, "RGBX")) {
         PyErr_SetString(PyExc_ValueError, "unsupported image mode");
         return -1;
-    }
-
-    if (strcmp(im->mode, "RGBA")) {
-        mask = MASK_UINT32_CHANNEL_3;
     }
 
     frame->width = im->xsize;
@@ -113,10 +109,18 @@ import_frame_libwebp(WebPPicture *frame, Imaging im) {
     for (int y = 0; y < im->ysize; ++y) {
         UINT8 *src = (UINT8 *)im->image32[y];
         UINT32 *dst = frame->argb + frame->argb_stride * y;
-        for (int x = 0; x < im->xsize; ++x) {
-            UINT32 pix =
-                MAKE_UINT32(src[x * 4 + 2], src[x * 4 + 1], src[x * 4], src[x * 4 + 3]);
-            dst[x] = pix | mask;
+        if (drop_alpha) {
+            for (int x = 0; x < im->xsize; ++x) {
+                dst[x] =
+                    ((UINT32)(src[x * 4 + 2]) | ((UINT32)(src[x * 4 + 1]) << 8) |
+                     ((UINT32)(src[x * 4]) << 16) | (0xff << 24));
+            }
+        } else {
+            for (int x = 0; x < im->xsize; ++x) {
+                dst[x] =
+                    ((UINT32)(src[x * 4 + 2]) | ((UINT32)(src[x * 4 + 1]) << 8) |
+                     ((UINT32)(src[x * 4]) << 16) | ((UINT32)(src[x * 4 + 3]) << 24));
+            }
         }
     }
 


### PR DESCRIPTION
Adoption of #8341 ideas

### Improvements

* Doesn't create extra image copy (`.tobytes("raw", rawmode)`)
* Uses the same more appropriate API `.has_transparency_data` for save and save_all.
* Supports saving `RGBX` mode without conversion
* Adds `ImagingSectionEnter/Leave` for `WebPAnimEncoder`