### PR TITLE
Revert "Ignore brew dependencies for libraqm on macOS 13"

### DIFF
--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -10,15 +10,11 @@ brew install \
     ghostscript \
     jpeg-turbo \
     libimagequant \
+    libraqm \
     libtiff \
     little-cms2 \
     openjpeg \
     webp
-if [[ "$ImageOS" == "macos13" ]]; then
-    brew install --ignore-dependencies libraqm
-else
-    brew install libraqm
-fi
 export PKG_CONFIG_PATH="/usr/local/opt/openblas/lib/pkgconfig"
 
 python3 -m pip install coverage


### PR DESCRIPTION
#8140 added `--ignore-dependencies` when using brew to install libraqm on macos13, to avoid an error that our separate request for libjpeg was conflicting with jpeg-turbo.

Since #8596 stopping asking for libjpeg and switched to jpeg-turbo instead, the change from the first PR is no longer needed.