### PR TITLE
Remove mention that 1-bit images use 1 byte per pixel

### DIFF
--- a/docs/handbook/concepts.rst
+++ b/docs/handbook/concepts.rst
@@ -30,7 +30,7 @@ image. Each pixel uses the full range of the bit depth. So a 1-bit pixel has a r
 INT32 and a 32-bit floating point pixel has the range of FLOAT32. The current release
 supports the following standard modes:
 
-    * ``1`` (1-bit pixels, black and white, stored with one pixel per byte)
+    * ``1`` (1-bit pixels, black and white)
     * ``L`` (8-bit pixels, grayscale)
     * ``P`` (8-bit pixels, mapped to any other mode using a color palette)
     * ``RGB`` (3x8-bit pixels, true color)


### PR DESCRIPTION
> (1-bit pixels, black and white, stored with one pixel per byte)

That line in the documentation implies that a 1-bit (W, H)-sized image would occupy W*H bytes in raw form, at least that's how I understand it.

But it doesn't seem to be the case in Pillow 11.1.0:

```pycon
>>> Image.new("1", (3, 2), 1).tobytes()
b'\xe0\xe0'
```

It seems that it now stores strips of (up to) 8 horizontal pixels. Since that line in the documentation was last edited 12 years ago, I guess it was true at the time but the format has been changed for efficiency since. Which is great, but the documentation is misleading.

I suggest to simply remove the 1-byte-per-pixel part.