### PR TITLE
Removed quotes after dropping support for Python 3.8

### DIFF
--- a/src/PIL/_typing.py
+++ b/src/PIL/_typing.py
@@ -47,7 +47,7 @@ class SupportsRead(Protocol[_T_co]):
     def read(self, __length: int = ...) -> _T_co: ...
 
 
-StrOrBytesPath = Union[str, bytes, "os.PathLike[str]", "os.PathLike[bytes]"]
+StrOrBytesPath = Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]
 
 
 __all__ = ["Buffer", "IntegralLike", "StrOrBytesPath", "SupportsRead", "TypeGuard"]


### PR DESCRIPTION
See previous discussion of this at https://github.com/python-pillow/Pillow/pull/7750#discussion_r1468360968