### PR TITLE
Upgraded multibuild to remove openjpeg lib64 copy

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -91,9 +91,6 @@ function build {
     build_libpng
     build_lcms2
     build_openjpeg
-    if [ -f /usr/local/lib64/libopenjp2.so ]; then
-        cp /usr/local/lib64/libopenjp2.so /usr/local/lib
-    fi
 
     ORIGINAL_CFLAGS=$CFLAGS
     CFLAGS="$CFLAGS -O3 -DNDEBUG"


### PR DESCRIPTION
Upgrades multibuild to include https://github.com/multi-build/multibuild/pull/538, meaning that

https://github.com/python-pillow/Pillow/blob/bdd0b8630c77172245aae3b1e7902685a2d40dca/.github/workflows/wheels-dependencies.sh#L94-L96

can now be removed. Without the multibuild upgrade, the wheels [could](https://github.com/radarhere/Pillow/commit/094f2eccce716ccda8a428a35a927ad62752a454) [fail](https://github.com/radarhere/Pillow/actions/runs/11563407753) to find OpenJPEG.