### PR TITLE
Raise FileNotFoundError when opening an empty path

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -160,6 +160,10 @@ class TestImage:
         with pytest.raises(AttributeError):
             im.mode = "P"  # type: ignore[misc]
 
+    def test_empty_path(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            Image.open("")
+
     def test_invalid_image(self) -> None:
         im = io.BytesIO(b"")
         with pytest.raises(UnidentifiedImageError):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3510,8 +3510,6 @@ def open(
     filename: str | bytes = ""
     if is_path(fp):
         filename = os.fspath(fp)
-
-    if filename:
         fp = builtins.open(filename, "rb")
         exclusive_fp = True
     else:


### PR DESCRIPTION
Resolves #9047

The following code didn't consider the possibility of an empty `filename` being passed in by the user, and tries to treat it as a file handle instead.

https://github.com/python-pillow/Pillow/blob/2b39f7581e9637a7262c070d5cebb12fa70f2c86/src/PIL/Image.py#L3510-L3518

This fixes that.