### PR TITLE
Prevent division by zero

### DIFF
--- a/src/libImaging/FliDecode.c
+++ b/src/libImaging/FliDecode.c
@@ -224,7 +224,7 @@ ImagingFliDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t byt
                 break;
             case 16:
                 /* COPY chunk */
-                if (INT32_MAX / state->xsize < state->ysize) {
+                if (INT32_MAX < (uint64_t)state->xsize * state->ysize) {
                     /* Integer overflow, bail */
                     state->errcode = IMAGING_CODEC_OVERRUN;
                     return -1;


### PR DESCRIPTION
Resolves #8405. Alternative to #8406

The issue is concerned that at
https://github.com/python-pillow/Pillow/blob/731bcda904544d9d26bce268eca3a5cb4fcc1c46/src/libImaging/FliDecode.c#L227
`state->xsize` might be zero, and so we might be dividing by zero.

However, in the context of our library as a whole, images that say one of their dimensions are zero will be stopped at https://github.com/python-pillow/Pillow/blob/731bcda904544d9d26bce268eca3a5cb4fcc1c46/src/PIL/ImageFile.py#L154-L156

Even if you consider just the C decoding process, we have
https://github.com/python-pillow/Pillow/blob/731bcda904544d9d26bce268eca3a5cb4fcc1c46/src/decode.c#L189-L192

So this is not a scenario that should actually occur. However, in order to allay concerns from a casual observer, it might be worth updating the code. I don't consider changes to address this to be a 'fix', but rather a 'If all else fails' safety net.

#8406 suggests resolving the concern by raising an error from within FliDecode.c. My minor concern with that strategy is that we could make someone reading the code think that `xsize` might be zero there.

Instead, I'm going to suggest just removing the division operation altogether.
```c
if (INT32_MAX < (long)state->xsize * state->ysize) {
```