### PR TITLE
Use ABCMeta in classes with abstractmethod

### DIFF
--- a/src/PIL/BlpImagePlugin.py
+++ b/src/PIL/BlpImagePlugin.py
@@ -291,7 +291,7 @@ class BlpImageFile(ImageFile.ImageFile):
         self.tile = [ImageFile._Tile(decoder, (0, 0) + self.size, offset, args)]
 
 
-class _BLPBaseDecoder(ImageFile.PyDecoder):
+class _BLPBaseDecoder(abc.ABC, ImageFile.PyDecoder):
     _pulls_fd = True
 
     def decode(self, buffer: bytes | Image.SupportsArrayInterface) -> tuple[int, int]:

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2966,7 +2966,7 @@ class Image:
 # Abstract handlers.
 
 
-class ImagePointHandler:
+class ImagePointHandler(abc.ABC):
     """
     Used as a mixin by point transforms
     (for use with :py:meth:`~PIL.Image.Image.point`)
@@ -2977,7 +2977,7 @@ class ImagePointHandler:
         pass
 
 
-class ImageTransformHandler:
+class ImageTransformHandler(abc.ABC):
     """
     Used as a mixin by geometry transforms
     (for use with :py:meth:`~PIL.Image.Image.transform`)

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -438,7 +438,7 @@ class ImageFile(Image.Image):
         return self.tell() != frame
 
 
-class StubHandler:
+class StubHandler(abc.ABC):
     def open(self, im: StubImageFile) -> None:
         pass
 

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -447,7 +447,7 @@ class StubHandler(abc.ABC):
         pass
 
 
-class StubImageFile(ImageFile):
+class StubImageFile(ImageFile, metaclass=abc.ABCMeta):
     """
     Base class for stub image loaders.
 
@@ -455,9 +455,9 @@ class StubImageFile(ImageFile):
     certain format, but relies on external code to load the file.
     """
 
+    @abc.abstractmethod
     def _open(self) -> None:
-        msg = "StubImageFile subclass must implement _open"
-        raise NotImplementedError(msg)
+        pass
 
     def load(self) -> Image.core.PixelAccess | None:
         loader = self._load()
@@ -471,10 +471,10 @@ class StubImageFile(ImageFile):
         self.__dict__ = image.__dict__
         return image.load()
 
+    @abc.abstractmethod
     def _load(self) -> StubHandler | None:
         """(Hook) Find actual image loader."""
-        msg = "StubImageFile subclass must implement _load"
-        raise NotImplementedError(msg)
+        pass
 
 
 class Parser:

--- a/src/PIL/ImageFilter.py
+++ b/src/PIL/ImageFilter.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from ._typing import NumpyArray
 
 
-class Filter:
+class Filter(abc.ABC):
     @abc.abstractmethod
     def filter(self, image: _imaging.ImagingCore) -> _imaging.ImagingCore:
         pass

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -192,7 +192,7 @@ if sys.platform == "darwin":
     register(MacViewer)
 
 
-class UnixViewer(Viewer):
+class UnixViewer(abc.ABC, Viewer):
     format = "PNG"
     options = {"compress_level": 1, "save_all": True}
 


### PR DESCRIPTION
https://docs.python.org/3/library/abc.html#abc.abstractmethod
> **@abc.abstractmethod**
> A decorator indicating abstract methods.
>
> Using this decorator requires that the class’s metaclass is [ABCMeta](https://docs.python.org/3/library/abc.html#abc.ABCMeta) or is derived from it.

This is true. In main,
```pycon
>>> from PIL import Image
>>> Image.ImagePointHandler()
<PIL.Image.ImagePointHandler object at 0x1044f93d0>
```
but once this PR changes the class to inherit from `abc.ABC`,
```pycon
>>> from PIL import Image
>>> Image.ImagePointHandler()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Can't instantiate abstract class ImagePointHandler with abstract method point
```

While I'm here, I'm also going to replace https://github.com/python-pillow/Pillow/blob/75528937923c5b00c71cfef7812925cee3467204/src/PIL/ImageFile.py#L458-L460 and https://github.com/python-pillow/Pillow/blob/75528937923c5b00c71cfef7812925cee3467204/src/PIL/ImageFile.py#L474-L477 with abstract methods.