### PR TITLE
Revert "Do not install libimagequant"

### DIFF
--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -60,6 +60,7 @@ jobs:
               mingw-w64-x86_64-gcc \
               mingw-w64-x86_64-ghostscript \
               mingw-w64-x86_64-lcms2 \
+              mingw-w64-x86_64-libimagequant \
               mingw-w64-x86_64-libjpeg-turbo \
               mingw-w64-x86_64-libraqm \
               mingw-w64-x86_64-libtiff \


### PR DESCRIPTION
Reverts #8724 

After that pull request temporarily removed mingw-w64-x86_64-libimagequant, I created https://github.com/msys2/MINGW-packages/issues/23316. That lead to https://github.com/msys2/MINGW-packages/pull/23387, and that fix has now propagated.