### PR TITLE
Allow alpha_composite to use LA images

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -398,6 +398,37 @@ class TestImage:
         assert img_colors is not None
         assert sorted(img_colors) == expected_colors
 
+    def test_alpha_composite_la(self) -> None:
+        # Arrange
+        expected_colors = sorted(
+            [
+                (3300, (255, 255)),
+                (1156, (170, 192)),
+                (1122, (128, 255)),
+                (1089, (0, 0)),
+                (1122, (255, 128)),
+                (1122, (0, 128)),
+                (1089, (0, 255)),
+            ]
+        )
+
+        dst = Image.new("LA", size=(100, 100), color=(0, 255))
+        draw = ImageDraw.Draw(dst)
+        draw.rectangle((0, 33, 100, 66), fill=(0, 128))
+        draw.rectangle((0, 67, 100, 100), fill=(0, 0))
+        src = Image.new("LA", size=(100, 100), color=(255, 255))
+        draw = ImageDraw.Draw(src)
+        draw.rectangle((33, 0, 66, 100), fill=(255, 128))
+        draw.rectangle((67, 0, 100, 100), fill=(255, 0))
+
+        # Act
+        img = Image.alpha_composite(dst, src)
+
+        # Assert
+        img_colors = img.getcolors()
+        assert img_colors is not None
+        assert sorted(img_colors) == expected_colors
+
     def test_alpha_inplace(self) -> None:
         src = Image.new("RGBA", (128, 128), "blue")
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3588,9 +3588,8 @@ def alpha_composite(im1: Image, im2: Image) -> Image:
     """
     Alpha composite im2 over im1.
 
-    :param im1: The first image. Must have mode RGBA.
-    :param im2: The second image.  Must have mode RGBA, and the same size as
-       the first image.
+    :param im1: The first image. Must have mode RGBA or LA.
+    :param im2: The second image. Must have the same mode and size as the first image.
     :returns: An :py:class:`~PIL.Image.Image` object.
     """
 

--- a/src/libImaging/AlphaComposite.c
+++ b/src/libImaging/AlphaComposite.c
@@ -25,7 +25,8 @@ ImagingAlphaComposite(Imaging imDst, Imaging imSrc) {
     int x, y;
 
     /* Check arguments */
-    if (!imDst || !imSrc || strcmp(imDst->mode, "RGBA")) {
+    if (!imDst || !imSrc ||
+        (strcmp(imDst->mode, "RGBA") && strcmp(imDst->mode, "LA"))) {
         return ImagingError_ModeError();
     }
 

--- a/src/libImaging/AlphaComposite.c
+++ b/src/libImaging/AlphaComposite.c
@@ -25,13 +25,11 @@ ImagingAlphaComposite(Imaging imDst, Imaging imSrc) {
     int x, y;
 
     /* Check arguments */
-    if (!imDst || !imSrc || strcmp(imDst->mode, "RGBA") ||
-        imDst->type != IMAGING_TYPE_UINT8 || imDst->bands != 4) {
+    if (!imDst || !imSrc || strcmp(imDst->mode, "RGBA")) {
         return ImagingError_ModeError();
     }
 
-    if (strcmp(imDst->mode, imSrc->mode) || imDst->type != imSrc->type ||
-        imDst->bands != imSrc->bands || imDst->xsize != imSrc->xsize ||
+    if (strcmp(imDst->mode, imSrc->mode) || imDst->xsize != imSrc->xsize ||
         imDst->ysize != imSrc->ysize) {
         return ImagingError_Mismatch();
     }


### PR DESCRIPTION
Resolves #9051

Currently,`alpha_composite()` can only use RGBA images. This expands it to allow RGBA or LA images - although the input images must have the same mode.