### PR TITLE
If every TIFF tile covers the image, only use the last offset

### DIFF
--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1608,6 +1608,10 @@ class TiffImageFile(ImageFile.ImageFile):
                     raise ValueError(msg)
                 w = tilewidth
 
+            if w == xsize and h == ysize and self._planar_configuration != 2:
+                # Every tile covers the image. Only use the last offset
+                offsets = offsets[-1:]
+
             for offset in offsets:
                 if x + w > xsize:
                     stride = w * sum(bps_tuple) / 8  # bytes per line
@@ -1630,11 +1634,11 @@ class TiffImageFile(ImageFile.ImageFile):
                         args,
                     )
                 )
-                x = x + w
+                x += w
                 if x >= xsize:
                     x, y = 0, y + h
                     if y >= ysize:
-                        x = y = 0
+                        y = 0
                         layer += 1
         else:
             logger.debug("- unsupported data organization")


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/5919 reduced the load time for images that have consecutive tiles only differing in their offset. The test image in `test_timeout()` was a TIFF file, but the change was made more generally to ImageFile.

After https://github.com/python-pillow/docker-images/pull/232, QEMU jobs in the docker-images repository are slower, and `test_timeout()` is now timing out.

This PR adds specific logic to TiffImagePlugin. Each tile has the same width and height, so if that width and height covers the image and there are no layers involved, then only the last offset is needed.