### PR TITLE
Added media_white_point to ImageCms documentation

### DIFF
--- a/docs/reference/ImageCms.rst
+++ b/docs/reference/ImageCms.rst
@@ -286,6 +286,14 @@ can be easily displayed in a chromaticity diagram, for example).
 
         The value is in the format ``((X, Y, Z), (x, y, Y))``, if available.
 
+    .. py:attribute:: media_white_point
+        :type: tuple[tuple[float, float, float], tuple[float, float, float]] | None
+
+        This tag specifies the media white point and is used for
+        generating absolute colorimetry.
+
+        The value is in the format ``((X, Y, Z), (x, y, Y))``, if available.
+
     .. py:attribute:: media_white_point_temperature
         :type: float | None
 


### PR DESCRIPTION
Resolves #8827

Page 40 of https://www.color.org/icc32.pdf
> This tag specifies the media white point and is used for generating absolute colorimetry.

This is mostly a copy of https://pillow.readthedocs.io/en/stable/reference/ImageCms.html#PIL.ImageCms.core.CmsProfile.media_black_point, although without
> This tag was available in ICC 3.2, but it is removed from version 4.

Looking for evidence that media black point was removed in version 4, I found https://www.color.org/v4spec.xalter, that mentions the black tag, but not the white tag. Checking in https://www.color.org/specification/icc1v43_2010-12.pdf, the black tag is gone, but the white tag is still present.