### PR TITLE
Removed unused code

### DIFF
--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -922,10 +922,7 @@ font_render(FontObject *self, PyObject *args) {
     width += ceil(stroke_width * 2 + x_start);
     height += ceil(stroke_width * 2 + y_start);
     image = PyObject_CallFunction(fill, "ii", width, height);
-    if (image == Py_None) {
-        PyMem_Del(glyph_info);
-        return Py_BuildValue("N(ii)", image, 0, 0);
-    } else if (image == NULL) {
+    if (image == NULL) {
         PyMem_Del(glyph_info);
         return NULL;
     }


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/27c1bb265432cb5a1138e39165f0610e2d8a4e94/src/_imagingft.c#L924-L927

The scenario where the Python `fill()` function might return `None` began in #7247. However, when it was removed in #7645, the C code to handle it stayed. This PR now removes that code.