### PR TITLE
Removed unnecessary code

### DIFF
--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -103,7 +103,6 @@ class GifImageFile(ImageFile.ImageFile):
 
         self.info["version"] = s[:6]
         self._size = i16(s, 6), i16(s, 8)
-        self.tile = []
         flags = s[10]
         bits = (flags & 7) + 1
 

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -60,7 +60,6 @@ class WebPImageFile(ImageFile.ImageFile):
         self.is_animated = self.n_frames > 1
         self._mode = "RGB" if mode == "RGBX" else mode
         self.rawmode = mode
-        self.tile = []
 
         # Attempt to read ICC / EXIF / XMP chunks from file
         icc_profile = self._decoder.get_chunk("ICCP")


### PR DESCRIPTION
`self.tile` is initialized to an empty list in `ImageFile.__init__()`.

https://github.com/python-pillow/Pillow/blob/f2cc87b1f0627dfce07ab2867e29ba07e5055f33/src/PIL/ImageFile.py#L122

So when it calls `_open` on plugins, `self.tile` doesn't need to be set to an empty list again.

https://github.com/python-pillow/Pillow/blob/f2cc87b1f0627dfce07ab2867e29ba07e5055f33/src/PIL/ImageFile.py#L144
https://github.com/python-pillow/Pillow/blob/f2cc87b1f0627dfce07ab2867e29ba07e5055f33/src/PIL/GifImagePlugin.py#L97-L106
https://github.com/python-pillow/Pillow/blob/f2cc87b1f0627dfce07ab2867e29ba07e5055f33/src/PIL/WebPImagePlugin.py#L43-L63