### PR TITLE
Updated xz to 5.8.0 on manylinux2014 by removing po4a dependency

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -42,11 +42,7 @@ HARFBUZZ_VERSION=11.0.0
 LIBPNG_VERSION=1.6.47
 JPEGTURBO_VERSION=3.1.0
 OPENJPEG_VERSION=2.5.3
-if [[ $MB_ML_VER == 2014 ]]; then
-  XZ_VERSION=5.6.4
-else
-  XZ_VERSION=5.8.0
-fi
+XZ_VERSION=5.8.0
 TIFF_VERSION=4.7.0
 LCMS2_VERSION=2.17
 ZLIB_VERSION=1.3.1
@@ -55,6 +51,20 @@ LIBWEBP_VERSION=1.5.0
 BZIP2_VERSION=1.0.8
 LIBXCB_VERSION=1.17.0
 BROTLI_VERSION=1.1.0
+
+if [[ $MB_ML_VER == 2014 ]]; then
+    function build_xz {
+        if [ -e xz-stamp ]; then return; fi
+        yum install -y gettext-devel
+        fetch_unpack https://tukaani.org/xz/xz-$XZ_VERSION.tar.gz
+        (cd xz-$XZ_VERSION \
+            && ./autogen.sh --no-po4a \
+            && ./configure --prefix=$BUILD_PREFIX \
+            && make -j4 \
+            && make install)
+        touch xz-stamp
+    }
+fi
 
 function build_pkg_config {
     if [ -e pkg-config-stamp ]; then return; fi


### PR DESCRIPTION
Sequel to #8836

After finding a Makefile error when updating xz to 5.8.0 on manylinux2014, I asked in the xz repository about this - https://github.com/tukaani-project/xz/issues/170#issuecomment-2763301018

The initial response suggested changing our build to handle the fact that xz 5.8.0 no longer worked out of the box for our environment. I didn't immediately consider manylinux2014 a priority, and thought we could live with the older version until Amazon Linux 2 goes EOL in [a year and a bit](https://aws.amazon.com/amazon-linux-2/faqs/) (if Amazon doesn't extend support again) and we drop manylinux2014 support.

However, it turns out that xz would [like us to use the latest version](https://github.com/tukaani-project/xz/issues/170#issuecomment-2763394507). So this PR uses one of their suggestions, removing po4a.

https://tukaani.org/xz/#_optional_dependencies

> **Optional dependencies**
> [po4a](https://po4a.org/) is needed for translated documentation (man pages).
> 
> Autotools: To build without po4a, pass --no-po4a as the argument to autogen.sh.

They have also said that this is a temporary situation, and that xz 5.8.1 will restore support.