### PR TITLE
Corrected loadImageSeries type hint

### DIFF
--- a/src/PIL/SpiderImagePlugin.py
+++ b/src/PIL/SpiderImagePlugin.py
@@ -211,26 +211,27 @@ class SpiderImageFile(ImageFile.ImageFile):
 
 
 # given a list of filenames, return a list of images
-def loadImageSeries(filelist: list[str] | None = None) -> list[SpiderImageFile] | None:
+def loadImageSeries(filelist: list[str] | None = None) -> list[Image.Image] | None:
     """create a list of :py:class:`~PIL.Image.Image` objects for use in a montage"""
     if filelist is None or len(filelist) < 1:
         return None
 
-    imglist = []
+    byte_imgs = []
     for img in filelist:
         if not os.path.exists(img):
             print(f"unable to find {img}")
             continue
         try:
             with Image.open(img) as im:
-                im = im.convert2byte()
+                assert isinstance(im, SpiderImageFile)
+                byte_im = im.convert2byte()
         except Exception:
             if not isSpiderImage(img):
                 print(f"{img} is not a Spider image file")
             continue
-        im.info["filename"] = img
-        imglist.append(im)
-    return imglist
+        byte_im.info["filename"] = img
+        byte_imgs.append(byte_im)
+    return byte_imgs
 
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
This is part of #8362 - I'm hoping to break down that PR into easier-to-review chunks.

Two changes to `loadImageSeries`.
https://github.com/python-pillow/Pillow/blob/0e3f51dec67991e4dee53bcc149218d6c65cf820/src/PIL/SpiderImagePlugin.py#L214-L233

1. `convert2byte()` is a SpiderImageFile method, so the image must be a SPIDER image to call that
2. `convert2byte()` returns an `Image` instance, meaning that `loadImageSeries` returns a list of `Image`s, not `SpiderImageFile`s.

https://github.com/python-pillow/Pillow/blob/0e3f51dec67991e4dee53bcc149218d6c65cf820/src/PIL/SpiderImagePlugin.py#L189