### PR TITLE
Skip pyroma test if git is not available

### DIFF
--- a/Tests/test_pyroma.py
+++ b/Tests/test_pyroma.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import shutil
+
 import pytest
 
 from PIL import __version__
@@ -7,6 +9,7 @@ from PIL import __version__
 pyroma = pytest.importorskip("pyroma", reason="Pyroma not installed")
 
 
+@pytest.mark.skipif(not shutil.which("git"), reason="Git is used by check-manifest")
 def test_pyroma() -> None:
     # Arrange
     data = pyroma.projectdata.get_data(".")


### PR DESCRIPTION
When testing our Windows and iOS wheels, pyroma is currently failing - https://github.com/python-pillow/Pillow/actions/runs/16496343257/job/46642872391#step:7:8765

Investigating, I've found that it is because [check-manifest uses git](https://github.com/mgedmin/check-manifest/blob/6efaec39f7239b96405922d286f55f30ec947850/check_manifest.py#L404-L408), and that isn't always available.