### PR TITLE
CI: Require Python >= 3.13.5 on Windows

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.11", "pypy3.10", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["pypy3.11", "pypy3.10", "3.10", "3.11", "3.12", ">=3.13.5", "3.14"]
         architecture: ["x64"]
         include:
             # Test the oldest Python on 32-bit


### PR DESCRIPTION
Re: https://github.com/python-pillow/Pillow/pull/9014#issuecomment-2969799037

Some Windows jobs are failing because it's Python 3.13.4, which incorrectly tries to link to the threaded version. See https://github.com/python/cpython/issues/135151

This has been fixed in [this week's 3.13.5 release,](https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211) but it's not necessarily in the default CI images yet, so let's specify `>= 3.13.5` to ensure the new one is always installed on-demand.

We can revert this at some point in the future.