### PR TITLE
Updated libjpeg-turbo and harfbuzz URLs

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -93,7 +93,7 @@ function build_harfbuzz {
     if [ -e harfbuzz-stamp ]; then return; fi
     python3 -m pip install meson ninja
 
-    local out_dir=$(fetch_unpack https://github.com/harfbuzz/harfbuzz/releases/download/$HARFBUZZ_VERSION/$HARFBUZZ_VERSION.tar.xz harfbuzz-$HARFBUZZ_VERSION.tar.xz)
+    local out_dir=$(fetch_unpack https://github.com/harfbuzz/harfbuzz/releases/download/$HARFBUZZ_VERSION/harfbuzz-$HARFBUZZ_VERSION.tar.xz harfbuzz-$HARFBUZZ_VERSION.tar.xz)
     (cd $out_dir \
         && meson setup build --prefix=$BUILD_PREFIX --libdir=$BUILD_PREFIX/lib --buildtype=release -Dfreetype=enabled -Dglib=disabled)
     (cd $out_dir/build \

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -129,7 +129,7 @@ V["LIBPNG_XY"] = "".join(V["LIBPNG"].split(".")[:2])
 # dependencies, listed in order of compilation
 DEPS: dict[str, dict[str, Any]] = {
     "libjpeg": {
-        "url": f"{SF_PROJECTS}/libjpeg-turbo/files/{V['JPEGTURBO']}/FILENAME/download",
+        "url": f"https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/{V['JPEGTURBO']}/libjpeg-turbo-{V['JPEGTURBO']}.tar.gz",
         "filename": f"libjpeg-turbo-{V['JPEGTURBO']}.tar.gz",
         "dir": f"libjpeg-turbo-{V['JPEGTURBO']}",
         "license": ["README.ijg", "LICENSE.md"],


### PR DESCRIPTION
Helps #8603

It looks like https://sourceforge.net/projects/libjpeg-turbo/files/ is no longer being updated, so this switches the winbuild libjpeg-turbo URL to GitHub.

Testing further, I also found that the harfbuzz URL wasn't quite correct in the macOS and Linux dependencies script.