### PR TITLE
Replace Windows zlib with zlib-ng

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -104,8 +104,16 @@ SF_PROJECTS = "https://sourceforge.net/projects"
 
 ARCHITECTURES = {
     "x86": {"vcvars_arch": "x86", "msbuild_arch": "Win32", "zlibng_arch": "x86"},
-    "AMD64": {"vcvars_arch": "x86_amd64", "msbuild_arch": "x64", "zlibng_arch": "x86-64"},
-    "ARM64": {"vcvars_arch": "x86_arm64", "msbuild_arch": "ARM64", "zlibng_arch": "arm64"},
+    "AMD64": {
+        "vcvars_arch": "x86_amd64",
+        "msbuild_arch": "x64",
+        "zlibng_arch": "x86-64",
+    },
+    "ARM64": {
+        "vcvars_arch": "x86_arm64",
+        "msbuild_arch": "ARM64",
+        "zlibng_arch": "arm64",
+    },
 }
 
 V = {
@@ -161,7 +169,7 @@ DEPS: dict[str, dict[str, Any]] = {
     },
     "zlib": {
         "url": f"https://github.com/zlib-ng/zlib-ng/releases/download/{V['ZLIBNG']}/zlib-ng-win-{{zlibng_arch}}-compat.zip",
-        "filename": f"zlib-ng-win-{{zlibng_arch}}-compat.zip",
+        "filename": "zlib-ng-win-{zlibng_arch}-compat.zip",
         "dir": "",
         "release": f"zlib-ng-{V['ZLIBNG']}",
         "license": "LICENSE.md",

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -120,11 +120,10 @@ V = {
     "OPENJPEG": "2.5.2",
     "TIFF": "4.6.0",
     "XZ": "5.6.3",
-    "ZLIB": "1.3.1",
+    "ZLIBNG": "2.2.2",
 }
 V["LIBPNG_DOTLESS"] = V["LIBPNG"].replace(".", "")
 V["LIBPNG_XY"] = "".join(V["LIBPNG"].split(".")[:2])
-V["ZLIB_DOTLESS"] = V["ZLIB"].replace(".", "")
 
 
 # dependencies, listed in order of compilation
@@ -161,14 +160,13 @@ DEPS: dict[str, dict[str, Any]] = {
         "bins": ["cjpeg.exe", "djpeg.exe"],
     },
     "zlib": {
-        "url": f"https://zlib.net/zlib{V['ZLIB_DOTLESS']}.zip",
-        "filename": f"zlib{V['ZLIB_DOTLESS']}.zip",
-        "dir": f"zlib-{V['ZLIB']}",
-        "license": "README",
-        "license_pattern": "Copyright notice:\n\n(.+)$",
+        "url": f"https://github.com/zlib-ng/zlib-ng/archive/refs/tags/{V['ZLIBNG']}.zip",
+        "filename": f"zlib-ng-{V['ZLIBNG']}.zip",
+        "dir": f"zlib-ng-{V['ZLIBNG']}",
+        "license": "LICENSE.md",
         "build": [
             cmd_nmake(r"win32\Makefile.msc", "clean"),
-            cmd_nmake(r"win32\Makefile.msc", "zlib.lib"),
+            cmd_nmake(r"win32\Makefile.msc", "zlib.lib", ["ZLIB_COMPAT=yes"]),
             cmd_copy("zlib.lib", "z.lib"),
         ],
         "headers": [r"z*.h"],


### PR DESCRIPTION
Changes proposed in this pull request:

 * Replacing zlib with [zlib-ng](https://github.com/zlib-ng/zlib-ng) makes huge speedup for PNG encoding.

Here are my quick and dirty benchmark.
(on x64 Windows, read/write PNG 10 times)

Original (with zlib):
```
PIL.__version__='11.1.0.dev0'
read PNG: 0.092544 (sec)
on-memory PNG: 1.034144 (sec)
write PNG: 1.054776 (sec)
PNG size 1352945 bytes
```

With zlib-ng:
```
PIL.__version__='11.1.0.dev0'
read PNG: 0.089149 (sec)
on-memory PNG: 0.515073 (sec)
write PNG: 0.527402 (sec)
PNG size 1394511 bytes
```

It's about 2x speed-up with little effort.


Comparison & benchmark of zlib forks (JAN 2021):
https://aws.amazon.com/blogs/opensource/improving-zlib-cloudflare-and-comparing-performance-with-other-zlib-forks/