### PR TITLE
Test 3.13t (free-threaded) from Quansight-Labs/setup-python on Linux and macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
         ]
         python-version: [
           "pypy3.10",
+          "3.13t",
           "3.13",
           "3.12",
           "3.11",
@@ -52,14 +53,14 @@ jobs:
         - { python-version: "3.11", PYTHONOPTIMIZE: 1, REVERSE: "--reverse" }
         - { python-version: "3.10", PYTHONOPTIMIZE: 2 }
         # Free-threaded
-        - { os: "ubuntu-latest", python-version: "3.13-dev", disable-gil: true }
+        - { python-version: "3.13t", disable-gil: true }
         # M1 only available for 3.10+
         - { os: "macos-13", python-version: "3.9" }
         exclude:
         - { os: "macos-latest", python-version: "3.9" }
 
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }} Python ${{ matrix.python-version }} ${{ matrix.disable-gil && 'free-threaded' || '' }}
+    name: ${{ matrix.os }} Python ${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v4
@@ -67,8 +68,7 @@ jobs:
         persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      if: "${{ !matrix.disable-gil }}"
+      uses: Quansight-Labs/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -76,13 +76,6 @@ jobs:
         cache-dependency-path: |
           ".ci/*.sh"
           "pyproject.toml"
-
-    - name: Set up Python ${{ matrix.python-version }} (free-threaded)
-      uses: deadsnakes/action@v3.2.0
-      if: "${{ matrix.disable-gil }}"
-      with:
-        python-version: ${{ matrix.python-version }}
-        nogil: ${{ matrix.disable-gil }}
 
     - name: Set PYTHON_GIL
       if: "${{ matrix.disable-gil }}"


### PR DESCRIPTION
We've been waiting a year for actions/setup-python to add support for free-threading, and they're finally planning on working on it _next_ quarter:

* https://github.com/actions/setup-python/issues/771#issuecomment-2490607417

In the meantime, we've been using deadsnakes to test on Linux only. However, Quansight Labs has forked actions/setup-python to add `3.13t`:

* https://github.com/actions/setup-python/pull/973#issuecomment-2495900996
* https://github.com/Quansight-Labs/setup-python

We can use this instead of deadsnakes until GitHub adds support, and therefore also test macOS and Windows.

Although I've left Windows out of this PR:

* Example addition: https://github.com/hugovk/Pillow/commit/9bf5b55c52e0878081efc72df575f38dc99df201
* Need to skip PyQt6: https://github.com/hugovk/Pillow/actions/runs/11995731097/job/33439347828
* Pillow fails to build for some reason: https://github.com/hugovk/Pillow/actions/runs/11995836047/job/33439569015

cc @lysnikolaou 