### PR TITLE
Corrected Palm P mode save

### DIFF
--- a/Tests/test_file_palm.py
+++ b/Tests/test_file_palm.py
@@ -43,6 +43,11 @@ def roundtrip(tmp_path: Path, mode: str) -> None:
 
     im.save(outfile)
     converted = open_with_magick(magick, tmp_path, outfile)
+    if mode == "P":
+        assert converted.mode == "P"
+
+        im = im.convert("RGB")
+        converted = converted.convert("RGB")
     assert_image_equal(converted, im)
 
 
@@ -55,7 +60,6 @@ def test_monochrome(tmp_path: Path) -> None:
     roundtrip(tmp_path, mode)
 
 
-@pytest.mark.xfail(reason="Palm P image is wrong")
 def test_p_mode(tmp_path: Path) -> None:
     # Arrange
     mode = "P"

--- a/src/PIL/PalmImagePlugin.py
+++ b/src/PIL/PalmImagePlugin.py
@@ -116,9 +116,6 @@ _COMPRESSION_TYPES = {"none": 0xFF, "rle": 0x01, "scanline": 0x00}
 
 def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
     if im.mode == "P":
-        # we assume this is a color Palm image with the standard colormap,
-        # unless the "info" dict has a "custom-colormap" field
-
         rawmode = "P"
         bpp = 8
         version = 1
@@ -172,12 +169,11 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
     compression_type = _COMPRESSION_TYPES["none"]
 
     flags = 0
-    if im.mode == "P" and "custom-colormap" in im.info:
-        assert im.palette is not None
-        flags = flags & _FLAGS["custom-colormap"]
-        colormapsize = 4 * 256 + 2
-        colormapmode = im.palette.mode
-        colormap = im.getdata().getpalette()
+    if im.mode == "P":
+        flags |= _FLAGS["custom-colormap"]
+        colormap = im.im.getpalette()
+        colors = len(colormap) // 3
+        colormapsize = 4 * colors + 2
     else:
         colormapsize = 0
 
@@ -196,22 +192,11 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
 
     # now write colormap if necessary
 
-    if colormapsize > 0:
-        fp.write(o16b(256))
-        for i in range(256):
+    if colormapsize:
+        fp.write(o16b(colors))
+        for i in range(colors):
             fp.write(o8(i))
-            if colormapmode == "RGB":
-                fp.write(
-                    o8(colormap[3 * i])
-                    + o8(colormap[3 * i + 1])
-                    + o8(colormap[3 * i + 2])
-                )
-            elif colormapmode == "RGBA":
-                fp.write(
-                    o8(colormap[4 * i])
-                    + o8(colormap[4 * i + 1])
-                    + o8(colormap[4 * i + 2])
-                )
+            fp.write(colormap[3 * i : 3 * i + 3])
 
     # now convert data to raw form
     ImageFile._save(


### PR DESCRIPTION
Removes an xfail
https://github.com/python-pillow/Pillow/blob/8878511476959f576e50c993627fd4d6dc02d4dc/Tests/test_file_palm.py#L58-L59

with the following changes
1. Always save the colormap for a P mode image, because
https://github.com/python-pillow/Pillow/blob/8878511476959f576e50c993627fd4d6dc02d4dc/src/PIL/PalmImagePlugin.py#L118-L120
is an odd assumption.
2. Use OR instead of AND to apply the custom colormap flag
https://github.com/python-pillow/Pillow/blob/8878511476959f576e50c993627fd4d6dc02d4dc/src/PIL/PalmImagePlugin.py#L177
3. Do not presume that palettes are 256 in length.

At first glance, you might think that
https://github.com/python-pillow/Pillow/blob/8878511476959f576e50c993627fd4d6dc02d4dc/src/PIL/PalmImagePlugin.py#L209-L214
offered support for saving RGBA palettes. But if you look again, you will see that is only writing three values, meaning it's not writing RGBA palettes, it's converting them to RGB. However, `getpalette()` will [only return a RGB palette](https://github.com/python-pillow/Pillow/blob/8878511476959f576e50c993627fd4d6dc02d4dc/src/_imaging.c#L1107-L1115), so we won't need to worry about handling that.