### PR TITLE
Add PyPy3.11 to CI

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -2,12 +2,12 @@
 
 aptget_update()
 {
-    if [ ! -z $1 ]; then
+    if [ -n "$1" ]; then
         echo ""
         echo "Retrying apt-get update..."
         echo ""
     fi
-    output=`sudo apt-get update 2>&1`
+    output=$(sudo apt-get update 2>&1)
     echo "$output"
     if [[ $output == *[WE]:\ * ]]; then
         return 1

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.10", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["pypy3.11", "pypy3.10", "3.10", "3.11", "3.12", "3.13", "3.14"]
         architecture: ["x64"]
         os: ["windows-latest"]
         include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
           "ubuntu-latest",
         ]
         python-version: [
+          "pypy3.11",
           "pypy3.10",
           "3.14",
           "3.13t",


### PR DESCRIPTION
PyPy v7.3.18 is out:

> This release includes a python 3.11 interpreter. We are labelling it "beta" because it is the first one. In the next release we will drop 3.10 and remove the "beta" label. 

https://pypy.org/posts/2025/02/pypy-v7318-release.html

---

https://github.com/python-pillow/Pillow/pull/8757 already updated `src/thirdparty/pythoncapi_compat.h`, this is how it looked without it:

https://github.com/hugovk/Pillow/actions/runs/13203645421/job/36861505207

We also need to skip NumPy for now:

```
      [288/320] Compiling C object numpy/random/_mt19937.pypy311-pp73-darwin.so.p/meson-generated_numpy_random__mt19937.pyx.c.o
      FAILED: numpy/random/_mt19937.pypy311-pp73-darwin.so.p/meson-generated_numpy_random__mt19937.pyx.c.o
      cc -Inumpy/random/_mt19937.pypy311-pp73-darwin.so.p -Inumpy/random -I../numpy/random -I../numpy/random/src -Inumpy/_core -I../numpy/_core -Inumpy/_core/include -I../numpy/_core/include -I../numpy/_core/src/common -Inumpy -I/Users/runner/hostedtoolcache/PyPy/3.11.11/arm64/include/pypy3.11 -I/private/var/folders/s3/vj2zzxnd01l53jcjc04ljvz80000gn/T/pip-install-maut6y05/numpy_06cedbb72a3e4bbd8e8f8f77a973eb38/.mesonpy-9_4rjp9t/meson_cpu -fvisibility=hidden -fdiagnostics-color=always -DNDEBUG -Wall -Winvalid-pch -std=c11 -O3 -fno-strict-aliasing -ftrapping-math -DNPY_HAVE_CLANG_FPSTRICT -DNPY_HAVE_NEON_VFPV4 -DNPY_HAVE_NEON_FP16 -DNPY_HAVE_NEON -DNPY_HAVE_ASIMD -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DNPY_NO_DEPRECATED_API=0 -MD -MQ numpy/random/_mt19937.pypy311-pp73-darwin.so.p/meson-generated_numpy_random__mt19937.pyx.c.o -MF numpy/random/_mt19937.pypy311-pp73-darwin.so.p/meson-generated_numpy_random__mt19937.pyx.c.o.d -o numpy/random/_mt19937.pypy311-pp73-darwin.so.p/meson-generated_numpy_random__mt19937.pyx.c.o -c numpy/random/_mt19937.pypy311-pp73-darwin.so.p/numpy/random/_mt19937.pyx.c
      numpy/random/_mt19937.pypy311-pp73-darwin.so.p/numpy/random/_mt19937.pyx.c:12442:12: fatal error: 'internal/pycore_frame.h' file not found
        #include "internal/pycore_frame.h"
                 ^~~~~~~~~~~~~~~~~~~~~~~~~
      1 error generated.
      [289/320] Compiling Cython source /private/var/folders/s3/vj2zzxnd01l53jcjc04ljvz80000gn/T/pip-install-maut6y05/numpy_06cedbb72a3e4bbd8e8f8f77a973eb38/numpy/random/_philox.pyx
      [290/320] Compiling C++ object numpy/fft/_pocketfft_umath.pypy311-pp73-darwin.so.p/_pocketfft_umath.cpp.o
      [291/320] Compiling Cython source numpy/random/_bounded_integers.pyx
      [292/320] Compiling Cython source /private/var/folders/s3/vj2zzxnd01l53jcjc04ljvz80000gn/T/pip-install-maut6y05/numpy_06cedbb72a3e4bbd8e8f8f77a973eb38/numpy/random/_common.pyx
      ninja: build stopped: subcommand failed.
```

https://github.com/hugovk/Pillow/actions/runs/13203963591/job/36862554511

---

Also fix some ShellCheck warnings in `.ci/install.sh`.