### PR TITLE
Limit length of read operation in ImageFont._load_pilfont_data()

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -492,6 +492,11 @@ def test_stroke_mask() -> None:
     assert mask.getpixel((42, 5)) == 255
 
 
+def test_load_invalid_file() -> None:
+    with pytest.raises(SyntaxError, match="Not a PILfont file"):
+        ImageFont.load("Tests/images/1_trns.png")
+
+
 def test_load_when_image_not_found() -> None:
     with tempfile.NamedTemporaryFile(delete=False) as tmp:
         pass

--- a/Tests/test_imagefontpil.py
+++ b/Tests/test_imagefontpil.py
@@ -30,6 +30,14 @@ def test_default_font(font: ImageFont.ImageFont) -> None:
     assert_image_equal_tofile(im, "Tests/images/default_font.png")
 
 
+def test_invalid_mode() -> None:
+    font = ImageFont.ImageFont()
+    fp = BytesIO()
+    with Image.open("Tests/images/hopper.png") as im:
+        with pytest.raises(TypeError, match="invalid font image mode"):
+            font._load_pilfont_data(fp, im)
+
+
 def test_without_freetype() -> None:
     original_core = ImageFont.core
     if features.check_module("freetype2"):

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -129,7 +129,7 @@ class ImageFont:
         if file.readline() != b"PILfont\n":
             msg = "Not a PILfont file"
             raise SyntaxError(msg)
-        file.readline().split(b";")
+        file.readline()
         self.info = []  # FIXME: should be a dictionary
         while True:
             s = file.readline()

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -126,7 +126,7 @@ class ImageFont:
 
     def _load_pilfont_data(self, file: IO[bytes], image: Image.Image) -> None:
         # read PILfont header
-        if file.readline() != b"PILfont\n":
+        if file.read(8) != b"PILfont\n":
             msg = "Not a PILfont file"
             raise SyntaxError(msg)
         file.readline()

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -125,6 +125,11 @@ class ImageFont:
             image.close()
 
     def _load_pilfont_data(self, file: IO[bytes], image: Image.Image) -> None:
+        # check image
+        if image.mode not in ("1", "L"):
+            msg = "invalid font image mode"
+            raise TypeError(msg)
+
         # read PILfont header
         if file.read(8) != b"PILfont\n":
             msg = "Not a PILfont file"
@@ -139,11 +144,6 @@ class ImageFont:
 
         # read PILfont metrics
         data = file.read(256 * 20)
-
-        # check image
-        if image.mode not in ("1", "L"):
-            msg = "invalid font image mode"
-            raise TypeError(msg)
 
         image.load()
 


### PR DESCRIPTION
A few `ImageFont._load_pilfont_data()` suggestions.

1. Remove an unnecessary `split()`
https://github.com/python-pillow/Pillow/blob/31eee6e5f706cd0a41ac26c45694adef1eca72a3/src/PIL/ImageFont.py#L132
2. Check `image` mode before reading from `file`, to return the error faster.
3. Rather than potentially reading an entire line,
https://github.com/python-pillow/Pillow/blob/31eee6e5f706cd0a41ac26c45694adef1eca72a3/src/PIL/ImageFont.py#L129
we can limit the length of the read operation by just using `read(8)`.