### PR TITLE
Always update rust when building libavif on Windows

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -160,11 +160,6 @@ jobs:
           & python.exe winbuild\build_prepare.py -v --no-imagequant --architecture=${{ matrix.cibw_arch }}
         shell: pwsh
 
-      - name: Update rust
-        if: matrix.cibw_arch == 'AMD64'
-        run: |
-          rustup update
-
       - name: Build wheels
         run: |
           setlocal EnableDelayedExpansion

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -385,6 +385,7 @@ DEPS: dict[str, dict[str, Any]] = {
         "filename": f"libavif-{V['LIBAVIF']}.zip",
         "license": "LICENSE",
         "build": [
+            "rustup update",
             f"{sys.executable} -m pip install meson",
             *cmds_cmake(
                 "avif_static",


### PR DESCRIPTION
Recently in the libavif PR, an error occurred when building rav1e in Windows wheels. I reported it at https://github.com/AOMediaCodec/libavif/issues/2703, and the suggestion was to install a Rust toolchain - https://github.com/fdintino/Pillow/pull/32

I opted for a simpler fix, `rustup update` - https://github.com/fdintino/Pillow/pull/33

I noticed the same problem happening in the non-wheels Windows jobs, but a new runner image fixed the problem.

https://github.com/python-pillow/Pillow/pull/8851#issuecomment-2768884176 has now reported a problem building rav1e in the Windows jobs. Those jobs have, for some reason, decided to suddenly use a runner image two weeks old.

Running the jobs again allows them to pass, but I offer this PR as a more proactive measure if you would like one - running `rustup update` in all the Windows builds.