### PR TITLE
Removed miniconda CPPFLAGS

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -3,8 +3,5 @@
 set -e
 
 python3 -m coverage erase
-if [ $(uname) == "Darwin" ]; then
-    export CPPFLAGS="-I/usr/local/miniconda/include";
-fi
 make clean
 make install-coverage


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/84d58a0282df5ec081502f99f2c363b79c513ee4/.ci/build.sh#L6-L8

This was originally added in https://github.com/python-pillow/Pillow/pull/4169. It no longer appears necessary.