### PR TITLE
Do not call sys.executable in ImageShow in PyInstaller application

### DIFF
--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -175,7 +175,9 @@ class MacViewer(Viewer):
         if not os.path.exists(path):
             raise FileNotFoundError
         subprocess.call(["open", "-a", "Preview.app", path])
-        executable = sys.executable or shutil.which("python3")
+
+        pyinstaller = getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")
+        executable = (not pyinstaller and sys.executable) or shutil.which("python3")
         if executable:
             subprocess.Popen(
                 [


### PR DESCRIPTION
Resolves #9027

The issue has reported that a PyInstaller application does not have a Python instance as `sys.executable` - it has the application.

https://pyinstaller.org/en/stable/runtime-information.html
> When a normal Python script runs, sys.executable is the path to the program that was executed, namely, the Python interpreter. In a frozen app, sys.executable is also the path to the program that was executed, but that is not Python

This means that
https://github.com/python-pillow/Pillow/blob/ef0bab0c6579fd00987740a6a327603ff3886a38/src/PIL/ImageShow.py#L178-L185
will not be able to delete the image, and might inadvertently launch the application a second time.

Using a check from https://pyinstaller.org/en/stable/runtime-information.html, this PR ignores `sys.executable` if in a PyInstaller application. `python3` might still be used.