### PR TITLE
Updated xz to 5.8.1

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -42,7 +42,7 @@ HARFBUZZ_VERSION=11.0.0
 LIBPNG_VERSION=1.6.47
 JPEGTURBO_VERSION=3.1.0
 OPENJPEG_VERSION=2.5.3
-XZ_VERSION=5.8.0
+XZ_VERSION=5.8.1
 TIFF_VERSION=4.7.0
 LCMS2_VERSION=2.17
 ZLIB_VERSION=1.3.1
@@ -52,20 +52,6 @@ BZIP2_VERSION=1.0.8
 LIBXCB_VERSION=1.17.0
 BROTLI_VERSION=1.1.0
 LIBAVIF_VERSION=1.2.1
-
-if [[ $MB_ML_VER == 2014 ]]; then
-    function build_xz {
-        if [ -e xz-stamp ]; then return; fi
-        yum install -y gettext-devel
-        fetch_unpack https://tukaani.org/xz/xz-$XZ_VERSION.tar.gz
-        (cd xz-$XZ_VERSION \
-            && ./autogen.sh --no-po4a \
-            && ./configure --prefix=$BUILD_PREFIX \
-            && make -j4 \
-            && make install)
-        touch xz-stamp
-    }
-fi
 
 function build_pkg_config {
     if [ -e pkg-config-stamp ]; then return; fi

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -122,7 +122,7 @@ V = {
     "LIBWEBP": "1.5.0",
     "OPENJPEG": "2.5.3",
     "TIFF": "4.7.0",
-    "XZ": "5.6.4" if struct.calcsize("P") == 4 else "5.8.1",
+    "XZ": "5.8.1",
     "ZLIBNG": "2.2.4",
 }
 V["LIBPNG_XY"] = "".join(V["LIBPNG"].split(".")[:2])
@@ -181,7 +181,11 @@ DEPS: dict[str, dict[str, Any]] = {
         "filename": f"xz-{V['XZ']}.tar.gz",
         "license": "COPYING",
         "build": [
-            *cmds_cmake("liblzma", "-DBUILD_SHARED_LIBS:BOOL=OFF"),
+            *cmds_cmake(
+                "liblzma",
+                "-DBUILD_SHARED_LIBS:BOOL=OFF"
+                + (" -DXZ_CLMUL_CRC:BOOL=OFF" if struct.calcsize("P") == 4 else ""),
+            ),
             cmd_mkdir(r"{inc_dir}\lzma"),
             cmd_copy(r"src\liblzma\api\lzma\*.h", r"{inc_dir}\lzma"),
         ],

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -122,7 +122,7 @@ V = {
     "LIBWEBP": "1.5.0",
     "OPENJPEG": "2.5.3",
     "TIFF": "4.7.0",
-    "XZ": "5.6.4",
+    "XZ": "5.6.4" if struct.calcsize("P") == 4 else "5.8.1",
     "ZLIBNG": "2.2.4",
 }
 V["LIBPNG_XY"] = "".join(V["LIBPNG"].split(".")[:2])


### PR DESCRIPTION
xz 5.8.1 has been released - https://github.com/tukaani-project/xz/releases/tag/v5.8.1

This updates it, except for on 32-bit Windows. That would fail with https://github.com/radarhere/Pillow/actions/runs/14264115010/job/39981991680#step:30:1096
> E           OSError: decoder error -2
> 
> C:\hostedtoolcache\windows\Python\3.9.13\x86\lib\site-packages\PIL\TiffImagePlugin.py:1416: OSError
> ---------------------------- Captured stderr call -----------------------------
> LZMADecode: Decoding error at scanline 0, data is corrupt.
> LZMADecode: Not enough data at scanline 0 (short 49152 bytes).

I initially reported this to libtiff at https://gitlab.com/libtiff/libtiff/-/issues/677, but have since moved on and reported it directly to xz at https://github.com/tukaani-project/xz/issues/171