### PR TITLE
Reduce number of bytes read for PCX header

### DIFF
--- a/src/PIL/PcxImagePlugin.py
+++ b/src/PIL/PcxImagePlugin.py
@@ -54,7 +54,7 @@ class PcxImageFile(ImageFile.ImageFile):
         # header
         assert self.fp is not None
 
-        s = self.fp.read(128)
+        s = self.fp.read(68)
         if not _accept(s):
             msg = "not a PCX file"
             raise SyntaxError(msg)
@@ -66,7 +66,7 @@ class PcxImageFile(ImageFile.ImageFile):
             raise SyntaxError(msg)
         logger.debug("BBox: %s %s %s %s", *bbox)
 
-        offset = self.fp.tell()
+        offset = self.fp.tell() + 60
 
         # format
         version = s[1]

--- a/src/PIL/PcxImagePlugin.py
+++ b/src/PIL/PcxImagePlugin.py
@@ -66,6 +66,8 @@ class PcxImageFile(ImageFile.ImageFile):
             raise SyntaxError(msg)
         logger.debug("BBox: %s %s %s %s", *bbox)
 
+        offset = self.fp.tell()
+
         # format
         version = s[1]
         bits = s[3]
@@ -102,7 +104,6 @@ class PcxImageFile(ImageFile.ImageFile):
                         break
                 if mode == "P":
                     self.palette = ImagePalette.raw("RGB", s[1:])
-            self.fp.seek(128)
 
         elif version == 5 and bits == 8 and planes == 3:
             mode = "RGB"
@@ -128,9 +129,7 @@ class PcxImageFile(ImageFile.ImageFile):
         bbox = (0, 0) + self.size
         logger.debug("size: %sx%s", *self.size)
 
-        self.tile = [
-            ImageFile._Tile("pcx", bbox, self.fp.tell(), (rawmode, planes * stride))
-        ]
+        self.tile = [ImageFile._Tile("pcx", bbox, offset, (rawmode, planes * stride))]
 
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
1. PcxImagePlugin initially reads 128 bytes
https://github.com/python-pillow/Pillow/blob/8e5a15bab746f87822b75cd47db17ae0174ed05e/src/PIL/PcxImagePlugin.py#L57
But the header only uses up to 68 bytes.
https://github.com/python-pillow/Pillow/blob/8e5a15bab746f87822b75cd47db17ae0174ed05e/src/PIL/PcxImagePlugin.py#L73
So the number of bytes can be reduced.

2. After seeking to the end of the file for one type of header, PcxImagePlugin seeks back to the start.
https://github.com/python-pillow/Pillow/blob/8e5a15bab746f87822b75cd47db17ae0174ed05e/src/PIL/PcxImagePlugin.py#L96-L105

This is unnecessary, since `load()` will seek to the tile offset.