### PR TITLE
Corrected argument types

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -667,7 +667,7 @@ class TestImage:
         # Test illegal image mode
         with hopper() as im:
             with pytest.raises(ValueError):
-                im.remap_palette(None)
+                im.remap_palette([])
 
     def test_remap_palette_transparency(self) -> None:
         im = Image.new("P", (1, 2), (0, 0, 0))
@@ -770,7 +770,7 @@ class TestImage:
         assert dict(exif)
 
         # Test that exif data is cleared after another load
-        exif.load(None)
+        exif.load(b"")
         assert not dict(exif)
 
         # Test loading just the EXIF header

--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -309,7 +309,7 @@ class TestImageResize:
         # Test unknown resampling filter
         with hopper() as im:
             with pytest.raises(ValueError):
-                im.resize((10, 10), "unknown")
+                im.resize((10, 10), -1)
 
     @skip_unless_feature("libtiff")
     def test_transposed(self) -> None:


### PR DESCRIPTION
This is part of #8362 - I'm hoping to break down that PR into easier-to-review chunks.

1. https://github.com/python-pillow/Pillow/blob/af3b9042335a63f7c9269808c296e414d6a2a7fd/Tests/test_image.py#L670
should use a list, as per

https://github.com/python-pillow/Pillow/blob/af3b9042335a63f7c9269808c296e414d6a2a7fd/src/PIL/Image.py#L2138-L2140

2. https://github.com/python-pillow/Pillow/blob/af3b9042335a63f7c9269808c296e414d6a2a7fd/Tests/test_image.py#L773
should use a bytestring, as per https://github.com/python-pillow/Pillow/blob/af3b9042335a63f7c9269808c296e414d6a2a7fd/src/PIL/Image.py#L3952

3. https://github.com/python-pillow/Pillow/blob/af3b9042335a63f7c9269808c296e414d6a2a7fd/Tests/test_image_resize.py#L312 should use an int (or None) for the second argument, as per https://github.com/python-pillow/Pillow/blob/af3b9042335a63f7c9269808c296e414d6a2a7fd/src/PIL/Image.py#L2250-L2256