### PR TITLE
Update ruff pre-commit ID

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.12
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror


### PR DESCRIPTION
With ruff-pre-commit 0.11.10, https://github.com/astral-sh/ruff-pre-commit/pull/124 was included, which prefers `ruff-check` to the `ruff` ID in pre-commit.