### PR TITLE
Removed unused image open

### DIFF
--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -253,8 +253,7 @@ def test_truncated_mask() -> None:
 
     try:
         with Image.open(io.BytesIO(data)) as im:
-            with Image.open("Tests/images/hopper_mask.png") as expected:
-                assert im.mode == "1"
+            assert im.mode == "1"
 
         # 32 bpp
         output = io.BytesIO()


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/aa0f4127b8040b82822808fa2037fea1a162d3c5/Tests/test_file_ico.py#L255-L259

The result of opening hopper_mask.png is not used here, so it can be removed.

You might think that we are testing just opening the image, but that has already been done earlier in the file.

https://github.com/python-pillow/Pillow/blob/aa0f4127b8040b82822808fa2037fea1a162d3c5/Tests/test_file_ico.py#L32