### PR TITLE
Added reading of J2K comments

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -424,8 +424,9 @@ def test_pclr() -> None:
 
 
 def test_comment() -> None:
-    with Image.open("Tests/images/comment.jp2") as im:
-        assert im.info["comment"] == b"Created by OpenJPEG version 2.5.0"
+    for path in ("Tests/images/9bit.j2k", "Tests/images/comment.jp2"):
+        with Image.open(path) as im:
+            assert im.info["comment"] == b"Created by OpenJPEG version 2.5.0"
 
     # Test an image that is truncated partway through a codestream
     with open("Tests/images/comment.jp2", "rb") as fp:

--- a/docs/releasenotes/11.1.0.rst
+++ b/docs/releasenotes/11.1.0.rst
@@ -52,6 +52,12 @@ zlib library, and what version of zlib-ng is being used::
 Other Changes
 =============
 
+Reading JPEG 2000 comments
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When opening a JPEG 2000 image, the comment may now be read into
+:py:attr:`~PIL.Image.Image.info` for J2K images, not just JP2 images.
+
 zlib-ng in wheels
 ^^^^^^^^^^^^^^^^^
 

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -252,6 +252,7 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
         if sig == b"\xff\x4f\xff\x51":
             self.codec = "j2k"
             self._size, self._mode = _parse_codestream(self.fp)
+            self._parse_comment()
         else:
             sig = sig + self.fp.read(8)
 
@@ -262,6 +263,9 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
                 if dpi is not None:
                     self.info["dpi"] = dpi
                 if self.fp.read(12).endswith(b"jp2c\xff\x4f\xff\x51"):
+                    hdr = self.fp.read(2)
+                    length = _binary.i16be(hdr)
+                    self.fp.seek(length - 2, os.SEEK_CUR)
                     self._parse_comment()
             else:
                 msg = "not a JPEG 2000 file"
@@ -296,10 +300,6 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
         ]
 
     def _parse_comment(self) -> None:
-        hdr = self.fp.read(2)
-        length = _binary.i16be(hdr)
-        self.fp.seek(length - 2, os.SEEK_CUR)
-
         while True:
             marker = self.fp.read(2)
             if not marker:


### PR DESCRIPTION
#6909 added reading of JP2 comments. This adds reading of J2K comments as well.

JP2 comments are read from a ["Contiguous codestream box"](https://www.ics.uci.edu/~dan/class/267/papers/jpeg2000.pdf) that "contains a valid and complete JPEG 2000 codestream"

https://github.com/python-pillow/Pillow/blob/0e3f51dec67991e4dee53bcc149218d6c65cf820/src/PIL/Jpeg2KImagePlugin.py#L264-L265

and starts by skipping `hdr`.

https://github.com/python-pillow/Pillow/blob/0e3f51dec67991e4dee53bcc149218d6c65cf820/src/PIL/Jpeg2KImagePlugin.py#L298-L301

Reading from a J2K image,

https://github.com/python-pillow/Pillow/blob/0e3f51dec67991e4dee53bcc149218d6c65cf820/src/PIL/Jpeg2KImagePlugin.py#L252-L254

the `hdr` is already read.

https://github.com/python-pillow/Pillow/blob/0e3f51dec67991e4dee53bcc149218d6c65cf820/src/PIL/Jpeg2KImagePlugin.py#L101-L107

So this PR moves the `hdr` handling out of `_parse_comment`.