### PR TITLE
Add zizmor to pre-commit and fix potential cache-poisoning in wheels workflow

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -263,8 +263,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.x"
-        cache: pip
-        cache-dependency-path: "Makefile"
 
     - run: make sdist
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.1
+    rev: v0.8.4
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
@@ -24,7 +24,7 @@ repos:
         exclude: (Makefile$|\.bat$|\.cmake$|\.eps$|\.fits$|\.gd$|\.opt$)
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v19.1.4
+    rev: v19.1.5
     hooks:
       - id: clang-format
         types: [c]
@@ -55,6 +55,11 @@ repos:
       - id: check-github-workflows
       - id: check-readthedocs
       - id: check-renovate
+
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v0.10.0
+    hooks:
+      - id: zizmor
 
   - repo: https://github.com/sphinx-contrib/sphinx-lint
     rev: v1.0.0


### PR DESCRIPTION
Follow on from https://github.com/python-pillow/Pillow/pull/8526.

Add zizmor to pre-commit, run the new version 0.10.0, and fix the one new thing it finds:

```
error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
   --> /Users/hugo/github/Pillow/.github/workflows/wheels.yml:3:1
    |
  3 | / on:
  4 | |   schedule:
...   |
 29 | |       - "winbuild/fribidi.cmake"
 30 | |   workflow_dispatch:
    | |____________________^ generally used when publishing artifacts generated at runtime
 31 |
...
263 |         uses: actions/setup-python@v5
264 | /       with:
265 | |         python-version: "3.x"
266 | |         cache: pip
267 | |         cache-dependency-path: "Makefile"
    | |_________________________________________^ opt-in for caching here
    |
    = note: audit confidence → Low

54 findings (53 suppressed): 0 unknown, 0 informational, 0 low, 0 medium, 1 high
```

More info: https://woodruffw.github.io/zizmor/audits/#cache-poisoning

In short, the idea is not to use caches in workflows that produce release artifacts.

This featured in the recent Ultralytics supply chain attack:

* https://blog.pypi.org/posts/2024-12-11-ultralytics-attack-analysis/
* https://blog.yossarian.net/2024/12/06/zizmor-ultralytics-injection

We don't run the wheels workflow that often, and the main time bottleneck is building and testing all the wheels, so it's not a big loss to download things from PyPI each time.
