### PR TITLE
Updated link to OSS Fuzz issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ As of 2019, Pillow development is
             <a href="https://app.codecov.io/gh/python-pillow/Pillow"><img
                 alt="Code coverage"
                 src="https://codecov.io/gh/python-pillow/Pillow/branch/main/graph/badge.svg"></a>
-            <a href="https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:pillow"><img
+            <a href="https://issues.oss-fuzz.com/issues?q=title:pillow"><img
                 alt="Fuzzing Status"
                 src="https://oss-fuzz-build-logs.storage.googleapis.com/badges/pillow.svg"></a>
         </td>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,7 +54,7 @@ Pillow for enterprise is available via the Tidelift Subscription. `Learn more <h
    :alt: Tidelift
 
 .. image:: https://oss-fuzz-build-logs.storage.googleapis.com/badges/pillow.svg
-   :target: https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:pillow
+   :target: https://issues.oss-fuzz.com/issues?q=title:pillow
    :alt: Fuzzing Status
 
 .. image:: https://img.shields.io/pypi/v/pillow.svg


### PR DESCRIPTION
The OSS Fuzz issue tracker has moved. See https://github.com/google/oss-fuzz/issues/12508

This means that our badge link to Pillow OSS Fuzz issues is no longer correct.