### PR TITLE
Added ImageText

### DIFF
--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -35,10 +35,10 @@ import math
 import struct
 from collections.abc import Sequence
 from types import ModuleType
-from typing import Any, AnyStr, Callable, Union, cast
+from typing import Any, AnyStr, Callable, cast
 
-from . import Image, ImageColor
-from ._typing import Coords
+from . import Image, ImageColor, ImageText
+from ._typing import Coords, _Ink
 
 # experimental access to the outline API
 Outline: Callable[[], Image.core._Outline] = Image.core.outline
@@ -46,8 +46,6 @@ Outline: Callable[[], Image.core._Outline] = Image.core.outline
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from . import ImageDraw2, ImageFont
-
-_Ink = Union[float, tuple[int, ...], str]
 
 """
 A simple 2D drawing interface for PIL images.
@@ -536,11 +534,6 @@ class ImageDraw:
                     right[3] -= r + 1
                 self.draw.draw_rectangle(right, ink, 1)
 
-    def _multiline_check(self, text: AnyStr) -> bool:
-        split_character = "\n" if isinstance(text, str) else b"\n"
-
-        return split_character in text
-
     def text(
         self,
         xy: tuple[float, float],
@@ -565,29 +558,15 @@ class ImageDraw:
         **kwargs: Any,
     ) -> None:
         """Draw text."""
-        if embedded_color and self.mode not in ("RGB", "RGBA"):
-            msg = "Embedded color supported only in RGB and RGBA modes"
-            raise ValueError(msg)
-
         if font is None:
             font = self._getfont(kwargs.get("font_size"))
-
-        if self._multiline_check(text):
-            return self.multiline_text(
-                xy,
-                text,
-                fill,
-                font,
-                anchor,
-                spacing,
-                align,
-                direction,
-                features,
-                language,
-                stroke_width,
-                stroke_fill,
-                embedded_color,
-            )
+        imagetext = ImageText.ImageText(
+            text, font, self.mode, spacing, direction, features, language
+        )
+        if embedded_color:
+            imagetext.embed_color()
+        if stroke_width:
+            imagetext.stroke(stroke_width)
 
         def getink(fill: _Ink | None) -> int:
             ink, fill_ink = self._getink(fill)
@@ -596,66 +575,71 @@ class ImageDraw:
                 return fill_ink
             return ink
 
-        def draw_text(ink: int, stroke_width: float = 0) -> None:
-            mode = self.fontmode
-            if stroke_width == 0 and embedded_color:
-                mode = "RGBA"
-            coord = []
-            for i in range(2):
-                coord.append(int(xy[i]))
-            start = (math.modf(xy[0])[0], math.modf(xy[1])[0])
-            try:
-                mask, offset = font.getmask2(  # type: ignore[union-attr,misc]
-                    text,
-                    mode,
-                    direction=direction,
-                    features=features,
-                    language=language,
-                    stroke_width=stroke_width,
-                    stroke_filled=True,
-                    anchor=anchor,
-                    ink=ink,
-                    start=start,
-                    *args,
-                    **kwargs,
-                )
-                coord = [coord[0] + offset[0], coord[1] + offset[1]]
-            except AttributeError:
+        ink = getink(fill)
+        if ink is None:
+            return
+
+        stroke_ink = None
+        if stroke_width:
+            stroke_ink = getink(stroke_fill) if stroke_fill is not None else ink
+
+        for xy, anchor, line in imagetext._split(xy, anchor, align):
+
+            def draw_text(ink: int, stroke_width: float = 0) -> None:
+                mode = self.fontmode
+                if stroke_width == 0 and embedded_color:
+                    mode = "RGBA"
+                coord = []
+                for i in range(2):
+                    coord.append(int(xy[i]))
+                start = (math.modf(xy[0])[0], math.modf(xy[1])[0])
                 try:
-                    mask = font.getmask(  # type: ignore[misc]
-                        text,
+                    mask, offset = font.getmask2(  # type: ignore[union-attr,misc]
+                        line,
                         mode,
-                        direction,
-                        features,
-                        language,
-                        stroke_width,
-                        anchor,
-                        ink,
+                        direction=direction,
+                        features=features,
+                        language=language,
+                        stroke_width=stroke_width,
+                        stroke_filled=True,
+                        anchor=anchor,
+                        ink=ink,
                         start=start,
                         *args,
                         **kwargs,
                     )
-                except TypeError:
-                    mask = font.getmask(text)
-            if mode == "RGBA":
-                # font.getmask2(mode="RGBA") returns color in RGB bands and mask in A
-                # extract mask and set text alpha
-                color, mask = mask, mask.getband(3)
-                ink_alpha = struct.pack("i", ink)[3]
-                color.fillband(3, ink_alpha)
-                x, y = coord
-                if self.im is not None:
-                    self.im.paste(
-                        color, (x, y, x + mask.size[0], y + mask.size[1]), mask
-                    )
-            else:
-                self.draw.draw_bitmap(coord, mask, ink)
-
-        ink = getink(fill)
-        if ink is not None:
-            stroke_ink = None
-            if stroke_width:
-                stroke_ink = getink(stroke_fill) if stroke_fill is not None else ink
+                    coord = [coord[0] + offset[0], coord[1] + offset[1]]
+                except AttributeError:
+                    try:
+                        mask = font.getmask(  # type: ignore[misc]
+                            line,
+                            mode,
+                            direction,
+                            features,
+                            language,
+                            stroke_width,
+                            anchor,
+                            ink,
+                            start=start,
+                            *args,
+                            **kwargs,
+                        )
+                    except TypeError:
+                        mask = font.getmask(line)
+                if mode == "RGBA":
+                    # font.getmask2(mode="RGBA")
+                    # returns color in RGB bands and mask in A
+                    # extract mask and set text alpha
+                    color, mask = mask, mask.getband(3)
+                    ink_alpha = struct.pack("i", ink)[3]
+                    color.fillband(3, ink_alpha)
+                    x, y = coord
+                    if self.im is not None:
+                        self.im.paste(
+                            color, (x, y, x + mask.size[0], y + mask.size[1]), mask
+                        )
+                else:
+                    self.draw.draw_bitmap(coord, mask, ink)
 
             if stroke_ink is not None:
                 # Draw stroked text
@@ -667,132 +651,6 @@ class ImageDraw:
             else:
                 # Only draw normal text
                 draw_text(ink)
-
-    def _prepare_multiline_text(
-        self,
-        xy: tuple[float, float],
-        text: AnyStr,
-        font: (
-            ImageFont.ImageFont
-            | ImageFont.FreeTypeFont
-            | ImageFont.TransposedFont
-            | None
-        ),
-        anchor: str | None,
-        spacing: float,
-        align: str,
-        direction: str | None,
-        features: list[str] | None,
-        language: str | None,
-        stroke_width: float,
-        embedded_color: bool,
-        font_size: float | None,
-    ) -> tuple[
-        ImageFont.ImageFont | ImageFont.FreeTypeFont | ImageFont.TransposedFont,
-        list[tuple[tuple[float, float], str, AnyStr]],
-    ]:
-        if anchor is None:
-            anchor = "lt" if direction == "ttb" else "la"
-        elif len(anchor) != 2:
-            msg = "anchor must be a 2 character string"
-            raise ValueError(msg)
-        elif anchor[1] in "tb" and direction != "ttb":
-            msg = "anchor not supported for multiline text"
-            raise ValueError(msg)
-
-        if font is None:
-            font = self._getfont(font_size)
-
-        lines = text.split("\n" if isinstance(text, str) else b"\n")
-        line_spacing = (
-            self.textbbox((0, 0), "A", font, stroke_width=stroke_width)[3]
-            + stroke_width
-            + spacing
-        )
-
-        top = xy[1]
-        parts = []
-        if direction == "ttb":
-            left = xy[0]
-            for line in lines:
-                parts.append(((left, top), anchor, line))
-                left += line_spacing
-        else:
-            widths = []
-            max_width: float = 0
-            for line in lines:
-                line_width = self.textlength(
-                    line,
-                    font,
-                    direction=direction,
-                    features=features,
-                    language=language,
-                    embedded_color=embedded_color,
-                )
-                widths.append(line_width)
-                max_width = max(max_width, line_width)
-
-            if anchor[1] == "m":
-                top -= (len(lines) - 1) * line_spacing / 2.0
-            elif anchor[1] == "d":
-                top -= (len(lines) - 1) * line_spacing
-
-            for idx, line in enumerate(lines):
-                left = xy[0]
-                width_difference = max_width - widths[idx]
-
-                # align by align parameter
-                if align in ("left", "justify"):
-                    pass
-                elif align == "center":
-                    left += width_difference / 2.0
-                elif align == "right":
-                    left += width_difference
-                else:
-                    msg = 'align must be "left", "center", "right" or "justify"'
-                    raise ValueError(msg)
-
-                if (
-                    align == "justify"
-                    and width_difference != 0
-                    and idx != len(lines) - 1
-                ):
-                    words = line.split(" " if isinstance(text, str) else b" ")
-                    if len(words) > 1:
-                        # align left by anchor
-                        if anchor[0] == "m":
-                            left -= max_width / 2.0
-                        elif anchor[0] == "r":
-                            left -= max_width
-
-                        word_widths = [
-                            self.textlength(
-                                word,
-                                font,
-                                direction=direction,
-                                features=features,
-                                language=language,
-                                embedded_color=embedded_color,
-                            )
-                            for word in words
-                        ]
-                        word_anchor = "l" + anchor[1]
-                        width_difference = max_width - sum(word_widths)
-                        for i, word in enumerate(words):
-                            parts.append(((left, top), word_anchor, word))
-                            left += word_widths[i] + width_difference / (len(words) - 1)
-                        top += line_spacing
-                        continue
-
-                # align left by anchor
-                if anchor[0] == "m":
-                    left -= width_difference / 2.0
-                elif anchor[0] == "r":
-                    left -= width_difference
-                parts.append(((left, top), anchor, line))
-                top += line_spacing
-
-        return font, parts
 
     def multiline_text(
         self,
@@ -817,9 +675,10 @@ class ImageDraw:
         *,
         font_size: float | None = None,
     ) -> None:
-        font, lines = self._prepare_multiline_text(
+        return self.text(
             xy,
             text,
+            fill,
             font,
             anchor,
             spacing,
@@ -828,24 +687,10 @@ class ImageDraw:
             features,
             language,
             stroke_width,
+            stroke_fill,
             embedded_color,
-            font_size,
+            font_size=font_size,
         )
-
-        for xy, anchor, line in lines:
-            self.text(
-                xy,
-                line,
-                fill,
-                font,
-                anchor,
-                direction=direction,
-                features=features,
-                language=language,
-                stroke_width=stroke_width,
-                stroke_fill=stroke_fill,
-                embedded_color=embedded_color,
-            )
 
     def textlength(
         self,
@@ -864,17 +709,19 @@ class ImageDraw:
         font_size: float | None = None,
     ) -> float:
         """Get the length of a given string, in pixels with 1/64 precision."""
-        if self._multiline_check(text):
-            msg = "can't measure length of multiline text"
-            raise ValueError(msg)
-        if embedded_color and self.mode not in ("RGB", "RGBA"):
-            msg = "Embedded color supported only in RGB and RGBA modes"
-            raise ValueError(msg)
-
         if font is None:
             font = self._getfont(font_size)
-        mode = "RGBA" if embedded_color else self.fontmode
-        return font.getlength(text, mode, direction, features, language)
+        imagetext = ImageText.ImageText(
+            text,
+            font,
+            self.mode,
+            direction=direction,
+            features=features,
+            language=language,
+        )
+        if embedded_color:
+            imagetext.embed_color()
+        return imagetext.get_length()
 
     def textbbox(
         self,
@@ -898,33 +745,16 @@ class ImageDraw:
         font_size: float | None = None,
     ) -> tuple[float, float, float, float]:
         """Get the bounding box of a given string, in pixels."""
-        if embedded_color and self.mode not in ("RGB", "RGBA"):
-            msg = "Embedded color supported only in RGB and RGBA modes"
-            raise ValueError(msg)
-
         if font is None:
             font = self._getfont(font_size)
-
-        if self._multiline_check(text):
-            return self.multiline_textbbox(
-                xy,
-                text,
-                font,
-                anchor,
-                spacing,
-                align,
-                direction,
-                features,
-                language,
-                stroke_width,
-                embedded_color,
-            )
-
-        mode = "RGBA" if embedded_color else self.fontmode
-        bbox = font.getbbox(
-            text, mode, direction, features, language, stroke_width, anchor
+        imagetext = ImageText.ImageText(
+            text, font, self.mode, spacing, direction, features, language
         )
-        return bbox[0] + xy[0], bbox[1] + xy[1], bbox[2] + xy[0], bbox[3] + xy[1]
+        if embedded_color:
+            imagetext.embed_color()
+        if stroke_width:
+            imagetext.stroke(stroke_width)
+        return imagetext.get_bbox(xy, anchor)
 
     def multiline_textbbox(
         self,
@@ -947,7 +777,7 @@ class ImageDraw:
         *,
         font_size: float | None = None,
     ) -> tuple[float, float, float, float]:
-        font, lines = self._prepare_multiline_text(
+        return self.textbbox(
             xy,
             text,
             font,
@@ -959,36 +789,8 @@ class ImageDraw:
             language,
             stroke_width,
             embedded_color,
-            font_size,
+            font_size=font_size,
         )
-
-        bbox: tuple[float, float, float, float] | None = None
-
-        for xy, anchor, line in lines:
-            bbox_line = self.textbbox(
-                xy,
-                line,
-                font,
-                anchor,
-                direction=direction,
-                features=features,
-                language=language,
-                stroke_width=stroke_width,
-                embedded_color=embedded_color,
-            )
-            if bbox is None:
-                bbox = bbox_line
-            else:
-                bbox = (
-                    min(bbox[0], bbox_line[0]),
-                    min(bbox[1], bbox_line[1]),
-                    max(bbox[2], bbox_line[2]),
-                    max(bbox[3], bbox_line[3]),
-                )
-
-        if bbox is None:
-            return xy[0], xy[1], xy[0], xy[1]
-        return bbox
 
 
 def Draw(im: Image.Image, mode: str | None = None) -> ImageDraw:

--- a/src/PIL/ImageText.py
+++ b/src/PIL/ImageText.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from typing import AnyStr
+
+from . import ImageFont
+from ._typing import _Ink
+
+
+class ImageText:
+    def __init__(
+        self,
+        text: AnyStr,
+        font: (
+            ImageFont.ImageFont
+            | ImageFont.FreeTypeFont
+            | ImageFont.TransposedFont
+            | None
+        ) = None,
+        mode: str = "RGB",
+        spacing: float = 4,
+        direction: str | None = None,
+        features: list[str] | None = None,
+        language: str | None = None,
+    ) -> None:
+        self.text = text.encode() if isinstance(text, str) else text
+        self.font = font or ImageFont.load_default()
+
+        self.mode = mode
+        self.spacing = spacing
+        self.direction = direction
+        self.features = features
+        self.language = language
+
+        self.embedded_color = False
+
+        self.stroke_width: float = 0
+        self.stroke_fill: _Ink | None = None
+
+    def embed_color(self) -> None:
+        if self.mode not in ("RGB", "RGBA"):
+            msg = "Embedded color supported only in RGB and RGBA modes"
+            raise ValueError(msg)
+        self.embedded_color = True
+
+    def stroke(self, width: float = 0, fill: _Ink | None = None) -> None:
+        self.stroke_width = width
+        self.stroke_fill = fill
+
+    def _get_fontmode(self) -> str:
+        if self.mode in ("1", "P", "I", "F"):
+            return "1"
+        elif self.embedded_color:
+            return "RGBA"
+        else:
+            return "L"
+
+    def get_length(self):
+        if b"\n" in self.text:
+            msg = "can't measure length of multiline text"
+            raise ValueError(msg)
+        return self.font.getlength(
+            self.text,
+            self._get_fontmode(),
+            self.direction,
+            self.features,
+            self.language,
+        )
+
+    def _split(
+        self, xy: tuple[float, float], anchor: str | None, align: str = "left"
+    ) -> list[tuple[tuple[float, float], str, bytes]]:
+        if anchor is None:
+            anchor = "lt" if self.direction == "ttb" else "la"
+        elif len(anchor) != 2:
+            msg = "anchor must be a 2 character string"
+            raise ValueError(msg)
+
+        lines = self.text.split(b"\n")
+        if len(lines) == 1:
+            return [(xy, anchor, self.text)]
+
+        if anchor[1] in "tb" and self.direction != "ttb":
+            msg = "anchor not supported for multiline text"
+            raise ValueError(msg)
+
+        fontmode = self._get_fontmode()
+        line_spacing = (
+            self.font.getbbox(
+                "A",
+                fontmode,
+                self.direction,
+                self.features,
+                self.language,
+                self.stroke_width,
+            )[3]
+            + self.stroke_width
+            + self.spacing
+        )
+
+        top = xy[1]
+        parts = []
+        if self.direction == "ttb":
+            left = xy[0]
+            for line in lines:
+                parts.append(((left, top), anchor, line))
+                left += line_spacing
+        else:
+            widths = []
+            max_width: float = 0
+            for line in lines:
+                line_width = self.font.getlength(
+                    line, fontmode, self.direction, self.features, self.language
+                )
+                widths.append(line_width)
+                max_width = max(max_width, line_width)
+
+            if anchor[1] == "m":
+                top -= (len(lines) - 1) * line_spacing / 2.0
+            elif anchor[1] == "d":
+                top -= (len(lines) - 1) * line_spacing
+
+            for idx, line in enumerate(lines):
+                left = xy[0]
+                width_difference = max_width - widths[idx]
+
+                # align by align parameter
+                if align in ("left", "justify"):
+                    pass
+                elif align == "center":
+                    left += width_difference / 2.0
+                elif align == "right":
+                    left += width_difference
+                else:
+                    msg = 'align must be "left", "center", "right" or "justify"'
+                    raise ValueError(msg)
+
+                if (
+                    align == "justify"
+                    and width_difference != 0
+                    and idx != len(lines) - 1
+                ):
+                    words = line.split(b" ")
+                    if len(words) > 1:
+                        # align left by anchor
+                        if anchor[0] == "m":
+                            left -= max_width / 2.0
+                        elif anchor[0] == "r":
+                            left -= max_width
+
+                        word_widths = [
+                            self.font.getlength(
+                                word,
+                                fontmode,
+                                self.direction,
+                                self.features,
+                                self.language,
+                            )
+                            for word in words
+                        ]
+                        word_anchor = "l" + anchor[1]
+                        width_difference = max_width - sum(word_widths)
+                        for i, word in enumerate(words):
+                            parts.append(((left, top), word_anchor, word))
+                            left += word_widths[i] + width_difference / (len(words) - 1)
+                        top += line_spacing
+                        continue
+
+                # align left by anchor
+                if anchor[0] == "m":
+                    left -= width_difference / 2.0
+                elif anchor[0] == "r":
+                    left -= width_difference
+                parts.append(((left, top), anchor, line))
+                top += line_spacing
+
+        return parts
+
+    def get_bbox(
+        self, xy: tuple[float, float] = (0, 0), anchor: str | None = None
+    ) -> tuple[float, float, float, float]:
+        bbox: tuple[float, float, float, float] | None = None
+        fontmode = self._get_fontmode()
+        for xy, anchor, line in self._split(xy, anchor):
+            bbox_line = self.font.getbbox(
+                line,
+                fontmode,
+                self.direction,
+                self.features,
+                self.language,
+                self.stroke_width,
+                anchor,
+            )
+            bbox_line = (
+                bbox_line[0] + xy[0],
+                bbox_line[1] + xy[1],
+                bbox_line[2] + xy[0],
+                bbox_line[3] + xy[1],
+            )
+            if bbox is None:
+                bbox = bbox_line
+            else:
+                bbox = (
+                    min(bbox[0], bbox_line[0]),
+                    min(bbox[1], bbox_line[1]),
+                    max(bbox[2], bbox_line[2]),
+                    max(bbox[3], bbox_line[3]),
+                )
+
+        if bbox is None:
+            return xy[0], xy[1], xy[0], xy[1]
+        return bbox

--- a/src/PIL/_typing.py
+++ b/src/PIL/_typing.py
@@ -38,6 +38,8 @@ else:
                 return bool
 
 
+_Ink = Union[float, tuple[int, ...], str]
+
 Coords = Union[Sequence[float], Sequence[Sequence[float]]]
 
 


### PR DESCRIPTION
`ImageDraw.multiline_text` currently takes 14 arguments, and `ImageDraw.multiline_textbbox` currently accepts 12 arguments.

#6201 would probably lead to that number increasing further, and there are [some](https://github.com/python-pillow/Pillow/issues/5816#issuecomment-962864866) [comments](https://github.com/python-pillow/Pillow/issues/7013#issuecomment-2948807948) that wonder why calculating multiline text bounding box dimensions requires an ImageDraw instance.

I'm going to suggest adding a new `ImageText` class. I consider this to be a tidying of the API, rather than something motivated by a pressing need, so if this is accepted, maybe we don't need an immediate deprecation.

Before
```python
from PIL import Image, ImageDraw
im = Image.new(mode, (0, 0))
d = ImageDraw.Draw(im)

d.multiline_textlength(text, font, direction, features, language, embedded_color)
d.multiline_textbbox(xy, text, font, anchor, spacing, align, direction, features, language, stroke_width, embedded_color)
```

After
```python
from PIL import ImageText
text = ImageText.ImageText(text, font, mode, spacing, direction, features, language)
text.embed_color()
text.stroke(stroke_width)

text.get_length()
text.get_bbox(xy, anchor)
```

New features like #6201 would just be made exclusive to the new class, something like `text.wrap(width, height, scaling, limit)`.

If nothing else, this will separate the text handling logic from the rest of the ImageDraw code.

I have some further improvements to make, but wanted to see if there was any feedback.