### PR TITLE
Build Windows arm64 wheels on arm64 runner

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -121,14 +121,17 @@ jobs:
   windows:
     if: github.event_name != 'schedule' || github.repository_owner == 'python-pillow'
     name: Windows ${{ matrix.cibw_arch }}
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - cibw_arch: x86
+            os: windows-latest
           - cibw_arch: AMD64
+            os: windows-latest
           - cibw_arch: ARM64
+            os: windows-11-arm
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Windows arm64 runners are now in public preview - https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/