### PR TITLE
Fixed orientation when opening YCbCr TIFF images

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -1030,6 +1030,17 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open("Tests/images/old-style-jpeg-compression.tif") as im:
             assert_image_equal_tofile(im, "Tests/images/old-style-jpeg-compression.png")
 
+    def test_old_style_jpeg_orientation(self) -> None:
+        with open("Tests/images/old-style-jpeg-compression.tif", "rb") as fp:
+            data = fp.read()
+
+            # Set EXIF Orientation to 2
+            data = data[:102] + b"\x02" + data[103:]
+
+            with Image.open(io.BytesIO(data)) as im:
+                im = im.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
+            assert_image_equal_tofile(im, "Tests/images/old-style-jpeg-compression.png")
+
     def test_open_missing_samplesperpixel(self) -> None:
         with Image.open(
             "Tests/images/old-style-jpeg-compression-no-samplesperpixel.tif"

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -299,6 +299,7 @@ _decodeAsRGBA(Imaging im, ImagingCodecState state, TIFF *tiff) {
         return -1;
     }
 
+    img.orientation = ORIENTATION_TOPLEFT;
     img.req_orientation = ORIENTATION_TOPLEFT;
     img.col_offset = 0;
 


### PR DESCRIPTION
Resolves #8554

When a TIFF image is YCbCr, Pillow calls libtiff's `TIFFRGBAImageBegin`
https://github.com/python-pillow/Pillow/blob/5bff2f3b2894ec6923c590d0c37b18177d0634bd/src/libImaging/TiffDecode.c#L729
https://github.com/python-pillow/Pillow/blob/5bff2f3b2894ec6923c590d0c37b18177d0634bd/src/libImaging/TiffDecode.c#L739-L740
https://github.com/python-pillow/Pillow/blob/5bff2f3b2894ec6923c590d0c37b18177d0634bd/src/libImaging/TiffDecode.c#L295

Looking at that libtiff code, it then calls either [`PickContigCase` or `PickSeparateCase`](https://gitlab.com/libtiff/libtiff/-/blob/master/libtiff/tif_getimage.c#L564-574). Those set `img->get` to [`gtTileContig`, `gtStripContig`](https://gitlab.com/libtiff/libtiff/-/blob/master/libtiff/tif_getimage.c#L2935), [`gtTileSeparate` or `gtStripSeparate`](https://gitlab.com/libtiff/libtiff/-/blob/master/libtiff/tif_getimage.c#L3099). All four of those functions [apply orientation to the image](https://gitlab.com/libtiff/libtiff/-/blob/master/libtiff/tif_getimage.c#L888-889) [based on `img->orientation`](https://gitlab.com/libtiff/libtiff/-/blob/master/libtiff/tif_getimage.c#L644-646).

Pillow expects to manage image orientation itself. This PR sets `img.orientation` to prevent libtiff from doing so.