### PR TITLE
Fixed exceptions when closing AppendingTiffWriter

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -780,15 +780,17 @@ class TestFileTiff:
         data = b"II\x2A\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
         b = BytesIO(data)
         with TiffImagePlugin.AppendingTiffWriter(b) as a:
+            a.seek(-4, os.SEEK_CUR)
             a.writeLong(2**32 - 1)
-            assert b.getvalue() == data + b"\xff\xff\xff\xff"
+            assert b.getvalue() == data[:-4] + b"\xff\xff\xff\xff"
 
     def test_appending_tiff_writer_rewritelastshorttolong(self) -> None:
         data = b"II\x2A\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
         b = BytesIO(data)
         with TiffImagePlugin.AppendingTiffWriter(b) as a:
+            a.seek(-2, os.SEEK_CUR)
             a.rewriteLastShortToLong(2**32 - 1)
-            assert b.getvalue() == data[:-2] + b"\xff\xff\xff\xff"
+            assert b.getvalue() == data[:-4] + b"\xff\xff\xff\xff"
 
     def test_saving_icc_profile(self, tmp_path: Path) -> None:
         # Tests saving TIFF with icc_profile set.


### PR DESCRIPTION
Two exceptions are being raised in testing - https://github.com/python-pillow/Pillow/actions/runs/13051364088/job/36412180284#step:11:4911
```pytb
Tests/test_file_tiff.py::TestFileTiff::test_appending_tiff_writer_writelong
  /Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/_pytest/unraisableexception.py:85: PytestUnraisableExceptionWarning: Exception ignored in: <PIL.TiffImagePlugin.AppendingTiffWriter object at 0x114c785e0>
  
  Traceback (most recent call last):
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/PIL/TiffImagePlugin.py", line 2212, in close
      self.finalize()
      ~~~~~~~~~~~~~^^
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/PIL/TiffImagePlugin.py", line 2082, in finalize
      raise RuntimeError(msg)
  RuntimeError: IIMM of new page doesn't match IIMM of first page
  
    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))

Tests/test_file_tiff.py::TestFileTiff::test_appending_tiff_writer_rewritelastshorttolong
  /Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/_pytest/unraisableexception.py:85: PytestUnraisableExceptionWarning: Exception ignored in: <PIL.TiffImagePlugin.AppendingTiffWriter object at 0x114c7ade0>
  
  Traceback (most recent call last):
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/PIL/TiffImagePlugin.py", line 2212, in close
      self.finalize()
      ~~~~~~~~~~~~~^^
    File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/PIL/TiffImagePlugin.py", line 2082, in finalize
      raise RuntimeError(msg)
  RuntimeError: IIMM of new page doesn't match IIMM of first page
  
    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
```

These exceptions are occurred when AppendingTiffWriter is being closed at the end of the test method.

https://github.com/python-pillow/Pillow/blob/e4f2a4a291ccd439bff6c7ced1d219dcd0c67291/Tests/test_file_tiff.py#L779-L791

Since that is after the `assert`, [the code that is run during close](https://github.com/python-pillow/Pillow/blob/e4f2a4a291ccd439bff6c7ced1d219dcd0c67291/src/PIL/TiffImagePlugin.py#L2068-L2082) can simply be disabled.