### PR TITLE
Return PixelAccess from first load of ICO and IPTC images

### DIFF
--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -99,6 +99,7 @@ def test_getpixel(tmp_path: Path) -> None:
         reloaded.load()
         reloaded.size = (32, 32)
 
+        assert reloaded.load() is not None
         assert reloaded.getpixel((0, 0)) == (18, 20, 62)
 
 

--- a/Tests/test_file_iptc.py
+++ b/Tests/test_file_iptc.py
@@ -23,6 +23,9 @@ def test_open() -> None:
         assert im.tile == [("iptc", (0, 0, 1, 1), 25, "raw")]
         assert_image_equal(im, expected)
 
+    with Image.open(f) as im:
+        assert im.load() is not None
+
 
 def test_getiptcinfo_jpg_none() -> None:
     # Arrange

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -362,7 +362,7 @@ class IcoImageFile(ImageFile.ImageFile):
             self.info["sizes"] = set(sizes)
 
             self.size = im.size
-        return None
+        return Image.Image.load(self)
 
     def load_seek(self, pos: int) -> None:
         # Flag the ImageFile.Parser so that it

--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -179,6 +179,7 @@ class IptcImageFile(ImageFile.ImageFile):
         with Image.open(o) as _im:
             _im.load()
             self.im = _im.im
+        self.tile = []
         return None
 
 

--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -180,7 +180,7 @@ class IptcImageFile(ImageFile.ImageFile):
             _im.load()
             self.im = _im.im
         self.tile = []
-        return None
+        return Image.Image.load(self)
 
 
 Image.register_open(IptcImageFile.format, IptcImageFile)


### PR DESCRIPTION
ICO and IPTC `load()` return `None` the first time processing data, leading to the following assertions failing.
```python
from PIL import Image
with Image.open("Tests/images/hopper.png") as im:
    im.save("out.ico", sizes=[(32, 32), (64, 64)])
with Image.open("out.ico") as reloaded:
    reloaded.size = (32, 32)
    assert reloaded.load() is not None
```
and
```python
import io
from PIL import Image
f = io.BytesIO(
    b"\x1c\x03<\x00\x02\x01\x00\x1c\x03x\x00\x01\x01\x1c\x03\x14\x00\x01\x01"
    b"\x1c\x03\x1e\x00\x01\x01\x1c\x08\n\x00\x01\x00"
)
with Image.open(f) as im:
    assert im.load() is not None
```

This fixes that, and also prevents repeated IPTC `load()` calls from regenerating the C image instance.