### PR TITLE
Do not load image during save if file extension is unknown

### DIFF
--- a/Tests/test_file_hdf5stub.py
+++ b/Tests/test_file_hdf5stub.py
@@ -43,7 +43,7 @@ def test_save() -> None:
     # Arrange
     with Image.open(TEST_FILE) as im:
         dummy_fp = BytesIO()
-        dummy_filename = "dummy.filename"
+        dummy_filename = "dummy.h5"
 
         # Act / Assert: stub cannot save without an implemented handler
         with pytest.raises(OSError):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2510,13 +2510,6 @@ class Image:
             # only set the name for metadata purposes
             filename = os.fspath(fp.name)
 
-        # may mutate self!
-        self._ensure_mutable()
-
-        save_all = params.pop("save_all", False)
-        self.encoderinfo = {**getattr(self, "encoderinfo", {}), **params}
-        self.encoderconfig: tuple[Any, ...] = ()
-
         preinit()
 
         filename_ext = os.path.splitext(filename)[1].lower()
@@ -2530,6 +2523,13 @@ class Image:
             except KeyError as e:
                 msg = f"unknown file extension: {ext}"
                 raise ValueError(msg) from e
+
+        # may mutate self!
+        self._ensure_mutable()
+
+        save_all = params.pop("save_all", False)
+        self.encoderinfo = {**getattr(self, "encoderinfo", {}), **params}
+        self.encoderconfig: tuple[Any, ...] = ()
 
         if format.upper() not in SAVE:
             init()


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/b8abded99b4f77db591e270836156349a074c3bc/src/PIL/Image.py#L2513-L2532

where

https://github.com/python-pillow/Pillow/blob/b8abded99b4f77db591e270836156349a074c3bc/src/PIL/Image.py#L636-L640

If the ValueError is hit, there is no need to have loaded the image first. Avoiding that is a performance improvement for this situation.

A test needed to be updated to continue testing a failed load operation, rather than an unknown file extension.