### PR TITLE
Keep new IFDs when converting EXIF to bytes

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -793,6 +793,10 @@ class TestImage:
         ifd[36864] = b"0220"
         assert exif.get_ifd(0x8769) == {36864: b"0220"}
 
+        reloaded_exif = Image.Exif()
+        reloaded_exif.load(exif.tobytes())
+        assert reloaded_exif.get_ifd(0x8769) == {36864: b"0220"}
+
     @mark_if_feature_version(
         pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
     )

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -4023,6 +4023,9 @@ class Exif(_ExifBase):
 
         head = self._get_head()
         ifd = TiffImagePlugin.ImageFileDirectory_v2(ifh=head)
+        for tag, ifd_dict in self._ifds.items():
+            if tag not in self:
+                ifd[tag] = ifd_dict
         for tag, value in self.items():
             if tag in [
                 ExifTags.IFD.Exif,


### PR DESCRIPTION
Resolves #8634

The following code doesn't currently keep the new IFD tag when converting to bytes.
```python
from PIL import Image
exif = Image.Exif()
ifd = exif.get_ifd(0x8769)
ifd[36864] = b"0220"
exif.tobytes()
```

This is because the new IFD is added to `exif._ifds`, but not `exif._data`. It makes sense to not save it to `exif._data`, because a tag value for the IFD would indicate the IFD offset, which only has meaning in byte format. However, `exif._ifds` isn't checked when converting to bytes, so the new IFD is forgotten.

This PR fixes that.