### PR TITLE
Platform guessing affects more than just Linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -344,7 +344,7 @@ class pil_build_ext(build_ext):
             for x in ("raqm", "fribidi")
         ]
         + [
-            ("disable-platform-guessing", None, "Disable platform guessing on Linux"),
+            ("disable-platform-guessing", None, "Disable platform guessing"),
             ("debug", None, "Debug logging"),
         ]
         + [("add-imaging-libs=", None, "Add libs to _imaging build")]


### PR DESCRIPTION
Despite
https://github.com/python-pillow/Pillow/blob/5bff2f3b2894ec6923c590d0c37b18177d0634bd/setup.py#L347

the `disable_platform_guessing` setting also affects macOS and Cygwin.
https://github.com/python-pillow/Pillow/blob/5bff2f3b2894ec6923c590d0c37b18177d0634bd/setup.py#L553-L566