### PR TITLE
Use python-numpy and python-olefile instead of virtual python3 packages

### DIFF
--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -66,8 +66,8 @@ jobs:
               mingw-w64-x86_64-libtiff \
               mingw-w64-x86_64-libwebp \
               mingw-w64-x86_64-openjpeg2 \
-              mingw-w64-x86_64-python3-numpy \
-              mingw-w64-x86_64-python3-olefile \
+              mingw-w64-x86_64-python-numpy \
+              mingw-w64-x86_64-python-olefile \
               mingw-w64-x86_64-python-pip \
               mingw-w64-x86_64-python-pytest \
               mingw-w64-x86_64-python-pytest-cov \


### PR DESCRIPTION
Follow on from https://github.com/python-pillow/Pillow/pull/8678.

These aren't failing to install, but the `python3-*` names are virtual packages provided by the main, `python-*` packages:

* https://packages.msys2.org/search?t=pkg&q=numpy
  * https://packages.msys2.org/packages/mingw-w64-x86_64-python-numpy provides:
    * virtual package https://packages.msys2.org/packages/mingw-w64-x86_64-python3-numpy

* https://packages.msys2.org/search?q=olefile
  * https://packages.msys2.org/packages/mingw-w64-x86_64-python-olefile provides:
    * virtual package https://packages.msys2.org/packages/mingw-w64-x86_64-python3-olefile
 
Let's use the main names directly.