### PR TITLE
When converting RGBA to PA, use RGB to P quantization

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1076,6 +1076,12 @@ class TestImage:
             assert im.palette is not None
             assert im.palette.colors[(27, 35, 6, 214)] == 24
 
+    def test_merge_pa(self) -> None:
+        p = hopper("P")
+        a = Image.new("L", p.size)
+        pa = Image.merge("PA", (p, a))
+        assert p.getpalette() == pa.getpalette()
+
     def test_constants(self) -> None:
         for enum in (
             Image.Transpose,

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -107,6 +107,13 @@ def test_rgba_p() -> None:
     assert_image_similar(im, comparable, 20)
 
 
+def test_rgba_pa() -> None:
+    im = hopper("RGBA").convert("PA").convert("RGB")
+    expected = hopper("RGB")
+
+    assert_image_similar(im, expected, 9.3)
+
+
 def test_rgba() -> None:
     with Image.open("Tests/images/transparent.png") as im:
         assert im.mode == "RGBA"

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1010,8 +1010,14 @@ class Image:
                 new_im.info["transparency"] = transparency
             return new_im
 
-        if mode == "P" and self.mode == "RGBA":
-            return self.quantize(colors)
+        if self.mode == "RGBA":
+            if mode == "P":
+                return self.quantize(colors)
+            elif mode == "PA":
+                r, g, b, a = self.split()
+                rgb = merge("RGB", (r, g, b))
+                p = rgb.quantize(colors)
+                return merge("PA", (p, a))
 
         trns = None
         delete_trns = False

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -2419,7 +2419,12 @@ _merge(PyObject *self, PyObject *args) {
         bands[3] = band3->image;
     }
 
-    return PyImagingNew(ImagingMerge(mode, bands));
+    Imaging imOut = ImagingMerge(mode, bands);
+    if (!imOut) {
+        return NULL;
+    }
+    ImagingCopyPalette(imOut, bands[0]);
+    return PyImagingNew(imOut);
 }
 
 static PyObject *


### PR DESCRIPTION
Resolves #9151 with two changes.

1. Currently,
```python
p = hopper("P")
a = Image.new("L", p.size)
pa = Image.merge("PA", (p, a))
print(pa.palette.colors)
```
returns populated palette data, but
```python
print(pa.getpalette())
```
is empty. This fixes that.

2. When converting RGBA to PA, rather than using the C method [`topalette()`](https://github.com/python-pillow/Pillow/blob/092d4422d590835c5a75831a4ff29caf0df08ae2/src/libImaging/Convert.c#L1620), quality can be improved by using the Python [`quantize()`](https://github.com/python-pillow/Pillow/blob/092d4422d590835c5a75831a4ff29caf0df08ae2/src/PIL/Image.py#L1171) to convert the RGB channels to P, and copying the A channel exactly by using `split()` and `merge()`.