### PR TITLE
Fix License in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,7 @@ readme = "README.md"
 keywords = [
   "Imaging",
 ]
-license = "MIT-CMU"
-license-files = [ "LICENSE" ]
+license = { file = "LICENSE" }
 authors = [
   { name = "Jeffrey A. Clark", email = "aclark@aclark.net" },
 ]


### PR DESCRIPTION
I'm maintaining a Flatpak program that depends on pillow and with the update to version 11.2.1 the Flathub build bot gave me an [error](https://buildbot.flathub.org/#/builders/6/builds/193292).

```  
ValueError: invalid pyproject.toml config: `project.license`.
  configuration error: `project.license` must be valid exactly by one definition (2 matches found):
```

I think the cause is [this commit](https://github.com/python-pillow/Pillow/commit/cda26be10e93472cca7cc2c07c045037572d9b38) which adds another license reference so that the license is now referenced as a file and as a text and at least the Flathub builder only allows one.

So my pull request should hopefully fix this problem for Flatpak projects depending on Pillow. 

