### PR TITLE
Removed version from PDF comment

### DIFF
--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -27,7 +27,7 @@ import os
 import time
 from typing import IO, Any
 
-from . import Image, ImageFile, ImageSequence, PdfParser, __version__, features
+from . import Image, ImageFile, ImageSequence, PdfParser, features
 
 #
 # --------------------------------------------------------------------
@@ -221,7 +221,7 @@ def _save(
 
     existing_pdf.start_writing()
     existing_pdf.write_header()
-    existing_pdf.write_comment(f"created by Pillow {__version__} PDF driver")
+    existing_pdf.write_comment("created by Pillow PDF driver")
 
     #
     # pages


### PR DESCRIPTION
Resolves #9175

When saving a PDF, there is a comment that mentions what Pillow version is being used.
https://github.com/python-pillow/Pillow/blob/97a4d1f593dc9dc59a2115d249784bf0a45a68d7/src/PIL/PdfImagePlugin.py#L224

This PR removes the version from the string. I don't think it's necessary, and may conceivably help an attacker - if a user is able to determine what Pillow version is being used, then they might learn that it is an outdated version with known vulnerabilities.