### PR TITLE
If pasting an image onto itself at a lower position, copy from bottom

### DIFF
--- a/Tests/test_image_paste.py
+++ b/Tests/test_image_paste.py
@@ -124,6 +124,18 @@ class TestImagingPaste:
         im = im.crop((12, 23, im2.width + 12, im2.height + 23))
         assert_image_equal(im, im2)
 
+    @pytest.mark.parametrize("y", [10, -10])
+    def test_image_self(self, y: int) -> None:
+        im = self.gradient_RGB
+
+        im_self = im.copy()
+        im_self.paste(im_self, (0, y))
+
+        im_copy = im.copy()
+        im_copy.paste(im_copy.copy(), (0, y))
+
+        assert_image_equal(im_self, im_copy)
+
     @pytest.mark.parametrize("mode", ["RGBA", "RGB", "L"])
     def test_image_mask_1(self, mode: str) -> None:
         im = Image.new(mode, (200, 200), "white")

--- a/src/libImaging/Paste.c
+++ b/src/libImaging/Paste.c
@@ -44,8 +44,14 @@ paste(
 
     xsize *= pixelsize;
 
-    for (y = 0; y < ysize; y++) {
-        memcpy(imOut->image[y + dy] + dx, imIn->image[y + sy] + sx, xsize);
+    if (imOut == imIn && dy > sy) {
+        for (y = ysize - 1; y >= 0; y--) {
+            memcpy(imOut->image[y + dy] + dx, imIn->image[y + sy] + sx, xsize);
+        }
+    } else {
+        for (y = 0; y < ysize; y++) {
+            memcpy(imOut->image[y + dy] + dx, imIn->image[y + sy] + sx, xsize);
+        }
     }
 }
 


### PR DESCRIPTION
Resolves #8881

When pasting an image,
https://github.com/python-pillow/Pillow/blob/c8d98d56a02e0729f794546d6f270b3cea5baecf/src/libImaging/Paste.c#L47-L49
will copy the rows of the image from top to bottom.

However, if the image is pasting onto itself, but say, 10 pixels lower,
after those 10 rows, it will start reading from a part of the image that has already been written to. This results in a repeating effect.

```python
from PIL import Image
im = Image.open("Tests/images/hopper.png")
im.paste(im, (0, 10))
```
![repeat](https://github.com/user-attachments/assets/91dcf39e-1072-4113-b9bc-55973cc736f8)

A solution for that situation is to instead copy the rows of the image from bottom to top.

![copy](https://github.com/user-attachments/assets/57c839c8-36c2-4be0-9978-5af1ebc80947)