### PR TITLE
Thread-local arenas

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -3938,7 +3938,7 @@ _get_stats(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_LOCK(&ImagingDefaultArena.mutex);
     ImagingMemoryArena arena = &ImagingDefaultArena;
 
     v = PyLong_FromLong(arena->stats_new_count);
@@ -3965,7 +3965,7 @@ _get_stats(PyObject *self, PyObject *args) {
     PyDict_SetItemString(d, "blocks_cached", v ? v : Py_None);
     Py_XDECREF(v);
 
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_UNLOCK(&ImagingDefaultArena.mutex);
     return d;
 }
 
@@ -3975,14 +3975,14 @@ _reset_stats(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_LOCK(&ImagingDefaultArena.mutex);
     ImagingMemoryArena arena = &ImagingDefaultArena;
     arena->stats_new_count = 0;
     arena->stats_allocated_blocks = 0;
     arena->stats_reused_blocks = 0;
     arena->stats_reallocated_blocks = 0;
     arena->stats_freed_blocks = 0;
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_UNLOCK(&ImagingDefaultArena.mutex);
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -3994,9 +3994,9 @@ _get_alignment(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_LOCK(&ImagingDefaultArena.mutex);
     int alignment = ImagingDefaultArena.alignment;
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_UNLOCK(&ImagingDefaultArena.mutex);
     return PyLong_FromLong(alignment);
 }
 
@@ -4006,9 +4006,9 @@ _get_block_size(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_LOCK(&ImagingDefaultArena.mutex);
     int block_size = ImagingDefaultArena.block_size;
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_UNLOCK(&ImagingDefaultArena.mutex);
     return PyLong_FromLong(block_size);
 }
 
@@ -4018,9 +4018,9 @@ _get_blocks_max(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_LOCK(&ImagingDefaultArena.mutex);
     int blocks_max = ImagingDefaultArena.blocks_max;
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_UNLOCK(&ImagingDefaultArena.mutex);
     return PyLong_FromLong(blocks_max);
 }
 
@@ -4041,9 +4041,9 @@ _set_alignment(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_LOCK(&ImagingDefaultArena.mutex);
     ImagingDefaultArena.alignment = alignment;
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_UNLOCK(&ImagingDefaultArena.mutex);
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -4066,9 +4066,9 @@ _set_block_size(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_LOCK(&ImagingDefaultArena.mutex);
     ImagingDefaultArena.block_size = block_size;
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_UNLOCK(&ImagingDefaultArena.mutex);
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -4092,9 +4092,9 @@ _set_blocks_max(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_LOCK(&ImagingDefaultArena.mutex);
     int status = ImagingMemorySetBlocksMax(&ImagingDefaultArena, blocks_max);
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_UNLOCK(&ImagingDefaultArena.mutex);
     if (!status) {
         return ImagingError_MemoryError();
     }
@@ -4111,9 +4111,9 @@ _clear_cache(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_LOCK(&ImagingDefaultArena.mutex);
     ImagingMemoryClearCache(&ImagingDefaultArena, i);
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
+    IMAGING_ARENA_UNLOCK(&ImagingDefaultArena.mutex);
 
     Py_INCREF(Py_None);
     return Py_None;


### PR DESCRIPTION
## Summary

Currently, all threads use the same arena for imaging. When there are enough workers, in regular Python the GIL will be under lots of contention and in free-threaded Python the mutex will be under lots of contention.

This commit instead introduces lockless thread-local arenas for environments that support it. For environments that do not support thread-locals (or for environments where we couldn't determine if they do or not) we fall back to either the GIL or a mutex if there is no GIL.

This has some implications for statistics, as statistics are now thread-specific. This could be solved in a couple of ways (in C or in Python), or left unsolved and just documented. I think either way is fine.

## Code

Most of the code doesn't actually need to change. The bulk of the changes were getting `setup.py` to emit the proper compilation definitions so that we could check which kind of thread-local declarations were supported at compile-time. Other than that, the declaration of the default arena now has the thread-local declaration and the places where we previously locked the mutex the macro name has changed to reflect that it is specific to the thread-local arena.

## Benchmarks

For regular Python, this didn't make much of a difference. (The difference in the samples wasn't statistically significant, 95% CI). For free-threaded Python, however, the difference was fairly massive (about a 70% increase).

### v3.13.0 on main

```
Max: 0.439743 Mean: 0.355661 Min: 0.305783
Max: 0.415384 Mean: 0.361710 Min: 0.304075
Max: 0.427207 Mean: 0.366160 Min: 0.300381
Max: 0.460026 Mean: 0.388431 Min: 0.316797
Max: 0.419853 Mean: 0.361484 Min: 0.309495
Max: 0.393699 Mean: 0.350330 Min: 0.302294
Max: 0.443584 Mean: 0.372369 Min: 0.311351
Max: 0.404041 Mean: 0.355057 Min: 0.309706
Max: 0.420880 Mean: 0.341415 Min: 0.280980
Max: 0.408922 Mean: 0.320707 Min: 0.228622
```

### v3.13.0t on main

```
Max: 0.218140 Mean: 0.143962 Min: 0.091831
Max: 0.195644 Mean: 0.124187 Min: 0.079139
Max: 0.169986 Mean: 0.124365 Min: 0.081508
Max: 0.194228 Mean: 0.136258 Min: 0.103134
Max: 0.192837 Mean: 0.131196 Min: 0.094301
Max: 0.180463 Mean: 0.126546 Min: 0.079336
Max: 0.181516 Mean: 0.126875 Min: 0.083507
Max: 0.178397 Mean: 0.120558 Min: 0.083620
Max: 0.182262 Mean: 0.129299 Min: 0.087499
Max: 0.167291 Mean: 0.114647 Min: 0.074147
```

### v3.13.0 on branch

```
Max: 0.429302 Mean: 0.362776 Min: 0.314723
Max: 0.406314 Mean: 0.355255 Min: 0.299485
Max: 0.438540 Mean: 0.378539 Min: 0.308898
Max: 0.425942 Mean: 0.368141 Min: 0.310095
Max: 0.408924 Mean: 0.365672 Min: 0.313756
Max: 0.419717 Mean: 0.361498 Min: 0.307699
Max: 0.418639 Mean: 0.355136 Min: 0.314148
Max: 0.426816 Mean: 0.377236 Min: 0.321773
Max: 0.424230 Mean: 0.358225 Min: 0.291148
Max: 0.421029 Mean: 0.363783 Min: 0.315103
```

### v3.13.0t on branch

```
Max: 0.103066 Mean: 0.041306 Min: 0.018575
Max: 0.121496 Mean: 0.043042 Min: 0.018622
Max: 0.129727 Mean: 0.040726 Min: 0.014389
Max: 0.124282 Mean: 0.037581 Min: 0.018034
Max: 0.112015 Mean: 0.042051 Min: 0.017231
Max: 0.123254 Mean: 0.042117 Min: 0.019646
Max: 0.129165 Mean: 0.043886 Min: 0.017393
Max: 0.157608 Mean: 0.045151 Min: 0.017874
Max: 0.117050 Mean: 0.043070 Min: 0.016238
Max: 0.131859 Mean: 0.044563 Min: 0.017736
```

### Script

Below is the script that I used to run these benchmarks.

<details>
<summary>bench.py</summary>

```python
import concurrent.futures
import os
import threading
import time

from PIL import Image

num_threads = 16
num_images = 1024


def operation():
    images = []
    for i in range(num_images):
        img = Image.new(
            "RGB", (100, 100), color=(i % 256, (i // 256) % 256, (i // 65536) % 256)
        )
        images.append(img)

    for img in images:
        img = img.convert("CMYK")

    images.clear()


def worker(barrier):
    barrier.wait()
    runtimes = []

    for _ in range(5):
        start_time = time.time()
        operation()
        end_time = time.time()
        runtimes.append(end_time - start_time)

    return runtimes


def benchmark():
    with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
        barrier = threading.Barrier(num_threads)
        futures = [executor.submit(worker, barrier) for _ in range(num_threads)]

        run_times = []
        for future in concurrent.futures.as_completed(futures):
            try:
                run_times.extend(future.result())
            except IndexError:
                os._exit(-1)

        min_time = min(run_times)
        max_time = max(run_times)
        mean_time = sum(run_times) / len(run_times)
        print(f"Max: {max_time:.6f} Mean: {mean_time:.6f} Min: {min_time:.6f}")


benchmark()
```

</details>