### PR TITLE
Add overloads for exif_transpose

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -353,7 +353,6 @@ class TestFileJpeg:
             assert exif.get_ifd(0x8825) == {}
 
             transposed = ImageOps.exif_transpose(im)
-        assert transposed is not None
         exif = transposed.getexif()
         assert exif.get_ifd(0x8825) == {}
 

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -405,7 +405,6 @@ def test_exif_transpose() -> None:
                     else:
                         original_exif = im.info["exif"]
                     transposed_im = ImageOps.exif_transpose(im)
-                    assert transposed_im is not None
                     assert_image_similar(base_im, transposed_im, 17)
                     if orientation_im is base_im:
                         assert "exif" not in im.info
@@ -417,7 +416,6 @@ def test_exif_transpose() -> None:
 
                     # Repeat the operation to test that it does not keep transposing
                     transposed_im2 = ImageOps.exif_transpose(transposed_im)
-                    assert transposed_im2 is not None
                     assert_image_equal(transposed_im2, transposed_im)
 
             check(base_im)
@@ -433,7 +431,6 @@ def test_exif_transpose() -> None:
             assert im.getexif()[0x0112] == 3
 
             transposed_im = ImageOps.exif_transpose(im)
-            assert transposed_im is not None
             assert 0x0112 not in transposed_im.getexif()
 
             transposed_im._reload_exif()
@@ -446,14 +443,12 @@ def test_exif_transpose() -> None:
         assert im.getexif()[0x0112] == 3
 
         transposed_im = ImageOps.exif_transpose(im)
-        assert transposed_im is not None
         assert 0x0112 not in transposed_im.getexif()
 
     # Orientation set directly on Image.Exif
     im = hopper()
     im.getexif()[0x0112] = 3
     transposed_im = ImageOps.exif_transpose(im)
-    assert transposed_im is not None
     assert 0x0112 not in transposed_im.getexif()
 
 
@@ -464,7 +459,6 @@ def test_exif_transpose_xml_without_xmp() -> None:
 
         del im.info["xmp"]
         transposed_im = ImageOps.exif_transpose(im)
-        assert transposed_im is not None
         assert 0x0112 not in transposed_im.getexif()
 
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -22,7 +22,7 @@ import functools
 import operator
 import re
 from collections.abc import Sequence
-from typing import Protocol, cast
+from typing import Literal, Protocol, cast, overload
 
 from . import ExifTags, Image, ImagePalette
 
@@ -671,6 +671,16 @@ def solarize(image: Image.Image, threshold: int = 128) -> Image.Image:
         else:
             lut.append(255 - i)
     return _lut(image, lut)
+
+
+@overload
+def exif_transpose(image: Image.Image, *, in_place: Literal[True]) -> None: ...
+
+
+@overload
+def exif_transpose(
+    image: Image.Image, *, in_place: Literal[False] = False
+) -> Image.Image: ...
 
 
 def exif_transpose(image: Image.Image, *, in_place: bool = False) -> Image.Image | None:


### PR DESCRIPTION
Add overloads for `exif_transpose` to improve the return type based on the `in_place` argument.
https://github.com/python-pillow/Pillow/blob/66f5a3facc43170824eae69c7817c0ed6e2c908f/src/PIL/ImageOps.py#L682-L686