### PR TITLE
Downgrade libXau to 1.0.11

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -170,7 +170,7 @@ function build {
     build_simple xcb-proto 1.17.0 https://xorg.freedesktop.org/archive/individual/proto
     if [ -n "$IS_MACOS" ]; then
         build_simple xorgproto 2024.1 https://www.x.org/pub/individual/proto
-        build_simple libXau 1.0.12 https://www.x.org/pub/individual/lib
+        build_simple libXau 1.0.11 https://www.x.org/pub/individual/lib
         build_simple libpthread-stubs 0.5 https://xcb.freedesktop.org/dist
     else
         sed s/\${pc_sysrootdir\}// $BUILD_PREFIX/share/pkgconfig/xcb-proto.pc > $BUILD_PREFIX/lib/pkgconfig/xcb-proto.pc


### PR DESCRIPTION
http://x.org/ is currently down

Some of our dependencies are hosted there. Fortunately, most are cached at https://github.com/python-pillow/pillow-depends. Unfortunately, libXau 1.0.12 is not, and so there are failures in our macOS wheel builds - https://github.com/python-pillow/Pillow/actions/runs/14210030070

So this PR downgrades libXau to 1.0.11 so that the wheels are able to build again.