### PR TITLE
Use Ubuntu 22.04 for 24.04 ppc64le and s390x

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -35,10 +35,6 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         docker: [
-          # Run slower jobs first to give them a headstart and reduce waiting time
-          ubuntu-24.04-noble-ppc64le,
-          ubuntu-24.04-noble-s390x,
-          # Then run the remainder
           alpine,
           amazon-2-amd64,
           amazon-2023-amd64,
@@ -56,9 +52,13 @@ jobs:
         dockerTag: [main]
         include:
           - docker: "ubuntu-24.04-noble-ppc64le"
+            os: "ubuntu-22.04"
             qemu-arch: "ppc64le"
+            dockerTag: main
           - docker: "ubuntu-24.04-noble-s390x"
+            os: "ubuntu-22.04"
             qemu-arch: "s390x"
+            dockerTag: main
           - docker: "ubuntu-24.04-noble-arm64v8"
             os: "ubuntu-24.04-arm"
             dockerTag: main


### PR DESCRIPTION
The ppc64le and s390x jobs have started experiencing segfaults.

https://github.com/python-pillow/Pillow/actions/runs/12938692000/job/36093724713#step:6:235
>   powerpc64le-linux-gnu-gcc: internal compiler error: Segmentation fault signal terminated program cc1

https://github.com/python-pillow/Pillow/actions/runs/12938692000/job/36093724972#step:6:249
>   s390x-linux-gnu-gcc: internal compiler error: Segmentation fault signal terminated program collect2

The problem started occurring with version 20250120.5.0 of the runner image. I've found [another user having segfaults recently](https://github.com/actions/runner-images/issues/10636#issuecomment-2610539943) who suggested switching back to Ubuntu 22.04, and changing the host does fix the problem. Perhaps this works as a temporary fix?

Edit: More specifically, I've found [a report](https://github.com/actions/runner-images/issues/10636#issuecomment-2397720931) of a problem with ubuntu-latest and QEMU, although from a while ago.