### PR TITLE
Only use outside border of stroke in text()

### DIFF
--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -1397,6 +1397,28 @@ def test_stroke_descender() -> None:
 
 
 @skip_unless_feature("freetype2")
+def test_stroke_inside_gap() -> None:
+    # Arrange
+    im = Image.new("RGB", (120, 130))
+    draw = ImageDraw.Draw(im)
+    font = ImageFont.truetype("Tests/fonts/FreeMono.ttf", 120)
+
+    # Act
+    draw.text((12, 12), "i", "#f00", font, stroke_width=20)
+
+    # Assert
+    for y in range(im.height):
+        glyph = ""
+        for x in range(im.width):
+            if im.getpixel((x, y)) == (0, 0, 0):
+                if glyph == "started":
+                    glyph = "ended"
+            else:
+                assert glyph != "ended", "Gap inside stroked glyph"
+                glyph = "started"
+
+
+@skip_unless_feature("freetype2")
 def test_split_word() -> None:
     # Arrange
     im = Image.new("RGB", (230, 55))

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -461,6 +461,20 @@ def test_free_type_font_get_mask(font: ImageFont.FreeTypeFont) -> None:
     assert mask.size == (108, 13)
 
 
+def test_stroke_mask() -> None:
+    # Arrange
+    text = "i"
+
+    # Act
+    font = ImageFont.truetype(FONT_PATH, 128)
+    mask = font.getmask(text, stroke_width=2)
+
+    # Assert
+    assert mask.getpixel((34, 5)) == 255
+    assert mask.getpixel((38, 5)) == 0
+    assert mask.getpixel((42, 5)) == 255
+
+
 def test_load_when_image_not_found() -> None:
     with tempfile.NamedTemporaryFile(delete=False) as tmp:
         pass

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -643,6 +643,7 @@ class ImageDraw:
                     features=features,
                     language=language,
                     stroke_width=stroke_width,
+                    stroke_filled=True,
                     anchor=anchor,
                     ink=ink,
                     start=start,

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -693,7 +693,8 @@ class ImageDraw:
                 draw_text(stroke_ink, stroke_width)
 
                 # Draw normal text
-                draw_text(ink, 0)
+                if ink != stroke_ink:
+                    draw_text(ink)
             else:
                 # Only draw normal text
                 draw_text(ink)

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -644,6 +644,7 @@ class FreeTypeFont:
             features,
             language,
             stroke_width,
+            kwargs.get("stroke_filled", False),
             anchor,
             ink,
             start[0],

--- a/src/PIL/_imagingft.pyi
+++ b/src/PIL/_imagingft.pyi
@@ -28,6 +28,7 @@ class Font:
         features: list[str] | None,
         lang: str | None,
         stroke_width: float,
+        stroke_filled: bool,
         anchor: str | None,
         foreground_ink_long: int,
         x_start: float,

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -834,6 +834,7 @@ font_render(FontObject *self, PyObject *args) {
     int mask = 0;  /* is FT_LOAD_TARGET_MONO enabled? */
     int color = 0; /* is FT_LOAD_COLOR enabled? */
     float stroke_width = 0;
+    int stroke_filled = 0;
     PY_LONG_LONG foreground_ink_long = 0;
     unsigned int foreground_ink;
     const char *mode = NULL;
@@ -853,7 +854,7 @@ font_render(FontObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(
             args,
-            "OO|zzOzfzLffO:render",
+            "OO|zzOzfpzLffO:render",
             &string,
             &fill,
             &mode,
@@ -861,6 +862,7 @@ font_render(FontObject *self, PyObject *args) {
             &features,
             &lang,
             &stroke_width,
+            &stroke_filled,
             &anchor,
             &foreground_ink_long,
             &x_start,
@@ -1005,7 +1007,8 @@ font_render(FontObject *self, PyObject *args) {
         if (stroker != NULL) {
             error = FT_Get_Glyph(glyph_slot, &glyph);
             if (!error) {
-                error = FT_Glyph_Stroke(&glyph, stroker, 1);
+                error = stroke_filled ? FT_Glyph_StrokeBorder(&glyph, stroker, 0, 1)
+                                      : FT_Glyph_Stroke(&glyph, stroker, 1);
             }
             if (!error) {
                 FT_Vector origin = {0, 0};


### PR DESCRIPTION
Resolves #8697

The issue finds that when Pillow draws [normal text onto stroked text](https://github.com/python-pillow/Pillow/blob/a92a664ee5a3d5e3ee9b17bd6d6a2a3130394d75/src/PIL/ImageDraw.py#L691-L695), there might be an unexpected gap between the  the outside of the normal text and the inside border of the stroked text.

![main](https://github.com/user-attachments/assets/5d0b9d46-8893-452a-8c59-dc64a384db1e)

When drawing stroked text, FreeType returns a glyph with an outside border and an inside border. We can ask FreeType to leave out the inside border though, creating a filled glyph. With that change, the output is corrected.

![branch](https://github.com/user-attachments/assets/ea505850-e920-44b4-8dc4-20e495e71c67)

See https://freetype.org/freetype2/docs/reference/ft2-glyph_stroker.html#ft_glyph_stroke and https://freetype.org/freetype2/docs/reference/ft2-glyph_stroker.html#ft_glyph_strokeborder for documentation.