### PR TITLE
Updated AffineTransform docstring to mention it uses the inverse matrix

### DIFF
--- a/src/PIL/ImageTransform.py
+++ b/src/PIL/ImageTransform.py
@@ -48,9 +48,9 @@ class AffineTransform(Transform):
     Define an affine image transform.
 
     This function takes a 6-tuple (a, b, c, d, e, f) which contain the first
-    two rows from an affine transform matrix. For each pixel (x, y) in the
-    output image, the new value is taken from a position (a x + b y + c,
-    d x + e y + f) in the input image, rounded to nearest pixel.
+    two rows from the inverse of an affine transform matrix. For each pixel
+    (x, y) in the output image, the new value is taken from a position (a x +
+    b y + c, d x + e y + f) in the input image, rounded to nearest pixel.
 
     This function can be used to scale, translate, rotate, and shear the
     original image.
@@ -58,7 +58,7 @@ class AffineTransform(Transform):
     See :py:meth:`.Image.transform`
 
     :param matrix: A 6-tuple (a, b, c, d, e, f) containing the first two rows
-        from an affine transform matrix.
+        from the inverse of an affine transform matrix.
     """
 
     method = Image.Transform.AFFINE


### PR DESCRIPTION
The `AffineTransform` docstring currently [states](https://pillow.readthedocs.io/en/stable/reference/ImageTransform.html#PIL.ImageTransform.AffineTransform)
> This function takes a 6-tuple (a, b, c, d, e, f) which contain the first two rows from an affine transform matrix. For each pixel (x, y) in the output image, the new value is taken from a position (a x + b y + c, d x + e y + f) in the input image, rounded to nearest pixel.

#8728 implied that this could be clearer
> Yes... I know that PIL takes the inverse

and #8731 is now requesting that we clarify that the inverse matrix is used.

For further reading, see https://stackabuse.com/affine-image-transformations-in-python-with-numpy-pillow-and-opencv/#affinetransformationswithpillow
> The `Image.transform(...)` method actually requires the inverse of the transformation matrix be supplied to the `data` parameter as a flattened array (or tuple) excluding the last row.

So I'm here updating the first sentence to
> This function takes a 6-tuple (a, b, c, d, e, f) which contain the first two rows from the inverse of an affine transform matrix.