### PR TITLE
Remove reference to libtiff 3.x

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -12,13 +12,6 @@ Deprecated features
 Below are features which are considered deprecated. Where appropriate,
 a :py:exc:`DeprecationWarning` is issued.
 
-ImageDraw.getdraw hints parameter
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. deprecated:: 10.4.0
-
-The ``hints`` parameter in :py:meth:`~PIL.ImageDraw.getdraw()` has been deprecated.
-
 ExifTags.IFD.Makernote
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -186,6 +179,7 @@ ICNS (width, height, scale) sizes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. deprecated:: 11.0.0
+.. versionremoved:: 12.0.0
 
 Setting an ICNS image size to ``(width, height, scale)`` before loading has been
 removed. Instead, ``load(scale)`` can be used.

--- a/docs/installation/building-from-source.rst
+++ b/docs/installation/building-from-source.rst
@@ -44,7 +44,7 @@ Many of Pillow's features require external libraries:
 
 * **libtiff** provides compressed TIFF functionality
 
-  * Pillow has been tested with libtiff versions **3.x** and **4.0-4.7.0**
+  * Pillow has been tested with libtiff versions **4.0-4.7.0**
 
 * **libfreetype** provides type related services
 

--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -9,7 +9,6 @@ from typing import IO
 import PIL
 
 from . import Image
-from ._deprecate import deprecate
 
 modules = {
     "pil": ("PIL._imaging", "PILLOW_VERSION"),
@@ -120,7 +119,7 @@ def get_supported_codecs() -> list[str]:
     return [f for f in codecs if check_codec(f)]
 
 
-features: dict[str, tuple[str, str | bool, str | None]] = {
+features: dict[str, tuple[str, str, str | None]] = {
     "raqm": ("PIL._imagingft", "HAVE_RAQM", "raqm_version"),
     "fribidi": ("PIL._imagingft", "HAVE_FRIBIDI", "fribidi_version"),
     "harfbuzz": ("PIL._imagingft", "HAVE_HARFBUZZ", "harfbuzz_version"),
@@ -146,12 +145,8 @@ def check_feature(feature: str) -> bool | None:
 
     module, flag, ver = features[feature]
 
-    if isinstance(flag, bool):
-        deprecate(f'check_feature("{feature}")', 12)
     try:
         imported_module = __import__(module, fromlist=["PIL"])
-        if isinstance(flag, bool):
-            return flag
         return getattr(imported_module, flag)
     except ModuleNotFoundError:
         return None
@@ -181,17 +176,7 @@ def get_supported_features() -> list[str]:
     """
     :returns: A list of all supported features.
     """
-    supported_features = []
-    for f, (module, flag, _) in features.items():
-        if flag is True:
-            for feature, (feature_module, _) in modules.items():
-                if feature_module == module:
-                    if check_module(feature):
-                        supported_features.append(f)
-                    break
-        elif check_feature(f):
-            supported_features.append(f)
-    return supported_features
+    return [f for f in features if check_feature(f)]
 
 
 def check(feature: str) -> bool | None:


### PR DESCRIPTION
Sequel to #9053

1. https://pillow.readthedocs.io/en/latest/installation/building-from-source.html#external-libraries lists
> **libtiff** provides compressed TIFF functionality
> Pillow has been tested with libtiff versions **3.x** and **4.0-4.7.0**

Since support for libtiff < 4 was removed, this should be updated.

2. In the PR, I added `hints` to the removed section, but managed to leave it in the deprecated section.
3. #8213 added a bool flag value for deprecated features. I forgot to remove handling for this.