### PR TITLE
Use python-pip instead of python3-pip in MinGW

### DIFF
--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -68,7 +68,7 @@ jobs:
               mingw-w64-x86_64-openjpeg2 \
               mingw-w64-x86_64-python3-numpy \
               mingw-w64-x86_64-python3-olefile \
-              mingw-w64-x86_64-python3-pip \
+              mingw-w64-x86_64-python-pip \
               mingw-w64-x86_64-python-pytest \
               mingw-w64-x86_64-python-pytest-cov \
               mingw-w64-x86_64-python-pytest-timeout \


### PR DESCRIPTION
MinGW has started failing on main - https://github.com/python-pillow/Pillow/actions/runs/12675616361/job/35338978926
> Run pacman -S --noconfirm \
> error: target not found: mingw-w64-x86_64-python3-pip

This PR switches from `mingw-w64-x86_64-python3-pip` to `mingw-w64-x86_64-python-pip`. See also https://packages.msys2.org/search?q=pip