### PR TITLE
Use macos-14 for iOS arm64 simulator

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -99,7 +99,7 @@ jobs:
             cibw_arch: arm64_iphoneos
           - name: "iOS arm64 simulator"
             platform: ios
-            os: macos-latest
+            os: macos-14
             cibw_arch: arm64_iphonesimulator
           - name: "iOS x86_64 simulator"
             platform: ios


### PR DESCRIPTION
The iOS arm64 simulator has started failing in [main](https://github.com/python-pillow/Pillow/actions/runs/17002152562/job/48205826204).

Based on https://github.com/pypa/cibuildwheel/pull/2557, @freakboy3742's suggested solution is to use macos-14 instead of macos-latest.