### PR TITLE
Generate and upload attestations to PyPI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -296,3 +296,5 @@ jobs:
           merge-multiple: true
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true


### PR DESCRIPTION
PEP 740 ("Index support for digital attestations" introduces digital attestations which links the PyPI package to the GitHub repo, and helps users verify the source and authenticity of packages.

PyPI is still implementing support, but we can already start using it, which should also help them test out.

* https://peps.python.org/pep-0740/
* https://github.com/pypa/gh-action-pypi-publish#generating-and-uploading-attestations
* https://github.com/pypi/warehouse/issues/15871
