### PR TITLE
Use CVE and CWE roles from Sphinx 8.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,10 @@ coverage:
 .PHONY: doc
 .PHONY: html
 doc html:
-	python3 -c "import PIL" > /dev/null 2>&1 || python3 -m pip install .
 	$(MAKE) -C docs html
 
 .PHONY: htmlview
 htmlview:
-	python3 -c "import PIL" > /dev/null 2>&1 || python3 -m pip install .
 	$(MAKE) -C docs htmlview
 
 .PHONY: doccheck

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -46,7 +46,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 install-sphinx:
-	$(PYTHON) -m pip install --quiet furo olefile sphinx sphinx-copybutton sphinx-inline-tabs sphinxext-opengraph
+	$(PYTHON) -m pip install -e ..[docs]
 
 .PHONY: html
 html:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ import PIL
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "7.3"
+needs_sphinx = "8.1"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -338,8 +338,6 @@ linkcheck_allowed_redirects = {
 # https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html
 _repo = "https://github.com/python-pillow/Pillow/"
 extlinks = {
-    "cve": ("https://www.cve.org/CVERecord?id=CVE-%s", "CVE-%s"),
-    "cwe": ("https://cwe.mitre.org/data/definitions/%s.html", "CWE-%s"),
     "issue": (_repo + "issues/%s", "#%s"),
     "pr": (_repo + "pull/%s", "#%s"),
     "pypi": ("https://pypi.org/project/%s/", "%s"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dynamic = [
 optional-dependencies.docs = [
   "furo",
   "olefile",
-  "sphinx>=7.3",
+  "sphinx>=8.1",
   "sphinx-copybutton",
   "sphinx-inline-tabs",
   "sphinxext-opengraph",


### PR DESCRIPTION
Changes proposed in this pull request:

 * Sphinx 8.1 adds roles for referencing CVEs ([`:cve:`](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-cve)) and CWEs ([`:cwe:`](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-cwe))
 * https://www.sphinx-doc.org/en/master/changes/index.html
 * Let's use those instead of our own `extlinks`
 * Update `Makefile` so we install Pillow for docs builds using the `docs` extra, so installs Sphinx 8.1+, and avoids defining the docs dependencies in two places