### PR TITLE
Simplify check for GBR width and height

### DIFF
--- a/Tests/test_file_gbr.py
+++ b/Tests/test_file_gbr.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from io import BytesIO
+
 import pytest
 
-from PIL import GbrImagePlugin, Image
+from PIL import GbrImagePlugin, Image, _binary
 
 from .helper import assert_image_equal_tofile
 
@@ -31,8 +33,49 @@ def test_multiple_load_operations() -> None:
         assert_image_equal_tofile(im, "Tests/images/gbr.png")
 
 
-def test_invalid_file() -> None:
-    invalid_file = "Tests/images/flower.jpg"
+def create_gbr_image(info: dict[str, int] = {}, magic_number=b"") -> BytesIO:
+    return BytesIO(
+        b"".join(
+            _binary.o32be(i)
+            for i in [
+                info.get("header_size", 20),
+                info.get("version", 1),
+                info.get("width", 1),
+                info.get("height", 1),
+                info.get("color_depth", 1),
+            ]
+        )
+        + magic_number
+    )
 
-    with pytest.raises(SyntaxError):
+
+def test_invalid_file() -> None:
+    for f in [
+        create_gbr_image({"header_size": 0}),
+        create_gbr_image({"width": 0}),
+        create_gbr_image({"height": 0}),
+    ]:
+        with pytest.raises(SyntaxError, match="not a GIMP brush"):
+            GbrImagePlugin.GbrImageFile(f)
+
+    invalid_file = "Tests/images/flower.jpg"
+    with pytest.raises(SyntaxError, match="Unsupported GIMP brush version"):
         GbrImagePlugin.GbrImageFile(invalid_file)
+
+
+def test_unsupported_gimp_brush() -> None:
+    f = create_gbr_image({"color_depth": 2})
+    with pytest.raises(SyntaxError, match="Unsupported GIMP brush color depth: 2"):
+        GbrImagePlugin.GbrImageFile(f)
+
+
+def test_bad_magic_number() -> None:
+    f = create_gbr_image({"version": 2}, magic_number=b"badm")
+    with pytest.raises(SyntaxError, match="not a GIMP brush, bad magic number"):
+        GbrImagePlugin.GbrImageFile(f)
+
+
+def test_L() -> None:
+    f = create_gbr_image()
+    with Image.open(f) as im:
+        assert im.mode == "L"

--- a/src/PIL/GbrImagePlugin.py
+++ b/src/PIL/GbrImagePlugin.py
@@ -54,7 +54,7 @@ class GbrImageFile(ImageFile.ImageFile):
         width = i32(self.fp.read(4))
         height = i32(self.fp.read(4))
         color_depth = i32(self.fp.read(4))
-        if width <= 0 or height <= 0:
+        if width == 0 or height == 0:
             msg = "not a GIMP brush"
             raise SyntaxError(msg)
         if color_depth not in (1, 4):
@@ -71,7 +71,7 @@ class GbrImageFile(ImageFile.ImageFile):
                 raise SyntaxError(msg)
             self.info["spacing"] = i32(self.fp.read(4))
 
-        comment = self.fp.read(comment_length)[:-1]
+        self.info["comment"] = self.fp.read(comment_length)[:-1]
 
         if color_depth == 1:
             self._mode = "L"
@@ -79,8 +79,6 @@ class GbrImageFile(ImageFile.ImageFile):
             self._mode = "RGBA"
 
         self._size = width, height
-
-        self.info["comment"] = comment
 
         # Image might not be small
         Image._decompression_bomb_check(self.size)


### PR DESCRIPTION
1. Simplify a check for `width` and `height`, as they cannot actually be less than zero.
https://github.com/python-pillow/Pillow/blob/d80cf0ee1b2b571aef5c844560574ee852a506dd/src/PIL/GbrImagePlugin.py#L29
https://github.com/python-pillow/Pillow/blob/d80cf0ee1b2b571aef5c844560574ee852a506dd/src/PIL/GbrImagePlugin.py#L54-L57
https://github.com/python-pillow/Pillow/blob/d80cf0ee1b2b571aef5c844560574ee852a506dd/src/PIL/_binary.py#L94-L95
where `I` is an [unsigned integer.](https://docs.python.org/3/library/struct.html#format-characters)

3. Add coverage for the lines missing at https://app.codecov.io/gh/python-pillow/Pillow/blob/main/src%2FPIL%2FGbrImagePlugin.py