### PR TITLE
Fixed catching warnings

### DIFF
--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -22,6 +22,8 @@ def test_bad() -> None:
     for f in get_files("b"):
         # Assert that there is no unclosed file warning
         with warnings.catch_warnings():
+            warnings.simplefilter("error")
+
             try:
                 with Image.open(f) as im:
                     im.load()

--- a/Tests/test_file_dcx.py
+++ b/Tests/test_file_dcx.py
@@ -36,6 +36,8 @@ def test_unclosed_file() -> None:
 
 def test_closed_file() -> None:
     with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
         im = Image.open(TEST_FILE)
         im.load()
         im.close()
@@ -43,6 +45,8 @@ def test_closed_file() -> None:
 
 def test_context_manager() -> None:
     with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
         with Image.open(TEST_FILE) as im:
             im.load()
 

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -65,6 +65,8 @@ def test_unclosed_file() -> None:
 
 def test_closed_file() -> None:
     with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
         im = Image.open(static_test_file)
         im.load()
         im.close()
@@ -81,6 +83,8 @@ def test_seek_after_close() -> None:
 
 def test_context_manager() -> None:
     with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
         with Image.open(static_test_file) as im:
             im.load()
 

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -46,6 +46,8 @@ def test_unclosed_file() -> None:
 
 def test_closed_file() -> None:
     with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
         im = Image.open(TEST_GIF)
         im.load()
         im.close()
@@ -67,6 +69,8 @@ def test_seek_after_close() -> None:
 
 def test_context_manager() -> None:
     with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
         with Image.open(TEST_GIF) as im:
             im.load()
 

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -21,6 +21,8 @@ def test_sanity() -> None:
     with Image.open(TEST_FILE) as im:
         # Assert that there is no unclosed file warning
         with warnings.catch_warnings():
+            warnings.simplefilter("error")
+
             im.load()
 
         assert im.mode == "RGBA"

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -41,6 +41,8 @@ def test_unclosed_file() -> None:
 
 def test_closed_file() -> None:
     with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
         im = Image.open(TEST_IM)
         im.load()
         im.close()
@@ -48,6 +50,8 @@ def test_closed_file() -> None:
 
 def test_context_manager() -> None:
     with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
         with Image.open(TEST_IM) as im:
             im.load()
 

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -850,6 +850,8 @@ class TestFileJpeg:
 
             out = str(tmp_path / "out.jpg")
             with warnings.catch_warnings():
+                warnings.simplefilter("error")
+
                 im.save(out, exif=exif)
 
         with Image.open(out) as reloaded:

--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -48,6 +48,8 @@ def test_unclosed_file() -> None:
 
 def test_closed_file() -> None:
     with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
         im = Image.open(test_files[0])
         im.load()
         im.close()
@@ -63,6 +65,8 @@ def test_seek_after_close() -> None:
 
 def test_context_manager() -> None:
     with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
         with Image.open(test_files[0]) as im:
             im.load()
 

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -338,6 +338,8 @@ class TestFilePng:
         with Image.open(TEST_PNG_FILE) as im:
             # Assert that there is no unclosed file warning
             with warnings.catch_warnings():
+                warnings.simplefilter("error")
+
                 im.verify()
 
         with Image.open(TEST_PNG_FILE) as im:

--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -35,6 +35,8 @@ def test_unclosed_file() -> None:
 
 def test_closed_file() -> None:
     with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
         im = Image.open(test_file)
         im.load()
         im.close()
@@ -42,6 +44,8 @@ def test_closed_file() -> None:
 
 def test_context_manager() -> None:
     with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
         with Image.open(test_file) as im:
             im.load()
 

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -34,6 +34,8 @@ def test_unclosed_file() -> None:
 
 def test_closed_file() -> None:
     with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
         im = Image.open(TEST_FILE)
         im.load()
         im.close()
@@ -41,6 +43,8 @@ def test_closed_file() -> None:
 
 def test_context_manager() -> None:
     with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
         with Image.open(TEST_FILE) as im:
             im.load()
 

--- a/Tests/test_file_tar.py
+++ b/Tests/test_file_tar.py
@@ -37,11 +37,15 @@ def test_unclosed_file() -> None:
 
 def test_close() -> None:
     with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
         tar = TarIO.TarIO(TEST_TAR_FILE, "hopper.jpg")
         tar.close()
 
 
 def test_contextmanager() -> None:
     with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
         with TarIO.TarIO(TEST_TAR_FILE, "hopper.jpg"):
             pass

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -72,6 +72,8 @@ class TestFileTiff:
 
     def test_closed_file(self) -> None:
         with warnings.catch_warnings():
+            warnings.simplefilter("error")
+
             im = Image.open("Tests/images/multipage.tiff")
             im.load()
             im.close()
@@ -88,6 +90,8 @@ class TestFileTiff:
 
     def test_context_manager(self) -> None:
         with warnings.catch_warnings():
+            warnings.simplefilter("error")
+
             with Image.open("Tests/images/multipage.tiff") as im:
                 im.load()
 

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -191,6 +191,8 @@ class TestFileWebp:
         file_path = "Tests/images/hopper.webp"
         with Image.open(file_path) as image:
             with warnings.catch_warnings():
+                warnings.simplefilter("error")
+
                 image.save(tmp_path / "temp.webp")
 
     def test_file_pointer_could_be_reused(self) -> None:

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -737,6 +737,8 @@ class TestImage:
         # Act/Assert
         with Image.open(test_file) as im:
             with warnings.catch_warnings():
+                warnings.simplefilter("error")
+
                 im.save(temp_file)
 
     def test_no_new_file_on_error(self, tmp_path: Path) -> None:

--- a/Tests/test_imageqt.py
+++ b/Tests/test_imageqt.py
@@ -52,4 +52,6 @@ def test_image(mode: str) -> None:
 
 def test_closed_file() -> None:
     with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
         ImageQt.ImageQt("Tests/images/hopper.gif")

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -264,4 +264,6 @@ def test_no_resource_warning_for_numpy_array() -> None:
     with Image.open(test_file) as im:
         # Act/Assert
         with warnings.catch_warnings():
+            warnings.simplefilter("error")
+
             array(im)


### PR DESCRIPTION
https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests states

> To ensure that no warnings are emitted, use:
> 
> ```python
> def test_warning():
>     with warnings.catch_warnings():
>         warnings.simplefilter("error")
>         ...
> ```

However, in #6076, I decided not to add `warnings.simplefilter("error")`. I've now concluded that was a mistake, and that this doesn't turn warnings into errors as intended - if I add [`warnings.warn("This should cause a failure")`](https://github.com/radarhere/Pillow/commit/55a80c491256a90d441c494a650d84a933c80e26), the test suite [still passes](https://github.com/radarhere/Pillow/actions/runs/11529275107). Restoring [`simplefilter`](https://github.com/radarhere/Pillow/commit/ce5f5e36a450242abb2abe57e201e2e70a0d519b), only then does it [fail](https://github.com/radarhere/Pillow/actions/runs/11529279285) like it should.