### PR TITLE
Install libjpeg-turbo8-dev

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -21,7 +21,7 @@ set -e
 
 if [[ $(uname) != CYGWIN* ]]; then
     sudo apt-get -qq install libfreetype6-dev liblcms2-dev python3-tk\
-                             ghostscript libjpeg-turbo-progs libopenjp2-7-dev\
+                             ghostscript libjpeg-turbo8-dev libopenjp2-7-dev\
                              cmake meson imagemagick libharfbuzz-dev libfribidi-dev\
                              sway wl-clipboard libopenblas-dev
 fi


### PR DESCRIPTION
The Ubuntu GitHub Actions builds have started failing, unable to find libjpeg - https://github.com/python-pillow/Pillow/actions/runs/12413240959/job/34674748066#step:10:326

This switches from the libjpeg-turbo-progs package to libjpeg-turbo8-dev.