### PR TITLE
Use same AVIF URL when fetching dependency

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -381,8 +381,8 @@ DEPS: dict[str, dict[str, Any]] = {
         "bins": [r"*.dll"],
     },
     "libavif": {
-        "url": f"https://github.com/AOMediaCodec/libavif/archive/v{V['LIBAVIF']}.zip",
-        "filename": f"libavif-{V['LIBAVIF']}.zip",
+        "url": f"https://github.com/AOMediaCodec/libavif/archive/v{V['LIBAVIF']}.tar.gz",
+        "filename": f"libavif-{V['LIBAVIF']}.tar.gz",
         "license": "LICENSE",
         "build": [
             f"{sys.executable} -m pip install meson",


### PR DESCRIPTION
Update the winbuild libavif URL to match https://github.com/python-pillow/Pillow/blob/cda26be10e93472cca7cc2c07c045037572d9b38/.github/workflows/wheels-dependencies.sh#L135