### PR TITLE
Added filename placeholder in winbuild URL

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -130,8 +130,7 @@ V["ZLIB_DOTLESS"] = V["ZLIB"].replace(".", "")
 # dependencies, listed in order of compilation
 DEPS: dict[str, dict[str, Any]] = {
     "libjpeg": {
-        "url": f"{SF_PROJECTS}/libjpeg-turbo/files/{V['JPEGTURBO']}/"
-        "FILENAME/download",
+        "url": f"{SF_PROJECTS}/libjpeg-turbo/files/{V['JPEGTURBO']}/FILENAME/download",
         "filename": f"libjpeg-turbo-{V['JPEGTURBO']}.tar.gz",
         "dir": f"libjpeg-turbo-{V['JPEGTURBO']}",
         "license": ["README.ijg", "LICENSE.md"],

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -131,7 +131,7 @@ V["ZLIB_DOTLESS"] = V["ZLIB"].replace(".", "")
 DEPS: dict[str, dict[str, Any]] = {
     "libjpeg": {
         "url": f"{SF_PROJECTS}/libjpeg-turbo/files/{V['JPEGTURBO']}/"
-        f"libjpeg-turbo-{V['JPEGTURBO']}.tar.gz/download",
+        "FILENAME/download",
         "filename": f"libjpeg-turbo-{V['JPEGTURBO']}.tar.gz",
         "dir": f"libjpeg-turbo-{V['JPEGTURBO']}",
         "license": ["README.ijg", "LICENSE.md"],
@@ -161,7 +161,7 @@ DEPS: dict[str, dict[str, Any]] = {
         "bins": ["cjpeg.exe", "djpeg.exe"],
     },
     "zlib": {
-        "url": f"https://zlib.net/zlib{V['ZLIB_DOTLESS']}.zip",
+        "url": "https://zlib.net/FILENAME",
         "filename": f"zlib{V['ZLIB_DOTLESS']}.zip",
         "dir": f"zlib-{V['ZLIB']}",
         "license": "README",
@@ -175,7 +175,7 @@ DEPS: dict[str, dict[str, Any]] = {
         "libs": [r"*.lib"],
     },
     "xz": {
-        "url": f"https://github.com/tukaani-project/xz/releases/download/v{V['XZ']}/xz-{V['XZ']}.tar.gz",
+        "url": f"https://github.com/tukaani-project/xz/releases/download/v{V['XZ']}/FILENAME",
         "filename": f"xz-{V['XZ']}.tar.gz",
         "dir": f"xz-{V['XZ']}",
         "license": "COPYING",
@@ -188,7 +188,7 @@ DEPS: dict[str, dict[str, Any]] = {
         "libs": [r"lzma.lib"],
     },
     "libwebp": {
-        "url": f"http://downloads.webmproject.org/releases/webp/libwebp-{V['LIBWEBP']}.tar.gz",
+        "url": "http://downloads.webmproject.org/releases/webp/FILENAME",
         "filename": f"libwebp-{V['LIBWEBP']}.tar.gz",
         "dir": f"libwebp-{V['LIBWEBP']}",
         "license": "COPYING",
@@ -210,7 +210,7 @@ DEPS: dict[str, dict[str, Any]] = {
         "libs": [r"libsharpyuv.lib", r"libwebp*.lib"],
     },
     "libtiff": {
-        "url": f"https://download.osgeo.org/libtiff/tiff-{V['TIFF']}.tar.gz",
+        "url": "https://download.osgeo.org/libtiff/FILENAME",
         "filename": f"tiff-{V['TIFF']}.tar.gz",
         "dir": f"tiff-{V['TIFF']}",
         "license": "LICENSE.md",
@@ -268,7 +268,7 @@ DEPS: dict[str, dict[str, Any]] = {
         "libs": ["*.lib"],
     },
     "freetype": {
-        "url": f"https://download.savannah.gnu.org/releases/freetype/freetype-{V['FREETYPE']}.tar.gz",
+        "url": "https://download.savannah.gnu.org/releases/freetype/FILENAME",
         "filename": f"freetype-{V['FREETYPE']}.tar.gz",
         "dir": f"freetype-{V['FREETYPE']}",
         "license": ["LICENSE.TXT", r"docs\FTL.TXT", r"docs\GPLv2.TXT"],
@@ -303,7 +303,7 @@ DEPS: dict[str, dict[str, Any]] = {
         "libs": [r"objs\{msbuild_arch}\Release Static\freetype.lib"],
     },
     "lcms2": {
-        "url": f"{SF_PROJECTS}/lcms/files/lcms/{V['LCMS2']}/lcms2-{V['LCMS2']}.tar.gz/download",  # noqa: E501
+        "url": f"{SF_PROJECTS}/lcms/files/lcms/{V['LCMS2']}/FILENAME/download",
         "filename": f"lcms2-{V['LCMS2']}.tar.gz",
         "dir": f"lcms2-{V['LCMS2']}",
         "license": "LICENSE",
@@ -497,7 +497,7 @@ def extract_dep(url: str, filename: str, prefs: dict[str, str]) -> None:
         except RuntimeError as exc:
             # Otherwise try upstream
             print(exc)
-            download_dep(url, file)
+            download_dep(url.replace("FILENAME", filename), file)
 
     print("Extracting " + filename)
     sources_dir_abs = os.path.abspath(sources_dir)


### PR DESCRIPTION
There are several places in `winbuild/build_prepare.py` where the "filename" is replicated in the "url"
https://github.com/python-pillow/Pillow/blob/822ec3d05dfbaf2e3209c2b26e3392040e274975/winbuild/build_prepare.py#L163-L165

I wonder if
```python
"zlib": {
    "url": "https://zlib.net/FILENAME",
    "filename": f"zlib{V['ZLIB_DOTLESS']}.zip",
```
is neater, reducing duplication?

Feel free to reject if others think it isn't simpler.