### PR TITLE
Simplified converting to char *

### DIFF
--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -339,29 +339,23 @@ text_layout_raqm(
         len = PySequence_Fast_GET_SIZE(seq);
         for (j = 0; j < len; j++) {
             PyObject *item = PySequence_Fast_GET_ITEM(seq, j);
-            char *feature = NULL;
-            Py_ssize_t size = 0;
-            PyObject *bytes;
-
             if (!PyUnicode_Check(item)) {
                 Py_DECREF(seq);
                 PyErr_SetString(PyExc_TypeError, "expected a string");
                 goto failed;
             }
-            bytes = PyUnicode_AsUTF8String(item);
-            if (bytes == NULL) {
+
+            Py_ssize_t size;
+            const char *feature = PyUnicode_AsUTF8AndSize(item, &size);
+            if (feature == NULL) {
                 Py_DECREF(seq);
                 goto failed;
             }
-            feature = PyBytes_AS_STRING(bytes);
-            size = PyBytes_GET_SIZE(bytes);
             if (!raqm_add_font_feature(rq, feature, size)) {
                 Py_DECREF(seq);
-                Py_DECREF(bytes);
                 PyErr_SetString(PyExc_ValueError, "raqm_add_font_feature() failed");
                 goto failed;
             }
-            Py_DECREF(bytes);
         }
         Py_DECREF(seq);
     }


### PR DESCRIPTION
Rather than [`PyUnicode_AsUTF8String`](https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsUTF8String) to get a `PyObject` and then passing that to [`PyBytes_AS_STRING`](https://docs.python.org/3/c-api/bytes.html#c.PyBytes_AS_STRING) to get `char *` and [`PyBytes_GET_SIZE`](https://docs.python.org/3/c-api/bytes.html#c.PyBytes_GET_SIZE) to get `Py_ssize_t`,

just use [`PyUnicode_AsUTF8AndSize`](https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsUTF8AndSize). It returns `const char *` and passes back `Py_ssize_t`.