### PR TITLE
Corrected EMF DPI

### DIFF
--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from io import BytesIO
 from pathlib import Path
 from typing import IO
 
@@ -60,6 +61,12 @@ def test_register_handler(tmp_path: Path) -> None:
 def test_load_float_dpi() -> None:
     with Image.open("Tests/images/drawing.emf") as im:
         assert im.info["dpi"] == 1423.7668161434979
+
+    with open("Tests/images/drawing.emf", "rb") as fp:
+        data = fp.read()
+    b = BytesIO(data[:8] + b"\x06\xFA" + data[10:])
+    with Image.open(b) as im:
+        assert im.info["dpi"][0] == 2540
 
 
 def test_load_set_dpi() -> None:

--- a/src/PIL/WmfImagePlugin.py
+++ b/src/PIL/WmfImagePlugin.py
@@ -128,7 +128,7 @@ class WmfStubImageFile(ImageFile.StubImageFile):
             size = x1 - x0, y1 - y0
 
             # calculate dots per inch from bbox and frame
-            xdpi = 2540.0 * (x1 - y0) / (frame[2] - frame[0])
+            xdpi = 2540.0 * (x1 - x0) / (frame[2] - frame[0])
             ydpi = 2540.0 * (y1 - y0) / (frame[3] - frame[1])
 
             self.info["wmf_bbox"] = x0, y0, x1, y1


### PR DESCRIPTION
Resolves #8462

Corrects a typo when calculating the X DPI of an EMF image - `x1 - y0` should be `x1 - x0`.

https://github.com/python-pillow/Pillow/blob/331e4e751733eb0af018602ef26746a7e0571107/src/PIL/WmfImagePlugin.py#L130-L132