### PR TITLE
Use docker/setup-qemu-action

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -35,6 +35,10 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         docker: [
+          # Run slower jobs first to give them a headstart and reduce waiting time
+          ubuntu-24.04-noble-ppc64le,
+          ubuntu-24.04-noble-s390x,
+          # Then run the remainder
           alpine,
           amazon-2-amd64,
           amazon-2023-amd64,
@@ -52,13 +56,9 @@ jobs:
         dockerTag: [main]
         include:
           - docker: "ubuntu-24.04-noble-ppc64le"
-            os: "ubuntu-22.04"
             qemu-arch: "ppc64le"
-            dockerTag: main
           - docker: "ubuntu-24.04-noble-s390x"
-            os: "ubuntu-22.04"
             qemu-arch: "s390x"
-            dockerTag: main
           - docker: "ubuntu-24.04-noble-arm64v8"
             os: "ubuntu-24.04-arm"
             dockerTag: main

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -75,8 +75,9 @@ jobs:
 
     - name: Set up QEMU
       if: "matrix.qemu-arch"
-      run: |
-        docker run --rm --privileged aptman/qus -s -- -p ${{ matrix.qemu-arch }}
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: ${{ matrix.qemu-arch }}
 
     - name: Docker pull
       run: |


### PR DESCRIPTION
In January, the ppc64le and s390x jobs started experiencing segfaults. We downgraded the hosts to Ubuntu 22 in #8713, but the segfaults have started happening again since then. I presumed a fix would eventually occur upstream, but it's been a while and we're approaching a release.

This is a suggestion to switch from
```
docker run --rm --privileged aptman/qus -s -- -p ${{ matrix.qemu-arch }}
```
to https://github.com/docker/setup-qemu-action

- Seems simpler
- Fixes the segfaults
- We can revert the temporary downgrading of the hosts