### PR TITLE
Improved support for Python 3.14

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -84,7 +84,7 @@ jobs:
         python3 -m pip install --upgrade pip
 
     - name: Install CPython dependencies
-      if: "!contains(matrix.python-version, 'pypy') && matrix.architecture != 'x86'"
+      if: "!contains(matrix.python-version, 'pypy') && !contains(matrix.python-version, '3.14') && matrix.architecture != 'x86'"
       run: |
         python3 -m pip install PyQt6
 

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -462,7 +462,7 @@ class TestCoreResampleBox:
         im.resize((32, 32), resample, (20, 20, 20, 100))
         im.resize((32, 32), resample, (20, 20, 100, 20))
 
-        with pytest.raises(TypeError, match="must be sequence of length 4"):
+        with pytest.raises(TypeError, match="must be (sequence|tuple) of length 4"):
             im.resize((32, 32), resample, (im.width, im.height))  # type: ignore[arg-type]
 
         with pytest.raises(ValueError, match="can't be negative"):

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ WEBP_ROOT = None
 ZLIB_ROOT = None
 FUZZING_BUILD = "LIB_FUZZING_ENGINE" in os.environ
 
-if sys.platform == "win32" and sys.version_info >= (3, 14):
+if sys.platform == "win32" and sys.version_info >= (3, 15):
     import atexit
 
     atexit.register(


### PR DESCRIPTION
1. A test has started failing now that an error message has changed in Python 3.14

https://github.com/python-pillow/Pillow/actions/runs/14903027962/job/41859109942#step:11:3834
> E       AssertionError: Regex pattern did not match.
> E        Regex: 'must be sequence of length 4'
> E        Input: 'argument 3 must be tuple of length 4, not 2'

2. An error has started occurring when building PyQt6 on Python 3.14 - https://github.com/python-pillow/Pillow/actions/runs/14903027971/job/41859749652#step:8:12

Let's skip it for now.

3. Those changes then triggers our [Windows message about unsupported Python versions](https://github.com/python-pillow/Pillow/blob/d02f7868732cdacc227dd794f6ff84bd6f1858c9/setup.py#L49) - https://github.com/python-pillow/Pillow/actions/runs/14906195788/job/41869036883?pr=8948#step:28:779. Since Python 3.14 has now reached [beta](https://www.python.org/downloads/release/python-3140b1/), we would like users to be able to install and it, so let's increment the version check.

...this then leads to the same error from building PyQt6 occurring when building Pillow - https://github.com/python-pillow/Pillow/actions/runs/14906674076/job/41870606277?pr=8948#step:28:769
>   LINK : fatal error LNK1104: cannot open file 'python314t.lib'