### PR TITLE
Apply security fixes to GitHub Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: pre-commit cache
       uses: actions/cache@v4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  issues: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,6 +15,8 @@ concurrency:
 jobs:
   stale:
     if: github.repository_owner == 'python-pillow'
+    permissions:
+      issues: write
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Checkout Pillow
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Cygwin
         uses: cygwin/cygwin-install-action@v4

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -65,6 +65,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Build system information
       run: python3 .github/workflows/system-info.py

--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: Checkout Pillow
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up shell
         run: echo "C:\msys64\usr\bin\" >> $env:GITHUB_PATH

--- a/.github/workflows/test-valgrind.yml
+++ b/.github/workflows/test-valgrind.yml
@@ -40,6 +40,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Build system information
       run: python3 .github/workflows/system-info.py

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -44,16 +44,20 @@ jobs:
     steps:
     - name: Checkout Pillow
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Checkout cached dependencies
       uses: actions/checkout@v4
       with:
+        persist-credentials: false
         repository: python-pillow/pillow-depends
         path: winbuild\depends
 
     - name: Checkout extra test images
       uses: actions/checkout@v4
       with:
+        persist-credentials: false
         repository: python-pillow/test-images
         path: Tests\test-images
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -61,6 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: true
 
       - uses: actions/setup-python@v5
@@ -132,6 +133,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: true
 
       - uses: actions/setup-python@v5
@@ -173,10 +175,13 @@ jobs:
           - cibw_arch: ARM64
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Checkout extra test images
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: python-pillow/test-images
           path: Tests\test-images
 
@@ -253,6 +258,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
There's a new tool that flags potential security issues in GitHub Actions workflows: https://github.com/woodruffw/zizmor

<details>
<summary>Details</summary>

```console
❯ zizmor .
🌈 completed cifuzz.yml
🌈 completed release-drafter.yml
🌈 completed stale.yml
🌈 completed docs.yml
🌈 completed test-valgrind.yml
🌈 completed test-windows.yml
🌈 completed test-mingw.yml
🌈 completed test-docker.yml
🌈 completed lint.yml
🌈 completed test.yml
🌈 completed test-cygwin.yml
🌈 completed wheels.yml
error[excessive-permissions]: overly broad workflow or job-level permissions
 --> /Users/hugo/github/Pillow/.github/workflows/stale.yml:8:1
  |
8 | / permissions:
9 | |   issues: write
  | |_______________^ issues: write is overly broad at the workflow level
  |

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/hugo/github/Pillow/.github/workflows/docs.yml:35:7
   |
35 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/hugo/github/Pillow/.github/workflows/test-valgrind.yml:42:7
   |
42 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/hugo/github/Pillow/.github/workflows/test-windows.yml:45:7
   |
45 |       - name: Checkout Pillow
   |  _______-
46 | |       uses: actions/checkout@v4
   | |_______________________________- does not set persist-credentials: false
   |

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/hugo/github/Pillow/.github/workflows/test-windows.yml:48:7
   |
48 |       - name: Checkout cached dependencies
   |  _______-
49 | |       uses: actions/checkout@v4
50 | |       with:
51 | |         repository: python-pillow/pillow-depends
52 | |         path: winbuild\depends
   | |______________________________- does not set persist-credentials: false
   |

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/hugo/github/Pillow/.github/workflows/test-windows.yml:54:7
   |
54 |       - name: Checkout extra test images
   |  _______-
55 | |       uses: actions/checkout@v4
...  |
59 | |
60 | |     # sets env: pythonLocation
   | |______________________________- does not set persist-credentials: false
   |

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/hugo/github/Pillow/.github/workflows/test-mingw.yml:47:9
   |
47 |         - name: Checkout Pillow
   |  _________-
48 | |         uses: actions/checkout@v4
   | |_________________________________- does not set persist-credentials: false
   |

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/hugo/github/Pillow/.github/workflows/test-docker.yml:67:7
   |
67 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/hugo/github/Pillow/.github/workflows/lint.yml:23:7
   |
23 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/hugo/github/Pillow/.github/workflows/test.yml:65:7
   |
65 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/hugo/github/Pillow/.github/workflows/test-cygwin.yml:49:9
   |
49 |         - name: Checkout Pillow
   |  _________-
50 | |         uses: actions/checkout@v4
   | |_________________________________- does not set persist-credentials: false
   |

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/hugo/github/Pillow/.github/workflows/wheels.yml:62:9
   |
62 |         - uses: actions/checkout@v4
   |  _________-
63 | |         with:
64 | |           submodules: true
   | |__________________________- does not set persist-credentials: false
   |

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> /Users/hugo/github/Pillow/.github/workflows/wheels.yml:255:7
    |
255 |     - uses: actions/checkout@v4
    |       ------------------------- does not set persist-credentials: false
    |

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> /Users/hugo/github/Pillow/.github/workflows/wheels.yml:133:9
    |
133 |         - uses: actions/checkout@v4
    |  _________-
134 | |         with:
135 | |           submodules: true
    | |__________________________- does not set persist-credentials: false
    |

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> /Users/hugo/github/Pillow/.github/workflows/wheels.yml:175:9
    |
175 |       - uses: actions/checkout@v4
    |         ------------------------- does not set persist-credentials: false
    |

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> /Users/hugo/github/Pillow/.github/workflows/wheels.yml:177:9
    |
177 |         - name: Checkout extra test images
    |  _________-
178 | |         uses: actions/checkout@v4
179 | |         with:
180 | |           repository: python-pillow/test-images
181 | |           path: Tests\test-images
    | |_________________________________- does not set persist-credentials: false
    |

16 findings (0 unknown, 0 informational, 0 low, 15 medium, 1 high)
```

</details>

Some of these could be ignored, like:

```
error[excessive-permissions]: overly broad workflow or job-level permissions
 --> /Users/hugo/github/Pillow/.github/workflows/stale.yml:8:1
  |
8 | / permissions:
9 | |   issues: write
  | |_______________^ issues: write is overly broad at the workflow level
```

Because there's only one job in this workflow, so it only applies there. But it's easy enough to silence the error and means if we add another job later then we're covered.

