### PR TITLE
Deprecate fromarray mode argument

### DIFF
--- a/Tests/test_image_array.py
+++ b/Tests/test_image_array.py
@@ -101,7 +101,8 @@ def test_fromarray_strides_without_tobytes() -> None:
 
     with pytest.raises(ValueError):
         wrapped = Wrapper({"shape": (1, 1), "strides": (1, 1)})
-        Image.fromarray(wrapped, "L")
+        with pytest.warns(DeprecationWarning):
+            Image.fromarray(wrapped, "L")
 
 
 def test_fromarray_palette() -> None:
@@ -110,7 +111,8 @@ def test_fromarray_palette() -> None:
     a = numpy.array(i)
 
     # Act
-    out = Image.fromarray(a, "P")
+    with pytest.warns(DeprecationWarning):
+        out = Image.fromarray(a, "P")
 
     # Assert that the Python and C palettes match
     assert out.palette is not None

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -193,6 +193,14 @@ Image.Image.get_child_images()
 method uses an image's file pointer, and so child images could only be retrieved from
 an :py:class:`PIL.ImageFile.ImageFile` instance.
 
+Image.fromarray mode parameter
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. deprecated:: 11.3.0
+
+The ``mode`` parameter in :py:meth:`~PIL.Image.fromarray()` has been deprecated. The
+mode can be automatically determined from the object's shape and type instead.
+
 Removed features
 ----------------
 

--- a/docs/releasenotes/11.3.0.rst
+++ b/docs/releasenotes/11.3.0.rst
@@ -23,10 +23,11 @@ TODO
 Deprecations
 ============
 
-TODO
-^^^^
+Image.fromarray mode parameter
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-TODO
+The ``mode`` parameter in :py:meth:`~PIL.Image.fromarray()` has been deprecated. The
+mode can be automatically determined from the object's shape and type instead.
 
 API changes
 ===========

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3272,7 +3272,7 @@ def fromarray(obj: SupportsArrayInterface, mode: str | None = None) -> Image:
 
     :param obj: Object with array interface
     :param mode: Optional mode to use when reading ``obj``. Will be determined from
-      type if ``None``.
+      type if ``None``. Deprecated.
 
       This will not be used to convert the data after reading, but will be used to
       change how the data is read::
@@ -3307,6 +3307,7 @@ def fromarray(obj: SupportsArrayInterface, mode: str | None = None) -> Image:
             msg = f"Cannot handle this data type: {typekey_shape}, {typestr}"
             raise TypeError(msg) from e
     else:
+        deprecate("'mode' parameter", 13)
         rawmode = mode
     if mode in ["1", "L", "I", "P", "F"]:
         ndmax = 2


### PR DESCRIPTION
Resolves #9006

#2856 (with 12 likes), #3781, #4887, #5227, #5465 and #5723 are all issues were the `Image.fromarray()` `mode` parameter has caused confusion.

https://github.com/python-pillow/Pillow/issues/5465#issuecomment-831871276
> I think that the mode to use parameter is a footgun. It’s not an implicit conversion, it’s a cast.

Since those, #5849 improved the documentation, but it's not done causing problems, as #9006 objects to the fact that one type of array can't be correctly read using an explicit mode argument, but `mode=None` can handle it without a problem.

This PR suggests just deprecating the argument altogether.