### PR TITLE
Improved Docker coverage reporting

### DIFF
--- a/.ci/after_success.sh
+++ b/.ci/after_success.sh
@@ -2,8 +2,4 @@
 
 # gather the coverage data
 python3 -m pip install coverage
-if [[ $MATRIX_DOCKER ]]; then
-  python3 -m coverage xml --ignore-errors
-else
-  python3 -m coverage xml
-fi
+python3 -m coverage xml

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -90,15 +90,15 @@ jobs:
 
     - name: After success
       run: |
-        PATH="$PATH:~/.local/bin"
         docker start pillow_container
+        sudo docker cp pillow_container:/Pillow /Pillow
+        sudo chown -R runner /Pillow
         pil_path=`docker exec pillow_container /vpy3/bin/python -c 'import os, PIL;print(os.path.realpath(os.path.dirname(PIL.__file__)))'`
         docker stop pillow_container
         sudo mkdir -p $pil_path
         sudo cp src/PIL/*.py $pil_path
+        cd /Pillow
         .ci/after_success.sh
-      env:
-        MATRIX_DOCKER: ${{ matrix.docker }}
 
     - name: Upload coverage
       uses: codecov/codecov-action@v5


### PR DESCRIPTION
The Ubuntu 22.04 amd64 job has started failing to report coverage - https://github.com/python-pillow/Pillow/actions/runs/12622957940/job/35171447617
> No data to report.

Thinking that `.coverage` might only exist within the Docker container, I copied `/Pillow` to the host, and that fixes it.