### PR TITLE
In Image.Image.seek(), clear core image if mode or size has changed

### DIFF
--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -428,3 +428,32 @@ class TestPyEncoder(CodecsTest):
     def test_zero_height(self) -> None:
         with pytest.raises(UnidentifiedImageError):
             Image.open("Tests/images/zero_height.j2k")
+
+    def test_load_prepare(self):
+        class TestImageFile(ImageFile.ImageFile):
+            def _open(self) -> None:
+                self._mode = "1"
+                self._size = (1, 1)
+                self._frame = 0
+
+            def seek(self, frame: int) -> None:
+                self._mode = "L"
+                self._size = (2, 2)
+                self._frame = frame
+                super().seek(frame)
+
+            def tell(self) -> int:
+                return self._frame
+
+        fp = BytesIO()
+        im = TestImageFile(fp)
+        im.load_prepare()
+        assert im._im is not None
+
+        im.seek(1)
+        assert im._im is None
+
+        im.load_prepare()
+        assert im._im is not None
+        assert im._im.mode == im.mode
+        assert im._im.size == im.size

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2633,9 +2633,15 @@ class Image:
         """
 
         # overridden by file handlers
-        if frame != 0:
+        if frame != self.tell():
+            # The file handler likely did not override this method
             msg = "no more images in file"
             raise EOFError(msg)
+
+        if self._im is not None and (
+            self.im.size != self.size or self.im.mode != self.mode
+        ):
+            self._im = None
 
     def show(self, title: str | None = None) -> None:
         """


### PR DESCRIPTION
Addresses #8439

#8390 stopped `load_prepare()` from recreating the core image instance if the mode or size had changed, as might happen at the end of a `seek()` operation. After that PR, this was no longer needed for any of our internal plugins.

However, #8439 has pointed out that this would still be helpful for external plugins. Rather than reverting the change, this PR suggests that external plugins can call `super().seek()` at the end of their `seek()` methods. That will then clear the core image instance if the mode or size has changed, allowing `load_prepare()` to detect that a new core image is needed.

The advantage of this over a simple revert is that if a user calls `seek()` on an image, but not `load()`, then the core image instance is discarded.