### PR TITLE
Remove pre-C99 definitions

### DIFF
--- a/docs/releasenotes/11.1.0.rst
+++ b/docs/releasenotes/11.1.0.rst
@@ -80,6 +80,11 @@ Saving JPEG 2000 CMYK images
 
 With OpenJPEG 2.5.3 or later, Pillow can now save CMYK images as JPEG 2000 files.
 
+Minimum C version
+^^^^^^^^^^^^^^^^^
+
+C99 is now the minimum version of C required to compile Pillow from source.
+
 zlib-ng in wheels
 ^^^^^^^^^^^^^^^^^
 

--- a/src/libImaging/ImPlatform.h
+++ b/src/libImaging/ImPlatform.h
@@ -44,8 +44,6 @@
    defines their own types with the same names, so we need to be able to undef
    ours before including the JPEG code. */
 
-#if __STDC_VERSION__ >= 199901L /* C99+ */
-
 #include <stdint.h>
 
 #define INT8 int8_t
@@ -54,34 +52,6 @@
 #define UINT16 uint16_t
 #define INT32 int32_t
 #define UINT32 uint32_t
-
-#else /* < C99 */
-
-#define INT8 signed char
-
-#if SIZEOF_SHORT == 2
-#define INT16 short
-#elif SIZEOF_INT == 2
-#define INT16 int
-#else
-#error Cannot find required 16-bit integer type
-#endif
-
-#if SIZEOF_SHORT == 4
-#define INT32 short
-#elif SIZEOF_INT == 4
-#define INT32 int
-#elif SIZEOF_LONG == 4
-#define INT32 long
-#else
-#error Cannot find required 32-bit integer type
-#endif
-
-#define UINT8 unsigned char
-#define UINT16 unsigned INT16
-#define UINT32 unsigned INT32
-
-#endif /* < C99 */
 
 #endif /* not WIN */
 


### PR DESCRIPTION
See #6516 for previous discussion about whether C99 can be the minimum version.