### PR TITLE
Remove outdated comment

### DIFF
--- a/src/PIL/AvifImagePlugin.py
+++ b/src/PIL/AvifImagePlugin.py
@@ -16,7 +16,6 @@ except ImportError:
 # Decoder options as module globals, until there is a way to pass parameters
 # to Image.open (see https://github.com/python-pillow/Pillow/issues/569)
 DECODE_CODEC_CHOICE = "auto"
-# Decoding is only affected by this for libavif **0.8.4** or greater.
 DEFAULT_MAX_THREADS = 0
 
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/58e48745cc7b6c6f7dd26a50fe68d1a82ea51562/src/PIL/AvifImagePlugin.py#L19-L20

As per https://pillow.readthedocs.io/en/stable/installation/building-from-source.html#external-libraries though, Pillow only supports libavif 1.0.0 or greater.
> **libavif** provides support for the AVIF format.
> - Pillow requires libavif version **1.0.0** or greater.

So the comment can be removed.