### PR TITLE
Change back to actions/setup-python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
         persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: Quansight-Labs/setup-python@v5
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true


### PR DESCRIPTION
Follow up to #8565

actions/setup-python has just been updated to include support for 3.13t, https://github.com/actions/setup-python/releases/tag/v5.5.0, so we can switch back to it instead of Quansight-Labs/setup-python