### PR TITLE
Use ruff check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ lint-fix:
 	python3 -c "import black" > /dev/null 2>&1 || python3 -m pip install black
 	python3 -m black .
 	python3 -c "import ruff" > /dev/null 2>&1 || python3 -m pip install ruff
-	python3 -m ruff --fix .
+	python3 -m ruff check --fix .
 
 .PHONY: mypy
 mypy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,9 +97,13 @@ config-settings = "raqm=enable raqm=vendor fribidi=vendor imagequant=disable"
 test-command = "cd {project} && .github/workflows/wheels-test.sh"
 test-extras = "tests"
 
-[tool.ruff]
-fix = true
+[tool.black]
+exclude = "wheels/multibuild"
 
+[tool.ruff]
+exclude = [ "wheels/multibuild" ]
+
+fix = true
 lint.select = [
   "C4",     # flake8-comprehensions
   "E",      # pycodestyle errors


### PR DESCRIPTION
- Update Makefile to use `ruff check .` rather than `ruff .`, as per https://github.com/astral-sh/ruff/pull/10169
- Do not run ruff or black over the multibuild submodule. The effect of this is not usually seen, but if you were using multibuild for some reason (`git submodule update`), and then ran either ruff or black in Pillow, they would both modify the code.