### PR TITLE
Replace python-pillow.org with python-pillow.github.io

### DIFF
--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -678,7 +678,7 @@ Reading from URL
 
     from PIL import Image
     from urllib.request import urlopen
-    url = "https://python-pillow.org/assets/images/pillow-logo.png"
+    url = "https://python-pillow.github.io/assets/images/pillow-logo.png"
     img = Image.open(urlopen(url))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ optional-dependencies.xmp = [
 urls.Changelog = "https://github.com/python-pillow/Pillow/releases"
 urls.Documentation = "https://pillow.readthedocs.io"
 urls.Funding = "https://tidelift.com/subscription/pkg/pypi-pillow?utm_source=pypi-pillow&utm_medium=pypi"
-urls.Homepage = "https://python-pillow.org"
+urls.Homepage = "https://python-pillow.github.io"
 urls.Mastodon = "https://fosstodon.org/@pillow"
 urls."Release notes" = "https://pillow.readthedocs.io/en/stable/releasenotes/index.html"
 urls.Source = "https://github.com/python-pillow/Pillow"


### PR DESCRIPTION
Fixes https://github.com/python-pillow/Pillow/issues/8585.