### PR TITLE
Removed CMAKE_POLICY_VERSION_MINIMUM=3.5 for libavif

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -66,7 +66,7 @@ if [[ $(uname) != CYGWIN* ]]; then
     pushd depends && ./install_raqm.sh && popd
 
     # libavif
-    pushd depends && CMAKE_POLICY_VERSION_MINIMUM=3.5 ./install_libavif.sh && popd
+    pushd depends && ./install_libavif.sh && popd
 
     # extra test images
     pushd depends && ./install_extra_test_images.sh && popd


### PR DESCRIPTION
In #8949, I removed `CMAKE_POLICY_VERSION_MINIMUM=3.5` in winbuild, as it is no longer necessary with the updated version, but forgot about install.sh.

If you're interested in the background, see https://github.com/python-pillow/Pillow/pull/5201#issuecomment-2770692611 for a discussion between a libavif maintainer and myself.