### PR TITLE
Updated check script paths

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -18,6 +18,5 @@ exclude_also =
 
 [run]
 omit =
-    Tests/32bit_segfault_check.py
-    Tests/check_*.py
+    checks/*.py
     Tests/createfontdatachunk.py

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ debug:
 
 .PHONY: release-test
 release-test:
-	python3 Tests/check_release_notes.py
+	python3 checks/check_release_notes.py
 	python3 -m pip install -e .[tests]
 	python3 selftest.py
 	python3 -m pytest Tests

--- a/checks/check_jpeg_leaks.py
+++ b/checks/check_jpeg_leaks.py
@@ -13,7 +13,7 @@ iterations = 5000
 When run on a system without the jpeg leak fixes,
 the valgrind runs look like this.
 
-valgrind --tool=massif python test-installed.py -s -v Tests/check_jpeg_leaks.py
+valgrind --tool=massif python test-installed.py -s -v checks/check_jpeg_leaks.py
 
 """
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,6 +16,5 @@ coverage:
 
 # Matches 'omit:' in .coveragerc
 ignore:
-  - "Tests/32bit_segfault_check.py"
-  - "Tests/check_*.py"
+  - "checks/*.py"
   - "Tests/createfontdatachunk.py"


### PR DESCRIPTION
Updates after #9030 moved some scripts from the 'Tests' directory into a new 'checks' directory