### PR TITLE
Use .tar.gz zlib in Windows build to match macOS and Linux

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -159,8 +159,8 @@ DEPS: dict[str, dict[str, Any]] = {
         "bins": ["cjpeg.exe", "djpeg.exe"],
     },
     "zlib": {
-        "url": f"https://github.com/zlib-ng/zlib-ng/archive/refs/tags/{V['ZLIBNG']}.zip",
-        "filename": f"zlib-ng-{V['ZLIBNG']}.zip",
+        "url": f"https://github.com/zlib-ng/zlib-ng/archive/refs/tags/{V['ZLIBNG']}.tar.gz",
+        "filename": f"zlib-ng-{V['ZLIBNG']}.tar.gz",
         "dir": f"zlib-ng-{V['ZLIBNG']}",
         "license": "LICENSE.md",
         "patch": {


### PR DESCRIPTION
Changes
https://github.com/python-pillow/Pillow/blob/a7338f8ce7bc79b0b15df5c4711dcbebe1fbdea9/winbuild/build_prepare.py#L161-L163
to use .tar.gz, to match
https://github.com/python-pillow/Pillow/blob/a7338f8ce7bc79b0b15df5c4711dcbebe1fbdea9/.github/workflows/wheels-dependencies.sh#L73-L75

This means that only one file is needed in pillow-depends.