### PR TITLE
Added logging to TiffImagePlugin fixIFD()

### DIFF
--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -2202,6 +2202,12 @@ class AppendingTiffWriter(io.BytesIO):
             if tag in self.Tags:
                 cur_pos = self.f.tell()
 
+                tagname = TiffTags.lookup(tag).name
+                typname = TYPES.get(field_type, "unknown")
+                msg = f"fixIFD: {tagname} ({tag}) - type: {typname} ({field_type})"
+                msg += f"- type size: {field_size} - count: {count}"
+                logger.debug(msg)
+
                 if is_local:
                     self._fixOffsets(count, field_size)
                     self.f.seek(cur_pos + 4)


### PR DESCRIPTION
Alternative to #8316

For this TiffImagePlugin `fixIFD()` code
https://github.com/python-pillow/Pillow/blob/4304414473768e581bfb6cf519c8a1f9065ad1df/src/PIL/TiffImagePlugin.py#L2205-L2211
the original PR suggests catching `RunTimeError`s (["not implemented"](https://github.com/python-pillow/Pillow/blob/4304414473768e581bfb6cf519c8a1f9065ad1df/src/PIL/TiffImagePlugin.py#L2224-L2225C28), ["wrote only {bytes_written} bytes but wanted {expected}"](https://github.com/python-pillow/Pillow/blob/4304414473768e581bfb6cf519c8a1f9065ad1df/src/PIL/TiffImagePlugin.py#L2155-L2156) or ["offset is not supported"](https://github.com/python-pillow/Pillow/blob/4304414473768e581bfb6cf519c8a1f9065ad1df/src/PIL/TiffImagePlugin.py#L2137-L2138)) and re-raising it with tag info appended to the error message.

I think the way this is done in the rest of TiffImagePlugin is to use `logger.debug()`.

https://github.com/python-pillow/Pillow/blob/4304414473768e581bfb6cf519c8a1f9065ad1df/src/PIL/TiffImagePlugin.py#L982-L988

So this PR uses `logger.debug()` instead.