### PR TITLE
Fixed unclosed file warning in test_imageshow.py

### DIFF
--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -117,5 +117,5 @@ def test_ipythonviewer() -> None:
     else:
         pytest.fail("IPythonViewer not found")
 
-    im = hopper()
-    assert test_viewer.show(im) == 1
+    with hopper() as im:
+        assert test_viewer.show(im) == 1


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/11202062547/job/31137725975#step:12:4820
> Tests/test_imageshow.py::test_ipythonviewer
>   /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/_pytest/python.py:159: ResourceWarning: unclosed file <_io.BufferedReader name='/Users/runner/work/Pillow/Pillow/Tests/images/hopper.ppm'>

The file is opened in `hopper()`
https://github.com/python-pillow/Pillow/blob/27c1bb265432cb5a1138e39165f0610e2d8a4e94/Tests/helper.py#L252-L261

and then called in
https://github.com/python-pillow/Pillow/blob/27c1bb265432cb5a1138e39165f0610e2d8a4e94/Tests/test_imageshow.py#L120-L121

Adding a context manager fixes the warning.