### PR TITLE
Do not set core to DeferredError

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -103,7 +103,6 @@ try:
         raise ImportError(msg)
 
 except ImportError as v:
-    core = DeferredError.new(ImportError("The _imaging C module is not installed."))
     # Explanations for ways that we know we might have an import error
     if str(v).startswith("Module use of python"):
         # The _imaging C module is present, but not compiled for


### PR DESCRIPTION
There's no need to set `core` in 
https://github.com/python-pillow/Pillow/blob/34c651deb8390ef752425a31e1473af4d6c9db3d/src/PIL/Image.py#L106
if we're just going to `raise` a few lines later, and not use it in between.

https://github.com/python-pillow/Pillow/blob/34c651deb8390ef752425a31e1473af4d6c9db3d/src/PIL/Image.py#L107-L120