### PR TITLE
Added default values for _Tile offset and args

### DIFF
--- a/src/PIL/BlpImagePlugin.py
+++ b/src/PIL/BlpImagePlugin.py
@@ -273,7 +273,7 @@ class BlpImageFile(ImageFile.ImageFile):
             raise BLPFormatError(msg)
 
         self._mode = "RGBA" if self._blp_alpha_depth else "RGB"
-        self.tile = [ImageFile._Tile(decoder, (0, 0) + self.size, 0, (self.mode, 0, 1))]
+        self.tile = [ImageFile._Tile(decoder, (0, 0) + self.size, 0, self.mode)]
 
 
 class _BLPBaseDecoder(ImageFile.PyDecoder):

--- a/src/PIL/DdsImagePlugin.py
+++ b/src/PIL/DdsImagePlugin.py
@@ -560,9 +560,7 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
         + struct.pack("<4I", *rgba_mask)  # dwRGBABitMask
         + struct.pack("<5I", DDSCAPS.TEXTURE, 0, 0, 0, 0)
     )
-    ImageFile._save(
-        im, fp, [ImageFile._Tile("raw", (0, 0) + im.size, 0, (rawmode, 0, 1))]
-    )
+    ImageFile._save(im, fp, [ImageFile._Tile("raw", (0, 0) + im.size, 0, rawmode)])
 
 
 def _accept(prefix: bytes) -> bool:

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -454,7 +454,7 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes, eps: int = 1) -
     if hasattr(fp, "flush"):
         fp.flush()
 
-    ImageFile._save(im, fp, [ImageFile._Tile("eps", (0, 0) + im.size, 0, None)])
+    ImageFile._save(im, fp, [ImageFile._Tile("eps", (0, 0) + im.size, 0)])
 
     fp.write(b"\n%%%%EndBinary\n")
     fp.write(b"grestore end\n")

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -454,7 +454,7 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes, eps: int = 1) -
     if hasattr(fp, "flush"):
         fp.flush()
 
-    ImageFile._save(im, fp, [ImageFile._Tile("eps", (0, 0) + im.size, 0)])
+    ImageFile._save(im, fp, [ImageFile._Tile("eps", (0, 0) + im.size)])
 
     fp.write(b"\n%%%%EndBinary\n")
     fp.write(b"grestore end\n")

--- a/src/PIL/FliImagePlugin.py
+++ b/src/PIL/FliImagePlugin.py
@@ -159,7 +159,7 @@ class FliImageFile(ImageFile.ImageFile):
         framesize = i32(s)
 
         self.decodermaxblock = framesize
-        self.tile = [ImageFile._Tile("fli", (0, 0) + self.size, self.__offset, None)]
+        self.tile = [ImageFile._Tile("fli", (0, 0) + self.size, self.__offset)]
 
         self.__offset += framesize
 

--- a/src/PIL/FpxImagePlugin.py
+++ b/src/PIL/FpxImagePlugin.py
@@ -170,7 +170,7 @@ class FpxImageFile(ImageFile.ImageFile):
                         "raw",
                         (x, y, x1, y1),
                         i32(s, i) + 28,
-                        (self.rawmode,),
+                        self.rawmode,
                     )
                 )
 

--- a/src/PIL/FtexImagePlugin.py
+++ b/src/PIL/FtexImagePlugin.py
@@ -95,7 +95,7 @@ class FtexImageFile(ImageFile.ImageFile):
             self._mode = "RGBA"
             self.tile = [ImageFile._Tile("bcn", (0, 0) + self.size, 0, (1,))]
         elif format == Format.UNCOMPRESSED:
-            self.tile = [ImageFile._Tile("raw", (0, 0) + self.size, 0, ("RGB", 0, 1))]
+            self.tile = [ImageFile._Tile("raw", (0, 0) + self.size, 0, "RGB")]
         else:
             msg = f"Invalid texture compression format: {repr(format)}"
             raise ValueError(msg)

--- a/src/PIL/GdImageFile.py
+++ b/src/PIL/GdImageFile.py
@@ -76,7 +76,7 @@ class GdImageFile(ImageFile.ImageFile):
                 "raw",
                 (0, 0) + self.size,
                 7 + true_color_offset + 4 + 256 * 4,
-                ("L", 0, 1),
+                "L",
             )
         ]
 

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -98,7 +98,7 @@ def _tilesort(t: _Tile) -> int:
 class _Tile(NamedTuple):
     codec_name: str
     extents: tuple[int, int, int, int] | None
-    offset: int
+    offset: int = 0
     args: tuple[Any, ...] | str | None = None
 
 

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -99,7 +99,7 @@ class _Tile(NamedTuple):
     codec_name: str
     extents: tuple[int, int, int, int] | None
     offset: int
-    args: tuple[Any, ...] | str | None
+    args: tuple[Any, ...] | str | None = None
 
 
 #

--- a/src/PIL/ImtImagePlugin.py
+++ b/src/PIL/ImtImagePlugin.py
@@ -62,7 +62,7 @@ class ImtImageFile(ImageFile.ImageFile):
                         "raw",
                         (0, 0) + self.size,
                         self.fp.tell() - len(buffer),
-                        (self.mode, 0, 1),
+                        self.mode,
                     )
                 ]
 

--- a/src/PIL/MspImagePlugin.py
+++ b/src/PIL/MspImagePlugin.py
@@ -70,7 +70,7 @@ class MspImageFile(ImageFile.ImageFile):
         self._size = i16(s, 4), i16(s, 6)
 
         if s[:4] == b"DanM":
-            self.tile = [ImageFile._Tile("raw", (0, 0) + self.size, 32, ("1", 0, 1))]
+            self.tile = [ImageFile._Tile("raw", (0, 0) + self.size, 32, "1")]
         else:
             self.tile = [ImageFile._Tile("MSP", (0, 0) + self.size, 32)]
 
@@ -188,7 +188,7 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
         fp.write(o16(h))
 
     # image body
-    ImageFile._save(im, fp, [ImageFile._Tile("raw", (0, 0) + im.size, 32, ("1", 0, 1))])
+    ImageFile._save(im, fp, [ImageFile._Tile("raw", (0, 0) + im.size, 32, "1")])
 
 
 #

--- a/src/PIL/MspImagePlugin.py
+++ b/src/PIL/MspImagePlugin.py
@@ -72,7 +72,7 @@ class MspImageFile(ImageFile.ImageFile):
         if s[:4] == b"DanM":
             self.tile = [ImageFile._Tile("raw", (0, 0) + self.size, 32, ("1", 0, 1))]
         else:
-            self.tile = [ImageFile._Tile("MSP", (0, 0) + self.size, 32, None)]
+            self.tile = [ImageFile._Tile("MSP", (0, 0) + self.size, 32)]
 
 
 class MspDecoder(ImageFile.PyDecoder):

--- a/src/PIL/PcdImagePlugin.py
+++ b/src/PIL/PcdImagePlugin.py
@@ -47,7 +47,7 @@ class PcdImageFile(ImageFile.ImageFile):
 
         self._mode = "RGB"
         self._size = 768, 512  # FIXME: not correct for rotated images!
-        self.tile = [ImageFile._Tile("pcd", (0, 0) + self.size, 96 * 2048, None)]
+        self.tile = [ImageFile._Tile("pcd", (0, 0) + self.size, 96 * 2048)]
 
     def load_end(self) -> None:
         if self.tile_post_rotate:

--- a/src/PIL/PixarImagePlugin.py
+++ b/src/PIL/PixarImagePlugin.py
@@ -61,9 +61,7 @@ class PixarImageFile(ImageFile.ImageFile):
         # FIXME: to be continued...
 
         # create tile descriptor (assuming "dumped")
-        self.tile = [
-            ImageFile._Tile("raw", (0, 0) + self.size, 1024, (self.mode, 0, 1))
-        ]
+        self.tile = [ImageFile._Tile("raw", (0, 0) + self.size, 1024, self.mode)]
 
 
 #

--- a/src/PIL/QoiImagePlugin.py
+++ b/src/PIL/QoiImagePlugin.py
@@ -32,7 +32,7 @@ class QoiImageFile(ImageFile.ImageFile):
         self._mode = "RGB" if channels == 3 else "RGBA"
 
         self.fp.seek(1, os.SEEK_CUR)  # colorspace
-        self.tile = [ImageFile._Tile("qoi", (0, 0) + self._size, self.fp.tell(), None)]
+        self.tile = [ImageFile._Tile("qoi", (0, 0) + self._size, self.fp.tell())]
 
 
 class QoiDecoder(ImageFile.PyDecoder):

--- a/src/PIL/SpiderImagePlugin.py
+++ b/src/PIL/SpiderImagePlugin.py
@@ -154,9 +154,7 @@ class SpiderImageFile(ImageFile.ImageFile):
             self.rawmode = "F;32F"
         self._mode = "F"
 
-        self.tile = [
-            ImageFile._Tile("raw", (0, 0) + self.size, offset, (self.rawmode, 0, 1))
-        ]
+        self.tile = [ImageFile._Tile("raw", (0, 0) + self.size, offset, self.rawmode)]
         self._fp = self.fp  # FIXME: hack
 
     @property
@@ -280,9 +278,7 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
     fp.writelines(hdr)
 
     rawmode = "F;32NF"  # 32-bit native floating point
-    ImageFile._save(
-        im, fp, [ImageFile._Tile("raw", (0, 0) + im.size, 0, (rawmode, 0, 1))]
-    )
+    ImageFile._save(im, fp, [ImageFile._Tile("raw", (0, 0) + im.size, 0, rawmode)])
 
 
 def _save_spider(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:

--- a/src/PIL/XVThumbImagePlugin.py
+++ b/src/PIL/XVThumbImagePlugin.py
@@ -74,9 +74,7 @@ class XVThumbImageFile(ImageFile.ImageFile):
         self.palette = ImagePalette.raw("RGB", PALETTE)
 
         self.tile = [
-            ImageFile._Tile(
-                "raw", (0, 0) + self.size, self.fp.tell(), (self.mode, 0, 1)
-            )
+            ImageFile._Tile("raw", (0, 0) + self.size, self.fp.tell(), self.mode)
         ]
 
 

--- a/src/PIL/XbmImagePlugin.py
+++ b/src/PIL/XbmImagePlugin.py
@@ -85,7 +85,7 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
 
     fp.write(b"static char im_bits[] = {\n")
 
-    ImageFile._save(im, fp, [ImageFile._Tile("xbm", (0, 0) + im.size, 0)])
+    ImageFile._save(im, fp, [ImageFile._Tile("xbm", (0, 0) + im.size)])
 
     fp.write(b"};\n")
 

--- a/src/PIL/XbmImagePlugin.py
+++ b/src/PIL/XbmImagePlugin.py
@@ -67,7 +67,7 @@ class XbmImageFile(ImageFile.ImageFile):
         self._mode = "1"
         self._size = xsize, ysize
 
-        self.tile = [ImageFile._Tile("xbm", (0, 0) + self.size, m.end(), None)]
+        self.tile = [ImageFile._Tile("xbm", (0, 0) + self.size, m.end())]
 
 
 def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
@@ -85,7 +85,7 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
 
     fp.write(b"static char im_bits[] = {\n")
 
-    ImageFile._save(im, fp, [ImageFile._Tile("xbm", (0, 0) + im.size, 0, None)])
+    ImageFile._save(im, fp, [ImageFile._Tile("xbm", (0, 0) + im.size, 0)])
 
     fp.write(b"};\n")
 

--- a/src/PIL/XpmImagePlugin.py
+++ b/src/PIL/XpmImagePlugin.py
@@ -101,9 +101,7 @@ class XpmImageFile(ImageFile.ImageFile):
         self._mode = "P"
         self.palette = ImagePalette.raw("RGB", b"".join(palette))
 
-        self.tile = [
-            ImageFile._Tile("raw", (0, 0) + self.size, self.fp.tell(), ("P", 0, 1))
-        ]
+        self.tile = [ImageFile._Tile("raw", (0, 0) + self.size, self.fp.tell(), "P")]
 
     def load_read(self, read_bytes: int) -> bytes:
         #


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/5bff2f3b2894ec6923c590d0c37b18177d0634bd/src/PIL/ImageFile.py#L98-L102

Adding defaults of 0 for offset and None for args will allow small simplifications to some instantiations of `ImageFile._Tile`.

An args value of `(mode, 0, 1)` can also be replaced by `mode`
https://github.com/python-pillow/Pillow/blob/5bff2f3b2894ec6923c590d0c37b18177d0634bd/src/PIL/ImageFile.py#L221-L222