### PR TITLE
Clear TIFF core image if memory mapping was used for last load

### DIFF
--- a/Tests/test_tiff_crashes.py
+++ b/Tests/test_tiff_crashes.py
@@ -52,3 +52,17 @@ def test_tiff_crashes(test_file: str) -> None:
         pytest.skip("test image not found")
     except OSError:
         pass
+
+
+def test_tiff_mmap() -> None:
+    try:
+        with Image.open("Tests/images/crash_mmap.tif") as im:
+            im.seek(1)
+            im.load()
+
+            im.seek(0)
+            im.load()
+    except FileNotFoundError:
+        if on_ci():
+            raise
+        pytest.skip("test image not found")

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1217,9 +1217,10 @@ class TiffImageFile(ImageFile.ImageFile):
             return
         self._seek(frame)
         if self._im is not None and (
-            self.im.size != self._tile_size or self.im.mode != self.mode
+            self.im.size != self._tile_size
+            or self.im.mode != self.mode
+            or self.readonly
         ):
-            # The core image will no longer be used
             self._im = None
 
     def _seek(self, frame: int) -> None:

--- a/src/map.c
+++ b/src/map.c
@@ -137,6 +137,7 @@ PyImaging_MapBuffer(PyObject *self, PyObject *args) {
         }
     }
 
+    im->read_only = view.readonly;
     im->destroy = mapping_destroy_buffer;
 
     Py_INCREF(target);


### PR DESCRIPTION
Resolves #8961

I've used the test image from the issue, but due to a larger file size, I've placed it in https://github.com/python-pillow/test-images/pull/7. This will fail without that pull request.

Using memory mapping to load one frame, and then not using it for the next frame, is causing a problem. This would be because memory mapping is replacing the core image.

https://github.com/python-pillow/Pillow/blob/3c71559804e661a5f727e2007a5be51f26d9af27/src/PIL/ImageFile.py#L324-L326

But TiffImagePlugin tries to keep using it afterwards.

https://github.com/python-pillow/Pillow/blob/3c71559804e661a5f727e2007a5be51f26d9af27/src/PIL/TiffImagePlugin.py#L1214-L1223