### PR TITLE
Added compile-time mozjpeg feature flag

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -281,7 +281,10 @@ class TestFileJpeg:
         assert not im2.info.get("progressive")
         assert im3.info.get("progressive")
 
-        assert_image_equal(im1, im3)
+        if features.check_feature("mozjpeg"):
+            assert_image_similar(im1, im3, 9.39)
+        else:
+            assert_image_equal(im1, im3)
         assert im1_bytes >= im3_bytes
 
     def test_progressive_large_buffer(self, tmp_path: Path) -> None:
@@ -424,8 +427,12 @@ class TestFileJpeg:
 
         im2 = self.roundtrip(hopper(), progressive=1)
         im3 = self.roundtrip(hopper(), progression=1)  # compatibility
-        assert_image_equal(im1, im2)
-        assert_image_equal(im1, im3)
+        if features.check_feature("mozjpeg"):
+            assert_image_similar(im1, im2, 9.39)
+            assert_image_similar(im1, im3, 9.39)
+        else:
+            assert_image_equal(im1, im2)
+            assert_image_equal(im1, im3)
         assert im2.info.get("progressive")
         assert im2.info.get("progression")
         assert im3.info.get("progressive")

--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -127,6 +127,7 @@ features: dict[str, tuple[str, str | bool, str | None]] = {
     "fribidi": ("PIL._imagingft", "HAVE_FRIBIDI", "fribidi_version"),
     "harfbuzz": ("PIL._imagingft", "HAVE_HARFBUZZ", "harfbuzz_version"),
     "libjpeg_turbo": ("PIL._imaging", "HAVE_LIBJPEGTURBO", "libjpeg_turbo_version"),
+    "mozjpeg": ("PIL._imaging", "HAVE_MOZJPEG", "libjpeg_turbo_version"),
     "zlib_ng": ("PIL._imaging", "HAVE_ZLIBNG", "zlib_ng_version"),
     "libimagequant": ("PIL._imaging", "HAVE_LIBIMAGEQUANT", "imagequant_version"),
     "xcb": ("PIL._imaging", "HAVE_XCB", None),
@@ -300,7 +301,8 @@ def pilinfo(out: IO[str] | None = None, supported_formats: bool = True) -> None:
             if name == "jpg":
                 libjpeg_turbo_version = version_feature("libjpeg_turbo")
                 if libjpeg_turbo_version is not None:
-                    v = "libjpeg-turbo " + libjpeg_turbo_version
+                    v = "mozjpeg" if check_feature("mozjpeg") else "libjpeg-turbo"
+                    v += " " + libjpeg_turbo_version
             if v is None:
                 v = version(name)
             if v is not None:

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -76,6 +76,13 @@
 
 #ifdef HAVE_LIBJPEG
 #include "jconfig.h"
+#ifdef LIBJPEG_TURBO_VERSION
+#define JCONFIG_INCLUDED
+#ifdef __CYGWIN__
+#define _BASETSD_H
+#endif
+#include "jpeglib.h"
+#endif
 #endif
 
 #ifdef HAVE_LIBZ
@@ -4366,6 +4373,15 @@ setup_module(PyObject *m) {
 #endif
     Py_INCREF(have_libjpegturbo);
     PyModule_AddObject(m, "HAVE_LIBJPEGTURBO", have_libjpegturbo);
+
+    PyObject *have_mozjpeg;
+#ifdef JPEG_C_PARAM_SUPPORTED
+    have_mozjpeg = Py_True;
+#else
+    have_mozjpeg = Py_False;
+#endif
+    Py_INCREF(have_mozjpeg);
+    PyModule_AddObject(m, "HAVE_MOZJPEG", have_mozjpeg);
 
     PyObject *have_libimagequant;
 #ifdef HAVE_LIBIMAGEQUANT

--- a/src/libImaging/JpegEncode.c
+++ b/src/libImaging/JpegEncode.c
@@ -134,7 +134,16 @@ ImagingJpegEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
                     return -1;
             }
 
-            /* Compressor configuration */
+                /* Compressor configuration */
+#ifdef JPEG_C_PARAM_SUPPORTED
+            /* MozJPEG */
+            if (!context->progressive) {
+                /* Do not use MozJPEG progressive default */
+                jpeg_c_set_int_param(
+                    &context->cinfo, JINT_COMPRESS_PROFILE, JCP_FASTEST
+                );
+            }
+#endif
             jpeg_set_defaults(&context->cinfo);
 
             /* Prevent RGB -> YCbCr conversion */


### PR DESCRIPTION
Resolves #539

Pillow will currently detect and use [MozJPEG](https://github.com/mozilla/mozjpeg) if it is installed. However,

1.  Pillow will [report](https://github.com/radarhere/Pillow/actions/runs/12558654968/job/35013138448#step:10:603)
> --- JPEG support ok, compiled for libjpeg-turbo 4.1.1

4.1.1 is not a [libjpeg-turbo version](https://github.com/libjpeg-turbo/libjpeg-turbo/releases). It is the [MozJPEG version](https://github.com/mozilla/mozjpeg/releases). So this PR detects MozJPEG, and updates the report to say 'compiled for mozjpeg 4.1.1'

I've also added `features.check_feature("mozjpeg")`

2. Testing in Ubuntu on GitHub Actions, there are currently [12 test failures](https://github.com/radarhere/Pillow/actions/runs/12558654968/job/35013138448#step:11:5915).

Our current default behaviour is to not save progressive JPEGs, as documented in the saving keyword arguments at https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#jpeg-saving
> **progressive**
> If present and true, indicates that this image should be stored as a progressive JPEG file.

However, mozjpeg does save progressive JPEGs by default, unlike libjpeg-turbo. If I change the ['compression profile'](https://github.com/mozilla/mozjpeg/blob/19999bc0b98934bc85acc5f3cac178541a61e219/jpeglib.h#L343-L355) from 'best compression ratio (progressive, all mozjpeg extensions)' to 'libjpeg[-turbo] defaults (baseline, no mozjpeg extensions)', then after I relax some image comparison checks, [our test suite passes.](https://github.com/radarhere/Pillow/actions/runs/12558657374/job/35013144328)