### PR TITLE
Drop support for PyPy3.10

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.11", "pypy3.10", "3.10", "3.11", "3.12", ">=3.13.5", "3.14"]
+        python-version: ["pypy3.11", "3.10", "3.11", "3.12", ">=3.13.5", "3.14"]
         architecture: ["x64"]
         include:
             # Test the oldest Python on 32-bit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,6 @@ jobs:
         ]
         python-version: [
           "pypy3.11",
-          "pypy3.10",
           "3.14t",
           "3.14",
           "3.13t",


### PR DESCRIPTION
PyPy3.10 has been removed from the latest PyPy release - https://pypy.org/posts/2025/07/pypy-v7320-release.html