### PR TITLE
Improved handling of RGBA palettes when saving GIF images

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -4,6 +4,7 @@ import warnings
 from collections.abc import Generator
 from io import BytesIO
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -1431,7 +1432,8 @@ def test_saving_rgba(tmp_path: Path) -> None:
         assert reloaded_rgba.load()[0, 0][3] == 0
 
 
-def test_optimizing_p_rgba(tmp_path: Path) -> None:
+@pytest.mark.parametrize("params", ({}, {"disposal": 2, "optimize": False}))
+def test_p_rgba(tmp_path: Path, params: dict[str, Any]) -> None:
     out = str(tmp_path / "temp.gif")
 
     im1 = Image.new("P", (100, 100))
@@ -1443,7 +1445,7 @@ def test_optimizing_p_rgba(tmp_path: Path) -> None:
     im2 = Image.new("P", (100, 100))
     im2.putpalette(data, "RGBA")
 
-    im1.save(out, save_all=True, append_images=[im2])
+    im1.save(out, save_all=True, append_images=[im2], **params)
 
     with Image.open(out) as reloaded:
         assert reloaded.n_frames == 2

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -695,8 +695,9 @@ def _write_multiple_frames(
                         )
                         background = _get_background(im_frame, color)
                         background_im = Image.new("P", im_frame.size, background)
-                        assert im_frames[0].im.palette is not None
-                        background_im.putpalette(im_frames[0].im.palette)
+                        first_palette = im_frames[0].im.palette
+                        assert first_palette is not None
+                        background_im.putpalette(first_palette, first_palette.mode)
                     bbox = _getbbox(background_im, im_frame)[1]
                 elif encoderinfo.get("optimize") and im_frame.mode != "1":
                     if "transparency" not in encoderinfo:


### PR DESCRIPTION
Resolves #8493

Passes the palette mode to `im.putpalette()` when saving GIF images, so that RGBA palettes aren't handled as RGB, raising an error if they are too large.