### PR TITLE
Use test image filename

### DIFF
--- a/docs/reference/ImageFile.rst
+++ b/docs/reference/ImageFile.rst
@@ -19,7 +19,7 @@ Example: Parse an image
 
     from PIL import ImageFile
 
-    fp = open("hopper.pgm", "rb")
+    fp = open("hopper.ppm", "rb")
 
     p = ImageFile.Parser()
 


### PR DESCRIPTION
https://pillow.readthedocs.io/en/latest/reference/ImageFile.html has an example where users are invited to open "hopper.pgm".

Maybe no one else is bothered by this, but hopper.pgm doesn't exist as one of our test files, so I think the example code should be updated to refer to [hopper.ppm](https://github.com/python-pillow/Pillow/blob/main/Tests/images/hopper.ppm) instead.