### PR TITLE
Simplified test code

### DIFF
--- a/Tests/check_j2k_overflow.py
+++ b/Tests/check_j2k_overflow.py
@@ -9,6 +9,6 @@ from PIL import Image
 
 def test_j2k_overflow(tmp_path: Path) -> None:
     im = Image.new("RGBA", (1024, 131584))
-    target = str(tmp_path / "temp.jpc")
+    target = tmp_path / "temp.jpc"
     with pytest.raises(OSError):
         im.save(target)

--- a/Tests/check_large_memory.py
+++ b/Tests/check_large_memory.py
@@ -32,7 +32,7 @@ pytestmark = pytest.mark.skipif(sys.maxsize <= 2**32, reason="requires 64-bit sy
 
 
 def _write_png(tmp_path: Path, xdim: int, ydim: int) -> None:
-    f = str(tmp_path / "temp.png")
+    f = tmp_path / "temp.png"
     im = Image.new("L", (xdim, ydim), 0)
     im.save(f)
 

--- a/Tests/check_large_memory_numpy.py
+++ b/Tests/check_large_memory_numpy.py
@@ -28,7 +28,7 @@ pytestmark = pytest.mark.skipif(sys.maxsize <= 2**32, reason="requires 64-bit sy
 def _write_png(tmp_path: Path, xdim: int, ydim: int) -> None:
     dtype = np.uint8
     a = np.zeros((xdim, ydim), dtype=dtype)
-    f = str(tmp_path / "temp.png")
+    f = tmp_path / "temp.png"
     im = Image.fromarray(a, "L")
     im.save(f)
 

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -13,6 +13,7 @@ import tempfile
 from collections.abc import Sequence
 from functools import lru_cache
 from io import BytesIO
+from pathlib import Path
 from typing import Any, Callable
 
 import pytest
@@ -95,7 +96,10 @@ def assert_image_equal(a: Image.Image, b: Image.Image, msg: str | None = None) -
 
 
 def assert_image_equal_tofile(
-    a: Image.Image, filename: str, msg: str | None = None, mode: str | None = None
+    a: Image.Image,
+    filename: str | Path,
+    msg: str | None = None,
+    mode: str | None = None,
 ) -> None:
     with Image.open(filename) as img:
         if mode:
@@ -136,7 +140,7 @@ def assert_image_similar(
 
 def assert_image_similar_tofile(
     a: Image.Image,
-    filename: str,
+    filename: str | Path,
     epsilon: float,
     msg: str | None = None,
 ) -> None:

--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -345,7 +345,7 @@ def test_apng_sequence_errors(test_file: str) -> None:
 
 def test_apng_save(tmp_path: Path) -> None:
     with Image.open("Tests/images/apng/single_frame.png") as im:
-        test_file = str(tmp_path / "temp.png")
+        test_file = tmp_path / "temp.png"
         im.save(test_file, save_all=True)
 
     with Image.open(test_file) as im:
@@ -375,7 +375,7 @@ def test_apng_save(tmp_path: Path) -> None:
 
 
 def test_apng_save_alpha(tmp_path: Path) -> None:
-    test_file = str(tmp_path / "temp.png")
+    test_file = tmp_path / "temp.png"
 
     im = Image.new("RGBA", (1, 1), (255, 0, 0, 255))
     im2 = Image.new("RGBA", (1, 1), (255, 0, 0, 127))
@@ -393,7 +393,7 @@ def test_apng_save_split_fdat(tmp_path: Path) -> None:
     # frames with image data spanning multiple fdAT chunks (in this case
     # both the default image and first animation frame will span multiple
     # data chunks)
-    test_file = str(tmp_path / "temp.png")
+    test_file = tmp_path / "temp.png"
     with Image.open("Tests/images/old-style-jpeg-compression.png") as im:
         frames = [im.copy(), Image.new("RGBA", im.size, (255, 0, 0, 255))]
         im.save(
@@ -408,7 +408,7 @@ def test_apng_save_split_fdat(tmp_path: Path) -> None:
 
 
 def test_apng_save_duration_loop(tmp_path: Path) -> None:
-    test_file = str(tmp_path / "temp.png")
+    test_file = tmp_path / "temp.png"
     with Image.open("Tests/images/apng/delay.png") as im:
         frames = []
         durations = []
@@ -471,7 +471,7 @@ def test_apng_save_duration_loop(tmp_path: Path) -> None:
 
 
 def test_apng_save_disposal(tmp_path: Path) -> None:
-    test_file = str(tmp_path / "temp.png")
+    test_file = tmp_path / "temp.png"
     size = (128, 64)
     red = Image.new("RGBA", size, (255, 0, 0, 255))
     green = Image.new("RGBA", size, (0, 255, 0, 255))
@@ -572,7 +572,7 @@ def test_apng_save_disposal(tmp_path: Path) -> None:
 
 
 def test_apng_save_disposal_previous(tmp_path: Path) -> None:
-    test_file = str(tmp_path / "temp.png")
+    test_file = tmp_path / "temp.png"
     size = (128, 64)
     blue = Image.new("RGBA", size, (0, 0, 255, 255))
     red = Image.new("RGBA", size, (255, 0, 0, 255))
@@ -594,7 +594,7 @@ def test_apng_save_disposal_previous(tmp_path: Path) -> None:
 
 
 def test_apng_save_blend(tmp_path: Path) -> None:
-    test_file = str(tmp_path / "temp.png")
+    test_file = tmp_path / "temp.png"
     size = (128, 64)
     red = Image.new("RGBA", size, (255, 0, 0, 255))
     green = Image.new("RGBA", size, (0, 255, 0, 255))
@@ -662,7 +662,7 @@ def test_apng_save_blend(tmp_path: Path) -> None:
 
 
 def test_apng_save_size(tmp_path: Path) -> None:
-    test_file = str(tmp_path / "temp.png")
+    test_file = tmp_path / "temp.png"
 
     im = Image.new("L", (100, 100))
     im.save(test_file, save_all=True, append_images=[Image.new("L", (200, 200))])
@@ -686,7 +686,7 @@ def test_seek_after_close() -> None:
 def test_different_modes_in_later_frames(
     mode: str, default_image: bool, duplicate: bool, tmp_path: Path
 ) -> None:
-    test_file = str(tmp_path / "temp.png")
+    test_file = tmp_path / "temp.png"
 
     im = Image.new("L", (1, 1))
     im.save(
@@ -700,7 +700,7 @@ def test_different_modes_in_later_frames(
 
 
 def test_different_durations(tmp_path: Path) -> None:
-    test_file = str(tmp_path / "temp.png")
+    test_file = tmp_path / "temp.png"
 
     with Image.open("Tests/images/apng/different_durations.png") as im:
         for _ in range(3):

--- a/Tests/test_file_blp.py
+++ b/Tests/test_file_blp.py
@@ -46,7 +46,7 @@ def test_invalid_file() -> None:
 
 
 def test_save(tmp_path: Path) -> None:
-    f = str(tmp_path / "temp.blp")
+    f = tmp_path / "temp.blp"
 
     for version in ("BLP1", "BLP2"):
         im = hopper("P")
@@ -56,7 +56,7 @@ def test_save(tmp_path: Path) -> None:
             assert_image_equal(im.convert("RGB"), reloaded)
 
         with Image.open("Tests/images/transparent.png") as im:
-            f = str(tmp_path / "temp.blp")
+            f = tmp_path / "temp.blp"
             im.convert("P").save(f, blp_version=version)
 
             with Image.open(f) as reloaded:

--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -17,7 +17,7 @@ from .helper import (
 
 def test_sanity(tmp_path: Path) -> None:
     def roundtrip(im: Image.Image) -> None:
-        outfile = str(tmp_path / "temp.bmp")
+        outfile = tmp_path / "temp.bmp"
 
         im.save(outfile, "BMP")
 
@@ -66,7 +66,7 @@ def test_small_palette(tmp_path: Path) -> None:
     colors = [0, 0, 0, 125, 125, 125, 255, 255, 255]
     im.putpalette(colors)
 
-    out = str(tmp_path / "temp.bmp")
+    out = tmp_path / "temp.bmp"
     im.save(out)
 
     with Image.open(out) as reloaded:
@@ -74,7 +74,7 @@ def test_small_palette(tmp_path: Path) -> None:
 
 
 def test_save_too_large(tmp_path: Path) -> None:
-    outfile = str(tmp_path / "temp.bmp")
+    outfile = tmp_path / "temp.bmp"
     with Image.new("RGB", (1, 1)) as im:
         im._size = (37838, 37838)
         with pytest.raises(ValueError):
@@ -96,7 +96,7 @@ def test_dpi() -> None:
 def test_save_bmp_with_dpi(tmp_path: Path) -> None:
     # Test for #1301
     # Arrange
-    outfile = str(tmp_path / "temp.jpg")
+    outfile = tmp_path / "temp.jpg"
     with Image.open("Tests/images/hopper.bmp") as im:
         assert im.info["dpi"] == (95.98654816726399, 95.98654816726399)
 
@@ -112,7 +112,7 @@ def test_save_bmp_with_dpi(tmp_path: Path) -> None:
 
 
 def test_save_float_dpi(tmp_path: Path) -> None:
-    outfile = str(tmp_path / "temp.bmp")
+    outfile = tmp_path / "temp.bmp"
     with Image.open("Tests/images/hopper.bmp") as im:
         im.save(outfile, dpi=(72.21216100543306, 72.21216100543306))
         with Image.open(outfile) as reloaded:
@@ -152,7 +152,7 @@ def test_dib_header_size(header_size: int, path: str) -> None:
 
 
 def test_save_dib(tmp_path: Path) -> None:
-    outfile = str(tmp_path / "temp.dib")
+    outfile = tmp_path / "temp.dib"
 
     with Image.open("Tests/images/clipboard.dib") as im:
         im.save(outfile)

--- a/Tests/test_file_bufrstub.py
+++ b/Tests/test_file_bufrstub.py
@@ -43,7 +43,7 @@ def test_load() -> None:
 def test_save(tmp_path: Path) -> None:
     # Arrange
     im = hopper()
-    tmpfile = str(tmp_path / "temp.bufr")
+    tmpfile = tmp_path / "temp.bufr"
 
     # Act / Assert: stub cannot save without an implemented handler
     with pytest.raises(OSError):
@@ -79,7 +79,7 @@ def test_handler(tmp_path: Path) -> None:
         im.load()
         assert handler.is_loaded()
 
-        temp_file = str(tmp_path / "temp.bufr")
+        temp_file = tmp_path / "temp.bufr"
         im.save(temp_file)
         assert handler.saved
 

--- a/Tests/test_file_dds.py
+++ b/Tests/test_file_dds.py
@@ -116,7 +116,7 @@ def test_sanity_ati1_bc4u(image_path: str) -> None:
 
 
 def test_dx10_bc2(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.dds")
+    out = tmp_path / "temp.dds"
     with Image.open(TEST_FILE_DXT3) as im:
         im.save(out, pixel_format="BC2")
 
@@ -129,7 +129,7 @@ def test_dx10_bc2(tmp_path: Path) -> None:
 
 
 def test_dx10_bc3(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.dds")
+    out = tmp_path / "temp.dds"
     with Image.open(TEST_FILE_DXT5) as im:
         im.save(out, pixel_format="BC3")
 
@@ -400,7 +400,7 @@ def test_not_implemented(test_file: str) -> None:
 
 
 def test_save_unsupported_mode(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.dds")
+    out = tmp_path / "temp.dds"
     im = hopper("HSV")
     with pytest.raises(OSError, match="cannot write mode HSV as DDS"):
         im.save(out)
@@ -416,7 +416,7 @@ def test_save_unsupported_mode(tmp_path: Path) -> None:
     ],
 )
 def test_save(mode: str, test_file: str, tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.dds")
+    out = tmp_path / "temp.dds"
     with Image.open(test_file) as im:
         assert im.mode == mode
         im.save(out)
@@ -425,7 +425,7 @@ def test_save(mode: str, test_file: str, tmp_path: Path) -> None:
 
 
 def test_save_unsupported_pixel_format(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.dds")
+    out = tmp_path / "temp.dds"
     im = hopper()
     with pytest.raises(OSError, match="cannot write pixel format UNKNOWN"):
         im.save(out, pixel_format="UNKNOWN")
@@ -433,7 +433,7 @@ def test_save_unsupported_pixel_format(tmp_path: Path) -> None:
 
 def test_save_dxt1(tmp_path: Path) -> None:
     # RGB
-    out = str(tmp_path / "temp.dds")
+    out = tmp_path / "temp.dds"
     with Image.open(TEST_FILE_DXT1) as im:
         im.convert("RGB").save(out, pixel_format="DXT1")
     assert_image_similar_tofile(im, out, 1.84)
@@ -458,7 +458,7 @@ def test_save_dxt1(tmp_path: Path) -> None:
 
 def test_save_dxt3(tmp_path: Path) -> None:
     # RGB
-    out = str(tmp_path / "temp.dds")
+    out = tmp_path / "temp.dds"
     with Image.open(TEST_FILE_DXT3) as im:
         im_rgb = im.convert("RGB")
     im_rgb.save(out, pixel_format="DXT3")
@@ -481,7 +481,7 @@ def test_save_dxt3(tmp_path: Path) -> None:
 
 def test_save_dxt5(tmp_path: Path) -> None:
     # RGB
-    out = str(tmp_path / "temp.dds")
+    out = tmp_path / "temp.dds"
     with Image.open(TEST_FILE_DXT1) as im:
         im.convert("RGB").save(out, pixel_format="DXT5")
     assert_image_similar_tofile(im, out, 1.84)
@@ -503,7 +503,7 @@ def test_save_dxt5(tmp_path: Path) -> None:
 
 
 def test_save_dx10_bc5(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.dds")
+    out = tmp_path / "temp.dds"
     with Image.open(TEST_FILE_DX10_BC5_TYPELESS) as im:
         im.save(out, pixel_format="BC5")
     assert_image_similar_tofile(im, out, 9.56)

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -239,7 +239,7 @@ def test_transparency() -> None:
 def test_file_object(tmp_path: Path) -> None:
     # issue 479
     with Image.open(FILE1) as image1:
-        with open(str(tmp_path / "temp.eps"), "wb") as fh:
+        with open(tmp_path / "temp.eps", "wb") as fh:
             image1.save(fh, "EPS")
 
 
@@ -274,7 +274,7 @@ def test_1(filename: str) -> None:
 
 def test_image_mode_not_supported(tmp_path: Path) -> None:
     im = hopper("RGBA")
-    tmpfile = str(tmp_path / "temp.eps")
+    tmpfile = tmp_path / "temp.eps"
     with pytest.raises(ValueError):
         im.save(tmpfile)
 

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1242,7 +1242,7 @@ def test_rgba_transparency(tmp_path: Path) -> None:
         assert_image_equal(hopper("P").convert("RGB"), reloaded)
 
 
-def test_background_outside_palettte(tmp_path: Path) -> None:
+def test_background_outside_palettte() -> None:
     with Image.open("Tests/images/background_outside_palette.gif") as im:
         im.seek(1)
         assert im.info["background"] == 255

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -228,7 +228,7 @@ def test_optimize_if_palette_can_be_reduced_by_half() -> None:
 
 
 def test_full_palette_second_frame(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im = Image.new("P", (1, 256))
 
     full_palette_im = Image.new("P", (1, 256))
@@ -249,7 +249,7 @@ def test_full_palette_second_frame(tmp_path: Path) -> None:
 
 
 def test_roundtrip(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im = hopper()
     im.save(out)
     with Image.open(out) as reread:
@@ -258,7 +258,7 @@ def test_roundtrip(tmp_path: Path) -> None:
 
 def test_roundtrip2(tmp_path: Path) -> None:
     # see https://github.com/python-pillow/Pillow/issues/403
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     with Image.open(TEST_GIF) as im:
         im2 = im.copy()
         im2.save(out)
@@ -268,7 +268,7 @@ def test_roundtrip2(tmp_path: Path) -> None:
 
 def test_roundtrip_save_all(tmp_path: Path) -> None:
     # Single frame image
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im = hopper()
     im.save(out, save_all=True)
     with Image.open(out) as reread:
@@ -276,7 +276,7 @@ def test_roundtrip_save_all(tmp_path: Path) -> None:
 
     # Multiframe image
     with Image.open("Tests/images/dispose_bgnd.gif") as im:
-        out = str(tmp_path / "temp.gif")
+        out = tmp_path / "temp.gif"
         im.save(out, save_all=True)
 
     with Image.open(out) as reread:
@@ -284,7 +284,7 @@ def test_roundtrip_save_all(tmp_path: Path) -> None:
 
 
 def test_roundtrip_save_all_1(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im = Image.new("1", (1, 1))
     im2 = Image.new("1", (1, 1), 1)
     im.save(out, save_all=True, append_images=[im2])
@@ -329,7 +329,7 @@ def test_headers_saving_for_animated_gifs(tmp_path: Path) -> None:
     with Image.open("Tests/images/dispose_bgnd.gif") as im:
         info = im.info.copy()
 
-        out = str(tmp_path / "temp.gif")
+        out = tmp_path / "temp.gif"
         im.save(out, save_all=True)
     with Image.open(out) as reread:
         for header in important_headers:
@@ -345,7 +345,7 @@ def test_palette_handling(tmp_path: Path) -> None:
         im = im.resize((100, 100), Image.Resampling.LANCZOS)
         im2 = im.convert("P", palette=Image.Palette.ADAPTIVE, colors=256)
 
-        f = str(tmp_path / "temp.gif")
+        f = tmp_path / "temp.gif"
         im2.save(f, optimize=True)
 
     with Image.open(f) as reloaded:
@@ -356,7 +356,7 @@ def test_palette_434(tmp_path: Path) -> None:
     # see https://github.com/python-pillow/Pillow/issues/434
 
     def roundtrip(im: Image.Image, **kwargs: bool) -> Image.Image:
-        out = str(tmp_path / "temp.gif")
+        out = tmp_path / "temp.gif"
         im.copy().save(out, "GIF", **kwargs)
         reloaded = Image.open(out)
 
@@ -599,7 +599,7 @@ def test_previous_frame_loaded() -> None:
 
 
 def test_save_dispose(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im_list = [
         Image.new("L", (100, 100), "#000"),
         Image.new("L", (100, 100), "#111"),
@@ -627,7 +627,7 @@ def test_save_dispose(tmp_path: Path) -> None:
 
 
 def test_dispose2_palette(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
 
     # Four colors: white, gray, black, red
     circles = [(255, 255, 255), (153, 153, 153), (0, 0, 0), (255, 0, 0)]
@@ -661,7 +661,7 @@ def test_dispose2_palette(tmp_path: Path) -> None:
 
 
 def test_dispose2_diff(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
 
     # 4 frames: red/blue, red/red, blue/blue, red/blue
     circles = [
@@ -703,7 +703,7 @@ def test_dispose2_diff(tmp_path: Path) -> None:
 
 
 def test_dispose2_background(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
 
     im_list = []
 
@@ -729,7 +729,7 @@ def test_dispose2_background(tmp_path: Path) -> None:
 
 
 def test_dispose2_background_frame(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
 
     im_list = [Image.new("RGBA", (1, 20))]
 
@@ -747,7 +747,7 @@ def test_dispose2_background_frame(tmp_path: Path) -> None:
 
 
 def test_dispose2_previous_frame(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
 
     im = Image.new("P", (100, 100))
     im.info["transparency"] = 0
@@ -766,7 +766,7 @@ def test_dispose2_previous_frame(tmp_path: Path) -> None:
 
 
 def test_dispose2_without_transparency(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
 
     im = Image.new("P", (100, 100))
 
@@ -781,7 +781,7 @@ def test_dispose2_without_transparency(tmp_path: Path) -> None:
 
 
 def test_transparency_in_second_frame(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     with Image.open("Tests/images/different_transparency.gif") as im:
         assert im.info["transparency"] == 0
 
@@ -811,7 +811,7 @@ def test_no_transparency_in_second_frame() -> None:
 
 
 def test_remapped_transparency(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
 
     im = Image.new("P", (1, 2))
     im2 = im.copy()
@@ -829,7 +829,7 @@ def test_remapped_transparency(tmp_path: Path) -> None:
 def test_duration(tmp_path: Path) -> None:
     duration = 1000
 
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im = Image.new("L", (100, 100), "#000")
 
     # Check that the argument has priority over the info settings
@@ -843,7 +843,7 @@ def test_duration(tmp_path: Path) -> None:
 def test_multiple_duration(tmp_path: Path) -> None:
     duration_list = [1000, 2000, 3000]
 
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im_list = [
         Image.new("L", (100, 100), "#000"),
         Image.new("L", (100, 100), "#111"),
@@ -878,7 +878,7 @@ def test_multiple_duration(tmp_path: Path) -> None:
 def test_roundtrip_info_duration(tmp_path: Path) -> None:
     duration_list = [100, 500, 500]
 
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     with Image.open("Tests/images/transparent_dispose.gif") as im:
         assert [
             frame.info["duration"] for frame in ImageSequence.Iterator(im)
@@ -893,7 +893,7 @@ def test_roundtrip_info_duration(tmp_path: Path) -> None:
 
 
 def test_roundtrip_info_duration_combined(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     with Image.open("Tests/images/duplicate_frame.gif") as im:
         assert [frame.info["duration"] for frame in ImageSequence.Iterator(im)] == [
             1000,
@@ -911,7 +911,7 @@ def test_roundtrip_info_duration_combined(tmp_path: Path) -> None:
 def test_identical_frames(tmp_path: Path) -> None:
     duration_list = [1000, 1500, 2000, 4000]
 
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im_list = [
         Image.new("L", (100, 100), "#000"),
         Image.new("L", (100, 100), "#000"),
@@ -944,7 +944,7 @@ def test_identical_frames(tmp_path: Path) -> None:
 def test_identical_frames_to_single_frame(
     duration: int | list[int], tmp_path: Path
 ) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im_list = [
         Image.new("L", (100, 100), "#000"),
         Image.new("L", (100, 100), "#000"),
@@ -961,7 +961,7 @@ def test_identical_frames_to_single_frame(
 
 
 def test_loop_none(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im = Image.new("L", (100, 100), "#000")
     im.save(out, loop=None)
     with Image.open(out) as reread:
@@ -971,7 +971,7 @@ def test_loop_none(tmp_path: Path) -> None:
 def test_number_of_loops(tmp_path: Path) -> None:
     number_of_loops = 2
 
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im = Image.new("L", (100, 100), "#000")
     im.save(out, loop=number_of_loops)
     with Image.open(out) as reread:
@@ -987,7 +987,7 @@ def test_number_of_loops(tmp_path: Path) -> None:
 
 
 def test_background(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im = Image.new("L", (100, 100), "#000")
     im.info["background"] = 1
     im.save(out)
@@ -996,7 +996,7 @@ def test_background(tmp_path: Path) -> None:
 
 
 def test_webp_background(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
 
     # Test opaque WebP background
     if features.check("webp"):
@@ -1014,7 +1014,7 @@ def test_comment(tmp_path: Path) -> None:
     with Image.open(TEST_GIF) as im:
         assert im.info["comment"] == b"File written by Adobe Photoshop\xa8 4.0"
 
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im = Image.new("L", (100, 100), "#000")
     im.info["comment"] = b"Test comment text"
     im.save(out)
@@ -1031,7 +1031,7 @@ def test_comment(tmp_path: Path) -> None:
 
 
 def test_comment_over_255(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im = Image.new("L", (100, 100), "#000")
     comment = b"Test comment text"
     while len(comment) < 256:
@@ -1057,7 +1057,7 @@ def test_read_multiple_comment_blocks() -> None:
 
 
 def test_empty_string_comment(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     with Image.open("Tests/images/chi.gif") as im:
         assert "comment" in im.info
 
@@ -1091,7 +1091,7 @@ def test_retain_comment_in_subsequent_frames(tmp_path: Path) -> None:
         assert "comment" not in im.info
 
     # Test that a saved image keeps the comment
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     with Image.open("Tests/images/dispose_prev.gif") as im:
         im.save(out, save_all=True, comment="Test")
 
@@ -1101,7 +1101,7 @@ def test_retain_comment_in_subsequent_frames(tmp_path: Path) -> None:
 
 
 def test_version(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
 
     def assert_version_after_save(im: Image.Image, version: bytes) -> None:
         im.save(out)
@@ -1131,7 +1131,7 @@ def test_version(tmp_path: Path) -> None:
 
 
 def test_append_images(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
 
     # Test appending single frame images
     im = Image.new("RGB", (100, 100), "#f00")
@@ -1160,7 +1160,7 @@ def test_append_images(tmp_path: Path) -> None:
 
 
 def test_append_different_size_image(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
 
     im = Image.new("RGB", (100, 100))
     bigger_im = Image.new("RGB", (200, 200), "#f00")
@@ -1187,7 +1187,7 @@ def test_transparent_optimize(tmp_path: Path) -> None:
     im.frombytes(data)
     im.putpalette(palette)
 
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im.save(out, transparency=im.getpixel((252, 0)))
 
     with Image.open(out) as reloaded:
@@ -1195,7 +1195,7 @@ def test_transparent_optimize(tmp_path: Path) -> None:
 
 
 def test_removed_transparency(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im = Image.new("RGB", (256, 1))
 
     for x in range(256):
@@ -1210,7 +1210,7 @@ def test_removed_transparency(tmp_path: Path) -> None:
 
 
 def test_rgb_transparency(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
 
     # Single frame
     im = Image.new("RGB", (1, 1))
@@ -1232,7 +1232,7 @@ def test_rgb_transparency(tmp_path: Path) -> None:
 
 
 def test_rgba_transparency(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
 
     im = hopper("P")
     im.save(out, save_all=True, append_images=[Image.new("RGBA", im.size)])
@@ -1249,7 +1249,7 @@ def test_background_outside_palettte(tmp_path: Path) -> None:
 
 
 def test_bbox(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
 
     im = Image.new("RGB", (100, 100), "#fff")
     ims = [Image.new("RGB", (100, 100), "#000")]
@@ -1260,7 +1260,7 @@ def test_bbox(tmp_path: Path) -> None:
 
 
 def test_bbox_alpha(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
 
     im = Image.new("RGBA", (1, 2), (255, 0, 0, 255))
     im.putpixel((0, 1), (255, 0, 0, 0))
@@ -1279,7 +1279,7 @@ def test_palette_save_L(tmp_path: Path) -> None:
     palette = im.getpalette()
     assert palette is not None
 
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im_l.save(out, palette=bytes(palette))
 
     with Image.open(out) as reloaded:
@@ -1290,7 +1290,7 @@ def test_palette_save_P(tmp_path: Path) -> None:
     im = Image.new("P", (1, 2))
     im.putpixel((0, 1), 1)
 
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im.save(out, palette=bytes((1, 2, 3, 4, 5, 6)))
 
     with Image.open(out) as reloaded:
@@ -1306,7 +1306,7 @@ def test_palette_save_duplicate_entries(tmp_path: Path) -> None:
 
     im.putpalette((0, 0, 0, 0, 0, 0))
 
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im.save(out, palette=[0, 0, 0, 0, 0, 0, 1, 1, 1])
 
     with Image.open(out) as reloaded:
@@ -1321,7 +1321,7 @@ def test_palette_save_all_P(tmp_path: Path) -> None:
         frame.putpalette(color)
         frames.append(frame)
 
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     frames[0].save(
         out, save_all=True, palette=[255, 0, 0, 0, 255, 0], append_images=frames[1:]
     )
@@ -1344,7 +1344,7 @@ def test_palette_save_ImagePalette(tmp_path: Path) -> None:
     im = hopper("P")
     palette = ImagePalette.ImagePalette("RGB", list(range(256))[::-1] * 3)
 
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im.save(out, palette=palette)
 
     with Image.open(out) as reloaded:
@@ -1357,7 +1357,7 @@ def test_save_I(tmp_path: Path) -> None:
 
     im = hopper("I")
 
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     im.save(out)
 
     with Image.open(out) as reloaded:
@@ -1441,7 +1441,7 @@ def test_missing_background() -> None:
 
 
 def test_saving_rgba(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
     with Image.open("Tests/images/transparent.png") as im:
         im.save(out)
 
@@ -1452,7 +1452,7 @@ def test_saving_rgba(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("params", ({}, {"disposal": 2, "optimize": False}))
 def test_p_rgba(tmp_path: Path, params: dict[str, Any]) -> None:
-    out = str(tmp_path / "temp.gif")
+    out = tmp_path / "temp.gif"
 
     im1 = Image.new("P", (100, 100))
     d = ImageDraw.Draw(im1)

--- a/Tests/test_file_gribstub.py
+++ b/Tests/test_file_gribstub.py
@@ -43,7 +43,7 @@ def test_load() -> None:
 def test_save(tmp_path: Path) -> None:
     # Arrange
     im = hopper()
-    tmpfile = str(tmp_path / "temp.grib")
+    tmpfile = tmp_path / "temp.grib"
 
     # Act / Assert: stub cannot save without an implemented handler
     with pytest.raises(OSError):
@@ -79,7 +79,7 @@ def test_handler(tmp_path: Path) -> None:
         im.load()
         assert handler.is_loaded()
 
-        temp_file = str(tmp_path / "temp.grib")
+        temp_file = tmp_path / "temp.grib"
         im.save(temp_file)
         assert handler.saved
 

--- a/Tests/test_file_hdf5stub.py
+++ b/Tests/test_file_hdf5stub.py
@@ -81,7 +81,7 @@ def test_handler(tmp_path: Path) -> None:
         im.load()
         assert handler.is_loaded()
 
-        temp_file = str(tmp_path / "temp.h5")
+        temp_file = tmp_path / "temp.h5"
         im.save(temp_file)
         assert handler.saved
 

--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -43,7 +43,7 @@ def test_load() -> None:
 
 
 def test_save(tmp_path: Path) -> None:
-    temp_file = str(tmp_path / "temp.icns")
+    temp_file = tmp_path / "temp.icns"
 
     with Image.open(TEST_FILE) as im:
         im.save(temp_file)
@@ -60,7 +60,7 @@ def test_save(tmp_path: Path) -> None:
 
 
 def test_save_append_images(tmp_path: Path) -> None:
-    temp_file = str(tmp_path / "temp.icns")
+    temp_file = tmp_path / "temp.icns"
     provided_im = Image.new("RGBA", (32, 32), (255, 0, 0, 128))
 
     with Image.open(TEST_FILE) as im:

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -41,7 +41,7 @@ def test_black_and_white() -> None:
 
 
 def test_palette(tmp_path: Path) -> None:
-    temp_file = str(tmp_path / "temp.ico")
+    temp_file = tmp_path / "temp.ico"
 
     im = Image.new("P", (16, 16))
     im.save(temp_file)
@@ -88,7 +88,7 @@ def test_save_to_bytes() -> None:
 
 
 def test_getpixel(tmp_path: Path) -> None:
-    temp_file = str(tmp_path / "temp.ico")
+    temp_file = tmp_path / "temp.ico"
 
     im = hopper()
     im.save(temp_file, "ico", sizes=[(32, 32), (64, 64)])
@@ -101,8 +101,8 @@ def test_getpixel(tmp_path: Path) -> None:
 
 
 def test_no_duplicates(tmp_path: Path) -> None:
-    temp_file = str(tmp_path / "temp.ico")
-    temp_file2 = str(tmp_path / "temp2.ico")
+    temp_file = tmp_path / "temp.ico"
+    temp_file2 = tmp_path / "temp2.ico"
 
     im = hopper()
     sizes = [(32, 32), (64, 64)]
@@ -115,8 +115,8 @@ def test_no_duplicates(tmp_path: Path) -> None:
 
 
 def test_different_bit_depths(tmp_path: Path) -> None:
-    temp_file = str(tmp_path / "temp.ico")
-    temp_file2 = str(tmp_path / "temp2.ico")
+    temp_file = tmp_path / "temp.ico"
+    temp_file2 = tmp_path / "temp2.ico"
 
     im = hopper()
     im.save(temp_file, "ico", bitmap_format="bmp", sizes=[(128, 128)])
@@ -132,8 +132,8 @@ def test_different_bit_depths(tmp_path: Path) -> None:
     assert os.path.getsize(temp_file) != os.path.getsize(temp_file2)
 
     # Test that only matching sizes of different bit depths are saved
-    temp_file3 = str(tmp_path / "temp3.ico")
-    temp_file4 = str(tmp_path / "temp4.ico")
+    temp_file3 = tmp_path / "temp3.ico"
+    temp_file4 = tmp_path / "temp4.ico"
 
     im.save(temp_file3, "ico", bitmap_format="bmp", sizes=[(128, 128)])
     im.save(
@@ -186,7 +186,7 @@ def test_save_256x256(tmp_path: Path) -> None:
     """Issue #2264 https://github.com/python-pillow/Pillow/issues/2264"""
     # Arrange
     with Image.open("Tests/images/hopper_256x256.ico") as im:
-        outfile = str(tmp_path / "temp_saved_hopper_256x256.ico")
+        outfile = tmp_path / "temp_saved_hopper_256x256.ico"
 
         # Act
         im.save(outfile)
@@ -202,7 +202,7 @@ def test_only_save_relevant_sizes(tmp_path: Path) -> None:
     """
     # Arrange
     with Image.open("Tests/images/python.ico") as im:  # 16x16, 32x32, 48x48
-        outfile = str(tmp_path / "temp_saved_python.ico")
+        outfile = tmp_path / "temp_saved_python.ico"
         # Act
         im.save(outfile)
 
@@ -215,7 +215,7 @@ def test_save_append_images(tmp_path: Path) -> None:
     # append_images should be used for scaled down versions of the image
     im = hopper("RGBA")
     provided_im = Image.new("RGBA", (32, 32), (255, 0, 0))
-    outfile = str(tmp_path / "temp_saved_multi_icon.ico")
+    outfile = tmp_path / "temp_saved_multi_icon.ico"
     im.save(outfile, sizes=[(32, 32), (128, 128)], append_images=[provided_im])
 
     with Image.open(outfile) as reread:
@@ -235,7 +235,7 @@ def test_unexpected_size() -> None:
 
 def test_draw_reloaded(tmp_path: Path) -> None:
     with Image.open(TEST_ICO_FILE) as im:
-        outfile = str(tmp_path / "temp_saved_hopper_draw.ico")
+        outfile = tmp_path / "temp_saved_hopper_draw.ico"
 
         draw = ImageDraw.Draw(im)
         draw.line((0, 0) + im.size, "#f00")

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -23,7 +23,7 @@ def test_sanity() -> None:
 
 
 def test_name_limit(tmp_path: Path) -> None:
-    out = str(tmp_path / ("name_limit_test" * 7 + ".im"))
+    out = tmp_path / ("name_limit_test" * 7 + ".im")
     with Image.open(TEST_IM) as im:
         im.save(out)
     assert filecmp.cmp(out, "Tests/images/hopper_long_name.im")
@@ -87,7 +87,7 @@ def test_eoferror() -> None:
 
 @pytest.mark.parametrize("mode", ("RGB", "P", "PA"))
 def test_roundtrip(mode: str, tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.im")
+    out = tmp_path / "temp.im"
     im = hopper(mode)
     im.save(out)
     assert_image_equal_tofile(im, out)
@@ -98,7 +98,7 @@ def test_small_palette(tmp_path: Path) -> None:
     colors = [0, 1, 2]
     im.putpalette(colors)
 
-    out = str(tmp_path / "temp.im")
+    out = tmp_path / "temp.im"
     im.save(out)
 
     with Image.open(out) as reloaded:
@@ -106,7 +106,7 @@ def test_small_palette(tmp_path: Path) -> None:
 
 
 def test_save_unsupported_mode(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.im")
+    out = tmp_path / "temp.im"
     im = hopper("HSV")
     with pytest.raises(ValueError):
         im.save(out)

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -83,7 +83,7 @@ class TestFileJpeg:
 
     @pytest.mark.parametrize("size", ((1, 0), (0, 1), (0, 0)))
     def test_zero(self, size: tuple[int, int], tmp_path: Path) -> None:
-        f = str(tmp_path / "temp.jpg")
+        f = tmp_path / "temp.jpg"
         im = Image.new("RGB", size)
         with pytest.raises(ValueError):
             im.save(f)
@@ -194,7 +194,7 @@ class TestFileJpeg:
             icc_profile = im1.info["icc_profile"]
             assert len(icc_profile) == 3144
             # Roundtrip via physical file.
-            f = str(tmp_path / "temp.jpg")
+            f = tmp_path / "temp.jpg"
             im1.save(f, icc_profile=icc_profile)
         with Image.open(f) as im2:
             assert im2.info.get("icc_profile") == icc_profile
@@ -238,7 +238,7 @@ class TestFileJpeg:
         # Sometimes the meta data on the icc_profile block is bigger than
         # Image.MAXBLOCK or the image size.
         with Image.open("Tests/images/icc_profile_big.jpg") as im:
-            f = str(tmp_path / "temp.jpg")
+            f = tmp_path / "temp.jpg"
             icc_profile = im.info["icc_profile"]
             # Should not raise OSError for image with icc larger than image size.
             im.save(
@@ -250,11 +250,11 @@ class TestFileJpeg:
             )
 
         with Image.open("Tests/images/flower2.jpg") as im:
-            f = str(tmp_path / "temp2.jpg")
+            f = tmp_path / "temp2.jpg"
             im.save(f, progressive=True, quality=94, icc_profile=b" " * 53955)
 
         with Image.open("Tests/images/flower2.jpg") as im:
-            f = str(tmp_path / "temp3.jpg")
+            f = tmp_path / "temp3.jpg"
             im.save(f, progressive=True, quality=94, exif=b" " * 43668)
 
     def test_optimize(self) -> None:
@@ -268,7 +268,7 @@ class TestFileJpeg:
 
     def test_optimize_large_buffer(self, tmp_path: Path) -> None:
         # https://github.com/python-pillow/Pillow/issues/148
-        f = str(tmp_path / "temp.jpg")
+        f = tmp_path / "temp.jpg"
         # this requires ~ 1.5x Image.MAXBLOCK
         im = Image.new("RGB", (4096, 4096), 0xFF3333)
         im.save(f, format="JPEG", optimize=True)
@@ -288,13 +288,13 @@ class TestFileJpeg:
         assert im1_bytes >= im3_bytes
 
     def test_progressive_large_buffer(self, tmp_path: Path) -> None:
-        f = str(tmp_path / "temp.jpg")
+        f = tmp_path / "temp.jpg"
         # this requires ~ 1.5x Image.MAXBLOCK
         im = Image.new("RGB", (4096, 4096), 0xFF3333)
         im.save(f, format="JPEG", progressive=True)
 
     def test_progressive_large_buffer_highest_quality(self, tmp_path: Path) -> None:
-        f = str(tmp_path / "temp.jpg")
+        f = tmp_path / "temp.jpg"
         im = self.gen_random_image((255, 255))
         # this requires more bytes than pixels in the image
         im.save(f, format="JPEG", progressive=True, quality=100)
@@ -307,7 +307,7 @@ class TestFileJpeg:
 
     def test_large_exif(self, tmp_path: Path) -> None:
         # https://github.com/python-pillow/Pillow/issues/148
-        f = str(tmp_path / "temp.jpg")
+        f = tmp_path / "temp.jpg"
         im = hopper()
         im.save(f, "JPEG", quality=90, exif=b"1" * 65533)
 
@@ -335,7 +335,7 @@ class TestFileJpeg:
             assert exif[gps_index] == expected_exif_gps
 
         # Writing
-        f = str(tmp_path / "temp.jpg")
+        f = tmp_path / "temp.jpg"
         exif = Image.Exif()
         exif[gps_index] = expected_exif_gps
         hopper().save(f, exif=exif)
@@ -505,15 +505,15 @@ class TestFileJpeg:
     def test_quality_keep(self, tmp_path: Path) -> None:
         # RGB
         with Image.open("Tests/images/hopper.jpg") as im:
-            f = str(tmp_path / "temp.jpg")
+            f = tmp_path / "temp.jpg"
             im.save(f, quality="keep")
         # Grayscale
         with Image.open("Tests/images/hopper_gray.jpg") as im:
-            f = str(tmp_path / "temp.jpg")
+            f = tmp_path / "temp.jpg"
             im.save(f, quality="keep")
         # CMYK
         with Image.open("Tests/images/pil_sample_cmyk.jpg") as im:
-            f = str(tmp_path / "temp.jpg")
+            f = tmp_path / "temp.jpg"
             im.save(f, quality="keep")
 
     def test_junk_jpeg_header(self) -> None:
@@ -726,7 +726,7 @@ class TestFileJpeg:
 
     def test_MAXBLOCK_scaling(self, tmp_path: Path) -> None:
         im = self.gen_random_image((512, 512))
-        f = str(tmp_path / "temp.jpeg")
+        f = tmp_path / "temp.jpeg"
         im.save(f, quality=100, optimize=True)
 
         with Image.open(f) as reloaded:
@@ -762,7 +762,7 @@ class TestFileJpeg:
 
     def test_save_tiff_with_dpi(self, tmp_path: Path) -> None:
         # Arrange
-        outfile = str(tmp_path / "temp.tif")
+        outfile = tmp_path / "temp.tif"
         with Image.open("Tests/images/hopper.tif") as im:
             # Act
             im.save(outfile, "JPEG", dpi=im.info["dpi"])
@@ -773,7 +773,7 @@ class TestFileJpeg:
                 assert im.info["dpi"] == reloaded.info["dpi"]
 
     def test_save_dpi_rounding(self, tmp_path: Path) -> None:
-        outfile = str(tmp_path / "temp.jpg")
+        outfile = tmp_path / "temp.jpg"
         with Image.open("Tests/images/hopper.jpg") as im:
             im.save(outfile, dpi=(72.2, 72.2))
 
@@ -859,7 +859,7 @@ class TestFileJpeg:
             exif = im.getexif()
             assert exif[282] == 180
 
-            out = str(tmp_path / "out.jpg")
+            out = tmp_path / "out.jpg"
             with warnings.catch_warnings():
                 warnings.simplefilter("error")
 
@@ -1005,7 +1005,7 @@ class TestFileJpeg:
                 assert im.getxmp() == {"xmpmeta": None}
 
     def test_save_xmp(self, tmp_path: Path) -> None:
-        f = str(tmp_path / "temp.jpg")
+        f = tmp_path / "temp.jpg"
         im = hopper()
         im.save(f, xmp=b"XMP test")
         with Image.open(f) as reloaded:
@@ -1094,7 +1094,7 @@ class TestFileJpeg:
 @skip_unless_feature("jpg")
 class TestFileCloseW32:
     def test_fd_leak(self, tmp_path: Path) -> None:
-        tmpfile = str(tmp_path / "temp.jpg")
+        tmpfile = tmp_path / "temp.jpg"
 
         with Image.open("Tests/images/hopper.jpg") as im:
             im.save(tmpfile)

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -99,7 +99,7 @@ def test_bytesio(card: ImageFile.ImageFile) -> None:
 def test_lossless(card: ImageFile.ImageFile, tmp_path: Path) -> None:
     with Image.open("Tests/images/test-card-lossless.jp2") as im:
         im.load()
-        outfile = str(tmp_path / "temp_test-card.png")
+        outfile = tmp_path / "temp_test-card.png"
         im.save(outfile)
     assert_image_similar(im, card, 1.0e-3)
 
@@ -213,7 +213,7 @@ def test_header_errors() -> None:
 
 
 def test_layers_type(card: ImageFile.ImageFile, tmp_path: Path) -> None:
-    outfile = str(tmp_path / "temp_layers.jp2")
+    outfile = tmp_path / "temp_layers.jp2"
     for quality_layers in [[100, 50, 10], (100, 50, 10), None]:
         card.save(outfile, quality_layers=quality_layers)
 
@@ -289,7 +289,7 @@ def test_mct(card: ImageFile.ImageFile) -> None:
 
 
 def test_sgnd(tmp_path: Path) -> None:
-    outfile = str(tmp_path / "temp.jp2")
+    outfile = tmp_path / "temp.jp2"
 
     im = Image.new("L", (1, 1))
     im.save(outfile)

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -39,7 +39,7 @@ class LibTiffTestCase:
         assert im._compression == "group4"
 
         # can we write it back out, in a different form.
-        out = str(tmp_path / "temp.png")
+        out = tmp_path / "temp.png"
         im.save(out)
 
         out_bytes = io.BytesIO()
@@ -123,7 +123,7 @@ class TestFileLibTiff(LibTiffTestCase):
         """Checking to see that the saved image is the same as what we wrote"""
         test_file = "Tests/images/hopper_g4_500.tif"
         with Image.open(test_file) as orig:
-            out = str(tmp_path / "temp.tif")
+            out = tmp_path / "temp.tif"
             rot = orig.transpose(Image.Transpose.ROTATE_90)
             assert rot.size == (500, 500)
             rot.save(out)
@@ -151,7 +151,7 @@ class TestFileLibTiff(LibTiffTestCase):
     @pytest.mark.parametrize("legacy_api", (False, True))
     def test_write_metadata(self, legacy_api: bool, tmp_path: Path) -> None:
         """Test metadata writing through libtiff"""
-        f = str(tmp_path / "temp.tiff")
+        f = tmp_path / "temp.tiff"
         with Image.open("Tests/images/hopper_g4.tif") as img:
             img.save(f, tiffinfo=img.tag)
 
@@ -247,7 +247,7 @@ class TestFileLibTiff(LibTiffTestCase):
             # Extra samples really doesn't make sense in this application.
             del new_ifd[338]
 
-            out = str(tmp_path / "temp.tif")
+            out = tmp_path / "temp.tif"
             monkeypatch.setattr(TiffImagePlugin, "WRITE_LIBTIFF", True)
 
             im.save(out, tiffinfo=new_ifd)
@@ -313,7 +313,7 @@ class TestFileLibTiff(LibTiffTestCase):
         ) -> None:
             im = hopper()
 
-            out = str(tmp_path / "temp.tif")
+            out = tmp_path / "temp.tif"
             im.save(out, tiffinfo=tiffinfo)
 
             with Image.open(out) as reloaded:
@@ -347,13 +347,13 @@ class TestFileLibTiff(LibTiffTestCase):
         )
 
     def test_osubfiletype(self, tmp_path: Path) -> None:
-        outfile = str(tmp_path / "temp.tif")
+        outfile = tmp_path / "temp.tif"
         with Image.open("Tests/images/g4_orientation_6.tif") as im:
             im.tag_v2[OSUBFILETYPE] = 1
             im.save(outfile)
 
     def test_subifd(self, tmp_path: Path) -> None:
-        outfile = str(tmp_path / "temp.tif")
+        outfile = tmp_path / "temp.tif"
         with Image.open("Tests/images/g4_orientation_6.tif") as im:
             im.tag_v2[SUBIFD] = 10000
 
@@ -365,7 +365,7 @@ class TestFileLibTiff(LibTiffTestCase):
     ) -> None:
         monkeypatch.setattr(TiffImagePlugin, "WRITE_LIBTIFF", True)
 
-        out = str(tmp_path / "temp.tif")
+        out = tmp_path / "temp.tif"
         hopper().save(out, tiffinfo={700: b"xmlpacket tag"})
 
         with Image.open(out) as reloaded:
@@ -375,7 +375,7 @@ class TestFileLibTiff(LibTiffTestCase):
     def test_int_dpi(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         # issue #1765
         im = hopper("RGB")
-        out = str(tmp_path / "temp.tif")
+        out = tmp_path / "temp.tif"
         monkeypatch.setattr(TiffImagePlugin, "WRITE_LIBTIFF", True)
         im.save(out, dpi=(72, 72))
         with Image.open(out) as reloaded:
@@ -383,7 +383,7 @@ class TestFileLibTiff(LibTiffTestCase):
 
     def test_g3_compression(self, tmp_path: Path) -> None:
         with Image.open("Tests/images/hopper_g4_500.tif") as i:
-            out = str(tmp_path / "temp.tif")
+            out = tmp_path / "temp.tif"
             i.save(out, compression="group3")
 
             with Image.open(out) as reread:
@@ -400,7 +400,7 @@ class TestFileLibTiff(LibTiffTestCase):
             assert b[0] == ord(b"\xe0")
             assert b[1] == ord(b"\x01")
 
-            out = str(tmp_path / "temp.tif")
+            out = tmp_path / "temp.tif"
             # out = "temp.le.tif"
             im.save(out)
         with Image.open(out) as reread:
@@ -420,7 +420,7 @@ class TestFileLibTiff(LibTiffTestCase):
             assert b[0] == ord(b"\x01")
             assert b[1] == ord(b"\xe0")
 
-            out = str(tmp_path / "temp.tif")
+            out = tmp_path / "temp.tif"
             im.save(out)
             with Image.open(out) as reread:
                 assert reread.info["compression"] == im.info["compression"]
@@ -430,7 +430,7 @@ class TestFileLibTiff(LibTiffTestCase):
         """Tests String data in info directory"""
         test_file = "Tests/images/hopper_g4_500.tif"
         with Image.open(test_file) as orig:
-            out = str(tmp_path / "temp.tif")
+            out = tmp_path / "temp.tif"
 
             orig.tag[269] = "temp.tif"
             orig.save(out)
@@ -457,7 +457,7 @@ class TestFileLibTiff(LibTiffTestCase):
     def test_blur(self, tmp_path: Path) -> None:
         # test case from irc, how to do blur on b/w image
         # and save to compressed tif.
-        out = str(tmp_path / "temp.tif")
+        out = tmp_path / "temp.tif"
         with Image.open("Tests/images/pport_g4.tif") as im:
             im = im.convert("L")
 
@@ -470,7 +470,7 @@ class TestFileLibTiff(LibTiffTestCase):
         # Test various tiff compressions and assert similar image content but reduced
         # file sizes.
         im = hopper("RGB")
-        out = str(tmp_path / "temp.tif")
+        out = tmp_path / "temp.tif"
         im.save(out)
         size_raw = os.path.getsize(out)
 
@@ -494,7 +494,7 @@ class TestFileLibTiff(LibTiffTestCase):
 
     def test_tiff_jpeg_compression(self, tmp_path: Path) -> None:
         im = hopper("RGB")
-        out = str(tmp_path / "temp.tif")
+        out = tmp_path / "temp.tif"
         im.save(out, compression="tiff_jpeg")
 
         with Image.open(out) as reloaded:
@@ -502,7 +502,7 @@ class TestFileLibTiff(LibTiffTestCase):
 
     def test_tiff_deflate_compression(self, tmp_path: Path) -> None:
         im = hopper("RGB")
-        out = str(tmp_path / "temp.tif")
+        out = tmp_path / "temp.tif"
         im.save(out, compression="tiff_deflate")
 
         with Image.open(out) as reloaded:
@@ -510,7 +510,7 @@ class TestFileLibTiff(LibTiffTestCase):
 
     def test_quality(self, tmp_path: Path) -> None:
         im = hopper("RGB")
-        out = str(tmp_path / "temp.tif")
+        out = tmp_path / "temp.tif"
 
         with pytest.raises(ValueError):
             im.save(out, compression="tiff_lzw", quality=50)
@@ -525,7 +525,7 @@ class TestFileLibTiff(LibTiffTestCase):
 
     def test_cmyk_save(self, tmp_path: Path) -> None:
         im = hopper("CMYK")
-        out = str(tmp_path / "temp.tif")
+        out = tmp_path / "temp.tif"
 
         im.save(out, compression="tiff_adobe_deflate")
         assert_image_equal_tofile(im, out)
@@ -534,7 +534,7 @@ class TestFileLibTiff(LibTiffTestCase):
     def test_palette_save(
         self, im: Image.Image, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        out = str(tmp_path / "temp.tif")
+        out = tmp_path / "temp.tif"
 
         monkeypatch.setattr(TiffImagePlugin, "WRITE_LIBTIFF", True)
         im.save(out)
@@ -546,7 +546,7 @@ class TestFileLibTiff(LibTiffTestCase):
     @pytest.mark.parametrize("compression", ("tiff_ccitt", "group3", "group4"))
     def test_bw_compression_w_rgb(self, compression: str, tmp_path: Path) -> None:
         im = hopper("RGB")
-        out = str(tmp_path / "temp.tif")
+        out = tmp_path / "temp.tif"
 
         with pytest.raises(OSError):
             im.save(out, compression=compression)
@@ -686,7 +686,7 @@ class TestFileLibTiff(LibTiffTestCase):
 
     def test_save_ycbcr(self, tmp_path: Path) -> None:
         im = hopper("YCbCr")
-        outfile = str(tmp_path / "temp.tif")
+        outfile = tmp_path / "temp.tif"
         im.save(outfile, compression="jpeg")
 
         with Image.open(outfile) as reloaded:
@@ -713,7 +713,7 @@ class TestFileLibTiff(LibTiffTestCase):
     ) -> None:
         # issue 1597
         with Image.open("Tests/images/rdf.tif") as im:
-            out = str(tmp_path / "temp.tif")
+            out = tmp_path / "temp.tif"
 
             monkeypatch.setattr(TiffImagePlugin, "WRITE_LIBTIFF", True)
             # this shouldn't crash
@@ -724,7 +724,7 @@ class TestFileLibTiff(LibTiffTestCase):
         # Test TIFF with tag 297 (Page Number) having value of 0 0.
         # The first number is the current page number.
         # The second is the total number of pages, zero means not available.
-        outfile = str(tmp_path / "temp.tif")
+        outfile = tmp_path / "temp.tif"
         # Created by printing a page in Chrome to PDF, then:
         # /usr/bin/gs -q -sDEVICE=tiffg3 -sOutputFile=total-pages-zero.tif
         # -dNOPAUSE /tmp/test.pdf -c quit
@@ -736,7 +736,7 @@ class TestFileLibTiff(LibTiffTestCase):
     def test_fd_duplication(self, tmp_path: Path) -> None:
         # https://github.com/python-pillow/Pillow/issues/1651
 
-        tmpfile = str(tmp_path / "temp.tif")
+        tmpfile = tmp_path / "temp.tif"
         with open(tmpfile, "wb") as f:
             with open("Tests/images/g4-multi.tiff", "rb") as src:
                 f.write(src.read())
@@ -779,7 +779,7 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open("Tests/images/hopper.iccprofile.tif") as img:
             icc_profile = img.info["icc_profile"]
 
-            out = str(tmp_path / "temp.tif")
+            out = tmp_path / "temp.tif"
             img.save(out, icc_profile=icc_profile)
         with Image.open(out) as reloaded:
             assert icc_profile == reloaded.info["icc_profile"]
@@ -802,7 +802,7 @@ class TestFileLibTiff(LibTiffTestCase):
 
     def test_save_tiff_with_jpegtables(self, tmp_path: Path) -> None:
         # Arrange
-        outfile = str(tmp_path / "temp.tif")
+        outfile = tmp_path / "temp.tif"
 
         # Created with ImageMagick: convert hopper.jpg hopper_jpg.tif
         # Contains JPEGTables (347) tag
@@ -864,7 +864,7 @@ class TestFileLibTiff(LibTiffTestCase):
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         im = Image.new("F", (1, 1))
-        out = str(tmp_path / "temp.tif")
+        out = tmp_path / "temp.tif"
         monkeypatch.setattr(TiffImagePlugin, "WRITE_LIBTIFF", True)
         im.save(out)
 
@@ -1008,7 +1008,7 @@ class TestFileLibTiff(LibTiffTestCase):
     @pytest.mark.parametrize("compression", (None, "jpeg"))
     def test_block_tile_tags(self, compression: str | None, tmp_path: Path) -> None:
         im = hopper()
-        out = str(tmp_path / "temp.tif")
+        out = tmp_path / "temp.tif"
 
         tags = {
             TiffImagePlugin.TILEWIDTH: 256,
@@ -1147,7 +1147,7 @@ class TestFileLibTiff(LibTiffTestCase):
     @pytest.mark.parametrize("compression", ("tiff_adobe_deflate", "jpeg"))
     def test_save_multistrip(self, compression: str, tmp_path: Path) -> None:
         im = hopper("RGB").resize((256, 256))
-        out = str(tmp_path / "temp.tif")
+        out = tmp_path / "temp.tif"
         im.save(out, compression=compression)
 
         with Image.open(out) as im:
@@ -1160,7 +1160,7 @@ class TestFileLibTiff(LibTiffTestCase):
         self, argument: bool, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         im = hopper("RGB").resize((256, 256))
-        out = str(tmp_path / "temp.tif")
+        out = tmp_path / "temp.tif"
 
         if not argument:
             monkeypatch.setattr(TiffImagePlugin, "STRIP_SIZE", 2**18)
@@ -1176,13 +1176,13 @@ class TestFileLibTiff(LibTiffTestCase):
     @pytest.mark.parametrize("compression", ("tiff_adobe_deflate", None))
     def test_save_zero(self, compression: str | None, tmp_path: Path) -> None:
         im = Image.new("RGB", (0, 0))
-        out = str(tmp_path / "temp.tif")
+        out = tmp_path / "temp.tif"
         with pytest.raises(SystemError):
             im.save(out, compression=compression)
 
     def test_save_many_compressed(self, tmp_path: Path) -> None:
         im = hopper()
-        out = str(tmp_path / "temp.tif")
+        out = tmp_path / "temp.tif"
         for _ in range(10000):
             im.save(out, compression="jpeg")
 

--- a/Tests/test_file_msp.py
+++ b/Tests/test_file_msp.py
@@ -15,7 +15,7 @@ YA_EXTRA_DIR = "Tests/images/msp"
 
 
 def test_sanity(tmp_path: Path) -> None:
-    test_file = str(tmp_path / "temp.msp")
+    test_file = tmp_path / "temp.msp"
 
     hopper("1").save(test_file)
 
@@ -84,7 +84,7 @@ def test_msp_v2() -> None:
 def test_cannot_save_wrong_mode(tmp_path: Path) -> None:
     # Arrange
     im = hopper()
-    filename = str(tmp_path / "temp.msp")
+    filename = tmp_path / "temp.msp"
 
     # Act/Assert
     with pytest.raises(OSError):

--- a/Tests/test_file_palm.py
+++ b/Tests/test_file_palm.py
@@ -14,7 +14,7 @@ from .helper import assert_image_equal, hopper, magick_command
 def helper_save_as_palm(tmp_path: Path, mode: str) -> None:
     # Arrange
     im = hopper(mode)
-    outfile = str(tmp_path / ("temp_" + mode + ".palm"))
+    outfile = tmp_path / ("temp_" + mode + ".palm")
 
     # Act
     im.save(outfile)
@@ -25,7 +25,7 @@ def helper_save_as_palm(tmp_path: Path, mode: str) -> None:
 
 
 def open_with_magick(magick: list[str], tmp_path: Path, f: str) -> Image.Image:
-    outfile = str(tmp_path / "temp.png")
+    outfile = tmp_path / "temp.png"
     rc = subprocess.call(
         magick + [f, outfile], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT
     )

--- a/Tests/test_file_pcx.py
+++ b/Tests/test_file_pcx.py
@@ -11,7 +11,7 @@ from .helper import assert_image_equal, hopper
 
 
 def _roundtrip(tmp_path: Path, im: Image.Image) -> None:
-    f = str(tmp_path / "temp.pcx")
+    f = tmp_path / "temp.pcx"
     im.save(f)
     with Image.open(f) as im2:
         assert im2.mode == im.mode
@@ -31,7 +31,7 @@ def test_sanity(tmp_path: Path) -> None:
     _roundtrip(tmp_path, im)
 
     # Test an unsupported mode
-    f = str(tmp_path / "temp.pcx")
+    f = tmp_path / "temp.pcx"
     im = hopper("RGBA")
     with pytest.raises(ValueError):
         im.save(f)

--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -55,7 +55,7 @@ def test_save_alpha(tmp_path: Path, mode: str) -> None:
 
 def test_p_alpha(tmp_path: Path) -> None:
     # Arrange
-    outfile = str(tmp_path / "temp.pdf")
+    outfile = tmp_path / "temp.pdf"
     with Image.open("Tests/images/pil123p.png") as im:
         assert im.mode == "P"
         assert isinstance(im.info["transparency"], bytes)
@@ -80,7 +80,7 @@ def test_monochrome(tmp_path: Path) -> None:
 
 def test_unsupported_mode(tmp_path: Path) -> None:
     im = hopper("PA")
-    outfile = str(tmp_path / "temp_PA.pdf")
+    outfile = tmp_path / "temp_PA.pdf"
 
     with pytest.raises(ValueError):
         im.save(outfile)
@@ -89,7 +89,7 @@ def test_unsupported_mode(tmp_path: Path) -> None:
 def test_resolution(tmp_path: Path) -> None:
     im = hopper()
 
-    outfile = str(tmp_path / "temp.pdf")
+    outfile = tmp_path / "temp.pdf"
     im.save(outfile, resolution=150)
 
     with open(outfile, "rb") as fp:
@@ -117,7 +117,7 @@ def test_resolution(tmp_path: Path) -> None:
 def test_dpi(params: dict[str, int | tuple[int, int]], tmp_path: Path) -> None:
     im = hopper()
 
-    outfile = str(tmp_path / "temp.pdf")
+    outfile = tmp_path / "temp.pdf"
     im.save(outfile, "PDF", **params)
 
     with open(outfile, "rb") as fp:
@@ -144,7 +144,7 @@ def test_save_all(tmp_path: Path) -> None:
 
     # Multiframe image
     with Image.open("Tests/images/dispose_bgnd.gif") as im:
-        outfile = str(tmp_path / "temp.pdf")
+        outfile = tmp_path / "temp.pdf"
         im.save(outfile, save_all=True)
 
         assert os.path.isfile(outfile)
@@ -177,7 +177,7 @@ def test_save_all(tmp_path: Path) -> None:
 def test_multiframe_normal_save(tmp_path: Path) -> None:
     # Test saving a multiframe image without save_all
     with Image.open("Tests/images/dispose_bgnd.gif") as im:
-        outfile = str(tmp_path / "temp.pdf")
+        outfile = tmp_path / "temp.pdf"
         im.save(outfile)
 
     assert os.path.isfile(outfile)

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -68,7 +68,7 @@ def roundtrip(im: Image.Image, **options: Any) -> PngImagePlugin.PngImageFile:
 
 @skip_unless_feature("zlib")
 class TestFilePng:
-    def get_chunks(self, filename: str) -> list[bytes]:
+    def get_chunks(self, filename: Path) -> list[bytes]:
         chunks = []
         with open(filename, "rb") as fp:
             fp.read(8)
@@ -89,7 +89,7 @@ class TestFilePng:
         assert version is not None
         assert re.search(r"\d+(\.\d+){1,3}(\.zlib\-ng)?$", version)
 
-        test_file = str(tmp_path / "temp.png")
+        test_file = tmp_path / "temp.png"
 
         hopper("RGB").save(test_file)
 
@@ -250,7 +250,7 @@ class TestFilePng:
             # each palette entry
             assert len(im.info["transparency"]) == 256
 
-            test_file = str(tmp_path / "temp.png")
+            test_file = tmp_path / "temp.png"
             im.save(test_file)
 
         # check if saved image contains same transparency
@@ -271,7 +271,7 @@ class TestFilePng:
             assert im.info["transparency"] == 164
             assert im.getpixel((31, 31)) == 164
 
-            test_file = str(tmp_path / "temp.png")
+            test_file = tmp_path / "temp.png"
             im.save(test_file)
 
         # check if saved image contains same transparency
@@ -294,7 +294,7 @@ class TestFilePng:
         assert im.getcolors() == [(100, (0, 0, 0, 0))]
 
         im = im.convert("P")
-        test_file = str(tmp_path / "temp.png")
+        test_file = tmp_path / "temp.png"
         im.save(test_file)
 
         # check if saved image contains same transparency
@@ -315,7 +315,7 @@ class TestFilePng:
                 im_rgba = im.convert("RGBA")
             assert im_rgba.getchannel("A").getcolors()[0][0] == num_transparent
 
-            test_file = str(tmp_path / "temp.png")
+            test_file = tmp_path / "temp.png"
             im.save(test_file)
 
             with Image.open(test_file) as test_im:
@@ -329,7 +329,7 @@ class TestFilePng:
     def test_save_rgb_single_transparency(self, tmp_path: Path) -> None:
         in_file = "Tests/images/caption_6_33_22.png"
         with Image.open(in_file) as im:
-            test_file = str(tmp_path / "temp.png")
+            test_file = tmp_path / "temp.png"
             im.save(test_file)
 
     def test_load_verify(self) -> None:
@@ -488,7 +488,7 @@ class TestFilePng:
         im = hopper("P")
         im.info["transparency"] = 0
 
-        f = str(tmp_path / "temp.png")
+        f = tmp_path / "temp.png"
         im.save(f)
 
         with Image.open(f) as im2:
@@ -549,7 +549,7 @@ class TestFilePng:
 
     def test_chunk_order(self, tmp_path: Path) -> None:
         with Image.open("Tests/images/icc_profile.png") as im:
-            test_file = str(tmp_path / "temp.png")
+            test_file = tmp_path / "temp.png"
             im.convert("P").save(test_file, dpi=(100, 100))
 
         chunks = self.get_chunks(test_file)
@@ -661,7 +661,7 @@ class TestFilePng:
     def test_specify_bits(self, save_all: bool, tmp_path: Path) -> None:
         im = hopper("P")
 
-        out = str(tmp_path / "temp.png")
+        out = tmp_path / "temp.png"
         im.save(out, bits=4, save_all=save_all)
 
         with Image.open(out) as reloaded:
@@ -671,8 +671,8 @@ class TestFilePng:
         im = Image.new("P", (1, 1))
         im.putpalette((1, 1, 1))
 
-        out = str(tmp_path / "temp.png")
-        im.save(str(tmp_path / "temp.png"))
+        out = tmp_path / "temp.png"
+        im.save(tmp_path / "temp.png")
 
         with Image.open(out) as reloaded:
             assert len(reloaded.png.im_palette[1]) == 3
@@ -721,7 +721,7 @@ class TestFilePng:
 
     def test_exif_save(self, tmp_path: Path) -> None:
         # Test exif is not saved from info
-        test_file = str(tmp_path / "temp.png")
+        test_file = tmp_path / "temp.png"
         with Image.open("Tests/images/exif.png") as im:
             im.save(test_file)
 
@@ -741,7 +741,7 @@ class TestFilePng:
     )
     def test_exif_from_jpg(self, tmp_path: Path) -> None:
         with Image.open("Tests/images/pil_sample_rgb.jpg") as im:
-            test_file = str(tmp_path / "temp.png")
+            test_file = tmp_path / "temp.png"
             im.save(test_file, exif=im.getexif())
 
         with Image.open(test_file) as reloaded:
@@ -750,7 +750,7 @@ class TestFilePng:
 
     def test_exif_argument(self, tmp_path: Path) -> None:
         with Image.open(TEST_PNG_FILE) as im:
-            test_file = str(tmp_path / "temp.png")
+            test_file = tmp_path / "temp.png"
             im.save(test_file, exif=b"exifstring")
 
         with Image.open(test_file) as reloaded:

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -672,7 +672,7 @@ class TestFilePng:
         im.putpalette((1, 1, 1))
 
         out = tmp_path / "temp.png"
-        im.save(tmp_path / "temp.png")
+        im.save(out)
 
         with Image.open(out) as reloaded:
             assert len(reloaded.png.im_palette[1]) == 3

--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -94,7 +94,7 @@ def test_16bit_pgm() -> None:
 
 def test_16bit_pgm_write(tmp_path: Path) -> None:
     with Image.open("Tests/images/16_bit_binary.pgm") as im:
-        filename = str(tmp_path / "temp.pgm")
+        filename = tmp_path / "temp.pgm"
         im.save(filename, "PPM")
         assert_image_equal_tofile(im, filename)
 
@@ -106,7 +106,7 @@ def test_pnm(tmp_path: Path) -> None:
     with Image.open("Tests/images/hopper.pnm") as im:
         assert_image_similar(im, hopper(), 0.0001)
 
-        filename = str(tmp_path / "temp.pnm")
+        filename = tmp_path / "temp.pnm"
         im.save(filename)
 
         assert_image_equal_tofile(im, filename)
@@ -117,7 +117,7 @@ def test_pfm(tmp_path: Path) -> None:
         assert im.info["scale"] == 1.0
         assert_image_equal(im, hopper("F"))
 
-        filename = str(tmp_path / "tmp.pfm")
+        filename = tmp_path / "tmp.pfm"
         im.save(filename)
 
         assert_image_equal_tofile(im, filename)
@@ -128,7 +128,7 @@ def test_pfm_big_endian(tmp_path: Path) -> None:
         assert im.info["scale"] == 2.5
         assert_image_equal(im, hopper("F"))
 
-        filename = str(tmp_path / "tmp.pfm")
+        filename = tmp_path / "tmp.pfm"
         im.save(filename)
 
         assert_image_equal_tofile(im, filename)
@@ -194,8 +194,8 @@ def test_16bit_plain_pgm() -> None:
 def test_plain_data_with_comment(
     tmp_path: Path, header: bytes, data: bytes, comment_count: int
 ) -> None:
-    path1 = str(tmp_path / "temp1.ppm")
-    path2 = str(tmp_path / "temp2.ppm")
+    path1 = tmp_path / "temp1.ppm"
+    path2 = tmp_path / "temp2.ppm"
     comment = b"# comment" * comment_count
     with open(path1, "wb") as f1, open(path2, "wb") as f2:
         f1.write(header + b"\n\n" + data)
@@ -207,7 +207,7 @@ def test_plain_data_with_comment(
 
 @pytest.mark.parametrize("data", (b"P1\n128 128\n", b"P3\n128 128\n255\n"))
 def test_plain_truncated_data(tmp_path: Path, data: bytes) -> None:
-    path = str(tmp_path / "temp.ppm")
+    path = tmp_path / "temp.ppm"
     with open(path, "wb") as f:
         f.write(data)
 
@@ -218,7 +218,7 @@ def test_plain_truncated_data(tmp_path: Path, data: bytes) -> None:
 
 @pytest.mark.parametrize("data", (b"P1\n128 128\n1009", b"P3\n128 128\n255\n100A"))
 def test_plain_invalid_data(tmp_path: Path, data: bytes) -> None:
-    path = str(tmp_path / "temp.ppm")
+    path = tmp_path / "temp.ppm"
     with open(path, "wb") as f:
         f.write(data)
 
@@ -235,7 +235,7 @@ def test_plain_invalid_data(tmp_path: Path, data: bytes) -> None:
     ),
 )
 def test_plain_ppm_token_too_long(tmp_path: Path, data: bytes) -> None:
-    path = str(tmp_path / "temp.ppm")
+    path = tmp_path / "temp.ppm"
     with open(path, "wb") as f:
         f.write(data)
 
@@ -245,7 +245,7 @@ def test_plain_ppm_token_too_long(tmp_path: Path, data: bytes) -> None:
 
 
 def test_plain_ppm_value_negative(tmp_path: Path) -> None:
-    path = str(tmp_path / "temp.ppm")
+    path = tmp_path / "temp.ppm"
     with open(path, "wb") as f:
         f.write(b"P3\n128 128\n255\n-1")
 
@@ -255,7 +255,7 @@ def test_plain_ppm_value_negative(tmp_path: Path) -> None:
 
 
 def test_plain_ppm_value_too_large(tmp_path: Path) -> None:
-    path = str(tmp_path / "temp.ppm")
+    path = tmp_path / "temp.ppm"
     with open(path, "wb") as f:
         f.write(b"P3\n128 128\n255\n256")
 
@@ -270,7 +270,7 @@ def test_magic() -> None:
 
 
 def test_header_with_comments(tmp_path: Path) -> None:
-    path = str(tmp_path / "temp.ppm")
+    path = tmp_path / "temp.ppm"
     with open(path, "wb") as f:
         f.write(b"P6 #comment\n#comment\r12#comment\r8\n128 #comment\n255\n")
 
@@ -279,7 +279,7 @@ def test_header_with_comments(tmp_path: Path) -> None:
 
 
 def test_non_integer_token(tmp_path: Path) -> None:
-    path = str(tmp_path / "temp.ppm")
+    path = tmp_path / "temp.ppm"
     with open(path, "wb") as f:
         f.write(b"P6\nTEST")
 
@@ -289,7 +289,7 @@ def test_non_integer_token(tmp_path: Path) -> None:
 
 
 def test_header_token_too_long(tmp_path: Path) -> None:
-    path = str(tmp_path / "temp.ppm")
+    path = tmp_path / "temp.ppm"
     with open(path, "wb") as f:
         f.write(b"P6\n 01234567890")
 
@@ -300,7 +300,7 @@ def test_header_token_too_long(tmp_path: Path) -> None:
 
 def test_truncated_file(tmp_path: Path) -> None:
     # Test EOF in header
-    path = str(tmp_path / "temp.pgm")
+    path = tmp_path / "temp.pgm"
     with open(path, "wb") as f:
         f.write(b"P6")
 
@@ -316,7 +316,7 @@ def test_truncated_file(tmp_path: Path) -> None:
 
 
 def test_not_enough_image_data(tmp_path: Path) -> None:
-    path = str(tmp_path / "temp.ppm")
+    path = tmp_path / "temp.ppm"
     with open(path, "wb") as f:
         f.write(b"P2 1 2 255 255")
 
@@ -327,7 +327,7 @@ def test_not_enough_image_data(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("maxval", (b"0", b"65536"))
 def test_invalid_maxval(maxval: bytes, tmp_path: Path) -> None:
-    path = str(tmp_path / "temp.ppm")
+    path = tmp_path / "temp.ppm"
     with open(path, "wb") as f:
         f.write(b"P6\n3 1 " + maxval)
 
@@ -350,7 +350,7 @@ def test_neg_ppm() -> None:
 
 
 def test_mimetypes(tmp_path: Path) -> None:
-    path = str(tmp_path / "temp.pgm")
+    path = tmp_path / "temp.pgm"
 
     with open(path, "wb") as f:
         f.write(b"P4\n128 128\n255")

--- a/Tests/test_file_sgi.py
+++ b/Tests/test_file_sgi.py
@@ -73,11 +73,11 @@ def test_invalid_file() -> None:
 
 def test_write(tmp_path: Path) -> None:
     def roundtrip(img: Image.Image) -> None:
-        out = str(tmp_path / "temp.sgi")
+        out = tmp_path / "temp.sgi"
         img.save(out, format="sgi")
         assert_image_equal_tofile(img, out)
 
-        out = str(tmp_path / "fp.sgi")
+        out = tmp_path / "fp.sgi"
         with open(out, "wb") as fp:
             img.save(fp)
             assert_image_equal_tofile(img, out)
@@ -95,7 +95,7 @@ def test_write16(tmp_path: Path) -> None:
     test_file = "Tests/images/hopper16.rgb"
 
     with Image.open(test_file) as im:
-        out = str(tmp_path / "temp.sgi")
+        out = tmp_path / "temp.sgi"
         im.save(out, format="sgi", bpc=2)
 
         assert_image_equal_tofile(im, out)
@@ -103,7 +103,7 @@ def test_write16(tmp_path: Path) -> None:
 
 def test_unsupported_mode(tmp_path: Path) -> None:
     im = hopper("LA")
-    out = str(tmp_path / "temp.sgi")
+    out = tmp_path / "temp.sgi"
 
     with pytest.raises(ValueError):
         im.save(out, format="sgi")

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -51,7 +51,7 @@ def test_context_manager() -> None:
 
 def test_save(tmp_path: Path) -> None:
     # Arrange
-    temp = str(tmp_path / "temp.spider")
+    temp = tmp_path / "temp.spider"
     im = hopper()
 
     # Act

--- a/Tests/test_file_tga.py
+++ b/Tests/test_file_tga.py
@@ -65,7 +65,7 @@ def test_sanity(mode: str, tmp_path: Path) -> None:
                     roundtrip(original_im)
 
 
-def test_palette_depth_8(tmp_path: Path) -> None:
+def test_palette_depth_8() -> None:
     with pytest.raises(UnidentifiedImageError):
         Image.open("Tests/images/p_8.tga")
 

--- a/Tests/test_file_tga.py
+++ b/Tests/test_file_tga.py
@@ -24,7 +24,7 @@ _ORIGIN_TO_ORIENTATION = {"tl": 1, "bl": -1}
 @pytest.mark.parametrize("mode", _MODES)
 def test_sanity(mode: str, tmp_path: Path) -> None:
     def roundtrip(original_im: Image.Image) -> None:
-        out = str(tmp_path / "temp.tga")
+        out = tmp_path / "temp.tga"
 
         original_im.save(out, rle=rle)
         with Image.open(out) as saved_im:
@@ -76,7 +76,7 @@ def test_palette_depth_16(tmp_path: Path) -> None:
         assert im.palette.mode == "RGBA"
         assert_image_equal_tofile(im.convert("RGBA"), "Tests/images/p_16.png")
 
-        out = str(tmp_path / "temp.png")
+        out = tmp_path / "temp.png"
         im.save(out)
         with Image.open(out) as reloaded:
             assert_image_equal_tofile(reloaded.convert("RGBA"), "Tests/images/p_16.png")
@@ -122,7 +122,7 @@ def test_cross_scan_line() -> None:
 def test_save(tmp_path: Path) -> None:
     test_file = "Tests/images/tga_id_field.tga"
     with Image.open(test_file) as im:
-        out = str(tmp_path / "temp.tga")
+        out = tmp_path / "temp.tga"
 
         # Save
         im.save(out)
@@ -141,7 +141,7 @@ def test_small_palette(tmp_path: Path) -> None:
     colors = [0, 0, 0]
     im.putpalette(colors)
 
-    out = str(tmp_path / "temp.tga")
+    out = tmp_path / "temp.tga"
     im.save(out)
 
     with Image.open(out) as reloaded:
@@ -155,7 +155,7 @@ def test_missing_palette() -> None:
 
 def test_save_wrong_mode(tmp_path: Path) -> None:
     im = hopper("PA")
-    out = str(tmp_path / "temp.tga")
+    out = tmp_path / "temp.tga"
 
     with pytest.raises(OSError):
         im.save(out)
@@ -172,7 +172,7 @@ def test_save_mapdepth() -> None:
 def test_save_id_section(tmp_path: Path) -> None:
     test_file = "Tests/images/rgb32rle.tga"
     with Image.open(test_file) as im:
-        out = str(tmp_path / "temp.tga")
+        out = tmp_path / "temp.tga"
 
         # Check there is no id section
         im.save(out)
@@ -202,7 +202,7 @@ def test_save_id_section(tmp_path: Path) -> None:
 
 def test_save_orientation(tmp_path: Path) -> None:
     test_file = "Tests/images/rgb32rle.tga"
-    out = str(tmp_path / "temp.tga")
+    out = tmp_path / "temp.tga"
     with Image.open(test_file) as im:
         assert im.info["orientation"] == -1
 
@@ -229,7 +229,7 @@ def test_save_rle(tmp_path: Path) -> None:
     with Image.open(test_file) as im:
         assert im.info["compression"] == "tga_rle"
 
-        out = str(tmp_path / "temp.tga")
+        out = tmp_path / "temp.tga"
 
         # Save
         im.save(out)
@@ -266,7 +266,7 @@ def test_save_l_transparency(tmp_path: Path) -> None:
         assert im.mode == "LA"
         assert im.getchannel("A").getcolors()[0][0] == num_transparent
 
-        out = str(tmp_path / "temp.tga")
+        out = tmp_path / "temp.tga"
         im.save(out)
 
     with Image.open(out) as test_im:

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -31,7 +31,7 @@ except ImportError:
 
 class TestFileTiff:
     def test_sanity(self, tmp_path: Path) -> None:
-        filename = str(tmp_path / "temp.tif")
+        filename = tmp_path / "temp.tif"
 
         hopper("RGB").save(filename)
 
@@ -112,11 +112,11 @@ class TestFileTiff:
             assert_image_equal_tofile(im, "Tests/images/hopper.tif")
 
         with Image.open("Tests/images/hopper_bigtiff.tif") as im:
-            outfile = str(tmp_path / "temp.tif")
+            outfile = tmp_path / "temp.tif"
             im.save(outfile, save_all=True, append_images=[im], tiffinfo=im.tag_v2)
 
     def test_bigtiff_save(self, tmp_path: Path) -> None:
-        outfile = str(tmp_path / "temp.tif")
+        outfile = tmp_path / "temp.tif"
         im = hopper()
         im.save(outfile, big_tiff=True)
 
@@ -185,7 +185,7 @@ class TestFileTiff:
             assert im.info["dpi"] == (dpi, dpi)
 
     def test_save_float_dpi(self, tmp_path: Path) -> None:
-        outfile = str(tmp_path / "temp.tif")
+        outfile = tmp_path / "temp.tif"
         with Image.open("Tests/images/hopper.tif") as im:
             dpi = (72.2, 72.2)
             im.save(outfile, dpi=dpi)
@@ -220,12 +220,12 @@ class TestFileTiff:
 
     def test_save_rgba(self, tmp_path: Path) -> None:
         im = hopper("RGBA")
-        outfile = str(tmp_path / "temp.tif")
+        outfile = tmp_path / "temp.tif"
         im.save(outfile)
 
     def test_save_unsupported_mode(self, tmp_path: Path) -> None:
         im = hopper("HSV")
-        outfile = str(tmp_path / "temp.tif")
+        outfile = tmp_path / "temp.tif"
         with pytest.raises(OSError):
             im.save(outfile)
 
@@ -485,14 +485,14 @@ class TestFileTiff:
             assert gps[0] == b"\x03\x02\x00\x00"
             assert gps[18] == "WGS-84"
 
-        outfile = str(tmp_path / "temp.tif")
+        outfile = tmp_path / "temp.tif"
         with Image.open("Tests/images/ifd_tag_type.tiff") as im:
             exif = im.getexif()
             check_exif(exif)
 
             im.save(outfile, exif=exif)
 
-        outfile2 = str(tmp_path / "temp2.tif")
+        outfile2 = tmp_path / "temp2.tif"
         with Image.open(outfile) as im:
             exif = im.getexif()
             check_exif(exif)
@@ -504,7 +504,7 @@ class TestFileTiff:
             check_exif(exif)
 
     def test_modify_exif(self, tmp_path: Path) -> None:
-        outfile = str(tmp_path / "temp.tif")
+        outfile = tmp_path / "temp.tif"
         with Image.open("Tests/images/ifd_tag_type.tiff") as im:
             exif = im.getexif()
             exif[264] = 100
@@ -533,7 +533,7 @@ class TestFileTiff:
 
     @pytest.mark.parametrize("mode", ("1", "L"))
     def test_photometric(self, mode: str, tmp_path: Path) -> None:
-        filename = str(tmp_path / "temp.tif")
+        filename = tmp_path / "temp.tif"
         im = hopper(mode)
         im.save(filename, tiffinfo={262: 0})
         with Image.open(filename) as reloaded:
@@ -612,7 +612,7 @@ class TestFileTiff:
 
     def test_with_underscores(self, tmp_path: Path) -> None:
         kwargs = {"resolution_unit": "inch", "x_resolution": 72, "y_resolution": 36}
-        filename = str(tmp_path / "temp.tif")
+        filename = tmp_path / "temp.tif"
         hopper("RGB").save(filename, "TIFF", **kwargs)
         with Image.open(filename) as im:
             # legacy interface
@@ -630,14 +630,14 @@ class TestFileTiff:
         with Image.open(infile) as im:
             assert im.getpixel((0, 0)) == pixel_value
 
-            tmpfile = str(tmp_path / "temp.tif")
+            tmpfile = tmp_path / "temp.tif"
             im.save(tmpfile)
 
             assert_image_equal_tofile(im, tmpfile)
 
     def test_iptc(self, tmp_path: Path) -> None:
         # Do not preserve IPTC_NAA_CHUNK by default if type is LONG
-        outfile = str(tmp_path / "temp.tif")
+        outfile = tmp_path / "temp.tif"
         with Image.open("Tests/images/hopper.tif") as im:
             im.load()
             assert isinstance(im, TiffImagePlugin.TiffImageFile)
@@ -652,7 +652,7 @@ class TestFileTiff:
             assert 33723 not in im.tag_v2
 
     def test_rowsperstrip(self, tmp_path: Path) -> None:
-        outfile = str(tmp_path / "temp.tif")
+        outfile = tmp_path / "temp.tif"
         im = hopper()
         im.save(outfile, tiffinfo={278: 256})
 
@@ -703,7 +703,7 @@ class TestFileTiff:
         with Image.open(infile) as im:
             assert im._planar_configuration == 2
 
-            outfile = str(tmp_path / "temp.tif")
+            outfile = tmp_path / "temp.tif"
             im.save(outfile)
 
             with Image.open(outfile) as reloaded:
@@ -718,7 +718,7 @@ class TestFileTiff:
 
     @pytest.mark.parametrize("mode", ("P", "PA"))
     def test_palette(self, mode: str, tmp_path: Path) -> None:
-        outfile = str(tmp_path / "temp.tif")
+        outfile = tmp_path / "temp.tif"
 
         im = hopper(mode)
         im.save(outfile)
@@ -812,7 +812,7 @@ class TestFileTiff:
         im.info["icc_profile"] = "Dummy value"
 
         # Try save-load round trip to make sure both handle icc_profile.
-        tmpfile = str(tmp_path / "temp.tif")
+        tmpfile = tmp_path / "temp.tif"
         im.save(tmpfile, "TIFF", compression="raw")
         with Image.open(tmpfile) as reloaded:
             assert b"Dummy value" == reloaded.info["icc_profile"]
@@ -821,7 +821,7 @@ class TestFileTiff:
         im = hopper()
         assert "icc_profile" not in im.info
 
-        outfile = str(tmp_path / "temp.tif")
+        outfile = tmp_path / "temp.tif"
         icc_profile = b"Dummy value"
         im.save(outfile, icc_profile=icc_profile)
 
@@ -832,11 +832,11 @@ class TestFileTiff:
         with Image.open("Tests/images/hopper.bmp") as im:
             assert im.info["compression"] == 0
 
-            outfile = str(tmp_path / "temp.tif")
+            outfile = tmp_path / "temp.tif"
             im.save(outfile)
 
     def test_discard_icc_profile(self, tmp_path: Path) -> None:
-        outfile = str(tmp_path / "temp.tif")
+        outfile = tmp_path / "temp.tif"
 
         with Image.open("Tests/images/icc_profile.png") as im:
             assert "icc_profile" in im.info
@@ -889,7 +889,7 @@ class TestFileTiff:
             ]
 
     def test_tiff_chunks(self, tmp_path: Path) -> None:
-        tmpfile = str(tmp_path / "temp.tif")
+        tmpfile = tmp_path / "temp.tif"
 
         im = hopper()
         with open(tmpfile, "wb") as fp:
@@ -911,7 +911,7 @@ class TestFileTiff:
 
     def test_close_on_load_exclusive(self, tmp_path: Path) -> None:
         # similar to test_fd_leak, but runs on unixlike os
-        tmpfile = str(tmp_path / "temp.tif")
+        tmpfile = tmp_path / "temp.tif"
 
         with Image.open("Tests/images/uint16_1_4660.tif") as im:
             im.save(tmpfile)
@@ -923,7 +923,7 @@ class TestFileTiff:
         assert fp.closed
 
     def test_close_on_load_nonexclusive(self, tmp_path: Path) -> None:
-        tmpfile = str(tmp_path / "temp.tif")
+        tmpfile = tmp_path / "temp.tif"
 
         with Image.open("Tests/images/uint16_1_4660.tif") as im:
             im.save(tmpfile)
@@ -974,7 +974,7 @@ class TestFileTiff:
 @pytest.mark.skipif(not is_win32(), reason="Windows only")
 class TestFileTiffW32:
     def test_fd_leak(self, tmp_path: Path) -> None:
-        tmpfile = str(tmp_path / "temp.tif")
+        tmpfile = tmp_path / "temp.tif"
 
         # this is an mmaped file.
         with Image.open("Tests/images/uint16_1_4660.tif") as im:

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -56,7 +56,7 @@ def test_rt_metadata(tmp_path: Path) -> None:
 
     info[ImageDescription] = text_data
 
-    f = str(tmp_path / "temp.tif")
+    f = tmp_path / "temp.tif"
 
     img.save(f, tiffinfo=info)
 
@@ -128,7 +128,7 @@ def test_read_metadata() -> None:
 def test_write_metadata(tmp_path: Path) -> None:
     """Test metadata writing through the python code"""
     with Image.open("Tests/images/hopper.tif") as img:
-        f = str(tmp_path / "temp.tiff")
+        f = tmp_path / "temp.tiff"
         del img.tag[278]
         img.save(f, tiffinfo=img.tag)
 
@@ -163,7 +163,7 @@ def test_write_metadata(tmp_path: Path) -> None:
 
 
 def test_change_stripbytecounts_tag_type(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.tiff")
+    out = tmp_path / "temp.tiff"
     with Image.open("Tests/images/hopper.tif") as im:
         info = im.tag_v2
         del info[278]
@@ -210,7 +210,7 @@ def test_no_duplicate_50741_tag() -> None:
 
 
 def test_iptc(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.tiff")
+    out = tmp_path / "temp.tiff"
     with Image.open("Tests/images/hopper.Lab.tif") as im:
         im.save(out)
 
@@ -227,7 +227,7 @@ def test_writing_other_types_to_ascii(
     info[271] = value
 
     im = hopper()
-    out = str(tmp_path / "temp.tiff")
+    out = tmp_path / "temp.tiff"
     im.save(out, tiffinfo=info)
 
     with Image.open(out) as reloaded:
@@ -244,7 +244,7 @@ def test_writing_other_types_to_bytes(value: int | IFDRational, tmp_path: Path) 
 
     info[700] = value
 
-    out = str(tmp_path / "temp.tiff")
+    out = tmp_path / "temp.tiff"
     im.save(out, tiffinfo=info)
 
     with Image.open(out) as reloaded:
@@ -263,7 +263,7 @@ def test_writing_other_types_to_undefined(
 
     info[33723] = value
 
-    out = str(tmp_path / "temp.tiff")
+    out = tmp_path / "temp.tiff"
     im.save(out, tiffinfo=info)
 
     with Image.open(out) as reloaded:
@@ -296,7 +296,7 @@ def test_empty_metadata() -> None:
 
 def test_iccprofile(tmp_path: Path) -> None:
     # https://github.com/python-pillow/Pillow/issues/1462
-    out = str(tmp_path / "temp.tiff")
+    out = tmp_path / "temp.tiff"
     with Image.open("Tests/images/hopper.iccprofile.tif") as im:
         im.save(out)
 
@@ -317,13 +317,13 @@ def test_iccprofile_binary() -> None:
 
 def test_iccprofile_save_png(tmp_path: Path) -> None:
     with Image.open("Tests/images/hopper.iccprofile.tif") as im:
-        outfile = str(tmp_path / "temp.png")
+        outfile = tmp_path / "temp.png"
         im.save(outfile)
 
 
 def test_iccprofile_binary_save_png(tmp_path: Path) -> None:
     with Image.open("Tests/images/hopper.iccprofile_binary.tif") as im:
-        outfile = str(tmp_path / "temp.png")
+        outfile = tmp_path / "temp.png"
         im.save(outfile)
 
 
@@ -332,7 +332,7 @@ def test_exif_div_zero(tmp_path: Path) -> None:
     info = TiffImagePlugin.ImageFileDirectory_v2()
     info[41988] = TiffImagePlugin.IFDRational(0, 0)
 
-    out = str(tmp_path / "temp.tiff")
+    out = tmp_path / "temp.tiff"
     im.save(out, tiffinfo=info, compression="raw")
 
     with Image.open(out) as reloaded:
@@ -351,7 +351,7 @@ def test_ifd_unsigned_rational(tmp_path: Path) -> None:
 
     info[41493] = TiffImagePlugin.IFDRational(numerator, 1)
 
-    out = str(tmp_path / "temp.tiff")
+    out = tmp_path / "temp.tiff"
     im.save(out, tiffinfo=info, compression="raw")
 
     with Image.open(out) as reloaded:
@@ -363,7 +363,7 @@ def test_ifd_unsigned_rational(tmp_path: Path) -> None:
 
     info[41493] = TiffImagePlugin.IFDRational(numerator, 1)
 
-    out = str(tmp_path / "temp.tiff")
+    out = tmp_path / "temp.tiff"
     im.save(out, tiffinfo=info, compression="raw")
 
     with Image.open(out) as reloaded:
@@ -381,7 +381,7 @@ def test_ifd_signed_rational(tmp_path: Path) -> None:
 
     info[37380] = TiffImagePlugin.IFDRational(numerator, denominator)
 
-    out = str(tmp_path / "temp.tiff")
+    out = tmp_path / "temp.tiff"
     im.save(out, tiffinfo=info, compression="raw")
 
     with Image.open(out) as reloaded:
@@ -393,7 +393,7 @@ def test_ifd_signed_rational(tmp_path: Path) -> None:
 
     info[37380] = TiffImagePlugin.IFDRational(numerator, denominator)
 
-    out = str(tmp_path / "temp.tiff")
+    out = tmp_path / "temp.tiff"
     im.save(out, tiffinfo=info, compression="raw")
 
     with Image.open(out) as reloaded:
@@ -406,7 +406,7 @@ def test_ifd_signed_rational(tmp_path: Path) -> None:
 
     info[37380] = TiffImagePlugin.IFDRational(numerator, denominator)
 
-    out = str(tmp_path / "temp.tiff")
+    out = tmp_path / "temp.tiff"
     im.save(out, tiffinfo=info, compression="raw")
 
     with Image.open(out) as reloaded:
@@ -420,7 +420,7 @@ def test_ifd_signed_long(tmp_path: Path) -> None:
 
     info[37000] = -60000
 
-    out = str(tmp_path / "temp.tiff")
+    out = tmp_path / "temp.tiff"
     im.save(out, tiffinfo=info, compression="raw")
 
     with Image.open(out) as reloaded:
@@ -446,7 +446,7 @@ def test_photoshop_info(tmp_path: Path) -> None:
     with Image.open("Tests/images/issue_2278.tif") as im:
         assert len(im.tag_v2[34377]) == 70
         assert isinstance(im.tag_v2[34377], bytes)
-        out = str(tmp_path / "temp.tiff")
+        out = tmp_path / "temp.tiff"
         im.save(out)
     with Image.open(out) as reloaded:
         assert len(reloaded.tag_v2[34377]) == 70
@@ -480,7 +480,7 @@ def test_tag_group_data() -> None:
 
 
 def test_empty_subifd(tmp_path: Path) -> None:
-    out = str(tmp_path / "temp.jpg")
+    out = tmp_path / "temp.jpg"
 
     im = hopper()
     exif = im.getexif()

--- a/Tests/test_file_webp_alpha.py
+++ b/Tests/test_file_webp_alpha.py
@@ -42,7 +42,7 @@ def test_write_lossless_rgb(tmp_path: Path) -> None:
     Does it have the bits we expect?
     """
 
-    temp_file = str(tmp_path / "temp.webp")
+    temp_file = tmp_path / "temp.webp"
     # temp_file = "temp.webp"
 
     pil_image = hopper("RGBA")
@@ -71,7 +71,7 @@ def test_write_rgba(tmp_path: Path) -> None:
     Does it have the bits we expect?
     """
 
-    temp_file = str(tmp_path / "temp.webp")
+    temp_file = tmp_path / "temp.webp"
 
     pil_image = Image.new("RGBA", (10, 10), (255, 0, 0, 20))
     pil_image.save(temp_file)
@@ -104,7 +104,7 @@ def test_keep_rgb_values_when_transparent(tmp_path: Path) -> None:
     half_transparent_image.putalpha(new_alpha)
 
     # save with transparent area preserved
-    temp_file = str(tmp_path / "temp.webp")
+    temp_file = tmp_path / "temp.webp"
     half_transparent_image.save(temp_file, exact=True, lossless=True)
 
     with Image.open(temp_file) as reloaded:
@@ -123,7 +123,7 @@ def test_write_unsupported_mode_PA(tmp_path: Path) -> None:
     should work, and be similar to the original file.
     """
 
-    temp_file = str(tmp_path / "temp.webp")
+    temp_file = tmp_path / "temp.webp"
     file_path = "Tests/images/transparent.gif"
     with Image.open(file_path) as im:
         im.save(temp_file)
@@ -142,10 +142,10 @@ def test_write_unsupported_mode_PA(tmp_path: Path) -> None:
 
 def test_alpha_quality(tmp_path: Path) -> None:
     with Image.open("Tests/images/transparent.png") as im:
-        out = str(tmp_path / "temp.webp")
+        out = tmp_path / "temp.webp"
         im.save(out)
 
-        out_quality = str(tmp_path / "quality.webp")
+        out_quality = tmp_path / "quality.webp"
         im.save(out_quality, alpha_quality=50)
         with Image.open(out) as reloaded:
             with Image.open(out_quality) as reloaded_quality:

--- a/Tests/test_file_webp_animated.py
+++ b/Tests/test_file_webp_animated.py
@@ -39,7 +39,7 @@ def test_write_animation_L(tmp_path: Path) -> None:
     with Image.open("Tests/images/iss634.gif") as orig:
         assert orig.n_frames > 1
 
-        temp_file = str(tmp_path / "temp.webp")
+        temp_file = tmp_path / "temp.webp"
         orig.save(temp_file, save_all=True)
         with Image.open(temp_file) as im:
             assert im.n_frames == orig.n_frames
@@ -67,7 +67,7 @@ def test_write_animation_RGB(tmp_path: Path) -> None:
     are visually similar to the originals.
     """
 
-    def check(temp_file: str) -> None:
+    def check(temp_file: Path) -> None:
         with Image.open(temp_file) as im:
             assert im.n_frames == 2
 
@@ -87,7 +87,7 @@ def test_write_animation_RGB(tmp_path: Path) -> None:
 
     with Image.open("Tests/images/anim_frame1.webp") as frame1:
         with Image.open("Tests/images/anim_frame2.webp") as frame2:
-            temp_file1 = str(tmp_path / "temp.webp")
+            temp_file1 = tmp_path / "temp.webp"
             frame1.copy().save(
                 temp_file1, save_all=True, append_images=[frame2], lossless=True
             )
@@ -99,7 +99,7 @@ def test_write_animation_RGB(tmp_path: Path) -> None:
             ) -> Generator[Image.Image, None, None]:
                 yield from ims
 
-            temp_file2 = str(tmp_path / "temp_generator.webp")
+            temp_file2 = tmp_path / "temp_generator.webp"
             frame1.copy().save(
                 temp_file2,
                 save_all=True,
@@ -116,7 +116,7 @@ def test_timestamp_and_duration(tmp_path: Path) -> None:
     """
 
     durations = [0, 10, 20, 30, 40]
-    temp_file = str(tmp_path / "temp.webp")
+    temp_file = tmp_path / "temp.webp"
     with Image.open("Tests/images/anim_frame1.webp") as frame1:
         with Image.open("Tests/images/anim_frame2.webp") as frame2:
             frame1.save(
@@ -141,7 +141,7 @@ def test_timestamp_and_duration(tmp_path: Path) -> None:
 
 
 def test_float_duration(tmp_path: Path) -> None:
-    temp_file = str(tmp_path / "temp.webp")
+    temp_file = tmp_path / "temp.webp"
     with Image.open("Tests/images/iss634.apng") as im:
         assert im.info["duration"] == 70.0
 
@@ -159,7 +159,7 @@ def test_seeking(tmp_path: Path) -> None:
     """
 
     dur = 33
-    temp_file = str(tmp_path / "temp.webp")
+    temp_file = tmp_path / "temp.webp"
     with Image.open("Tests/images/anim_frame1.webp") as frame1:
         with Image.open("Tests/images/anim_frame2.webp") as frame2:
             frame1.save(
@@ -196,10 +196,10 @@ def test_alpha_quality(tmp_path: Path) -> None:
     with Image.open("Tests/images/transparent.png") as im:
         first_frame = Image.new("L", im.size)
 
-        out = str(tmp_path / "temp.webp")
+        out = tmp_path / "temp.webp"
         first_frame.save(out, save_all=True, append_images=[im])
 
-        out_quality = str(tmp_path / "quality.webp")
+        out_quality = tmp_path / "quality.webp"
         first_frame.save(
             out_quality, save_all=True, append_images=[im], alpha_quality=50
         )

--- a/Tests/test_file_webp_lossless.py
+++ b/Tests/test_file_webp_lossless.py
@@ -13,7 +13,7 @@ RGB_MODE = "RGB"
 
 
 def test_write_lossless_rgb(tmp_path: Path) -> None:
-    temp_file = str(tmp_path / "temp.webp")
+    temp_file = tmp_path / "temp.webp"
 
     hopper(RGB_MODE).save(temp_file, lossless=True)
 

--- a/Tests/test_file_webp_metadata.py
+++ b/Tests/test_file_webp_metadata.py
@@ -146,7 +146,7 @@ def test_write_animated_metadata(tmp_path: Path) -> None:
     exif_data = b"<exif_data>"
     xmp_data = b"<xmp_data>"
 
-    temp_file = str(tmp_path / "temp.webp")
+    temp_file = tmp_path / "temp.webp"
     with Image.open("Tests/images/anim_frame1.webp") as frame1:
         with Image.open("Tests/images/anim_frame2.webp") as frame2:
             frame1.save(

--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -59,7 +59,7 @@ def test_register_handler(tmp_path: Path) -> None:
     WmfImagePlugin.register_handler(handler)
 
     im = hopper()
-    tmpfile = str(tmp_path / "temp.wmf")
+    tmpfile = tmp_path / "temp.wmf"
     im.save(tmpfile)
     assert handler.methodCalled
 
@@ -93,6 +93,6 @@ def test_load_set_dpi() -> None:
 def test_save(ext: str, tmp_path: Path) -> None:
     im = hopper()
 
-    tmpfile = str(tmp_path / ("temp" + ext))
+    tmpfile = tmp_path / ("temp" + ext)
     with pytest.raises(OSError):
         im.save(tmpfile)

--- a/Tests/test_file_xbm.py
+++ b/Tests/test_file_xbm.py
@@ -73,7 +73,7 @@ def test_invalid_file() -> None:
 
 def test_save_wrong_mode(tmp_path: Path) -> None:
     im = hopper()
-    out = str(tmp_path / "temp.xbm")
+    out = tmp_path / "temp.xbm"
 
     with pytest.raises(OSError):
         im.save(out)
@@ -81,7 +81,7 @@ def test_save_wrong_mode(tmp_path: Path) -> None:
 
 def test_hotspot(tmp_path: Path) -> None:
     im = hopper("1")
-    out = str(tmp_path / "temp.xbm")
+    out = tmp_path / "temp.xbm"
 
     hotspot = (0, 7)
     im.save(out, hotspot=hotspot)

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -175,6 +175,13 @@ class TestImage:
             with Image.open(io.StringIO()):  # type: ignore[arg-type]
                 pass
 
+    def test_string(self, tmp_path: Path) -> None:
+        out = str(tmp_path / "temp.png")
+        im = hopper()
+        im.save(out)
+        with Image.open(out) as reloaded:
+            assert_image_equal(im, reloaded)
+
     def test_pathlib(self, tmp_path: Path) -> None:
         with Image.open(Path("Tests/images/multipage-mmap.tiff")) as im:
             assert im.mode == "P"

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -187,14 +187,14 @@ class TestImage:
             for ext in (".jpg", ".jp2"):
                 if ext == ".jp2" and not features.check_codec("jpg_2000"):
                     pytest.skip("jpg_2000 not available")
-                temp_file = str(tmp_path / ("temp." + ext))
+                temp_file = tmp_path / ("temp." + ext)
                 im.save(Path(temp_file))
 
     def test_fp_name(self, tmp_path: Path) -> None:
-        temp_file = str(tmp_path / "temp.jpg")
+        temp_file = tmp_path / "temp.jpg"
 
         class FP(io.BytesIO):
-            name: str
+            name: Path
 
             if sys.version_info >= (3, 12):
                 from collections.abc import Buffer
@@ -225,7 +225,7 @@ class TestImage:
 
     def test_unknown_extension(self, tmp_path: Path) -> None:
         im = hopper()
-        temp_file = str(tmp_path / "temp.unknown")
+        temp_file = tmp_path / "temp.unknown"
         with pytest.raises(ValueError):
             im.save(temp_file)
 
@@ -245,7 +245,7 @@ class TestImage:
         reason="Test requires opening an mmaped file for writing",
     )
     def test_readonly_save(self, tmp_path: Path) -> None:
-        temp_file = str(tmp_path / "temp.bmp")
+        temp_file = tmp_path / "temp.bmp"
         shutil.copy("Tests/images/rgb32bf-rgba.bmp", temp_file)
 
         with Image.open(temp_file) as im:
@@ -728,7 +728,7 @@ class TestImage:
         # https://github.com/python-pillow/Pillow/issues/835
         # Arrange
         test_file = "Tests/images/hopper.png"
-        temp_file = str(tmp_path / "temp.jpg")
+        temp_file = tmp_path / "temp.jpg"
 
         # Act/Assert
         with Image.open(test_file) as im:
@@ -738,7 +738,7 @@ class TestImage:
                 im.save(temp_file)
 
     def test_no_new_file_on_error(self, tmp_path: Path) -> None:
-        temp_file = str(tmp_path / "temp.jpg")
+        temp_file = tmp_path / "temp.jpg"
 
         im = Image.new("RGB", (0, 0))
         with pytest.raises(ValueError):
@@ -805,7 +805,7 @@ class TestImage:
             assert exif[296] == 2
             assert exif[11] == "gThumb 3.0.1"
 
-            out = str(tmp_path / "temp.jpg")
+            out = tmp_path / "temp.jpg"
             exif[258] = 8
             del exif[274]
             del exif[282]
@@ -827,7 +827,7 @@ class TestImage:
             assert exif[274] == 1
             assert exif[305] == "Adobe Photoshop CC 2017 (Macintosh)"
 
-            out = str(tmp_path / "temp.jpg")
+            out = tmp_path / "temp.jpg"
             exif[258] = 8
             del exif[306]
             exif[274] = 455
@@ -846,7 +846,7 @@ class TestImage:
             exif = im.getexif()
             assert exif == {}
 
-            out = str(tmp_path / "temp.webp")
+            out = tmp_path / "temp.webp"
             exif[258] = 8
             exif[40963] = 455
             exif[305] = "Pillow test"
@@ -868,7 +868,7 @@ class TestImage:
             exif = im.getexif()
             assert exif == {274: 1}
 
-            out = str(tmp_path / "temp.png")
+            out = tmp_path / "temp.png"
             exif[258] = 8
             del exif[274]
             exif[40963] = 455

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -187,8 +187,7 @@ class TestImage:
             for ext in (".jpg", ".jp2"):
                 if ext == ".jp2" and not features.check_codec("jpg_2000"):
                     pytest.skip("jpg_2000 not available")
-                temp_file = tmp_path / ("temp." + ext)
-                im.save(Path(temp_file))
+                im.save(tmp_path / ("temp." + ext))
 
     def test_fp_name(self, tmp_path: Path) -> None:
         temp_file = tmp_path / "temp.jpg"

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -118,7 +118,7 @@ def test_trns_p(tmp_path: Path) -> None:
     im = hopper("P")
     im.info["transparency"] = 0
 
-    f = str(tmp_path / "temp.png")
+    f = tmp_path / "temp.png"
 
     im_l = im.convert("L")
     assert im_l.info["transparency"] == 0
@@ -154,7 +154,7 @@ def test_trns_l(tmp_path: Path) -> None:
     im = hopper("L")
     im.info["transparency"] = 128
 
-    f = str(tmp_path / "temp.png")
+    f = tmp_path / "temp.png"
 
     im_la = im.convert("LA")
     assert "transparency" not in im_la.info
@@ -177,7 +177,7 @@ def test_trns_RGB(tmp_path: Path) -> None:
     im = hopper("RGB")
     im.info["transparency"] = im.getpixel((0, 0))
 
-    f = str(tmp_path / "temp.png")
+    f = tmp_path / "temp.png"
 
     im_l = im.convert("L")
     assert im_l.info["transparency"] == im_l.getpixel((0, 0))  # undone

--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -171,7 +171,7 @@ class TestImagingCoreResize:
         # platforms. So if a future Pillow change requires that the test file
         # be updated, that is okay.
         im = hopper().resize((64, 64))
-        temp_file = str(tmp_path / "temp.gif")
+        temp_file = tmp_path / "temp.gif"
         im.save(temp_file)
 
         with Image.open(temp_file) as reloaded:

--- a/Tests/test_image_split.py
+++ b/Tests/test_image_split.py
@@ -45,9 +45,9 @@ def test_split_merge(mode: str) -> None:
 
 def test_split_open(tmp_path: Path) -> None:
     if features.check("zlib"):
-        test_file = str(tmp_path / "temp.png")
+        test_file = tmp_path / "temp.png"
     else:
-        test_file = str(tmp_path / "temp.pcx")
+        test_file = tmp_path / "temp.pcx"
 
     def split_open(mode: str) -> int:
         hopper(mode).save(test_file)

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -124,7 +124,7 @@ def test_render_equal(layout_engine: ImageFont.Layout) -> None:
 
 
 def test_non_ascii_path(tmp_path: Path, layout_engine: ImageFont.Layout) -> None:
-    tempfile = str(tmp_path / ("temp_" + chr(128) + ".ttf"))
+    tempfile = tmp_path / ("temp_" + chr(128) + ".ttf")
     try:
         shutil.copy(FONT_PATH, tempfile)
     except UnicodeEncodeError:

--- a/Tests/test_imagesequence.py
+++ b/Tests/test_imagesequence.py
@@ -10,7 +10,7 @@ from .helper import assert_image_equal, hopper, skip_unless_feature
 
 
 def test_sanity(tmp_path: Path) -> None:
-    test_file = str(tmp_path / "temp.im")
+    test_file = tmp_path / "temp.im"
 
     im = hopper("RGB")
     im.save(test_file)

--- a/Tests/test_imagewin_pointers.py
+++ b/Tests/test_imagewin_pointers.py
@@ -88,7 +88,7 @@ if is_win32():
     def test_pointer(tmp_path: Path) -> None:
         im = hopper()
         (width, height) = im.size
-        opath = str(tmp_path / "temp.png")
+        opath = tmp_path / "temp.png"
         imdib = ImageWin.Dib(im)
 
         hdr = BITMAPINFOHEADER()

--- a/Tests/test_mode_i16.py
+++ b/Tests/test_mode_i16.py
@@ -44,7 +44,7 @@ def test_basic(tmp_path: Path, mode: str) -> None:
     im_out = im_in.transform((w, h), Image.Transform.EXTENT, (0, 0, w, h))
     verify(im_out)  # transform
 
-    filename = str(tmp_path / "temp.im")
+    filename = tmp_path / "temp.im"
     im_in.save(filename)
 
     with Image.open(filename) as im_out:

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -18,7 +18,7 @@ def helper_pickle_file(
 ) -> None:
     # Arrange
     with Image.open(test_file) as im:
-        filename = str(tmp_path / "temp.pkl")
+        filename = tmp_path / "temp.pkl"
         if mode:
             im = im.convert(mode)
 
@@ -87,7 +87,7 @@ def test_pickle_jpeg() -> None:
 
 def test_pickle_la_mode_with_palette(tmp_path: Path) -> None:
     # Arrange
-    filename = str(tmp_path / "temp.pkl")
+    filename = tmp_path / "temp.pkl"
     with Image.open("Tests/images/hopper.jpg") as im:
         im = im.convert("PA")
 
@@ -151,7 +151,7 @@ def test_pickle_font_string(protocol: int) -> None:
 def test_pickle_font_file(tmp_path: Path, protocol: int) -> None:
     # Arrange
     font = ImageFont.truetype(FONT_PATH, FONT_SIZE)
-    filename = str(tmp_path / "temp.pkl")
+    filename = tmp_path / "temp.pkl"
 
     # Act: roundtrip
     with open(filename, "wb") as f:

--- a/Tests/test_psdraw.py
+++ b/Tests/test_psdraw.py
@@ -35,7 +35,7 @@ def test_draw_postscript(tmp_path: Path) -> None:
     # https://pillow.readthedocs.io/en/latest/handbook/tutorial.html#drawing-postscript
 
     # Arrange
-    tempfile = str(tmp_path / "temp.ps")
+    tempfile = tmp_path / "temp.ps"
     with open(tempfile, "wb") as fp:
         # Act
         ps = PSDraw.PSDraw(fp)

--- a/Tests/test_shell_injection.py
+++ b/Tests/test_shell_injection.py
@@ -35,7 +35,7 @@ class TestShellInjection:
     @pytest.mark.skipif(not djpeg_available(), reason="djpeg not available")
     def test_load_djpeg_filename(self, tmp_path: Path) -> None:
         for filename in test_filenames:
-            src_file = str(tmp_path / filename)
+            src_file = tmp_path / filename
             shutil.copy(TEST_JPG, src_file)
 
             with Image.open(src_file) as im:

--- a/Tests/test_tiff_ifdrational.py
+++ b/Tests/test_tiff_ifdrational.py
@@ -65,7 +65,7 @@ def test_ifd_rational_save(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, libtiff: bool
 ) -> None:
     im = hopper()
-    out = str(tmp_path / "temp.tiff")
+    out = tmp_path / "temp.tiff"
     res = IFDRational(301, 1)
 
     monkeypatch.setattr(TiffImagePlugin, "WRITE_LIBTIFF", libtiff)


### PR DESCRIPTION
Replace
```python
f = str(tmp_path / "temp.png")
```
with
```python
f = tmp_path / "temp.png"
```
where possible.