### PR TITLE
Test cifuzz when wheel dependencies change

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -6,11 +6,13 @@ on:
       - "**"
     paths:
       - ".github/workflows/cifuzz.yml"
+      - ".github/workflows/wheels-dependencies.sh"
       - "**.c"
       - "**.h"
   pull_request:
     paths:
       - ".github/workflows/cifuzz.yml"
+      - ".github/workflows/wheels-dependencies.sh"
       - "**.c"
       - "**.h"
   workflow_dispatch:


### PR DESCRIPTION
Since our cifuzz job is [a different environment to our other jobs](https://github.com/google/oss-fuzz/blob/7fa4a40a8547a007bdf13c2bb391cec8c14d8dc0/infra/base-images/base-image/Dockerfile#L19), and [calls wheels-dependencies.sh](https://github.com/google/oss-fuzz/blob/38d4a5abcb47b8257fd05b5bdd7d752ed19a0d1f/projects/pillow/build_depends.sh#L26), I think it makes sense to test cifuzz when a change is made to wheels-dependencies.sh.

A concrete demonstration of this was made in #8421, when it featured a change in wheels-dependencies.sh specifically targeted at the cifuzz job.

