### PR TITLE
Use arm64 Linux runners for wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -105,7 +105,7 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
           CIBW_BUILD: ${{ matrix.build }}
-          CIBW_ENABLE: cpython-prerelease cpython-freethreading
+          CIBW_ENABLE: cpython-prerelease cpython-freethreading pypy
           CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux }}
           CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: ${{ matrix.manylinux }}
           CIBW_MANYLINUX_PYPY_X86_64_IMAGE: ${{ matrix.manylinux }}
@@ -184,7 +184,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
           CIBW_BEFORE_ALL: "{package}\\winbuild\\build\\build_dep_all.cmd"
           CIBW_CACHE_PATH: "C:\\cibw"
-          CIBW_ENABLE: cpython-prerelease cpython-freethreading
+          CIBW_ENABLE: cpython-prerelease cpython-freethreading pypy
           CIBW_SKIP: pp39-*
           CIBW_TEST_SKIP: "*-win_arm64"
           CIBW_TEST_COMMAND: 'docker run --rm

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,62 +42,7 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  build-1-QEMU-emulated-wheels:
-    if: github.event_name != 'schedule'
-    name: aarch64 ${{ matrix.python-version }} ${{ matrix.spec }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version:
-          - pp310
-          - cp3{9,10,11}
-          - cp3{12,13}
-        spec:
-          - manylinux2014
-          - manylinux_2_28
-          - musllinux
-        exclude:
-          - { python-version: pp310, spec: musllinux }
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          submodules: true
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-
-      # https://github.com/docker/setup-qemu-action
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Install cibuildwheel
-        run: |
-          python3 -m pip install -r .ci/requirements-cibw.txt
-
-      - name: Build wheels
-        run: |
-          python3 -m cibuildwheel --output-dir wheelhouse
-        env:
-          # Build only the currently selected Linux architecture (so we can
-          # parallelise for speed).
-          CIBW_ARCHS: "aarch64"
-          # Likewise, select only one Python version per job to speed this up.
-          CIBW_BUILD: "${{ matrix.python-version }}-${{ matrix.spec == 'musllinux' && 'musllinux' || 'manylinux' }}*"
-          CIBW_ENABLE: cpython-prerelease
-          # Extra options for manylinux.
-          CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.spec }}
-          CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: ${{ matrix.spec }}
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: dist-qemu-${{ matrix.python-version }}-${{ matrix.spec }}
-          path: ./wheelhouse/*.whl
-
-  build-2-native-wheels:
+  build-native-wheels:
     if: github.event_name != 'schedule' || github.repository_owner == 'python-pillow'
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -132,6 +77,14 @@ jobs:
             cibw_arch: x86_64
             build: "*manylinux*"
             manylinux: "manylinux_2_28"
+          - name: "manylinux2014 and musllinux aarch64"
+            os: ubuntu-24.04-arm
+            cibw_arch: aarch64
+          - name: "manylinux_2_28 aarch64"
+            os: ubuntu-24.04-arm
+            cibw_arch: aarch64
+            build: "*manylinux*"
+            manylinux: "manylinux_2_28"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -153,6 +106,8 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
           CIBW_BUILD: ${{ matrix.build }}
           CIBW_ENABLE: cpython-prerelease cpython-freethreading
+          CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux }}
+          CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: ${{ matrix.manylinux }}
           CIBW_MANYLINUX_PYPY_X86_64_IMAGE: ${{ matrix.manylinux }}
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux }}
           CIBW_SKIP: pp39-*
@@ -275,7 +230,7 @@ jobs:
 
   scientific-python-nightly-wheels-publish:
     if: github.repository_owner == 'python-pillow' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-    needs: [build-2-native-wheels, windows]
+    needs: [build-native-wheels, windows]
     runs-on: ubuntu-latest
     name: Upload wheels to scientific-python-nightly-wheels
     steps:
@@ -292,7 +247,7 @@ jobs:
 
   pypi-publish:
     if: github.repository_owner == 'python-pillow' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    needs: [build-1-QEMU-emulated-wheels, build-2-native-wheels, windows, sdist]
+    needs: [build-native-wheels, windows, sdist]
     runs-on: ubuntu-latest
     name: Upload release to PyPI
     environment:


### PR DESCRIPTION
GitHub has announced that arm64 Linux runners are now free for public repositories - https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

This means that we can use them, rather than QEMU, to build aarch64 wheels, greatly reducing the time that it takes to build all of our wheels.

While I'm here, I've also added 'pypy' to `CIBW_ENABLE`, since it will be turned off by default in cibuildwheel 3. You can see a warning about this at https://github.com/python-pillow/Pillow/actions/runs/12755221825 and read more at https://cibuildwheel.pypa.io/en/stable/options/#enable