### PR TITLE
Update licence to MIT-CMU

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,7 @@ repos:
     rev: v0.20.2
     hooks:
       - id: validate-pyproject
+        additional_dependencies: [trove-classifiers>=2024.10.12]
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
     rev: 1.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,14 +14,14 @@ readme = "README.md"
 keywords = [
   "Imaging",
 ]
-license = { text = "HPND" }
+license = { text = "MIT-CMU" }
 authors = [
   { name = "Jeffrey A. Clark", email = "aclark@aclark.net" },
 ]
 requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 6 - Mature",
-  "License :: OSI Approved :: Historical Permission Notice and Disclaimer (HPND)",
+  "License :: OSI Approved :: CMU License (MIT-CMU)",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Closes https://github.com/python-pillow/Pillow/issues/7942.

Pending https://github.com/pypa/trove-classifiers/pull/189.