### PR TITLE
Load image palette into Python after converting to PA

### DIFF
--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -107,6 +107,14 @@ def test_rgba_p() -> None:
     assert_image_similar(im, comparable, 20)
 
 
+def test_pa() -> None:
+    im = hopper().convert("PA")
+
+    palette = im.palette
+    assert palette is not None
+    assert palette.colors != {}
+
+
 def test_rgba() -> None:
     with Image.open("Tests/images/transparent.png") as im:
         assert im.mode == "RGBA"

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1143,7 +1143,7 @@ class Image:
                 raise ValueError(msg) from e
 
         new_im = self._new(im)
-        if mode == "P" and palette != Palette.ADAPTIVE:
+        if mode in ("P", "PA") and palette != Palette.ADAPTIVE:
             from . import ImagePalette
 
             new_im.palette = ImagePalette.ImagePalette("RGB", im.getpalette("RGB"))


### PR DESCRIPTION
Currently,
```python
hopper().convert("P").palette.colors
```
returns a populated palette, but
```python
hopper().convert("PA").palette.colors
```
does not. This fixes that.