### PR TITLE
Always raise warnings for deprecated feature checks

### DIFF
--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -56,17 +56,17 @@ def test_version() -> None:
 
 def test_webp_transparency() -> None:
     with pytest.warns(DeprecationWarning):
-        assert features.check("transp_webp") == features.check_module("webp")
+        assert (features.check("transp_webp") or False) == features.check_module("webp")
 
 
 def test_webp_mux() -> None:
     with pytest.warns(DeprecationWarning):
-        assert features.check("webp_mux") == features.check_module("webp")
+        assert (features.check("webp_mux") or False) == features.check_module("webp")
 
 
 def test_webp_anim() -> None:
     with pytest.warns(DeprecationWarning):
-        assert features.check("webp_anim") == features.check_module("webp")
+        assert (features.check("webp_anim") or False) == features.check_module("webp")
 
 
 @skip_unless_feature("libjpeg_turbo")

--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -146,10 +146,11 @@ def check_feature(feature: str) -> bool | None:
 
     module, flag, ver = features[feature]
 
+    if isinstance(flag, bool):
+        deprecate(f'check_feature("{feature}")', 12)
     try:
         imported_module = __import__(module, fromlist=["PIL"])
         if isinstance(flag, bool):
-            deprecate(f'check_feature("{feature}")', 12)
             return flag
         return getattr(imported_module, flag)
     except ModuleNotFoundError:


### PR DESCRIPTION
When I run the test suite [without WebP installed](https://github.com/radarhere/Pillow/commit/d6b8c8cc4d0a45629c2ad0caf1963c420c4fb18a), it [fails.](https://github.com/radarhere/Pillow/actions/runs/11290360694/job/31402063623#step:26:143)

```
Tests/test_features.py::test_check FAILED                                [  2%]

================================== FAILURES ===================================
_________________________________ test_check __________________________________

    def test_check() -> None:
        # Check the correctness of the convenience function
        for module in features.modules:
            assert features.check_module(module) == features.check(module)
        for codec in features.codecs:
            assert features.check_codec(codec) == features.check(codec)
        for feature in features.features:
            if "webp" in feature:
>               with pytest.warns(DeprecationWarning):
E               Failed: DID NOT WARN. No warnings of type (<class 'DeprecationWarning'>,) were emitted.
E                Emitted warnings: [].
```

The backstory of this is that #8213 deprecated `features.check("transp_webp")`, `features.check("webp_mux")` and `features.check("webp_anim")`.

However, the deprecation warning is only raised if the underlying WebP module is installed, and the missing module doesn't raise an error earlier than the warning.

https://github.com/python-pillow/Pillow/blob/e93dcc15780d29af45fa64cf54ff6b11c2c27c46/src/PIL/features.py#L149-L159

This PR updates features.py so that the feature checks raise a deprecation warning when WebP is not installed as well.