### PR TITLE
Removed ImageCmsProfile._set method

### DIFF
--- a/src/PIL/ImageCms.py
+++ b/src/PIL/ImageCms.py
@@ -248,6 +248,9 @@ class ImageCmsProfile:
             low-level profile object
 
         """
+        self.filename = None
+        self.product_name = None  # profile.product_name
+        self.product_info = None  # profile.product_info
 
         if isinstance(profile, str):
             if sys.platform == "win32":
@@ -256,22 +259,17 @@ class ImageCmsProfile:
                     profile_bytes_path.decode("ascii")
                 except UnicodeDecodeError:
                     with open(profile, "rb") as f:
-                        self._set(core.profile_frombytes(f.read()))
+                        self.profile = core.profile_frombytes(f.read())
                     return
-            self._set(core.profile_open(profile), profile)
+            self.filename = profile
+            self.profile = core.profile_open(profile)
         elif hasattr(profile, "read"):
-            self._set(core.profile_frombytes(profile.read()))
+            self.profile = core.profile_frombytes(profile.read())
         elif isinstance(profile, core.CmsProfile):
-            self._set(profile)
+            self.profile = profile
         else:
             msg = "Invalid type for Profile"  # type: ignore[unreachable]
             raise TypeError(msg)
-
-    def _set(self, profile: core.CmsProfile, filename: str | None = None) -> None:
-        self.profile = profile
-        self.filename = filename
-        self.product_name = None  # profile.product_name
-        self.product_info = None  # profile.product_info
 
     def tobytes(self) -> bytes:
         """


### PR DESCRIPTION
This separates part of #8995. I have a [question](https://github.com/python-pillow/Pillow/pull/8995/#discussion_r2126067896) about another part of that PR, so this moves forward a portion of it at least.

https://github.com/python-pillow/Pillow/pull/8995/#issue-3113558776
> The _set method is no longer necessary, since we no longer compute any attributes from the profile. In most cases, we only set the profile, and in only one branch do we set the filename to anything non-None.