### PR TITLE
Only F mode starts with F

### DIFF
--- a/src/PIL/SpiderImagePlugin.py
+++ b/src/PIL/SpiderImagePlugin.py
@@ -267,7 +267,7 @@ def makeSpiderHeader(im: Image.Image) -> list[bytes]:
 
 
 def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
-    if im.mode[0] != "F":
+    if im.mode != "F":
         im = im.convert("F")
 
     hdr = makeSpiderHeader(im)


### PR DESCRIPTION
The following check can be simplified.

https://github.com/python-pillow/Pillow/blob/8878511476959f576e50c993627fd4d6dc02d4dc/src/PIL/SpiderImagePlugin.py#L270-L271

See https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes for a list of modes.