### PR TITLE
Detach PyQt6 QPixmap instance before returning

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -80,6 +80,12 @@ jobs:
         pytest-cov
         pytest-timeout
 
+    - name: Install CPython dependencies
+      if: "!contains(matrix.python-version, 'pypy')"
+      run: >
+        python3 -m pip install
+        PyQt6
+
     - name: Install dependencies
       id: install
       run: |

--- a/src/PIL/ImageQt.py
+++ b/src/PIL/ImageQt.py
@@ -213,4 +213,7 @@ def toqimage(im: Image.Image | str | QByteArray) -> ImageQt:
 
 def toqpixmap(im: Image.Image | str | QByteArray) -> QPixmap:
     qimage = toqimage(im)
-    return getattr(QPixmap, "fromImage")(qimage)
+    pixmap = getattr(QPixmap, "fromImage")(qimage)
+    if qt_version == "6":
+        pixmap.detach()
+    return pixmap


### PR DESCRIPTION
Alternative to #8507

The user in that PR reported seeing corrupt output from `ImageQt.toqpixmap()` on Windows.

https://github.com/python-pillow/Pillow/blob/9a4b3e05d643c92f050df5713e48225a9f36497e/src/PIL/ImageQt.py#L214-L216

Testing, I found I was able to use GitHub Actions to reproduce the matter.

Testing further, I found that it was only happening when `qimage` was inside the function - if I unwrapped the function so that `qimage` wouldn't be garbage collected, the problem disappeared. I created a reproduction just using PyQt6 and asked about this at https://stackoverflow.com/questions/79133259/corrupted-display-from-qpixmap-fromimage. The response I received was

> This is caused by [Qt's implicit data sharing](https://doc.qt.io/qt-6/implicit-sharing.html). The QImage will be garbage-collected when wrap returns, which may mean some of the shared data is no longer accesible. To avoid these problems, call pixmap.detach() to enforce a copy-on-write.

This fix allows us to test PyQt6 in GitHub Actions with CPython, which would [otherwise](https://github.com/radarhere/Pillow/commit/a957a36ad21eac1fb757cf5f3402f13a6c537d2a) [fail.](https://github.com/radarhere/Pillow/actions/runs/11554960167)