### PR TITLE
Fixed type hint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1001,7 +1001,7 @@ def debug_build() -> bool:
     return hasattr(sys, "gettotalrefcount") or FUZZING_BUILD
 
 
-files = ["src/_imaging.c"]
+files: list[str | os.PathLike[str]] = ["src/_imaging.c"]
 for src_file in _IMAGING:
     files.append("src/" + src_file + ".c")
 for src_file in _LIB_IMAGING:


### PR DESCRIPTION
An error has started occurring in main - https://github.com/python-pillow/Pillow/actions/runs/11677258842/job/32514847792

```
setup.py:1010: error: Argument 2 to "Extension" has incompatible type
"list[str]"; expected "list[Union[str, PathLike[str]]]"  [arg-type]
        Extension("PIL._imaging", files),
                                  ^~~~~
setup.py:1010: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
setup.py:1010: note: Consider using "Sequence" instead, which is covariant
Found 1 error in 1 file (checked 294 source files)
```