### PR TITLE
Set color table fourth channel to zero for 1 and L mode when saving BMP

### DIFF
--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -445,9 +445,9 @@ def _save(
     image = stride * im.size[1]
 
     if im.mode == "1":
-        palette = b"".join(o8(i) * 4 for i in (0, 255))
+        palette = b"".join(o8(i) * 3 + b"\x00" for i in (0, 255))
     elif im.mode == "L":
-        palette = b"".join(o8(i) * 4 for i in range(256))
+        palette = b"".join(o8(i) * 3 + b"\x00" for i in range(256))
     elif im.mode == "P":
         palette = im.im.getpalette("RGB", "BGRX")
         colors = len(palette) // 4


### PR DESCRIPTION
Resolves #8888

https://www.ece.ualberta.ca/~elliott/ee552/studentAppNotes/2003_w/misc/bmp_file_format/bmp_file_format.htm states that the fourth channel in a BMP color table is 'unused (=0)'.

It seems reasonable to do so when saving 1 and L mode BMPs, and makes more intuitive sense than our current strategy of making setting the fourth channel to the same value as the other three.