### PR TITLE
Handle UNDEFINED XMP data

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -989,7 +989,7 @@ class TestImage:
         im = Image.new("RGB", (1, 1))
         im.info["xmp"] = (
             b'<?xpacket begin="\xef\xbb\xbf" id="W5M0MpCehiHzreSzNTczkc9d"?>\n'
-            b'<x:xmpmeta xmlns:x="adobe:ns:meta/" />\n<?xpacket end="w"?>\x00\x00'
+            b'<x:xmpmeta xmlns:x="adobe:ns:meta/" />\n<?xpacket end="w"?>\x00\x00 '
         )
         if ElementTree is None:
             with pytest.warns(

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1511,7 +1511,7 @@ class Image:
             return {}
         if "xmp" not in self.info:
             return {}
-        root = ElementTree.fromstring(self.info["xmp"].rstrip(b"\x00"))
+        root = ElementTree.fromstring(self.info["xmp"].rstrip(b"\x00 "))
         return {get_name(root.tag): get_value(root)}
 
     def getexif(self) -> Exif:

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1259,7 +1259,10 @@ class TiffImageFile(ImageFile.ImageFile):
         self.fp.seek(self._frame_pos[frame])
         self.tag_v2.load(self.fp)
         if XMP in self.tag_v2:
-            self.info["xmp"] = self.tag_v2[XMP]
+            xmp = self.tag_v2[XMP]
+            if isinstance(xmp, tuple) and len(xmp) == 1:
+                xmp = xmp[0]
+            self.info["xmp"] = xmp
         elif "xmp" in self.info:
             del self.info["xmp"]
         self._reload_exif()


### PR DESCRIPTION
Resolves #8986

The issue has found an image with XMP data that incorrectly uses an UNDEFINED tag, [rather than the specified BYTE tag](https://web.archive.org/web/20240616234124/https://www.awaresystems.be/imaging/tiff/tifftags/xmp.html). This PR updates `im.info["xmp"]` to still end up with a string, rather than a tuple.

The XMP data is also padded with spaces at the end, similar to zero-byte padding that [we've been before](https://github.com/python-pillow/Pillow/pull/8171). This PR trims it from the end when parsing the data in `im.getxmp()`.