### PR TITLE
Fix warning

### DIFF
--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -294,9 +294,10 @@ def test_header_token_too_long(tmp_path: Path, data: bytes) -> None:
     with open(path, "wb") as f:
         f.write(data)
 
-    with pytest.raises(ValueError, match="Token too long in file header: "):
+    with pytest.raises(ValueError) as e:
         with Image.open(path):
             pass
+    assert "Token too long in file header: " in repr(e)
 
 
 def test_truncated_file(tmp_path: Path) -> None:


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/15630701553/job/44036926021#step:11:5178

> Tests/test_file_ppm.py::test_header_token_too_long[P3\x0cAAAAAAAAAA\xee]
> Tests/test_file_ppm.py::test_header_token_too_long[P6\n 01234567890]
>   /Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/_pytest/_code/code.py:482: BytesWarning: str() on a bytes instance
>     message = str(exc)

This warning would have been introduced by #8958