### PR TITLE
Cast int before potentially exceeding INT_MAX

### DIFF
--- a/src/libImaging/SgiRleDecode.c
+++ b/src/libImaging/SgiRleDecode.c
@@ -183,7 +183,7 @@ ImagingSgiRleDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t 
        each with 4 bytes per element of tablen
        Check here before we allocate any memory
     */
-    if (c->bufsize < 8 * c->tablen) {
+    if (c->bufsize < 8 * (int64_t)c->tablen) {
         state->errcode = IMAGING_CODEC_OVERRUN;
         return -1;
     }


### PR DESCRIPTION
Resolves #8401

`tablen` is an integer
https://github.com/python-pillow/Pillow/blob/b557876ec3aa4d5d236d8044519f1c613031fbee/src/libImaging/Sgi.h#L22

and before we set it to `im->bands * im->ysize`, we check that the value will be less than `INT_MAX`
https://github.com/python-pillow/Pillow/blob/b557876ec3aa4d5d236d8044519f1c613031fbee/src/libImaging/SgiRleDecode.c#L170-L172

but we then temporarily multiply it by 8, which might exceed `INT_MAX`.
https://github.com/python-pillow/Pillow/blob/b557876ec3aa4d5d236d8044519f1c613031fbee/src/libImaging/SgiRleDecode.c#L181-L186

So this PR casts it to `int64_t` before applying the multiplication.