### PR TITLE
Escape period in pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
       - id: end-of-file-fixer
         exclude: ^Tests/images/
       - id: trailing-whitespace
-        exclude: ^.github/.*TEMPLATE|^Tests/(fonts|images)/
+        exclude: ^\.github/.*TEMPLATE|^Tests/(fonts|images)/
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.33.0


### PR DESCRIPTION
Considering
https://github.com/python-pillow/Pillow/blob/1e5eb3b29d1b368f2b647f70025d1a66dd5232ca/.pre-commit-config.yaml#L51
particularly in comparison with
https://github.com/python-pillow/Pillow/blob/1e5eb3b29d1b368f2b647f70025d1a66dd5232ca/.pre-commit-config.yaml#L24
it is apparent that the first period in '.github' should be escaped.