### PR TITLE
Remove unused `bdf_slant` and `bdf_spacing` variables

### DIFF
--- a/src/PIL/BdfFontFile.py
+++ b/src/PIL/BdfFontFile.py
@@ -26,17 +26,6 @@ from typing import BinaryIO
 
 from . import FontFile, Image
 
-bdf_slant = {
-    "R": "Roman",
-    "I": "Italic",
-    "O": "Oblique",
-    "RI": "Reverse Italic",
-    "RO": "Reverse Oblique",
-    "OT": "Other",
-}
-
-bdf_spacing = {"P": "Proportional", "M": "Monospaced", "C": "Cell"}
-
 
 def bdf_char(
     f: BinaryIO,


### PR DESCRIPTION
Present since the 2010 PIL fork: https://github.com/python-pillow/Pillow/commit/9a640e3157150e35f17354517e8c6304fc428060

Commented out in 2015: https://github.com/python-pillow/Pillow/commit/cfaf95a5a44f21a1d30d84316bd74094c0b3494f https://github.com/python-pillow/Pillow/pull/1530

Commented-out code removed in 2018: https://github.com/python-pillow/Pillow/commit/37f10651bdd97df4ea907b772ead24d1c8efcea6 https://github.com/python-pillow/Pillow/pull/3333
