### PR TITLE
Replace deprecated Renovate schedule with cron syntax

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,6 +16,6 @@
         }
     ],
     "schedule": [
-        "on the 3rd day of the month"
+        "* * 3 * *"
     ]
 }


### PR DESCRIPTION
https://docs.renovatebot.com/key-concepts/scheduling/#deprecated-breejslater-syntax says the wordy Later.js syntax is deprecated:

> This section explains the deprecated `@breejs/later` syntax. We plan to remove the `@breejs/later` library in a future major Renovate release if we can find a way to migrate all valid schedules to cron syntax. Due to this upcoming change, we strongly recommend you use `cron` schedules.

https://docs.renovatebot.com/key-concepts/scheduling/#recommended-cron-syntax says:

> For Cron schedules, you _must_ use the `*` wildcard for the minutes value, as Renovate doesn't support minute granularity. And the cron schedule must have five parts.

https://crontab.guru/#*_*_3_*_* says `* * 3 * *` is:

> “At every minute on day-of-month 3.”
