### PR TITLE
Check image value before use

### DIFF
--- a/src/libImaging/Geometry.c
+++ b/src/libImaging/Geometry.c
@@ -791,13 +791,13 @@ ImagingGenericTransform(
     char *out;
     double xx, yy;
 
+    if (!imOut || !imIn || strcmp(imIn->mode, imOut->mode) != 0) {
+        return (Imaging)ImagingError_ModeError();
+    }
+
     ImagingTransformFilter filter = getfilter(imIn, filterid);
     if (!filter) {
         return (Imaging)ImagingError_ValueError("bad filter number");
-    }
-
-    if (!imOut || !imIn || strcmp(imIn->mode, imOut->mode) != 0) {
-        return (Imaging)ImagingError_ModeError();
     }
 
     ImagingCopyPalette(imOut, imIn);


### PR DESCRIPTION
Similar to https://github.com/python-pillow/Pillow/pull/8398, check the value of `imIn` before using it.

https://github.com/python-pillow/Pillow/blob/b557876ec3aa4d5d236d8044519f1c613031fbee/src/libImaging/Geometry.c#L794-L801
https://github.com/python-pillow/Pillow/blob/b557876ec3aa4d5d236d8044519f1c613031fbee/src/libImaging/Geometry.c#L709-L712