### PR TITLE
Pass file handle to ContainerIO

### DIFF
--- a/Tests/test_file_container.py
+++ b/Tests/test_file_container.py
@@ -4,8 +4,6 @@ import pytest
 
 from PIL import ContainerIO, Image
 
-from .helper import hopper
-
 TEST_FILE = "Tests/images/dummy.container"
 
 
@@ -15,15 +13,15 @@ def test_sanity() -> None:
 
 
 def test_isatty() -> None:
-    with hopper() as im:
-        container = ContainerIO.ContainerIO(im, 0, 0)
+    with open(TEST_FILE, "rb") as fh:
+        container = ContainerIO.ContainerIO(fh, 0, 0)
 
     assert container.isatty() is False
 
 
 def test_seekable() -> None:
-    with hopper() as im:
-        container = ContainerIO.ContainerIO(im, 0, 0)
+    with open(TEST_FILE, "rb") as fh:
+        container = ContainerIO.ContainerIO(fh, 0, 0)
 
     assert container.seekable() is True
 


### PR DESCRIPTION
This is part of #8362 - I'm hoping to break down that PR into easier-to-review chunks.

#7656 set `ContainerIO` to receive `IO` as the type of the first argument.

https://github.com/python-pillow/Pillow/blob/f9767fb00fe78f118e36be2e7e6c816af07fe78b/src/PIL/ContainerIO.py#L29

Currently, test_file_container.py passes an image instance to it sometimes - the wrong type.

https://github.com/python-pillow/Pillow/blob/f9767fb00fe78f118e36be2e7e6c816af07fe78b/Tests/test_file_container.py#L18-L19

This PR fixes that, passing a file handle to it like the rest of the test file does.

https://github.com/python-pillow/Pillow/blob/f9767fb00fe78f118e36be2e7e6c816af07fe78b/Tests/test_file_container.py#L41-L42