### PR TITLE
Change harfbuzz versions in wheels

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -156,12 +156,10 @@ if [[ -n "$IS_MACOS" ]]; then
   fi
 
   brew install meson pkg-config
-elif [[ "$MB_ML_LIBC" == "manylinux" ]]; then
-  if [[ "$HARFBUZZ_VERSION" != 8.5.0 ]]; then
-    yum install -y meson
-  fi
-else
+elif [[ -n "$IS_ALPINE" ]]; then
   apk add meson
+elif [[ "$HARFBUZZ_VERSION" != 8.5.0 ]]; then
+  yum install -y meson
 fi
 
 wrap_wheel_builder build

--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -16,7 +16,7 @@ ARCHIVE_SDIR=pillow-depends-main
 
 # Package versions for fresh source builds
 FREETYPE_VERSION=2.13.2
-if [[ "$MB_ML_VER" != 2014 ]] && [[ -z "$SANITIZER" ]]; then
+if [[ -n "$IS_MACOS" ]] || ([[ "$MB_ML_VER" != 2014 ]] && [[ -z "$SANITIZER" ]]); then
     HARFBUZZ_VERSION=10.0.1
 else
     HARFBUZZ_VERSION=8.5.0

--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -16,7 +16,7 @@ ARCHIVE_SDIR=pillow-depends-main
 
 # Package versions for fresh source builds
 FREETYPE_VERSION=2.13.2
-if [[ "$MB_ML_VER" != 2014 ]]; then
+if [[ "$MB_ML_VER" != 2014 ]] && [[ -z "$SANITIZER" ]]; then
     HARFBUZZ_VERSION=10.0.1
 else
     HARFBUZZ_VERSION=8.5.0


### PR DESCRIPTION
Two changes here.

1. As noted in #8361, harfbuzz has switched to meson - https://github.com/harfbuzz/harfbuzz/releases/tag/9.0.0.

More specifically though, it now requires [meson >= 0.55](https://github.com/harfbuzz/harfbuzz/blob/c7ef6a2ed58ae8ec108ee0962bef46f42c73a60c/meson.build#L2).

This is a problem, as the base image for oss-fuzz uses [Ubuntu 20.04](https://github.com/google/oss-fuzz/blob/7fa4a40a8547a007bdf13c2bb391cec8c14d8dc0/infra/base-images/base-image/Dockerfile#L19), which only has [meson 0.53.2](https://packages.ubuntu.com/focal/meson)

So this PR downgrades harfuzz on OSS Fuzz to the version before meson became mandatory. I've used the environment variable 'SANITIZER' to detect OSS Fuzz.

2. I found that harfbuzz 8.5.0 was being [installed on macOS](https://github.com/python-pillow/Pillow/actions/runs/11025025842/job/30619203668#step:5:6955). I've fixed that, and 10.0.1 is now installed instead.