### PR TITLE
Fix unclosed file warning

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -873,8 +873,8 @@ class TestFileLibTiff(LibTiffTestCase):
                 assert im.mode == "RGB"
                 assert im.size == (128, 128)
                 assert im.format == "TIFF"
-                im2 = hopper()
-                assert_image_similar(im, im2, 5)
+                with hopper() as im2:
+                    assert_image_similar(im, im2, 5)
         except OSError:
             captured = capfd.readouterr()
             if "LZMA compression support is not configured" in captured.err:


### PR DESCRIPTION
I've noticed an unclosed file warning - https://github.com/python-pillow/Pillow/actions/runs/15993042615/job/45110055855#step:6:5751

> Tests/test_file_libtiff.py::TestFileLibTiff::test_realloc_overflow
>   <frozen abc>:117: ResourceWarning: unclosed file <_io.FileIO name='Tests/images/hopper.ppm' mode='rb' closefd=True>