### PR TITLE
Remove support for FreeType <= 2.9.0

### DIFF
--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -671,11 +671,7 @@ class FreeTypeFont:
         :returns: A list of the named styles in a variation font.
         :exception OSError: If the font is not a variation font.
         """
-        try:
-            names = self.font.getvarnames()
-        except AttributeError as e:
-            msg = "FreeType 2.9.1 or greater is required"
-            raise NotImplementedError(msg) from e
+        names = self.font.getvarnames()
         return [name.replace(b"\x00", b"") for name in names]
 
     def set_variation_by_name(self, name: str | bytes) -> None:
@@ -702,11 +698,7 @@ class FreeTypeFont:
         :returns: A list of the axes in a variation font.
         :exception OSError: If the font is not a variation font.
         """
-        try:
-            axes = self.font.getvaraxes()
-        except AttributeError as e:
-            msg = "FreeType 2.9.1 or greater is required"
-            raise NotImplementedError(msg) from e
+        axes = self.font.getvaraxes()
         for axis in axes:
             if axis["name"]:
                 axis["name"] = axis["name"].replace(b"\x00", b"")
@@ -717,11 +709,7 @@ class FreeTypeFont:
         :param axes: A list of values for each axis.
         :exception OSError: If the font is not a variation font.
         """
-        try:
-            self.font.setvaraxes(axes)
-        except AttributeError as e:
-            msg = "FreeType 2.9.1 or greater is required"
-            raise NotImplementedError(msg) from e
+        self.font.setvaraxes(axes)
 
 
 class TransposedFont:

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -1221,8 +1221,6 @@ glyph_error:
     return NULL;
 }
 
-#if FREETYPE_MAJOR > 2 || (FREETYPE_MAJOR == 2 && FREETYPE_MINOR > 9) || \
-    (FREETYPE_MAJOR == 2 && FREETYPE_MINOR == 9 && FREETYPE_PATCH == 1)
 static PyObject *
 font_getvarnames(FontObject *self) {
     int error;
@@ -1432,7 +1430,6 @@ font_setvaraxes(FontObject *self, PyObject *args) {
 
     Py_RETURN_NONE;
 }
-#endif
 
 static void
 font_dealloc(FontObject *self) {
@@ -1451,13 +1448,10 @@ static PyMethodDef font_methods[] = {
     {"render", (PyCFunction)font_render, METH_VARARGS},
     {"getsize", (PyCFunction)font_getsize, METH_VARARGS},
     {"getlength", (PyCFunction)font_getlength, METH_VARARGS},
-#if FREETYPE_MAJOR > 2 || (FREETYPE_MAJOR == 2 && FREETYPE_MINOR > 9) || \
-    (FREETYPE_MAJOR == 2 && FREETYPE_MINOR == 9 && FREETYPE_PATCH == 1)
     {"getvarnames", (PyCFunction)font_getvarnames, METH_NOARGS},
     {"getvaraxes", (PyCFunction)font_getvaraxes, METH_NOARGS},
     {"setvarname", (PyCFunction)font_setvarname, METH_VARARGS},
     {"setvaraxes", (PyCFunction)font_setvaraxes, METH_VARARGS},
-#endif
     {NULL, NULL}
 };
 


### PR DESCRIPTION
Sequel to #9053

While I previously removed support for FreeType <= 2.9.0 from the Tests and docs, I didn't actually remove support from the code itself.