### PR TITLE
Revert to zlib on macOS < 10.15

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -45,6 +45,7 @@ OPENJPEG_VERSION=2.5.3
 XZ_VERSION=5.6.4
 TIFF_VERSION=4.7.0
 LCMS2_VERSION=2.17
+ZLIB_VERSION=1.3.1
 ZLIB_NG_VERSION=2.2.4
 LIBWEBP_VERSION=1.5.0
 BZIP2_VERSION=1.0.8
@@ -106,7 +107,11 @@ function build {
     if [ -z "$IS_ALPINE" ] && [ -z "$SANITIZER" ] && [ -z "$IS_MACOS" ]; then
         yum remove -y zlib-devel
     fi
-    build_zlib_ng
+    if [[ -n "$IS_MACOS" ]] && [[ "$MACOSX_DEPLOYMENT_TARGET" == "10.10" || "$MACOSX_DEPLOYMENT_TARGET" == "10.13" ]]; then
+        build_new_zlib
+    else
+        build_zlib_ng
+    fi
 
     build_simple xcb-proto 1.17.0 https://xorg.freedesktop.org/archive/individual/proto
     if [ -n "$IS_MACOS" ]; then

--- a/Tests/check_wheel.py
+++ b/Tests/check_wheel.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import platform
 import sys
 
 from PIL import features
+
+from .helper import is_pypy
 
 
 def test_wheel_modules() -> None:
@@ -40,5 +43,7 @@ def test_wheel_features() -> None:
 
     if sys.platform == "win32":
         expected_features.remove("xcb")
+    elif sys.platform == "darwin" and not is_pypy() and platform.processor() != "arm":
+        expected_features.remove("zlib_ng")
 
     assert set(features.get_supported_features()) == expected_features


### PR DESCRIPTION
#8500 switched to zlib-ng in our wheels. However, #8750 has reported that wheels now segfault on macOS 10.13 and 10.14.

https://github.com/zlib-ng/zlib-ng/issues/1877 was created to investigate this, and there is now a proposed fix in https://github.com/zlib-ng/zlib-ng/pull/1878.

However, in case it is not merged and released before Pillow 11.2.0, this PR temporarily reverts to using zlib on macOS < 10.15.