### PR TITLE
Allow saving multiple frames as BigTIFF

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -746,7 +746,7 @@ class TestFileTiff:
             assert reread.n_frames == 3
 
     def test_fixoffsets(self) -> None:
-        b = BytesIO(b"II\x2a\x00\x00\x00\x00\x00")
+        b = BytesIO(b"II\x2A\x00\x00\x00\x00\x00")
         with TiffImagePlugin.AppendingTiffWriter(b) as a:
             b.seek(0)
             a.fixOffsets(1, isShort=True)
@@ -759,12 +759,36 @@ class TestFileTiff:
             with pytest.raises(RuntimeError):
                 a.fixOffsets(1)
 
+        b = BytesIO(b"II\x2A\x00\x00\x00\x00\x00")
+        with TiffImagePlugin.AppendingTiffWriter(b) as a:
+            a.offsetOfNewPage = 2**16
+
+            b.seek(0)
+            a.fixOffsets(1, isShort=True)
+
+        b = BytesIO(b"II\x2B\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+        with TiffImagePlugin.AppendingTiffWriter(b) as a:
+            a.offsetOfNewPage = 2**32
+
+            b.seek(0)
+            a.fixOffsets(1, isShort=True)
+
+            b.seek(0)
+            a.fixOffsets(1, isLong=True)
+
     def test_appending_tiff_writer_writelong(self) -> None:
         data = b"II\x2A\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
         b = BytesIO(data)
         with TiffImagePlugin.AppendingTiffWriter(b) as a:
             a.writeLong(2**32 - 1)
             assert b.getvalue() == data + b"\xff\xff\xff\xff"
+
+    def test_appending_tiff_writer_rewritelastshorttolong(self) -> None:
+        data = b"II\x2A\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+        b = BytesIO(data)
+        with TiffImagePlugin.AppendingTiffWriter(b) as a:
+            a.rewriteLastShortToLong(2**32 - 1)
+            assert b.getvalue() == data[:-2] + b"\xff\xff\xff\xff"
 
     def test_saving_icc_profile(self, tmp_path: Path) -> None:
         # Tests saving TIFF with icc_profile set.

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -962,13 +962,16 @@ class ImageFileDirectory_v2(_IFDv2Base):
         result = self._pack("Q" if self._bigtiff else "H", len(self._tags_v2))
 
         entries: list[tuple[int, int, int, bytes, bytes]] = []
-        offset += len(result) + len(self._tags_v2) * (20 if self._bigtiff else 12) + 4
+
+        fmt = "Q" if self._bigtiff else "L"
+        fmt_size = 8 if self._bigtiff else 4
+        offset += (
+            len(result) + len(self._tags_v2) * (20 if self._bigtiff else 12) + fmt_size
+        )
         stripoffsets = None
 
         # pass 1: convert tags to binary format
         # always write tags in ascending order
-        fmt = "Q" if self._bigtiff else "L"
-        fmt_size = 8 if self._bigtiff else 4
         for tag, value in sorted(self._tags_v2.items()):
             if tag == STRIPOFFSETS:
                 stripoffsets = len(entries)
@@ -1024,7 +1027,7 @@ class ImageFileDirectory_v2(_IFDv2Base):
             )
 
         # -- overwrite here for multi-page --
-        result += b"\0\0\0\0"  # end of entries
+        result += self._pack(fmt, 0)  # end of entries
 
         # pass 3: write auxiliary data to file
         for tag, typ, count, value, data in entries:
@@ -2043,20 +2046,21 @@ class AppendingTiffWriter(io.BytesIO):
         self.offsetOfNewPage = 0
 
         self.IIMM = iimm = self.f.read(4)
+        self._bigtiff = b"\x2B" in iimm
         if not iimm:
             # empty file - first page
             self.isFirst = True
             return
 
         self.isFirst = False
-        if iimm == b"II\x2a\x00":
-            self.setEndian("<")
-        elif iimm == b"MM\x00\x2a":
-            self.setEndian(">")
-        else:
+        if iimm not in PREFIXES:
             msg = "Invalid TIFF file header"
             raise RuntimeError(msg)
 
+        self.setEndian("<" if iimm.startswith(II) else ">")
+
+        if self._bigtiff:
+            self.f.seek(4, os.SEEK_CUR)
         self.skipIFDs()
         self.goToEnd()
 
@@ -2076,11 +2080,13 @@ class AppendingTiffWriter(io.BytesIO):
             msg = "IIMM of new page doesn't match IIMM of first page"
             raise RuntimeError(msg)
 
-        ifd_offset = self.readLong()
+        if self._bigtiff:
+            self.f.seek(4, os.SEEK_CUR)
+        ifd_offset = self._read(8 if self._bigtiff else 4)
         ifd_offset += self.offsetOfNewPage
         assert self.whereToWriteNewIFDOffset is not None
         self.f.seek(self.whereToWriteNewIFDOffset)
-        self.writeLong(ifd_offset)
+        self._write(ifd_offset, 8 if self._bigtiff else 4)
         self.f.seek(ifd_offset)
         self.fixIFD()
 
@@ -2126,18 +2132,20 @@ class AppendingTiffWriter(io.BytesIO):
         self.endian = endian
         self.longFmt = f"{self.endian}L"
         self.shortFmt = f"{self.endian}H"
-        self.tagFormat = f"{self.endian}HHL"
+        self.tagFormat = f"{self.endian}HH" + ("Q" if self._bigtiff else "L")
 
     def skipIFDs(self) -> None:
         while True:
-            ifd_offset = self.readLong()
+            ifd_offset = self._read(8 if self._bigtiff else 4)
             if ifd_offset == 0:
-                self.whereToWriteNewIFDOffset = self.f.tell() - 4
+                self.whereToWriteNewIFDOffset = self.f.tell() - (
+                    8 if self._bigtiff else 4
+                )
                 break
 
             self.f.seek(ifd_offset)
-            num_tags = self.readShort()
-            self.f.seek(num_tags * 12, os.SEEK_CUR)
+            num_tags = self._read(8 if self._bigtiff else 2)
+            self.f.seek(num_tags * (20 if self._bigtiff else 12), os.SEEK_CUR)
 
     def write(self, data: Buffer, /) -> int:
         return self.f.write(data)
@@ -2185,13 +2193,17 @@ class AppendingTiffWriter(io.BytesIO):
     def rewriteLastLong(self, value: int) -> None:
         return self._rewriteLast(value, 4)
 
+    def _write(self, value: int, field_size: int) -> None:
+        bytes_written = self.f.write(
+            struct.pack(self.endian + self._fmt(field_size), value)
+        )
+        self._verify_bytes_written(bytes_written, field_size)
+
     def writeShort(self, value: int) -> None:
-        bytes_written = self.f.write(struct.pack(self.shortFmt, value))
-        self._verify_bytes_written(bytes_written, 2)
+        self._write(value, 2)
 
     def writeLong(self, value: int) -> None:
-        bytes_written = self.f.write(struct.pack(self.longFmt, value))
-        self._verify_bytes_written(bytes_written, 4)
+        self._write(value, 4)
 
     def close(self) -> None:
         self.finalize()
@@ -2199,24 +2211,27 @@ class AppendingTiffWriter(io.BytesIO):
             self.f.close()
 
     def fixIFD(self) -> None:
-        num_tags = self.readShort()
+        num_tags = self._read(8 if self._bigtiff else 2)
 
         for i in range(num_tags):
-            tag, field_type, count = struct.unpack(self.tagFormat, self.f.read(8))
+            tag, field_type, count = struct.unpack(
+                self.tagFormat, self.f.read(12 if self._bigtiff else 8)
+            )
 
             field_size = self.fieldSizes[field_type]
             total_size = field_size * count
-            is_local = total_size <= 4
+            fmt_size = 8 if self._bigtiff else 4
+            is_local = total_size <= fmt_size
             if not is_local:
-                offset = self.readLong() + self.offsetOfNewPage
-                self.rewriteLastLong(offset)
+                offset = self._read(fmt_size) + self.offsetOfNewPage
+                self._rewriteLast(offset, fmt_size)
 
             if tag in self.Tags:
                 cur_pos = self.f.tell()
 
                 if is_local:
                     self._fixOffsets(count, field_size)
-                    self.f.seek(cur_pos + 4)
+                    self.f.seek(cur_pos + fmt_size)
                 else:
                     self.f.seek(offset)
                     self._fixOffsets(count, field_size)
@@ -2224,7 +2239,7 @@ class AppendingTiffWriter(io.BytesIO):
 
             elif is_local:
                 # skip the locally stored value that is not an offset
-                self.f.seek(4, os.SEEK_CUR)
+                self.f.seek(fmt_size, os.SEEK_CUR)
 
     def _fixOffsets(self, count: int, field_size: int) -> None:
         for i in range(count):


### PR DESCRIPTION
Sequel to #8642

Allows `big_tiff=True` to be used with `save_all=True` when writing TIFF images.

See https://web.archive.org/web/20240706160214/https://www.awaresystems.be/imaging/tiff/bigtiff.html for a description of the BigTIFF header structure.