### PR TITLE
Revert "Skip QEMU-emulated wheels on workflow dispatch event"

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   build-1-QEMU-emulated-wheels:
-    if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+    if: github.event_name != 'schedule'
     name: aarch64 ${{ matrix.python-version }} ${{ matrix.spec }}
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Reverts #8243

I think it is helpful to be able to manually trigger all of the wheel jobs before a release, to increase confidence that everything will work correctly.

If anyone has a reason for more commonly wanting to manually trigger all of the wheel jobs except for the emulated ones, please let me know.