### PR TITLE
Mention that tobytes() with the raw encoder uses Pack.c

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -767,18 +767,20 @@ class Image:
 
         .. warning::
 
-            This method returns the raw image data from the internal
-            storage.  For compressed image data (e.g. PNG, JPEG) use
-            :meth:`~.save`, with a BytesIO parameter for in-memory
-            data.
+            This method returns raw image data derived from Pillow's internal
+            storage. For compressed image data (e.g. PNG, JPEG) use
+            :meth:`~.save`, with a BytesIO parameter for in-memory data.
 
-        :param encoder_name: What encoder to use.  The default is to
-                             use the standard "raw" encoder.
+        :param encoder_name: What encoder to use.
 
-                             A list of C encoders can be seen under
-                             codecs section of the function array in
-                             :file:`_imaging.c`. Python encoders are
-                             registered within the relevant plugins.
+                             The default is to use the standard "raw" encoder.
+                             To see how this packs pixel data into the returned
+                             bytes, see :file:`libImaging/Pack.c`.
+
+                             A list of C encoders can be seen under codecs
+                             section of the function array in
+                             :file:`_imaging.c`. Python encoders are registered
+                             within the relevant plugins.
         :param args: Extra arguments to the encoder.
         :returns: A :py:class:`bytes` object.
         """


### PR DESCRIPTION
Alternative to #8777

In that PR, a user read https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.tobytes
![Screenshot 2025-04-10 at 8 51 07 pm](https://github.com/user-attachments/assets/177708cf-150d-43e2-9287-f0d17c5db125)

and interpreted it as "`tobytes()` will return data exactly matching Pillow's internal storage".

This isn't always true for the raw encoder, and it definitely isn't true for the other encoders.

I've tried to clarify that here by updating the documentation to say that the method returns "raw image data **derived** from Pillow's internal storage". I've also mentioned Pack.c as the user [suggested](https://github.com/python-pillow/Pillow/pull/8777#issuecomment-2689336609).