### PR TITLE
Updated macOS deployment target for PyPy on Intel to 10.15

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -105,13 +105,18 @@ jobs:
           - name: "macOS 10.10 x86_64"
             os: macos-13
             cibw_arch: x86_64
-            build: "pp310* cp3{9,10,11}*"
+            build: "cp3{9,10,11}*"
             macosx_deployment_target: "10.10"
           - name: "macOS 10.13 x86_64"
             os: macos-13
             cibw_arch: x86_64
             build: "cp3{12,13}*"
             macosx_deployment_target: "10.13"
+          - name: "macOS 10.15 x86_64"
+            os: macos-13
+            cibw_arch: x86_64
+            build: "pp310*"
+            macosx_deployment_target: "10.15"
           - name: "macOS arm64"
             os: macos-latest
             cibw_arch: arm64


### PR DESCRIPTION
https://doc.pypy.org/en/latest/release-v7.3.17.html
> Bump `MACOSX_DEPLOYMENT_TARGET` to 10.15 on x86_64 and 11.0 on arm64 ([#4975](https://github.com/pypy/pypy/issues/4975))

https://pypy.org/download.html
> MacOS x86_64 | Download | Download | MacOS >= 10.15, not for Mojave and below.