### PR TITLE
Updated build option error messages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -393,13 +393,14 @@ class pil_build_ext(build_ext):
                 self.feature.required.discard(x)
                 _dbg("Disabling %s", x)
                 if getattr(self, f"enable_{x}"):
-                    msg = f"Conflicting options: --enable-{x} and --disable-{x}"
+                    msg = f"Conflicting options: '-C {x}=enable' and '-C {x}=disable'"
                     raise ValueError(msg)
                 if x == "freetype":
-                    _dbg("--disable-freetype implies --disable-raqm")
+                    _dbg("'-C freetype=disable' implies '-C raqm=disable'")
                     if getattr(self, "enable_raqm"):
                         msg = (
-                            "Conflicting options: --enable-raqm and --disable-freetype"
+                            "Conflicting options: "
+                            "'-C raqm=enable' and '-C freetype=disable'"
                         )
                         raise ValueError(msg)
                     setattr(self, "disable_raqm", True)
@@ -407,15 +408,17 @@ class pil_build_ext(build_ext):
                 _dbg("Requiring %s", x)
                 self.feature.required.add(x)
                 if x == "raqm":
-                    _dbg("--enable-raqm implies --enable-freetype")
+                    _dbg("'-C raqm=enable' implies '-C freetype=enable'")
                     self.feature.required.add("freetype")
         for x in ("raqm", "fribidi"):
             if getattr(self, f"vendor_{x}"):
                 if getattr(self, "disable_raqm"):
-                    msg = f"Conflicting options: --vendor-{x} and --disable-raqm"
+                    msg = f"Conflicting options: '-C {x}=vendor' and '-C raqm=disable'"
                     raise ValueError(msg)
                 if x == "fribidi" and not getattr(self, "vendor_raqm"):
-                    msg = f"Conflicting options: --vendor-{x} and not --vendor-raqm"
+                    msg = (
+                        f"Conflicting options: '-C {x}=vendor' and not '-C raqm=vendor'"
+                    )
                     raise ValueError(msg)
                 _dbg("Using vendored version of %s", x)
                 self.feature.vendor.add(x)
@@ -1047,7 +1050,7 @@ except DependencyException as err:
     msg = f"""
 
 The headers or library files could not be found for {str(err)},
-which was requested by the option flag --enable-{str(err)}
+which was requested by the option flag '-C {str(err)}=enable'
 
 """
     sys.stderr.write(msg)


### PR DESCRIPTION
#7171 moved Pillow build options from
```
python3 -m pip install --upgrade Pillow --global-option="build_ext" --global-option="--enable-[feature]"
```
to
```
python3 -m pip install --upgrade Pillow -C [feature]=enable
```
but did not update error and debug messages in setup.py.