### PR TITLE
ImageFile tile is never None

### DIFF
--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -120,7 +120,7 @@ class ImageFile(Image.Image):
         self.custom_mimetype: str | None = None
 
         self.tile: list[_Tile] = []
-        """ A list of tile descriptors, or ``None`` """
+        """ A list of tile descriptors """
 
         self.readonly = 1  # until we know better
 


### PR DESCRIPTION
Update a docstring after #8336 changed ImageFile `tile` to never be None