### PR TITLE
Updated TIFF decode error message string

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -1146,7 +1146,7 @@ class TestFileLibTiff(LibTiffTestCase):
                 im.load()
 
             # Assert that the error code is IMAGING_CODEC_MEMORY
-            assert str(e.value) == "-9"
+            assert str(e.value) == "decoder error -9"
 
     @pytest.mark.parametrize("compression", ("tiff_adobe_deflate", "jpeg"))
     def test_save_multistrip(self, compression: str, tmp_path: Path) -> None:

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1406,7 +1406,8 @@ class TiffImageFile(ImageFile.ImageFile):
             self.fp = None  # might be shared
 
         if err < 0:
-            raise OSError(err)
+            msg = f"decoder error {err}"
+            raise OSError(msg)
 
         return Image.Image.load(self)
 


### PR DESCRIPTION
OSError caused by decode error should use string argument to be in line with rest of module

Changes proposed in this pull request:

 * Changed an OSError raised in TiffImagePlugin.py during a decoder error to contain a str message as its argument, instead of directly passing the error code as an integer. This change brings this specific OSError in line with the way errors are raised in the rest of TiffImagePlugin.py and thus reduces surprise.