### PR TITLE
Do not close provided file handles with libtiff when saving

### DIFF
--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1864,7 +1864,7 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
         if hasattr(fp, "fileno"):
             try:
                 fp.seek(0)
-                _fp = os.dup(fp.fileno())
+                _fp = fp.fileno()
             except io.UnsupportedOperation:
                 pass
 
@@ -1943,11 +1943,6 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
                 fp.write(data)
             if errcode:
                 break
-        if _fp:
-            try:
-                os.close(_fp)
-            except OSError:
-                pass
         if errcode < 0:
             msg = f"encoder error {errcode} when writing image file"
             raise OSError(msg)


### PR DESCRIPTION
Addresses https://github.com/python-pillow/Pillow/issues/7042#issuecomment-2404653713

#7199 made a change to C code so that libtiff did not always close the file handle when decoding an image, removing the need for the file handle to be duplicated in Python.

This makes the save change, but for encoding an image.