### PR TITLE
Set correct size for rotated PCD images after opening

### DIFF
--- a/Tests/test_file_pcd.py
+++ b/Tests/test_file_pcd.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+from io import BytesIO
+
+import pytest
+
 from PIL import Image
 
 
 def test_load_raw() -> None:
     with Image.open("Tests/images/hopper.pcd") as im:
+        assert im.size == (768, 512)
         im.load()  # should not segfault.
 
     # Note that this image was created with a resized hopper
@@ -15,3 +20,13 @@ def test_load_raw() -> None:
 
     # target = hopper().resize((768,512))
     # assert_image_similar(im, target, 10)
+
+
+@pytest.mark.parametrize("orientation", (1, 3))
+def test_rotated(orientation: int) -> None:
+    with open("Tests/images/hopper.pcd", "rb") as fp:
+        data = bytearray(fp.read())
+    data[2048 + 1538] = orientation
+    f = BytesIO(data)
+    with Image.open(f) as im:
+        assert im.size == (512, 768)

--- a/src/PIL/PcdImagePlugin.py
+++ b/src/PIL/PcdImagePlugin.py
@@ -46,14 +46,13 @@ class PcdImageFile(ImageFile.ImageFile):
             self.tile_post_rotate = -90
 
         self._mode = "RGB"
-        self._size = 768, 512  # FIXME: not correct for rotated images!
+        self._size = (512, 768) if orientation in (1, 3) else (768, 512)
         self.tile = [ImageFile._Tile("pcd", (0, 0) + self.size, 96 * 2048)]
 
     def load_end(self) -> None:
         if self.tile_post_rotate:
             # Handle rotated PCDs
             self.im = self.im.rotate(self.tile_post_rotate)
-            self._size = self.im.size
 
 
 #

--- a/src/PIL/PcdImagePlugin.py
+++ b/src/PIL/PcdImagePlugin.py
@@ -32,7 +32,7 @@ class PcdImageFile(ImageFile.ImageFile):
         assert self.fp is not None
 
         self.fp.seek(2048)
-        s = self.fp.read(2048)
+        s = self.fp.read(1539)
 
         if not s.startswith(b"PCD_"):
             msg = "not a PCD file"


### PR DESCRIPTION
Resolves FIXME
https://github.com/python-pillow/Pillow/blob/d74fdc4b5de5a22b91e82c123292ff7780dd20a4/src/PIL/PcdImagePlugin.py#L49
by setting rotated size in `open()` instead of waiting until `load()`