### PR TITLE
Remove unused _save_cjpeg

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -291,16 +291,6 @@ def djpeg_available() -> bool:
     return False
 
 
-def cjpeg_available() -> bool:
-    if shutil.which("cjpeg"):
-        try:
-            subprocess.check_call(["cjpeg", "-version"])
-            return True
-        except subprocess.CalledProcessError:  # pragma: no cover
-            return False
-    return False
-
-
 def netpbm_available() -> bool:
     return bool(shutil.which("ppmquant") and shutil.which("ppmtogif"))
 

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -26,7 +26,6 @@ from .helper import (
     assert_image_equal_tofile,
     assert_image_similar,
     assert_image_similar_tofile,
-    cjpeg_available,
     djpeg_available,
     hopper,
     is_win32,
@@ -730,14 +729,6 @@ class TestFileJpeg:
             assert isinstance(img, JpegImagePlugin.JpegImageFile)
             img.load_djpeg()
             assert_image_similar_tofile(img, TEST_FILE, 5)
-
-    @pytest.mark.skipif(not cjpeg_available(), reason="cjpeg not available")
-    def test_save_cjpeg(self, tmp_path: Path) -> None:
-        with Image.open(TEST_FILE) as img:
-            tempfile = str(tmp_path / "temp.jpg")
-            JpegImagePlugin._save_cjpeg(img, BytesIO(), tempfile)
-            # Default save quality is 75%, so a tiny bit of difference is alright
-            assert_image_similar_tofile(img, tempfile, 17)
 
     def test_no_duplicate_0x1001_tag(self) -> None:
         # Arrange

--- a/Tests/test_shell_injection.py
+++ b/Tests/test_shell_injection.py
@@ -9,7 +9,7 @@ import pytest
 
 from PIL import GifImagePlugin, Image, JpegImagePlugin
 
-from .helper import cjpeg_available, djpeg_available, is_win32, netpbm_available
+from .helper import djpeg_available, is_win32, netpbm_available
 
 TEST_JPG = "Tests/images/hopper.jpg"
 TEST_GIF = "Tests/images/hopper.gif"
@@ -41,11 +41,6 @@ class TestShellInjection:
             with Image.open(src_file) as im:
                 assert isinstance(im, JpegImagePlugin.JpegImageFile)
                 im.load_djpeg()
-
-    @pytest.mark.skipif(not cjpeg_available(), reason="cjpeg not available")
-    def test_save_cjpeg_filename(self, tmp_path: Path) -> None:
-        with Image.open(TEST_JPG) as im:
-            self.assert_save_filename_check(tmp_path, im, JpegImagePlugin._save_cjpeg)
 
     @pytest.mark.skipif(not netpbm_available(), reason="Netpbm not available")
     def test_save_netpbm_filename_bmp_mode(self, tmp_path: Path) -> None:

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -845,16 +845,6 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
     )
 
 
-def _save_cjpeg(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
-    # ALTERNATIVE: handle JPEGs via the IJG command line utilities.
-    tempfile = im._dump()
-    subprocess.check_call(["cjpeg", "-outfile", filename, tempfile])
-    try:
-        os.unlink(tempfile)
-    except OSError:
-        pass
-
-
 ##
 # Factory for making JPEG and MPO instances
 def jpeg_factory(

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -149,18 +149,17 @@ DEPS: dict[str, dict[str, Any]] = {
         },
         "build": [
             *cmds_cmake(
-                ("jpeg-static", "cjpeg-static", "djpeg-static"),
+                ("jpeg-static", "djpeg-static"),
                 "-DENABLE_SHARED:BOOL=FALSE",
                 "-DWITH_JPEG8:BOOL=TRUE",
                 "-DWITH_CRT_DLL:BOOL=TRUE",
             ),
             cmd_copy("jpeg-static.lib", "libjpeg.lib"),
-            cmd_copy("cjpeg-static.exe", "cjpeg.exe"),
             cmd_copy("djpeg-static.exe", "djpeg.exe"),
         ],
         "headers": ["jconfig.h", r"src\j*.h"],
         "libs": ["libjpeg.lib"],
-        "bins": ["cjpeg.exe", "djpeg.exe"],
+        "bins": ["djpeg.exe"],
     },
     "zlib": {
         "url": f"https://github.com/zlib-ng/zlib-ng/archive/refs/tags/{V['ZLIBNG']}.tar.gz",


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/d74fdc4b5de5a22b91e82c123292ff7780dd20a4/src/PIL/JpegImagePlugin.py#L848-L855

While we test this method, it is never actually called anywhere, so I'm going to suggest removing it.