### PR TITLE
Added USE_RAW_ALPHA for BMP images

### DIFF
--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -230,3 +230,13 @@ def test_offset() -> None:
     # to exclude the palette size from the pixel data offset
     with Image.open("Tests/images/pal8_offset.bmp") as im:
         assert_image_equal_tofile(im, "Tests/images/bmp/g/pal8.bmp")
+
+
+def test_use_raw_alpha(monkeypatch: pytest.MonkeyPatch) -> None:
+    with Image.open("Tests/images/bmp/g/rgb32.bmp") as im:
+        assert im.info["compression"] == BmpImagePlugin.BmpImageFile.COMPRESSIONS["RAW"]
+        assert im.mode == "RGB"
+
+    monkeypatch.setattr(BmpImagePlugin, "USE_RAW_ALPHA", True)
+    with Image.open("Tests/images/bmp/g/rgb32.bmp") as im:
+        assert im.mode == "RGBA"

--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -48,6 +48,8 @@ BIT2MODE = {
     32: ("RGB", "BGRX"),
 }
 
+USE_RAW_ALPHA = False
+
 
 def _accept(prefix: bytes) -> bool:
     return prefix[:2] == b"BM"
@@ -242,7 +244,9 @@ class BmpImageFile(ImageFile.ImageFile):
                 msg = "Unsupported BMP bitfields layout"
                 raise OSError(msg)
         elif file_info["compression"] == self.COMPRESSIONS["RAW"]:
-            if file_info["bits"] == 32 and header == 22:  # 32-bit .cur offset
+            if file_info["bits"] == 32 and (
+                header == 22 or USE_RAW_ALPHA  # 32-bit .cur offset
+            ):
                 raw_mode, self._mode = "BGRA", "RGBA"
         elif file_info["compression"] in (
             self.COMPRESSIONS["RLE8"],


### PR DESCRIPTION
Resolves #8594

https://learn.microsoft.com/en-us/windows/win32/wmdm/-bitmapinfoheader describes 32 bitcount as
> The bitmap has a maximum of 2^32 colors. If the biCompression member is BI_RGB, the bmiColors member is NULL. Each DWORD in the bitmap array represents the relative intensities of blue, green, and red, respectively, for a pixel. The high byte in each DWORD is not used.

where BI_RGB is what we call RAW compression. It is saying that the fourth channel is unused, as Pillow currently treats it as such for DIB images.

However, the issue has found that some images do not follow the documentation and store alpha data in the fourth channel anyway.

Because this is not the documented behaviour, it seems possible that using it anyway could introduce problems. If the user thinks that their images are in this form though, then I've added a `USE_RAW_ALPHA` setting that can be enabled.