### PR TITLE
Test Windows amd64 wheels with NumPy

### DIFF
--- a/.github/workflows/wheels-test.ps1
+++ b/.github/workflows/wheels-test.ps1
@@ -11,6 +11,9 @@ if ("$venv" -like "*\cibw-run-*\pp*-win_amd64\*") {
 $env:path += ";$pillow\winbuild\build\bin\"
 & "$venv\Scripts\activate.ps1"
 & reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\python.exe" /v "GlobalFlag" /t REG_SZ /d "0x02000000" /f
+if ("$venv" -like "*\cibw-run-*-win_amd64\*") {
+  & python -m pip install numpy
+}
 cd $pillow
 & python -VV
 if (!$?) { exit $LASTEXITCODE }


### PR DESCRIPTION
Currently, Windows amd64 does not test the built wheels with NumPy - https://github.com/python-pillow/Pillow/actions/runs/12780081778/job/35625773713#step:7:7599

This adds it - https://github.com/python-pillow/Pillow/actions/runs/12807915960/job/35709512334?pr=8696#step:7:7611