### PR TITLE
Add list of third party plugins

### DIFF
--- a/docs/handbook/appendices.rst
+++ b/docs/handbook/appendices.rst
@@ -8,4 +8,5 @@ Appendices
 
   image-file-formats
   text-anchors
+  third-party-plugins
   writing-your-own-image-plugin

--- a/docs/handbook/third-party-plugins.rst
+++ b/docs/handbook/third-party-plugins.rst
@@ -14,5 +14,5 @@ Here is a list of PyPI projects that offer additional plugins:
     * :pypi:`pillow-jpls`: Plugin for the JPEG-LS codec, based on the Charls JPEG-LS implemetation. Python bindings implemented using pybind11.
     * :pypi:`pillow-jxl-plugin`: Plugin for JPEG-XL, using Rust for bindings.
     * :pypi:`pillow-mbm`: Adds support for KSP's proprietary MBM texture format.
-    * :pypi:`pillow-svg`: Implements basic SVG read support. Currently supports basic paths, shapes, and text.
+    * :pypi:`pillow-svg`: Implements basic SVG read support. Supports basic paths, shapes, and text.
     * :pypi:`raw-pillow-opener`: Simple camera raw opener, based on the rawpy library.

--- a/docs/handbook/third-party-plugins.rst
+++ b/docs/handbook/third-party-plugins.rst
@@ -7,12 +7,12 @@ itself.
 
 Here is a list of PyPI projects that offer additional plugins:
 
-    * :pypi:`DjvuRleImagePlugin`: Plugin for the DjVu RLE image format as defined in the DjVuLibre docs.
-    * :pypi:`heif-image-plugin`: Simple HEIF/HEIC images plugin, based on the pyheif library.
-    * :pypi:`jxlpy`: Introduces reading and writing support for JPEG XL.
-    * :pypi:`pillow-heif`: Python bindings to libheif for working with HEIF images.
-    * :pypi:`pillow-jpls`: Plugin for the JPEG-LS codec, based on the Charls JPEG-LS implemetation. Python bindings implemented using pybind11.
-    * :pypi:`pillow-jxl-plugin`: Plugin for JPEG-XL, using Rust for bindings.
-    * :pypi:`pillow-mbm`: Adds support for KSP's proprietary MBM texture format.
-    * :pypi:`pillow-svg`: Implements basic SVG read support. Supports basic paths, shapes, and text.
-    * :pypi:`raw-pillow-opener`: Simple camera raw opener, based on the rawpy library.
+* :pypi:`DjvuRleImagePlugin`: Plugin for the DjVu RLE image format as defined in the DjVuLibre docs.
+* :pypi:`heif-image-plugin`: Simple HEIF/HEIC images plugin, based on the pyheif library.
+* :pypi:`jxlpy`: Introduces reading and writing support for JPEG XL.
+* :pypi:`pillow-heif`: Python bindings to libheif for working with HEIF images.
+* :pypi:`pillow-jpls`: Plugin for the JPEG-LS codec, based on the Charls JPEG-LS implemetation. Python bindings implemented using pybind11.
+* :pypi:`pillow-jxl-plugin`: Plugin for JPEG-XL, using Rust for bindings.
+* :pypi:`pillow-mbm`: Adds support for KSP's proprietary MBM texture format.
+* :pypi:`pillow-svg`: Implements basic SVG read support. Supports basic paths, shapes, and text.
+* :pypi:`raw-pillow-opener`: Simple camera raw opener, based on the rawpy library.

--- a/docs/handbook/third-party-plugins.rst
+++ b/docs/handbook/third-party-plugins.rst
@@ -1,0 +1,18 @@
+Third Party Plugins
+===================
+
+Pillow uses a plugin model which allows users to add their own
+decoders and encoders to the library, without any changes to the library
+itself.
+
+Here is a list of PyPI projects that offer additional plugins:
+
+    * :pypi:`DjvuRleImagePlugin`: Plugin for the DjVu RLE image format as defined in the DjVuLibre docs.
+    * :pypi:`heif-image-plugin`: Simple HEIF/HEIC images plugin, based on the pyheif library.
+    * :pypi:`jxlpy`: Introduces reading and writing support for JPEG XL.
+    * :pypi:`pillow-heif`: Python bindings to libheif for working with HEIF images.
+    * :pypi:`pillow-jpls`: Plugin for the JPEG-LS codec, based on the Charls JPEG-LS implemetation. Python bindings implemented using pybind11.
+    * :pypi:`pillow-jxl-plugin`: Plugin for JPEG-XL, using Rust for bindings.
+    * :pypi:`pillow-mbm`: Adds support for KSP's proprietary MBM texture format.
+    * :pypi:`pillow-svg`: Implements basic SVG read support. Currently supports basic paths, shapes, and text.
+    * :pypi:`raw-pillow-opener`: Simple camera raw opener, based on the rawpy library.

--- a/docs/handbook/third-party-plugins.rst
+++ b/docs/handbook/third-party-plugins.rst
@@ -1,4 +1,4 @@
-Third Party Plugins
+Third-party plugins
 ===================
 
 Pillow uses a plugin model which allows users to add their own


### PR DESCRIPTION
Resolves #8909

I suggest adding another appendix, 'Third Party Plugins', to sit before 'Writing Your Own Image Plugin'.

['Writing Your Own Image Plugin'](https://pillow.readthedocs.io/en/stable/handbook/writing-your-own-image-plugin.html) starts with
> Pillow uses a plugin model which allows you to add your own decoders and encoders to the library, without any changes to the library itself.

I've closely mirrored that, and then written a list with approximately the start of each project's description.

This uses the list of PyPI projects from https://github.com/python-pillow/Pillow/issues/8892, with the exceptions of
- https://pypi.org/project/pillow-stackblur/, because it doesn’t appear to offer additional format support. Feel free to tell me to rework this so that it’s not just about formats.
- https://pypi.org/project/pillow-avif-plugin/, because it describes itself as “a plugin that adds support for AVIF files until official support has been added”, specifically referencing our recently merged AVIF pull request.
- https://pypi.org/project/pyheif-pillow-opener/, because https://github.com/ciotto/pyheif-pillow-opener says it has been discontinued.