### PR TITLE
Restore pyroma test for iOS

### DIFF
--- a/.ci/requirements-cibw.txt
+++ b/.ci/requirements-cibw.txt
@@ -1,1 +1,1 @@
-cibuildwheel==3.0.1
+cibuildwheel==3.1.2

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -320,5 +320,5 @@ int main(int argc, char* argv[])
         try:
             os.remove("embed_pil.c")
         except FileNotFoundError:
-            # If the test was skipped or failed, the file won't exist,
+            # If the test was skipped or failed, the file won't exist
             pass

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -317,4 +317,8 @@ int main(int argc, char* argv[])
         assert process.returncode == 0
 
     def teardown_method(self) -> None:
-        os.remove("embed_pil.c")
+        try:
+            os.remove("embed_pil.c")
+        except FileNotFoundError:
+            # If the test was skipped or failed, the file won't exist,
+            pass

--- a/Tests/test_pyroma.py
+++ b/Tests/test_pyroma.py
@@ -10,10 +10,10 @@ pyroma = pytest.importorskip("pyroma", reason="Pyroma not installed")
 
 
 def map_metadata_keys(metadata):
-    "Convert installed wheel metadata into canonical Core Metadata 2.4 format."
-    # This was a utility method in pyroma 4.3.3; it was removed in 5.0
+    # Convert installed wheel metadata into canonical Core Metadata 2.4 format.
+    # This was a utility method in pyroma 4.3.3; it was removed in 5.0.
     # This implementation is constructed from the relevant logic from
-    # PyRoma 5.0's `build_metadata()` implementation.
+    # Pyroma 5.0's `build_metadata()` implementation.
 
     data = {}
     for key in set(metadata.keys()):

--- a/Tests/test_pyroma.py
+++ b/Tests/test_pyroma.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from importlib.metadata import metadata
+
 import pytest
 
 from PIL import __version__
@@ -7,9 +9,29 @@ from PIL import __version__
 pyroma = pytest.importorskip("pyroma", reason="Pyroma not installed")
 
 
+def map_metadata_keys(metadata):
+    "Convert installed wheel metadata into canonical Core Metadata 2.4 format."
+    # This was a utility method in pyroma 4.3.3; it was removed in 5.0
+    # This implementation is constructed from the relevant logic from
+    # PyRoma 5.0's `build_metadata()` implementation.
+
+    data = {}
+    for key in set(metadata.keys()):
+        value = metadata.get_all(key)
+        key = pyroma.projectdata.normalize(key)
+
+        if len(value) == 1:
+            value = value[0]
+            if value.strip() == "UNKNOWN":
+                continue
+
+        data[key] = value
+    return data
+
+
 def test_pyroma() -> None:
     # Arrange
-    data = pyroma.projectdata.get_data(".")
+    data = map_metadata_keys(metadata("Pillow"))
 
     # Act
     rating = pyroma.ratings.rate(data)

--- a/Tests/test_pyroma.py
+++ b/Tests/test_pyroma.py
@@ -13,8 +13,9 @@ def map_metadata_keys(metadata):
     # Convert installed wheel metadata into canonical Core Metadata 2.4 format.
     # This was a utility method in pyroma 4.3.3; it was removed in 5.0.
     # This implementation is constructed from the relevant logic from
-    # Pyroma 5.0's `build_metadata()` implementation.
-
+    # Pyroma 5.0's `build_metadata()` implementation. This has been submitted
+    # upstream to Pyroma as https://github.com/regebro/pyroma/pull/116,
+    # so it may be possible to simplify this test in future.
     data = {}
     for key in set(metadata.keys()):
         value = metadata.get_all(key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ optional-dependencies.tests = [
   "markdown2",
   "olefile",
   "packaging",
-  "pyroma",
+  "pyroma>=5",
   "pytest",
   "pytest-cov",
   "pytest-timeout",


### PR DESCRIPTION
Restores the Pyroma check on iOS.

Bumping the version of cibuildwheel ensures an updated iOS support package is used; this support package treats the installed dependencies directory as a site package, ensuring that the pyroma module can be discovered by pytest.

The change to the pyroma test itself is required because the `get_data()` call requires the use of subprocess - the test builds an entirely fresh wheel, and checks the data of *that* wheel. 

The approach proposed here uses importlib to extract the metadata of the wheel that is actually installed for testing purposes (which, really, is the wheel that we *should* be testing).

Unfortunately, the `map_metadata_keys()` method that *was* available in pyroma 4.3.3 has been removed in 5.0, and internalised into the `build_metadata()` method that uses it. As the implementation is a fairly straightforward key/value transformation, I've opted to replicate that logic. 
