### PR TITLE
Refactor docs `Makefile`

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,8 +12,6 @@ BUILDDIR      = _build
 PAPEROPT_a4     = --define latex_paper_size=a4
 PAPEROPT_letter = --define latex_paper_size=letter
 ALLSPHINXOPTS   = --doctree-dir $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
-# the i18n builder cannot share the environment and doctrees with the others
-I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
 .PHONY: help
 help:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -55,10 +55,6 @@ singlehtml: html
 .PHONY: linkcheck
 linkcheck: BUILDER = linkcheck
 linkcheck: html
-linkcheck:
-	@echo
-	@echo "Link check complete; look for any errors in the above output " \
-	      "or in $(BUILDDIR)/linkcheck/output.txt."
 
 .PHONY: htmlview
 htmlview: html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,8 +3,8 @@
 
 # You can set these variables from the command line.
 PYTHON        = python3
-SPHINXOPTS    =
 SPHINXBUILD   = $(PYTHON) -m sphinx.cmd.build
+SPHINXOPTS    = --fail-on-warning --keep-going
 PAPER         =
 BUILDDIR      = _build
 BUILDER       = html
@@ -40,7 +40,7 @@ install-sphinx:
 .PHONY: html
 html:
 	$(MAKE) install-sphinx
-	$(SPHINXBUILD) --fail-on-warning --keep-going $(ALLSPHINXOPTS)
+	$(SPHINXBUILD) $(ALLSPHINXOPTS)
 
 .PHONY: dirhtml
 dirhtml: BUILDER = dirhtml

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,14 +7,17 @@ SPHINXOPTS    =
 SPHINXBUILD   = $(PYTHON) -m sphinx.cmd.build
 PAPER         =
 BUILDDIR      = _build
+BUILDER       = html
 
 # Internal variables.
 PAPEROPT_a4     = --define latex_paper_size=a4
 PAPEROPT_letter = --define latex_paper_size=letter
 
-ALLSPHINXOPTS   = --doctree-dir $(BUILDDIR)/doctrees \
+ALLSPHINXOPTS   = --builder $(BUILDER) \
+                  --doctree-dir $(BUILDDIR)/doctrees \
                   $(PAPEROPT_$(PAPER)) \
-                  $(SPHINXOPTS) .
+                  $(SPHINXOPTS) \
+                  . $(BUILDDIR)/$(BUILDER)
 
 .PHONY: help
 help:
@@ -37,28 +40,31 @@ install-sphinx:
 .PHONY: html
 html:
 	$(MAKE) install-sphinx
-	$(SPHINXBUILD) --builder html --fail-on-warning --keep-going $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) --fail-on-warning --keep-going $(ALLSPHINXOPTS)
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 .PHONY: dirhtml
+dirhtml: BUILDER = dirhtml
 dirhtml:
 	$(MAKE) install-sphinx
-	$(SPHINXBUILD) --builder dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
+	$(SPHINXBUILD) $(ALLSPHINXOPTS)
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
 .PHONY: singlehtml
+singlehtml: BUILDER = singlehtml
 singlehtml:
 	$(MAKE) install-sphinx
-	$(SPHINXBUILD) --builder singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
+	$(SPHINXBUILD) $(ALLSPHINXOPTS)
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
 
 .PHONY: linkcheck
+linkcheck: BUILDER = linkcheck
 linkcheck:
 	$(MAKE) install-sphinx
-	$(SPHINXBUILD) --builder linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck -j auto
+	$(SPHINXBUILD) $(ALLSPHINXOPTS) -j auto
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,9 +5,10 @@
 PYTHON        = python3
 SPHINXBUILD   = $(PYTHON) -m sphinx.cmd.build
 SPHINXOPTS    = --fail-on-warning --keep-going
-PAPER         =
 BUILDDIR      = _build
 BUILDER       = html
+JOBS          = auto
+PAPER         =
 
 # Internal variables.
 PAPEROPT_a4     = --define latex_paper_size=a4
@@ -15,6 +16,7 @@ PAPEROPT_letter = --define latex_paper_size=letter
 
 ALLSPHINXOPTS   = --builder $(BUILDER) \
                   --doctree-dir $(BUILDDIR)/doctrees \
+                  --jobs $(JOBS) \
                   $(PAPEROPT_$(PAPER)) \
                   $(SPHINXOPTS) \
                   . $(BUILDDIR)/$(BUILDER)
@@ -58,7 +60,7 @@ singlehtml:
 linkcheck: BUILDER = linkcheck
 linkcheck:
 	$(MAKE) install-sphinx
-	$(SPHINXBUILD) $(ALLSPHINXOPTS) -j auto
+	$(SPHINXBUILD) $(ALLSPHINXOPTS)
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 PYTHON        = python3
 SPHINXBUILD   = $(PYTHON) -m sphinx.cmd.build
-SPHINXOPTS    = --fail-on-warning --keep-going
+SPHINXOPTS    = --fail-on-warning
 BUILDDIR      = _build
 BUILDER       = html
 JOBS          = auto

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,7 +11,10 @@ BUILDDIR      = _build
 # Internal variables.
 PAPEROPT_a4     = --define latex_paper_size=a4
 PAPEROPT_letter = --define latex_paper_size=letter
-ALLSPHINXOPTS   = --doctree-dir $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+
+ALLSPHINXOPTS   = --doctree-dir $(BUILDDIR)/doctrees \
+                  $(PAPEROPT_$(PAPER)) \
+                  $(SPHINXOPTS) .
 
 .PHONY: help
 help:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -41,24 +41,18 @@ install-sphinx:
 html:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) --fail-on-warning --keep-going $(ALLSPHINXOPTS)
-	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 .PHONY: dirhtml
 dirhtml: BUILDER = dirhtml
 dirhtml:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) $(ALLSPHINXOPTS)
-	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
 .PHONY: singlehtml
 singlehtml: BUILDER = singlehtml
 singlehtml:
 	$(MAKE) install-sphinx
 	$(SPHINXBUILD) $(ALLSPHINXOPTS)
-	@echo
-	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
 
 .PHONY: linkcheck
 linkcheck: BUILDER = linkcheck

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -46,21 +46,16 @@ html:
 
 .PHONY: dirhtml
 dirhtml: BUILDER = dirhtml
-dirhtml:
-	$(MAKE) install-sphinx
-	$(SPHINXBUILD) $(ALLSPHINXOPTS)
+dirhtml: html
 
 .PHONY: singlehtml
 singlehtml: BUILDER = singlehtml
-singlehtml:
-	$(MAKE) install-sphinx
-	$(SPHINXBUILD) $(ALLSPHINXOPTS)
+singlehtml: html
 
 .PHONY: linkcheck
 linkcheck: BUILDER = linkcheck
+linkcheck: html
 linkcheck:
-	$(MAKE) install-sphinx
-	$(SPHINXBUILD) $(ALLSPHINXOPTS)
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."

--- a/docs/handbook/appendices.rst
+++ b/docs/handbook/appendices.rst
@@ -8,4 +8,5 @@ Appendices
 
   image-file-formats
   text-anchors
+  third-party-plugins
   writing-your-own-image-plugin

--- a/docs/handbook/third-party-plugins.rst
+++ b/docs/handbook/third-party-plugins.rst
@@ -1,0 +1,18 @@
+Third-party plugins
+===================
+
+Pillow uses a plugin model which allows users to add their own
+decoders and encoders to the library, without any changes to the library
+itself.
+
+Here is a list of PyPI projects that offer additional plugins:
+
+* :pypi:`DjvuRleImagePlugin`: Plugin for the DjVu RLE image format as defined in the DjVuLibre docs.
+* :pypi:`heif-image-plugin`: Simple HEIF/HEIC images plugin, based on the pyheif library.
+* :pypi:`jxlpy`: Introduces reading and writing support for JPEG XL.
+* :pypi:`pillow-heif`: Python bindings to libheif for working with HEIF images.
+* :pypi:`pillow-jpls`: Plugin for the JPEG-LS codec, based on the Charls JPEG-LS implemetation. Python bindings implemented using pybind11.
+* :pypi:`pillow-jxl-plugin`: Plugin for JPEG-XL, using Rust for bindings.
+* :pypi:`pillow-mbm`: Adds support for KSP's proprietary MBM texture format.
+* :pypi:`pillow-svg`: Implements basic SVG read support. Supports basic paths, shapes, and text.
+* :pypi:`raw-pillow-opener`: Simple camera raw opener, based on the rawpy library.


### PR DESCRIPTION
Mainly to remove duplication.

Some functional changes:

* Use `--jobs auto` for all builders, not just `linkcheck`. This speeds `make -C docs clean html` for me from 25 seconds to 14 seconds.
* Use `--fail-on-warning --keep-going` for all builders, not just `html`.
