### PR TITLE
Improved copying imagequant libraries

### DIFF
--- a/depends/install_imagequant.sh
+++ b/depends/install_imagequant.sh
@@ -23,19 +23,14 @@ else
     cargo cinstall --prefix=/usr --destdir=.
 
     # Copy into place
-    if [ -d "usr/lib64" ]; then
-        lib="lib64"
-    else
-        lib="lib"
-    fi
-    sudo cp usr/$lib/libimagequant.so* /usr/lib/
+    sudo find usr -name libimagequant.so* -exec cp {} /usr/lib/ \;
     sudo cp usr/include/libimagequant.h /usr/include/
 
     if [ -n "$GITHUB_ACTIONS" ]; then
         # Copy to cache
         rm -rf ~/cache-$archive_name
         mkdir ~/cache-$archive_name
-        cp usr/lib/libimagequant.so* ~/cache-$archive_name/
+        find usr -name libimagequant.so* -exec cp {} ~/cache-$archive_name/ \;
         cp usr/include/libimagequant.h ~/cache-$archive_name/
     fi
 


### PR DESCRIPTION
#8407 updated the path to shared libraries in libimagequant to allow for usr/lib64.

I've made two improvements here.
1. The previous PR didn't update the path to copy from for the caching mechanism. This is inconsistent, and might cause problems one day.
2. I found that the path for Debian is usr/lib/x86_64-linux-gnu. Rather than adding a third possible path, I've used `find` to allow for the path to vary.