### PR TITLE
Fixed unclosed file warnings

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -1103,13 +1103,15 @@ class TestFileLibTiff(LibTiffTestCase):
     )
     def test_buffering(self, test_file: str) -> None:
         # load exif first
-        with Image.open(open(test_file, "rb", buffering=1048576)) as im:
-            exif = dict(im.getexif())
+        with open(test_file, "rb", buffering=1048576) as f:
+            with Image.open(f) as im:
+                exif = dict(im.getexif())
 
         # load image before exif
-        with Image.open(open(test_file, "rb", buffering=1048576)) as im2:
-            im2.load()
-            exif_after_load = dict(im2.getexif())
+        with open(test_file, "rb", buffering=1048576) as f:
+            with Image.open(f) as im2:
+                im2.load()
+                exif_after_load = dict(im2.getexif())
 
         assert exif == exif_after_load
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/12842724013/job/35813939701#step:6:5420

> Tests/test_file_libtiff.py::TestFileLibTiff::test_buffering[Tests/images/old-style-jpeg-compression-no-samplesperpixel.tif]
> Tests/test_file_libtiff.py::TestFileLibTiff::test_buffering[Tests/images/old-style-jpeg-compression-no-samplesperpixel.tif]
>   /vpy3/lib/python3.10/site-packages/_pytest/python.py:159: ResourceWarning: unclosed file <_io.BufferedReader name='Tests/images/old-style-jpeg-compression-no-samplesperpixel.tif'>
>     result = testfunction(**testargs)
>   Enable tracemalloc to get traceback where the object was allocated.
>   See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
> 
> Tests/test_file_libtiff.py::TestFileLibTiff::test_buffering[Tests/images/old-style-jpeg-compression.tif]
> Tests/test_file_libtiff.py::TestFileLibTiff::test_buffering[Tests/images/old-style-jpeg-compression.tif]
>   /vpy3/lib/python3.10/site-packages/_pytest/python.py:159: ResourceWarning: unclosed file <_io.BufferedReader name='Tests/images/old-style-jpeg-compression.tif'>
>     result = testfunction(**testargs)
>   Enable tracemalloc to get traceback where the object was allocated.
>   See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.