### PR TITLE
Add libavif support for iOS

### DIFF
--- a/.ci/requirements-cibw.txt
+++ b/.ci/requirements-cibw.txt
@@ -1,1 +1,1 @@
-cibuildwheel==3.0.1
+cibuildwheel==3.1.2

--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -286,7 +286,12 @@ function build {
         build_tiff
     fi
 
-    build_libavif
+    if [[ -z "$IOS_SDK" ]] || [[ "$PLAT" == "arm64" ]]; then
+        # Building libavif for x86_64 iOS simulator isn't currently possible
+        # because it requires the use of nasm, which doesn't create
+        # iOS-compatible binaries.
+        build_libavif
+    fi
     build_libpng
     build_lcms2
     build_openjpeg

--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -191,6 +191,7 @@ function build_libavif {
     fi
 
     local build_type=MinSizeRel
+    local build_shared=ON
     local lto=ON
 
     local libavif_cmake_flags
@@ -202,20 +203,14 @@ function build_libavif {
             -DCMAKE_CXX_FLAGS_MINSIZEREL="-Oz -DNDEBUG -flto" \
             -DCMAKE_SHARED_LINKER_FLAGS_INIT="-Wl,-S,-x,-dead_strip_dylibs" \
         )
-        if [[ -z "$IOS_SDK" ]]; then
-            libavif_cmake_flags=(
-                "${libavif_cmake_flags[@]}" \
-                -DBUILD_SHARED_LIBS=ON
-            )
+        if [[ -n "$IOS_SDK" ]]; then
+            build_shared=OFF
         fi
     else
         if [[ "$MB_ML_VER" == 2014 ]] && [[ "$PLAT" == "x86_64" ]]; then
             build_type=Release
         fi
-        libavif_cmake_flags=(
-            -DCMAKE_SHARED_LINKER_FLAGS_INIT="-Wl,--strip-all,-z,relro,-z,now" \
-            -DBUILD_SHARED_LIBS=ON \
-        )
+        libavif_cmake_flags=(-DCMAKE_SHARED_LINKER_FLAGS_INIT="-Wl,--strip-all,-z,relro,-z,now")
     fi
 
     local out_dir=$(fetch_unpack https://github.com/AOMediaCodec/libavif/archive/refs/tags/v$LIBAVIF_VERSION.tar.gz libavif-$LIBAVIF_VERSION.tar.gz)
@@ -227,6 +222,7 @@ function build_libavif {
             -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX \
             -DCMAKE_INSTALL_LIBDIR=$BUILD_PREFIX/lib \
             -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib \
+            -DBUILD_SHARED_LIBS=$build_shared \
             -DAVIF_LIBSHARPYUV=LOCAL \
             -DAVIF_LIBYUV=LOCAL \
             -DAVIF_CODEC_AOM=LOCAL \

--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -204,7 +204,7 @@ function build_libavif {
         )
         if [[ -z "$IOS_SDK" ]]; then
             libavif_cmake_flags=(
-                $libavif_cmake_flags
+                "${libavif_cmake_flags[@]}" \
                 -DBUILD_SHARED_LIBS=ON
             )
         fi

--- a/checks/check_wheel.py
+++ b/checks/check_wheel.py
@@ -25,8 +25,7 @@ def test_wheel_modules() -> None:
 
     elif sys.platform == "ios":
         # tkinter is not available on iOS
-        # libavif is not available on iOS (for now)
-        expected_modules -= {"tkinter", "avif"}
+        expected_modules.remove("tkinter")
 
     assert set(features.get_supported_modules()) == expected_modules
 

--- a/checks/check_wheel.py
+++ b/checks/check_wheel.py
@@ -27,10 +27,6 @@ def test_wheel_modules() -> None:
         # tkinter is not available on iOS
         expected_modules.remove("tkinter")
 
-        # libavif is not available on x86_64 iOS simulators
-        if platform.machine() == "x86_64":
-            expected_modules.remove("avif")
-
     assert set(features.get_supported_modules()) == expected_modules
 
 

--- a/checks/check_wheel.py
+++ b/checks/check_wheel.py
@@ -27,6 +27,10 @@ def test_wheel_modules() -> None:
         # tkinter is not available on iOS
         expected_modules.remove("tkinter")
 
+        # libavif is not available on x86_64 iOS simulators
+        if platform.machine() == "x86_64":
+            expected_modules.remove("avif")
+
     assert set(features.get_supported_modules()) == expected_modules
 
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * Adds build instructions to add libavif to the compiled dependencies.
 * Bumps cibuildwheel to 3.1.2 to pick up bug fixes and Python 3.14 support for iOS