### PR TITLE
Mention MAX_TEXT_CHUNK limit in PNG error message

### DIFF
--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -140,7 +140,7 @@ def _safe_zlib_decompress(s: bytes) -> bytes:
     dobj = zlib.decompressobj()
     plaintext = dobj.decompress(s, MAX_TEXT_CHUNK)
     if dobj.unconsumed_tail:
-        msg = "Decompressed Data Too Large"
+        msg = "Decompressed data too large for PngImagePlugin.MAX_TEXT_CHUNK"
         raise ValueError(msg)
     return plaintext
 


### PR DESCRIPTION
Resolves #8363

https://github.com/python-pillow/Pillow/blob/08d9c89d8a7db84e8145814bca36d7dd5b7465ce/src/PIL/PngImagePlugin.py#L141-L144

This PR changes the error message to "Decompressed data too large for PngImagePlugin.MAX_TEXT_CHUNK".

This is more informative. If the user [searches our docs for "PngImagePlugin.MAX_TEXT_CHUNK"](https://pillow.readthedocs.io/en/stable/search.html?q=PngImagePlugin.MAX_TEXT_CHUNK) they will find https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#png-opening
> Individual compressed chunks are limited to a decompressed size of [PngImagePlugin.MAX_TEXT_CHUNK](https://pillow.readthedocs.io/en/stable/reference/plugins.html#PIL.PngImagePlugin.MAX_TEXT_CHUNK), by default 1MB, to prevent decompression bombs.