### PR TITLE
Remove unused code

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -870,8 +870,6 @@ PyImaging_Jpeg2KDecoderNew(PyObject *self, PyObject *args) {
 
     if (strcmp(format, "j2k") == 0) {
         codec_format = OPJ_CODEC_J2K;
-    } else if (strcmp(format, "jpt") == 0) {
-        codec_format = OPJ_CODEC_JPT;
     } else if (strcmp(format, "jp2") == 0) {
         codec_format = OPJ_CODEC_JP2;
     } else {


### PR DESCRIPTION
When decoding JPEG2000 images in C, we allow for 3 codecs.
https://github.com/python-pillow/Pillow/blob/7dbcb32cbe524a8ec4c12f21c762cd7153b2b03b/src/decode.c#L871-L876

But only 2 are ever set in Python.
https://github.com/python-pillow/Pillow/blob/7dbcb32cbe524a8ec4c12f21c762cd7153b2b03b/src/PIL/Jpeg2KImagePlugin.py#L253-L260