### PR TITLE
Release drafter: move removals, deprecations, documentation up, and uncategorised changes last

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,18 +3,19 @@ tag-template: "$NEXT_MINOR_VERSION"
 change-template: '- $TITLE #$NUMBER [@$AUTHOR]'
 
 categories:
-  - title: "Dependencies"
-    label: "Dependency"
+  - title: "Removals"
+    label: "Removal"
   - title: "Deprecations"
     label: "Deprecation"
   - title: "Documentation"
     label: "Documentation"
-  - title: "Removals"
-    label: "Removal"
+  - title: "Dependencies"
+    label: "Dependency"
   - title: "Testing"
     label: "Testing"
   - title: "Type hints"
     label: "Type hints"
+  - title: "Other changes"
 
 exclude-labels:
   - "changelog: skip"
@@ -22,7 +23,5 @@ exclude-labels:
 template: |
 
   https://pillow.readthedocs.io/en/stable/releasenotes/$NEXT_MINOR_VERSION.html
-
-  ## Changes
 
   $CHANGES


### PR DESCRIPTION
For #8569.

Changes proposed in this pull request:

 * https://github.com/python-pillow/Pillow/releases/tag/11.0.0 has the uncategorised "Changes" first, and then more important things like removals and deprecations further down
 * Let's put uncategorised ones last (see https://github.com/release-drafter/release-drafter/pull/1013), and move more important Removals, Deprecations further up.
 * Also moved Documentation above Dependencies
