### PR TITLE
Restore cifuzz

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -24,8 +24,6 @@ concurrency:
 
 jobs:
   Fuzzing:
-    # Disabled until google/oss-fuzz#11419 upgrades Python to 3.9+
-    if: false
     runs-on: ubuntu-latest
     steps:
     - name: Build Fuzzers


### PR DESCRIPTION
Reverts #8239 now that https://github.com/google/oss-fuzz/pull/12546 has been merged.