### PR TITLE
Require trove-classifiers>=2024.10.12

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -79,6 +79,7 @@ jobs:
         pytest
         pytest-cov
         pytest-timeout
+        trove-classifiers>=2024.10.12
 
     - name: Install CPython dependencies
       if: "!contains(matrix.python-version, 'pypy')"


### PR DESCRIPTION
main has started failing - https://github.com/python-pillow/Pillow/actions/runs/11573601676/job/32216060741#step:28:4035
```
   +         'Some of your classifiers are not standard classifiers:\n'
   +         'License :: OSI Approved :: CMU License (MIT-CMU)',
```