### PR TITLE
Restore original encoderinfo after saving

### DIFF
--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -315,6 +315,9 @@ def test_save_xmp() -> None:
     im2.encoderinfo = {"xmp": b"Second frame"}
     im_reloaded = roundtrip(im, xmp=b"First frame", save_all=True, append_images=[im2])
 
+    # Test that encoderinfo is unchanged
+    assert im2.encoderinfo == {"xmp": b"Second frame"}
+
     assert im_reloaded.info["xmp"] == b"First frame"
 
     im_reloaded.seek(1)

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2551,7 +2551,8 @@ class Image:
             self.load()
 
         save_all = params.pop("save_all", None)
-        self.encoderinfo = {**getattr(self, "encoderinfo", {}), **params}
+        encoderinfo = getattr(self, "encoderinfo", {})
+        self.encoderinfo = {**encoderinfo, **params}
         self.encoderconfig: tuple[Any, ...] = ()
 
         if format.upper() not in SAVE:
@@ -2589,10 +2590,7 @@ class Image:
                     pass
             raise
         finally:
-            try:
-                del self.encoderinfo
-            except AttributeError:
-                pass
+            self.encoderinfo = encoderinfo
         if open_fp:
             fp.close()
 


### PR DESCRIPTION
Resolves #8936

#8483 added a generic way to set additional options when saving subsequent frames.
```python
from PIL import Image

im = Image.open("Tests/images/hopper.png")
second_im = Image.new("RGB", (128, 128))
second_im.encoderinfo = {"xmp": b"Second frame"}
im.save("out.mpo", save_all=True, append_images=[second_im])
```

In that PR, I deleted the image's `encoderinfo` at the end of the save process. The user would more likely expect the image's `encoderinfo` to still hold the same information.