### PR TITLE
Updated MakerNote capitalization

### DIFF
--- a/src/PIL/ExifTags.py
+++ b/src/PIL/ExifTags.py
@@ -303,38 +303,38 @@ TAGS = {
 
 
 class GPS(IntEnum):
-    GPSVersionID = 0
-    GPSLatitudeRef = 1
-    GPSLatitude = 2
-    GPSLongitudeRef = 3
-    GPSLongitude = 4
-    GPSAltitudeRef = 5
-    GPSAltitude = 6
-    GPSTimeStamp = 7
-    GPSSatellites = 8
-    GPSStatus = 9
-    GPSMeasureMode = 10
-    GPSDOP = 11
-    GPSSpeedRef = 12
-    GPSSpeed = 13
-    GPSTrackRef = 14
-    GPSTrack = 15
-    GPSImgDirectionRef = 16
-    GPSImgDirection = 17
-    GPSMapDatum = 18
-    GPSDestLatitudeRef = 19
-    GPSDestLatitude = 20
-    GPSDestLongitudeRef = 21
-    GPSDestLongitude = 22
-    GPSDestBearingRef = 23
-    GPSDestBearing = 24
-    GPSDestDistanceRef = 25
-    GPSDestDistance = 26
-    GPSProcessingMethod = 27
-    GPSAreaInformation = 28
-    GPSDateStamp = 29
-    GPSDifferential = 30
-    GPSHPositioningError = 31
+    GPSVersionID = 0x00
+    GPSLatitudeRef = 0x01
+    GPSLatitude = 0x02
+    GPSLongitudeRef = 0x03
+    GPSLongitude = 0x04
+    GPSAltitudeRef = 0x05
+    GPSAltitude = 0x06
+    GPSTimeStamp = 0x07
+    GPSSatellites = 0x08
+    GPSStatus = 0x09
+    GPSMeasureMode = 0x0A
+    GPSDOP = 0x0B
+    GPSSpeedRef = 0x0C
+    GPSSpeed = 0x0D
+    GPSTrackRef = 0x0E
+    GPSTrack = 0x0F
+    GPSImgDirectionRef = 0x10
+    GPSImgDirection = 0x11
+    GPSMapDatum = 0x12
+    GPSDestLatitudeRef = 0x13
+    GPSDestLatitude = 0x14
+    GPSDestLongitudeRef = 0x15
+    GPSDestLongitude = 0x16
+    GPSDestBearingRef = 0x17
+    GPSDestBearing = 0x18
+    GPSDestDistanceRef = 0x19
+    GPSDestDistance = 0x1A
+    GPSProcessingMethod = 0x1B
+    GPSAreaInformation = 0x1C
+    GPSDateStamp = 0x1D
+    GPSDifferential = 0x1E
+    GPSHPositioningError = 0x1F
 
 
 """Maps EXIF GPS tags to tag names."""
@@ -342,40 +342,40 @@ GPSTAGS = {i.value: i.name for i in GPS}
 
 
 class Interop(IntEnum):
-    InteropIndex = 1
-    InteropVersion = 2
-    RelatedImageFileFormat = 4096
-    RelatedImageWidth = 4097
-    RelatedImageHeight = 4098
+    InteropIndex = 0x0001
+    InteropVersion = 0x0002
+    RelatedImageFileFormat = 0x1000
+    RelatedImageWidth = 0x1001
+    RelatedImageHeight = 0x1002
 
 
 class IFD(IntEnum):
-    Exif = 34665
-    GPSInfo = 34853
-    MakerNote = 37500
-    Interop = 40965
+    Exif = 0x8769
+    GPSInfo = 0x8825
+    MakerNote = 0x927C
+    Interop = 0xA005
     IFD1 = -1
 
 
 class LightSource(IntEnum):
-    Unknown = 0
-    Daylight = 1
-    Fluorescent = 2
-    Tungsten = 3
-    Flash = 4
-    Fine = 9
-    Cloudy = 10
-    Shade = 11
-    DaylightFluorescent = 12
-    DayWhiteFluorescent = 13
-    CoolWhiteFluorescent = 14
-    WhiteFluorescent = 15
-    StandardLightA = 17
-    StandardLightB = 18
-    StandardLightC = 19
-    D55 = 20
-    D65 = 21
-    D75 = 22
-    D50 = 23
-    ISO = 24
-    Other = 255
+    Unknown = 0x00
+    Daylight = 0x01
+    Fluorescent = 0x02
+    Tungsten = 0x03
+    Flash = 0x04
+    Fine = 0x09
+    Cloudy = 0x0A
+    Shade = 0x0B
+    DaylightFluorescent = 0x0C
+    DayWhiteFluorescent = 0x0D
+    CoolWhiteFluorescent = 0x0E
+    WhiteFluorescent = 0x0F
+    StandardLightA = 0x11
+    StandardLightB = 0x12
+    StandardLightC = 0x13
+    D55 = 0x14
+    D65 = 0x15
+    D75 = 0x16
+    D50 = 0x17
+    ISO = 0x18
+    Other = 0xFF

--- a/src/PIL/ExifTags.py
+++ b/src/PIL/ExifTags.py
@@ -352,7 +352,7 @@ class Interop(IntEnum):
 class IFD(IntEnum):
     Exif = 34665
     GPSInfo = 34853
-    Makernote = 37500
+    MakerNote = 37500
     Interop = 40965
     IFD1 = -1
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3884,7 +3884,7 @@ class Exif(_ExifBase):
       gps_ifd = exif.get_ifd(ExifTags.IFD.GPSInfo)
       print(gps_ifd)
 
-    Other IFDs include ``ExifTags.IFD.Exif``, ``ExifTags.IFD.Makernote``,
+    Other IFDs include ``ExifTags.IFD.Exif``, ``ExifTags.IFD.MakerNote``,
     ``ExifTags.IFD.Interop`` and ``ExifTags.IFD.IFD1``.
 
     :py:mod:`~PIL.ExifTags` also has enum classes to provide names for data::
@@ -4047,11 +4047,11 @@ class Exif(_ExifBase):
                     ifd = self._get_ifd_dict(offset, tag)
                     if ifd is not None:
                         self._ifds[tag] = ifd
-            elif tag in [ExifTags.IFD.Interop, ExifTags.IFD.Makernote]:
+            elif tag in [ExifTags.IFD.Interop, ExifTags.IFD.MakerNote]:
                 if ExifTags.IFD.Exif not in self._ifds:
                     self.get_ifd(ExifTags.IFD.Exif)
                 tag_data = self._ifds[ExifTags.IFD.Exif][tag]
-                if tag == ExifTags.IFD.Makernote:
+                if tag == ExifTags.IFD.MakerNote:
                     from .TiffImagePlugin import ImageFileDirectory_v2
 
                     if tag_data[:8] == b"FUJIFILM":
@@ -4138,7 +4138,7 @@ class Exif(_ExifBase):
             ifd = {
                 k: v
                 for (k, v) in ifd.items()
-                if k not in (ExifTags.IFD.Interop, ExifTags.IFD.Makernote)
+                if k not in (ExifTags.IFD.Interop, ExifTags.IFD.MakerNote)
             }
         return ifd
 


### PR DESCRIPTION
Resolves #8614

The issue has pointed out that the capitalization between
https://github.com/python-pillow/Pillow/blob/cf4110ff06b4d4e0ec43b4a9ca13a28b7d3b11d2/src/PIL/ExifTags.py#L156
and
https://github.com/python-pillow/Pillow/blob/cf4110ff06b4d4e0ec43b4a9ca13a28b7d3b11d2/src/PIL/ExifTags.py#L355
is inconsistent.

I've chosen `MakerNote`, to match https://www.loc.gov/preservation/digital/formats/content/tiff_tags.shtml

This also updates ExifTags to use hex values more consistently.