### PR TITLE
Only read until the offset of the next tile

### DIFF
--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -118,6 +118,26 @@ class TestImageFile:
 
         assert_image_equal(im1, im2)
 
+    def test_tile_size(self) -> None:
+        with open("Tests/images/hopper.tif", "rb") as im_fp:
+            data = im_fp.read()
+
+        reads = []
+
+        class FP(BytesIO):
+            def read(self, size: int | None = None) -> bytes:
+                reads.append(size)
+                return super().read(size)
+
+        fp = FP(data)
+        with Image.open(fp) as im:
+            assert len(im.tile) == 7
+
+            im.load()
+
+        # Despite multiple tiles, assert only one tile caused a read of maxblock size
+        assert reads.count(im.decodermaxblock) == 1
+
     def test_raise_oserror(self) -> None:
         with pytest.warns(DeprecationWarning):
             with pytest.raises(OSError):

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -263,7 +263,7 @@ class ImageFile(Image.Image):
                     self.tile, lambda tile: (tile[0], tile[1], tile[3])
                 )
             ]
-            for decoder_name, extents, offset, args in self.tile:
+            for i, (decoder_name, extents, offset, args) in enumerate(self.tile):
                 seek(offset)
                 decoder = Image._getdecoder(
                     self.mode, decoder_name, args, self.decoderconfig
@@ -276,8 +276,13 @@ class ImageFile(Image.Image):
                     else:
                         b = prefix
                         while True:
+                            read_bytes = self.decodermaxblock
+                            if i + 1 < len(self.tile):
+                                next_offset = self.tile[i + 1].offset
+                                if next_offset > offset:
+                                    read_bytes = next_offset - offset
                             try:
-                                s = read(self.decodermaxblock)
+                                s = read(read_bytes)
                             except (IndexError, struct.error) as e:
                                 # truncated png/gif
                                 if LOAD_TRUNCATED_IMAGES:


### PR DESCRIPTION
Resolves #8607

At the moment, ImageFile reads from files in `MAXBLOCK` chunks (unless `pulls_fd` is in use). There is no problem with this if there is only one tile. If there are multiple tiles however, that may be smaller than `MAXBLOCK`, then the size of the read operation can be reduced - by stopping the read operation before the next tile starts.