### PR TITLE
Skip test_embeddable if compiler cannot be initialized

### DIFF
--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -278,6 +278,18 @@ class TestEmbeddable:
 
         from setuptools.command import build_ext
 
+        compiler = getattr(build_ext, "new_compiler")()
+        compiler.add_include_dir(sysconfig.get_config_var("INCLUDEPY"))
+
+        libdir = sysconfig.get_config_var("LIBDIR") or sysconfig.get_config_var(
+            "INCLUDEPY"
+        ).replace("include", "libs")
+        compiler.add_library_dir(libdir)
+        try:
+            compiler.initialize()
+        except Exception:
+            pytest.skip("Compiler could not be initialized")
+
         with open("embed_pil.c", "w", encoding="utf-8") as fh:
             home = sys.prefix.replace("\\", "\\\\")
             fh.write(
@@ -305,13 +317,6 @@ int main(int argc, char* argv[])
         """
             )
 
-        compiler = getattr(build_ext, "new_compiler")()
-        compiler.add_include_dir(sysconfig.get_config_var("INCLUDEPY"))
-
-        libdir = sysconfig.get_config_var("LIBDIR") or sysconfig.get_config_var(
-            "INCLUDEPY"
-        ).replace("include", "libs")
-        compiler.add_library_dir(libdir)
         objects = compiler.compile(["embed_pil.c"])
         compiler.link_executable(objects, "embed_pil")
 


### PR DESCRIPTION
It turns out that when `test_embeddable` was marked as passing in Python 3.13 in #8683, there was an error when using Windows x86 or AMD64 after building the wheels - https://github.com/python-pillow/Pillow/actions/runs/12721987647/job/35465533303#step:7:25500
> distutils.errors.DistutilsPlatformError: Microsoft Visual C++ 14.0 or greater is required. Get it with "Microsoft C++ Build Tools"

Because this problem may occur in a local setup when running the test suite, this PR initializes the compiler (as seen two steps earlier in the error traceback) separately, and if that throws an error, before anything Pillow-related occurs, then the test is skipped.

With this change, the wheels start passing - https://github.com/radarhere/Pillow/actions/runs/12722505250/job/35466599838