### PR TITLE
Fixed loading GD images

### DIFF
--- a/Tests/test_file_gd.py
+++ b/Tests/test_file_gd.py
@@ -4,6 +4,8 @@ import pytest
 
 from PIL import GdImageFile, UnidentifiedImageError
 
+from .helper import assert_image_similar_tofile
+
 TEST_GD_FILE = "Tests/images/hopper.gd"
 
 
@@ -11,6 +13,7 @@ def test_sanity() -> None:
     with GdImageFile.open(TEST_GD_FILE) as im:
         assert im.size == (128, 128)
         assert im.format == "GD"
+        assert_image_similar_tofile(im.convert("RGB"), "Tests/images/hopper.jpg", 14)
 
 
 def test_bad_mode() -> None:

--- a/src/PIL/GdImageFile.py
+++ b/src/PIL/GdImageFile.py
@@ -56,7 +56,7 @@ class GdImageFile(ImageFile.ImageFile):
             msg = "Not a valid GD 2.x .gd file"
             raise SyntaxError(msg)
 
-        self._mode = "L"  # FIXME: "P"
+        self._mode = "P"
         self._size = i16(s, 2), i16(s, 4)
 
         true_color = s[6]
@@ -68,14 +68,14 @@ class GdImageFile(ImageFile.ImageFile):
             self.info["transparency"] = tindex
 
         self.palette = ImagePalette.raw(
-            "XBGR", s[7 + true_color_offset + 4 : 7 + true_color_offset + 4 + 256 * 4]
+            "RGBX", s[7 + true_color_offset + 6 : 7 + true_color_offset + 6 + 256 * 4]
         )
 
         self.tile = [
             ImageFile._Tile(
                 "raw",
                 (0, 0) + self.size,
-                7 + true_color_offset + 4 + 256 * 4,
+                7 + true_color_offset + 6 + 256 * 4,
                 "L",
             )
         ]


### PR DESCRIPTION
Currently,
```python
from PIL import GdImageFile
with GdImageFile.open("Tests/images/hopper.gd") as im:
  im.save("out.png")
```
gives
![before](https://github.com/user-attachments/assets/6a9d5b4e-8703-4507-acfb-5fc5b796fce5)

With this PR, it gives
![after](https://github.com/user-attachments/assets/c476d990-1c9a-4c2f-8265-0887b215e1b7)