### PR TITLE
Fixed conversion of AVIF image rotation property to EXIF orientation

### DIFF
--- a/Tests/test_file_avif.py
+++ b/Tests/test_file_avif.py
@@ -309,7 +309,7 @@ class TestFileAvif:
         assert exif[274] == 3
 
     @pytest.mark.parametrize("use_bytes", [True, False])
-    @pytest.mark.parametrize("orientation", [1, 2])
+    @pytest.mark.parametrize("orientation", [1, 2, 3, 4, 5, 6, 7, 8])
     def test_exif_save(
         self,
         tmp_path: Path,
@@ -327,6 +327,7 @@ class TestFileAvif:
             if orientation == 1:
                 assert "exif" not in reloaded.info
             else:
+                assert reloaded.getexif()[274] == orientation
                 assert reloaded.info["exif"] == exif_data
 
     def test_exif_without_orientation(self, tmp_path: Path) -> None:

--- a/src/_avif.c
+++ b/src/_avif.c
@@ -59,7 +59,7 @@ irot_imir_to_exif_orientation(const avifImage *image) {
                 return axis ? 7   // 90 degrees anti-clockwise then swap left and right.
                             : 5;  // 90 degrees anti-clockwise then swap top and bottom.
             }
-            return 6;  // 90 degrees anti-clockwise.
+            return 8;  // 90 degrees anti-clockwise.
         }
         if (angle == 2) {
             if (imir) {
@@ -75,7 +75,7 @@ irot_imir_to_exif_orientation(const avifImage *image) {
                            ? 5   // 270 degrees anti-clockwise then swap left and right.
                            : 7;  // 270 degrees anti-clockwise then swap top and bottom.
             }
-            return 8;  // 270 degrees anti-clockwise.
+            return 6;  // 270 degrees anti-clockwise.
         }
     }
     if (imir) {


### PR DESCRIPTION
This implements a fix for the issue identified in AOMediaCodec/libavif#2727 and fixed in AOMediaCodec/libavif#2729. The code in Pillow that converts irot and imir properties to EXIF orientation was repurposed from libavif, so it suffers the same bug.