### PR TITLE
Use multibuild build_github

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -80,11 +80,7 @@ function build_pkg_config {
 
 function build_zlib_ng {
     if [ -e zlib-stamp ]; then return; fi
-    fetch_unpack https://github.com/zlib-ng/zlib-ng/archive/$ZLIB_NG_VERSION.tar.gz zlib-ng-$ZLIB_NG_VERSION.tar.gz
-    (cd zlib-ng-$ZLIB_NG_VERSION \
-        && ./configure --prefix=$BUILD_PREFIX --zlib-compat \
-        && make -j4 \
-        && make install)
+    build_github zlib-ng/zlib-ng $ZLIB_NG_VERSION --zlib-compat
 
     if [ -n "$IS_MACOS" ]; then
         # Ensure that on macOS, the library name is an absolute path, not an


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/7c56b383ff3ef952854306bbe2c48c5e21066b9c/.github/workflows/wheels-dependencies.sh#L83-L87

can be replaced with

```bash
build_github zlib-ng/zlib-ng $ZLIB_NG_VERSION --zlib-compat
```

thanks to [`build_github()`](https://github.com/multi-build/multibuild/blob/42d761728d141d8462cd9943f4329f12fe62b155/library_builders.sh#L77-L92), which anticipated this scenario.