### PR TITLE
Remove debug `Image._wedge`

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1348,7 +1348,7 @@ def test_save_I(tmp_path: Path) -> None:
 def test_getdata(monkeypatch: pytest.MonkeyPatch) -> None:
     # Test getheader/getdata against legacy values.
     # Create a 'P' image with holes in the palette.
-    im = Image._wedge().resize((16, 16), Image.Resampling.NEAREST)
+    im = Image.linear_gradient(mode="L").resize((16, 16), Image.Resampling.NEAREST)
     im.putpalette(ImagePalette.ImagePalette("RGB"))
     im.info = {"background": 0}
 

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -34,12 +34,12 @@ def test_sanity() -> None:
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file() -> None:
-    def open() -> None:
+    def open_test_image() -> None:
         im = Image.open(TEST_GIF)
         im.load()
 
     with pytest.warns(ResourceWarning):
-        open()
+        open_test_image()
 
 
 def test_closed_file() -> None:

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -22,9 +22,6 @@ from .helper import (
 # sample gif stream
 TEST_GIF = "Tests/images/hopper.gif"
 
-with open(TEST_GIF, "rb") as f:
-    data = f.read()
-
 
 def test_sanity() -> None:
     with Image.open(TEST_GIF) as im:

--- a/Tests/test_format_hsv.py
+++ b/Tests/test_format_hsv.py
@@ -22,28 +22,26 @@ def test_sanity() -> None:
     Image.new("HSV", (100, 100))
 
 
-def wedge() -> Image.Image:
-    w = Image._wedge()
-    w90 = w.rotate(90)
+def linear_gradient() -> Image.Image:
+    im = Image.linear_gradient(mode="L")
+    im90 = im.rotate(90)
 
-    (px, h) = w.size
+    (px, h) = im.size
 
     r = Image.new("L", (px * 3, h))
     g = r.copy()
     b = r.copy()
 
-    r.paste(w, (0, 0))
-    r.paste(w90, (px, 0))
+    r.paste(im, (0, 0))
+    r.paste(im90, (px, 0))
 
-    g.paste(w90, (0, 0))
-    g.paste(w, (2 * px, 0))
+    g.paste(im90, (0, 0))
+    g.paste(im, (2 * px, 0))
 
-    b.paste(w, (px, 0))
-    b.paste(w90, (2 * px, 0))
+    b.paste(im, (px, 0))
+    b.paste(im90, (2 * px, 0))
 
-    img = Image.merge("RGB", (r, g, b))
-
-    return img
+    return Image.merge("RGB", (r, g, b))
 
 
 def to_xxx_colorsys(
@@ -79,8 +77,8 @@ def to_rgb_colorsys(im: Image.Image) -> Image.Image:
     return to_xxx_colorsys(im, colorsys.hsv_to_rgb, "RGB")
 
 
-def test_wedge() -> None:
-    src = wedge().resize((3 * 32, 32), Image.Resampling.BILINEAR)
+def test_linear_gradient() -> None:
+    src = linear_gradient().resize((3 * 32, 32), Image.Resampling.BILINEAR)
     im = src.convert("HSV")
     comparable = to_hsv_colorsys(src)
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2996,15 +2996,6 @@ class ImageTransformHandler:
 # --------------------------------------------------------------------
 # Factories
 
-#
-# Debugging
-
-
-def _wedge() -> Image:
-    """Create grayscale wedge (for debugging only)"""
-
-    return Image()._new(core.wedge("L"))
-
 
 def _check_size(size: Any) -> None:
     """

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -4256,7 +4256,6 @@ static PyMethodDef functions[] = {
     {"effect_noise", (PyCFunction)_effect_noise, METH_VARARGS},
     {"linear_gradient", (PyCFunction)_linear_gradient, METH_VARARGS},
     {"radial_gradient", (PyCFunction)_radial_gradient, METH_VARARGS},
-    {"wedge", (PyCFunction)_linear_gradient, METH_VARARGS}, /* Compatibility */
 
     /* Drawing support stuff */
     {"font", (PyCFunction)_font_new, METH_VARARGS},


### PR DESCRIPTION
The Python `Image._wedge` function is marked as "for debugging only".

The C `wedge` function does the same as the C `linear_gradient` function.

We call the Python `Image._wedge()` twice in tests. Both of these can be replaced with `Image.linear_gradient(mode="L")`.

Also a bit of test code cleanup:

* The global `data` variable isn't used in tests, let's remove it and save a redundant file load
* Rename an `open()` helper so as not to shadow the builtin
