### PR TITLE
winbuild: Build freetype.vcxproj to fix passing in custom parameters

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -292,8 +292,12 @@ DEPS: dict[str, dict[str, Any]] = {
         },
         "build": [
             cmd_rmdir("objs"),
-            cmd_msbuild("MSBuild.sln", "Release Static", "Clean"),
-            cmd_msbuild("MSBuild.sln", "Release Static", "Build"),
+            cmd_msbuild(
+                r"builds\windows\vc2010\freetype.vcxproj", "Release Static", "Clean"
+            ),
+            cmd_msbuild(
+                r"builds\windows\vc2010\freetype.vcxproj", "Release Static", "Build"
+            ),
             cmd_xcopy("include", "{inc_dir}"),
         ],
         "libs": [r"objs\{msbuild_arch}\Release Static\freetype.lib"],


### PR DESCRIPTION
#8302 broke passing in custom properties to FreeType, fix it by using the VS project file directly instead of the solution file.

This should fix the skipped CBDT/SBIX/WOFF2 tests.