### PR TITLE
Improved FliImagePlugin test coverage

### DIFF
--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import warnings
 
 import pytest
@@ -130,6 +131,15 @@ def test_eoferror() -> None:
 
         # Test that seeking to the last frame does not raise an error
         im.seek(n_frames - 1)
+
+
+def test_missing_frame_size() -> None:
+    with open(animated_test_file, "rb") as fp:
+        data = fp.read()
+    data = data[:6188]
+    with Image.open(io.BytesIO(data)) as im:
+        with pytest.raises(EOFError, match="missing frame size"):
+            im.seek(1)
 
 
 def test_seek_tell() -> None:

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -317,12 +317,12 @@ def test_grayscale_four_channels() -> None:
     with open("Tests/images/rgb_trns_ycbc.jp2", "rb") as fp:
         data = fp.read()
 
-        # Change color space to OPJ_CLRSPC_GRAY
-        data = data[:76] + b"\x11" + data[77:]
+    # Change color space to OPJ_CLRSPC_GRAY
+    data = data[:76] + b"\x11" + data[77:]
 
-        with Image.open(BytesIO(data)) as im:
-            im.load()
-            assert im.mode == "RGBA"
+    with Image.open(BytesIO(data)) as im:
+        im.load()
+        assert im.mode == "RGBA"
 
 
 @pytest.mark.skipif(

--- a/Tests/test_file_pcx.py
+++ b/Tests/test_file_pcx.py
@@ -40,7 +40,7 @@ def test_sanity(tmp_path: Path) -> None:
 def test_bad_image_size() -> None:
     with open("Tests/images/pil184.pcx", "rb") as fp:
         data = fp.read()
-        data = data[:4] + b"\xff\xff" + data[6:]
+    data = data[:4] + b"\xff\xff" + data[6:]
 
     b = io.BytesIO(data)
     with pytest.raises(SyntaxError, match="bad PCX image size"):
@@ -51,7 +51,7 @@ def test_bad_image_size() -> None:
 def test_unknown_mode() -> None:
     with open("Tests/images/pil184.pcx", "rb") as fp:
         data = fp.read()
-        data = data[:3] + b"\xff" + data[4:]
+    data = data[:3] + b"\xff" + data[4:]
 
     b = io.BytesIO(data)
     with pytest.raises(OSError, match="unknown PCX mode"):

--- a/Tests/test_font_bdf.py
+++ b/Tests/test_font_bdf.py
@@ -20,8 +20,8 @@ def test_sanity() -> None:
 def test_zero_width_chars() -> None:
     with open(filename, "rb") as fp:
         data = fp.read()
-        data = data[:2650] + b"\x00\x00" + data[2652:]
-        BdfFontFile.BdfFontFile(io.BytesIO(data))
+    data = data[:2650] + b"\x00\x00" + data[2652:]
+    BdfFontFile.BdfFontFile(io.BytesIO(data))
 
 
 def test_invalid_file() -> None:


### PR DESCRIPTION
Adds coverage for the lines missing at https://app.codecov.io/gh/python-pillow/Pillow/blob/main/src%2FPIL%2FFliImagePlugin.py

While I'm here, I've also updated some tests to move code outside of file handle context managers once we've finished interacting with the file handle.