### PR TITLE
PngImageFile text is a property

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -618,7 +618,7 @@ class TestFilePng:
         with Image.open("Tests/images/truncated_image.png") as im:
             # The file is truncated
             with pytest.raises(OSError):
-                im.text()
+                im.text
             ImageFile.LOAD_TRUNCATED_IMAGES = True
             assert isinstance(im.text, dict)
             ImageFile.LOAD_TRUNCATED_IMAGES = False


### PR DESCRIPTION
This is part of #8362 - I'm hoping to break down that PR into easier-to-review chunks.

https://github.com/python-pillow/Pillow/blob/aa0f4127b8040b82822808fa2037fea1a162d3c5/Tests/test_file_png.py#L617-L621
is testing
https://github.com/python-pillow/Pillow/blob/aa0f4127b8040b82822808fa2037fea1a162d3c5/src/PIL/PngImagePlugin.py#L821-L822

Since this is a `@property`, it can be accessed with just `im.text`