### PR TITLE
Do not convert images unnecessarily in ImageEnhance

### DIFF
--- a/src/PIL/ImageEnhance.py
+++ b/src/PIL/ImageEnhance.py
@@ -55,7 +55,9 @@ class Color(_Enhance):
         if "A" in image.getbands():
             self.intermediate_mode = "LA"
 
-        self.degenerate = image.convert(self.intermediate_mode).convert(image.mode)
+        if self.intermediate_mode != image.mode:
+            image = image.convert(self.intermediate_mode).convert(image.mode)
+        self.degenerate = image
 
 
 class Contrast(_Enhance):
@@ -68,11 +70,15 @@ class Contrast(_Enhance):
 
     def __init__(self, image: Image.Image) -> None:
         self.image = image
-        mean = int(ImageStat.Stat(image.convert("L")).mean[0] + 0.5)
-        self.degenerate = Image.new("L", image.size, mean).convert(image.mode)
+        if image.mode != "L":
+            image = image.convert("L")
+        mean = int(ImageStat.Stat(image).mean[0] + 0.5)
+        self.degenerate = Image.new("L", image.size, mean)
+        if self.degenerate.mode != self.image.mode:
+            self.degenerate = self.degenerate.convert(self.image.mode)
 
-        if "A" in image.getbands():
-            self.degenerate.putalpha(image.getchannel("A"))
+        if "A" in self.image.getbands():
+            self.degenerate.putalpha(self.image.getchannel("A"))
 
 
 class Brightness(_Enhance):


### PR DESCRIPTION
If an attempt is made to convert an image to its current mode [(without a matrix), a copy is simply returned.](https://github.com/python-pillow/Pillow/blob/c6b08ef32c39dc6517e9140c92dde7e10999da5e/src/PIL/Image.py#L1009-L1010)

However, `copy()` still consumes resources, and it would be ideal to avoid it where possible. In ImageEnhance, there are a few such instances.

What if the image already matches `self.intermediate_mode` in `Color`?
https://github.com/python-pillow/Pillow/blob/c6b08ef32c39dc6517e9140c92dde7e10999da5e/src/PIL/ImageEnhance.py#L58

What if the image is already L mode in `Enhance`?
https://github.com/python-pillow/Pillow/blob/c6b08ef32c39dc6517e9140c92dde7e10999da5e/src/PIL/ImageEnhance.py#L69-L72

This PR skips calling `convert()` for those scenarios.