### PR TITLE
Call `startswith`/`endswith` once with a tuple, and `range` without `start=0`

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -601,7 +601,7 @@ def test_save_dispose(tmp_path: Path) -> None:
         Image.new("L", (100, 100), "#111"),
         Image.new("L", (100, 100), "#222"),
     ]
-    for method in range(0, 4):
+    for method in range(4):
         im_list[0].save(out, save_all=True, append_images=im_list[1:], disposal=method)
         with Image.open(out) as img:
             for _ in range(2):

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -231,7 +231,7 @@ class TestFileWebp:
 
         with Image.open(out_gif) as reread:
             reread_value = reread.convert("RGB").getpixel((1, 1))
-        difference = sum(abs(original_value[i] - reread_value[i]) for i in range(0, 3))
+        difference = sum(abs(original_value[i] - reread_value[i]) for i in range(3))
         assert difference < 5
 
     def test_duration(self, tmp_path: Path) -> None:

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -1044,8 +1044,8 @@ def create_base_image_draw(
     background2: tuple[int, int, int] = GRAY,
 ) -> tuple[Image.Image, ImageDraw.ImageDraw]:
     img = Image.new(mode, size, background1)
-    for x in range(0, size[0]):
-        for y in range(0, size[1]):
+    for x in range(size[0]):
+        for y in range(size[1]):
             if (x + y) % 2 == 0:
                 img.putpixel((x, y), background2)
     return img, ImageDraw.Draw(img)

--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -112,7 +112,7 @@ def test_make_linear_lut() -> None:
     assert isinstance(lut, list)
     assert len(lut) == 256
     # Check values
-    for i in range(0, len(lut)):
+    for i in range(len(lut)):
         assert lut[i] == i
 
 

--- a/Tests/test_imagesequence.py
+++ b/Tests/test_imagesequence.py
@@ -32,7 +32,7 @@ def test_sanity(tmp_path: Path) -> None:
 def test_iterator() -> None:
     with Image.open("Tests/images/multipage.tiff") as im:
         i = ImageSequence.Iterator(im)
-        for index in range(0, im.n_frames):
+        for index in range(im.n_frames):
             assert i[index] == next(i)
         with pytest.raises(IndexError):
             i[index + 1]

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -65,7 +65,7 @@ def helper_pickle_string(protocol: int, test_file: str, mode: str | None) -> Non
         ("Tests/images/itxt_chunks.png", None),
     ],
 )
-@pytest.mark.parametrize("protocol", range(0, pickle.HIGHEST_PROTOCOL + 1))
+@pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL + 1))
 def test_pickle_image(
     tmp_path: Path, test_file: str, test_mode: str | None, protocol: int
 ) -> None:
@@ -92,7 +92,7 @@ def test_pickle_la_mode_with_palette(tmp_path: Path) -> None:
         im = im.convert("PA")
 
     # Act / Assert
-    for protocol in range(0, pickle.HIGHEST_PROTOCOL + 1):
+    for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
         im._mode = "LA"
         with open(filename, "wb") as f:
             pickle.dump(im, f, protocol)
@@ -133,7 +133,7 @@ def helper_assert_pickled_font_images(
 
 
 @skip_unless_feature("freetype2")
-@pytest.mark.parametrize("protocol", list(range(0, pickle.HIGHEST_PROTOCOL + 1)))
+@pytest.mark.parametrize("protocol", list(range(pickle.HIGHEST_PROTOCOL + 1)))
 def test_pickle_font_string(protocol: int) -> None:
     # Arrange
     font = ImageFont.truetype(FONT_PATH, FONT_SIZE)
@@ -147,7 +147,7 @@ def test_pickle_font_string(protocol: int) -> None:
 
 
 @skip_unless_feature("freetype2")
-@pytest.mark.parametrize("protocol", list(range(0, pickle.HIGHEST_PROTOCOL + 1)))
+@pytest.mark.parametrize("protocol", list(range(pickle.HIGHEST_PROTOCOL + 1)))
 def test_pickle_font_file(tmp_path: Path, protocol: int) -> None:
     # Arrange
     font = ImageFont.truetype(FONT_PATH, FONT_SIZE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ lint.select = [
   "ISC",    # flake8-implicit-str-concat
   "LOG",    # flake8-logging
   "PGH",    # pygrep-hooks
+  "PIE",    # flake8-pie
   "PT",     # flake8-pytest-style
   "PYI",    # flake8-pyi
   "RUF100", # unused noqa (yesqa)
@@ -133,6 +134,7 @@ lint.ignore = [
   "E221",   # Multiple spaces before operator
   "E226",   # Missing whitespace around arithmetic operator
   "E241",   # Multiple spaces after ','
+  "PIE790", # flake8-pie: unnecessary-placeholder
   "PT001",  # pytest-fixture-incorrect-parentheses-style
   "PT007",  # pytest-parametrize-values-wrong-type
   "PT011",  # pytest-raises-too-broad

--- a/src/PIL/IcnsImagePlugin.py
+++ b/src/PIL/IcnsImagePlugin.py
@@ -123,8 +123,7 @@ def read_png_or_jpeg2000(
         Image._decompression_bomb_check(im.size)
         return {"RGBA": im}
     elif (
-        sig.startswith(b"\xff\x4f\xff\x51")
-        or sig.startswith(b"\x0d\x0a\x87\x0a")
+        sig.startswith((b"\xff\x4f\xff\x51", b"\x0d\x0a\x87\x0a"))
         or sig == b"\x00\x00\x00\x0cjP  \x0d\x0a\x87\x0a"
     ):
         if not enable_jpeg2k:

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1001,7 +1001,7 @@ class Image:
                 elif len(mode) == 3:
                     transparency = tuple(
                         convert_transparency(matrix[i * 4 : i * 4 + 4], transparency)
-                        for i in range(0, len(transparency))
+                        for i in range(len(transparency))
                     )
                 new_im.info["transparency"] = transparency
             return new_im
@@ -4003,7 +4003,7 @@ class Exif(_ExifBase):
                         ifd_data = tag_data[ifd_offset:]
 
                         makernote = {}
-                        for i in range(0, struct.unpack("<H", ifd_data[:2])[0]):
+                        for i in range(struct.unpack("<H", ifd_data[:2])[0]):
                             ifd_tag, typ, count, data = struct.unpack(
                                 "<HHL4s", ifd_data[i * 12 + 2 : (i + 1) * 12 + 2]
                             )
@@ -4038,7 +4038,7 @@ class Exif(_ExifBase):
                         self._ifds[tag] = dict(self._fixup_dict(makernote))
                     elif self.get(0x010F) == "Nintendo":
                         makernote = {}
-                        for i in range(0, struct.unpack(">H", tag_data[:2])[0]):
+                        for i in range(struct.unpack(">H", tag_data[:2])[0]):
                             ifd_tag, typ, count, data = struct.unpack(
                                 ">HHL4s", tag_data[i * 12 + 2 : (i + 1) * 12 + 2]
                             )

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -1204,7 +1204,7 @@ def _compute_regular_polygon_vertices(
         degrees = 360 / n_sides
         # Start with the bottom left polygon vertex
         current_angle = (270 - 0.5 * degrees) + rotation
-        for _ in range(0, n_sides):
+        for _ in range(n_sides):
             angles.append(current_angle)
             current_angle += degrees
             if current_angle > 360:
@@ -1227,4 +1227,4 @@ def _color_diff(
     first = color1 if isinstance(color1, tuple) else (color1,)
     second = color2 if isinstance(color2, tuple) else (color2,)
 
-    return sum(abs(first[i] - second[i]) for i in range(0, len(second)))
+    return sum(abs(first[i] - second[i]) for i in range(len(second)))

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -213,14 +213,14 @@ def colorize(
     blue = []
 
     # Create the low-end values
-    for i in range(0, blackpoint):
+    for i in range(blackpoint):
         red.append(rgb_black[0])
         green.append(rgb_black[1])
         blue.append(rgb_black[2])
 
     # Create the mapping (2-color)
     if rgb_mid is None:
-        range_map = range(0, whitepoint - blackpoint)
+        range_map = range(whitepoint - blackpoint)
 
         for i in range_map:
             red.append(
@@ -235,8 +235,8 @@ def colorize(
 
     # Create the mapping (3-color)
     else:
-        range_map1 = range(0, midpoint - blackpoint)
-        range_map2 = range(0, whitepoint - midpoint)
+        range_map1 = range(midpoint - blackpoint)
+        range_map2 = range(whitepoint - midpoint)
 
         for i in range_map1:
             red.append(
@@ -256,7 +256,7 @@ def colorize(
             blue.append(rgb_mid[2] + i * (rgb_white[2] - rgb_mid[2]) // len(range_map2))
 
     # Create the high-end values
-    for i in range(0, 256 - whitepoint):
+    for i in range(256 - whitepoint):
         red.append(rgb_white[0])
         green.append(rgb_white[1])
         blue.append(rgb_white[2])

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -569,7 +569,7 @@ def _getmp(self: JpegImageFile) -> dict[int, Any] | None:
     mpentries = []
     try:
         rawmpentries = mp[0xB002]
-        for entrynum in range(0, quant):
+        for entrynum in range(quant):
             unpackedentry = struct.unpack_from(
                 f"{endianness}LLLHH", rawmpentries, entrynum * 16
             )

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1584,7 +1584,7 @@ class TiffImageFile(ImageFile.ImageFile):
             # byte order.
             elif rawmode == "I;16":
                 rawmode = "I;16N"
-            elif rawmode.endswith(";16B") or rawmode.endswith(";16L"):
+            elif rawmode.endswith((";16B", ";16L")):
                 rawmode = rawmode[:-1] + "N"
 
             # Offset in the tile tuple is 0, we go from 0,0 to


### PR DESCRIPTION
Some small cleanups found with https://docs.astral.sh/ruff/rules/#flake8-pie-pie.