### PR TITLE
Fix off by one error in refcount implementation for arrow

### DIFF
--- a/src/libImaging/Storage.c
+++ b/src/libImaging/Storage.c
@@ -302,7 +302,7 @@ ImagingDelete(Imaging im) {
     MUTEX_LOCK(&im->mutex);
     im->refcount--;
 
-    if (im->refcount > 0) {
+    if (im->refcount > 1) {
         MUTEX_UNLOCK(&im->mutex);
         return;
     }


### PR DESCRIPTION
Fixes #8950 .

Changes proposed in this pull request:

 * Fix refcount implementation so it doesn't leak image memory. 
