### PR TITLE
Removed unused code

### DIFF
--- a/Tests/test_font_crash.py
+++ b/Tests/test_font_crash.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from PIL import Image, ImageDraw, ImageFont
+from PIL import ImageFont
 
 from .helper import skip_unless_feature
 
@@ -12,10 +12,6 @@ class TestFontCrash:
         # from fuzzers.fuzz_font
         font.getbbox("ABC")
         font.getmask("test text")
-        with Image.new(mode="RGBA", size=(200, 200)) as im:
-            draw = ImageDraw.Draw(im)
-            draw.multiline_textbbox((10, 10), "ABC\nAaaa", font, stroke_width=2)
-            draw.text((10, 10), "Test Text", font=font, fill="#000")
 
     @skip_unless_feature("freetype2")
     def test_segfault(self) -> None:


### PR DESCRIPTION
In Tests/test_font_crash.py, there is some code that is never run because
https://github.com/python-pillow/Pillow/blob/31eee6e5f706cd0a41ac26c45694adef1eca72a3/Tests/test_font_crash.py#L14
raises `OSError: Bitmap missing for glyph`, and the subsequent lines are never reached.