### PR TITLE
Removed xfail for test_embeddable on Python 3.13

### DIFF
--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -271,7 +271,7 @@ class TestImagePutPixelError:
 
 
 class TestEmbeddable:
-    @pytest.mark.xfail(reason="failing test")
+    @pytest.mark.xfail(not (sys.version_info >= (3, 13)), reason="failing test")
     @pytest.mark.skipif(not is_win32(), reason="requires Windows")
     def test_embeddable(self) -> None:
         import ctypes


### PR DESCRIPTION
At first, `test_embeddable` wasn't run in our CIs, only locally.
Then @nulano added the `xfail` in #6703, after reports that it didn't actually pass locally.

It has now started passing in Python 3.13 in our CIs.