### PR TITLE
DXT3 images are read in RGBA mode

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -68,7 +68,7 @@ by DirectX.
 DXT1 and DXT5 pixel formats can be read, only in ``RGBA`` mode.
 
 .. versionadded:: 3.4.0
-   DXT3 images can be read in ``RGB`` mode and DX10 images can be read in
+   DXT3 images can be read in ``RGBA`` mode and DX10 images can be read in
    ``RGB`` and ``RGBA`` mode.
 
 .. versionadded:: 6.0.0


### PR DESCRIPTION
https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#dds
> Added in version 3.4.0: DXT3 images can be read in RGB mode

This is incorrect. DXT3 images are read in RGBA mode
https://github.com/python-pillow/Pillow/blob/5efcaa460372e91d9d18f2f812f590728903927a/src/PIL/DdsImagePlugin.py#L390-L391
https://github.com/python-pillow/Pillow/blob/5efcaa460372e91d9d18f2f812f590728903927a/Tests/test_file_dds.py#L68-L72

This has been the case since #2068