### PR TITLE
Pyroma now supports PEP 639

### DIFF
--- a/Tests/test_pyroma.py
+++ b/Tests/test_pyroma.py
@@ -25,11 +25,5 @@ def test_pyroma() -> None:
         )
 
     else:
-        # Should have a perfect score, but pyroma does not support PEP 639 yet.
-        assert rating == (
-            9,
-            [
-                "Your package does neither have a license field "
-                "nor any license classifiers."
-            ],
-        )
+        # Should have a perfect score
+        assert rating == (10, [])


### PR DESCRIPTION
Revert a commit from #8850, now that [Pyroma 4.3.2 supports PEP 639.](https://github.com/regebro/pyroma/blob/master/CHANGES.txt)