### PR TITLE
Fix dereference before checking for NULL in ImagingTransformAffine

### DIFF
--- a/src/libImaging/Geometry.c
+++ b/src/libImaging/Geometry.c
@@ -1035,6 +1035,10 @@ ImagingTransformAffine(
     double xx, yy;
     double xo, yo;
 
+    if (!imOut || !imIn || strcmp(imIn->mode, imOut->mode) != 0) {
+        return (Imaging)ImagingError_ModeError();
+    }    
+
     if (filterid || imIn->type == IMAGING_TYPE_SPECIAL) {
         return ImagingGenericTransform(
             imOut, imIn, x0, y0, x1, y1, affine_transform, a, filterid, fill
@@ -1044,10 +1048,6 @@ ImagingTransformAffine(
     if (a[1] == 0 && a[3] == 0) {
         /* Scaling */
         return ImagingScaleAffine(imOut, imIn, x0, y0, x1, y1, a, fill);
-    }
-
-    if (!imOut || !imIn || strcmp(imIn->mode, imOut->mode) != 0) {
-        return (Imaging)ImagingError_ModeError();
     }
 
     if (x0 < 0) {

--- a/src/libImaging/Geometry.c
+++ b/src/libImaging/Geometry.c
@@ -1037,7 +1037,7 @@ ImagingTransformAffine(
 
     if (!imOut || !imIn || strcmp(imIn->mode, imOut->mode) != 0) {
         return (Imaging)ImagingError_ModeError();
-    }    
+    }
 
     if (filterid || imIn->type == IMAGING_TYPE_SPECIAL) {
         return ImagingGenericTransform(


### PR DESCRIPTION
The `imIn` pointer is checked for `NULL`, but it seems to be dereferenced before this check. You must first make sure that the pointer is not `NULL` before using it.

Found by Linux Verification Center (linuxtesting.org) with SVACE.
Reporter: Pavel Nekrasov ([p.nekrasov@fobos-nt.ru](mailto:p.nekrasov@fobos-nt.ru)).


