### PR TITLE
Use monkeypatch

### DIFF
--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -110,7 +110,7 @@ def test_load_first_unless_jpeg(monkeypatch: pytest.MonkeyPatch) -> None:
         original_draft = im.draft
 
         def im_draft(
-            mode: str, size: tuple[int, int]
+            mode: str | None, size: tuple[int, int] | None
         ) -> tuple[str, tuple[int, int, float, float]] | None:
             result = original_draft(mode, size)
             assert result is not None

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -104,20 +104,20 @@ def test_transposed() -> None:
         assert im.size == (590, 88)
 
 
-def test_load_first_unless_jpeg() -> None:
+def test_load_first_unless_jpeg(monkeypatch: pytest.MonkeyPatch) -> None:
     # Test that thumbnail() still uses draft() for JPEG
     with Image.open("Tests/images/hopper.jpg") as im:
-        draft = im.draft
+        original_draft = im.draft
 
         def im_draft(
             mode: str, size: tuple[int, int]
         ) -> tuple[str, tuple[int, int, float, float]] | None:
-            result = draft(mode, size)
+            result = original_draft(mode, size)
             assert result is not None
 
             return result
 
-        im.draft = im_draft
+        monkeypatch.setattr(im, "draft", im_draft)
 
         im.thumbnail((64, 64))
 


### PR DESCRIPTION
This is part of #8362 - I'm hoping to break down that PR into easier-to-review chunks.

1. Uses monkeypatch for
https://github.com/python-pillow/Pillow/blob/f9767fb00fe78f118e36be2e7e6c816af07fe78b/Tests/test_image_thumbnail.py#L112-L120
2. Updates the type arguments in the mock method to match
https://github.com/python-pillow/Pillow/blob/f9767fb00fe78f118e36be2e7e6c816af07fe78b/src/PIL/Image.py#L1326-L1327