### PR TITLE
Use register_handler

### DIFF
--- a/Tests/test_file_bufrstub.py
+++ b/Tests/test_file_bufrstub.py
@@ -83,4 +83,4 @@ def test_handler(tmp_path: Path) -> None:
         im.save(temp_file)
         assert handler.saved
 
-    BufrStubImagePlugin._handler = None
+    BufrStubImagePlugin.register_handler(None)

--- a/Tests/test_file_gribstub.py
+++ b/Tests/test_file_gribstub.py
@@ -83,4 +83,4 @@ def test_handler(tmp_path: Path) -> None:
         im.save(temp_file)
         assert handler.saved
 
-    GribStubImagePlugin._handler = None
+    GribStubImagePlugin.register_handler(None)

--- a/Tests/test_file_hdf5stub.py
+++ b/Tests/test_file_hdf5stub.py
@@ -85,4 +85,4 @@ def test_handler(tmp_path: Path) -> None:
         im.save(temp_file)
         assert handler.saved
 
-    Hdf5StubImagePlugin._handler = None
+    Hdf5StubImagePlugin.register_handler(None)


### PR DESCRIPTION
Rather than setting the private `_handler` in our tests,
https://github.com/python-pillow/Pillow/blob/822ec3d05dfbaf2e3209c2b26e3392040e274975/Tests/test_file_bufrstub.py#L86

we can use the public method of `BufrStubImagePlugin.register_handler()`.