### PR TITLE
Search for libtiff library file first on Windows and macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -753,12 +753,12 @@ class pil_build_ext(build_ext):
         if feature.want("tiff"):
             _dbg("Looking for tiff")
             if _find_include_file(self, "tiff.h"):
-                if _find_library_file(self, "tiff"):
-                    feature.set("tiff", "tiff")
                 if sys.platform in ["win32", "darwin"] and _find_library_file(
                     self, "libtiff"
                 ):
                     feature.set("tiff", "libtiff")
+                elif _find_library_file(self, "tiff"):
+                    feature.set("tiff", "tiff")
 
         if feature.want("freetype"):
             _dbg("Looking for freetype")


### PR DESCRIPTION
libtiff takes priority over tiff on Windows and macOS
https://github.com/python-pillow/Pillow/blob/2954964cd2b70c463d75bd7f828c7bb7f3802bf2/setup.py#L757-L762

This rearranges the code so that if it is found, we skip searching for tiff.