### PR TITLE
Only crop GIF frames when saving with disposal method 2 if transparency is present

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -762,6 +762,21 @@ def test_dispose2_previous_frame(tmp_path: Path) -> None:
         assert im.getpixel((0, 0)) == (0, 0, 0, 255)
 
 
+def test_dispose2_without_transparency(tmp_path: Path) -> None:
+    out = str(tmp_path / "temp.gif")
+
+    im = Image.new("P", (100, 100))
+
+    im2 = Image.new("P", (100, 100), (0, 0, 0))
+    im2.putpixel((50, 50), (255, 0, 0))
+
+    im.save(out, save_all=True, append_images=[im2], disposal=2)
+
+    with Image.open(out) as reloaded:
+        reloaded.seek(1)
+        assert reloaded.tile[0].extents == (0, 0, 100, 100)
+
+
 def test_transparency_in_second_frame(tmp_path: Path) -> None:
     out = str(tmp_path / "temp.gif")
     with Image.open("Tests/images/different_transparency.gif") as im:

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -689,16 +689,21 @@ def _write_multiple_frames(
                         im_frames[-1].encoderinfo["duration"] += encoderinfo["duration"]
                     continue
                 if im_frames[-1].encoderinfo.get("disposal") == 2:
-                    if background_im is None:
-                        color = im.encoderinfo.get(
-                            "transparency", im.info.get("transparency", (0, 0, 0))
-                        )
-                        background = _get_background(im_frame, color)
-                        background_im = Image.new("P", im_frame.size, background)
-                        first_palette = im_frames[0].im.palette
-                        assert first_palette is not None
-                        background_im.putpalette(first_palette, first_palette.mode)
-                    bbox = _getbbox(background_im, im_frame)[1]
+                    # To appear correctly in viewers using a convention,
+                    # only consider transparency, and not background color
+                    color = im.encoderinfo.get(
+                        "transparency", im.info.get("transparency")
+                    )
+                    if color is not None:
+                        if background_im is None:
+                            background = _get_background(im_frame, color)
+                            background_im = Image.new("P", im_frame.size, background)
+                            first_palette = im_frames[0].im.palette
+                            assert first_palette is not None
+                            background_im.putpalette(first_palette, first_palette.mode)
+                        bbox = _getbbox(background_im, im_frame)[1]
+                    else:
+                        bbox = (0, 0) + im_frame.size
                 elif encoderinfo.get("optimize") and im_frame.mode != "1":
                     if "transparency" not in encoderinfo:
                         assert im_frame.palette is not None
@@ -764,7 +769,8 @@ def _write_multiple_frames(
             if not palette:
                 frame_data.encoderinfo["include_color_table"] = True
 
-            im_frame = im_frame.crop(frame_data.bbox)
+            if frame_data.bbox != (0, 0) + im_frame.size:
+                im_frame = im_frame.crop(frame_data.bbox)
             offset = frame_data.bbox[:2]
         _write_frame_data(fp, im_frame, offset, frame_data.encoderinfo)
     return True


### PR DESCRIPTION
Resolves #8746

When GIF frames are saved, Pillow crops out parts of frames i order to save space.

In #5557, I found https://legacy.imagemagick.org/Usage/anim_basics/#dispose. In the 'Dispose Background' section (a.k.a. disposal method 2), it states that
> As you can see as each overlaid frame is disposed of, that frames area is cleared to transparency, before the next image is overlaid.
> ...
> There is some thinking that rather than clearing the overlaid area to the transparent color, this disposal should clear it to the 'background' color meta-data setting stored in the GIF animation. In fact the old "Netscape" browser (version 2 and 3), did exactly that. But then it also failed to implement the 'Previous' dispose method correctly.
> On the other hand the initial canvas should also be set from the formats 'background' color too, and that is also not done. However all modern web browsers clear just the area that was last overlaid to transparency, as such this is now accepted practice, and what IM now follows.

So there is apparently a convention to clear to transparency for disposal method 2, rather than the background colour as described by the specification. The new issue has found this to be a problem with our saved GIFs.

To fix this, when saving with disposal method 2, this PR will only crop if there is transparency.