### PR TITLE
Do not install Pyroma in MinGW, to use only system packages

### DIFF
--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -68,11 +68,12 @@ jobs:
               mingw-w64-x86_64-openjpeg2 \
               mingw-w64-x86_64-python3-numpy \
               mingw-w64-x86_64-python3-olefile \
+              mingw-w64-x86_64-python3-pip \
               mingw-w64-x86_64-python3-setuptools \
+              mingw-w64-x86_64-python-pytest \
+              mingw-w64-x86_64-python-pytest-cov \
+              mingw-w64-x86_64-python-pytest-timeout \
               mingw-w64-x86_64-python-pyqt6
-
-          python3 -m ensurepip
-          python3 -m pip install pyroma pytest pytest-cov pytest-timeout
 
           pushd depends && ./install_extra_test_images.sh && popd
 

--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -69,7 +69,6 @@ jobs:
               mingw-w64-x86_64-python3-numpy \
               mingw-w64-x86_64-python3-olefile \
               mingw-w64-x86_64-python3-pip \
-              mingw-w64-x86_64-python3-setuptools \
               mingw-w64-x86_64-python-pytest \
               mingw-w64-x86_64-python-pytest-cov \
               mingw-w64-x86_64-python-pytest-timeout \
@@ -78,7 +77,7 @@ jobs:
           pushd depends && ./install_extra_test_images.sh && popd
 
       - name: Build Pillow
-        run: SETUPTOOLS_USE_DISTUTILS="stdlib" CFLAGS="-coverage" python3 -m pip install .
+        run: CFLAGS="-coverage" python3 -m pip install .
 
       - name: Test Pillow
         run: |

--- a/docs/installation/building-from-source.rst
+++ b/docs/installation/building-from-source.rst
@@ -195,11 +195,6 @@ Many of Pillow's features require external libraries:
             mingw-w64-x86_64-libimagequant \
             mingw-w64-x86_64-libraqm
 
-    https://www.msys2.org/docs/python/ states that setuptools >= 60 does not work with
-    MSYS2. To workaround this, before installing Pillow you must run::
-
-        export SETUPTOOLS_USE_DISTUTILS=stdlib
-
 .. tab:: FreeBSD
 
     .. Note:: Only FreeBSD 10 and 11 tested


### PR DESCRIPTION
MinGW has started failing in main - https://github.com/python-pillow/Pillow/actions/runs/11950775623/job/33312968743#step:4:233

> error: externally-managed-environment
> 
> This environment is externally managed
> 
> To install Python packages system-wide, try 'pacman -S
> $MINGW_PACKAGE_PREFIX-python-xyz', where xyz is the package you
> are trying to install.
> 
> If you wish to install a non-MSYS2-packaged Python package,
> create a virtual environment using 'python -m venv path/to/venv'.
> Then use path/to/venv/bin/python and path/to/venv/bin/pip.
> 
> If you wish to install a non-MSYS2 packaged Python application,
> it may be easiest to use 'pipx install xyz', which will manage a
> virtual environment for you. Make sure you have $MINGW_PACKAGE_PREFIX-python-pipx
> installed via pacman.

pyroma is the only library that we are using that [doesn't exist as a MinGW package](https://packages.msys2.org/search?t=binpkg&q=pyroma), and since it's not used by Pillow, but is rather a tool to check Pillow only in our test suite, I think the best solution is to just not install it - using system packages would be closest to what the standard user would do.

Also, https://www.msys2.org/docs/python/ now states
> 2024-07-01: [setuptools](https://github.com/pypa/setuptools) now supports building C extensions in MSYS2 since [v70.2.0](https://github.com/pypa/setuptools/releases/tag/v70.2.0). Previous versions required export SETUPTOOLS_USE_DISTUTILS=stdlib as a workaround.

so the changes from https://github.com/python-pillow/Pillow/pull/7131 and #7224 can be removed.