### PR TITLE
brew remove libdeflate

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -121,6 +121,7 @@ curl -fsSL -o pillow-depends-main.zip https://github.com/python-pillow/pillow-de
 untar pillow-depends-main.zip
 
 if [[ -n "$IS_MACOS" ]]; then
+  # libdeflate may cause a minimum target error when repairing the wheel
   # libtiff and libxcb cause a conflict with building libtiff and libxcb
   # libxau and libxdmcp cause an issue on macOS < 11
   # remove cairo to fix building harfbuzz on arm64
@@ -132,7 +133,7 @@ if [[ -n "$IS_MACOS" ]]; then
   if [[ "$CIBW_ARCHS" == "arm64" ]]; then
     brew remove --ignore-dependencies jpeg-turbo
   else
-    brew remove --ignore-dependencies webp
+    brew remove --ignore-dependencies libdeflate webp
   fi
 
   brew install pkg-config


### PR DESCRIPTION
An intermittent error has started appearing when building macOS < 11 wheels, due to the presence of Homebrew's libdeflate.

https://github.com/python-pillow/Pillow/actions/runs/11527160571/job/32095165039#step:5:8054
```pytb
File "/private/var/folders/nj/wh528zms06j9t8y7bmlvpmjm0000gn/T/cibw-run-lwy73nns/cp39-macosx_x86_64/build/venv/lib/python3.9/site-packages/delocate/delocating.py", line 925, in _check_and_update_wheel_name
  raise DelocationError(
delocate.libsana.DelocationError: Library dependencies do not satisfy target MacOS version 10.10:
/private/var/folders/nj/wh528zms06j9t8y7bmlvpmjm0000gn/T/tmp7e9dgm3u/wheel/PIL/.dylibs/libdeflate.0.dylib has a minimum target of 13.0
Set the environment variable 'MACOSX_DEPLOYMENT_TARGET=13.0' to update minimum supported macOS for this wheel.
```

#8497 is a long term solution to this type of problem, but this is a short term solution if we would like it, just removing Homebrew's libdeflate.