### PR TITLE
Only accept missing tkinter when building wheels on Windows

### DIFF
--- a/Tests/check_wheel.py
+++ b/Tests/check_wheel.py
@@ -11,13 +11,14 @@ from .helper import is_pypy
 def test_wheel_modules() -> None:
     expected_modules = {"pil", "tkinter", "freetype2", "littlecms2", "webp"}
 
-    # tkinter is not available in cibuildwheel installed CPython on Windows
-    try:
-        import tkinter
+    if sys.platform == "win32":
+        # tkinter is not available in cibuildwheel installed CPython on Windows
+        try:
+            import tkinter
 
-        assert tkinter
-    except ImportError:
-        expected_modules.remove("tkinter")
+            assert tkinter
+        except ImportError:
+            expected_modules.remove("tkinter")
 
     assert set(features.get_supported_modules()) == expected_modules
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/5a04b9581b16a7f1e1109f1e31a206a6550f314c/Tests/check_wheel.py#L14-L20

Let's increase the specificity of this code to only silently catch the error on Windows, as per the comment.

Since this PR hasn't actually triggered a Wheels job, I'll point to https://github.com/radarhere/Pillow/actions/runs/15235083611 as evidence that this does still pass.