### PR TITLE
Check return types

### DIFF
--- a/Tests/test_file_avif.py
+++ b/Tests/test_file_avif.py
@@ -220,6 +220,7 @@ class TestFileAvif:
     def test_background_from_gif(self, tmp_path: Path) -> None:
         with Image.open("Tests/images/chi.gif") as im:
             original_value = im.convert("RGB").getpixel((1, 1))
+            assert isinstance(original_value, tuple)
 
             # Save as AVIF
             out_avif = tmp_path / "temp.avif"
@@ -232,6 +233,7 @@ class TestFileAvif:
 
         with Image.open(out_gif) as reread:
             reread_value = reread.convert("RGB").getpixel((1, 1))
+        assert isinstance(reread_value, tuple)
         difference = sum([abs(original_value[i] - reread_value[i]) for i in range(3)])
         assert difference <= 6
 

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -229,7 +229,9 @@ class TestFilePng:
         assert_image(im, "RGBA", (162, 150))
 
         # image has 124 unique alpha values
-        assert len(im.getchannel("A").getcolors()) == 124
+        colors = im.getchannel("A").getcolors()
+        assert colors is not None
+        assert len(colors) == 124
 
     def test_load_transparent_rgb(self) -> None:
         test_file = "Tests/images/rgb_trns.png"
@@ -241,7 +243,9 @@ class TestFilePng:
         assert_image(im, "RGBA", (64, 64))
 
         # image has 876 transparent pixels
-        assert im.getchannel("A").getcolors()[0][0] == 876
+        colors = im.getchannel("A").getcolors()
+        assert colors is not None
+        assert colors[0][0] == 876
 
     def test_save_p_transparent_palette(self, tmp_path: Path) -> None:
         in_file = "Tests/images/pil123p.png"
@@ -262,7 +266,9 @@ class TestFilePng:
         assert_image(im, "RGBA", (162, 150))
 
         # image has 124 unique alpha values
-        assert len(im.getchannel("A").getcolors()) == 124
+        colors = im.getchannel("A").getcolors()
+        assert colors is not None
+        assert len(colors) == 124
 
     def test_save_p_single_transparency(self, tmp_path: Path) -> None:
         in_file = "Tests/images/p_trns_single.png"
@@ -285,7 +291,9 @@ class TestFilePng:
         assert im.getpixel((31, 31)) == (0, 255, 52, 0)
 
         # image has 876 transparent pixels
-        assert im.getchannel("A").getcolors()[0][0] == 876
+        colors = im.getchannel("A").getcolors()
+        assert colors is not None
+        assert colors[0][0] == 876
 
     def test_save_p_transparent_black(self, tmp_path: Path) -> None:
         # check if solid black image with full transparency
@@ -313,7 +321,9 @@ class TestFilePng:
                 assert im.info["transparency"] == 255
 
                 im_rgba = im.convert("RGBA")
-            assert im_rgba.getchannel("A").getcolors()[0][0] == num_transparent
+            colors = im_rgba.getchannel("A").getcolors()
+            assert colors is not None
+            assert colors[0][0] == num_transparent
 
             test_file = tmp_path / "temp.png"
             im.save(test_file)
@@ -324,7 +334,9 @@ class TestFilePng:
                 assert_image_equal(im, test_im)
 
             test_im_rgba = test_im.convert("RGBA")
-            assert test_im_rgba.getchannel("A").getcolors()[0][0] == num_transparent
+            colors = test_im_rgba.getchannel("A").getcolors()
+            assert colors is not None
+            assert colors[0][0] == num_transparent
 
     def test_save_rgb_single_transparency(self, tmp_path: Path) -> None:
         in_file = "Tests/images/caption_6_33_22.png"

--- a/Tests/test_file_tga.py
+++ b/Tests/test_file_tga.py
@@ -274,13 +274,17 @@ def test_save_l_transparency(tmp_path: Path) -> None:
     in_file = "Tests/images/la.tga"
     with Image.open(in_file) as im:
         assert im.mode == "LA"
-        assert im.getchannel("A").getcolors()[0][0] == num_transparent
+        colors = im.getchannel("A").getcolors()
+        assert colors is not None
+        assert colors[0][0] == num_transparent
 
         out = tmp_path / "temp.tga"
         im.save(out)
 
     with Image.open(out) as test_im:
         assert test_im.mode == "LA"
-        assert test_im.getchannel("A").getcolors()[0][0] == num_transparent
+        colors = test_im.getchannel("A").getcolors()
+        assert colors is not None
+        assert colors[0][0] == num_transparent
 
         assert_image_equal(im, test_im)

--- a/Tests/test_imagesequence.py
+++ b/Tests/test_imagesequence.py
@@ -76,9 +76,14 @@ def test_consecutive() -> None:
 def test_palette_mmap() -> None:
     # Using mmap in ImageFile can require to reload the palette.
     with Image.open("Tests/images/multipage-mmap.tiff") as im:
-        color1 = im.getpalette()[:3]
+        palette = im.getpalette()
+        assert palette is not None
+        color1 = palette[:3]
         im.seek(0)
-        color2 = im.getpalette()[:3]
+
+        palette = im.getpalette()
+        assert palette is not None
+        color2 = palette[:3]
         assert color1 == color2
 
 


### PR DESCRIPTION
This is part of https://github.com/python-pillow/Pillow/pull/8362 - I'm hoping to break down that PR into easier-to-review chunks.

1. Assert `getpixel()` returns a tuple, before using index access, since it might also return a `float` or `None`.
https://github.com/python-pillow/Pillow/blob/a370209fead92a1eb5114762502b82f7d6651b77/src/PIL/Image.py#L1645-L1647
2. Assert that `getcolors()` does not return `None`, because checking length or using index access.
https://github.com/python-pillow/Pillow/blob/a370209fead92a1eb5114762502b82f7d6651b77/src/PIL/Image.py#L1415-L1417
3. Assert that `getpalette()` does not return `None` before slicing a list.
https://github.com/python-pillow/Pillow/blob/a370209fead92a1eb5114762502b82f7d6651b77/src/PIL/Image.py#L1577