### PR TITLE
Seek relative to current position

### DIFF
--- a/src/PIL/BufrStubImagePlugin.py
+++ b/src/PIL/BufrStubImagePlugin.py
@@ -10,6 +10,7 @@
 #
 from __future__ import annotations
 
+import os
 from typing import IO
 
 from . import Image, ImageFile
@@ -40,13 +41,11 @@ class BufrStubImageFile(ImageFile.StubImageFile):
     format_description = "BUFR"
 
     def _open(self) -> None:
-        offset = self.fp.tell()
-
         if not _accept(self.fp.read(4)):
             msg = "Not a BUFR file"
             raise SyntaxError(msg)
 
-        self.fp.seek(offset)
+        self.fp.seek(-4, os.SEEK_CUR)
 
         # make something up
         self._mode = "F"

--- a/src/PIL/GribStubImagePlugin.py
+++ b/src/PIL/GribStubImagePlugin.py
@@ -10,6 +10,7 @@
 #
 from __future__ import annotations
 
+import os
 from typing import IO
 
 from . import Image, ImageFile
@@ -40,13 +41,11 @@ class GribStubImageFile(ImageFile.StubImageFile):
     format_description = "GRIB"
 
     def _open(self) -> None:
-        offset = self.fp.tell()
-
         if not _accept(self.fp.read(8)):
             msg = "Not a GRIB file"
             raise SyntaxError(msg)
 
-        self.fp.seek(offset)
+        self.fp.seek(-8, os.SEEK_CUR)
 
         # make something up
         self._mode = "F"

--- a/src/PIL/Hdf5StubImagePlugin.py
+++ b/src/PIL/Hdf5StubImagePlugin.py
@@ -10,6 +10,7 @@
 #
 from __future__ import annotations
 
+import os
 from typing import IO
 
 from . import Image, ImageFile
@@ -40,13 +41,11 @@ class HDF5StubImageFile(ImageFile.StubImageFile):
     format_description = "HDF5"
 
     def _open(self) -> None:
-        offset = self.fp.tell()
-
         if not _accept(self.fp.read(8)):
             msg = "Not an HDF file"
             raise SyntaxError(msg)
 
-        self.fp.seek(offset)
+        self.fp.seek(-8, os.SEEK_CUR)
 
         # make something up
         self._mode = "F"


### PR DESCRIPTION
To restore the previous position after a read,
seek relative to the current position,
rather than using `tell()` and then seeking relative to the start of the file.