### PR TITLE
Removed giflib as webp dependency

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -45,7 +45,6 @@ OPENJPEG_VERSION=2.5.3
 XZ_VERSION=5.6.3
 TIFF_VERSION=4.6.0
 LCMS2_VERSION=2.16
-GIFLIB_VERSION=5.2.2
 ZLIB_NG_VERSION=2.2.3
 LIBWEBP_VERSION=1.5.0
 BZIP2_VERSION=1.0.8
@@ -135,16 +134,10 @@ function build {
     CFLAGS="$CFLAGS -O3 -DNDEBUG"
     if [[ -n "$IS_MACOS" ]]; then
         CFLAGS="$CFLAGS -Wl,-headerpad_max_install_names"
-    # For giflib 5.2.2
-    elif [ -n "$IS_ALPINE" ]; then
-        apk add imagemagick
-    else
-        if [[ "$MB_ML_VER" == "_2_28" ]]; then
-            yum install -y epel-release
-        fi
-        yum install -y ImageMagick
     fi
-    build_libwebp
+    build_simple libwebp $LIBWEBP_VERSION \
+        https://storage.googleapis.com/downloads.webmproject.org/releases/webp tar.gz \
+        --enable-libwebpmux --enable-libwebpdemux
     CFLAGS=$ORIGINAL_CFLAGS
 
     build_brotli


### PR DESCRIPTION
Alternative to #8658

We started mentioning giflib because it is used by `build_libwebp` - https://github.com/python-pillow/pillow-wheels/pull/98 / https://github.com/multi-build/multibuild/blob/42d761728d141d8462cd9943f4329f12fe62b155/library_builders.sh#L286-L293

However, https://developers.google.com/speed/webp/docs/compiling states
> Install the libjpeg, libpng, libtiff and libgif packages, needed to convert between JPEG, PNG, TIFF, GIF and WebP image formats.

We don't ask libwebp to convert between GIF and WebP formats, so the dependency can be removed by replacing `build_libwebp` with a direct `build_simple` call.

---

cifuzz still appears to be failing because just runs on main - https://github.com/google/oss-fuzz/blob/master/projects/pillow/Dockerfile

If I test one of our old vulnerabilities on oss-fuzz, you can see the `convert` problem - https://github.com/radarhere/oss-fuzz/actions/runs/12605648048/job/35134631013#step:7:6363

But once I [switch to this branch](https://github.com/radarhere/oss-fuzz/commit/c9b3bf97ad24fab75680702bc2e183d73d6fd56c), it goes away - https://github.com/radarhere/oss-fuzz/actions/runs/12605660381