### PR TITLE
Removed unreachable code

### DIFF
--- a/src/PIL/MpegImagePlugin.py
+++ b/src/PIL/MpegImagePlugin.py
@@ -33,11 +33,7 @@ class BitStream:
 
     def peek(self, bits: int) -> int:
         while self.bits < bits:
-            c = self.next()
-            if c < 0:
-                self.bits = 0
-                continue
-            self.bitbuffer = (self.bitbuffer << 8) + c
+            self.bitbuffer = (self.bitbuffer << 8) + self.next()
             self.bits += 8
         return self.bitbuffer >> (self.bits - bits) & (1 << bits) - 1
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/03e7871afdb8f558cddc10cc9013e1db143298d9/src/PIL/_binary.py#L21-L22
https://github.com/python-pillow/Pillow/blob/03e7871afdb8f558cddc10cc9013e1db143298d9/src/PIL/MpegImagePlugin.py#L31-L39

`c < 0` will never be True. The value can range from 0 to 255, but will never be less than zero.