### PR TITLE
Improved type hints

### DIFF
--- a/Tests/test_file_avif.py
+++ b/Tests/test_file_avif.py
@@ -254,7 +254,9 @@ class TestFileAvif:
             assert_image(im, "RGBA", (64, 64))
 
             # image has 876 transparent pixels
-            assert im.getchannel("A").getcolors()[0] == (876, 0)
+            colors = im.getchannel("A").getcolors()
+            assert colors is not None
+            assert colors[0] == (876, 0)
 
     def test_save_transparent(self, tmp_path: Path) -> None:
         im = Image.new("RGBA", (10, 10), (0, 0, 0, 0))

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -540,7 +540,9 @@ def test_dispose_background_transparency() -> None:
         img.seek(2)
         px = img.load()
         assert px is not None
-        assert px[35, 30][3] == 0
+        value = px[35, 30]
+        assert isinstance(value, tuple)
+        assert value[3] == 0
 
 
 @pytest.mark.parametrize(
@@ -1479,7 +1481,9 @@ def test_saving_rgba(tmp_path: Path) -> None:
 
     with Image.open(out) as reloaded:
         reloaded_rgba = reloaded.convert("RGBA")
-        assert reloaded_rgba.load()[0, 0][3] == 0
+        value = reloaded_rgba.load()[0, 0]
+        assert isinstance(value, tuple)
+        assert value[3] == 0
 
 
 @pytest.mark.parametrize("params", ({}, {"disposal": 2, "optimize": False}))

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1422,7 +1422,9 @@ def test_getdata(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_lzw_bits() -> None:
     # see https://github.com/python-pillow/Pillow/issues/2811
     with Image.open("Tests/images/issue_2811.gif") as im:
-        assert im.tile[0][3][0] == 11  # LZW bits
+        args = im.tile[0][3]
+        assert isinstance(args, tuple)
+        assert args[0] == 11  # LZW bits
         # codec error prepatch
         im.load()
 

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -1481,7 +1481,9 @@ def test_saving_rgba(tmp_path: Path) -> None:
 
     with Image.open(out) as reloaded:
         reloaded_rgba = reloaded.convert("RGBA")
-        value = reloaded_rgba.load()[0, 0]
+        px = reloaded_rgba.load()
+        assert px is not None
+        value = px[0, 0]
         assert isinstance(value, tuple)
         assert value[3] == 0
 

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -132,26 +132,30 @@ class TestFileJpeg:
         f = "Tests/images/pil_sample_cmyk.jpg"
         with Image.open(f) as im:
             # the source image has red pixels in the upper left corner.
-            c, m, y, k = (x / 255.0 for x in im.getpixel((0, 0)))
+            value = im.getpixel((0, 0))
+            assert isinstance(value, tuple)
+            c, m, y, k = (x / 255.0 for x in value)
             assert c == 0.0
             assert m > 0.8
             assert y > 0.8
             assert k == 0.0
             # the opposite corner is black
-            c, m, y, k = (
-                x / 255.0 for x in im.getpixel((im.size[0] - 1, im.size[1] - 1))
-            )
+            value = im.getpixel((im.size[0] - 1, im.size[1] - 1))
+            assert isinstance(value, tuple)
+            c, m, y, k = (x / 255.0 for x in value)
             assert k > 0.9
             # roundtrip, and check again
             im = self.roundtrip(im)
-            c, m, y, k = (x / 255.0 for x in im.getpixel((0, 0)))
+            value = im.getpixel((0, 0))
+            assert isinstance(value, tuple)
+            c, m, y, k = (x / 255.0 for x in value)
             assert c == 0.0
             assert m > 0.8
             assert y > 0.8
             assert k == 0.0
-            c, m, y, k = (
-                x / 255.0 for x in im.getpixel((im.size[0] - 1, im.size[1] - 1))
-            )
+            value = im.getpixel((im.size[0] - 1, im.size[1] - 1))
+            assert isinstance(value, tuple)
+            c, m, y, k = (x / 255.0 for x in value)
             assert k > 0.9
 
     def test_rgb(self) -> None:

--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -156,6 +156,7 @@ def test_reload_exif_after_seek() -> None:
 def test_mp(test_file: str) -> None:
     with Image.open(test_file) as im:
         mpinfo = im._getmp()
+        assert mpinfo is not None
         assert mpinfo[45056] == b"0100"
         assert mpinfo[45057] == 2
 
@@ -165,6 +166,7 @@ def test_mp_offset() -> None:
     # in APP2 data, in contrast to normal 8
     with Image.open("Tests/images/sugarshack_ifd_offset.mpo") as im:
         mpinfo = im._getmp()
+        assert mpinfo is not None
         assert mpinfo[45056] == b"0100"
         assert mpinfo[45057] == 2
 
@@ -181,6 +183,7 @@ def test_mp_no_data() -> None:
 def test_mp_attribute(test_file: str) -> None:
     with Image.open(test_file) as im:
         mpinfo = im._getmp()
+    assert mpinfo is not None
     for frame_number, mpentry in enumerate(mpinfo[0xB002]):
         mpattr = mpentry["Attribute"]
         if frame_number:

--- a/Tests/test_file_tga.py
+++ b/Tests/test_file_tga.py
@@ -220,12 +220,16 @@ def test_horizontal_orientations() -> None:
     with Image.open("Tests/images/rgb32rle_top_right.tga") as im:
         px = im.load()
         assert px is not None
-        assert px[90, 90][:3] == (0, 0, 0)
+        value = px[90, 90]
+        assert isinstance(value, tuple)
+        assert value[:3] == (0, 0, 0)
 
     with Image.open("Tests/images/rgb32rle_bottom_right.tga") as im:
         px = im.load()
         assert px is not None
-        assert px[90, 90][:3] == (0, 255, 0)
+        value = px[90, 90]
+        assert isinstance(value, tuple)
+        assert value[:3] == (0, 255, 0)
 
 
 def test_save_rle(tmp_path: Path) -> None:

--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -219,6 +219,7 @@ class TestFileWebp:
         # Save P mode GIF with background
         with Image.open("Tests/images/chi.gif") as im:
             original_value = im.convert("RGB").getpixel((1, 1))
+            assert isinstance(original_value, tuple)
 
             # Save as WEBP
             im.save(out_webp, save_all=True)
@@ -230,6 +231,7 @@ class TestFileWebp:
 
         with Image.open(out_gif) as reread:
             reread_value = reread.convert("RGB").getpixel((1, 1))
+        assert isinstance(reread_value, tuple)
         difference = sum(abs(original_value[i] - reread_value[i]) for i in range(3))
         assert difference < 5
 


### PR DESCRIPTION
This is part of https://github.com/python-pillow/Pillow/pull/8362 - I'm hoping to break down that PR into easier-to-review chunks.

1. A tile's `args` might be a tuple, string or None.
https://github.com/python-pillow/Pillow/blob/c8d98d56a02e0729f794546d6f270b3cea5baecf/src/PIL/ImageFile.py#L101-L105
Assert that `args` is a tuple before accessing a value by index.

2. `_getmp` may return a dict or None.
https://github.com/python-pillow/Pillow/blob/c8d98d56a02e0729f794546d6f270b3cea5baecf/src/PIL/JpegImagePlugin.py#L528
Assert that it is not None before using a key.

3. Pixel access might return a tuple or a float.
https://github.com/python-pillow/Pillow/blob/c8d98d56a02e0729f794546d6f270b3cea5baecf/src/PIL/_imaging.pyi#L13-L14
Assert that it is a tuple before checking one of the channel values.

4. `load()` might return None.
https://github.com/python-pillow/Pillow/blob/c8d98d56a02e0729f794546d6f270b3cea5baecf/src/PIL/Image.py#L880
Assert that it isn't None before getting pixel data for a particular co-ordinate.

5. `getcolors()` might return None.
https://github.com/python-pillow/Pillow/blob/c8d98d56a02e0729f794546d6f270b3cea5baecf/src/PIL/Image.py#L1411-L1413
Assert that it isn't None before checking how much a colour is used.