### PR TITLE
Move XV Thumbnails to read only section

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1664,6 +1664,11 @@ The :py:meth:`~PIL.Image.open` method sets the following
     Transparency color index. This key is omitted if the image is not
     transparent.
 
+XV Thumbnails
+^^^^^^^^^^^^^
+
+Pillow can read XV thumbnail files.
+
 Write-only formats
 ------------------
 
@@ -1768,11 +1773,6 @@ The :py:meth:`~PIL.Image.Image.save` method can take the following keyword argum
     file, this will default to the current time.
 
     .. versionadded:: 5.3.0
-
-XV Thumbnails
-^^^^^^^^^^^^^
-
-Pillow can read XV thumbnail files.
 
 Identify-only formats
 ---------------------


### PR DESCRIPTION
Changes proposed in this pull request:

 * XV Thumbnails was under "Write only formats", moved to "Read only formats"
