### PR TITLE
Fixed unclosed file warning

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -230,10 +230,10 @@ class TestImage:
                 assert_image_similar(im, reloaded, 20)
 
     def test_unknown_extension(self, tmp_path: Path) -> None:
-        im = hopper()
         temp_file = tmp_path / "temp.unknown"
-        with pytest.raises(ValueError):
-            im.save(temp_file)
+        with hopper() as im:
+            with pytest.raises(ValueError):
+                im.save(temp_file)
 
     def test_internals(self) -> None:
         im = Image.new("L", (100, 100))


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/60b5131e9ff5f6350c5e58d92bd9e3355a19750b/Tests/test_image.py#L232-L236
raises an unclosed file warning - https://github.com/python-pillow/Pillow/actions/runs/14155530774/job/39654267057?pr=8844#step:6:5623

This is because `hopper()` is just returning an opened image.
https://github.com/python-pillow/Pillow/blob/60b5131e9ff5f6350c5e58d92bd9e3355a19750b/Tests/helper.py#L248-L257