### PR TITLE
Do not repeatedly save to the same path

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -541,7 +541,7 @@ class TestFileJpeg:
     @mark_if_feature_version(
         pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
     )
-    def test_qtables(self, tmp_path: Path) -> None:
+    def test_qtables(self) -> None:
         def _n_qtables_helper(n: int, test_file: str) -> None:
             b = BytesIO()
             with Image.open(test_file) as im:

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -543,10 +543,10 @@ class TestFileJpeg:
     )
     def test_qtables(self, tmp_path: Path) -> None:
         def _n_qtables_helper(n: int, test_file: str) -> None:
+            b = BytesIO()
             with Image.open(test_file) as im:
-                f = str(tmp_path / "temp.jpg")
-                im.save(f, qtables=[[n] * 64] * n)
-            with Image.open(f) as im:
+                im.save(b, "JPEG", qtables=[[n] * 64] * n)
+            with Image.open(b) as im:
                 assert len(im.quantization) == n
                 reloaded = self.roundtrip(im, qtables="keep")
                 assert im.quantization == reloaded.quantization


### PR DESCRIPTION
https://github.com/tonybaloney/pytest-freethreaded/issues/11 noted a segfault that can occur under free-threading with `Tests/test_file_jpeg.py::test_qtables`. I can replicate this with [`--require-gil-disabled`](https://github.com/radarhere/Pillow/commit/d928ddf06c75ca8e730d52df575314fc4788e825) - https://github.com/radarhere/Pillow/actions/runs/11572743510

Changing the test to save to a BytesIO instance rather than writing repeatedly to the same temporary path fixes this specific test - https://github.com/radarhere/Pillow/actions/runs/11572819452