### PR TITLE
Use brew formula to install libraqm

### DIFF
--- a/docs/installation/building-from-source.rst
+++ b/docs/installation/building-from-source.rst
@@ -148,13 +148,7 @@ Many of Pillow's features require external libraries:
     The easiest way to install external libraries is via `Homebrew
     <https://brew.sh/>`_. After you install Homebrew, run::
 
-        brew install libjpeg libtiff little-cms2 openjpeg webp
-
-    To install libraqm on macOS use Homebrew to install its dependencies::
-
-        brew install freetype harfbuzz fribidi
-
-    Then see ``depends/install_raqm_cmake.sh`` to install libraqm.
+        brew install libjpeg libraqm libtiff little-cms2 openjpeg webp
 
 .. tab:: Windows
 


### PR DESCRIPTION
https://pillow.readthedocs.io/en/latest/installation/building-from-source.html

> To install libraqm on macOS use Homebrew to install its dependencies:
> 
> `brew install freetype harfbuzz fribidi`
> Then see `depends/install_raqm_cmake.sh` to install libraqm.

This documented process can be made simpler by suggesting that users just `brew install libraqm` instead.

We have been using the libraqm formula in GitHub Actions since https://github.com/python-pillow/Pillow/pull/5061.