### PR TITLE
Added ImageFile close()

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -619,8 +619,6 @@ class Image:
 
     def close(self) -> None:
         """
-        Closes the file pointer, if possible.
-
         This operation will destroy the image core and release its memory.
         The image data will be unusable afterward.
 
@@ -629,13 +627,6 @@ class Image:
         :py:meth:`~PIL.Image.Image.load` method. See :ref:`file-handling` for
         more information.
         """
-        if hasattr(self, "fp"):
-            try:
-                self._close_fp()
-                self.fp = None
-            except Exception as msg:
-                logger.debug("Error closing: %s", msg)
-
         if getattr(self, "map", None):
             self.map: mmap.mmap | None = None
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -603,16 +603,10 @@ class Image:
     def __enter__(self):
         return self
 
-    def _close_fp(self):
-        if getattr(self, "_fp", False):
-            if self._fp != self.fp:
-                self._fp.close()
-            self._fp = DeferredError(ValueError("Operation on closed image"))
-        if self.fp:
-            self.fp.close()
-
     def __exit__(self, *args):
-        if hasattr(self, "fp"):
+        from . import ImageFile
+
+        if isinstance(self, ImageFile.ImageFile):
             if getattr(self, "_exclusive_fp", False):
                 self._close_fp()
             self.fp = None

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import abc
 import io
 import itertools
+import logging
 import os
 import struct
 import sys
@@ -42,6 +43,8 @@ from ._util import is_path
 
 if TYPE_CHECKING:
     from ._typing import StrOrBytesPath
+
+logger = logging.getLogger(__name__)
 
 MAXBLOCK = 65536
 
@@ -162,6 +165,26 @@ class ImageFile(Image.Image):
 
     def _open(self) -> None:
         pass
+
+    def close(self) -> None:
+        """
+        Closes the file pointer, if possible.
+
+        This operation will destroy the image core and release its memory.
+        The image data will be unusable afterward.
+
+        This function is required to close images that have multiple frames or
+        have not had their file read and closed by the
+        :py:meth:`~PIL.Image.Image.load` method. See :ref:`file-handling` for
+        more information.
+        """
+        try:
+            self._close_fp()
+            self.fp = None
+        except Exception as msg:
+            logger.debug("Error closing: %s", msg)
+
+        super().close()
 
     def get_child_images(self) -> list[ImageFile]:
         child_images = []

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -39,7 +39,7 @@ from typing import IO, TYPE_CHECKING, Any, NamedTuple, cast
 
 from . import ExifTags, Image
 from ._deprecate import deprecate
-from ._util import is_path
+from ._util import DeferredError, is_path
 
 if TYPE_CHECKING:
     from ._typing import StrOrBytesPath
@@ -165,6 +165,14 @@ class ImageFile(Image.Image):
 
     def _open(self) -> None:
         pass
+
+    def _close_fp(self):
+        if getattr(self, "_fp", False):
+            if self._fp != self.fp:
+                self._fp.close()
+            self._fp = DeferredError(ValueError("Operation on closed image"))
+        if self.fp:
+            self.fp.close()
 
     def close(self) -> None:
         """


### PR DESCRIPTION
This is part of #8362 - I'm hoping to break down that PR into easier-to-review chunks.

1. `Image`'s `close()` starts out with file handling.
https://github.com/python-pillow/Pillow/blob/cf7dd2f0e9ff3b0b228ad6cc5060096ab7267806/src/PIL/Image.py#L632-L637
Since file handling is only part of `ImageFile`, this PR moves that code into a new `ImageFile` `close()` method that then calls `super().close()` to return to the rest of the code.

2. Similarly, `Image`'s `_close_fp()` can be moved to `ImageFile` for the same reason.
https://github.com/python-pillow/Pillow/blob/cf7dd2f0e9ff3b0b228ad6cc5060096ab7267806/src/PIL/Image.py#L606-L612