### PR TITLE
Run gcc problem matcher on Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
         GHA_PYTHON_VERSION: ${{ matrix.python-version }}
 
     - name: Register gcc problem matcher
-      if: "matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'"
+      if: "matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'"
       run: echo "::add-matcher::.github/problem-matchers/gcc.json"
 
     - name: Build


### PR DESCRIPTION
Updates the Python version running the gcc problem matcher to Python 3.13

https://github.com/python-pillow/Pillow/blob/2e7da079cdadf24a5d17cc4b0d32df434777c789/.github/workflows/test.yml#L118-L120