### PR TITLE
Raise ValueError when WMF inch is zero

### DIFF
--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -35,6 +35,13 @@ def test_load() -> None:
             assert im.load()[0, 0] == (255, 255, 255)
 
 
+def test_load_zero_inch() -> None:
+    b = BytesIO(b"\xd7\xcd\xc6\x9a\x00\x00" + b"\x00" * 10)
+    with pytest.raises(ValueError):
+        with Image.open(b):
+            pass
+
+
 def test_register_handler(tmp_path: Path) -> None:
     class TestHandler(ImageFile.StubHandler):
         methodCalled = False

--- a/src/PIL/WmfImagePlugin.py
+++ b/src/PIL/WmfImagePlugin.py
@@ -92,6 +92,9 @@ class WmfStubImageFile(ImageFile.StubImageFile):
 
             # get units per inch
             self._inch = word(s, 14)
+            if self._inch == 0:
+                msg = "Invalid inch"
+                raise ValueError(msg)
 
             # get bounding box
             x0 = short(s, 6)


### PR DESCRIPTION
Resolves #8597

The issue is concerned that a `ZeroDivisionError` may be raised if `self._inch` is zero.

https://github.com/python-pillow/Pillow/blob/a7338f8ce7bc79b0b15df5c4711dcbebe1fbdea9/src/PIL/WmfImagePlugin.py#L104-L107

This raises a `ValueError` of "Invalid inch" first.