### PR TITLE
Revert "Fix memory leak in TiffEncode"

### DIFF
--- a/src/encode.c
+++ b/src/encode.c
@@ -703,8 +703,6 @@ PyImaging_LibTiffEncoderNew(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    encoder->cleanup = ImagingLibTiffEncodeCleanup;
-
     num_core_tags = sizeof(core_tags) / sizeof(int);
     for (pos = 0; pos < tags_size; pos++) {
         item = PyList_GetItemRef(tags, pos);

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -930,27 +930,6 @@ ImagingLibTiffSetField(ImagingCodecState state, ttag_t tag, ...) {
 }
 
 int
-ImagingLibTiffEncodeCleanup(ImagingCodecState state) {
-    TIFFSTATE *clientstate = (TIFFSTATE *)state->context;
-    TIFF *tiff = clientstate->tiff;
-
-    if (!tiff) {
-        return 0;
-    }
-    // TIFFClose in libtiff calls tif_closeproc and TIFFCleanup
-    if (clientstate->fp) {
-        // Python will manage the closing of the file rather than libtiff
-        // So only call TIFFCleanup
-        TIFFCleanup(tiff);
-    } else {
-        // When tif_closeproc refers to our custom _tiffCloseProc though,
-        // that is fine, as it does not close the file
-        TIFFClose(tiff);
-    }
-    return 0;
-}
-
-int
 ImagingLibTiffEncode(Imaging im, ImagingCodecState state, UINT8 *buffer, int bytes) {
     /* One shot encoder. Encode everything to the tiff in the clientstate.
        If we're running off of a FD, then run once, we're good, everything
@@ -1031,6 +1010,16 @@ ImagingLibTiffEncode(Imaging im, ImagingCodecState state, UINT8 *buffer, int byt
                 TRACE(("Encode Error, row %d\n", state->y));
                 state->errcode = IMAGING_CODEC_BROKEN;
 
+                // TIFFClose in libtiff calls tif_closeproc and TIFFCleanup
+                if (clientstate->fp) {
+                    // Python will manage the closing of the file rather than libtiff
+                    // So only call TIFFCleanup
+                    TIFFCleanup(tiff);
+                } else {
+                    // When tif_closeproc refers to our custom _tiffCloseProc though,
+                    // that is fine, as it does not close the file
+                    TIFFClose(tiff);
+                }
                 if (!clientstate->fp) {
                     free(clientstate->data);
                 }
@@ -1047,10 +1036,21 @@ ImagingLibTiffEncode(Imaging im, ImagingCodecState state, UINT8 *buffer, int byt
                 TRACE(("Error flushing the tiff"));
                 // likely reason is memory.
                 state->errcode = IMAGING_CODEC_MEMORY;
+                if (clientstate->fp) {
+                    TIFFCleanup(tiff);
+                } else {
+                    TIFFClose(tiff);
+                }
                 if (!clientstate->fp) {
                     free(clientstate->data);
                 }
                 return -1;
+            }
+            TRACE(("Closing \n"));
+            if (clientstate->fp) {
+                TIFFCleanup(tiff);
+            } else {
+                TIFFClose(tiff);
             }
             // reset the clientstate metadata to use it to read out the buffer.
             clientstate->loc = 0;

--- a/src/libImaging/TiffDecode.h
+++ b/src/libImaging/TiffDecode.h
@@ -40,8 +40,6 @@ ImagingLibTiffInit(ImagingCodecState state, int fp, uint32_t offset);
 extern int
 ImagingLibTiffEncodeInit(ImagingCodecState state, char *filename, int fp);
 extern int
-ImagingLibTiffEncodeCleanup(ImagingCodecState state);
-extern int
 ImagingLibTiffMergeFieldInfo(
     ImagingCodecState state, TIFFDataType field_type, int key, int is_var_length
 );


### PR DESCRIPTION
This reverts commit e2e40c54568236d2504921eb0b335cdab734a7d5.

Fixes https://github.com/python-pillow/Pillow/pull/8954#issuecomment-2929027106 .

Changes proposed in this pull request:

 * This reverts moving the cleanup for tiff encode into the cleanup function, as opposed to doing it in the actual encode
 * This is an intermittent issue on several of the platforms, it reasonably triggers using `pytest -v --random-order Tests/test_file_libtiff.py` on pypy3.10 on linux-x64
 * There's likely something else going on here, because the errors are on read and the changes are for write. 
