### PR TITLE
Fill alpha channel when quantizing RGB images

### DIFF
--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -116,6 +116,15 @@ def test_quantize_kmeans(method: Image.Quantize) -> None:
         im.quantize(kmeans=-1, method=method)
 
 
+@skip_unless_feature("libimagequant")
+def test_resize() -> None:
+    im = hopper().resize((100, 100))
+    converted = im.quantize(100, Image.Quantize.LIBIMAGEQUANT)
+    colors = converted.getcolors()
+    assert colors is not None
+    assert len(colors) == 100
+
+
 def test_colors() -> None:
     im = hopper()
     colors = 2

--- a/src/libImaging/Quant.c
+++ b/src/libImaging/Quant.c
@@ -1745,19 +1745,23 @@ ImagingQuantize(Imaging im, int colors, int mode, int kmeans) {
         for (i = y = 0; y < im->ysize; y++) {
             for (x = 0; x < im->xsize; x++, i++) {
                 p[i].v = im->image32[y][x];
-                if (withAlpha && p[i].c.a == 0) {
-                    if (transparency == 0) {
-                        transparency = 1;
-                        r = p[i].c.r;
-                        g = p[i].c.g;
-                        b = p[i].c.b;
-                    } else {
-                        /* Set all subsequent transparent pixels
-                        to the same colour as the first */
-                        p[i].c.r = r;
-                        p[i].c.g = g;
-                        p[i].c.b = b;
+                if (withAlpha) {
+                    if (p[i].c.a == 0) {
+                        if (transparency == 0) {
+                            transparency = 1;
+                            r = p[i].c.r;
+                            g = p[i].c.g;
+                            b = p[i].c.b;
+                        } else {
+                            /* Set all subsequent transparent pixels
+                            to the same colour as the first */
+                            p[i].c.r = r;
+                            p[i].c.g = g;
+                            p[i].c.b = b;
+                        }
                     }
+                } else {
+                    p[i].c.a = 255;
                 }
             }
         }


### PR DESCRIPTION
Resolves #9128

When quantizing an RGB image, do not use the values stored in the image's alpha channel.