### PR TITLE
Do not decode bytes in PPM error message

### DIFF
--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -288,12 +288,13 @@ def test_non_integer_token(tmp_path: Path) -> None:
             pass
 
 
-def test_header_token_too_long(tmp_path: Path) -> None:
+@pytest.mark.parametrize("data", (b"P3\x0cAAAAAAAAAA\xee", b"P6\n 01234567890"))
+def test_header_token_too_long(tmp_path: Path, data: bytes) -> None:
     path = tmp_path / "temp.ppm"
     with open(path, "wb") as f:
-        f.write(b"P6\n 01234567890")
+        f.write(data)
 
-    with pytest.raises(ValueError, match="Token too long in file header: 01234567890"):
+    with pytest.raises(ValueError, match="Token too long in file header: "):
         with Image.open(path):
             pass
 

--- a/src/PIL/PpmImagePlugin.py
+++ b/src/PIL/PpmImagePlugin.py
@@ -94,8 +94,8 @@ class PpmImageFile(ImageFile.ImageFile):
             msg = "Reached EOF while reading header"
             raise ValueError(msg)
         elif len(token) > 10:
-            msg = f"Token too long in file header: {token.decode()}"
-            raise ValueError(msg)
+            msg_too_long = b"Token too long in file header: %s" % token
+            raise ValueError(msg_too_long)
         return token
 
     def _open(self) -> None:


### PR DESCRIPTION
Resolves #8956

https://github.com/python-pillow/Pillow/blob/3c71559804e661a5f727e2007a5be51f26d9af27/src/PIL/PpmImagePlugin.py#L97-L98

The issue found a `token` value that could not be decoded, so this PR changes the error message to use bytes instead.