### PR TITLE
Reduced number of bytes read in WMF header

### DIFF
--- a/src/PIL/WmfImagePlugin.py
+++ b/src/PIL/WmfImagePlugin.py
@@ -81,7 +81,7 @@ class WmfStubImageFile(ImageFile.StubImageFile):
 
     def _open(self) -> None:
         # check placable header
-        s = self.fp.read(80)
+        s = self.fp.read(44)
 
         if s.startswith(b"\xd7\xcd\xc6\x9a\x00\x00"):
             # placeable windows metafile


### PR DESCRIPTION
WmfImagePlugin initially reads 80 bytes.

https://github.com/python-pillow/Pillow/blob/3c71559804e661a5f727e2007a5be51f26d9af27/src/PIL/WmfImagePlugin.py#L84

However, the furthest that is used is byte 44.

https://github.com/python-pillow/Pillow/blob/3c71559804e661a5f727e2007a5be51f26d9af27/src/PIL/WmfImagePlugin.py#L116

So the number of bytes can be reduced.