### PR TITLE
Fix typos

### DIFF
--- a/docs/handbook/third-party-plugins.rst
+++ b/docs/handbook/third-party-plugins.rst
@@ -11,7 +11,7 @@ Here is a list of PyPI projects that offer additional plugins:
 * :pypi:`heif-image-plugin`: Simple HEIF/HEIC images plugin, based on the pyheif library.
 * :pypi:`jxlpy`: Introduces reading and writing support for JPEG XL.
 * :pypi:`pillow-heif`: Python bindings to libheif for working with HEIF images.
-* :pypi:`pillow-jpls`: Plugin for the JPEG-LS codec, based on the Charls JPEG-LS implemetation. Python bindings implemented using pybind11.
+* :pypi:`pillow-jpls`: Plugin for the JPEG-LS codec, based on the Charls JPEG-LS implementation. Python bindings implemented using pybind11.
 * :pypi:`pillow-jxl-plugin`: Plugin for JPEG-XL, using Rust for bindings.
 * :pypi:`pillow-mbm`: Adds support for KSP's proprietary MBM texture format.
 * :pypi:`pillow-svg`: Implements basic SVG read support. Supports basic paths, shapes, and text.

--- a/src/PIL/WmfImagePlugin.py
+++ b/src/PIL/WmfImagePlugin.py
@@ -80,7 +80,7 @@ class WmfStubImageFile(ImageFile.StubImageFile):
     format_description = "Windows Metafile"
 
     def _open(self) -> None:
-        # check placable header
+        # check placeable header
         s = self.fp.read(44)
 
         if s.startswith(b"\xd7\xcd\xc6\x9a\x00\x00"):


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/680e68632c48b19fc77c6679741a043824bcaa03/src/PIL/WmfImagePlugin.py#L83-L87

The header is 'placeable'. See https://learn.microsoft.com/en-us/windows/win32/api/gdiplusmetaheader/ns-gdiplusmetaheader-wmfplaceablefileheader or https://en.wikipedia.org/wiki/Windows_Metafile#WMF