### PR TITLE
Use member names to initialize modules

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -4439,10 +4439,9 @@ PyInit__imaging(void) {
 
     static PyModuleDef module_def = {
         PyModuleDef_HEAD_INIT,
-        "_imaging", /* m_name */
-        NULL,       /* m_doc */
-        -1,         /* m_size */
-        functions,  /* m_methods */
+        .m_name = "_imaging",
+        .m_size = -1,
+        .m_methods = functions,
     };
 
     m = PyModule_Create(&module_def);

--- a/src/_imagingcms.c
+++ b/src/_imagingcms.c
@@ -1520,10 +1520,9 @@ PyInit__imagingcms(void) {
 
     static PyModuleDef module_def = {
         PyModuleDef_HEAD_INIT,
-        "_imagingcms",    /* m_name */
-        NULL,             /* m_doc */
-        -1,               /* m_size */
-        pyCMSdll_methods, /* m_methods */
+        .m_name = "_imagingcms",
+        .m_size = -1,
+        .m_methods = pyCMSdll_methods,
     };
 
     m = PyModule_Create(&module_def);

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -1630,10 +1630,9 @@ PyInit__imagingft(void) {
 
     static PyModuleDef module_def = {
         PyModuleDef_HEAD_INIT,
-        "_imagingft", /* m_name */
-        NULL,         /* m_doc */
-        -1,           /* m_size */
-        _functions,   /* m_methods */
+        .m_name = "_imagingft",
+        .m_size = -1,
+        .m_methods = _functions,
     };
 
     m = PyModule_Create(&module_def);

--- a/src/_imagingmath.c
+++ b/src/_imagingmath.c
@@ -308,10 +308,9 @@ PyInit__imagingmath(void) {
 
     static PyModuleDef module_def = {
         PyModuleDef_HEAD_INIT,
-        "_imagingmath", /* m_name */
-        NULL,           /* m_doc */
-        -1,             /* m_size */
-        _functions,     /* m_methods */
+        .m_name = "_imagingmath",
+        .m_size = -1,
+        .m_methods = _functions,
     };
 
     m = PyModule_Create(&module_def);

--- a/src/_imagingmorph.c
+++ b/src/_imagingmorph.c
@@ -252,10 +252,10 @@ PyInit__imagingmorph(void) {
 
     static PyModuleDef module_def = {
         PyModuleDef_HEAD_INIT,
-        "_imagingmorph",                       /* m_name */
-        "A module for doing image morphology", /* m_doc */
-        -1,                                    /* m_size */
-        functions,                             /* m_methods */
+        .m_name = "_imagingmorph",
+        .m_doc = "A module for doing image morphology",
+        .m_size = -1,
+        .m_methods = functions,
     };
 
     m = PyModule_Create(&module_def);

--- a/src/_imagingtk.c
+++ b/src/_imagingtk.c
@@ -50,10 +50,9 @@ PyMODINIT_FUNC
 PyInit__imagingtk(void) {
     static PyModuleDef module_def = {
         PyModuleDef_HEAD_INIT,
-        "_imagingtk", /* m_name */
-        NULL,         /* m_doc */
-        -1,           /* m_size */
-        functions,    /* m_methods */
+        .m_name = "_imagingtk",
+        .m_size = -1,
+        .m_methods = functions,
     };
     PyObject *m;
     m = PyModule_Create(&module_def);

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -835,10 +835,9 @@ PyInit__webp(void) {
 
     static PyModuleDef module_def = {
         PyModuleDef_HEAD_INIT,
-        "_webp",     /* m_name */
-        NULL,        /* m_doc */
-        -1,          /* m_size */
-        webpMethods, /* m_methods */
+        .m_name = "_webp",
+        .m_size = -1,
+        .m_methods = webpMethods,
     };
 
     m = PyModule_Create(&module_def);


### PR DESCRIPTION
Borrowing an idea from #5201

Rather than creating a struct with the members in order, and adding comments to describe their names,
https://github.com/python-pillow/Pillow/blob/2810d7c6ba3d2dcaba88cb642272b87696355602/src/_imaging.c#L4440-L4446
it seems simpler to just use the member names directly.
```c
static PyModuleDef module_def = {
    PyModuleDef_HEAD_INIT,
    .m_name = "_imaging",
    .m_size = -1,
    .m_methods = functions,
};
```