### PR TITLE
Improved comment

### DIFF
--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -7,7 +7,7 @@ import fuzzers
 import packaging
 import pytest
 
-from PIL import Image, UnidentifiedImageError, features
+from PIL import Image, features
 from Tests.helper import skip_unless_feature
 
 if sys.platform.startswith("win32"):
@@ -42,7 +42,6 @@ def test_fuzz_images(path: str) -> None:
         # Known Image.* exceptions
         Image.DecompressionBombError,
         Image.DecompressionBombWarning,
-        UnidentifiedImageError,
     ):
         assert True
     finally:

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -32,21 +32,18 @@ def test_fuzz_images(path: str) -> None:
             fuzzers.fuzz_image(f.read())
             assert True
     except (
+        # Known exceptions from Pillow
         OSError,
         SyntaxError,
         MemoryError,
         ValueError,
         NotImplementedError,
         OverflowError,
-    ):
-        # Known exceptions that are through from Pillow
-        assert True
-    except (
+        # Known Image.* exceptions
         Image.DecompressionBombError,
         Image.DecompressionBombWarning,
         UnidentifiedImageError,
     ):
-        # Known Image.* exceptions
         assert True
     finally:
         fuzzers.disable_decompressionbomb_error()


### PR DESCRIPTION
Two test-fuzzers.py changes

1. Improved the wording of https://github.com/python-pillow/Pillow/blob/f521a4be7db5fb1b6060d1dc48e69ee3bdec25ab/Tests/oss-fuzz/test_fuzzers.py#L42

2. Removed `UnidentifiedImageError` catching, when it would have already been caught by `OSError`, which `UnidentifiedImageError` inherits from.