### PR TITLE
Removed condition that is always true

### DIFF
--- a/src/_avif.c
+++ b/src/_avif.c
@@ -568,9 +568,7 @@ _encoder_add(AvifEncoderObject *self, PyObject *args) {
     }
 
 end:
-    if (&rgb) {
-        avifRGBImageFreePixels(&rgb);
-    }
+    avifRGBImageFreePixels(&rgb);
     if (!self->first_frame) {
         avifImageDestroy(frame);
     }


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/14220077307/job/39845672092#step:10:365
>   src/_avif.c:571:10: warning: address of 'rgb' will always evaluate to 'true' [-Wpointer-bool-conversion]
>       if (&rgb) {
>       ~~   ^~~