### PR TITLE
Test using _seek to skip frames

### DIFF
--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -34,8 +34,11 @@ def test_apng_basic() -> None:
         with pytest.raises(EOFError):
             im.seek(2)
 
-        # test rewind support
         im.seek(0)
+        with pytest.raises(ValueError, match="cannot seek to frame 2"):
+            im._seek(2)
+
+        # test rewind support
         assert im.getpixel((0, 0)) == (255, 0, 0, 255)
         assert im.getpixel((64, 32)) == (255, 0, 0, 255)
         im.seek(1)

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -160,6 +160,9 @@ def test_seek() -> None:
 
         assert_image_equal_tofile(im, "Tests/images/a_fli.png")
 
+        with pytest.raises(ValueError, match="cannot seek to frame 52"):
+            im._seek(52)
+
 
 @pytest.mark.parametrize(
     "test_file",

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -410,6 +410,10 @@ def test_seek() -> None:
         except EOFError:
             assert frame_count == 5
 
+        img.seek(0)
+        with pytest.raises(ValueError, match="cannot seek to frame 2"):
+            img._seek(2)
+
 
 def test_seek_info() -> None:
     with Image.open("Tests/images/iss634.gif") as im:


### PR DESCRIPTION
Three formats - [APNG](https://github.com/python-pillow/Pillow/blob/5ba72a9b54bd744724e4ec269268c16dd61bb472/src/PIL/PngImagePlugin.py#L855-L894), [FLI](https://github.com/python-pillow/Pillow/blob/5ba72a9b54bd744724e4ec269268c16dd61bb472/src/PIL/FliImagePlugin.py#L127-L147) and [GIF](https://github.com/python-pillow/Pillow/blob/5ba72a9b54bd744724e4ec269268c16dd61bb472/src/PIL/GifImagePlugin.py#L153-L186) raise an error if `_seek` is called to seek to frame that isn't the next one or the first one.

https://github.com/python-pillow/Pillow/blob/5ba72a9b54bd744724e4ec269268c16dd61bb472/src/PIL/FliImagePlugin.py#L127-L147

`_seek` shouldn't be called by end users, but ensuring it is called in the correct way internally would guard against bugs.