### PR TITLE
JPEG comments are from the COM marker

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -454,7 +454,8 @@ The :py:meth:`~PIL.Image.open` method may set the following
     Raw EXIF data from the image.
 
 **comment**
-    A comment about the image.
+    A comment about the image, from the COM marker. This is separate from the
+    UserComment tag that may be stored in the EXIF data.
 
     .. versionadded:: 7.1.0
 


### PR DESCRIPTION
Requested in https://github.com/python-pillow/Pillow/issues/8787#issuecomment-2692681329 - a note in the documentation that JpegImagePlugin's `info["comment"]` is from the COM marker

https://github.com/python-pillow/Pillow/blob/bcdb68823330a527b88f6315ce4d7a68a8275320/src/PIL/JpegImagePlugin.py#L173-L179

and that this is distinct from the `UserComment` EXIF tag.

https://github.com/python-pillow/Pillow/blob/bcdb68823330a527b88f6315ce4d7a68a8275320/src/PIL/ExifTags.py#L157