### PR TITLE
Build PyPy3.11 wheel for macOS 10.15 x86_64

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -63,7 +63,7 @@ jobs:
           - name: "macOS 10.15 x86_64"
             os: macos-13
             cibw_arch: x86_64
-            build: "pp310*"
+            build: "pp3*"
             macosx_deployment_target: "10.15"
           - name: "macOS arm64"
             os: macos-latest


### PR DESCRIPTION
cibuildwheel v2.23.0 (https://github.com/python-pillow/Pillow/pull/8785) now also builds PyPy3.11 (https://github.com/pypa/cibuildwheel/releases/tag/v2.23.0).

https://github.com/python-pillow/Pillow/actions/runs/13608693136 created PyPy3.10 and 3.11 wheels for all:

```
./dist-ubuntu-24.04-arm-aarch64/pillow-11.2.0.dev0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
./dist-ubuntu-24.04-arm-aarch64/pillow-11.2.0.dev0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
./dist-ubuntu-latest-x86_64-manylinux_2_28/pillow-11.2.0.dev0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl
./dist-ubuntu-latest-x86_64-manylinux_2_28/pillow-11.2.0.dev0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl
./dist-ubuntu-24.04-arm-aarch64-manylinux_2_28/pillow-11.2.0.dev0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl
./dist-ubuntu-24.04-arm-aarch64-manylinux_2_28/pillow-11.2.0.dev0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl
./dist-macos-latest-11.0-arm64/pillow-11.2.0.dev0-pp310-pypy310_pp73-macosx_11_0_arm64.whl
./dist-macos-latest-11.0-arm64/pillow-11.2.0.dev0-pp311-pypy311_pp73-macosx_11_0_arm64.whl
./dist-windows-AMD64/pillow-11.2.0.dev0-pp310-pypy310_pp73-win_amd64.whl
./dist-windows-AMD64/pillow-11.2.0.dev0-pp311-pypy311_pp73-win_amd64.whl
./dist-ubuntu-latest-x86_64/pillow-11.2.0.dev0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
./dist-ubuntu-latest-x86_64/pillow-11.2.0.dev0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
./dist-macos-13-10.15-x86_64/pillow-11.2.0.dev0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl
```

We already exclude PyPy3.9 explicitly, so we can make change this macOS 10.15 x86_64 wildcard from `pp310*` to `pp3*`.

This then also builds this wheel:
```
./dist-macos-13-10.15-x86_64/pillow-11.2.0.dev0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl
```
