### PR TITLE
Allow cmake<4 when building libavif and libtiff

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -235,6 +235,7 @@ DEPS: dict[str, dict[str, Any]] = {
                 "-DBUILD_SHARED_LIBS:BOOL=OFF",
                 "-DWebP_LIBRARY=libwebp",
                 '-DCMAKE_C_FLAGS="-nologo -DLZMA_API_STATIC"',
+                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
             )
         ],
         "headers": [r"libtiff\tiff*.h"],

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -395,6 +395,7 @@ DEPS: dict[str, dict[str, Any]] = {
                 "-DAVIF_CODEC_DAV1D=LOCAL",
                 "-DAVIF_CODEC_RAV1E=LOCAL",
                 "-DAVIF_CODEC_SVT=LOCAL",
+                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
             ),
             cmd_xcopy("include", "{inc_dir}"),
         ],


### PR DESCRIPTION
libtiff has started failing to build in main on WIndows - https://github.com/python-pillow/Pillow/actions/runs/14187037544/job/39744130790

This would be due to the recent release of cmake 4 - https://github.com/Kitware/CMake/releases/tag/v4.0.0

https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features
> Compatibility with versions of CMake older than 3.5 has been removed.