### PR TITLE
Install libtiff-dev on Ubuntu GitHub Actions

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -20,7 +20,7 @@ fi
 set -e
 
 if [[ $(uname) != CYGWIN* ]]; then
-    sudo apt-get -qq install libfreetype6-dev liblcms2-dev python3-tk\
+    sudo apt-get -qq install libfreetype6-dev liblcms2-dev libtiff-dev python3-tk\
                              ghostscript libjpeg-turbo8-dev libopenjp2-7-dev\
                              cmake meson imagemagick libharfbuzz-dev libfribidi-dev\
                              sway wl-clipboard libopenblas-dev


### PR DESCRIPTION
The Ubuntu jobs in the 'Test' workflow don't currently have libtiff - https://github.com/python-pillow/Pillow/actions/runs/13799845698/job/38599859172#step:11:48