### PR TITLE
Fixed indentation

### DIFF
--- a/src/_imagingcms.c
+++ b/src/_imagingcms.c
@@ -346,10 +346,10 @@ pyCMSdoTransform(Imaging im, Imaging imOut, cmsHTRANSFORM hTransform) {
         return -1;
     }
 
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
 
-        // transform color channels only
-        for (i = 0; i < im->ysize; i++) {
+    // transform color channels only
+    for (i = 0; i < im->ysize; i++) {
         cmsDoTransform(hTransform, im->image[i], imOut->image[i], im->xsize);
     }
 
@@ -362,9 +362,9 @@ pyCMSdoTransform(Imaging im, Imaging imOut, cmsHTRANSFORM hTransform) {
     // enough available on all platforms, so we polyfill it here for now.
     pyCMScopyAux(hTransform, imOut, im);
 
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
-        return 0;
+    return 0;
 }
 
 static cmsHTRANSFORM
@@ -378,17 +378,17 @@ _buildTransform(
 ) {
     cmsHTRANSFORM hTransform;
 
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
 
-        /* create the transform */
-        hTransform = cmsCreateTransform(
-            hInputProfile,
-            findLCMStype(sInMode),
-            hOutputProfile,
-            findLCMStype(sOutMode),
-            iRenderingIntent,
-            cmsFLAGS
-        );
+    /* create the transform */
+    hTransform = cmsCreateTransform(
+        hInputProfile,
+        findLCMStype(sInMode),
+        hOutputProfile,
+        findLCMStype(sOutMode),
+        iRenderingIntent,
+        cmsFLAGS
+    );
 
     Py_END_ALLOW_THREADS;
 
@@ -412,19 +412,19 @@ _buildProofTransform(
 ) {
     cmsHTRANSFORM hTransform;
 
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
 
-        /* create the transform */
-        hTransform = cmsCreateProofingTransform(
-            hInputProfile,
-            findLCMStype(sInMode),
-            hOutputProfile,
-            findLCMStype(sOutMode),
-            hProofProfile,
-            iRenderingIntent,
-            iProofIntent,
-            cmsFLAGS
-        );
+    /* create the transform */
+    hTransform = cmsCreateProofingTransform(
+        hInputProfile,
+        findLCMStype(sInMode),
+        hOutputProfile,
+        findLCMStype(sOutMode),
+        hProofProfile,
+        iRenderingIntent,
+        iProofIntent,
+        cmsFLAGS
+    );
 
     Py_END_ALLOW_THREADS;
 

--- a/src/display.c
+++ b/src/display.c
@@ -690,24 +690,26 @@ PyImaging_CreateWindowWin32(PyObject *self, PyObject *args) {
     SetWindowLongPtr(wnd, 0, (LONG_PTR)callback);
     SetWindowLongPtr(wnd, sizeof(callback), (LONG_PTR)PyThreadState_Get());
 
-    Py_BEGIN_ALLOW_THREADS ShowWindow(wnd, SW_SHOWNORMAL);
+    Py_BEGIN_ALLOW_THREADS;
+    ShowWindow(wnd, SW_SHOWNORMAL);
     SetForegroundWindow(wnd); /* to make sure it's visible */
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
-        return Py_BuildValue(F_HANDLE, wnd);
+    return Py_BuildValue(F_HANDLE, wnd);
 }
 
 PyObject *
 PyImaging_EventLoopWin32(PyObject *self, PyObject *args) {
     MSG msg;
 
-    Py_BEGIN_ALLOW_THREADS while (mainloop && GetMessage(&msg, NULL, 0, 0)) {
+    Py_BEGIN_ALLOW_THREADS;
+    while (mainloop && GetMessage(&msg, NULL, 0, 0)) {
         TranslateMessage(&msg);
         DispatchMessage(&msg);
     }
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
-        Py_INCREF(Py_None);
+    Py_INCREF(Py_None);
     return Py_None;
 }
 


### PR DESCRIPTION
Currently, the *_ALLOW_THREADS macros lead to odd indentation.

https://github.com/python-pillow/Pillow/blob/0e3f51dec67991e4dee53bcc149218d6c65cf820/src/_imagingcms.c#L349-L367

This PR consistently adds a semicolon after them to fix this.