### PR TITLE
Only use start year in copyright, remove end years

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ The Python Imaging Library (PIL) is
 
 Pillow is the friendly PIL fork. It is
 
-    Copyright © 2010-2024 by Jeffrey A. Clark and contributors
+    Copyright © 2010 by Jeffrey A. Clark and contributors
 
 Like PIL, Pillow is licensed under the open source MIT-CMU License:
 

--- a/docs/COPYING
+++ b/docs/COPYING
@@ -5,7 +5,7 @@ The Python Imaging Library (PIL) is
 
 Pillow is the friendly PIL fork. It is
 
-    Copyright © 2010-2024 by Jeffrey A. Clark and contributors
+    Copyright © 2010 by Jeffrey A. Clark and contributors
 
 Like PIL, Pillow is licensed under the open source PIL
 Software License:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ master_doc = "index"
 project = "Pillow (PIL Fork)"
 copyright = (
     "1995-2011 Fredrik Lundh and contributors, "
-    "2010-2024 Jeffrey A. Clark and contributors."
+    "2010 Jeffrey A. Clark and contributors."
 )
 author = "Fredrik Lundh (PIL), Jeffrey A. Clark (Pillow)"
 


### PR DESCRIPTION
Over in CPython, after consulting with the PSF's legal representative, we decided to remove the end years from the copyright notices because there's no need to update them each January.

See:

* https://devguide.python.org/getting-started/pull-request-lifecycle/#copyrights
* https://github.com/python/cpython/issues/126133#issuecomment-2460824052
* https://github.com/python/release-tools/pull/196