### PR TITLE
Test libjpeg-turbo on macOS

### DIFF
--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -8,8 +8,8 @@ fi
 brew install \
     freetype \
     ghostscript \
+    jpeg-turbo \
     libimagequant \
-    libjpeg \
     libtiff \
     little-cms2 \
     openjpeg \


### PR DESCRIPTION
It would appear that libjpeg isn't actually being installed on macOS builds. There is a [conflict message](https://github.com/python-pillow/Pillow/actions/runs/12314943668/job/34372091532#step:8:126), and libjpeg-turbo is [detected](https://github.com/python-pillow/Pillow/actions/runs/12314943668/job/34372091532#step:11:42).

This explicitly installs jpeg-turbo on macOS.