### PR TITLE
Shared imagequant libraries may be located within usr/lib64

### DIFF
--- a/depends/install_imagequant.sh
+++ b/depends/install_imagequant.sh
@@ -23,7 +23,12 @@ else
     cargo cinstall --prefix=/usr --destdir=.
 
     # Copy into place
-    sudo cp usr/lib/libimagequant.so* /usr/lib/
+    if [ -d "usr/lib64" ]; then
+        lib="lib64"
+    else
+        lib="lib"
+    fi
+    sudo cp usr/$lib/libimagequant.so* /usr/lib/
     sudo cp usr/include/libimagequant.h /usr/include/
 
     if [ -n "$GITHUB_ACTIONS" ]; then


### PR DESCRIPTION
The docker-images Gentoo job can't install libimagequant at the moment - https://github.com/python-pillow/docker-images/actions/runs/10988523287/job/30505070454#step:6:1356
> cp: cannot stat 'usr/lib/libimagequant.so*': No such file or directory

Testing, I find that the shared libraries are actually within 'lib64' instead. So this updates the install script to work with either directory.

With this change, libimagequant is installed and [detected successfully.](https://github.com/radarhere/docker-images/actions/runs/10990710903/job/30511535686#step:7:643)