### PR TITLE
Do not create core image in TIFF seek()

### DIFF
--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1193,11 +1193,11 @@ class TiffImageFile(ImageFile.ImageFile):
         if not self._seek_check(frame):
             return
         self._seek(frame)
-        # Create a new core image object on second and
-        # subsequent frames in the image. Image may be
-        # different size/mode.
-        Image._decompression_bomb_check(self._tile_size)
-        self.im = Image.core.new(self.mode, self._tile_size)
+        if self._im is not None and (
+            self.im.size != self._tile_size or self.im.mode != self.mode
+        ):
+            # The core image will no longer be used
+            self._im = None
 
     def _seek(self, frame: int) -> None:
         self.fp = self._fp
@@ -1279,6 +1279,7 @@ class TiffImageFile(ImageFile.ImageFile):
 
     def load_prepare(self) -> None:
         if self._im is None:
+            Image._decompression_bomb_check(self._tile_size)
             self.im = Image.core.new(self.mode, self._tile_size)
         ImageFile.ImageFile.load_prepare(self)
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/1ee3bd1d9e1a96da01ba55aff376e214082bcba8/src/PIL/TiffImagePlugin.py#L1189-L1198

The core image instance does not need to be created here. It can be set to `None` instead, and the initialisation can delayed until `load()` (or more specifically, `load_prepare()`).

https://github.com/python-pillow/Pillow/blob/1ee3bd1d9e1a96da01ba55aff376e214082bcba8/src/PIL/TiffImagePlugin.py#L1278-L1280