### PR TITLE
Raise UnidentifiedImageError when opening TIFF without dimensions

### DIFF
--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -93,6 +93,19 @@ class TestImageFile:
             assert p.image is not None
             assert (48, 48) == p.image.size
 
+    @pytest.mark.filterwarnings("ignore:Corrupt EXIF data")
+    def test_incremental_tiff(self) -> None:
+        with ImageFile.Parser() as p:
+            with open("Tests/images/hopper.tif", "rb") as f:
+                p.feed(f.read(1024))
+
+                # Check that insufficient data was given in the first feed
+                assert not p.image
+
+                p.feed(f.read())
+            assert p.image is not None
+            assert (128, 128) == p.image.size
+
     @skip_unless_feature("webp")
     def test_incremental_webp(self) -> None:
         with ImageFile.Parser() as p:

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1433,8 +1433,12 @@ class TiffImageFile(ImageFile.ImageFile):
         logger.debug("- YCbCr subsampling: %s", self.tag_v2.get(YCBCRSUBSAMPLING))
 
         # size
-        xsize = self.tag_v2.get(IMAGEWIDTH)
-        ysize = self.tag_v2.get(IMAGELENGTH)
+        try:
+            xsize = self.tag_v2[IMAGEWIDTH]
+            ysize = self.tag_v2[IMAGELENGTH]
+        except KeyError as e:
+            msg = "Missing dimensions"
+            raise TypeError(msg) from e
         if not isinstance(xsize, int) or not isinstance(ysize, int):
             msg = "Invalid dimensions"
             raise ValueError(msg)


### PR DESCRIPTION
Resolves #8530

#8319 changed
```python
xsize = int(self.tag_v2.get(IMAGEWIDTH))
ysize = int(self.tag_v2.get(IMAGELENGTH))
```
to
https://github.com/python-pillow/Pillow/blob/82199efbf77f369ad9b7c2c3759e08f517d9925b/src/PIL/TiffImagePlugin.py#L1436-L1440

This change seems reasonable, especially when you consider #4103.

However, if IMAGEWIDTH or IMAGELENGTH were missing, then `int(None)` previously raised a TypeError. TypeErrors are caught when opening images
https://github.com/python-pillow/Pillow/blob/82199efbf77f369ad9b7c2c3759e08f517d9925b/src/PIL/Image.py#L3497-L3506
but the ValueErrors are not.

So this change inadvertently broke feeding a TIFF image to `ImageFile.Parser`, which relies on OSError ([which UnidentifiedImageErrors are](https://github.com/python-pillow/Pillow/blob/82199efbf77f369ad9b7c2c3759e08f517d9925b/src/PIL/__init__.py#L77)) to know that there isn't enough data yet.

https://github.com/python-pillow/Pillow/blob/82199efbf77f369ad9b7c2c3759e08f517d9925b/src/PIL/ImageFile.py#L468-L473

This PR changes the code to raise a TypeError again.