### PR TITLE
Replace strncpy with strcpy

### DIFF
--- a/src/libImaging/Arrow.c
+++ b/src/libImaging/Arrow.c
@@ -61,7 +61,6 @@ export_named_type(struct ArrowSchema *schema, char *format, char *name) {
     size_t name_len = strlen(name) + 1;
 
     formatp = calloc(format_len, 1);
-
     if (!formatp) {
         return IMAGING_CODEC_MEMORY;
     }
@@ -72,8 +71,8 @@ export_named_type(struct ArrowSchema *schema, char *format, char *name) {
         return IMAGING_CODEC_MEMORY;
     }
 
-    strncpy(formatp, format, format_len);
-    strncpy(namep, name, name_len);
+    strcpy(formatp, format);
+    strcpy(namep, name);
 
     *schema = (struct ArrowSchema){// Type description
                                    .format = formatp,


### PR DESCRIPTION
I noticed warnings at https://github.com/python-pillow/Pillow/actions/runs/14210030070/job/39830689411#step:5:11057
```
    In file included from /usr/include/string.h:633,
                     from /opt/_internal/cpython-3.9.21/include/python3.9/Python.h:30,
                     from src/libImaging/ImPlatform.h:11,
                     from src/libImaging/Imaging.h:13,
                     from src/libImaging/Arrow.c:3:
    src/libImaging/Arrow.c: In function ‘export_named_type’:
    src/libImaging/Arrow.c:75:5: warning: ‘__builtin_strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
       75 |     strncpy(formatp, format, format_len);
          |     ^~~~~~~
    src/libImaging/Arrow.c:60:25: note: length computed here
       60 |     size_t format_len = strlen(format) + 1;
          |                         ^~~~~~~~~~~~~~
    In file included from /usr/include/string.h:633,
                     from /opt/_internal/cpython-3.9.21/include/python3.9/Python.h:30,
                     from src/libImaging/ImPlatform.h:11,
                     from src/libImaging/Imaging.h:13,
                     from src/libImaging/Arrow.c:3:
    src/libImaging/Arrow.c:76:5: warning: ‘__builtin_strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
       76 |     strncpy(namep, name, name_len);
          |     ^~~~~~~
    src/libImaging/Arrow.c:61:23: note: length computed here
       61 |     size_t name_len = strlen(name) + 1;
          |                       ^~~~~~~~~~~~
```