### PR TITLE
Docs: use sentence case for headers

### DIFF
--- a/Tests/README.rst
+++ b/Tests/README.rst
@@ -1,4 +1,4 @@
-Pillow Tests
+Pillow tests
 ============
 
 Test scripts are named ``test_xxx.py``. Helper classes and functions can be found in ``helper.py``.

--- a/docs/PIL.rst
+++ b/docs/PIL.rst
@@ -1,10 +1,10 @@
-PIL Package (autodoc of remaining modules)
+PIL package (autodoc of remaining modules)
 ==========================================
 
 Reference for modules whose documentation has not yet been ported or written
 can be found here.
 
-:mod:`PIL` Module
+:mod:`PIL` module
 -----------------
 
 .. py:module:: PIL
@@ -12,7 +12,7 @@ can be found here.
 .. autoexception:: UnidentifiedImageError
     :show-inheritance:
 
-:mod:`~PIL.BdfFontFile` Module
+:mod:`~PIL.BdfFontFile` module
 ------------------------------
 
 .. automodule:: PIL.BdfFontFile
@@ -20,7 +20,7 @@ can be found here.
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.ContainerIO` Module
+:mod:`~PIL.ContainerIO` module
 ------------------------------
 
 .. automodule:: PIL.ContainerIO
@@ -28,7 +28,7 @@ can be found here.
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.FontFile` Module
+:mod:`~PIL.FontFile` module
 ---------------------------
 
 .. automodule:: PIL.FontFile
@@ -36,7 +36,7 @@ can be found here.
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.GdImageFile` Module
+:mod:`~PIL.GdImageFile` module
 ------------------------------
 
 .. automodule:: PIL.GdImageFile
@@ -44,7 +44,7 @@ can be found here.
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.GimpGradientFile` Module
+:mod:`~PIL.GimpGradientFile` module
 -----------------------------------
 
 .. automodule:: PIL.GimpGradientFile
@@ -52,7 +52,7 @@ can be found here.
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.GimpPaletteFile` Module
+:mod:`~PIL.GimpPaletteFile` module
 ----------------------------------
 
 .. automodule:: PIL.GimpPaletteFile
@@ -60,7 +60,7 @@ can be found here.
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.ImageDraw2` Module
+:mod:`~PIL.ImageDraw2` module
 -----------------------------
 
 .. automodule:: PIL.ImageDraw2
@@ -69,7 +69,7 @@ can be found here.
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.ImageMode` Module
+:mod:`~PIL.ImageMode` module
 ----------------------------
 
 .. automodule:: PIL.ImageMode
@@ -77,7 +77,7 @@ can be found here.
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.PaletteFile` Module
+:mod:`~PIL.PaletteFile` module
 ------------------------------
 
 .. automodule:: PIL.PaletteFile
@@ -85,7 +85,7 @@ can be found here.
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.PcfFontFile` Module
+:mod:`~PIL.PcfFontFile` module
 ------------------------------
 
 .. automodule:: PIL.PcfFontFile
@@ -93,7 +93,7 @@ can be found here.
     :undoc-members:
     :show-inheritance:
 
-:class:`.PngImagePlugin.iTXt` Class
+:class:`.PngImagePlugin.iTXt` class
 -----------------------------------
 
 .. autoclass:: PIL.PngImagePlugin.iTXt
@@ -107,7 +107,7 @@ can be found here.
         :param lang: language code
         :param tkey: UTF-8 version of the key name
 
-:class:`.PngImagePlugin.PngInfo` Class
+:class:`.PngImagePlugin.PngInfo` class
 --------------------------------------
 
 .. autoclass:: PIL.PngImagePlugin.PngInfo
@@ -116,7 +116,7 @@ can be found here.
     :show-inheritance:
 
 
-:mod:`~PIL.TarIO` Module
+:mod:`~PIL.TarIO` module
 ------------------------
 
 .. automodule:: PIL.TarIO
@@ -124,7 +124,7 @@ can be found here.
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.WalImageFile` Module
+:mod:`~PIL.WalImageFile` module
 -------------------------------
 
 .. automodule:: PIL.WalImageFile

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -155,7 +155,7 @@ JpegImageFile.huffman_ac and JpegImageFile.huffman_dc
 The ``huffman_ac`` and ``huffman_dc`` dictionaries on JPEG images were unused. They
 have been deprecated, and will be removed in Pillow 12 (2025-10-15).
 
-Specific WebP Feature Checks
+Specific WebP feature checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. deprecated:: 11.0.0

--- a/docs/handbook/concepts.rst
+++ b/docs/handbook/concepts.rst
@@ -84,7 +84,7 @@ pixels.
 
 .. _coordinate-system:
 
-Coordinate System
+Coordinate system
 -----------------
 
 The Python Imaging Library uses a Cartesian pixel coordinate system, with (0,0)

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1222,7 +1222,7 @@ numbers are returned as a tuple of ``(numerator, denominator)``.
 
     .. deprecated:: 3.0.0
 
-Reading Multi-frame TIFF Images
+Reading multi-frame TIFF images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The TIFF loader supports the :py:meth:`~PIL.Image.Image.seek` and
@@ -1664,7 +1664,7 @@ The :py:meth:`~PIL.Image.open` method sets the following
     Transparency color index. This key is omitted if the image is not
     transparent.
 
-XV Thumbnails
+XV thumbnails
 ^^^^^^^^^^^^^
 
 Pillow can read XV thumbnail files.

--- a/docs/handbook/overview.rst
+++ b/docs/handbook/overview.rst
@@ -13,7 +13,7 @@ processing tool.
 
 Let’s look at a few possible uses of this library.
 
-Image Archives
+Image archives
 --------------
 
 The Python Imaging Library is ideal for image archival and batch processing
@@ -24,7 +24,7 @@ The current version identifies and reads a large number of formats. Write
 support is intentionally restricted to the most commonly used interchange and
 presentation formats.
 
-Image Display
+Image display
 -------------
 
 The current release includes Tk :py:class:`~PIL.ImageTk.PhotoImage` and
@@ -36,7 +36,7 @@ support.
 For debugging, there’s also a :py:meth:`~PIL.Image.Image.show` method which saves an image to
 disk, and calls an external display utility.
 
-Image Processing
+Image processing
 ----------------
 
 The library contains basic image processing functionality, including point operations, filtering with a set of built-in convolution kernels, and colour space conversions.

--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -122,7 +122,7 @@ This means that opening an image file is a fast operation, which is independent
 of the file size and compression type. Here’s a simple script to quickly
 identify a set of image files:
 
-Identify Image Files
+Identify image files
 ^^^^^^^^^^^^^^^^^^^^
 
 ::
@@ -399,7 +399,7 @@ Applying filters
 .. image:: enhanced_hopper.webp
     :align: center
 
-Point Operations
+Point operations
 ^^^^^^^^^^^^^^^^
 
 The :py:meth:`~PIL.Image.Image.point` method can be used to translate the pixel

--- a/docs/handbook/writing-your-own-image-plugin.rst
+++ b/docs/handbook/writing-your-own-image-plugin.rst
@@ -1,6 +1,6 @@
 .. _image-plugins:
 
-Writing Your Own Image Plugin
+Writing your own image plugin
 =============================
 
 Pillow uses a plugin model which allows you to add your own
@@ -329,7 +329,7 @@ The fields are used as follows:
 
 .. _file-codecs:
 
-Writing Your Own File Codec in C
+Writing your own file codec in C
 ================================
 
 There are 3 stages in a file codec's lifetime:
@@ -414,7 +414,7 @@ memory and release any resources from external libraries.
 
 .. _file-codecs-py:
 
-Writing Your Own File Codec in Python
+Writing your own file codec in Python
 =====================================
 
 Python file decoders and encoders should derive from

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,27 +3,27 @@
 Installation
 ============
 
-Basic Installation
+Basic installation
 ------------------
 
 .. Note:: This section has moved to :ref:`basic-installation`. Please update references accordingly.
 
-Python Support
+Python support
 --------------
 
 .. Note:: This section has moved to :ref:`python-support`. Please update references accordingly.
 
-Platform Support
+Platform support
 ----------------
 
 .. Note:: This section has moved to :ref:`platform-support`. Please update references accordingly.
 
-Building From Source
+Building from source
 --------------------
 
 .. Note:: This section has moved to :ref:`building-from-source`. Please update references accordingly.
 
-Old Versions
+Old versions
 ------------
 
 .. Note:: This section has moved to :ref:`old-versions`. Please update references accordingly.

--- a/docs/installation/basic-installation.rst
+++ b/docs/installation/basic-installation.rst
@@ -8,7 +8,7 @@
 
 .. _basic-installation:
 
-Basic Installation
+Basic installation
 ==================
 
 .. note::

--- a/docs/installation/building-from-source.rst
+++ b/docs/installation/building-from-source.rst
@@ -8,12 +8,12 @@
 
 .. _building-from-source:
 
-Building From Source
+Building from source
 ====================
 
 .. _external-libraries:
 
-External Libraries
+External libraries
 ------------------
 
 .. note::
@@ -271,7 +271,7 @@ After navigating to the Pillow directory, run::
 
 .. _compressed archive from PyPI: https://pypi.org/project/pillow/#files
 
-Build Options
+Build options
 ^^^^^^^^^^^^^
 
 * Config setting: ``-C parallel=n``. Can also be given
@@ -319,7 +319,7 @@ Sample usage::
 
 .. _old-versions:
 
-Old Versions
+Old versions
 ============
 
 You can download old distributions from the `release history at PyPI

--- a/docs/installation/platform-support.rst
+++ b/docs/installation/platform-support.rst
@@ -1,6 +1,6 @@
 .. _platform-support:
 
-Platform Support
+Platform support
 ================
 
 Current platform support for Pillow. Binary distributions are
@@ -9,7 +9,7 @@ should compile and run everywhere platform support is listed. In
 general, we aim to support all current versions of Linux, macOS, and
 Windows.
 
-Continuous Integration Targets
+Continuous integration targets
 ------------------------------
 
 These platforms are built and tested for every change.
@@ -59,7 +59,7 @@ These platforms are built and tested for every change.
 +----------------------------------+----------------------------+---------------------+
 
 
-Other Platforms
+Other platforms
 ---------------
 
 These platforms have been reported to work at the versions mentioned.

--- a/docs/installation/python-support.rst
+++ b/docs/installation/python-support.rst
@@ -1,6 +1,6 @@
 .. _python-support:
 
-Python Support
+Python support
 ==============
 
 Pillow supports these Python versions.

--- a/docs/reference/ExifTags.rst
+++ b/docs/reference/ExifTags.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ExifTags
 .. py:currentmodule:: PIL.ExifTags
 
-:py:mod:`~PIL.ExifTags` Module
+:py:mod:`~PIL.ExifTags` module
 ==============================
 
 The :py:mod:`~PIL.ExifTags` module exposes several :py:class:`enum.IntEnum`

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.Image
 .. py:currentmodule:: PIL.Image
 
-:py:mod:`~PIL.Image` Module
+:py:mod:`~PIL.Image` module
 ===========================
 
 The :py:mod:`~PIL.Image` module provides a class with the same name which is
@@ -113,7 +113,7 @@ Registering plugins
 .. autofunction:: register_decoder
 .. autofunction:: register_encoder
 
-The Image Class
+The Image class
 ---------------
 
 .. autoclass:: PIL.Image.Image
@@ -261,7 +261,7 @@ method. ::
 .. automethod:: PIL.Image.Image.load
 .. automethod:: PIL.Image.Image.close
 
-Image Attributes
+Image attributes
 ----------------
 
 Instances of the :py:class:`Image` class have the following attributes:

--- a/docs/reference/ImageChops.rst
+++ b/docs/reference/ImageChops.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImageChops
 .. py:currentmodule:: PIL.ImageChops
 
-:py:mod:`~PIL.ImageChops` ("Channel Operations") Module
+:py:mod:`~PIL.ImageChops` ("channel operations") module
 =======================================================
 
 The :py:mod:`~PIL.ImageChops` module contains a number of arithmetical image

--- a/docs/reference/ImageCms.rst
+++ b/docs/reference/ImageCms.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImageCms
 .. py:currentmodule:: PIL.ImageCms
 
-:py:mod:`~PIL.ImageCms` Module
+:py:mod:`~PIL.ImageCms` module
 ==============================
 
 The :py:mod:`~PIL.ImageCms` module provides color profile management

--- a/docs/reference/ImageColor.rst
+++ b/docs/reference/ImageColor.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImageColor
 .. py:currentmodule:: PIL.ImageColor
 
-:py:mod:`~PIL.ImageColor` Module
+:py:mod:`~PIL.ImageColor` module
 ================================
 
 The :py:mod:`~PIL.ImageColor` module contains color tables and converters from
@@ -11,7 +11,7 @@ others.
 
 .. _color-names:
 
-Color Names
+Color names
 -----------
 
 The ImageColor module supports the following string formats:

--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImageDraw
 .. py:currentmodule:: PIL.ImageDraw
 
-:py:mod:`~PIL.ImageDraw` Module
+:py:mod:`~PIL.ImageDraw` module
 ===============================
 
 The :py:mod:`~PIL.ImageDraw` module provides simple 2D graphics for
@@ -54,7 +54,7 @@ later, you can also use RGB 3-tuples or color names (see below). The drawing
 layer will automatically assign color indexes, as long as you don’t draw with
 more than 256 colors.
 
-Color Names
+Color names
 ^^^^^^^^^^^
 
 See :ref:`color-names` for the color names supported by Pillow.
@@ -75,7 +75,7 @@ To load a OpenType/TrueType font, use the truetype function in the
 :py:mod:`~PIL.ImageFont` module. Note that this function depends on third-party
 libraries, and may not available in all PIL builds.
 
-Example: Draw Partial Opacity Text
+Example: Draw partial opacity text
 ----------------------------------
 
 ::
@@ -102,7 +102,7 @@ Example: Draw Partial Opacity Text
 
         out.show()
 
-Example: Draw Multiline Text
+Example: Draw multiline text
 ----------------------------
 
 ::

--- a/docs/reference/ImageEnhance.rst
+++ b/docs/reference/ImageEnhance.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImageEnhance
 .. py:currentmodule:: PIL.ImageEnhance
 
-:py:mod:`~PIL.ImageEnhance` Module
+:py:mod:`~PIL.ImageEnhance` module
 ==================================
 
 The :py:mod:`~PIL.ImageEnhance` module contains a number of classes that can be used

--- a/docs/reference/ImageFile.rst
+++ b/docs/reference/ImageFile.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImageFile
 .. py:currentmodule:: PIL.ImageFile
 
-:py:mod:`~PIL.ImageFile` Module
+:py:mod:`~PIL.ImageFile` module
 ===============================
 
 The :py:mod:`~PIL.ImageFile` module provides support functions for the image open

--- a/docs/reference/ImageFilter.rst
+++ b/docs/reference/ImageFilter.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImageFilter
 .. py:currentmodule:: PIL.ImageFilter
 
-:py:mod:`~PIL.ImageFilter` Module
+:py:mod:`~PIL.ImageFilter` module
 =================================
 
 The :py:mod:`~PIL.ImageFilter` module contains definitions for a pre-defined set of

--- a/docs/reference/ImageFont.rst
+++ b/docs/reference/ImageFont.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImageFont
 .. py:currentmodule:: PIL.ImageFont
 
-:py:mod:`~PIL.ImageFont` Module
+:py:mod:`~PIL.ImageFont` module
 ===============================
 
 The :py:mod:`~PIL.ImageFont` module defines a class with the same name. Instances of

--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImageGrab
 .. py:currentmodule:: PIL.ImageGrab
 
-:py:mod:`~PIL.ImageGrab` Module
+:py:mod:`~PIL.ImageGrab` module
 ===============================
 
 The :py:mod:`~PIL.ImageGrab` module can be used to copy the contents of the screen

--- a/docs/reference/ImageMath.rst
+++ b/docs/reference/ImageMath.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImageMath
 .. py:currentmodule:: PIL.ImageMath
 
-:py:mod:`~PIL.ImageMath` Module
+:py:mod:`~PIL.ImageMath` module
 ===============================
 
 The :py:mod:`~PIL.ImageMath` module can be used to evaluate “image expressions”, that
@@ -86,7 +86,7 @@ Expression syntax
   It is not recommended to process expressions without considering this.
   :py:meth:`lambda_eval` is a more secure alternative.
 
-Standard Operators
+Standard operators
 ^^^^^^^^^^^^^^^^^^
 
 You can use standard arithmetical operators for addition (+), subtraction (-),
@@ -102,7 +102,7 @@ an 8-bit image, the result will be a 32-bit floating point image.
 You can force conversion using the ``convert()``, ``float()``, and ``int()``
 functions described below.
 
-Bitwise Operators
+Bitwise operators
 ^^^^^^^^^^^^^^^^^
 
 The module also provides operations that operate on individual bits. This
@@ -116,7 +116,7 @@ mask off unwanted bits.
 
 Bitwise operators don’t work on floating point images.
 
-Logical Operators
+Logical operators
 ^^^^^^^^^^^^^^^^^
 
 Logical operators like ``and``, ``or``, and ``not`` work
@@ -128,7 +128,7 @@ treated as true.
 Note that ``and`` and ``or`` return the last evaluated operand,
 while not always returns a boolean value.
 
-Built-in Functions
+Built-in functions
 ^^^^^^^^^^^^^^^^^^
 
 These functions are applied to each individual pixel.

--- a/docs/reference/ImageMorph.rst
+++ b/docs/reference/ImageMorph.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImageMorph
 .. py:currentmodule:: PIL.ImageMorph
 
-:py:mod:`~PIL.ImageMorph` Module
+:py:mod:`~PIL.ImageMorph` module
 ================================
 
 The :py:mod:`~PIL.ImageMorph` module provides morphology operations on images.

--- a/docs/reference/ImageOps.rst
+++ b/docs/reference/ImageOps.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImageOps
 .. py:currentmodule:: PIL.ImageOps
 
-:py:mod:`~PIL.ImageOps` Module
+:py:mod:`~PIL.ImageOps` module
 ==============================
 
 The :py:mod:`~PIL.ImageOps` module contains a number of ‘ready-made’ image

--- a/docs/reference/ImagePalette.rst
+++ b/docs/reference/ImagePalette.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImagePalette
 .. py:currentmodule:: PIL.ImagePalette
 
-:py:mod:`~PIL.ImagePalette` Module
+:py:mod:`~PIL.ImagePalette` module
 ==================================
 
 The :py:mod:`~PIL.ImagePalette` module contains a class of the same name to

--- a/docs/reference/ImagePath.rst
+++ b/docs/reference/ImagePath.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImagePath
 .. py:currentmodule:: PIL.ImagePath
 
-:py:mod:`~PIL.ImagePath` Module
+:py:mod:`~PIL.ImagePath` module
 ===============================
 
 The :py:mod:`~PIL.ImagePath` module is used to store and manipulate 2-dimensional

--- a/docs/reference/ImageQt.rst
+++ b/docs/reference/ImageQt.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImageQt
 .. py:currentmodule:: PIL.ImageQt
 
-:py:mod:`~PIL.ImageQt` Module
+:py:mod:`~PIL.ImageQt` module
 =============================
 
 The :py:mod:`~PIL.ImageQt` module contains support for creating PyQt6 or PySide6

--- a/docs/reference/ImageSequence.rst
+++ b/docs/reference/ImageSequence.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImageSequence
 .. py:currentmodule:: PIL.ImageSequence
 
-:py:mod:`~PIL.ImageSequence` Module
+:py:mod:`~PIL.ImageSequence` module
 ===================================
 
 The :py:mod:`~PIL.ImageSequence` module contains a wrapper class that lets you

--- a/docs/reference/ImageShow.rst
+++ b/docs/reference/ImageShow.rst
@@ -1,10 +1,10 @@
 .. py:module:: PIL.ImageShow
 .. py:currentmodule:: PIL.ImageShow
 
-:py:mod:`~PIL.ImageShow` Module
+:py:mod:`~PIL.ImageShow` module
 ===============================
 
-The :py:mod:`~PIL.ImageShow` Module is used to display images.
+The :py:mod:`~PIL.ImageShow` module is used to display images.
 All default viewers convert the image to be shown to PNG format.
 
 .. autofunction:: PIL.ImageShow.show

--- a/docs/reference/ImageStat.rst
+++ b/docs/reference/ImageStat.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImageStat
 .. py:currentmodule:: PIL.ImageStat
 
-:py:mod:`~PIL.ImageStat` Module
+:py:mod:`~PIL.ImageStat` module
 ===============================
 
 The :py:mod:`~PIL.ImageStat` module calculates global statistics for an image, or

--- a/docs/reference/ImageTk.rst
+++ b/docs/reference/ImageTk.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImageTk
 .. py:currentmodule:: PIL.ImageTk
 
-:py:mod:`~PIL.ImageTk` Module
+:py:mod:`~PIL.ImageTk` module
 =============================
 
 The :py:mod:`~PIL.ImageTk` module contains support to create and modify Tkinter

--- a/docs/reference/ImageTransform.rst
+++ b/docs/reference/ImageTransform.rst
@@ -2,7 +2,7 @@
 .. py:module:: PIL.ImageTransform
 .. py:currentmodule:: PIL.ImageTransform
 
-:py:mod:`~PIL.ImageTransform` Module
+:py:mod:`~PIL.ImageTransform` module
 ====================================
 
 The :py:mod:`~PIL.ImageTransform` module contains implementations of

--- a/docs/reference/ImageWin.rst
+++ b/docs/reference/ImageWin.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.ImageWin
 .. py:currentmodule:: PIL.ImageWin
 
-:py:mod:`~PIL.ImageWin` Module (Windows-only)
+:py:mod:`~PIL.ImageWin` module (Windows-only)
 =============================================
 
 The :py:mod:`~PIL.ImageWin` module contains support to create and display images on

--- a/docs/reference/JpegPresets.rst
+++ b/docs/reference/JpegPresets.rst
@@ -1,6 +1,6 @@
 .. py:currentmodule:: PIL.JpegPresets
 
-:py:mod:`~PIL.JpegPresets` Module
+:py:mod:`~PIL.JpegPresets` module
 =================================
 
 .. automodule:: PIL.JpegPresets

--- a/docs/reference/PSDraw.rst
+++ b/docs/reference/PSDraw.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.PSDraw
 .. py:currentmodule:: PIL.PSDraw
 
-:py:mod:`~PIL.PSDraw` Module
+:py:mod:`~PIL.PSDraw` module
 ============================
 
 The :py:mod:`~PIL.PSDraw` module provides simple print support for PostScript

--- a/docs/reference/PixelAccess.rst
+++ b/docs/reference/PixelAccess.rst
@@ -1,6 +1,6 @@
 .. _PixelAccess:
 
-:py:class:`PixelAccess` Class
+:py:class:`PixelAccess` class
 =============================
 
 The PixelAccess class provides read and write access to
@@ -40,7 +40,7 @@ Access using negative indexes is also possible. ::
 
 
 
-:py:class:`PixelAccess` Class
+:py:class:`PixelAccess` class
 -----------------------------
 
 .. class:: PixelAccess

--- a/docs/reference/TiffTags.rst
+++ b/docs/reference/TiffTags.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.TiffTags
 .. py:currentmodule:: PIL.TiffTags
 
-:py:mod:`~PIL.TiffTags` Module
+:py:mod:`~PIL.TiffTags` module
 ==============================
 
 The :py:mod:`~PIL.TiffTags` module exposes many of the standard TIFF

--- a/docs/reference/arrow_support.rst
+++ b/docs/reference/arrow_support.rst
@@ -1,7 +1,7 @@
 .. _arrow-support:
 
 =============
-Arrow Support
+Arrow support
 =============
 
 `Arrow <https://arrow.apache.org/>`__
@@ -18,7 +18,7 @@ with any Arrow provider or consumer in the Python ecosystem.
   full-copy memory cost to reading an Arrow image.
 
 
-Data Formats
+Data formats
 ============
 
 Pillow currently supports exporting Arrow images in all modes
@@ -43,7 +43,7 @@ interpreted using the mode-specific interpretation of the bytes.
 The image mode must match the Arrow band format when reading single
 channel images.
 
-Memory Allocator
+Memory allocator
 ================
 
 Pillow's default memory allocator, the :ref:`block_allocator`,
@@ -59,7 +59,7 @@ To enable the single block allocator::
 
 Note that this is a global setting, not a per-image setting.
 
-Unsupported Features
+Unsupported features
 ====================
 
 * Table/dataframe protocol. We support a single array.
@@ -71,7 +71,7 @@ Unsupported Features
   parameter.
 * Array metadata.
 
-Internal Details
+Internal details
 ================
 
 Python Arrow C interface:

--- a/docs/reference/block_allocator.rst
+++ b/docs/reference/block_allocator.rst
@@ -1,10 +1,10 @@
 
 .. _block_allocator:
 
-Block Allocator
+Block allocator
 ===============
 
-Previous Design
+Previous design
 ---------------
 
 Historically there have been two image allocators in Pillow:
@@ -16,7 +16,7 @@ large images and makes one allocation for each scan line of size
 between one allocation and potentially thousands of small allocations,
 leading to unpredictable performance penalties around the transition.
 
-New Design
+New design
 ----------
 
 ``ImagingAllocateArray`` now allocates space for images as a chain of
@@ -28,7 +28,7 @@ line. This is now the default for all internal allocations.
 specifically requesting a single segment of memory for sharing with
 other code.
 
-Memory Pools
+Memory pools
 ------------
 
 There is now a memory pool to contain a supply of recently freed

--- a/docs/reference/c_extension_debugging.rst
+++ b/docs/reference/c_extension_debugging.rst
@@ -1,5 +1,5 @@
-C Extension debugging on Linux, with gbd/valgrind.
-==================================================
+C extension debugging on Linux, with GBD/Valgrind
+=================================================
 
 Install the tools
 -----------------
@@ -17,7 +17,7 @@ Then ``sudo apt-get install libtiff5-dbgsym``
 
 -  There's a bug with the ``python3-dbg`` package for at least Python 3.8 on
    Ubuntu 20.04, and you need to add a new link or two to make it autoload when
-   running python:
+   running Python:
 
 ::
 
@@ -49,7 +49,7 @@ Then ``sudo apt-get install libtiff5-dbgsym``
     source ~/vpy38-dbg/bin/activate
     cd ~/Pillow && make install
 
-Test Case
+Test case
 ---------
 
 Take your test image, and make a really simple harness.

--- a/docs/reference/features.rst
+++ b/docs/reference/features.rst
@@ -1,7 +1,7 @@
 .. py:module:: PIL.features
 .. py:currentmodule:: PIL.features
 
-:py:mod:`~PIL.features` Module
+:py:mod:`~PIL.features` module
 ==============================
 
 The :py:mod:`PIL.features` module can be used to detect which Pillow features are available on your system.

--- a/docs/reference/internal_design.rst
+++ b/docs/reference/internal_design.rst
@@ -1,4 +1,4 @@
-Internal Reference
+Internal reference
 ==================
 
 .. toctree::

--- a/docs/reference/internal_modules.rst
+++ b/docs/reference/internal_modules.rst
@@ -1,7 +1,7 @@
-Internal Modules
+Internal modules
 ================
 
-:mod:`~PIL._binary` Module
+:mod:`~PIL._binary` module
 --------------------------
 
 .. automodule:: PIL._binary
@@ -9,7 +9,7 @@ Internal Modules
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL._deprecate` Module
+:mod:`~PIL._deprecate` module
 -----------------------------
 
 .. automodule:: PIL._deprecate
@@ -17,7 +17,7 @@ Internal Modules
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL._tkinter_finder` Module
+:mod:`~PIL._tkinter_finder` module
 ----------------------------------
 
 .. automodule:: PIL._tkinter_finder
@@ -25,7 +25,7 @@ Internal Modules
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL._typing` Module
+:mod:`~PIL._typing` module
 --------------------------
 
 .. module:: PIL._typing
@@ -58,7 +58,7 @@ on some Python versions.
 
     See :py:obj:`typing.TypeGuard`.
 
-:mod:`~PIL._util` Module
+:mod:`~PIL._util` module
 ------------------------
 
 .. automodule:: PIL._util
@@ -66,7 +66,7 @@ on some Python versions.
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL._version` Module
+:mod:`~PIL._version` module
 ---------------------------
 
 .. module:: PIL._version
@@ -78,7 +78,7 @@ on some Python versions.
     This is the master version number for Pillow,
     all other uses reference this module.
 
-:mod:`PIL.Image.core` Module
+:mod:`PIL.Image.core` module
 ----------------------------
 
 .. module:: PIL._imaging

--- a/docs/reference/limits.rst
+++ b/docs/reference/limits.rst
@@ -4,7 +4,7 @@ Limits
 This page is documentation to the various fundamental size limits in
 the Pillow implementation.
 
-Internal Limits
+Internal limits
 ===============
 
 * Image sizes cannot be negative. These are checked both in
@@ -25,10 +25,10 @@ Internal Limits
   is smaller than 2GB, as calculated by ``y*stride`` (so 2Gpx for 'L'
   images, and .5Gpx for 'RGB'
 
-Format Size Limits
+Format size limits
 ==================
 
 * ICO: Max size is 256x256
 
-* Webp: 16383x16383 (underlying library size limit:
+* WebP: 16383x16383 (underlying library size limit:
   https://developers.google.com/speed/webp/docs/api)

--- a/docs/reference/open_files.rst
+++ b/docs/reference/open_files.rst
@@ -1,6 +1,6 @@
 .. _file-handling:
 
-File Handling in Pillow
+File handling in Pillow
 =======================
 
 When opening a file as an image, Pillow requires a filename, ``os.PathLike``
@@ -36,7 +36,7 @@ have multiple frames.
 Pillow cannot in general close and reopen a file, so any access to
 that file needs to be prior to the close.
 
-Image Lifecycle
+Image lifecycle
 ---------------
 
 * ``Image.open()`` Filenames and ``Path`` objects are opened as a file.
@@ -97,7 +97,7 @@ Complications
     im6.load()  # FAILS, closed file
 
 
-Proposed File Handling
+Proposed file handling
 ----------------------
 
 * ``Image.Image.load()`` should close the image file, unless there are

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -1,7 +1,7 @@
 Plugin reference
 ================
 
-:mod:`~PIL.AvifImagePlugin` Module
+:mod:`~PIL.AvifImagePlugin` module
 ----------------------------------
 
 .. automodule:: PIL.AvifImagePlugin
@@ -9,7 +9,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.BmpImagePlugin` Module
+:mod:`~PIL.BmpImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.BmpImagePlugin
@@ -17,7 +17,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.BufrStubImagePlugin` Module
+:mod:`~PIL.BufrStubImagePlugin` module
 --------------------------------------
 
 .. automodule:: PIL.BufrStubImagePlugin
@@ -25,7 +25,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.CurImagePlugin` Module
+:mod:`~PIL.CurImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.CurImagePlugin
@@ -33,7 +33,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.DcxImagePlugin` Module
+:mod:`~PIL.DcxImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.DcxImagePlugin
@@ -41,7 +41,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.DdsImagePlugin` Module
+:mod:`~PIL.DdsImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.DdsImagePlugin
@@ -49,7 +49,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.EpsImagePlugin` Module
+:mod:`~PIL.EpsImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.EpsImagePlugin
@@ -57,7 +57,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.FitsImagePlugin` Module
+:mod:`~PIL.FitsImagePlugin` module
 --------------------------------------
 
 .. automodule:: PIL.FitsImagePlugin
@@ -65,7 +65,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.FliImagePlugin` Module
+:mod:`~PIL.FliImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.FliImagePlugin
@@ -73,7 +73,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.FpxImagePlugin` Module
+:mod:`~PIL.FpxImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.FpxImagePlugin
@@ -81,7 +81,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.GbrImagePlugin` Module
+:mod:`~PIL.GbrImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.GbrImagePlugin
@@ -89,7 +89,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.GifImagePlugin` Module
+:mod:`~PIL.GifImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.GifImagePlugin
@@ -97,7 +97,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.GribStubImagePlugin` Module
+:mod:`~PIL.GribStubImagePlugin` module
 --------------------------------------
 
 .. automodule:: PIL.GribStubImagePlugin
@@ -105,7 +105,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.Hdf5StubImagePlugin` Module
+:mod:`~PIL.Hdf5StubImagePlugin` module
 --------------------------------------
 
 .. automodule:: PIL.Hdf5StubImagePlugin
@@ -113,7 +113,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.IcnsImagePlugin` Module
+:mod:`~PIL.IcnsImagePlugin` module
 ----------------------------------
 
 .. automodule:: PIL.IcnsImagePlugin
@@ -121,7 +121,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.IcoImagePlugin` Module
+:mod:`~PIL.IcoImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.IcoImagePlugin
@@ -129,7 +129,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.ImImagePlugin` Module
+:mod:`~PIL.ImImagePlugin` module
 --------------------------------
 
 .. automodule:: PIL.ImImagePlugin
@@ -137,7 +137,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.ImtImagePlugin` Module
+:mod:`~PIL.ImtImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.ImtImagePlugin
@@ -145,7 +145,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.IptcImagePlugin` Module
+:mod:`~PIL.IptcImagePlugin` module
 ----------------------------------
 
 .. automodule:: PIL.IptcImagePlugin
@@ -153,7 +153,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.JpegImagePlugin` Module
+:mod:`~PIL.JpegImagePlugin` module
 ----------------------------------
 
 .. automodule:: PIL.JpegImagePlugin
@@ -161,7 +161,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.Jpeg2KImagePlugin` Module
+:mod:`~PIL.Jpeg2KImagePlugin` module
 ------------------------------------
 
 .. automodule:: PIL.Jpeg2KImagePlugin
@@ -169,7 +169,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.McIdasImagePlugin` Module
+:mod:`~PIL.McIdasImagePlugin` module
 ------------------------------------
 
 .. automodule:: PIL.McIdasImagePlugin
@@ -177,7 +177,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.MicImagePlugin` Module
+:mod:`~PIL.MicImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.MicImagePlugin
@@ -185,7 +185,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.MpegImagePlugin` Module
+:mod:`~PIL.MpegImagePlugin` module
 ----------------------------------
 
 .. automodule:: PIL.MpegImagePlugin
@@ -193,7 +193,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.MpoImagePlugin` Module
+:mod:`~PIL.MpoImagePlugin` module
 ----------------------------------
 
 .. automodule:: PIL.MpoImagePlugin
@@ -201,7 +201,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.MspImagePlugin` Module
+:mod:`~PIL.MspImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.MspImagePlugin
@@ -209,7 +209,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.PalmImagePlugin` Module
+:mod:`~PIL.PalmImagePlugin` module
 ----------------------------------
 
 .. automodule:: PIL.PalmImagePlugin
@@ -217,7 +217,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.PcdImagePlugin` Module
+:mod:`~PIL.PcdImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.PcdImagePlugin
@@ -225,7 +225,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.PcxImagePlugin` Module
+:mod:`~PIL.PcxImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.PcxImagePlugin
@@ -233,7 +233,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.PdfImagePlugin` Module
+:mod:`~PIL.PdfImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.PdfImagePlugin
@@ -241,7 +241,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.PixarImagePlugin` Module
+:mod:`~PIL.PixarImagePlugin` module
 -----------------------------------
 
 .. automodule:: PIL.PixarImagePlugin
@@ -249,7 +249,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.PngImagePlugin` Module
+:mod:`~PIL.PngImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.PngImagePlugin
@@ -260,7 +260,7 @@ Plugin reference
     :member-order: groupwise
 
 
-:mod:`~PIL.PpmImagePlugin` Module
+:mod:`~PIL.PpmImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.PpmImagePlugin
@@ -268,7 +268,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.PsdImagePlugin` Module
+:mod:`~PIL.PsdImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.PsdImagePlugin
@@ -276,7 +276,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.SgiImagePlugin` Module
+:mod:`~PIL.SgiImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.SgiImagePlugin
@@ -284,7 +284,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.SpiderImagePlugin` Module
+:mod:`~PIL.SpiderImagePlugin` module
 ------------------------------------
 
 .. automodule:: PIL.SpiderImagePlugin
@@ -292,7 +292,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.SunImagePlugin` Module
+:mod:`~PIL.SunImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.SunImagePlugin
@@ -300,7 +300,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.TgaImagePlugin` Module
+:mod:`~PIL.TgaImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.TgaImagePlugin
@@ -308,7 +308,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.TiffImagePlugin` Module
+:mod:`~PIL.TiffImagePlugin` module
 ----------------------------------
 
 .. automodule:: PIL.TiffImagePlugin
@@ -316,7 +316,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.WebPImagePlugin` Module
+:mod:`~PIL.WebPImagePlugin` module
 ----------------------------------
 
 .. automodule:: PIL.WebPImagePlugin
@@ -324,7 +324,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.WmfImagePlugin` Module
+:mod:`~PIL.WmfImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.WmfImagePlugin
@@ -332,7 +332,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.XVThumbImagePlugin` Module
+:mod:`~PIL.XVThumbImagePlugin` module
 -------------------------------------
 
 .. automodule:: PIL.XVThumbImagePlugin
@@ -340,7 +340,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.XbmImagePlugin` Module
+:mod:`~PIL.XbmImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.XbmImagePlugin
@@ -348,7 +348,7 @@ Plugin reference
     :undoc-members:
     :show-inheritance:
 
-:mod:`~PIL.XpmImagePlugin` Module
+:mod:`~PIL.XpmImagePlugin` module
 ---------------------------------
 
 .. automodule:: PIL.XpmImagePlugin

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -58,7 +58,7 @@ Plugin reference
     :show-inheritance:
 
 :mod:`~PIL.FitsImagePlugin` module
---------------------------------------
+----------------------------------
 
 .. automodule:: PIL.FitsImagePlugin
     :members:
@@ -194,7 +194,7 @@ Plugin reference
     :show-inheritance:
 
 :mod:`~PIL.MpoImagePlugin` module
-----------------------------------
+---------------------------------
 
 .. automodule:: PIL.MpoImagePlugin
     :members:

--- a/docs/releasenotes/10.0.0.rst
+++ b/docs/releasenotes/10.0.0.rst
@@ -28,7 +28,7 @@ This threshold can be changed by setting
 :py:data:`PIL.ImageFont.MAX_STRING_LENGTH`. It can be disabled by setting
 ``ImageFont.MAX_STRING_LENGTH = None``.
 
-Backwards Incompatible Changes
+Backwards incompatible changes
 ==============================
 
 Categories
@@ -164,7 +164,7 @@ Since Pillow's C API is now faster than PyAccess on PyPy,
 ``Image.USE_CFFI_ACCESS``, for switching from the C API to PyAccess, is
 similarly deprecated.
 
-API Changes
+API changes
 ===========
 
 Added line width parameter to ImageDraw regular_polygon
@@ -173,7 +173,7 @@ Added line width parameter to ImageDraw regular_polygon
 An optional line ``width`` parameter has been added to
 ``ImageDraw.Draw.regular_polygon``.
 
-API Additions
+API additions
 =============
 
 Added ``alpha_only`` argument to ``getbbox()``
@@ -184,7 +184,7 @@ Added ``alpha_only`` argument to ``getbbox()``
 and the image has an alpha channel, trim transparent pixels. Otherwise, trim
 pixels when all channels are zero.
 
-Other Changes
+Other changes
 =============
 
 32-bit wheels

--- a/docs/releasenotes/10.0.1.rst
+++ b/docs/releasenotes/10.0.1.rst
@@ -11,7 +11,7 @@ This release provides an updated install script and updated wheels to
 include libwebp 1.3.2, preventing a potential heap buffer overflow in
 WebP.
 
-Other Changes
+Other changes
 =============
 
 Updated tests to pass with latest zlib version

--- a/docs/releasenotes/10.1.0.rst
+++ b/docs/releasenotes/10.1.0.rst
@@ -1,7 +1,7 @@
 10.1.0
 ------
 
-API Changes
+API changes
 ===========
 
 Setting image mode
@@ -35,7 +35,7 @@ to be specified, rather than a single number for both dimensions. ::
     ImageFilter.BoxBlur((2, 5))
     ImageFilter.GaussianBlur((2, 5))
 
-API Additions
+API additions
 =============
 
 EpsImagePlugin.gs_binary
@@ -84,7 +84,7 @@ font size for this new builtin font::
     draw.multiline_text((0, 0), "test", font_size=24)
     draw.multiline_textbbox((0, 0), "test", font_size=24)
 
-Other Changes
+Other changes
 =============
 
 Python 3.12

--- a/docs/releasenotes/10.2.0.rst
+++ b/docs/releasenotes/10.2.0.rst
@@ -53,7 +53,7 @@ The functions ``IptcImageFile.dump`` and ``IptcImageFile.i``, and the constant
 for internal use, so there is no replacement. They can each be replaced
 by a single line of code using builtin functions in Python.
 
-API Changes
+API changes
 ===========
 
 Zero or negative font size error
@@ -63,7 +63,7 @@ When creating a :py:class:`~PIL.ImageFont.FreeTypeFont` instance, either directl
 through :py:func:`~PIL.ImageFont.truetype`, if the font size is zero or less, a
 :py:exc:`ValueError` will now be raised.
 
-API Additions
+API additions
 =============
 
 Added DdsImagePlugin enums
@@ -95,7 +95,7 @@ JPEG tables-only streamtype
 When saving JPEG files, ``streamtype`` can now be set to 1, for tables-only. This will
 output only the quantization and Huffman tables for the image.
 
-Other Changes
+Other changes
 =============
 
 Added DDS BC4U and DX10 BC1 and BC4 reading

--- a/docs/releasenotes/10.3.0.rst
+++ b/docs/releasenotes/10.3.0.rst
@@ -65,7 +65,7 @@ ImageMath.eval()
 :py:meth:`~PIL.ImageMath.unsafe_eval` instead. See earlier security notes for more
 information.
 
-API Changes
+API changes
 ===========
 
 Added alpha_quality argument when saving WebP images
@@ -87,7 +87,7 @@ Negative P1-P3 PPM value error
 If a P1-P3 PPM image contains a negative value, a :py:exc:`ValueError` will now be
 raised.
 
-API Additions
+API additions
 =============
 
 Added PerspectiveTransform
@@ -97,7 +97,7 @@ Added PerspectiveTransform
 that all of the :py:data:`~PIL.Image.Transform` values now have a corresponding
 subclass of :py:class:`~PIL.ImageTransform.Transform`.
 
-Other Changes
+Other changes
 =============
 
 Portable FloatMap (PFM) images

--- a/docs/releasenotes/10.4.0.rst
+++ b/docs/releasenotes/10.4.0.rst
@@ -41,7 +41,7 @@ ImageDraw.getdraw hints parameter
 
 The ``hints`` parameter in :py:meth:`~PIL.ImageDraw.getdraw()` has been deprecated.
 
-API Additions
+API additions
 =============
 
 ImageDraw.circle
@@ -51,7 +51,7 @@ Added :py:meth:`~PIL.ImageDraw.ImageDraw.circle`. It provides the same functiona
 :py:meth:`~PIL.ImageDraw.ImageDraw.ellipse`, but instead of taking a bounding box, it
 takes a center point and radius.
 
-Other Changes
+Other changes
 =============
 
 Python 3.13 beta

--- a/docs/releasenotes/11.0.0.rst
+++ b/docs/releasenotes/11.0.0.rst
@@ -1,7 +1,7 @@
 11.0.0
 ------
 
-Backwards Incompatible Changes
+Backwards incompatible changes
 ==============================
 
 Python 3.8
@@ -113,7 +113,7 @@ Specific WebP Feature Checks
 ``True`` if the WebP module is installed, until they are removed in Pillow
 12.0.0 (2025-10-15).
 
-API Changes
+API changes
 ===========
 
 Default resampling filter for I;16* image modes
@@ -122,7 +122,7 @@ Default resampling filter for I;16* image modes
 The default resampling filter for I;16, I;16L, I;16B and I;16N has been changed from
 ``Image.NEAREST`` to ``Image.BICUBIC``, to match the majority of modes.
 
-API Additions
+API additions
 =============
 
 Writing XMP bytes to JPEG and MPO
@@ -138,7 +138,7 @@ either JPEG or MPO images::
     im.info["xmp"] = b"test"
     im.save("out.jpg")
 
-Other Changes
+Other changes
 =============
 
 Python 3.13
@@ -154,7 +154,7 @@ Support has also been added for the experimental free-threaded mode of :pep:`703
 
 Python 3.13 only supports macOS versions 10.13 and later.
 
-C-level Flags
+C-level flags
 ^^^^^^^^^^^^^
 
 Some compiling flags like ``WITH_THREADING``, ``WITH_IMAGECHOPS``, and other

--- a/docs/releasenotes/11.0.0.rst
+++ b/docs/releasenotes/11.0.0.rst
@@ -103,7 +103,7 @@ JpegImageFile.huffman_ac and JpegImageFile.huffman_dc
 The ``huffman_ac`` and ``huffman_dc`` dictionaries on JPEG images were unused. They
 have been deprecated, and will be removed in Pillow 12 (2025-10-15).
 
-Specific WebP Feature Checks
+Specific WebP feature checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. deprecated:: 11.0.0

--- a/docs/releasenotes/11.1.0.rst
+++ b/docs/releasenotes/11.1.0.rst
@@ -10,7 +10,7 @@ ExifTags.IFD.Makernote
 ``ExifTags.IFD.Makernote`` has been deprecated. Instead, use
 ``ExifTags.IFD.MakerNote``.
 
-API Changes
+API changes
 ===========
 
 Writing XMP bytes to JPEG and MPO
@@ -34,7 +34,7 @@ be used::
     second_im.encoderinfo = {"xmp": b"test"}
     im.save("out.mpo", save_all=True, append_images=[second_im])
 
-API Additions
+API additions
 =============
 
 Check for zlib-ng
@@ -54,7 +54,7 @@ TIFF images can now be saved as BigTIFF using a ``big_tiff`` argument::
 
     im.save("out.tiff", big_tiff=True)
 
-Other Changes
+Other changes
 =============
 
 Reading JPEG 2000 comments

--- a/docs/releasenotes/11.2.1.rst
+++ b/docs/releasenotes/11.2.1.rst
@@ -32,7 +32,7 @@ Image.Image.get_child_images()
 method uses an image's file pointer, and so child images could only be retrieved from
 an :py:class:`PIL.ImageFile.ImageFile` instance.
 
-API Changes
+API changes
 ===========
 
 ``append_images`` no longer requires ``save_all``
@@ -44,7 +44,7 @@ supports saving multiple frames::
 
     im.save("out.gif", append_images=ims)
 
-API Additions
+API additions
 =============
 
 ``"justify"`` multiline text alignment
@@ -86,7 +86,7 @@ DXT5, BC2, BC3 and BC5 are supported::
 
     im.save("out.dds", pixel_format="DXT1")
 
-Other Changes
+Other changes
 =============
 
 Arrow support

--- a/docs/releasenotes/2.7.0.rst
+++ b/docs/releasenotes/2.7.0.rst
@@ -1,13 +1,13 @@
 2.7.0
 -----
 
-Sane Plugin
+Sane plugin
 ^^^^^^^^^^^
 
 The Sane plugin has now been split into its own repo:
 https://github.com/python-pillow/Sane .
 
-Png text chunk size limits
+PNG text chunk size limits
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To prevent potential denial of service attacks using compressed text
@@ -155,7 +155,7 @@ so the quality was worse compared to other Gaussian blur software.
 
 The new implementation does not have this drawback.
 
-TIFF Parameter Changes
+TIFF parameter changes
 ^^^^^^^^^^^^^^^^^^^^^^
 
 Several kwarg parameters for saving TIFF images were previously

--- a/docs/releasenotes/3.0.0.rst
+++ b/docs/releasenotes/3.0.0.rst
@@ -1,7 +1,7 @@
 3.0.0
 -----
 
-Backwards Incompatible Changes
+Backwards incompatible changes
 ==============================
 
 Several methods that have been marked as deprecated for many releases
@@ -18,10 +18,10 @@ have been removed in this release:
 * ``ImageWin.fromstring()``
 * ``ImageWin.tostring()``
 
-Other Changes
+Other changes
 =============
 
-Saving Multipage Images
+Saving multipage images
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 There is now support for saving multipage images in the ``GIF`` and
@@ -30,10 +30,10 @@ as a keyword argument to the save::
 
     im.save('test.pdf', save_all=True)
 
-Tiff ImageFileDirectory Rewrite
+TIFF ImageFileDirectory rewrite
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Tiff ImageFileDirectory metadata code has been rewritten. Where
+The TIFF ImageFileDirectory metadata code has been rewritten. Where
 previously it returned a somewhat arbitrary set of values and tuples,
 it now returns bare values where appropriate and tuples when the
 metadata item is a sequence or collection.
@@ -41,7 +41,7 @@ metadata item is a sequence or collection.
 The original metadata is still available in the TiffImage.tags, the
 new values are available in the TiffImage.tags_v2 member. The old
 structures will be deprecated at some point in the future.  When
-saving Tiff metadata, new code should use the
+saving TIFF metadata, new code should use the
 TiffImagePlugin.ImageFileDirectory_v2 class.
 
 LibJpeg and Zlib are required by default

--- a/docs/releasenotes/3.1.0.rst
+++ b/docs/releasenotes/3.1.0.rst
@@ -22,7 +22,7 @@ not the absolute height of each line.
 
 There is also now a default spacing of 4px between lines.
 
-Exif, Jpeg and Tiff Metadata
+EXIF, JPEG and TIFF metadata
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 There were major changes in the TIFF ImageFileDirectory support in
@@ -63,7 +63,7 @@ single item tuples have been unwrapped and return a bare element.
 The format returned by Pillow 3.0 has been abandoned. A more fully
 featured interface for EXIF is anticipated in a future release.
 
-Out of Spec Metadata
+Out of spec metadata
 ++++++++++++++++++++
 
 In Pillow 3.0 and 3.1, images that contain metadata that is internally

--- a/docs/releasenotes/3.2.0.rst
+++ b/docs/releasenotes/3.2.0.rst
@@ -1,7 +1,7 @@
 3.2.0
 -----
 
-New DDS and FTEX Image Plugins
+New DDS and FTEX image plugins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``DdsImagePlugin`` reading DXT1 and DXT5 encoded ``.dds`` images was
@@ -18,7 +18,7 @@ Updates to the GbrImagePlugin
 The ``GbrImagePlugin`` (GIMP brush format) has been updated to fix
 support for version 1 files and add support for version 2 files.
 
-Passthrough Parameters for ImageDraw.text
+Passthrough parameters for ImageDraw.text
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``ImageDraw.multiline_text`` and ``ImageDraw.multiline_size`` take extra

--- a/docs/releasenotes/3.3.0.rst
+++ b/docs/releasenotes/3.3.0.rst
@@ -11,7 +11,7 @@ libimagequant. We cannot distribute binaries due to licensing
 differences.
 
 
-New Setup.py options
+New setup.py options
 ^^^^^^^^^^^^^^^^^^^^
 
 There are two new options to control the ``build_ext`` task in ``setup.py``:
@@ -43,7 +43,7 @@ This greatly improves both quality and performance in this case.
 Also, the bug with wrong image size calculation when rotating by 90 degrees
 was fixed.
 
-Image Metadata
+Image metadata
 ^^^^^^^^^^^^^^
 
 The return type for binary data in version 2 Exif and Tiff metadata

--- a/docs/releasenotes/3.3.2.rst
+++ b/docs/releasenotes/3.3.2.rst
@@ -4,7 +4,7 @@
 Security
 ========
 
-Integer overflow in Map.c
+Integer overflow in map.c
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Pillow prior to 3.3.2 may experience integer overflow errors in map.c
@@ -27,7 +27,7 @@ memory without duplicating the image first.
 
 This issue was found by Cris Neckar at Divergent Security.
 
-Sign Extension in Storage.c
+Sign extension in Storage.c
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Pillow prior to 3.3.2 and PIL 1.1.7 (at least) do not check for

--- a/docs/releasenotes/3.4.0.rst
+++ b/docs/releasenotes/3.4.0.rst
@@ -1,7 +1,7 @@
 3.4.0
 -----
 
-Backwards Incompatible Changes
+Backwards incompatible changes
 ==============================
 
 Image.core.open_ppm removed
@@ -14,7 +14,7 @@ been removed. If you were using this function, please use
 Deprecations
 ============
 
-Deprecation Warning when Saving JPEGs
+Deprecation warning when saving JPEGs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 JPEG images cannot contain an alpha channel. Pillow prior to 3.4.0
@@ -22,7 +22,7 @@ silently drops the alpha channel. With this release Pillow will now
 issue a :py:exc:`DeprecationWarning` when attempting to save a ``RGBA`` mode
 image as a JPEG. This will become an error in Pillow 4.2.
 
-API Additions
+API additions
 =============
 
 New resizing filters
@@ -37,7 +37,7 @@ two times shorter window than ``BILINEAR``. It can be used for image reduction
 providing the image downscaling quality comparable to ``BICUBIC``.
 Both new filters don't show good quality for the image upscaling.
 
-New DDS Decoders
+New DDS decoders
 ^^^^^^^^^^^^^^^^
 
 Pillow can now decode DXT3 images, as well as the previously supported

--- a/docs/releasenotes/4.0.0.rst
+++ b/docs/releasenotes/4.0.0.rst
@@ -1,7 +1,7 @@
 4.0.0
 -----
 
-Python 2.6 and 3.2 Dropped
+Python 2.6 and 3.2 dropped
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Pillow 4.0 no longer supports Python 2.6 and 3.2. We will not be

--- a/docs/releasenotes/4.1.0.rst
+++ b/docs/releasenotes/4.1.0.rst
@@ -15,10 +15,10 @@ Several deprecated items have been removed.
   ``PIL.ImageDraw.ImageDraw.setfont`` have been removed.
 
 
-Other Changes
+Other changes
 =============
 
-Closing Files When Opening Images
+Closing files when opening images
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The file handling when opening images has been overhauled. Previously,
@@ -41,7 +41,7 @@ is specified:
   the underlying file until we are done with the image. The mapping
   will be closed in the ``close`` or ``__del__`` method.
 
-Changes to GIF Handling When Saving
+Changes to GIF handling when saving
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :py:class:`PIL.GifImagePlugin` code has been refactored to fix the flow when
@@ -57,14 +57,14 @@ saving images. There are two external changes that arise from this:
 This refactor fixed some bugs with palette handling when saving
 multiple frame GIFs.
 
-New Method: Image.remap_palette
+New method: Image.remap_palette
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The method :py:meth:`PIL.Image.Image.remap_palette()` has been
 added. This method was hoisted from the GifImagePlugin code used to
 optimize the palette.
 
-Added Decoder Registry and Support for Python Based Decoders
+Added decoder registry and support for Python-based decoders
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 There is now a decoder registry similar to the image plugin

--- a/docs/releasenotes/4.1.1.rst
+++ b/docs/releasenotes/4.1.1.rst
@@ -1,7 +1,7 @@
 4.1.1
 -----
 
-Fix Regression with reading DPI from EXIF data
+Fix regression with reading DPI from EXIF data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Some JPEG images don't contain DPI information in the image metadata,

--- a/docs/releasenotes/4.2.0.rst
+++ b/docs/releasenotes/4.2.0.rst
@@ -1,7 +1,7 @@
 4.2.0
 -----
 
-Backwards Incompatible Changes
+Backwards incompatible changes
 ==============================
 
 Several deprecated items have been removed
@@ -17,17 +17,17 @@ Several deprecated items have been removed
   was shown. From Pillow 4.2.0, the deprecation warning is removed and
   an :py:exc:`IOError` is raised.
 
-Removed Core Image Function
+Removed core Image function
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The unused function ``Image.core.new_array`` was removed. This is an
 internal function that should not have been used by user code, but it
 was accessible from the python layer.
 
-Other Changes
+Other changes
 =============
 
-Added Complex Text Rendering
+Added complex text rendering
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Pillow now supports complex text rendering for scripts requiring glyph
@@ -36,7 +36,7 @@ dependencies: harfbuzz, fribidi, and raqm. See the :doc:`install documentation
 <../installation>` for further details. This feature is tested and works on
 Unix and Mac, but has not yet been built on Windows platforms.
 
-New Optional Parameters
+New optional parameters
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 * :py:meth:`PIL.ImageDraw.floodfill` has a new optional parameter:
@@ -47,7 +47,7 @@ New Optional Parameters
   optional parameter for specifying additional images to create
   multipage outputs.
 
-New DecompressionBomb Warning
+New DecompressionBomb warning
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :py:meth:`PIL.Image.Image.crop` now may raise a DecompressionBomb

--- a/docs/releasenotes/4.2.1.rst
+++ b/docs/releasenotes/4.2.1.rst
@@ -3,7 +3,7 @@
 
 There are no functional changes in this release.
 
-Fixed Windows PyPy Build
+Fixed Windows PyPy build
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 A change in the 4.2.0 cycle broke the Windows PyPy build. This has

--- a/docs/releasenotes/4.3.0.rst
+++ b/docs/releasenotes/4.3.0.rst
@@ -1,7 +1,7 @@
 4.3.0
 -----
 
-API Changes
+API changes
 ===========
 
 Deprecations
@@ -12,7 +12,7 @@ Several undocumented functions in ImageOps have been deprecated:
 ``box_blur``. Use the equivalent operations in ``ImageFilter``
 instead. These functions will be removed in a future release.
 
-TIFF Metadata Changes
+TIFF metadata changes
 ^^^^^^^^^^^^^^^^^^^^^
 
 * TIFF tags with unknown type/quantity now default to being bare
@@ -27,7 +27,7 @@ TIFF Metadata Changes
   items, as there can be multiple items, one for UTF-8, and one for
   UTF-16.
 
-Core Image API Changes
+Core Image API changes
 ^^^^^^^^^^^^^^^^^^^^^^
 
 These are internal functions that should not have been used by user
@@ -44,10 +44,10 @@ The ``PIL.Image.core.getcount`` methods have been removed, use
 ``PIL.Image.core.get_stats()['new_count']`` property instead.
 
 
-API Additions
+API additions
 =============
 
-Get One Channel From Image
+Get one channel from image
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A new method :py:meth:`PIL.Image.Image.getchannel` has been added to
@@ -56,14 +56,14 @@ return a single channel by index or name. For example,
 ``getchannel`` should work up to 6 times faster than
 ``image.split()[0]`` in previous Pillow versions.
 
-Box Blur
+Box blur
 ^^^^^^^^
 
 A new filter, :py:class:`PIL.ImageFilter.BoxBlur`, has been
 added. This is a filter with similar results to a Gaussian blur, but
 is much faster.
 
-Partial Resampling
+Partial resampling
 ^^^^^^^^^^^^^^^^^^
 
 Added new argument ``box`` for :py:meth:`PIL.Image.Image.resize`. This
@@ -71,14 +71,14 @@ argument defines a source rectangle from within the source image to be
 resized.  This is very similar to the ``image.crop(box).resize(size)``
 sequence except that ``box`` can be specified with subpixel accuracy.
 
-New Transpose Operation
+New transpose operation
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``Image.TRANSVERSE`` operation has been added to
 :py:meth:`PIL.Image.Image.transpose`. This is equivalent to a transpose
 operation about the opposite diagonal.
 
-Multiband Filters
+Multiband filters
 ^^^^^^^^^^^^^^^^^
 
 There is a new :py:class:`PIL.ImageFilter.MultibandFilter` base class
@@ -87,10 +87,10 @@ operation. The original :py:class:`PIL.ImageFilter.Filter` class
 remains for image filters that can process only single band images, or
 require splitting of channels prior to filtering.
 
-Other Changes
+Other changes
 =============
 
-Loading 16-bit TIFF Images
+Loading 16-bit TIFF images
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Pillow now can read 16-bit multichannel TIFF files including files
@@ -101,7 +101,7 @@ Pillow now can read 16-bit signed integer single channel TIFF
 files. The image data is promoted to 32-bit for storage and
 processing.
 
-SGI Images
+SGI images
 ^^^^^^^^^^
 
 Pillow can now read and write uncompressed 16-bit multichannel SGI
@@ -129,7 +129,7 @@ This release contains several performance improvements:
   falling back to an allocation for each scan line for images larger
   than the block size.
 
-CMYK Conversion
+CMYK conversion
 ^^^^^^^^^^^^^^^
 
 The basic CMYK->RGB conversion has been tweaked to match the formula

--- a/docs/releasenotes/5.0.0.rst
+++ b/docs/releasenotes/5.0.0.rst
@@ -65,7 +65,7 @@ A new named parameter, ``fillcolor``, has been added to
 the area outside the transformed area in the output image. This
 parameter takes the same color specifications as used in ``Image.new``.
 
-GIF Disposal
+GIF disposal
 ^^^^^^^^^^^^
 
 Multiframe GIF images now take an optional disposal parameter to

--- a/docs/releasenotes/5.0.0.rst
+++ b/docs/releasenotes/5.0.0.rst
@@ -1,10 +1,10 @@
 5.0.0
 -----
 
-Backwards Incompatible Changes
+Backwards incompatible changes
 ==============================
 
-Python 3.3 Dropped
+Python 3.3 dropped
 ^^^^^^^^^^^^^^^^^^
 
 Python 3.3 is EOL and no longer supported due to moving testing from nose,
@@ -12,7 +12,7 @@ which is deprecated, to pytest, which doesn't support Python 3.3. We will not
 be creating binaries, testing, or retaining compatibility with this version.
 The final version of Pillow for Python 3.3 is 4.3.0.
 
-Decompression Bombs now raise Exceptions
+Decompression bombs now raise exceptions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Pillow has previously emitted warnings for images that are
@@ -31,7 +31,7 @@ separate package, pillow-scripts, living at
 https://github.com/python-pillow/pillow-scripts.
 
 
-API Changes
+API changes
 ===========
 
 OleFileIO.py
@@ -54,7 +54,7 @@ Several image plugins supported a named ``check`` parameter on their
 nominally private ``_save`` method to preflight if the image could be
 saved in that format. That parameter has been removed.
 
-API Additions
+API additions
 =============
 
 Image.transform
@@ -71,10 +71,10 @@ GIF Disposal
 Multiframe GIF images now take an optional disposal parameter to
 specify the disposal option for changed pixels.
 
-Other Changes
+Other changes
 =============
 
-Compressed TIFF Images
+Compressed TIFF images
 ^^^^^^^^^^^^^^^^^^^^^^
 
 Previously, there were some compression modes (JPEG, Packbits, and
@@ -82,7 +82,7 @@ LZW) that were supported with Pillow's internal TIFF decoder. All
 compressed TIFFs are now read using the ``libtiff`` decoder, as it
 implements the compression schemes more correctly.
 
-Libraqm is now Dynamically Linked
+Libraqm is now dynamically linked
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The libraqm dependency for complex text scripts is now linked
@@ -90,14 +90,14 @@ dynamically at runtime rather than at packaging time. This allows us
 to release binaries with support for libraqm if it is installed on the
 user's machine.
 
-Source Layout Changes
+Source layout changes
 ^^^^^^^^^^^^^^^^^^^^^
 
 The Pillow source is now stored within the ``src`` directory of the
 distribution. This prevents accidental imports of the PIL directory
 when running Python from the project directory.
 
-Setup.py Changes
+Setup.py changes
 ^^^^^^^^^^^^^^^^
 
 Multiarch support on Linux should be more robust, especially on Debian

--- a/docs/releasenotes/5.1.0.rst
+++ b/docs/releasenotes/5.1.0.rst
@@ -1,7 +1,7 @@
 5.1.0
 -----
 
-API Changes
+API changes
 ===========
 
 Optional channels for TIFF files
@@ -12,22 +12,22 @@ and ``CMYK`` with up to 6 8-bit channels, discarding any extra
 channels if the content is tagged as UNSPECIFIED.  Pillow still does
 not store more than 4 8-bit channels of image data.
 
-API Additions
+API additions
 =============
 
-Append to PDF Files
+Append to PDF files
 ^^^^^^^^^^^^^^^^^^^
 
 Images can now be appended to PDF files in place by passing in
 ``append=True`` when saving the image.
 
-New BLP File Format
+New BLP file format
 ^^^^^^^^^^^^^^^^^^^
 
 Pillow now supports reading the BLP "Blizzard Mipmap" file format used
 for tiles in Blizzard's engine.
 
-Other Changes
+Other changes
 =============
 
 WebP memory leak

--- a/docs/releasenotes/5.2.0.rst
+++ b/docs/releasenotes/5.2.0.rst
@@ -1,7 +1,7 @@
 5.2.0
 -----
 
-API Changes
+API changes
 ===========
 
 Deprecations
@@ -17,7 +17,7 @@ Pillow 6.0.0, and ``PILLOW_VERSION`` will be removed after that.
 
 Use ``PIL.__version__`` instead.
 
-API Additions
+API additions
 =============
 
 3D color lookup tables
@@ -75,7 +75,7 @@ TGA file format
 Pillow can now read and write LA data (in addition to L, P, RGB and RGBA), and
 write RLE data (in addition to uncompressed).
 
-Other Changes
+Other changes
 =============
 
 Support added for Python 3.7

--- a/docs/releasenotes/5.3.0.rst
+++ b/docs/releasenotes/5.3.0.rst
@@ -1,7 +1,7 @@
 5.3.0
 -----
 
-API Changes
+API changes
 ===========
 
 Image size
@@ -20,7 +20,7 @@ The exceptions to this are:
   as direct image size setting was previously necessary to work around an issue with tile extents.
 
 
-API Additions
+API additions
 =============
 
 Added line width parameter to rectangle and ellipse-based shapes
@@ -59,7 +59,7 @@ and size, new method ``ImageOps.pad`` pads images to fill a requested aspect
 ratio and size, filling new space with a provided ``color`` and positioning the
 image within the new area through a ``centering`` argument.
 
-Other Changes
+Other changes
 =============
 
 Added support for reading tiled TIFF images through LibTIFF. Compressed TIFF

--- a/docs/releasenotes/5.4.0.rst
+++ b/docs/releasenotes/5.4.0.rst
@@ -1,7 +1,7 @@
 5.4.0
 -----
 
-API Changes
+API changes
 ===========
 
 APNG extension to PNG plugin
@@ -55,7 +55,7 @@ TIFF images can now be saved with custom integer, float and string TIFF tags::
     print(im2.tag_v2[37002])  # "custom tag value"
     print(im2.tag_v2[37004])  # b"custom tag value"
 
-Other Changes
+Other changes
 =============
 
 ImageOps.fit

--- a/docs/releasenotes/6.0.0.rst
+++ b/docs/releasenotes/6.0.0.rst
@@ -1,7 +1,7 @@
 6.0.0
 -----
 
-Backwards Incompatible Changes
+Backwards incompatible changes
 ==============================
 
 Python 3.4 dropped
@@ -32,7 +32,7 @@ Removed deprecated VERSION
 ``VERSION`` (the old PIL version, always 1.1.7) has been removed. Use ``__version__``
 instead.
 
-API Changes
+API changes
 ===========
 
 Deprecations
@@ -137,7 +137,7 @@ loaded, ``Image.MIME["PPM"]`` will now return the generic "image/x-portable-anym
 The TGA, PCX and ICO formats also now have MIME types: "image/x-tga", "image/x-pcx" and
 "image/x-icon" respectively.
 
-API Additions
+API additions
 =============
 
 DIB file format
@@ -186,7 +186,7 @@ EXIF data can now be read from and saved to PNG images. However, unlike other im
 formats, EXIF data is not guaranteed to be present in :py:attr:`~PIL.Image.Image.info`
 until :py:meth:`~PIL.Image.Image.load` has been called.
 
-Other Changes
+Other changes
 =============
 
 Reading new DDS image format

--- a/docs/releasenotes/6.1.0.rst
+++ b/docs/releasenotes/6.1.0.rst
@@ -23,7 +23,7 @@ Use instead::
     with Image.open("hopper.png") as im:
         im.save("out.jpg")
 
-API Additions
+API additions
 =============
 
 Image.entropy
@@ -61,7 +61,7 @@ file. ``ImageFont.FreeTypeFont`` has four new methods,
 instead. An :py:exc:`IOError` will be raised if the font is not a variation font. FreeType
 2.9.1 or greater is required.
 
-Other Changes
+Other changes
 =============
 
 ImageTk.getimage

--- a/docs/releasenotes/6.2.0.rst
+++ b/docs/releasenotes/6.2.0.rst
@@ -29,7 +29,7 @@ perform operations on it.
 The CVE is regarding DOS problems, such as consuming large amounts of memory,
 or taking a large amount of time to process an image.
 
-API Changes
+API changes
 ===========
 
 Image.getexif
@@ -48,7 +48,7 @@ There has been a longstanding warning that the defaults of ``Image.frombuffer``
 may change in the future for the "raw" decoder. The change will now take place
 in Pillow 7.0.
 
-API Additions
+API additions
 =============
 
 Text stroking
@@ -93,7 +93,7 @@ ImageGrab on multi-monitor Windows
 An ``all_screens`` argument has been added to ``ImageGrab.grab``. If ``True``,
 all monitors will be included in the created image.
 
-Other Changes
+Other changes
 =============
 
 Removed bdist_wininst .exe installers

--- a/docs/releasenotes/6.2.1.rst
+++ b/docs/releasenotes/6.2.1.rst
@@ -1,7 +1,7 @@
 6.2.1
 -----
 
-API Changes
+API changes
 ===========
 
 Deprecations
@@ -15,7 +15,7 @@ Python 2.7 reaches end-of-life on 2020-01-01.
 Pillow 7.0.0 will be released on 2020-01-01 and will drop support for Python
 2.7, making Pillow 6.2.x the last release series to support Python 2.
 
-Other Changes
+Other changes
 =============
 
 Support added for Python 3.8

--- a/docs/releasenotes/7.0.0.rst
+++ b/docs/releasenotes/7.0.0.rst
@@ -1,7 +1,7 @@
 7.0.0
 -----
 
-Backwards Incompatible Changes
+Backwards incompatible changes
 ==============================
 
 Python 2.7
@@ -78,7 +78,7 @@ bounds of resulting image. This may be useful in a subsequent
 .. _chain methods: https://en.wikipedia.org/wiki/Method_chaining
 
 
-API Additions
+API additions
 =============
 
 Custom unidentified image error
@@ -124,7 +124,7 @@ now also be loaded at another resolution::
     with Image.open("drawing.wmf") as im:
         im.load(dpi=144)
 
-Other Changes
+Other changes
 =============
 
 Image.__del__

--- a/docs/releasenotes/7.1.0.rst
+++ b/docs/releasenotes/7.1.0.rst
@@ -35,7 +35,7 @@ out-of-bounds reads via a crafted JP2 file.
 In ``libImaging/SgiRleDecode.c`` in Pillow through 7.0.0, a number of out-of-bounds
 reads exist in the parsing of SGI image files, a different issue than :cve:`2020-5311`.
 
-API Changes
+API changes
 ===========
 
 Allow saving of zero quality JPEG images
@@ -50,7 +50,7 @@ been resolved. ::
     im = Image.open("hopper.jpg")
     im.save("out.jpg", quality=0)
 
-API Additions
+API additions
 =============
 
 New channel operations
@@ -101,7 +101,7 @@ Passing a different value on Windows or macOS will force taking a snapshot
 using the selected X server; pass an empty string to use the default X server.
 XCB support is not included in pre-compiled wheels for Windows and macOS.
 
-Other Changes
+Other changes
 =============
 
 If present, only use alpha channel for bounding box

--- a/docs/releasenotes/7.2.0.rst
+++ b/docs/releasenotes/7.2.0.rst
@@ -1,7 +1,7 @@
 7.2.0
 -----
 
-API Changes
+API changes
 ===========
 
 Replaced TiffImagePlugin DEBUG with logging

--- a/docs/releasenotes/8.0.0.rst
+++ b/docs/releasenotes/8.0.0.rst
@@ -1,7 +1,7 @@
 8.0.0
 -----
 
-Backwards Incompatible Changes
+Backwards incompatible changes
 ==============================
 
 Python 3.5
@@ -44,7 +44,7 @@ Removed                   Use instead
 ``product_model``         Unicode :py:attr:`~.CmsProfile.model`
 ========================  ===================================================
 
-API Changes
+API changes
 ===========
 
 ImageDraw.text: stroke_width
@@ -67,7 +67,7 @@ Add MIME type to PsdImagePlugin
 "image/vnd.adobe.photoshop" is now registered as the
 :py:class:`.PsdImagePlugin.PsdImageFile` MIME type.
 
-API Additions
+API additions
 =============
 
 Image.open: add formats parameter
@@ -135,7 +135,7 @@ and :py:meth:`.FreeTypeFont.getbbox` return the bounding box of rendered text.
 
 These functions accept an ``anchor`` parameter, see :ref:`text-anchors` for details.
 
-Other Changes
+Other changes
 =============
 
 Improved ellipse-drawing algorithm

--- a/docs/releasenotes/8.1.0.rst
+++ b/docs/releasenotes/8.1.0.rst
@@ -26,7 +26,7 @@ leading to an out-of-bounds write in ``TiffDecode.c``. This potentially affects 
 versions from 6.0.0 to 8.0.1, depending on the version of LibTIFF. This was reported through
 `Tidelift`_.
 
-:cve:`2020-35655`: SGI Decode buffer overrun
+:cve:`2020-35655`: SGI decode buffer overrun
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 4 byte read overflow in ``SgiRleDecode.c``, where the code was not correctly

--- a/docs/releasenotes/8.1.0.rst
+++ b/docs/releasenotes/8.1.0.rst
@@ -64,7 +64,7 @@ Makefile
 
 The ``install-venv`` target has been deprecated.
 
-API Additions
+API additions
 =============
 
 Append images to ICO
@@ -77,7 +77,7 @@ With this release, a list of images can be provided to the ``append_images`` par
 when saving, to replace the scaled down versions. This is the same functionality that
 already exists for the ICNS format.
 
-Other Changes
+Other changes
 =============
 
 Makefile

--- a/docs/releasenotes/8.1.1.rst
+++ b/docs/releasenotes/8.1.1.rst
@@ -32,7 +32,7 @@ DOS attack.
 
 There is an out-of-bounds read in ``SgiRleDecode.c`` since Pillow 4.3.0.
 
-Other Changes
+Other changes
 =============
 
 A crash with the feature flags for libimagequant, libjpeg-turbo, WebP and XCB on

--- a/docs/releasenotes/8.2.0.rst
+++ b/docs/releasenotes/8.2.0.rst
@@ -74,7 +74,7 @@ Tk/Tcl 8.4
 Support for Tk/Tcl 8.4 is deprecated and will be removed in Pillow 10.0.0 (2023-07-01),
 when Tk/Tcl 8.5 will be the minimum supported.
 
-API Changes
+API changes
 ===========
 
 Image.alpha_composite: dest
@@ -107,7 +107,7 @@ removed. Instead, ``Image.getmodebase()``, ``Image.getmodetype()``,
 ``Image.getmodebandnames()``, ``Image.getmodebands()`` or ``ImageMode.getmode()``
 can be used.
 
-API Additions
+API additions
 =============
 
 getxmp() for JPEG images
@@ -177,7 +177,7 @@ be specified through a keyword argument::
 
     im.save("out.tif", icc_profile=...)
 
-Other Changes
+Other changes
 =============
 
 GIF writer uses LZW encoding

--- a/docs/releasenotes/8.3.0.rst
+++ b/docs/releasenotes/8.3.0.rst
@@ -33,7 +33,7 @@ dictionary. The ``convert_dict_qtables`` method no longer
 performs any operations on the data given to it, has been deprecated and will be
 removed in Pillow 10.0.0 (2023-07-01).
 
-API Changes
+API changes
 ===========
 
 Changed WebP default "method" value when saving
@@ -73,7 +73,7 @@ through :py:meth:`~PIL.Image.Image.getexif`. This also provides access to the GP
 EXIF IFDs, through ``im.getexif().get_ifd(0x8825)`` and
 ``im.getexif().get_ifd(0x8769)`` respectively.
 
-API Additions
+API additions
 =============
 
 ImageOps.contain
@@ -100,7 +100,7 @@ format, through the new ``bitmap_format`` argument::
 
     im.save("out.ico", bitmap_format="bmp")
 
-Other Changes
+Other changes
 =============
 
 Added DDS BC5 reading and uncompressed saving

--- a/docs/releasenotes/8.3.2.rst
+++ b/docs/releasenotes/8.3.2.rst
@@ -20,7 +20,7 @@ bytes off the end of the allocated buffer from the heap. Present since Pillow 7.
 
 This bug was found by Google's `OSS-Fuzz`_ `CIFuzz`_ runs.
 
-Other Changes
+Other changes
 =============
 
 Python 3.10 wheels

--- a/docs/releasenotes/8.4.0.rst
+++ b/docs/releasenotes/8.4.0.rst
@@ -13,7 +13,7 @@ Before Pillow 8.3.0, ``ImagePalette`` required palette data of particular length
 default, and the size parameter could be used to override that. Pillow 8.3.0 removed
 the default required length, also removing the need for the size parameter.
 
-API Additions
+API additions
 =============
 
 Added "transparency" argument for loading EPS images
@@ -33,7 +33,7 @@ Added WalImageFile class
 :py:class:`PIL.Image.Image` instance. It now returns a dedicated
 :py:class:`PIL.WalImageFile.WalImageFile` class.
 
-Other Changes
+Other changes
 =============
 
 Speed improvement when rotating square images

--- a/docs/releasenotes/9.0.0.rst
+++ b/docs/releasenotes/9.0.0.rst
@@ -59,7 +59,7 @@ initializing ``ImagePath.Path``.
 
 .. _OSS-Fuzz: https://github.com/google/oss-fuzz
 
-Backwards Incompatible Changes
+Backwards incompatible changes
 ==============================
 
 Python 3.6
@@ -102,7 +102,7 @@ ImageFile.raise_ioerror
 has been removed. Use ``ImageFile.raise_oserror`` instead.
 
 
-API Changes
+API changes
 ===========
 
 Added line width parameter to ImageDraw polygon
@@ -111,7 +111,7 @@ Added line width parameter to ImageDraw polygon
 An optional line ``width`` parameter has been added to ``ImageDraw.Draw.polygon``.
 
 
-API Additions
+API additions
 =============
 
 ImageShow.XDGViewer
@@ -132,7 +132,7 @@ Support has been added for the "title" argument in
 argument will also now be supported, e.g. ``im.show(title="My Image")`` and
 ``ImageShow.show(im, title="My Image")``.
 
-Other Changes
+Other changes
 =============
 
 Convert subsequent GIF frames to RGB or RGBA

--- a/docs/releasenotes/9.0.1.rst
+++ b/docs/releasenotes/9.0.1.rst
@@ -21,7 +21,7 @@ While Pillow 9.0 restricted top-level builtins available to
 :py:meth:`!PIL.ImageMath.eval`, it did not prevent builtins
 available to lambda expressions. These are now also restricted.
 
-Other Changes
+Other changes
 =============
 
 Pillow 9.0 added support for ``xdg-open`` as an image viewer, but there have been

--- a/docs/releasenotes/9.1.0.rst
+++ b/docs/releasenotes/9.1.0.rst
@@ -94,7 +94,7 @@ The stub image plugin ``FitsStubImagePlugin`` has been deprecated and will be re
 Pillow 10.0.0 (2023-07-01). FITS images can be read without a handler through
 :mod:`~PIL.FitsImagePlugin` instead.
 
-API Changes
+API changes
 ===========
 
 Raise an error when performing a negative crop
@@ -137,7 +137,7 @@ On macOS, the last argument may need to be wrapped in quotes, e.g.
 Therefore ``requirements.txt`` has been removed along with the ``make install-req``
 command for installing its contents.
 
-API Additions
+API additions
 =============
 
 Added get_photoshop_blocks() to parse Photoshop TIFF tag
@@ -193,7 +193,7 @@ palette. ::
     from PIL import GifImagePlugin
     GifImagePlugin.LOADING_STRATEGY = GifImagePlugin.LoadingStrategy.RGB_AFTER_DIFFERENT_PALETTE_ONLY
 
-Other Changes
+Other changes
 =============
 
 musllinux wheels

--- a/docs/releasenotes/9.2.0.rst
+++ b/docs/releasenotes/9.2.0.rst
@@ -126,7 +126,7 @@ Use instead::
     draw = ImageDraw.Draw(im)
     draw.text((100 / 2, 100 / 2), "Hello world", font=font, anchor="mm")
 
-API Additions
+API additions
 =============
 
 Image.apply_transparency
@@ -137,7 +137,7 @@ with "transparency" in ``im.info``, and apply the transparency to the palette in
 The image's palette mode will become "RGBA", and "transparency" will be removed from
 ``im.info``.
 
-Other Changes
+Other changes
 =============
 
 Using gnome-screenshot on Linux

--- a/docs/releasenotes/9.3.0.rst
+++ b/docs/releasenotes/9.3.0.rst
@@ -28,7 +28,7 @@ This was introduced in Pillow 9.2.0, found with `OSS-Fuzz`_ and fixed by limitin
 ``SAMPLESPERPIXEL`` to the number of planes that we can decode.
 
 
-API Additions
+API additions
 =============
 
 Allow default ImageDraw font to be set
@@ -65,7 +65,7 @@ The data from :py:data:`~PIL.ExifTags.TAGS` and
 :py:data:`~PIL.ExifTags.GPS`.
 
 
-Other Changes
+Other changes
 =============
 
 Python 3.11 wheels

--- a/docs/releasenotes/9.4.0.rst
+++ b/docs/releasenotes/9.4.0.rst
@@ -20,7 +20,7 @@ Pillow attempted to dereference a null pointer in ``ImageFont``, leading to a
 crash. An error is now raised instead. This has been present since
 Pillow 8.0.0.
 
-API Additions
+API additions
 =============
 
 Added start position for getmask and getmask2
@@ -88,7 +88,7 @@ When saving a JPEG image, a comment can now be written from
 
     im.save(out, comment="Test comment")
 
-Other Changes
+Other changes
 =============
 
 Added support for DDS L and LA images

--- a/docs/releasenotes/9.5.0.rst
+++ b/docs/releasenotes/9.5.0.rst
@@ -37,7 +37,7 @@ be removed in Pillow 11 (2024-10-15). This class was only made as a helper to
 be used internally, so there is no replacement. If you need this functionality
 though, it is a very short class that can easily be recreated in your own code.
 
-API Additions
+API additions
 =============
 
 QOI file format
@@ -71,7 +71,7 @@ If OpenJPEG 2.4.0 or later is available and the ``plt`` keyword argument
 is present and true when saving JPEG2000 images, tell the encoder to generate
 PLT markers.
 
-Other Changes
+Other changes
 =============
 
 Added support for saving PDFs in RGBA mode

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -1,4 +1,4 @@
-Release Notes
+Release notes
 =============
 
 Pillow is released quarterly on January 2nd, April 1st, July 1st and October 15th.

--- a/docs/releasenotes/template.rst
+++ b/docs/releasenotes/template.rst
@@ -14,7 +14,7 @@ TODO
 
 TODO
 
-Backwards Incompatible Changes
+Backwards incompatible changes
 ==============================
 
 TODO
@@ -28,7 +28,7 @@ TODO
 
 TODO
 
-API Changes
+API changes
 ===========
 
 TODO
@@ -36,7 +36,7 @@ TODO
 
 TODO
 
-API Additions
+API additions
 =============
 
 TODO
@@ -44,7 +44,7 @@ TODO
 
 TODO
 
-Other Changes
+Other changes
 =============
 
 TODO


### PR DESCRIPTION
We have a mix of "Title Case" and "Sentence case" for headers in the docs.

I find "Sentence case" more readable, especially where we have a lot of headings in the right-hand menu. And as it happens, it's also the style of the CPython docs:

https://devguide.python.org/documentation/style-guide/#capitalization