### PR TITLE
Do not use DEFAULT_MAX_THREADS when saving AVIF images

### DIFF
--- a/src/PIL/AvifImagePlugin.py
+++ b/src/PIL/AvifImagePlugin.py
@@ -54,13 +54,10 @@ def _accept(prefix: bytes) -> bool | str:
     return False
 
 
-def _get_default_max_threads() -> int:
-    if DEFAULT_MAX_THREADS:
-        return DEFAULT_MAX_THREADS
+def _get_max_threads() -> int:
     if hasattr(os, "sched_getaffinity"):
         return len(os.sched_getaffinity(0))
-    else:
-        return os.cpu_count() or 1
+    return os.cpu_count() or 1
 
 
 class AvifImageFile(ImageFile.ImageFile):
@@ -81,7 +78,7 @@ class AvifImageFile(ImageFile.ImageFile):
         self._decoder = _avif.AvifDecoder(
             self.fp.read(),
             DECODE_CODEC_CHOICE,
-            _get_default_max_threads(),
+            DEFAULT_MAX_THREADS or _get_max_threads(),
         )
 
         # Get info from decoder
@@ -164,7 +161,7 @@ def _save(
     duration = info.get("duration", 0)
     subsampling = info.get("subsampling", "4:2:0")
     speed = info.get("speed", 6)
-    max_threads = info.get("max_threads", _get_default_max_threads())
+    max_threads = info.get("max_threads", _get_max_threads())
     codec = info.get("codec", "auto")
     if codec != "auto" and not _avif.encoder_codec_available(codec):
         msg = "Invalid saving codec"


### PR DESCRIPTION
At the moment, `DEFAULT_MAX_THREADS` may be used when saving an AVIF image.
https://github.com/python-pillow/Pillow/blob/58e48745cc7b6c6f7dd26a50fe68d1a82ea51562/src/PIL/AvifImagePlugin.py#L57-L59
https://github.com/python-pillow/Pillow/blob/58e48745cc7b6c6f7dd26a50fe68d1a82ea51562/src/PIL/AvifImagePlugin.py#L167

However, I don't think that's indicated by comments.
https://github.com/python-pillow/Pillow/blob/58e48745cc7b6c6f7dd26a50fe68d1a82ea51562/src/PIL/AvifImagePlugin.py#L16-L20

And it's not mentioned in the docs - https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#avif
> **max_threads**
> Limit the number of active threads used. By default, there is no limit. If the aom codec is used, there is a maximum of 64.

So this PR suggests not using it when saving. The user can specify it through `im.save(max_threads=...)`.

cc @fdintino 