### PR TITLE
Ensure dynamic libjpeg libraries are not linked.

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -60,7 +60,7 @@ if [[ "$CIBW_PLATFORM" == "ios" ]]; then
     # on using the Xcode builder, which isn't very helpful for most of Pillow's
     # dependencies. Therefore, we lean on the OSX configurations, plus CC, CFLAGS
     # etc. to ensure the right sysroot is selected.
-    HOST_CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=$CMAKE_SYSTEM_NAME -DCMAKE_SYSTEM_PROCESSOR=$GNU_ARCH -DCMAKE_OSX_DEPLOYMENT_TARGET=$IPHONEOS_DEPLOYMENT_TARGET -DCMAKE_OSX_SYSROOT=$IOS_SDK_PATH -DBUILD_SHARED_LIBS=NO"
+    HOST_CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=$CMAKE_SYSTEM_NAME -DCMAKE_SYSTEM_PROCESSOR=$GNU_ARCH -DCMAKE_OSX_DEPLOYMENT_TARGET=$IPHONEOS_DEPLOYMENT_TARGET -DCMAKE_OSX_SYSROOT=$IOS_SDK_PATH -DBUILD_SHARED_LIBS=NO -DENABLE_SHARED=NO"
 
     # Meson needs to be pointed at a cross-platform configuration file
     # This will be generated once CC etc. have been evaluated.
@@ -379,6 +379,15 @@ if [[ -n "$IS_MACOS" ]]; then
 fi
 
 wrap_wheel_builder build
+
+# A safety catch for iOS. iOS can't use dynamic libraries, but clang will prefer
+# to link dynamic libraries to static libraries. The only way to reliably
+# prevent this is to not have dynamic libraries available in the first place.
+# The build process *shouldn't* generate any dylibs... but just in case, purge
+# any dylibs that *have* been installed into the build prefix directory.
+if [[ -n "$IOS_SDK" ]]; then
+    find "$BUILD_PREFIX" -name "*.dylib" -exec rm -rf {} \;
+fi
 
 # Return to the project root to finish the build
 popd > /dev/null


### PR DESCRIPTION
Fixes #9079.

Changes proposed in this pull request:

 * Turns on another CMake flag (`-DENABLE_SHARED=NO`) to prevent libjpeg-turbo from producing dynamic libraries on iOS
 * Adds a safety catch that purges any dylibs that *are* produced by the dependency build, so they can't be picked up by clang at link time.

I've manually audited all the binary modules that are produced as a result of this build, and I don't see any other dynamic artefacts being linked.
