### PR TITLE
Allow loading ImageFile state from Pillow < 11.2.1

### DIFF
--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -162,3 +162,13 @@ def test_pickle_font_file(tmp_path: Path, protocol: int) -> None:
 
     # Assert
     helper_assert_pickled_font_images(font, unpickled_font)
+
+
+def test_load_earlier_data() -> None:
+    im = pickle.loads(
+        b"\x80\x04\x95@\x00\x00\x00\x00\x00\x00\x00\x8c\x12PIL.PngImagePlugin"
+        b"\x94\x8c\x0cPngImageFile\x94\x93\x94)\x81\x94]\x94(}\x94\x8c\x01L\x94K\x01"
+        b"K\x01\x86\x94NC\x01\x00\x94eb."
+    )
+    assert im.mode == "L"
+    assert im.size == (1, 1)

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -257,7 +257,8 @@ class ImageFile(Image.Image):
 
     def __setstate__(self, state: list[Any]) -> None:
         self.tile = []
-        self.filename = state[5]
+        if len(state) > 5:
+            self.filename = state[5]
         super().__setstate__(state)
 
     def verify(self) -> None:


### PR DESCRIPTION
Resolves #8935

A user pickled an imageFile before #8859 added `self.filename` to the state, and would like to unpickle the data with the latest version of Pillow.