### PR TITLE
Remove unused `gcov: true` for codecov-action@v4

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -102,7 +102,6 @@ jobs:
       with:
         flags: GHA_Docker
         name: ${{ matrix.docker }}
-        gcov: true
         token: ${{ secrets.CODECOV_ORG_TOKEN }}
 
   success:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,6 @@ jobs:
       with:
         flags: ${{ matrix.os == 'ubuntu-latest' && 'GHA_Ubuntu' || 'GHA_macOS' }}
         name: ${{ matrix.os }} Python ${{ matrix.python-version }}
-        gcov: true
         token: ${{ secrets.CODECOV_ORG_TOKEN }}
 
   success:


### PR DESCRIPTION
The `gcov` argument has been removed `codecov/codecov-action@v4` and has been replaced by an optional `plugin` that includes `gcov` by default:


Input | Description | Required
-- | -- | --
plugin | plugins to run. Options: xcode, gcov, pycoverage. The default behavior runs them all.


https://github.com/codecov/codecov-action#arguments



This will remove some warnings like:

> Unexpected input(s) 'gcov', valid inputs are ['token', 'codecov_yml_path', 'commit_parent', 'directory', 'disable_file_fixes', 'disable_search', 'disable_safe_directory', 'dry_run', 'env_vars', 'exclude', 'fail_ci_if_error', 'file', 'files', 'flags', 'git_service', 'handle_no_reports_found', 'job_code', 'name', 'network_filter', 'network_prefix', 'os', 'override_branch', 'override_build', 'override_build_url', 'override_commit', 'override_pr', 'plugin', 'plugins', 'report_code', 'root_dir', 'slug', 'url', 'use_legacy_upload_endpoint', 'use_oidc', 'verbose', 'version', 'working-directory']


https://github.com/python-pillow/Pillow/actions/runs/11641379867
https://github.com/python-pillow/Pillow/actions/runs/11641379864