### PR TITLE
Improved SPIDER test coverage

### DIFF
--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from PIL import Image, ImageSequence, SpiderImagePlugin
+from PIL import Image, SpiderImagePlugin
 
 from .helper import assert_image_equal, hopper, is_pypy
 
@@ -153,8 +153,8 @@ def test_nonstack_file() -> None:
 
 def test_nonstack_dos() -> None:
     with Image.open(TEST_FILE) as im:
-        for i, frame in enumerate(ImageSequence.Iterator(im)):
-            assert i <= 1, "Non-stack DOS file test failed"
+        with pytest.raises(EOFError):
+            im.seek(0)
 
 
 # for issue #4093


### PR DESCRIPTION
At https://app.codecov.io/gh/python-pillow/Pillow/blob/main/Tests%2Ftest_file_spider.py, you can see that the last line of
https://github.com/python-pillow/Pillow/blob/128f3f46d475de5ddf9859ae1e262287d0c126b6/Tests/test_file_spider.py#L154-L157
is not covered.

It is testing
https://github.com/python-pillow/Pillow/blob/128f3f46d475de5ddf9859ae1e262287d0c126b6/src/PIL/SpiderImagePlugin.py#L175-L178

This PR changes the test to directly call `seek()`, so all test lines are run, and test coverage is improved.