### PR TITLE
Added running_in_another_thread()

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -4,6 +4,7 @@ Helper functions.
 
 from __future__ import annotations
 
+import inspect
 import logging
 import os
 import shutil
@@ -28,6 +29,8 @@ if os.environ.get("SHOW_ERRORS"):
     uploader = "show"
 elif "GITHUB_ACTIONS" in os.environ:
     uploader = "github_actions"
+
+already_running = []
 
 
 def upload(a: Image.Image, b: Image.Image) -> str | None:
@@ -163,6 +166,18 @@ def assert_tuple_approx_equal(
     for i, target in enumerate(targets):
         if not (target - threshold <= actuals[i] <= target + threshold):
             pytest.fail(msg + ": " + repr(actuals) + " != " + repr(targets))
+
+
+def running_in_another_thread() -> bool:
+    frameInfo = inspect.stack()[1]
+    identifier = (
+        frameInfo.filename + ":" + frameInfo.function + ":" + str(frameInfo.lineno)
+    )
+    if identifier in already_running:
+        return True
+
+    already_running.append(identifier)
+    return False
 
 
 def skip_unless_feature(feature: str) -> pytest.MarkDecorator:

--- a/Tests/test_core_resources.py
+++ b/Tests/test_core_resources.py
@@ -6,7 +6,7 @@ import pytest
 
 from PIL import Image
 
-from .helper import is_pypy
+from .helper import is_pypy, running_in_another_thread
 
 
 def test_get_stats() -> None:
@@ -48,6 +48,9 @@ class TestCoreMemory:
         assert alignment > 0
 
     def test_set_alignment(self) -> None:
+        if running_in_another_thread():
+            return
+
         for i in [1, 2, 4, 8, 16, 32]:
             Image.core.set_alignment(i)
             alignment = Image.core.get_alignment()

--- a/Tests/test_file_bufrstub.py
+++ b/Tests/test_file_bufrstub.py
@@ -7,7 +7,7 @@ import pytest
 
 from PIL import BufrStubImagePlugin, Image, ImageFile
 
-from .helper import hopper
+from .helper import hopper, running_in_another_thread
 
 TEST_FILE = "Tests/images/gfs.t06z.rassda.tm00.bufr_d"
 
@@ -69,6 +69,9 @@ def test_handler(tmp_path: Path) -> None:
 
         def save(self, im: Image.Image, fp: IO[bytes], filename: str) -> None:
             self.saved = True
+
+    if running_in_another_thread():
+        return
 
     handler = TestHandler()
     BufrStubImagePlugin.register_handler(handler)

--- a/Tests/test_file_gribstub.py
+++ b/Tests/test_file_gribstub.py
@@ -7,7 +7,7 @@ import pytest
 
 from PIL import GribStubImagePlugin, Image, ImageFile
 
-from .helper import hopper
+from .helper import hopper, running_in_another_thread
 
 TEST_FILE = "Tests/images/WAlaska.wind.7days.grb"
 
@@ -69,6 +69,9 @@ def test_handler(tmp_path: Path) -> None:
 
         def save(self, im: Image.Image, fp: IO[bytes], filename: str) -> None:
             self.saved = True
+
+    if running_in_another_thread():
+        return
 
     handler = TestHandler()
     GribStubImagePlugin.register_handler(handler)

--- a/Tests/test_file_hdf5stub.py
+++ b/Tests/test_file_hdf5stub.py
@@ -8,6 +8,8 @@ import pytest
 
 from PIL import Hdf5StubImagePlugin, Image, ImageFile
 
+from .helper import running_in_another_thread
+
 TEST_FILE = "Tests/images/hdf5.h5"
 
 
@@ -71,6 +73,9 @@ def test_handler(tmp_path: Path) -> None:
 
         def save(self, im: Image.Image, fp: IO[bytes], filename: str) -> None:
             self.saved = True
+
+    if running_in_another_thread():
+        return
 
     handler = TestHandler()
     Hdf5StubImagePlugin.register_handler(handler)

--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -8,7 +8,7 @@ import pytest
 
 from PIL import Image, ImageFile, WmfImagePlugin
 
-from .helper import assert_image_similar_tofile, hopper
+from .helper import assert_image_similar_tofile, hopper, running_in_another_thread
 
 
 def test_load_raw() -> None:
@@ -44,6 +44,9 @@ def test_register_handler(tmp_path: Path) -> None:
 
         def save(self, im: Image.Image, fp: IO[bytes], filename: str) -> None:
             self.methodCalled = True
+
+    if running_in_another_thread():
+        return
 
     handler = TestHandler()
     original_handler = WmfImagePlugin._handler


### PR DESCRIPTION
Possible way to help #8492. Alternative to #8501

I've created a Tests/helper.py function called `running_in_another_thread()` that uses a global variable and `inspect` to determine if a test has already started running in another thread, so that we can return early if we would only like the test to run in one thread at a time.

This is used here in two cases
1. #8492 has found that running a test that calls `register_handler` at the beginning, and removes the handler at the end, fails when the test is run across multiple threads. My thinking is that if it ok for `register_handler` to operate across threads, and that it doesn't need to register multiple handlers in parallel. So this PR returns early from the relevant test if it is already running in another thread.
2. https://github.com/tonybaloney/pytest-freethreaded/issues/10 finds an error when running
https://github.com/python-pillow/Pillow/blob/16372dd951c5f7ab664286e6ad25b2e7ed645358/Tests/test_core_resources.py#L50-L54
across multiple threads. I again think that `Image.core.set_alignment` doesn't need to be run across multiple threads simultaneously, so this PR returns early.