### PR TITLE
Restored Makernote as a deprecated enum

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -175,6 +175,14 @@ deprecated and will be removed in Pillow 12 (2025-10-15). They were used for obt
 raw pointers to ``ImagingCore`` internals. To interact with C code, you can use
 ``Image.Image.getim()``, which returns a ``Capsule`` object.
 
+ExifTags.IFD.Makernote
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. deprecated:: 11.1.0
+
+``ExifTags.IFD.Makernote`` has been deprecated. Instead, use
+``ExifTags.IFD.MakerNote``.
+
 Removed features
 ----------------
 

--- a/docs/releasenotes/11.1.0.rst
+++ b/docs/releasenotes/11.1.0.rst
@@ -23,10 +23,11 @@ TODO
 Deprecations
 ============
 
-TODO
-^^^^
+ExifTags.IFD.Makernote
+^^^^^^^^^^^^^^^^^^^^^^
 
-TODO
+``ExifTags.IFD.Makernote`` has been deprecated. Instead, use
+``ExifTags.IFD.MakerNote``.
 
 API Changes
 ===========

--- a/src/PIL/ExifTags.py
+++ b/src/PIL/ExifTags.py
@@ -353,6 +353,7 @@ class IFD(IntEnum):
     Exif = 0x8769
     GPSInfo = 0x8825
     MakerNote = 0x927C
+    Makernote = 0x927C  # Deprecated
     Interop = 0xA005
     IFD1 = -1
 


### PR DESCRIPTION
#8615 replaced `ExifTags.IFD.Makernote` with `ExifTags.IFD.MakerNote`.

https://github.com/python-pillow/Pillow/issues/8614#issuecomment-2564126641 has requested that we keep `ExifTags.IFD.Makernote` for now, as a deprecated enum.