### PR TITLE
Removed shebang lines and executable flags

### DIFF
--- a/Tests/createfontdatachunk.py
+++ b/Tests/createfontdatachunk.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from __future__ import annotations
 
 import base64

--- a/checks/32bit_segfault_check.py
+++ b/checks/32bit_segfault_check.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from __future__ import annotations
 
 import sys

--- a/checks/check_imaging_leaks.py
+++ b/checks/check_imaging_leaks.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from __future__ import annotations
 
 import sys


### PR DESCRIPTION
`checks/32bit_segfault_check.py` and `checks/check_imaging_leaks.py` have shebang lines and executable flags.

This adds those to the other scripts in the `checks` directory.