### PR TITLE
Parse XMP tag bytes without decoding to string

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -973,6 +973,11 @@ class TestImage:
                     assert tag not in exif.get_ifd(0x8769)
                 assert exif.get_ifd(0xA005)
 
+    def test_exif_from_xmp_bytes(self) -> None:
+        im = Image.new("RGB", (1, 1))
+        im.info["xmp"] = b'\xff tiff:Orientation="2"'
+        assert im.getexif()[274] == 2
+
     def test_empty_xmp(self) -> None:
         with Image.open("Tests/images/hopper.gif") as im:
             if ElementTree is None:

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1538,10 +1538,11 @@ class Image:
         # XMP tags
         if ExifTags.Base.Orientation not in self._exif:
             xmp_tags = self.info.get("XML:com.adobe.xmp")
+            pattern: str | bytes = r'tiff:Orientation(="|>)([0-9])'
             if not xmp_tags and (xmp_tags := self.info.get("xmp")):
-                xmp_tags = xmp_tags.decode("utf-8")
+                pattern = rb'tiff:Orientation(="|>)([0-9])'
             if xmp_tags:
-                match = re.search(r'tiff:Orientation(="|>)([0-9])', xmp_tags)
+                match = re.search(pattern, xmp_tags)
                 if match:
                     self._exif[ExifTags.Base.Orientation] = int(match[2])
 


### PR DESCRIPTION
Resolves #8957

The issue has found that XMP tag bytes may contain non-ascii bytes. This raises an error when trying to parse them to get the orientation.

https://github.com/python-pillow/Pillow/blob/3c71559804e661a5f727e2007a5be51f26d9af27/src/PIL/Image.py#L1541-L1544

Instead of changing the XMP tag bytes to a string to match the pattern, this PR changes the pattern to bytes to match the XMP tag bytes.