### PR TITLE
Only check DHT marker for libjpeg-turbo

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -1067,10 +1067,16 @@ class TestFileJpeg:
         for marker in b"\xff\xd8", b"\xff\xd9":
             assert marker in data[1]
             assert marker in data[2]
-        # DHT, DQT
-        for marker in b"\xff\xc4", b"\xff\xdb":
+
+        # DQT
+        markers = [b"\xff\xdb"]
+        if features.check_feature("libjpeg_turbo"):
+            # DHT
+            markers.append(b"\xff\xc4")
+        for marker in markers:
             assert marker in data[1]
             assert marker not in data[2]
+
         # SOF0, SOS, APP0 (JFIF header)
         for marker in b"\xff\xc0", b"\xff\xda", b"\xff\xe0":
             assert marker not in data[1]


### PR DESCRIPTION
Resolves #9024

The issue found that with libjpeg, rather than libjpeg-turbo, a test checking for a DHT marker is not found.

From https://en.wikipedia.org/wiki/JPEG, a DHT marker is
> Define Huffman Table(s)

and it
> Specifies one or more Huffman tables.

From https://github.com/libjpeg-turbo/libjpeg-turbo,
> libjpeg-turbo can still outperform libjpeg by a significant amount, by virtue of its highly-optimized Huffman coding routines

It doesn't seem unreasonable that libjpeg-turbo would have different output regarding Huffman tables.

This PR skips checking that marker if libjpeg-turbo is not used.