### PR TITLE
Do not attempt to install cmake a second time when building macOS or Linux wheels

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -76,10 +76,9 @@ function build_pkg_config {
 
 function build_brotli {
     if [ -e brotli-stamp ]; then return; fi
-    local cmake=$(get_modern_cmake)
     local out_dir=$(fetch_unpack https://github.com/google/brotli/archive/v$BROTLI_VERSION.tar.gz brotli-$BROTLI_VERSION.tar.gz)
     (cd $out_dir \
-        && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_LIBDIR=$BUILD_PREFIX/lib -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib . \
+        && cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_LIBDIR=$BUILD_PREFIX/lib -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib . \
         && make install)
     touch brotli-stamp
 }


### PR DESCRIPTION
#8497 added
https://github.com/python-pillow/Pillow/blob/d7ffb397313e843d500816a8ac2a1f9faf0e89b5/.github/workflows/wheels-dependencies.sh#L185-L186
to the macOS and Linux wheels.

However, we still have an alternative attempt to install cmake.
https://github.com/python-pillow/Pillow/blob/d7ffb397313e843d500816a8ac2a1f9faf0e89b5/.github/workflows/wheels-dependencies.sh#L77-L82
where `get_modern_cmake` is [from multibuild](https://github.com/multi-build/multibuild/blob/9a9d1275f025f737cdaa3c451ba07129dd95f361/library_builders.sh#L199-L217).

That can now be removed.