### PR TITLE
Updated libimagequant to 4.3.4 on Windows

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -116,6 +116,7 @@ V = {
     "HARFBUZZ": "10.2.0",
     "JPEGTURBO": "3.1.0",
     "LCMS2": "2.16",
+    "LIBIMAGEQUANT": "4.3.4",
     "LIBPNG": "1.6.46",
     "LIBWEBP": "1.5.0",
     "OPENJPEG": "2.5.3",
@@ -335,24 +336,15 @@ DEPS: dict[str, dict[str, Any]] = {
         "libs": [r"bin\*.lib"],
     },
     "libimagequant": {
-        # commit: Merge branch 'master' into msvc (matches 2.17.0 tag)
-        "url": "https://github.com/ImageOptim/libimagequant/archive/e4c1334be0eff290af5e2b4155057c2953a313ab.zip",
-        "filename": "libimagequant-e4c1334be0eff290af5e2b4155057c2953a313ab.zip",
+        "url": "https://github.com/ImageOptim/libimagequant/archive/{V['LIBIMAGEQUANT']}.tar.gz",
+        "filename": f"libimagequant-{V['LIBIMAGEQUANT']}.tar.gz",
         "license": "COPYRIGHT",
-        "patch": {
-            "CMakeLists.txt": {
-                "if(OPENMP_FOUND)": "if(false)",
-                "install": "#install",
-                # libimagequant does not detect MSVC x86_arm64 cross-compiler correctly
-                "if(${{CMAKE_SYSTEM_PROCESSOR}} STREQUAL ARM64)": "if({architecture} STREQUAL ARM64)",  # noqa: E501
-            }
-        },
         "build": [
-            *cmds_cmake("imagequant_a"),
-            cmd_copy("imagequant_a.lib", "imagequant.lib"),
+            cmd_cd("imagequant-sys"),
+            "cargo build --release",
         ],
-        "headers": [r"*.h"],
-        "libs": [r"imagequant.lib"],
+        "headers": ["libimagequant.h"],
+        "libs": [r"..\target\release\imagequant_sys.lib"],
     },
     "harfbuzz": {
         "url": f"https://github.com/harfbuzz/harfbuzz/archive/{V['HARFBUZZ']}.zip",


### PR DESCRIPTION
Update our Windows build from 2.16.0 on the 'msvc' branch of libimagequant (which hasn't been updated in three years) to 4.3.4 on the 'main' branch.