### PR TITLE
Don't call `make clean` or `pip` in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,12 +11,8 @@ deps =
 extras =
     tests
 commands =
-    make clean
-    {envpython} -m pip install .
     {envpython} selftest.py
     {envpython} -m pytest -W always {posargs}
-allowlist_externals =
-    make
 
 [testenv:lint]
 skip_install = true


### PR DESCRIPTION
https://github.com/tox-dev/tox-uv is a tox plugin that uses uv instead of pip. By default, it doesn't install pip into the tox virtualenv.

We don't actually need to call `pip install .` here, because tox itself installs Pillow into its virtualenv.

And we don't need to run `make clean` either, because again tox installs into its own virtualenv, and the .so files are found at paths like:

```
./.tox/py313/lib/python3.13/site-packages/PIL/_imagingmath.cpython-313-darwin.so
./.tox/py313/lib/python3.13/site-packages/PIL/_imaging.cpython-313-darwin.so
./.tox/py313/lib/python3.13/site-packages/PIL/_webp.cpython-313-darwin.so
./.tox/py313/lib/python3.13/site-packages/PIL/_imagingcms.cpython-313-darwin.so
./.tox/py313/lib/python3.13/site-packages/PIL/_imagingft.cpython-313-darwin.so
./.tox/py313/lib/python3.13/site-packages/PIL/_imagingmorph.cpython-313-darwin.so
./.tox/py313/lib/python3.13/site-packages/PIL/_imagingtk.cpython-313-darwin.so
```

And not like these that `pip install .` creates:

```
./build/lib.macosx-10.13-universal2-cpython-313/PIL/_imagingmath.cpython-313-darwin.so
./build/lib.macosx-10.13-universal2-cpython-313/PIL/_imaging.cpython-313-darwin.so
./build/lib.macosx-10.13-universal2-cpython-313/PIL/_webp.cpython-313-darwin.so
./build/lib.macosx-10.13-universal2-cpython-313/PIL/_imagingcms.cpython-313-darwin.so
./build/lib.macosx-10.13-universal2-cpython-313/PIL/_imagingft.cpython-313-darwin.so
./build/lib.macosx-10.13-universal2-cpython-313/PIL/_imagingmorph.cpython-313-darwin.so
./build/lib.macosx-10.13-universal2-cpython-313/PIL/_imagingtk.cpython-313-darwin.so
```
