### PR TITLE
Do not import from Tests directory in checks

### DIFF
--- a/checks/check_imaging_leaks.py
+++ b/checks/check_imaging_leaks.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable
 from typing import Any
 
@@ -8,12 +9,12 @@ import pytest
 
 from PIL import Image
 
-from .helper import is_win32
-
 min_iterations = 100
 max_iterations = 10000
 
-pytestmark = pytest.mark.skipif(is_win32(), reason="requires Unix or macOS")
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win32"), reason="requires Unix or macOS"
+)
 
 
 def _get_mem_usage() -> float:

--- a/checks/check_j2k_leaks.py
+++ b/checks/check_j2k_leaks.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
+import sys
 from io import BytesIO
 
 import pytest
 
-from PIL import Image
-
-from .helper import is_win32, skip_unless_feature
+from PIL import Image, features
 
 # Limits for testing the leak
 mem_limit = 1024 * 1048576
@@ -15,8 +14,10 @@ iterations = int((mem_limit / stack_size) * 2)
 test_file = "Tests/images/rgb_trns_ycbc.jp2"
 
 pytestmark = [
-    pytest.mark.skipif(is_win32(), reason="requires Unix or macOS"),
-    skip_unless_feature("jpg_2000"),
+    pytest.mark.skipif(
+        sys.platform.startswith("win32"), reason="requires Unix or macOS"
+    ),
+    pytest.mark.skipif(not features.check("jpg_2000"), reason="jpg_2000 not available"),
 ]
 
 

--- a/checks/check_jpeg_leaks.py
+++ b/checks/check_jpeg_leaks.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import sys
 from io import BytesIO
 
 import pytest
 
-from .helper import hopper, is_win32
+from PIL import Image
 
 iterations = 5000
 
@@ -18,7 +19,9 @@ valgrind --tool=massif python test-installed.py -s -v checks/check_jpeg_leaks.py
 """
 
 
-pytestmark = pytest.mark.skipif(is_win32(), reason="requires Unix or macOS")
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win32"), reason="requires Unix or macOS"
+)
 
 """
 pre patch:
@@ -112,10 +115,10 @@ standard_chrominance_qtable = (
     ),
 )
 def test_qtables_leak(qtables: tuple[tuple[int, ...]] | list[tuple[int, ...]]) -> None:
-    im = hopper("RGB")
-    for _ in range(iterations):
-        test_output = BytesIO()
-        im.save(test_output, "JPEG", qtables=qtables)
+    with Image.open("Tests/images/hopper.ppm") as im:
+        for _ in range(iterations):
+            test_output = BytesIO()
+            im.save(test_output, "JPEG", qtables=qtables)
 
 
 def test_exif_leak() -> None:
@@ -173,12 +176,12 @@ def test_exif_leak() -> None:
        0 +----------------------------------------------------------------------->Gi
          0                                                                   11.33
     """
-    im = hopper("RGB")
     exif = b"12345678" * 4096
 
-    for _ in range(iterations):
-        test_output = BytesIO()
-        im.save(test_output, "JPEG", exif=exif)
+    with Image.open("Tests/images/hopper.ppm") as im:
+        for _ in range(iterations):
+            test_output = BytesIO()
+            im.save(test_output, "JPEG", exif=exif)
 
 
 def test_base_save() -> None:
@@ -207,8 +210,7 @@ def test_base_save() -> None:
          | :@ @@ @ # : : :: :: @:: :::: :::: :::: : : : : : : :::::::::::: :::@:::
        0 +----------------------------------------------------------------------->Gi
          0                                                                   7.882"""
-    im = hopper("RGB")
-
-    for _ in range(iterations):
-        test_output = BytesIO()
-        im.save(test_output, "JPEG")
+    with Image.open("Tests/images/hopper.ppm") as im:
+        for _ in range(iterations):
+            test_output = BytesIO()
+            im.save(test_output, "JPEG")

--- a/tox.ini
+++ b/tox.ini
@@ -30,4 +30,4 @@ skip_install = true
 deps =
     -r .ci/requirements-mypy.txt
 commands =
-    mypy conftest.py selftest.py setup.py docs src winbuild Tests {posargs}
+    mypy conftest.py selftest.py setup.py checks docs src winbuild Tests {posargs}


### PR DESCRIPTION
#9030 moved several scripts into a new 'checks' directory.

However, some of them still try to import from `Tests/helper.py`.
https://github.com/python-pillow/Pillow/blob/e786019e8304663fb41574c6f50e5724873e68fd/checks/check_imaging_leaks.py#L11

This copies the helper functions into `checks` to fix it, and adds the directory to mypy.