### PR TITLE
Improve ImageMath test coverage

### DIFF
--- a/Tests/test_imagemath_lambda_eval.py
+++ b/Tests/test_imagemath_lambda_eval.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from PIL import Image, ImageMath
+import pytest
+
+from PIL import Image, ImageMath, _imagingmath
 
 
 def pixel(im: Image.Image | int) -> str | int:
@@ -498,3 +500,31 @@ def test_logical_not_equal() -> None:
         )
         == "I 1"
     )
+
+
+def test_reflected_operands() -> None:
+    assert pixel(ImageMath.lambda_eval(lambda args: 1 + args["A"], **images)) == "I 2"
+    assert pixel(ImageMath.lambda_eval(lambda args: 1 - args["A"], **images)) == "I 0"
+    assert pixel(ImageMath.lambda_eval(lambda args: 1 * args["A"], **images)) == "I 1"
+    assert pixel(ImageMath.lambda_eval(lambda args: 1 / args["A"], **images)) == "I 1"
+    assert pixel(ImageMath.lambda_eval(lambda args: 1 % args["A"], **images)) == "I 0"
+    assert pixel(ImageMath.lambda_eval(lambda args: 1 ** args["A"], **images)) == "I 1"
+    assert pixel(ImageMath.lambda_eval(lambda args: 1 & args["A"], **images)) == "I 1"
+    assert pixel(ImageMath.lambda_eval(lambda args: 1 | args["A"], **images)) == "I 1"
+    assert pixel(ImageMath.lambda_eval(lambda args: 1 ^ args["A"], **images)) == "I 0"
+
+
+def test_unsupported_mode() -> None:
+    im = Image.new("RGB", (1, 1))
+    with pytest.raises(ValueError, match="unsupported mode: RGB"):
+        ImageMath.lambda_eval(lambda args: args["im"] + 1, im=im)
+
+
+def test_bad_operand_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delattr(_imagingmath, "abs_I")
+    with pytest.raises(TypeError, match="bad operand type for 'abs'"):
+        ImageMath.lambda_eval(lambda args: abs(args["I"]), I=I)
+
+    monkeypatch.delattr(_imagingmath, "max_F")
+    with pytest.raises(TypeError, match="bad operand type for 'max'"):
+        ImageMath.lambda_eval(lambda args: args["max"](args["I"], args["F"]), I=I, F=F)


### PR DESCRIPTION
Adds coverage for the lines missing at https://app.codecov.io/gh/python-pillow/Pillow/blob/main/src%2FPIL%2FImageMath.py