### PR TITLE
Improve _accept length check

### DIFF
--- a/src/PIL/FliImagePlugin.py
+++ b/src/PIL/FliImagePlugin.py
@@ -30,7 +30,7 @@ from ._util import DeferredError
 
 def _accept(prefix: bytes) -> bool:
     return (
-        len(prefix) >= 6
+        len(prefix) >= 16
         and i16(prefix, 4) in [0xAF11, 0xAF12]
         and i16(prefix, 14) in [0, 3]  # flags
     )

--- a/src/PIL/GribStubImagePlugin.py
+++ b/src/PIL/GribStubImagePlugin.py
@@ -33,7 +33,7 @@ def register_handler(handler: ImageFile.StubHandler | None) -> None:
 
 
 def _accept(prefix: bytes) -> bool:
-    return prefix.startswith(b"GRIB") and prefix[7] == 1
+    return len(prefix) >= 8 and prefix.startswith(b"GRIB") and prefix[7] == 1
 
 
 class GribStubImageFile(ImageFile.StubImageFile):

--- a/src/PIL/PcxImagePlugin.py
+++ b/src/PIL/PcxImagePlugin.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 
 def _accept(prefix: bytes) -> bool:
-    return prefix[0] == 10 and prefix[1] in [0, 2, 3, 5]
+    return len(prefix) >= 2 and prefix[0] == 10 and prefix[1] in [0, 2, 3, 5]
 
 
 ##

--- a/src/PIL/PpmImagePlugin.py
+++ b/src/PIL/PpmImagePlugin.py
@@ -47,7 +47,7 @@ MODES = {
 
 
 def _accept(prefix: bytes) -> bool:
-    return prefix.startswith(b"P") and prefix[1] in b"0123456fy"
+    return len(prefix) >= 2 and prefix.startswith(b"P") and prefix[1] in b"0123456fy"
 
 
 ##


### PR DESCRIPTION
This improves/adds length checks in `_accept` for several plugins.

Here are two examples of the errors this fixes.
```pycon
>>> from PIL import FliImagePlugin
>>> FliImagePlugin._accept(b"test\x11\xaf")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/FliImagePlugin.py", line 35, in _accept
    and i16(prefix, 14) in [0, 3]  # flags
  File "PIL/_binary.py", line 37, in i16le
    return unpack_from("<H", c, o)[0]
struct.error: unpack_from requires a buffer of at least 16 bytes for unpacking 2 bytes at offset 14 (actual buffer size is 6)
>>> from PIL import GribStubImagePlugin
>>> GribStubImagePlugin._accept(b"GRIB")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/GribStubImagePlugin.py", line 36, in _accept
    return prefix.startswith(b"GRIB") and prefix[7] == 1
IndexError: index out of range
```