### PR TITLE
Use transposed size after opening for TIFF images

### DIFF
--- a/Tests/test_image_copy.py
+++ b/Tests/test_image_copy.py
@@ -49,5 +49,7 @@ def test_copy_zero() -> None:
 @skip_unless_feature("libtiff")
 def test_deepcopy() -> None:
     with Image.open("Tests/images/g4_orientation_5.tif") as im:
+        assert im.size == (590, 88)
+
         out = copy.deepcopy(im)
     assert out.size == (590, 88)

--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -300,9 +300,7 @@ class TestImageResize:
                 im.resize((10, 10), "unknown")
 
     @skip_unless_feature("libtiff")
-    def test_load_first(self) -> None:
-        # load() may change the size of the image
-        # Test that resize() is calling it before getting the size
+    def test_transposed(self) -> None:
         with Image.open("Tests/images/g4_orientation_5.tif") as im:
             im = im.resize((64, 64))
             assert im.size == (64, 64)

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -92,15 +92,13 @@ def test_no_resize() -> None:
 
 
 @skip_unless_feature("libtiff")
-def test_load_first() -> None:
-    # load() may change the size of the image
-    # Test that thumbnail() is calling it before performing size calculations
+def test_transposed() -> None:
     with Image.open("Tests/images/g4_orientation_5.tif") as im:
+        assert im.size == (590, 88)
+
         im.thumbnail((64, 64))
         assert im.size == (64, 10)
 
-    # Test thumbnail(), without draft(),
-    # on an image that is large enough once load() has changed the size
     with Image.open("Tests/images/g4_orientation_5.tif") as im:
         im.thumbnail((590, 88), reducing_gap=None)
         assert im.size == (590, 88)

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -238,8 +238,10 @@ def test_zero_size() -> None:
 
 
 @skip_unless_feature("libtiff")
-def test_load_first() -> None:
+def test_transposed() -> None:
     with Image.open("Tests/images/g4_orientation_5.tif") as im:
+        assert im.size == (590, 88)
+
         a = numpy.array(im)
         assert a.shape == (88, 590)
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2332,7 +2332,6 @@ class Image:
             msg = "reducing_gap must be 1.0 or greater"
             raise ValueError(msg)
 
-        self.load()
         if box is None:
             box = (0, 0) + self.size
 
@@ -2781,27 +2780,18 @@ class Image:
                 )
             return x, y
 
-        box = None
-        final_size: tuple[int, int]
-        if reducing_gap is not None:
-            preserved_size = preserve_aspect_ratio()
-            if preserved_size is None:
-                return
-            final_size = preserved_size
+        preserved_size = preserve_aspect_ratio()
+        if preserved_size is None:
+            return
+        final_size = preserved_size
 
+        box = None
+        if reducing_gap is not None:
             res = self.draft(
                 None, (int(size[0] * reducing_gap), int(size[1] * reducing_gap))
             )
             if res is not None:
                 box = res[1]
-        if box is None:
-            self.load()
-
-            # load() may have changed the size of the image
-            preserved_size = preserve_aspect_ratio()
-            if preserved_size is None:
-                return
-            final_size = preserved_size
 
         if self.size != final_size:
             im = self.resize(final_size, resample, box=box, reducing_gap=reducing_gap)

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -322,7 +322,7 @@ class ImageFile(Image.Image):
 
     def load_prepare(self) -> None:
         # create image memory if necessary
-        if self._im is None or self.im.mode != self.mode or self.im.size != self.size:
+        if self._im is None or self.im.mode != self.mode:
             self.im = Image.core.new(self.mode, self.size)
         # create palette (optional)
         if self.mode == "P":

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -322,7 +322,7 @@ class ImageFile(Image.Image):
 
     def load_prepare(self) -> None:
         # create image memory if necessary
-        if self._im is None or self.im.mode != self.mode:
+        if self._im is None:
             self.im = Image.core.new(self.mode, self.size)
         # create palette (optional)
         if self.mode == "P":

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1421,12 +1421,8 @@ class TiffImageFile(ImageFile.ImageFile):
         if not isinstance(xsize, int) or not isinstance(ysize, int):
             msg = "Invalid dimensions"
             raise ValueError(msg)
-        self._will_be_transposed = self.tag_v2.get(ExifTags.Base.Orientation) in (
-            5,
-            6,
-            7,
-            8,
-        )
+        orientation = self.tag_v2.get(ExifTags.Base.Orientation)
+        self._will_be_transposed = orientation in (5, 6, 7, 8)
         if self._will_be_transposed:
             self._size = ysize, xsize
         else:

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1569,7 +1569,7 @@ class TiffImageFile(ImageFile.ImageFile):
             if STRIPOFFSETS in self.tag_v2:
                 offsets = self.tag_v2[STRIPOFFSETS]
                 h = self.tag_v2.get(ROWSPERSTRIP, ysize)
-                w = self.size[0]
+                w = xsize
             else:
                 # tiled image
                 offsets = self.tag_v2[TILEOFFSETS]
@@ -1603,9 +1603,9 @@ class TiffImageFile(ImageFile.ImageFile):
                     )
                 )
                 x = x + w
-                if x >= self.size[0]:
+                if x >= xsize:
                     x, y = 0, y + h
-                    if y >= self.size[1]:
+                    if y >= ysize:
                         x = y = 0
                         layer += 1
         else:


### PR DESCRIPTION
Alternative to #8387

At the moment, `load()` might change the size of a TIFF image, since TIFF images are [automatically transposed when doing so](https://github.com/python-pillow/Pillow/blob/08d9c89d8a7db84e8145814bca36d7dd5b7465ce/src/PIL/TiffImagePlugin.py#L1295).

`load()` is a method that many users are probably not even aware of, and so they might find
```python
from PIL import Image
im = Image.open("/Users/andrewmurray/pillow/Pillow/Tests/images/g4_orientation_5.tif")
print(im.size)  # (88, 590)
print(im.copy().size)  # (590, 88)
```
unexpected.

After this PR, the first `im.size` will also be (590, 88). This has means that changes from #6186 and #6190 can be removed.

#8387 solves this by making `im.size` sometimes different to `im._size`. I would like to avoid that, and have instead found a solution by adding `TiffImageFile.load_prepare()`.

While we are here streamlining things so that an image does not change its size after loading, I've also updated ImageFile to remove an implication that loading might change an image's mode.