### PR TITLE
Fix memory leak in arrow export using array structure

### DIFF
--- a/src/libImaging/Arrow.c
+++ b/src/libImaging/Arrow.c
@@ -127,9 +127,7 @@ static void
 release_const_array(struct ArrowArray *array) {
     Imaging im = (Imaging)array->private_data;
 
-    if (array->n_children == 0) {
-        ImagingDelete(im);
-    }
+    ImagingDelete(im);
 
     //  Free the buffers and the buffers array
     if (array->buffers) {


### PR DESCRIPTION
Fixes #8950 .

Changes proposed in this pull request:

 * Properly handle releasing the image associated with PyArrow capsules that have child arrays. 
