### PR TITLE
Trigger wheel builds from changes in pyproject.toml

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - ".ci/requirements-cibw.txt"
       - ".github/workflows/wheel*"
+      - "pyproject.toml"
       - "setup.py"
       - "wheels/*"
       - "winbuild/build_prepare.py"
@@ -23,6 +24,7 @@ on:
     paths:
       - ".ci/requirements-cibw.txt"
       - ".github/workflows/wheel*"
+      - "pyproject.toml"
       - "setup.py"
       - "wheels/*"
       - "winbuild/build_prepare.py"


### PR DESCRIPTION
In https://github.com/python-pillow/Pillow/pull/8672, I updated cibuildwheel settings in pyproject.toml, but that didn't trigger the wheels jobs.

This updates wheels.yml so that it would.