### PR TITLE
Remove support for NumPy 1.20 when type checking

### DIFF
--- a/src/PIL/_typing.py
+++ b/src/PIL/_typing.py
@@ -12,8 +12,8 @@ if TYPE_CHECKING:
     try:
         import numpy.typing as npt
 
-        NumpyArray = npt.NDArray[Any]  # requires numpy>=1.21
-    except (ImportError, AttributeError):
+        NumpyArray = npt.NDArray[Any]
+    except ImportError:
         pass
 
 if sys.version_info >= (3, 13):


### PR DESCRIPTION
NumPy 1.20 became EOL on 31 January 2023.

Support for it was added afterwards at the request of #8187, but that user was happy for the [support to be removed at the same time as Python 3.9 support is removed](https://github.com/python-pillow/Pillow/pull/8187#issuecomment-2202109282), which is now due to happen in our next release.

This PR only affects the use of NumPy when type checking.