### PR TITLE
Only change readonly if saved filename matches opened filename

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -258,6 +258,15 @@ class TestImage:
             assert im.readonly
             im.save(temp_file)
 
+    def test_save_without_changing_readonly(self, tmp_path: Path) -> None:
+        temp_file = tmp_path / "temp.bmp"
+
+        with Image.open("Tests/images/rgb32bf-rgba.bmp") as im:
+            assert im.readonly
+
+            im.save(temp_file)
+            assert im.readonly
+
     def test_dump(self, tmp_path: Path) -> None:
         im = Image.new("L", (10, 10))
         im._dump(str(tmp_path / "temp_L.ppm"))

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2540,8 +2540,13 @@ class Image:
                 msg = f"unknown file extension: {ext}"
                 raise ValueError(msg) from e
 
+        from . import ImageFile
+
         # may mutate self!
-        self._ensure_mutable()
+        if isinstance(self, ImageFile.ImageFile) and filename == self.filename:
+            self._ensure_mutable()
+        else:
+            self.load()
 
         save_all = params.pop("save_all", None)
         self.encoderinfo = {**getattr(self, "encoderinfo", {}), **params}


### PR DESCRIPTION
Resolves #8828

#3724 ensured that an image was mutable when saving, to fix the scenario where a user is opening an image from a file and then saving it back to the same file.

This reverses that change slightly, only ensuring an image is mutable when saving **if it has the same filename as the opened image**.