### PR TITLE
Fixed loading rotated PCD images

### DIFF
--- a/Tests/test_file_pcd.py
+++ b/Tests/test_file_pcd.py
@@ -6,6 +6,8 @@ import pytest
 
 from PIL import Image
 
+from .helper import assert_image_equal
+
 
 def test_load_raw() -> None:
     with Image.open("Tests/images/hopper.pcd") as im:
@@ -30,3 +32,8 @@ def test_rotated(orientation: int) -> None:
     f = BytesIO(data)
     with Image.open(f) as im:
         assert im.size == (512, 768)
+
+        with Image.open("Tests/images/hopper.pcd") as expected:
+            assert_image_equal(
+                im, expected.rotate(90 if orientation == 1 else -90, expand=True)
+            )

--- a/Tests/test_file_pcd.py
+++ b/Tests/test_file_pcd.py
@@ -35,5 +35,5 @@ def test_rotated(orientation: int) -> None:
 
         with Image.open("Tests/images/hopper.pcd") as expected:
             assert_image_equal(
-                im, expected.rotate(90 if orientation == 1 else -90, expand=True)
+                im, expected.rotate(90 if orientation == 1 else 270, expand=True)
             )

--- a/src/PIL/PcdImagePlugin.py
+++ b/src/PIL/PcdImagePlugin.py
@@ -47,12 +47,17 @@ class PcdImageFile(ImageFile.ImageFile):
 
         self._mode = "RGB"
         self._size = (512, 768) if orientation in (1, 3) else (768, 512)
-        self.tile = [ImageFile._Tile("pcd", (0, 0) + self.size, 96 * 2048)]
+        self.tile = [ImageFile._Tile("pcd", (0, 0, 768, 512), 96 * 2048)]
+
+    def load_prepare(self) -> None:
+        if self._im is None and self.tile_post_rotate:
+            self.im = Image.core.new(self.mode, (768, 512))
+        ImageFile.ImageFile.load_prepare(self)
 
     def load_end(self) -> None:
         if self.tile_post_rotate:
             # Handle rotated PCDs
-            self.im = self.im.rotate(self.tile_post_rotate)
+            self.im = self.rotate(self.tile_post_rotate, expand=True).im
 
 
 #

--- a/src/PIL/PcdImagePlugin.py
+++ b/src/PIL/PcdImagePlugin.py
@@ -43,7 +43,7 @@ class PcdImageFile(ImageFile.ImageFile):
         if orientation == 1:
             self.tile_post_rotate = 90
         elif orientation == 3:
-            self.tile_post_rotate = -90
+            self.tile_post_rotate = 270
 
         self._mode = "RGB"
         self._size = (512, 768) if orientation in (1, 3) else (768, 512)


### PR DESCRIPTION
Sequel to #9086

Currently, PcdImagePlugin calls C `rotate` method on an image.
https://github.com/python-pillow/Pillow/blob/35f23fb78c7893d0a23436f448ae7c8ac99c0b66/src/PIL/PcdImagePlugin.py#L55

However, this was removed in #1941. So instead, let's use the Python `rotate` method.

I've also added `load_prepare()`, to ensure that the image is the size that the tile expects, similar to #8390.