### PR TITLE
When deleting EXIF IFD tag, delete IFD data

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -922,6 +922,17 @@ class TestImage:
         reloaded_exif.load(exif.tobytes())
         assert reloaded_exif.get_ifd(0x8769) == exif.get_ifd(0x8769)
 
+    def test_delete_ifd_tag(self) -> None:
+        with Image.open("Tests/images/flower.jpg") as im:
+            exif = im.getexif()
+        exif.get_ifd(0x8769)
+        assert 0x8769 in exif
+        del exif[0x8769]
+
+        reloaded_exif = Image.Exif()
+        reloaded_exif.load(exif.tobytes())
+        assert 0x8769 not in reloaded_exif
+
     def test_exif_load_from_fp(self) -> None:
         with Image.open("Tests/images/flower.jpg") as im:
             data = im.info["exif"]

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -4215,6 +4215,8 @@ class Exif(_ExifBase):
             del self._info[tag]
         else:
             del self._data[tag]
+            if tag in self._ifds:
+                del self._ifds[tag]
 
     def __iter__(self) -> Iterator[int]:
         keys = set(self._data)


### PR DESCRIPTION
Resolves #9078

A user has found that after
```python
from PIL import Image, ExifTags
with Image.open("Tests/images/exif_gps.jpg") as im:
  exif = im.getexif()
  exif.get_ifd(ExifTags.IFD.GPSInfo)
  del exif[ExifTags.IFD.GPSInfo]
  im.save("out.jpg", exif=exif)
```
the saved image still has GPS data.

This is because `get_ifd()` [populates `_ifds`](https://github.com/python-pillow/Pillow/blob/d74fdc4b5de5a22b91e82c123292ff7780dd20a4/src/PIL/Image.py#L4071-L4077),  and `del exif[ExifTags.IFD.GPSInfo]` [doesn't clear it](https://github.com/python-pillow/Pillow/blob/d74fdc4b5de5a22b91e82c123292ff7780dd20a4/src/PIL/Image.py#L4213-L4217). This fixes that.