### PR TITLE
Do not allow coords to be sequence of lists

### DIFF
--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -802,14 +802,10 @@ def test_rectangle_translucent_outline(bbox: Coords) -> None:
 
 @pytest.mark.parametrize(
     "xy",
-    [(10, 20, 190, 180), ([10, 20], [190, 180]), ((10, 20), (190, 180))],
+    [(10, 20, 190, 180), ((10, 20), (190, 180))],
 )
 def test_rounded_rectangle(
-    xy: (
-        tuple[int, int, int, int]
-        | tuple[list[int]]
-        | tuple[tuple[int, int], tuple[int, int]]
-    ),
+    xy: tuple[int, int, int, int] | tuple[tuple[int, int], tuple[int, int]],
 ) -> None:
     # Arrange
     im = Image.new("RGB", (200, 200))

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -244,12 +244,12 @@ class ImageDraw:
         if ink is not None:
             self.draw.draw_lines(xy, ink, width)
             if joint == "curve" and width > 4:
-                points: Sequence[Sequence[float]]
-                if isinstance(xy[0], (list, tuple)):
-                    points = cast(Sequence[Sequence[float]], xy)
+                points: Sequence[tuple[float, ...]]
+                if isinstance(xy[0], tuple):
+                    points = cast(Sequence[tuple[float, ...]], xy)
                 else:
                     points = [
-                        cast(Sequence[float], tuple(xy[i : i + 2]))
+                        tuple(cast(Sequence[float], xy)[i : i + 2])
                         for i in range(0, len(xy), 2)
                     ]
                 for i in range(1, len(points) - 1):

--- a/src/PIL/_typing.py
+++ b/src/PIL/_typing.py
@@ -37,7 +37,7 @@ else:
                 return bool
 
 
-Coords = Union[Sequence[float], Sequence[Sequence[float]]]
+Coords = Union[Sequence[float], Sequence[tuple[float, ...]]]
 
 
 _T_co = TypeVar("_T_co", covariant=True)


### PR DESCRIPTION
Resolves #8798. Alternative to #8800

Restricts
https://github.com/python-pillow/Pillow/blob/c7ed097dd13ec5229c4e4875b170e41e6fdc8249/src/PIL/_typing.py#L40
so that sequences of lists are not allowed.

Only one test had to be updated, from #5208. I see no reason why I tested a sequence of lists in that PR. It isn't suggested in the [docs.](https://pillow.readthedocs.io/en/stable/reference/ImageDraw.html#PIL.ImageDraw.ImageDraw.rounded_rectangle)