### PR TITLE
Do not install libimagequant on MinGW

### DIFF
--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -60,7 +60,6 @@ jobs:
               mingw-w64-x86_64-gcc \
               mingw-w64-x86_64-ghostscript \
               mingw-w64-x86_64-lcms2 \
-              mingw-w64-x86_64-libimagequant \
               mingw-w64-x86_64-libjpeg-turbo \
               mingw-w64-x86_64-libraqm \
               mingw-w64-x86_64-libtiff \


### PR DESCRIPTION
MinGW has started failing in main - https://github.com/python-pillow/Pillow/actions/runs/13051364081

The failure occurs with [mingw-w64-x86_64-libimagequant-4.3.3-2](https://github.com/python-pillow/Pillow/actions/runs/13051364081/job/36444003076#step:4:35), but did not occur with [mingw-w64-x86_64-libimagequant-4.3.3-1](https://github.com/python-pillow/Pillow/actions/runs/12998202574/job/36250847064#step:4:35).

MinGW does not allow installation of older versions of packages, so this PR stops installing libimagequant on MinGW for the moment.