### PR TITLE
Do not create new image when exif_transpose() is used in place

### DIFF
--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -698,10 +698,11 @@ def exif_transpose(image: Image.Image, *, in_place: bool = False) -> Image.Image
         8: Image.Transpose.ROTATE_90,
     }.get(orientation)
     if method is not None:
-        transposed_image = image.transpose(method)
         if in_place:
-            image.im = transposed_image.im
-            image._size = transposed_image._size
+            image.im = image.im.transpose(method)
+            image._size = image.im.size
+        else:
+            transposed_image = image.transpose(method)
         exif_image = image if in_place else transposed_image
 
         exif = exif_image.getexif()


### PR DESCRIPTION
`im.transpose()` loads the image, calls the core `transpose()` method and returns a new image instance.
https://github.com/python-pillow/Pillow/blob/5bff2f3b2894ec6923c590d0c37b18177d0634bd/src/PIL/Image.py#L2982-L2994

When `im.transpose()` is called from `ImageOps.exif_transpose()`, if it is `in_place`, then the image is already loaded, and the new image instance is quickly abandoned.
https://github.com/python-pillow/Pillow/blob/5bff2f3b2894ec6923c590d0c37b18177d0634bd/src/PIL/ImageOps.py#L701-L705

So this can be simplified to just calling the core `transpose()` method directly.