### PR TITLE
Update MinGW package names

### DIFF
--- a/docs/installation/building-from-source.rst
+++ b/docs/installation/building-from-source.rst
@@ -194,9 +194,9 @@ Many of Pillow's features require external libraries:
 
         pacman -S \
             mingw-w64-x86_64-gcc \
-            mingw-w64-x86_64-python3 \
-            mingw-w64-x86_64-python3-pip \
-            mingw-w64-x86_64-python3-setuptools
+            mingw-w64-x86_64-python \
+            mingw-w64-x86_64-python-pip \
+            mingw-w64-x86_64-python-setuptools
 
     Prerequisites are installed on **MSYS2 MinGW 64-bit** with::
 


### PR DESCRIPTION
error: target not found: mingw-w64-x86_64-python3-pip
error: target not found: mingw-w64-x86_64-python3-setuptools

Changes proposed in this pull request:

 * packages list in msys2 build guide 

it did bother me for minutes that `mingw-w64-x86_64-python3` exists but `mingw-w64-x86_64-python3-pip` and `mingw-w64-x86_64-python3-setup-tools` doesnt