### PR TITLE
Add check for positive xsize/ysize in ImagingFliDecode

### DIFF
--- a/src/libImaging/FliDecode.c
+++ b/src/libImaging/FliDecode.c
@@ -62,6 +62,10 @@ ImagingFliDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t byt
         state->errcode = IMAGING_CODEC_UNKNOWN;
         return -1;
     }
+    if (state->xsize <= 0 || state->ysize <= 0) {
+        state->errcode = IMAGING_CODEC_CONFIG;
+        return -1;
+    }
 
     chunks = I16(ptr + 6);
     ptr += 16;


### PR DESCRIPTION
Fixes #8405

I put the check near the top, but is there any valid reason `xsize` or `ysize` would be 0, and the check would need to be later in the code?