### PR TITLE
Support saving I;16L TIFF images

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -49,25 +49,10 @@ class TestFileTiff:
         assert im.size == (128, 128)
         assert im.format == "TIFF"
 
-        hopper("1").save(filename)
-        with Image.open(filename):
-            pass
-
-        hopper("L").save(filename)
-        with Image.open(filename):
-            pass
-
-        hopper("P").save(filename)
-        with Image.open(filename):
-            pass
-
-        hopper("RGB").save(filename)
-        with Image.open(filename):
-            pass
-
-        hopper("I").save(filename)
-        with Image.open(filename):
-            pass
+        for mode in ("1", "L", "P", "RGB", "I", "I;16", "I;16L"):
+            hopper(mode).save(filename)
+            with Image.open(filename):
+                pass
 
     @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
     def test_unclosed_file(self) -> None:

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1680,6 +1680,7 @@ SAVE_INFO = {
     "PA": ("PA", II, 3, 1, (8, 8), 2),
     "I": ("I;32S", II, 1, 2, (32,), None),
     "I;16": ("I;16", II, 1, 1, (16,), None),
+    "I;16L": ("I;16L", II, 1, 1, (16,), None),
     "F": ("F;32F", II, 1, 3, (32,), None),
     "RGB": ("RGB", II, 2, 1, (8, 8, 8), None),
     "RGBX": ("RGBX", II, 2, 1, (8, 8, 8, 8), 0),
@@ -1963,7 +1964,7 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
         # we're storing image byte order. So, if the rawmode
         # contains I;16, we need to convert from native to image
         # byte order.
-        if im.mode in ("I;16B", "I;16"):
+        if im.mode in ("I;16", "I;16B", "I;16L"):
             rawmode = "I;16N"
 
         # Pass tags as sorted list so that the tags are set in a fixed order.

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1680,7 +1680,6 @@ SAVE_INFO = {
     "PA": ("PA", II, 3, 1, (8, 8), 2),
     "I": ("I;32S", II, 1, 2, (32,), None),
     "I;16": ("I;16", II, 1, 1, (16,), None),
-    "I;16S": ("I;16S", II, 1, 2, (16,), None),
     "F": ("F;32F", II, 1, 3, (32,), None),
     "RGB": ("RGB", II, 2, 1, (8, 8, 8), None),
     "RGBX": ("RGBX", II, 2, 1, (8, 8, 8, 8), 0),
@@ -1688,10 +1687,7 @@ SAVE_INFO = {
     "CMYK": ("CMYK", II, 5, 1, (8, 8, 8, 8), None),
     "YCbCr": ("YCbCr", II, 6, 1, (8, 8, 8), None),
     "LAB": ("LAB", II, 8, 1, (8, 8, 8), None),
-    "I;32BS": ("I;32BS", MM, 1, 2, (32,), None),
     "I;16B": ("I;16B", MM, 1, 1, (16,), None),
-    "I;16BS": ("I;16BS", MM, 1, 2, (16,), None),
-    "F;32BF": ("F;32BF", MM, 1, 3, (32,), None),
 }
 
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/issues/861#issuecomment-2967698512 requests that we support saving I;16L TIFF images.

While there, I noticed that [`SAVE_INFO`](https://github.com/python-pillow/Pillow/blob/2e5117305b86852f3cd21fe604eb966e09ec308e/src/PIL/TiffImagePlugin.py#L1673C1-L1700) has entries for a few modes that [don't exist](https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes) - I;16S, I;32BS, I;16BS and F;32BF. It's only use is to provide information for the mode of an image, so I've removed those entries.