### PR TITLE
Use ImageFile.MAXBLOCK when saving TIFF images

### DIFF
--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1937,8 +1937,7 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
         encoder = Image._getencoder(im.mode, "libtiff", a, encoderconfig)
         encoder.setimage(im.im, (0, 0) + im.size)
         while True:
-            # undone, change to self.decodermaxblock:
-            errcode, data = encoder.encode(16 * 1024)[1:]
+            errcode, data = encoder.encode(ImageFile.MAXBLOCK)[1:]
             if not _fp:
                 fp.write(data)
             if errcode:


### PR DESCRIPTION
Addresses an 'undone' that has been present since #98

https://github.com/python-pillow/Pillow/blob/08b561e25dd58daa6bc86989d1a8e55795a6b81e/src/PIL/TiffImagePlugin.py#L1940-L1941

`self.decodermaxblock` isn't necessarily available, because `im` may not be an `ImageFile` instance, but `ImageFile.MAXBLOCK` is usually the same.

https://github.com/python-pillow/Pillow/blob/08b561e25dd58daa6bc86989d1a8e55795a6b81e/src/PIL/ImageFile.py#L128