### PR TITLE
Close TarIO file handle on error

### DIFF
--- a/src/PIL/TarIO.py
+++ b/src/PIL/TarIO.py
@@ -35,12 +35,16 @@ class TarIO(ContainerIO.ContainerIO[bytes]):
         while True:
             s = self.fh.read(512)
             if len(s) != 512:
+                self.fh.close()
+
                 msg = "unexpected end of tar file"
                 raise OSError(msg)
 
             name = s[:100].decode("utf-8")
             i = name.find("\0")
             if i == 0:
+                self.fh.close()
+
                 msg = "cannot find subfile"
                 raise OSError(msg)
             if i > 0:


### PR DESCRIPTION
When testing TarIO errors, the file handle is not closed - https://github.com/python-pillow/Pillow/actions/runs/14155530774/job/39654267057?pr=8844#step:6:5611
```
Tests/test_file_tar.py::test_unexpected_end
  /Pillow/Tests/test_file_tar.py:38: ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/pytest-of-pillow/pytest-0/test_unexpected_end0/temp.tar'>
    with pytest.raises(OSError, match="unexpected end of tar file"):
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

Tests/test_file_tar.py::test_cannot_find_subfile
  /Pillow/Tests/test_file_tar.py:44: ResourceWarning: unclosed file <_io.BufferedReader name='Tests/images/hopper.tar'>
    with pytest.raises(OSError, match="cannot find subfile"):
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
```

This fixes that.