### PR TITLE
Fix test

### DIFF
--- a/Tests/test_deprecate.py
+++ b/Tests/test_deprecate.py
@@ -47,7 +47,6 @@ def test_unknown_version() -> None:
     ],
 )
 def test_old_version(deprecated: str, plural: bool, expected: str) -> None:
-    expected = r""
     with pytest.raises(RuntimeError, match=expected):
         _deprecate.deprecate(deprecated, 1, plural=plural)
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/070e1eba626736a5cfa4a90a8a97dfbbf6278b91/Tests/test_deprecate.py#L49-L52

Somehow, this test managed to immediately discard the `expected` argument and set it to an empty string instead.

The code originated in https://github.com/python-pillow/Pillow/pull/6184