### PR TITLE
Fix libtiff cleanup

### DIFF
--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -1032,7 +1032,10 @@ ImagingLibTiffEncode(Imaging im, ImagingCodecState state, UINT8 *buffer, int byt
                 TRACE(("Encode Error, row %d\n", state->y));
                 state->errcode = IMAGING_CODEC_BROKEN;
 
-                if (!clientstate->fp) {
+                if (clientstate->fp) {
+                    TIFFCleanup(tiff);
+                    clientstate->tiff = NULL;
+                } else {
                     free(clientstate->data);
                 }
                 return -1;


### PR DESCRIPTION
Alternative to #8992

I've found that since #8954 was merged, there have been intermittent errors.
- 'cannot identify image file' - https://github.com/python-pillow/Pillow/actions/runs/15371601710/job/43251458128
- 'attempt to seek outside sequence' - https://github.com/python-pillow/Pillow/actions/runs/15370070907/job/43247953625
- 'unrecognized data stream contents when reading image file' - https://github.com/python-pillow/Pillow/actions/runs/15370070907/job/43247953635

Testing, I find that the minimal change to fix the problem is to restore one of the calls to `TIFFCleanup`, and then to set `clientstate->tiff = NULL` to [prevent](https://github.com/python-pillow/Pillow/blob/f3b05d6fab2a8fb0db033fc507d0d6f19ed2330e/src/libImaging/TiffDecode.c#L936-L940) `ImagingLibTiffEncodeCleanup` from running afterwards.