### PR TITLE
Use member names to initialize PyTypeObjects

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -3773,7 +3773,6 @@ static PyTypeObject Imaging_Type = {
     .tp_basicsize = sizeof(ImagingObject),
     .tp_dealloc = (destructor)_dealloc,
     .tp_as_sequence = &image_as_sequence,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_methods = methods,
     .tp_getset = getsetters,
 };
@@ -3782,7 +3781,6 @@ static PyTypeObject ImagingFont_Type = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "ImagingFont",
     .tp_basicsize = sizeof(ImagingFontObject),
     .tp_dealloc = (destructor)_font_dealloc,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_methods = _font_methods,
 };
 
@@ -3790,7 +3788,6 @@ static PyTypeObject ImagingDraw_Type = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "ImagingDraw",
     .tp_basicsize = sizeof(ImagingDrawObject),
     .tp_dealloc = (destructor)_draw_dealloc,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_methods = _draw_methods,
 };
 

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -3769,102 +3769,29 @@ static PySequenceMethods image_as_sequence = {
 /* type description */
 
 static PyTypeObject Imaging_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0) "ImagingCore", /*tp_name*/
-    sizeof(ImagingObject),                        /*tp_basicsize*/
-    0,                                            /*tp_itemsize*/
-    /* methods */
-    (destructor)_dealloc, /*tp_dealloc*/
-    0,                    /*tp_vectorcall_offset*/
-    0,                    /*tp_getattr*/
-    0,                    /*tp_setattr*/
-    0,                    /*tp_as_async*/
-    0,                    /*tp_repr*/
-    0,                    /*tp_as_number*/
-    &image_as_sequence,   /*tp_as_sequence*/
-    0,                    /*tp_as_mapping*/
-    0,                    /*tp_hash*/
-    0,                    /*tp_call*/
-    0,                    /*tp_str*/
-    0,                    /*tp_getattro*/
-    0,                    /*tp_setattro*/
-    0,                    /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,   /*tp_flags*/
-    0,                    /*tp_doc*/
-    0,                    /*tp_traverse*/
-    0,                    /*tp_clear*/
-    0,                    /*tp_richcompare*/
-    0,                    /*tp_weaklistoffset*/
-    0,                    /*tp_iter*/
-    0,                    /*tp_iternext*/
-    methods,              /*tp_methods*/
-    0,                    /*tp_members*/
-    getsetters,           /*tp_getset*/
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "ImagingCore",
+    .tp_basicsize = sizeof(ImagingObject),
+    .tp_dealloc = (destructor)_dealloc,
+    .tp_as_sequence = &image_as_sequence,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_methods = methods,
+    .tp_getset = getsetters,
 };
 
 static PyTypeObject ImagingFont_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0) "ImagingFont", /*tp_name*/
-    sizeof(ImagingFontObject),                    /*tp_basicsize*/
-    0,                                            /*tp_itemsize*/
-    /* methods */
-    (destructor)_font_dealloc, /*tp_dealloc*/
-    0,                         /*tp_vectorcall_offset*/
-    0,                         /*tp_getattr*/
-    0,                         /*tp_setattr*/
-    0,                         /*tp_as_async*/
-    0,                         /*tp_repr*/
-    0,                         /*tp_as_number*/
-    0,                         /*tp_as_sequence*/
-    0,                         /*tp_as_mapping*/
-    0,                         /*tp_hash*/
-    0,                         /*tp_call*/
-    0,                         /*tp_str*/
-    0,                         /*tp_getattro*/
-    0,                         /*tp_setattro*/
-    0,                         /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,        /*tp_flags*/
-    0,                         /*tp_doc*/
-    0,                         /*tp_traverse*/
-    0,                         /*tp_clear*/
-    0,                         /*tp_richcompare*/
-    0,                         /*tp_weaklistoffset*/
-    0,                         /*tp_iter*/
-    0,                         /*tp_iternext*/
-    _font_methods,             /*tp_methods*/
-    0,                         /*tp_members*/
-    0,                         /*tp_getset*/
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "ImagingFont",
+    .tp_basicsize = sizeof(ImagingFontObject),
+    .tp_dealloc = (destructor)_font_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_methods = _font_methods,
 };
 
 static PyTypeObject ImagingDraw_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0) "ImagingDraw", /*tp_name*/
-    sizeof(ImagingDrawObject),                    /*tp_basicsize*/
-    0,                                            /*tp_itemsize*/
-    /* methods */
-    (destructor)_draw_dealloc, /*tp_dealloc*/
-    0,                         /*tp_vectorcall_offset*/
-    0,                         /*tp_getattr*/
-    0,                         /*tp_setattr*/
-    0,                         /*tp_as_async*/
-    0,                         /*tp_repr*/
-    0,                         /*tp_as_number*/
-    0,                         /*tp_as_sequence*/
-    0,                         /*tp_as_mapping*/
-    0,                         /*tp_hash*/
-    0,                         /*tp_call*/
-    0,                         /*tp_str*/
-    0,                         /*tp_getattro*/
-    0,                         /*tp_setattro*/
-    0,                         /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,        /*tp_flags*/
-    0,                         /*tp_doc*/
-    0,                         /*tp_traverse*/
-    0,                         /*tp_clear*/
-    0,                         /*tp_richcompare*/
-    0,                         /*tp_weaklistoffset*/
-    0,                         /*tp_iter*/
-    0,                         /*tp_iternext*/
-    _draw_methods,             /*tp_methods*/
-    0,                         /*tp_members*/
-    0,                         /*tp_getset*/
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "ImagingDraw",
+    .tp_basicsize = sizeof(ImagingDrawObject),
+    .tp_dealloc = (destructor)_draw_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_methods = _draw_methods,
 };
 
 static PyMappingMethods pixel_access_as_mapping = {
@@ -3876,20 +3803,10 @@ static PyMappingMethods pixel_access_as_mapping = {
 /* type description */
 
 static PyTypeObject PixelAccess_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0) "PixelAccess", /*tp_name*/
-    sizeof(PixelAccessObject),                    /*tp_basicsize*/
-    0,                                            /*tp_itemsize*/
-    /* methods */
-    (destructor)pixel_access_dealloc, /*tp_dealloc*/
-    0,                                /*tp_vectorcall_offset*/
-    0,                                /*tp_getattr*/
-    0,                                /*tp_setattr*/
-    0,                                /*tp_as_async*/
-    0,                                /*tp_repr*/
-    0,                                /*tp_as_number*/
-    0,                                /*tp_as_sequence*/
-    &pixel_access_as_mapping,         /*tp_as_mapping*/
-    0                                 /*tp_hash*/
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "PixelAccess",
+    .tp_basicsize = sizeof(PixelAccessObject),
+    .tp_dealloc = (destructor)pixel_access_dealloc,
+    .tp_as_mapping = &pixel_access_as_mapping,
 };
 
 /* -------------------------------------------------------------------- */

--- a/src/_imagingcms.c
+++ b/src/_imagingcms.c
@@ -1410,36 +1410,12 @@ static struct PyGetSetDef cms_profile_getsetters[] = {
 };
 
 static PyTypeObject CmsProfile_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0) "PIL.ImageCms.core.CmsProfile", /*tp_name*/
-    sizeof(CmsProfileObject),                                      /*tp_basicsize*/
-    0,                                                             /*tp_itemsize*/
-    /* methods */
-    (destructor)cms_profile_dealloc, /*tp_dealloc*/
-    0,                               /*tp_vectorcall_offset*/
-    0,                               /*tp_getattr*/
-    0,                               /*tp_setattr*/
-    0,                               /*tp_as_async*/
-    0,                               /*tp_repr*/
-    0,                               /*tp_as_number*/
-    0,                               /*tp_as_sequence*/
-    0,                               /*tp_as_mapping*/
-    0,                               /*tp_hash*/
-    0,                               /*tp_call*/
-    0,                               /*tp_str*/
-    0,                               /*tp_getattro*/
-    0,                               /*tp_setattro*/
-    0,                               /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,              /*tp_flags*/
-    0,                               /*tp_doc*/
-    0,                               /*tp_traverse*/
-    0,                               /*tp_clear*/
-    0,                               /*tp_richcompare*/
-    0,                               /*tp_weaklistoffset*/
-    0,                               /*tp_iter*/
-    0,                               /*tp_iternext*/
-    cms_profile_methods,             /*tp_methods*/
-    0,                               /*tp_members*/
-    cms_profile_getsetters,          /*tp_getset*/
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "PIL.ImageCms.core.CmsProfile",
+    .tp_basicsize = sizeof(CmsProfileObject),
+    .tp_dealloc = (destructor)cms_profile_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_methods = cms_profile_methods,
+    .tp_getset = cms_profile_getsetters,
 };
 
 static struct PyMethodDef cms_transform_methods[] = {
@@ -1447,36 +1423,11 @@ static struct PyMethodDef cms_transform_methods[] = {
 };
 
 static PyTypeObject CmsTransform_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0) "PIL.ImageCms.core.CmsTransform", /*tp_name*/
-    sizeof(CmsTransformObject),                                      /*tp_basicsize*/
-    0,                                                               /*tp_itemsize*/
-    /* methods */
-    (destructor)cms_transform_dealloc, /*tp_dealloc*/
-    0,                                 /*tp_vectorcall_offset*/
-    0,                                 /*tp_getattr*/
-    0,                                 /*tp_setattr*/
-    0,                                 /*tp_as_async*/
-    0,                                 /*tp_repr*/
-    0,                                 /*tp_as_number*/
-    0,                                 /*tp_as_sequence*/
-    0,                                 /*tp_as_mapping*/
-    0,                                 /*tp_hash*/
-    0,                                 /*tp_call*/
-    0,                                 /*tp_str*/
-    0,                                 /*tp_getattro*/
-    0,                                 /*tp_setattro*/
-    0,                                 /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,                /*tp_flags*/
-    0,                                 /*tp_doc*/
-    0,                                 /*tp_traverse*/
-    0,                                 /*tp_clear*/
-    0,                                 /*tp_richcompare*/
-    0,                                 /*tp_weaklistoffset*/
-    0,                                 /*tp_iter*/
-    0,                                 /*tp_iternext*/
-    cms_transform_methods,             /*tp_methods*/
-    0,                                 /*tp_members*/
-    0,                                 /*tp_getset*/
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "PIL.ImageCms.core.CmsTransform",
+    .tp_basicsize = sizeof(CmsTransformObject),
+    .tp_dealloc = (destructor)cms_transform_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_methods = cms_transform_methods,
 };
 
 static int

--- a/src/_imagingcms.c
+++ b/src/_imagingcms.c
@@ -1413,7 +1413,6 @@ static PyTypeObject CmsProfile_Type = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "PIL.ImageCms.core.CmsProfile",
     .tp_basicsize = sizeof(CmsProfileObject),
     .tp_dealloc = (destructor)cms_profile_dealloc,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_methods = cms_profile_methods,
     .tp_getset = cms_profile_getsetters,
 };
@@ -1426,7 +1425,6 @@ static PyTypeObject CmsTransform_Type = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "PIL.ImageCms.core.CmsTransform",
     .tp_basicsize = sizeof(CmsTransformObject),
     .tp_dealloc = (destructor)cms_transform_dealloc,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_methods = cms_transform_methods,
 };
 

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -1518,36 +1518,12 @@ static struct PyGetSetDef font_getsetters[] = {
 };
 
 static PyTypeObject Font_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0) "Font", /*tp_name*/
-    sizeof(FontObject),                    /*tp_basicsize*/
-    0,                                     /*tp_itemsize*/
-    /* methods */
-    (destructor)font_dealloc, /*tp_dealloc*/
-    0,                        /*tp_vectorcall_offset*/
-    0,                        /*tp_getattr*/
-    0,                        /*tp_setattr*/
-    0,                        /*tp_as_async*/
-    0,                        /*tp_repr*/
-    0,                        /*tp_as_number*/
-    0,                        /*tp_as_sequence*/
-    0,                        /*tp_as_mapping*/
-    0,                        /*tp_hash*/
-    0,                        /*tp_call*/
-    0,                        /*tp_str*/
-    0,                        /*tp_getattro*/
-    0,                        /*tp_setattro*/
-    0,                        /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,       /*tp_flags*/
-    0,                        /*tp_doc*/
-    0,                        /*tp_traverse*/
-    0,                        /*tp_clear*/
-    0,                        /*tp_richcompare*/
-    0,                        /*tp_weaklistoffset*/
-    0,                        /*tp_iter*/
-    0,                        /*tp_iternext*/
-    font_methods,             /*tp_methods*/
-    0,                        /*tp_members*/
-    font_getsetters,          /*tp_getset*/
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "Font",
+    .tp_basicsize = sizeof(FontObject),
+    .tp_dealloc = (destructor)font_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_methods = font_methods,
+    .tp_getset = font_getsetters,
 };
 
 static PyMethodDef _functions[] = {

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -1521,7 +1521,6 @@ static PyTypeObject Font_Type = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "Font",
     .tp_basicsize = sizeof(FontObject),
     .tp_dealloc = (destructor)font_dealloc,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_methods = font_methods,
     .tp_getset = font_getsetters,
 };

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -530,36 +530,11 @@ static struct PyMethodDef _anim_encoder_methods[] = {
 
 // WebPAnimEncoder type definition
 static PyTypeObject WebPAnimEncoder_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0) "WebPAnimEncoder", /*tp_name */
-    sizeof(WebPAnimEncoderObject),                    /*tp_basicsize */
-    0,                                                /*tp_itemsize */
-    /* methods */
-    (destructor)_anim_encoder_dealloc, /*tp_dealloc*/
-    0,                                 /*tp_vectorcall_offset*/
-    0,                                 /*tp_getattr*/
-    0,                                 /*tp_setattr*/
-    0,                                 /*tp_as_async*/
-    0,                                 /*tp_repr*/
-    0,                                 /*tp_as_number*/
-    0,                                 /*tp_as_sequence*/
-    0,                                 /*tp_as_mapping*/
-    0,                                 /*tp_hash*/
-    0,                                 /*tp_call*/
-    0,                                 /*tp_str*/
-    0,                                 /*tp_getattro*/
-    0,                                 /*tp_setattro*/
-    0,                                 /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,                /*tp_flags*/
-    0,                                 /*tp_doc*/
-    0,                                 /*tp_traverse*/
-    0,                                 /*tp_clear*/
-    0,                                 /*tp_richcompare*/
-    0,                                 /*tp_weaklistoffset*/
-    0,                                 /*tp_iter*/
-    0,                                 /*tp_iternext*/
-    _anim_encoder_methods,             /*tp_methods*/
-    0,                                 /*tp_members*/
-    0,                                 /*tp_getset*/
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "WebPAnimEncoder",
+    .tp_basicsize = sizeof(WebPAnimEncoderObject),
+    .tp_dealloc = (destructor)_anim_encoder_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_methods = _anim_encoder_methods,
 };
 
 // WebPAnimDecoder methods
@@ -573,36 +548,11 @@ static struct PyMethodDef _anim_decoder_methods[] = {
 
 // WebPAnimDecoder type definition
 static PyTypeObject WebPAnimDecoder_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0) "WebPAnimDecoder", /*tp_name */
-    sizeof(WebPAnimDecoderObject),                    /*tp_basicsize */
-    0,                                                /*tp_itemsize */
-    /* methods */
-    (destructor)_anim_decoder_dealloc, /*tp_dealloc*/
-    0,                                 /*tp_vectorcall_offset*/
-    0,                                 /*tp_getattr*/
-    0,                                 /*tp_setattr*/
-    0,                                 /*tp_as_async*/
-    0,                                 /*tp_repr*/
-    0,                                 /*tp_as_number*/
-    0,                                 /*tp_as_sequence*/
-    0,                                 /*tp_as_mapping*/
-    0,                                 /*tp_hash*/
-    0,                                 /*tp_call*/
-    0,                                 /*tp_str*/
-    0,                                 /*tp_getattro*/
-    0,                                 /*tp_setattro*/
-    0,                                 /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,                /*tp_flags*/
-    0,                                 /*tp_doc*/
-    0,                                 /*tp_traverse*/
-    0,                                 /*tp_clear*/
-    0,                                 /*tp_richcompare*/
-    0,                                 /*tp_weaklistoffset*/
-    0,                                 /*tp_iter*/
-    0,                                 /*tp_iternext*/
-    _anim_decoder_methods,             /*tp_methods*/
-    0,                                 /*tp_members*/
-    0,                                 /*tp_getset*/
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "WebPAnimDecoder",
+    .tp_basicsize = sizeof(WebPAnimDecoderObject),
+    .tp_dealloc = (destructor)_anim_decoder_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_methods = _anim_decoder_methods,
 };
 
 /* -------------------------------------------------------------------- */

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -533,7 +533,6 @@ static PyTypeObject WebPAnimEncoder_Type = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "WebPAnimEncoder",
     .tp_basicsize = sizeof(WebPAnimEncoderObject),
     .tp_dealloc = (destructor)_anim_encoder_dealloc,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_methods = _anim_encoder_methods,
 };
 
@@ -551,7 +550,6 @@ static PyTypeObject WebPAnimDecoder_Type = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "WebPAnimDecoder",
     .tp_basicsize = sizeof(WebPAnimDecoderObject),
     .tp_dealloc = (destructor)_anim_decoder_dealloc,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_methods = _anim_decoder_methods,
 };
 

--- a/src/decode.c
+++ b/src/decode.c
@@ -256,36 +256,12 @@ static struct PyGetSetDef getseters[] = {
 };
 
 static PyTypeObject ImagingDecoderType = {
-    PyVarObject_HEAD_INIT(NULL, 0) "ImagingDecoder", /*tp_name*/
-    sizeof(ImagingDecoderObject),                    /*tp_basicsize*/
-    0,                                               /*tp_itemsize*/
-    /* methods */
-    (destructor)_dealloc, /*tp_dealloc*/
-    0,                    /*tp_vectorcall_offset*/
-    0,                    /*tp_getattr*/
-    0,                    /*tp_setattr*/
-    0,                    /*tp_as_async*/
-    0,                    /*tp_repr*/
-    0,                    /*tp_as_number*/
-    0,                    /*tp_as_sequence*/
-    0,                    /*tp_as_mapping*/
-    0,                    /*tp_hash*/
-    0,                    /*tp_call*/
-    0,                    /*tp_str*/
-    0,                    /*tp_getattro*/
-    0,                    /*tp_setattro*/
-    0,                    /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,   /*tp_flags*/
-    0,                    /*tp_doc*/
-    0,                    /*tp_traverse*/
-    0,                    /*tp_clear*/
-    0,                    /*tp_richcompare*/
-    0,                    /*tp_weaklistoffset*/
-    0,                    /*tp_iter*/
-    0,                    /*tp_iternext*/
-    methods,              /*tp_methods*/
-    0,                    /*tp_members*/
-    getseters,            /*tp_getset*/
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "ImagingDecoder",
+    .tp_basicsize = sizeof(ImagingDecoderObject),
+    .tp_dealloc = (destructor)_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_methods = methods,
+    .tp_getset = getseters,
 };
 
 /* -------------------------------------------------------------------- */

--- a/src/decode.c
+++ b/src/decode.c
@@ -259,7 +259,6 @@ static PyTypeObject ImagingDecoderType = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "ImagingDecoder",
     .tp_basicsize = sizeof(ImagingDecoderObject),
     .tp_dealloc = (destructor)_dealloc,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_methods = methods,
     .tp_getset = getseters,
 };

--- a/src/display.c
+++ b/src/display.c
@@ -248,36 +248,12 @@ static struct PyGetSetDef getsetters[] = {
 };
 
 static PyTypeObject ImagingDisplayType = {
-    PyVarObject_HEAD_INIT(NULL, 0) "ImagingDisplay", /*tp_name*/
-    sizeof(ImagingDisplayObject),                    /*tp_basicsize*/
-    0,                                               /*tp_itemsize*/
-    /* methods */
-    (destructor)_delete, /*tp_dealloc*/
-    0,                   /*tp_vectorcall_offset*/
-    0,                   /*tp_getattr*/
-    0,                   /*tp_setattr*/
-    0,                   /*tp_as_async*/
-    0,                   /*tp_repr*/
-    0,                   /*tp_as_number*/
-    0,                   /*tp_as_sequence*/
-    0,                   /*tp_as_mapping*/
-    0,                   /*tp_hash*/
-    0,                   /*tp_call*/
-    0,                   /*tp_str*/
-    0,                   /*tp_getattro*/
-    0,                   /*tp_setattro*/
-    0,                   /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,  /*tp_flags*/
-    0,                   /*tp_doc*/
-    0,                   /*tp_traverse*/
-    0,                   /*tp_clear*/
-    0,                   /*tp_richcompare*/
-    0,                   /*tp_weaklistoffset*/
-    0,                   /*tp_iter*/
-    0,                   /*tp_iternext*/
-    methods,             /*tp_methods*/
-    0,                   /*tp_members*/
-    getsetters,          /*tp_getset*/
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "ImagingDisplay",
+    .tp_basicsize = sizeof(ImagingDisplayObject),
+    .tp_dealloc = (destructor)_delete,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_methods = methods,
+    .tp_getset = getsetters,
 };
 
 PyObject *

--- a/src/display.c
+++ b/src/display.c
@@ -251,7 +251,6 @@ static PyTypeObject ImagingDisplayType = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "ImagingDisplay",
     .tp_basicsize = sizeof(ImagingDisplayObject),
     .tp_dealloc = (destructor)_delete,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_methods = methods,
     .tp_getset = getsetters,
 };

--- a/src/encode.c
+++ b/src/encode.c
@@ -326,7 +326,6 @@ static PyTypeObject ImagingEncoderType = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "ImagingEncoder",
     .tp_basicsize = sizeof(ImagingEncoderObject),
     .tp_dealloc = (destructor)_dealloc,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_methods = methods,
     .tp_getset = getseters,
 };

--- a/src/encode.c
+++ b/src/encode.c
@@ -323,36 +323,12 @@ static struct PyGetSetDef getseters[] = {
 };
 
 static PyTypeObject ImagingEncoderType = {
-    PyVarObject_HEAD_INIT(NULL, 0) "ImagingEncoder", /*tp_name*/
-    sizeof(ImagingEncoderObject),                    /*tp_basicsize*/
-    0,                                               /*tp_itemsize*/
-    /* methods */
-    (destructor)_dealloc, /*tp_dealloc*/
-    0,                    /*tp_vectorcall_offset*/
-    0,                    /*tp_getattr*/
-    0,                    /*tp_setattr*/
-    0,                    /*tp_as_async*/
-    0,                    /*tp_repr*/
-    0,                    /*tp_as_number*/
-    0,                    /*tp_as_sequence*/
-    0,                    /*tp_as_mapping*/
-    0,                    /*tp_hash*/
-    0,                    /*tp_call*/
-    0,                    /*tp_str*/
-    0,                    /*tp_getattro*/
-    0,                    /*tp_setattro*/
-    0,                    /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,   /*tp_flags*/
-    0,                    /*tp_doc*/
-    0,                    /*tp_traverse*/
-    0,                    /*tp_clear*/
-    0,                    /*tp_richcompare*/
-    0,                    /*tp_weaklistoffset*/
-    0,                    /*tp_iter*/
-    0,                    /*tp_iternext*/
-    methods,              /*tp_methods*/
-    0,                    /*tp_members*/
-    getseters,            /*tp_getset*/
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "ImagingEncoder",
+    .tp_basicsize = sizeof(ImagingEncoderObject),
+    .tp_dealloc = (destructor)_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_methods = methods,
+    .tp_getset = getseters,
 };
 
 /* -------------------------------------------------------------------- */

--- a/src/outline.c
+++ b/src/outline.c
@@ -149,34 +149,9 @@ static struct PyMethodDef _outline_methods[] = {
 };
 
 static PyTypeObject OutlineType = {
-    PyVarObject_HEAD_INIT(NULL, 0) "Outline", /*tp_name*/
-    sizeof(OutlineObject),                    /*tp_basicsize*/
-    0,                                        /*tp_itemsize*/
-    /* methods */
-    (destructor)_outline_dealloc, /*tp_dealloc*/
-    0,                            /*tp_vectorcall_offset*/
-    0,                            /*tp_getattr*/
-    0,                            /*tp_setattr*/
-    0,                            /*tp_as_async*/
-    0,                            /*tp_repr*/
-    0,                            /*tp_as_number*/
-    0,                            /*tp_as_sequence*/
-    0,                            /*tp_as_mapping*/
-    0,                            /*tp_hash*/
-    0,                            /*tp_call*/
-    0,                            /*tp_str*/
-    0,                            /*tp_getattro*/
-    0,                            /*tp_setattro*/
-    0,                            /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,           /*tp_flags*/
-    0,                            /*tp_doc*/
-    0,                            /*tp_traverse*/
-    0,                            /*tp_clear*/
-    0,                            /*tp_richcompare*/
-    0,                            /*tp_weaklistoffset*/
-    0,                            /*tp_iter*/
-    0,                            /*tp_iternext*/
-    _outline_methods,             /*tp_methods*/
-    0,                            /*tp_members*/
-    0,                            /*tp_getset*/
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "Outline",
+    .tp_basicsize = sizeof(OutlineObject),
+    .tp_dealloc = (destructor)_outline_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_methods = _outline_methods,
 };

--- a/src/outline.c
+++ b/src/outline.c
@@ -152,6 +152,5 @@ static PyTypeObject OutlineType = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "Outline",
     .tp_basicsize = sizeof(OutlineObject),
     .tp_dealloc = (destructor)_outline_dealloc,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_methods = _outline_methods,
 };

--- a/src/path.c
+++ b/src/path.c
@@ -603,7 +603,6 @@ static PyTypeObject PyPathType = {
     .tp_dealloc = (destructor)path_dealloc,
     .tp_as_sequence = &path_as_sequence,
     .tp_as_mapping = &path_as_mapping,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_methods = methods,
     .tp_getset = getsetters,
 };

--- a/src/path.c
+++ b/src/path.c
@@ -598,34 +598,12 @@ static PyMappingMethods path_as_mapping = {
 };
 
 static PyTypeObject PyPathType = {
-    PyVarObject_HEAD_INIT(NULL, 0) "Path", /*tp_name*/
-    sizeof(PyPathObject),                  /*tp_basicsize*/
-    0,                                     /*tp_itemsize*/
-    /* methods */
-    (destructor)path_dealloc, /*tp_dealloc*/
-    0,                        /*tp_vectorcall_offset*/
-    0,                        /*tp_getattr*/
-    0,                        /*tp_setattr*/
-    0,                        /*tp_as_async*/
-    0,                        /*tp_repr*/
-    0,                        /*tp_as_number*/
-    &path_as_sequence,        /*tp_as_sequence*/
-    &path_as_mapping,         /*tp_as_mapping*/
-    0,                        /*tp_hash*/
-    0,                        /*tp_call*/
-    0,                        /*tp_str*/
-    0,                        /*tp_getattro*/
-    0,                        /*tp_setattro*/
-    0,                        /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,       /*tp_flags*/
-    0,                        /*tp_doc*/
-    0,                        /*tp_traverse*/
-    0,                        /*tp_clear*/
-    0,                        /*tp_richcompare*/
-    0,                        /*tp_weaklistoffset*/
-    0,                        /*tp_iter*/
-    0,                        /*tp_iternext*/
-    methods,                  /*tp_methods*/
-    0,                        /*tp_members*/
-    getsetters,               /*tp_getset*/
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "Path",
+    .tp_basicsize = sizeof(PyPathObject),
+    .tp_dealloc = (destructor)path_dealloc,
+    .tp_as_sequence = &path_as_sequence,
+    .tp_as_mapping = &path_as_mapping,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_methods = methods,
+    .tp_getset = getsetters,
 };


### PR DESCRIPTION
Borrowing an idea from #5201. Similar to #8734

As shown at https://docs.python.org/3/c-api/typeobj.html#examples, this uses member names to initialize `PyTypeObject`s, rather than being verbose and going through every member in sequence.

Also, I've removed specifying `tp_flags` as `Py_TPFLAGS_DEFAULT`, and so instead using the actual default from https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_flags, `Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE`. 

https://docs.python.org/3/c-api/typeobj.html#c.Py_TPFLAGS_BASETYPE
> **Py_TPFLAGS_BASETYPE**
> This bit is set when the type can be used as the base type of another type. If this bit is clear, the type cannot be subtyped (similar to a “final” class in Java).

I don't think we really need to specify that they can't be subtyped.