### PR TITLE
Use getpixel() instead of load()

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -86,12 +86,12 @@ def test_invalid_file() -> None:
 def test_l_mode_transparency() -> None:
     with Image.open("Tests/images/no_palette_with_transparency.gif") as im:
         assert im.mode == "L"
-        assert im.load()[0, 0] == 128
+        assert im.getpixel((0, 0)) == 128
         assert im.info["transparency"] == 255
 
         im.seek(1)
         assert im.mode == "L"
-        assert im.load()[0, 0] == 128
+        assert im.getpixel((0, 0)) == 128
 
 
 def test_l_mode_after_rgb() -> None:
@@ -311,7 +311,7 @@ def test_loading_multiple_palettes(path: str, mode: str) -> None:
     with Image.open(path) as im:
         assert im.mode == "P"
         first_frame_colors = im.palette.colors.keys()
-        original_color = im.convert("RGB").load()[0, 0]
+        original_color = im.convert("RGB").getpixel((0, 0))
 
         im.seek(1)
         assert im.mode == mode
@@ -319,10 +319,10 @@ def test_loading_multiple_palettes(path: str, mode: str) -> None:
             im = im.convert("RGB")
 
         # Check a color only from the old palette
-        assert im.load()[0, 0] == original_color
+        assert im.getpixel((0, 0)) == original_color
 
         # Check a color from the new palette
-        assert im.load()[24, 24] not in first_frame_colors
+        assert im.getpixel((24, 24)) not in first_frame_colors
 
 
 def test_headers_saving_for_animated_gifs(tmp_path: Path) -> None:
@@ -488,8 +488,7 @@ def test_eoferror() -> None:
 
 def test_first_frame_transparency() -> None:
     with Image.open("Tests/images/first_frame_transparency.gif") as im:
-        px = im.load()
-        assert px[0, 0] == im.info["transparency"]
+        assert im.getpixel((0, 0)) == im.info["transparency"]
 
 
 def test_dispose_none() -> None:

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -578,9 +578,7 @@ class TestImage:
     def test_one_item_tuple(self) -> None:
         for mode in ("I", "F", "L"):
             im = Image.new(mode, (100, 100), (5,))
-            px = im.load()
-            assert px is not None
-            assert px[0, 0] == 5
+            assert im.getpixel((0, 0)) == 5
 
     def test_linear_gradient_wrong_mode(self) -> None:
         # Arrange

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -222,9 +222,7 @@ def test_l_macro_rounding(convert_mode: str) -> None:
         im.palette.getcolor((0, 1, 2))
 
         converted_im = im.convert(convert_mode)
-        px = converted_im.load()
-        assert px is not None
-        converted_color = px[0, 0]
+        converted_color = converted_im.getpixel((0, 0))
         if convert_mode == "LA":
             assert isinstance(converted_color, tuple)
             converted_color = converted_color[0]

--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -148,10 +148,8 @@ def test_palette(method: Image.Quantize, color: tuple[int, ...]) -> None:
     im = Image.new("RGBA" if len(color) == 4 else "RGB", (1, 1), color)
 
     converted = im.quantize(method=method)
-    converted_px = converted.load()
-    assert converted_px is not None
     assert converted.palette is not None
-    assert converted_px[0, 0] == converted.palette.colors[color]
+    assert converted.getpixel((0, 0)) == converted.palette.colors[color]
 
 
 def test_small_palette() -> None:

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -165,14 +165,10 @@ def test_pad() -> None:
 def test_pad_round() -> None:
     im = Image.new("1", (1, 1), 1)
     new_im = ImageOps.pad(im, (4, 1))
-    px = new_im.load()
-    assert px is not None
-    assert px[2, 0] == 1
+    assert new_im.getpixel((2, 0)) == 1
 
     new_im = ImageOps.pad(im, (1, 4))
-    px = new_im.load()
-    assert px is not None
-    assert px[0, 2] == 1
+    assert new_im.getpixel((0, 2)) == 1
 
 
 @pytest.mark.parametrize("mode", ("P", "PA"))

--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -141,9 +141,7 @@ def test_save_tiff_uint16() -> None:
     a.shape = TEST_IMAGE_SIZE
     img = Image.fromarray(a)
 
-    img_px = img.load()
-    assert img_px is not None
-    assert img_px[0, 0] == pixel_value
+    assert img.getpixel((0, 0)) == pixel_value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Updates some locations in the test suite where I think it is simpler (and clearer) to use
```python
im.getpixel((x, y))
```
rather than
```python
im.load()[x, y]
```