### PR TITLE
Use common test scripts for more tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,9 +53,8 @@ test_script:
 - cd c:\pillow
 - '%PYTHON%\%EXECUTABLE% -m pip install pytest pytest-cov pytest-timeout defusedxml ipython numpy olefile pyroma'
 - c:\"Program Files (x86)"\"Windows Kits"\10\Debuggers\x86\gflags.exe /p /enable %PYTHON%\%EXECUTABLE%
-- '%PYTHON%\%EXECUTABLE% -c "from PIL import Image"'
-- '%PYTHON%\%EXECUTABLE% -m pytest -vx --cov PIL --cov Tests --cov-report term --cov-report xml Tests'
-#- '%PYTHON%\%EXECUTABLE% test-installed.py -v -s %TEST_OPTIONS%' TODO TEST_OPTIONS with pytest?
+- path %PYTHON%;%PATH%
+- .ci\test.cmd
 
 after_test:
 - curl -Os https://uploader.codecov.io/latest/windows/codecov.exe

--- a/.ci/test.cmd
+++ b/.ci/test.cmd
@@ -1,0 +1,3 @@
+python.exe -c "from PIL import Image"
+IF ERRORLEVEL 1 EXIT /B
+python.exe -bb -m pytest -v -x -W always --cov PIL --cov Tests --cov-report term --cov-report xml Tests

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -4,4 +4,4 @@ set -e
 
 python3 -c "from PIL import Image"
 
-python3 -bb -m pytest -v -x -W always --cov PIL --cov Tests --cov-report term Tests $REVERSE
+python3 -bb -m pytest -v -x -W always --cov PIL --cov Tests --cov-report term --cov-report xml Tests $REVERSE

--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -80,8 +80,7 @@ jobs:
       - name: Test Pillow
         run: |
           python3 selftest.py --installed
-          python3 -c "from PIL import Image"
-          python3 -m pytest -vx --cov PIL --cov Tests --cov-report term --cov-report xml Tests
+          .ci/test.sh
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -190,8 +190,8 @@ jobs:
 
     - name: Test Pillow
       run: |
-        path %GITHUB_WORKSPACE%\\winbuild\\build\\bin;%PATH%
-        python.exe -m pytest -vx -W always --cov PIL --cov Tests --cov-report term --cov-report xml Tests
+        path %GITHUB_WORKSPACE%\winbuild\build\bin;%PATH%
+        .ci\test.cmd
       shell: cmd
 
     - name: Prepare to upload errors


### PR DESCRIPTION
Add a CI test script for Windows, and update appveyor, mingw, and windows to use the common test scripts.