### PR TITLE
Always check XMLPacket value

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -365,8 +365,7 @@ class TestFileLibTiff(LibTiffTestCase):
 
         with Image.open(out) as reloaded:
             assert isinstance(reloaded, TiffImagePlugin.TiffImageFile)
-            if 700 in reloaded.tag_v2:
-                assert reloaded.tag_v2[700] == b"xmlpacket tag"
+            assert reloaded.tag_v2[700] == b"xmlpacket tag"
 
     def test_int_dpi(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         # issue #1765


### PR DESCRIPTION
#4605 added a check for roundtripping the XMLPacket tag through libtiff. It allowed the tag to be missing however.

https://github.com/python-pillow/Pillow/blob/7dbcb32cbe524a8ec4c12f21c762cd7153b2b03b/Tests/test_file_libtiff.py#L368-L369

This PR improves the check, by requiring that the tag be present.