### PR TITLE
Allow linking to zlib import library on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -691,7 +691,7 @@ class pil_build_ext(build_ext):
                 elif sys.platform == "win32" and _find_library_file(self, "zlib"):
                     feature.set("zlib", "zlib")  # alternative name
                 elif sys.platform == "win32" and _find_library_file(self, "zdll"):
-                    feature.set("zlib", "zdll")  # different name if shared
+                    feature.set("zlib", "zdll")  # dll import library
 
         if feature.want("jpeg"):
             _dbg("Looking for jpeg")

--- a/setup.py
+++ b/setup.py
@@ -690,6 +690,8 @@ class pil_build_ext(build_ext):
                     feature.set("zlib", "z")
                 elif sys.platform == "win32" and _find_library_file(self, "zlib"):
                     feature.set("zlib", "zlib")  # alternative name
+                elif sys.platform == "win32" and _find_library_file(self, "zdll"):
+                    feature.set("zlib", "zdll")  # different name if shared
 
         if feature.want("jpeg"):
             _dbg("Looking for jpeg")


### PR DESCRIPTION
This allows to link to zlib when used as shared library, in my environment I do not activate all of the external libraries so that part might influence the result, but I think it can still be valuable for others to try the same.