### PR TITLE
Updated libXau to 1.0.12

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -105,7 +105,7 @@ function build {
     build_simple xcb-proto 1.17.0 https://xorg.freedesktop.org/archive/individual/proto
     if [ -n "$IS_MACOS" ]; then
         build_simple xorgproto 2024.1 https://www.x.org/pub/individual/proto
-        build_simple libXau 1.0.11 https://www.x.org/pub/individual/lib
+        build_simple libXau 1.0.12 https://www.x.org/pub/individual/lib
         build_simple libpthread-stubs 0.5 https://xcb.freedesktop.org/dist
     else
         sed s/\${pc_sysrootdir\}// $BUILD_PREFIX/share/pkgconfig/xcb-proto.pc > $BUILD_PREFIX/lib/pkgconfig/xcb-proto.pc


### PR DESCRIPTION
libXau 1.0.12 has been released - https://gitlab.freedesktop.org/xorg/lib/libxau/-/tags/libXau-1.0.12