### PR TITLE
Use ImageFile.MAXBLOCK in tobytes()

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -800,7 +800,9 @@ class Image:
         e = _getencoder(self.mode, encoder_name, encoder_args)
         e.setimage(self.im)
 
-        bufsize = max(65536, self.size[0] * 4)  # see RawEncode.c
+        from . import ImageFile
+
+        bufsize = max(ImageFile.MAXBLOCK, self.size[0] * 4)  # see RawEncode.c
 
         output = []
         while True:


### PR DESCRIPTION
`tobytes()` sets a buffer size when encoding.
https://github.com/python-pillow/Pillow/blob/3d4119521c853e1014012f73fdf9b2a8dc137722/src/PIL/Image.py#L803

ImageFile also does this when saving an image, but the 65536 value is configurable.
https://github.com/python-pillow/Pillow/blob/3d4119521c853e1014012f73fdf9b2a8dc137722/src/PIL/ImageFile.py#L49
https://github.com/python-pillow/Pillow/blob/3d4119521c853e1014012f73fdf9b2a8dc137722/src/PIL/ImageFile.py#L641

Perhaps we should use `ImageFile.MAXBLOCK` in `tobytes()` as well?