### PR TITLE
Thanks, folks!

### DIFF
--- a/docs/releasenotes/11.3.0.rst
+++ b/docs/releasenotes/11.3.0.rst
@@ -69,12 +69,14 @@ AVIF support in wheels
 
 Support for reading and writing AVIF images is now included in Pillow's wheels, except
 for Windows ARM64 and iOS. libaom is available as an encoder and dav1d as a decoder.
+(Thank you Frankie Dintino and Andrew Murray!)
 
 iOS
 ^^^
 
 Pillow now provides wheels that can be used on iOS ARM64 devices, and on the iOS
 simulator on ARM64 and x86_64. Currently, only Python 3.13 wheels are available.
+(Thank you Russell Keith-Magee and Andrew Murray!)
 
 Python 3.14 beta
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
As a general rule I think we should acknowledge when significant contribtions come from outside the core team. We know the core team does a lot of work (thank you!) but it's not always obvious when significant contributions come from outside the core team.

In the old change log, we had ACKs via `[radarhere]` syntax which I miss. I don't expect we'll start using the old change log again but maybe we can make a note in the release notes to include such ACKs as needed and appropriate.

Fixes missing acknowledgments.

Changes proposed in this pull request:

- Acknowledge non-core team contributors for significant contributions.
