### PR TITLE
Removed FIXME

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -548,7 +548,6 @@ class Image:
 
     def __init__(self) -> None:
         # FIXME: take "new" parameters / other image?
-        # FIXME: turn mode and size into delegating properties?
         self._im: core.ImagingCore | DeferredError | None = None
         self._mode = ""
         self._size = (0, 0)


### PR DESCRIPTION
Removes the following comment from `Image.__init__()`
https://github.com/python-pillow/Pillow/blob/e66ebb64288f6deffe4ef54b624dcbf34570bb02/src/PIL/Image.py#L551

I think after #3203 and #7307, we've settled on the API for an image's mode and size.