### PR TITLE
Use transparency when combining P frames from APNGs

### DIFF
--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -258,8 +258,8 @@ def test_apng_mode() -> None:
         assert im.mode == "P"
         im.seek(im.n_frames - 1)
         im = im.convert("RGBA")
-        assert im.getpixel((0, 0)) == (255, 0, 0, 0)
-        assert im.getpixel((64, 32)) == (255, 0, 0, 0)
+        assert im.getpixel((0, 0)) == (0, 255, 0, 255)
+        assert im.getpixel((64, 32)) == (0, 255, 0, 255)
 
     with Image.open("Tests/images/apng/mode_palette_1bit_alpha.png") as im:
         assert im.mode == "P"

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -1063,6 +1063,12 @@ class PngImageFile(ImageFile.ImageFile):
                         "RGBA", self.info["transparency"]
                     )
                 else:
+                    if self.im.mode == "P" and "transparency" in self.info:
+                        t = self.info["transparency"]
+                        if isinstance(t, bytes):
+                            updated.putpalettealphas(t)
+                        elif isinstance(t, int):
+                            updated.putpalettealpha(t)
                     mask = updated.convert("RGBA")
                 self._prev_im.paste(updated, self.dispose_extent, mask)
                 self.im = self._prev_im


### PR DESCRIPTION
Helps #8440

When subsequent frames are loaded from an APNG image, transparency is considered for RGB core images, but not for P core images.

https://github.com/python-pillow/Pillow/blob/01bb78a8e7ae7656b5abddd2d9d37f67124f8a3e/src/PIL/PngImagePlugin.py#L1061-L1066

This adds that, modelled after
https://github.com/python-pillow/Pillow/blob/01bb78a8e7ae7656b5abddd2d9d37f67124f8a3e/src/PIL/Image.py#L1100-L1103