### PR TITLE
Assert palette is not None

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -224,6 +224,7 @@ def test_optimize_if_palette_can_be_reduced_by_half() -> None:
         out = BytesIO()
         im.save(out, "GIF", optimize=optimize)
         with Image.open(out) as reloaded:
+            assert reloaded.palette is not None
             assert len(reloaded.palette.palette) // 3 == colors
 
 
@@ -1359,6 +1360,7 @@ def test_palette_save_all_P(tmp_path: Path) -> None:
         # Assert that the frames are correct, and each frame has the same palette
         assert_image_equal(im.convert("RGB"), frames[0].convert("RGB"))
         assert im.palette is not None
+        assert im.global_palette is not None
         assert im.palette.palette == im.global_palette.palette
 
         im.seek(1)

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -673,6 +673,7 @@ class TestImage:
         im_remapped = im.remap_palette(list(range(256)))
         assert_image_equal(im, im_remapped)
         assert im.palette is not None
+        assert im_remapped.palette is not None
         assert im.palette.palette == im_remapped.palette.palette
 
         # Test illegal image mode

--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -70,6 +70,7 @@ def test_quantize_no_dither() -> None:
     converted = image.quantize(dither=Image.Dither.NONE, palette=palette)
     assert converted.mode == "P"
     assert converted.palette is not None
+    assert palette.palette is not None
     assert converted.palette.palette == palette.palette.palette
 
 

--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -48,6 +48,7 @@ class TestImageTransform:
                 im.size, Image.Transform.AFFINE, [1, 0, 0, 0, 1, 0]
             )
             assert im.palette is not None
+            assert transformed.palette is not None
             assert im.palette.palette == transformed.palette.palette
 
     def test_extent(self) -> None:


### PR DESCRIPTION
This is part of https://github.com/python-pillow/Pillow/pull/8362 - I'm hoping to break down that PR into easier-to-review chunks.

Image's `palette` may be `None`
```pycon
>>> from PIL import Image
>>> im = Image.new("RGB", (1, 1))
>>> im.palette is None
True
```
So before using it, let's assert that it isn't `None`.