### PR TITLE
Use correct bands for two band histograms

### DIFF
--- a/Tests/test_image_histogram.py
+++ b/Tests/test_image_histogram.py
@@ -10,9 +10,12 @@ def test_histogram() -> None:
 
     assert histogram("1") == (256, 0, 10994)
     assert histogram("L") == (256, 0, 662)
+    assert histogram("LA") == (512, 0, 16384)
+    assert histogram("La") == (512, 0, 16384)
     assert histogram("I") == (256, 0, 662)
     assert histogram("F") == (256, 0, 662)
     assert histogram("P") == (256, 0, 1551)
+    assert histogram("PA") == (512, 0, 16384)
     assert histogram("RGB") == (768, 4, 675)
     assert histogram("RGBA") == (1024, 0, 16384)
     assert histogram("CMYK") == (1024, 0, 16384)

--- a/src/libImaging/Histo.c
+++ b/src/libImaging/Histo.c
@@ -132,11 +132,15 @@ ImagingGetHistogram(Imaging im, Imaging imMask, void *minmax) {
                     ImagingSectionEnter(&cookie);
                     for (y = 0; y < im->ysize; y++) {
                         UINT8 *in = (UINT8 *)im->image[y];
-                        for (x = 0; x < im->xsize; x++) {
-                            h->histogram[(*in++)]++;
-                            h->histogram[(*in++) + 256]++;
-                            h->histogram[(*in++) + 512]++;
-                            h->histogram[(*in++) + 768]++;
+                        for (x = 0; x < im->xsize; x++, in += 4) {
+                            h->histogram[*in]++;
+                            if (im->bands == 2) {
+                                h->histogram[*(in + 3) + 256]++;
+                            } else {
+                                h->histogram[*(in + 1) + 256]++;
+                                h->histogram[*(in + 2) + 512]++;
+                                h->histogram[*(in + 3) + 768]++;
+                            }
                         }
                     }
                     ImagingSectionLeave(&cookie);


### PR DESCRIPTION
Resolves #9050

For an `image32` image without a mask, histogram values are generated with
https://github.com/python-pillow/Pillow/blob/37cd041e5e9041b0708551c02655328e8761226d/src/libImaging/Histo.c#L136-L139

However, this doesn't consider that some images (PA, LA and La) only have two bands
https://github.com/python-pillow/Pillow/blob/37cd041e5e9041b0708551c02655328e8761226d/src/libImaging/Storage.c#L78-L80

https://github.com/python-pillow/Pillow/blob/37cd041e5e9041b0708551c02655328e8761226d/src/_imaging.c#L1360-L1361
meaning that two band histograms only have 512 values, rather than 1024. So this PR skips the middle two bands when assigning values.