### PR TITLE
Fix reading RGB and CMYK IPTC images

### DIFF
--- a/Tests/test_file_iptc.py
+++ b/Tests/test_file_iptc.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from io import BytesIO
 
+import pytest
+
 from PIL import Image, IptcImagePlugin, TiffImagePlugin, TiffTags
 
 from .helper import assert_image_equal, hopper
@@ -9,19 +11,76 @@ from .helper import assert_image_equal, hopper
 TEST_FILE = "Tests/images/iptc.jpg"
 
 
+def create_iptc_image(info: dict[str, int] = {}) -> BytesIO:
+    def field(tag, value):
+        return bytes((0x1C,) + tag + (0, len(value))) + value
+
+    data = field((3, 60), bytes((info.get("layers", 1), info.get("component", 0))))
+    data += field((3, 120), bytes((info.get("compression", 1),)))
+    if "band" in info:
+        data += field((3, 65), bytes((info["band"] + 1,)))
+    data += field((3, 20), b"\x01")  # width
+    data += field((3, 30), b"\x01")  # height
+    data += field(
+        (8, 10),
+        bytes((info.get("data", 0),)),
+    )
+
+    return BytesIO(data)
+
+
 def test_open() -> None:
     expected = Image.new("L", (1, 1))
 
-    f = BytesIO(
-        b"\x1c\x03<\x00\x02\x01\x00\x1c\x03x\x00\x01\x01\x1c\x03\x14\x00\x01\x01"
-        b"\x1c\x03\x1e\x00\x01\x01\x1c\x08\n\x00\x01\x00"
-    )
+    f = create_iptc_image()
     with Image.open(f) as im:
-        assert im.tile == [("iptc", (0, 0, 1, 1), 25, "raw")]
+        assert im.tile == [("iptc", (0, 0, 1, 1), 25, ("raw", None))]
         assert_image_equal(im, expected)
 
     with Image.open(f) as im:
         assert im.load() is not None
+
+
+def test_field_length() -> None:
+    f = create_iptc_image()
+    f.seek(28)
+    f.write(b"\xff")
+    with pytest.raises(OSError, match="illegal field length in IPTC/NAA file"):
+        with Image.open(f):
+            pass
+
+
+@pytest.mark.parametrize("layers, mode", ((3, "RGB"), (4, "CMYK")))
+def test_layers(layers: int, mode: str) -> None:
+    for band in range(-1, layers):
+        info = {"layers": layers, "component": 1, "data": 5}
+        if band != -1:
+            info["band"] = band
+        f = create_iptc_image(info)
+        with Image.open(f) as im:
+            assert im.mode == mode
+
+            data = [0] * layers
+            data[max(band, 0)] = 5
+            assert im.getpixel((0, 0)) == tuple(data)
+
+
+def test_unknown_compression() -> None:
+    f = create_iptc_image({"compression": 2})
+    with pytest.raises(OSError, match="Unknown IPTC image compression"):
+        with Image.open(f):
+            pass
+
+
+def test_getiptcinfo() -> None:
+    f = create_iptc_image()
+    with Image.open(f) as im:
+        assert IptcImagePlugin.getiptcinfo(im) == {
+            (3, 60): b"\x01\x00",
+            (3, 120): b"\x01",
+            (3, 20): b"\x01",
+            (3, 30): b"\x01",
+        }
 
 
 def test_getiptcinfo_jpg_none() -> None:


### PR DESCRIPTION
When opening IPTC images at the moment, `self._mode` might be set to a single channel from RGB or CMYK.
https://github.com/python-pillow/Pillow/blob/d80cf0ee1b2b571aef5c844560574ee852a506dd/src/PIL/IptcImagePlugin.py#L109-L112

That's incorrect, as we don't have R, G, B, C, M, Y or K modes. Your first instinct might be to say that these should be the rawmode instead, but IptcImagePlugin just passes the image data on to be [opened by another plugin.](https://github.com/python-pillow/Pillow/blob/d80cf0ee1b2b571aef5c844560574ee852a506dd/src/PIL/IptcImagePlugin.py#L155) Instead, this PR uses `Image.merge()` to combine the image with empty bands for the other channels, to make up the full mode.

I've also made some simplifications. https://github.com/python-pillow/Pillow/blob/7b1ba29b5bd918a92fd305e5aa5db18cd8052f0e/src/PIL/IptcImagePlugin.py#L37-L38 is unused since https://github.com/python-pillow/Pillow/commit/0a29d6392afeaf6c7e8354dbfa67a1f9268028df, and so can be removed, and `codec` is always "iptc", so we don't have to check it.
https://github.com/python-pillow/Pillow/blob/d80cf0ee1b2b571aef5c844560574ee852a506dd/src/PIL/IptcImagePlugin.py#L127-L131