### PR TITLE
Assert fp is not None

### DIFF
--- a/Tests/test_file_bufrstub.py
+++ b/Tests/test_file_bufrstub.py
@@ -61,6 +61,7 @@ def test_handler(tmp_path: Path) -> None:
 
         def load(self, im: ImageFile.StubImageFile) -> Image.Image:
             self.loaded = True
+            assert im.fp is not None
             im.fp.close()
             return Image.new("RGB", (1, 1))
 

--- a/Tests/test_file_cur.py
+++ b/Tests/test_file_cur.py
@@ -26,6 +26,7 @@ def test_invalid_file() -> None:
     no_cursors_file = "Tests/images/no_cursors.cur"
 
     cur = CurImagePlugin.CurImageFile(TEST_FILE)
+    assert cur.fp is not None
     cur.fp.close()
     with open(no_cursors_file, "rb") as cur.fp:
         with pytest.raises(TypeError):

--- a/Tests/test_file_gribstub.py
+++ b/Tests/test_file_gribstub.py
@@ -61,6 +61,7 @@ def test_handler(tmp_path: Path) -> None:
 
         def load(self, im: Image.Image) -> Image.Image:
             self.loaded = True
+            assert im.fp is not None
             im.fp.close()
             return Image.new("RGB", (1, 1))
 

--- a/Tests/test_file_hdf5stub.py
+++ b/Tests/test_file_hdf5stub.py
@@ -63,6 +63,7 @@ def test_handler(tmp_path: Path) -> None:
 
         def load(self, im: Image.Image) -> Image.Image:
             self.loaded = True
+            assert im.fp is not None
             im.fp.close()
             return Image.new("RGB", (1, 1))
 

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -1085,8 +1085,9 @@ class TestFileCloseW32:
             im.save(tmpfile)
 
         im = Image.open(tmpfile)
+        assert im.fp is not None
+        assert not im.fp.closed
         fp = im.fp
-        assert not fp.closed
         with pytest.raises(OSError):
             os.remove(tmpfile)
         im.load()

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -11,7 +11,15 @@ from typing import Any, NamedTuple
 
 import pytest
 
-from PIL import Image, ImageFilter, ImageOps, TiffImagePlugin, TiffTags, features
+from PIL import (
+    Image,
+    ImageFile,
+    ImageFilter,
+    ImageOps,
+    TiffImagePlugin,
+    TiffTags,
+    features,
+)
 from PIL.TiffImagePlugin import OSUBFILETYPE, SAMPLEFORMAT, STRIPOFFSETS, SUBIFD
 
 from .helper import (
@@ -556,8 +564,9 @@ class TestFileLibTiff(LibTiffTestCase):
             im.save(out, compression=compression)
 
     def test_fp_leak(self) -> None:
-        im: Image.Image | None = Image.open("Tests/images/hopper_g4_500.tif")
+        im: ImageFile.ImageFile | None = Image.open("Tests/images/hopper_g4_500.tif")
         assert im is not None
+        assert im.fp is not None
         fn = im.fp.fileno()
 
         os.fstat(fn)

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -861,6 +861,7 @@ class TestFileTiff:
 
         im = Image.open(tmpfile)
         fp = im.fp
+        assert fp is not None
         assert not fp.closed
         im.load()
         assert fp.closed
@@ -874,6 +875,7 @@ class TestFileTiff:
         with open(tmpfile, "rb") as f:
             im = Image.open(f)
             fp = im.fp
+            assert fp is not None
             assert not fp.closed
             im.load()
             assert not fp.closed
@@ -925,8 +927,9 @@ class TestFileTiffW32:
             im.save(tmpfile)
 
         im = Image.open(tmpfile)
+        assert im.fp is not None
+        assert not im.fp.closed
         fp = im.fp
-        assert not fp.closed
         with pytest.raises(OSError):
             os.remove(tmpfile)
         im.load()

--- a/Tests/test_image_load.py
+++ b/Tests/test_image_load.py
@@ -38,6 +38,7 @@ def test_close_after_load(caplog: pytest.LogCaptureFixture) -> None:
 def test_contextmanager() -> None:
     fn = None
     with Image.open("Tests/images/hopper.gif") as im:
+        assert im.fp is not None
         fn = im.fp.fileno()
         os.fstat(fn)
 

--- a/docs/example/DdsImagePlugin.py
+++ b/docs/example/DdsImagePlugin.py
@@ -213,6 +213,7 @@ class DdsImageFile(ImageFile.ImageFile):
     format_description = "DirectDraw Surface"
 
     def _open(self) -> None:
+        assert self.fp is not None
         if not _accept(self.fp.read(4)):
             msg = "not a DDS file"
             raise SyntaxError(msg)

--- a/src/PIL/BlpImagePlugin.py
+++ b/src/PIL/BlpImagePlugin.py
@@ -258,6 +258,7 @@ class BlpImageFile(ImageFile.ImageFile):
     format_description = "Blizzard Mipmap Format"
 
     def _open(self) -> None:
+        assert self.fp is not None
         self.magic = self.fp.read(4)
 
         self.fp.seek(5, os.SEEK_CUR)

--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -74,6 +74,7 @@ class BmpImageFile(ImageFile.ImageFile):
 
     def _bitmap(self, header: int = 0, offset: int = 0) -> None:
         """Read relevant info about the BMP"""
+        assert self.fp is not None
         read, seek = self.fp.read, self.fp.seek
         if header:
             seek(header)
@@ -307,6 +308,7 @@ class BmpImageFile(ImageFile.ImageFile):
     def _open(self) -> None:
         """Open file, check magic number and read header"""
         # read 14 bytes: magic number, filesize, reserved, header final offset
+        assert self.fp is not None
         head_data = self.fp.read(14)
         # choke if the file does not have the required magic bytes
         if not _accept(head_data):

--- a/src/PIL/BufrStubImagePlugin.py
+++ b/src/PIL/BufrStubImagePlugin.py
@@ -40,6 +40,7 @@ class BufrStubImageFile(ImageFile.StubImageFile):
     format_description = "BUFR"
 
     def _open(self) -> None:
+        assert self.fp is not None
         offset = self.fp.tell()
 
         if not _accept(self.fp.read(4)):

--- a/src/PIL/CurImagePlugin.py
+++ b/src/PIL/CurImagePlugin.py
@@ -38,6 +38,7 @@ class CurImageFile(BmpImagePlugin.BmpImageFile):
     format_description = "Windows Cursor"
 
     def _open(self) -> None:
+        assert self.fp is not None
         offset = self.fp.tell()
 
         # check magic

--- a/src/PIL/DcxImagePlugin.py
+++ b/src/PIL/DcxImagePlugin.py
@@ -44,6 +44,7 @@ class DcxImageFile(PcxImageFile):
 
     def _open(self) -> None:
         # Header
+        assert self.fp is not None
         s = self.fp.read(4)
         if not _accept(s):
             msg = "not a DCX file"

--- a/src/PIL/DdsImagePlugin.py
+++ b/src/PIL/DdsImagePlugin.py
@@ -333,6 +333,7 @@ class DdsImageFile(ImageFile.ImageFile):
     format_description = "DirectDraw Surface"
 
     def _open(self) -> None:
+        assert self.fp is not None
         if not _accept(self.fp.read(4)):
             msg = "not a DDS file"
             raise SyntaxError(msg)

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -187,6 +187,7 @@ class EpsImageFile(ImageFile.ImageFile):
     mode_map = {1: "L", 2: "LAB", 3: "RGB", 4: "CMYK"}
 
     def _open(self) -> None:
+        assert self.fp is not None
         (length, offset) = self._find_offset(self.fp)
 
         # go to offset - start of "%!PS"
@@ -398,6 +399,7 @@ class EpsImageFile(ImageFile.ImageFile):
     ) -> Image.core.PixelAccess | None:
         # Load EPS via Ghostscript
         if self.tile:
+            assert self.fp is not None
             self.im = Ghostscript(self.tile, self.size, self.fp, scale, transparency)
             self._mode = self.im.mode
             self._size = self.im.size

--- a/src/PIL/FliImagePlugin.py
+++ b/src/PIL/FliImagePlugin.py
@@ -47,6 +47,7 @@ class FliImageFile(ImageFile.ImageFile):
 
     def _open(self) -> None:
         # HEAD
+        assert self.fp is not None
         s = self.fp.read(128)
         if not (_accept(s) and s[20:22] == b"\x00\x00"):
             msg = "not an FLI/FLC file"
@@ -110,6 +111,7 @@ class FliImageFile(ImageFile.ImageFile):
         # load palette
 
         i = 0
+        assert self.fp is not None
         for e in range(i16(self.fp.read(2))):
             s = self.fp.read(2)
             i = i + s[0]

--- a/src/PIL/FpxImagePlugin.py
+++ b/src/PIL/FpxImagePlugin.py
@@ -58,6 +58,7 @@ class FpxImageFile(ImageFile.ImageFile):
         # read the OLE directory and see if this is a likely
         # to be a FlashPix file
 
+        assert self.fp is not None
         try:
             self.ole = olefile.OleFileIO(self.fp)
         except OSError as e:
@@ -229,6 +230,7 @@ class FpxImageFile(ImageFile.ImageFile):
                 if y >= ysize:
                     break  # isn't really required
 
+        assert self.fp is not None
         self.stream = stream
         self._fp = self.fp
         self.fp = None

--- a/src/PIL/FtexImagePlugin.py
+++ b/src/PIL/FtexImagePlugin.py
@@ -72,6 +72,7 @@ class FtexImageFile(ImageFile.ImageFile):
     format_description = "Texture File Format (IW2:EOC)"
 
     def _open(self) -> None:
+        assert self.fp is not None
         if not _accept(self.fp.read(4)):
             msg = "not an FTEX file"
             raise SyntaxError(msg)

--- a/src/PIL/GbrImagePlugin.py
+++ b/src/PIL/GbrImagePlugin.py
@@ -42,6 +42,7 @@ class GbrImageFile(ImageFile.ImageFile):
     format_description = "GIMP brush file"
 
     def _open(self) -> None:
+        assert self.fp is not None
         header_size = i32(self.fp.read(4))
         if header_size < 20:
             msg = "not a GIMP brush"
@@ -90,6 +91,7 @@ class GbrImageFile(ImageFile.ImageFile):
 
     def load(self) -> Image.core.PixelAccess | None:
         if self._im is None:
+            assert self.fp is not None
             self.im = Image.core.new(self.mode, self.size)
             self.frombytes(self.fp.read(self._data_size))
         return Image.Image.load(self)

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -83,6 +83,7 @@ class GifImageFile(ImageFile.ImageFile):
     global_palette = None
 
     def data(self) -> bytes | None:
+        assert self.fp is not None
         s = self.fp.read(1)
         if s and s[0]:
             return self.fp.read(s[0])
@@ -96,6 +97,7 @@ class GifImageFile(ImageFile.ImageFile):
 
     def _open(self) -> None:
         # Screen
+        assert self.fp is not None
         s = self.fp.read(13)
         if not _accept(s):
             msg = "not a GIF file"

--- a/src/PIL/GribStubImagePlugin.py
+++ b/src/PIL/GribStubImagePlugin.py
@@ -40,6 +40,7 @@ class GribStubImageFile(ImageFile.StubImageFile):
     format_description = "GRIB"
 
     def _open(self) -> None:
+        assert self.fp is not None
         offset = self.fp.tell()
 
         if not _accept(self.fp.read(8)):

--- a/src/PIL/Hdf5StubImagePlugin.py
+++ b/src/PIL/Hdf5StubImagePlugin.py
@@ -40,6 +40,7 @@ class HDF5StubImageFile(ImageFile.StubImageFile):
     format_description = "HDF5"
 
     def _open(self) -> None:
+        assert self.fp is not None
         offset = self.fp.tell()
 
         if not _accept(self.fp.read(8)):

--- a/src/PIL/IcnsImagePlugin.py
+++ b/src/PIL/IcnsImagePlugin.py
@@ -267,6 +267,7 @@ class IcnsImageFile(ImageFile.ImageFile):
     format_description = "Mac OS icns resource"
 
     def _open(self) -> None:
+        assert self.fp is not None
         self.icns = IcnsFile(self.fp)
         self._mode = "RGBA"
         self.info["sizes"] = self.icns.itersizes()

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -326,6 +326,7 @@ class IcoImageFile(ImageFile.ImageFile):
     format_description = "Windows Icon"
 
     def _open(self) -> None:
+        assert self.fp is not None
         self.ico = IcoFile(self.fp)
         self.info["sizes"] = self.ico.sizes()
         self.size = self.ico.entry[0].dim

--- a/src/PIL/ImImagePlugin.py
+++ b/src/PIL/ImImagePlugin.py
@@ -124,6 +124,7 @@ class ImImageFile(ImageFile.ImageFile):
         # Quick rejection: if there's not an LF among the first
         # 100 bytes, this is (probably) not a text header.
 
+        assert self.fp is not None
         if b"\n" not in self.fp.read(100):
             msg = "not an IM file"
             raise SyntaxError(msg)

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -199,6 +199,7 @@ class ImageFile(Image.Image):
         # As of pypy 2.1.0, memory mapping was failing here.
         use_mmap = use_mmap and not hasattr(sys, "pypy_version_info")
 
+        assert self.fp is not None
         readonly = 0
 
         # look for read/seek overrides

--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -77,6 +77,7 @@ class IptcImageFile(ImageFile.ImageFile):
     def field(self) -> tuple[tuple[int, int] | None, int]:
         #
         # get a IPTC field header
+        assert self.fp is not None
         s = self.fp.read(5)
         if not s.strip(b"\x00"):
             return None, 0
@@ -104,6 +105,7 @@ class IptcImageFile(ImageFile.ImageFile):
 
     def _open(self) -> None:
         # load descriptive fields
+        assert self.fp is not None
         while True:
             offset = self.fp.tell()
             tag, size = self.field()
@@ -157,6 +159,7 @@ class IptcImageFile(ImageFile.ImageFile):
 
         offset, compression = self.tile[0][2:]
 
+        assert self.fp is not None
         self.fp.seek(offset)
 
         # Copy image data to temporary file

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -248,6 +248,7 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
     format_description = "JPEG 2000 (ISO 15444)"
 
     def _open(self) -> None:
+        assert self.fp is not None
         sig = self.fp.read(4)
         if sig == b"\xff\x4f\xff\x51":
             self.codec = "j2k"
@@ -296,6 +297,7 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
         ]
 
     def _parse_comment(self) -> None:
+        assert self.fp is not None
         hdr = self.fp.read(2)
         length = _binary.i16be(hdr)
         self.fp.seek(length - 2, os.SEEK_CUR)

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
 
 
 def Skip(self: JpegImageFile, marker: int) -> None:
+    assert self.fp is not None
     n = i16(self.fp.read(2)) - 2
     ImageFile._safe_read(self.fp, n)
 
@@ -69,6 +70,7 @@ def APP(self: JpegImageFile, marker: int) -> None:
     # Application marker.  Store these in the APP dictionary.
     # Also look for well-known application markers.
 
+    assert self.fp is not None
     n = i16(self.fp.read(2)) - 2
     s = ImageFile._safe_read(self.fp, n)
 
@@ -170,6 +172,7 @@ def APP(self: JpegImageFile, marker: int) -> None:
 def COM(self: JpegImageFile, marker: int) -> None:
     #
     # Comment marker.  Store these in the APP dictionary.
+    assert self.fp is not None
     n = i16(self.fp.read(2)) - 2
     s = ImageFile._safe_read(self.fp, n)
 
@@ -186,6 +189,7 @@ def SOF(self: JpegImageFile, marker: int) -> None:
     # mode.  Note that this could be made a bit brighter, by
     # looking for JFIF and Adobe APP markers.
 
+    assert self.fp is not None
     n = i16(self.fp.read(2)) - 2
     s = ImageFile._safe_read(self.fp, n)
     self._size = i16(s, 3), i16(s, 1)
@@ -234,6 +238,7 @@ def DQT(self: JpegImageFile, marker: int) -> None:
     # FIXME: The quantization tables can be used to estimate the
     # compression quality.
 
+    assert self.fp is not None
     n = i16(self.fp.read(2)) - 2
     s = ImageFile._safe_read(self.fp, n)
     while len(s):
@@ -334,6 +339,7 @@ class JpegImageFile(ImageFile.ImageFile):
     format_description = "JPEG (ISO 10918)"
 
     def _open(self) -> None:
+        assert self.fp is not None
         s = self.fp.read(3)
 
         if not _accept(s):
@@ -401,6 +407,7 @@ class JpegImageFile(ImageFile.ImageFile):
         For premature EOF and LOAD_TRUNCATED_IMAGES adds EOI marker
         so libjpeg can finish decoding
         """
+        assert self.fp is not None
         s = self.fp.read(read_bytes)
 
         if not s and ImageFile.LOAD_TRUNCATED_IMAGES and not hasattr(self, "_ended"):

--- a/src/PIL/MicImagePlugin.py
+++ b/src/PIL/MicImagePlugin.py
@@ -67,6 +67,7 @@ class MicImageFile(TiffImagePlugin.TiffImageFile):
         self._n_frames = len(self.images)
         self.is_animated = self._n_frames > 1
 
+        assert self.fp is not None
         self.__fp = self.fp
         self.seek(0)
 

--- a/src/PIL/MpoImagePlugin.py
+++ b/src/PIL/MpoImagePlugin.py
@@ -98,6 +98,7 @@ class MpoImageFile(JpegImagePlugin.JpegImageFile):
     _close_exclusive_fp_after_loading = False
 
     def _open(self) -> None:
+        assert self.fp is not None
         self.fp.seek(0)  # prep the fp in order to pass the JPEG test
         JpegImagePlugin.JpegImageFile._open(self)
         self._after_jpeg_open()
@@ -117,6 +118,7 @@ class MpoImageFile(JpegImagePlugin.JpegImageFile):
         assert self.n_frames == len(self.__mpoffsets)
         del self.info["mpoffset"]  # no longer needed
         self.is_animated = self.n_frames > 1
+        assert self.fp is not None
         self._fp = self.fp  # FIXME: hack
         self._fp.seek(self.__mpoffsets[0])  # get ready to read first frame
         self.__frame = 0

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -752,6 +752,7 @@ class PngImageFile(ImageFile.ImageFile):
     format_description = "Portable network graphics"
 
     def _open(self) -> None:
+        assert self.fp is not None
         if not _accept(self.fp.read(8)):
             msg = "not a PNG file"
             raise SyntaxError(msg)
@@ -981,6 +982,7 @@ class PngImageFile(ImageFile.ImageFile):
         """internal: read more image data"""
 
         assert self.png is not None
+        assert self.fp is not None
         while self.__idat == 0:
             # end of chunk, skip forward to next one
 
@@ -1014,6 +1016,7 @@ class PngImageFile(ImageFile.ImageFile):
     def load_end(self) -> None:
         """internal: finished reading image data"""
         assert self.png is not None
+        assert self.fp is not None
         if self.__idat != 0:
             self.fp.read(self.__idat)
         while True:

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -60,6 +60,7 @@ class PsdImageFile(ImageFile.ImageFile):
     _close_exclusive_fp_after_loading = False
 
     def _open(self) -> None:
+        assert self.fp is not None
         read = self.fp.read
 
         #

--- a/src/PIL/QoiImagePlugin.py
+++ b/src/PIL/QoiImagePlugin.py
@@ -22,6 +22,7 @@ class QoiImageFile(ImageFile.ImageFile):
     format_description = "Quite OK Image"
 
     def _open(self) -> None:
+        assert self.fp is not None
         if not _accept(self.fp.read(4)):
             msg = "not a QOI file"
             raise SyntaxError(msg)

--- a/src/PIL/SpiderImagePlugin.py
+++ b/src/PIL/SpiderImagePlugin.py
@@ -101,6 +101,7 @@ class SpiderImageFile(ImageFile.ImageFile):
     def _open(self) -> None:
         # check header
         n = 27 * 4  # read 27 float values
+        assert self.fp is not None
         f = self.fp.read(n)
 
         try:

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1168,6 +1168,7 @@ class TiffImageFile(ImageFile.ImageFile):
         """Open the first image in a TIFF file"""
 
         # Header
+        assert self.fp is not None
         ifh = self.fp.read(8)
         if ifh[2] == 43:
             ifh += self.fp.read(8)
@@ -1328,6 +1329,7 @@ class TiffImageFile(ImageFile.ImageFile):
         # To be nice on memory footprint, if there's a
         # file descriptor, use that instead of reading
         # into a string in python.
+        assert self.fp is not None
         try:
             fp = hasattr(self.fp, "fileno") and self.fp.fileno()
             # flush the file descriptor, prevents error on pypy 2.4+

--- a/src/PIL/WalImageFile.py
+++ b/src/PIL/WalImageFile.py
@@ -39,6 +39,7 @@ class WalImageFile(ImageFile.ImageFile):
         self._mode = "P"
 
         # read header fields
+        assert self.fp is not None
         header = self.fp.read(32 + 24 + 32 + 12)
         self._size = i32(header, 32), i32(header, 36)
         Image._decompression_bomb_check(self.size)
@@ -55,6 +56,7 @@ class WalImageFile(ImageFile.ImageFile):
 
     def load(self) -> Image.core.PixelAccess | None:
         if self._im is None:
+            assert self.fp is not None
             self.im = Image.core.new(self.mode, self.size)
             self.frombytes(self.fp.read(self.size[0] * self.size[1]))
             self.putpalette(quake2palette)

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -43,6 +43,7 @@ class WebPImageFile(ImageFile.ImageFile):
     def _open(self) -> None:
         # Use the newer AnimDecoder API to parse the (possibly) animated file,
         # and access muxed chunks like ICC/EXIF/XMP.
+        assert self.fp is not None
         self._decoder = _webp.WebPAnimDecoder(self.fp.read())
 
         # Get info from decoder

--- a/src/PIL/WmfImagePlugin.py
+++ b/src/PIL/WmfImagePlugin.py
@@ -49,6 +49,7 @@ if hasattr(Image.core, "drawwmf"):
             self.bbox = im.info["wmf_bbox"]
 
         def load(self, im: ImageFile.StubImageFile) -> Image.Image:
+            assert im.fp is not None
             im.fp.seek(0)  # rewind
             return Image.frombytes(
                 "RGB",
@@ -85,6 +86,7 @@ class WmfStubImageFile(ImageFile.StubImageFile):
         self._inch = None
 
         # check placable header
+        assert self.fp is not None
         s = self.fp.read(80)
 
         if s[:6] == b"\xd7\xcd\xc6\x9a\x00\x00":

--- a/src/PIL/XpmImagePlugin.py
+++ b/src/PIL/XpmImagePlugin.py
@@ -37,6 +37,7 @@ class XpmImageFile(ImageFile.ImageFile):
     format_description = "X11 Pixel Map"
 
     def _open(self) -> None:
+        assert self.fp is not None
         if not _accept(self.fp.read(9)):
             msg = "not an XPM file"
             raise SyntaxError(msg)
@@ -111,6 +112,7 @@ class XpmImageFile(ImageFile.ImageFile):
 
         xsize, ysize = self.size
 
+        assert self.fp is not None
         s = [self.fp.readline()[1 : xsize + 1].ljust(xsize) for i in range(ysize)]
 
         return b"".join(s)


### PR DESCRIPTION
This is part of #8362 - I'm hoping to break down that PR into easier-to-review chunks.

ImageFile's `fp` may be `None`.

```pycon
>>> from PIL import Image
>>> im = Image.open("Tests/images/hopper.png")
>>> im.fp
<_io.BufferedReader name='Tests/images/hopper.png'>
>>> im.close()
>>> im.fp is None
True
```

So before using it, let's assert that it isn't `None`.