### PR TITLE
Updated docstring

### DIFF
--- a/src/PIL/DdsImagePlugin.py
+++ b/src/PIL/DdsImagePlugin.py
@@ -1,5 +1,5 @@
 """
-A Pillow loader for .dds files (S3TC-compressed aka DXTC)
+A Pillow plugin for .dds files (S3TC-compressed aka DXTC)
 Jerome Leclanche <jerome@leclan.ch>
 
 Documentation:


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/07df26aa5d2cf0937737c787bc88ff05454e53d2/src/PIL/DdsImagePlugin.py#L2

Since #5402, this plugin has been able to save as well.