### PR TITLE
Increase pytest verbosity

### DIFF
--- a/.ci/test.cmd
+++ b/.ci/test.cmd
@@ -1,3 +1,3 @@
 python.exe -c "from PIL import Image"
 IF ERRORLEVEL 1 EXIT /B
-python.exe -bb -m pytest -v -x -W always --cov PIL --cov Tests --cov-report term --cov-report xml Tests
+python.exe -bb -m pytest -vv -x -W always --cov PIL --cov Tests --cov-report term --cov-report xml Tests

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -4,4 +4,4 @@ set -e
 
 python3 -c "from PIL import Image"
 
-python3 -bb -m pytest -v -x -W always --cov PIL --cov Tests --cov-report term --cov-report xml Tests $REVERSE
+python3 -bb -m pytest -vv -x -W always --cov PIL --cov Tests --cov-report term --cov-report xml Tests $REVERSE

--- a/.github/workflows/wheels-test.ps1
+++ b/.github/workflows/wheels-test.ps1
@@ -23,7 +23,7 @@ cd $pillow
 if (!$?) { exit $LASTEXITCODE }
 & $venv\Scripts\$python selftest.py
 if (!$?) { exit $LASTEXITCODE }
-& $venv\Scripts\$python -m pytest -vx Tests\check_wheel.py
+& $venv\Scripts\$python -m pytest -vv -x Tests\check_wheel.py
 if (!$?) { exit $LASTEXITCODE }
-& $venv\Scripts\$python -m pytest -vx Tests
+& $venv\Scripts\$python -m pytest -vv -x Tests
 if (!$?) { exit $LASTEXITCODE }

--- a/.github/workflows/wheels-test.sh
+++ b/.github/workflows/wheels-test.sh
@@ -35,5 +35,5 @@ fi
 
 # Runs tests
 python3 selftest.py
-python3 -m pytest Tests/check_wheel.py
-python3 -m pytest
+python3 -m pytest -vv Tests/check_wheel.py
+python3 -m pytest -vv

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ extras =
     tests
 commands =
     {envpython} selftest.py
-    {envpython} -m pytest -W always {posargs}
+    {envpython} -m pytest -vv -W always {posargs}
 
 [testenv:lint]
 skip_install = true

--- a/winbuild/README.md
+++ b/winbuild/README.md
@@ -24,6 +24,6 @@ cd ..
 %PYTHON%\python.exe -m pip install -v -C raqm=vendor -C fribidi=vendor .
 path C:\Pillow\winbuild\build\bin;%PATH%
 %PYTHON%\python.exe selftest.py
-%PYTHON%\python.exe -m pytest -vx --cov PIL --cov Tests --cov-report term --cov-report xml Tests
+%PYTHON%\python.exe -m pytest -vv -x --cov PIL --cov Tests --cov-report term --cov-report xml Tests
 %PYTHON%\python.exe -m pip wheel -v -C raqm=vendor -C fribidi=vendor .
 ```

--- a/winbuild/build.rst
+++ b/winbuild/build.rst
@@ -124,5 +124,5 @@ Here's an example script to build on Windows::
     %PYTHON%\python.exe -m pip install -v -C raqm=vendor -C fribidi=vendor .
     path C:\Pillow\winbuild\build\bin;%PATH%
     %PYTHON%\python.exe selftest.py
-    %PYTHON%\python.exe -m pytest -vx --cov PIL --cov Tests --cov-report term --cov-report xml Tests
+    %PYTHON%\python.exe -m pytest -vv -x --cov PIL --cov Tests --cov-report term --cov-report xml Tests
     %PYTHON%\python.exe -m pip wheel -v -C raqm=vendor -C fribidi=vendor .


### PR DESCRIPTION
In discussing the difference between `pytest -v` and `pytest -vv` with regards to checking iOS wheels, @freakboy3742 [said](https://github.com/python-pillow/Pillow/pull/9030#discussion_r2171216972)
> In case of success, there's no real difference; but in case of failure, `-vv` will sometimes include failure context (such as complete diffs) that is truncated by `-v`. If we *can* put the full context in the logs, why not do so?

I'm interested in consistency, so if that argument holds for testing iOS wheels, then why not everywhere else as well?

You can read about the effect at https://docs.pytest.org/en/stable/how-to/output.html#verbosity