### PR TITLE
Extract tar files with "data" filter in Windows build scripts

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import struct
 import subprocess
+import sys
 from typing import Any
 
 
@@ -520,7 +521,10 @@ def extract_dep(url: str, filename: str, prefs: dict[str, str]) -> None:
                 if sources_dir_abs != member_prefix:
                     msg = "Attempted Path Traversal in Tar File"
                     raise RuntimeError(msg)
-            tgz.extractall(sources_dir)
+            if sys.version_info <= (3, 11):
+                tgz.extractall(sources_dir)
+            else:
+                tgz.extractall(sources_dir, filter="data")
     else:
         msg = "Unknown archive type: " + filename
         raise RuntimeError(msg)

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -521,10 +521,10 @@ def extract_dep(url: str, filename: str, prefs: dict[str, str]) -> None:
                 if sources_dir_abs != member_prefix:
                     msg = "Attempted Path Traversal in Tar File"
                     raise RuntimeError(msg)
-            if sys.version_info <= (3, 11):
-                tgz.extractall(sources_dir)
-            else:
+            if sys.version_info >= (3, 12):
                 tgz.extractall(sources_dir, filter="data")
+            else:
+                tgz.extractall(sources_dir)
     else:
         msg = "Unknown archive type: " + filename
         raise RuntimeError(msg)


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/12361558292/job/34498979321#step:11:12
> D:\a\Pillow\Pillow\winbuild\build_prepare.py:523: DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.

This PR sets the 'filter' argument for Python >= 3.12 (when it was [added](https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractall)), set to 'data', the [default in Python 3.14.](https://docs.python.org/3/library/tarfile.html#extraction-filters)