### PR TITLE
Update Python 3.13 release date

### DIFF
--- a/docs/releasenotes/11.0.0.rst
+++ b/docs/releasenotes/11.0.0.rst
@@ -1,19 +1,6 @@
 11.0.0
 ------
 
-Security
-========
-
-TODO
-^^^^
-
-TODO
-
-:cve:`YYYY-XXXXX`: TODO
-^^^^^^^^^^^^^^^^^^^^^^^
-
-TODO
-
 Backwards Incompatible Changes
 ==============================
 
@@ -159,7 +146,7 @@ Python 3.13
 
 Pillow 10.4.0 had wheels built against Python 3.13 beta, available as a preview to help
 others prepare for 3.13, and to ensure Pillow could be used immediately at the release
-of 3.13.0 final (2024-10-01, :pep:`719`).
+of 3.13.0 final (2024-10-07, :pep:`719`).
 
 Pillow 11.0.0 now officially supports Python 3.13.
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * The final Python 3.13 release was [delayed by 6 days](https://discuss.python.org/t/incremental-gc-and-pushing-back-the-3-13-0-release/65285) but went out [successfully on 2024-10-07](https://discuss.python.org/t/python-3-13-0-final-has-been-released/66972)
 * https://peps.python.org/pep-0719/
