### PR TITLE
_seek_check already raises an EOFError

### DIFF
--- a/src/PIL/MicImagePlugin.py
+++ b/src/PIL/MicImagePlugin.py
@@ -73,12 +73,7 @@ class MicImageFile(TiffImagePlugin.TiffImageFile):
     def seek(self, frame: int) -> None:
         if not self._seek_check(frame):
             return
-        try:
-            filename = self.images[frame]
-        except IndexError as e:
-            msg = "no such frame"
-            raise EOFError(msg) from e
-
+        filename = self.images[frame]
         self.fp = self.ole.openstream(filename)
 
         TiffImagePlugin.TiffImageFile._open(self)

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -169,15 +169,11 @@ class PsdImageFile(ImageFile.ImageFile):
             return
 
         # seek to given layer (1..max)
-        try:
-            _, mode, _, tile = self.layers[layer - 1]
-            self._mode = mode
-            self.tile = tile
-            self.frame = layer
-            self.fp = self._fp
-        except IndexError as e:
-            msg = "no such layer"
-            raise EOFError(msg) from e
+        _, mode, _, tile = self.layers[layer - 1]
+        self._mode = mode
+        self.tile = tile
+        self.frame = layer
+        self.fp = self._fp
 
     def tell(self) -> int:
         # return layer number (0=image, 1..max=layers)


### PR DESCRIPTION
[`_seek_check`](https://github.com/python-pillow/Pillow/blob/d7d48df9af3b6177a62759cb00db391196f91f39/src/PIL/ImageFile.py#L425-L436) raises an `EOFError` if the user seeks outside of the image.

For MicImagePlugin and PsdImagePlugin, the call to that is enough, and no further error catching needs to be done to handle if seek will take us outside of the image - the `EOFError` would only be raised if a user deliberately changed `self.images` (or `self.layers` in the case of PsdImagePlugin).
https://github.com/python-pillow/Pillow/blob/d7d48df9af3b6177a62759cb00db391196f91f39/src/PIL/MicImagePlugin.py#L73-L80