### PR TITLE
Do not describe raw data as a table

### DIFF
--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -935,8 +935,8 @@ class ImageFileDirectory_v2(_IFDv2Base):
                 self._tagdata[tag] = data
                 self.tagtype[tag] = typ
 
-                bytes_value = size if size > 32 else repr(data)
-                msg += f" - value: <table: {bytes_value} bytes>"
+                msg += " - value: "
+                msg += f"<table: {size} bytes>" if size > 32 else repr(data)
 
                 logger.debug(msg)
 
@@ -981,11 +981,8 @@ class ImageFileDirectory_v2(_IFDv2Base):
 
             tagname = TiffTags.lookup(tag, self.group).name
             typname = "ifd" if is_ifd else TYPES.get(typ, "unknown")
-            bytes_value = len(data) if len(data) >= 16 else str(values)
-            msg = (
-                f"save: {tagname} ({tag}) - type: {typname} ({typ})"
-                f" - value: <table: {bytes_value} bytes>"
-            )
+            msg = f"save: {tagname} ({tag}) - type: {typname} ({typ}) - value: "
+            msg += f"<table: {len(data)} bytes>" if len(data) >= 16 else str(values)
             logger.debug(msg)
 
             # count is sum of lengths for string and arbitrary data


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/595bdf20579a68fba09d109b2a1830cdca6e82a2/src/PIL/TiffImagePlugin.py#L938-L939

If `size` is greater than 32, then this gives
> tag: unknown (8192) - type: byte (1) Tag Location: 94 - Data Location: 0 - value: <table: 159 bytes>

If it is not, then this gives
> tag: SamplesPerPixel (277) - type: long (4) - value: <table: b'\x92\x00\x12\x12' bytes>

I don't think we need to describe these bytes as a 'table'. It can be simplified to just

> tag: SamplesPerPixel (277) - type: long (4) - value: b'\x92\x00\x12\x12'>