### PR TITLE
Do not unnecessarily update FLI __offset

### DIFF
--- a/src/PIL/FliImagePlugin.py
+++ b/src/PIL/FliImagePlugin.py
@@ -77,8 +77,7 @@ class FliImageFile(ImageFile.ImageFile):
 
         if i16(s, 4) == 0xF100:
             # prefix chunk; ignore it
-            self.__offset = self.__offset + i32(s)
-            self.fp.seek(self.__offset)
+            self.fp.seek(self.__offset + i32(s))
             s = self.fp.read(16)
 
         if i16(s, 4) == 0xF1FA:


### PR DESCRIPTION
In FliImagePlugin, `self.__offset` is initially set to 128, and may then be updated to a different value.

https://github.com/python-pillow/Pillow/blob/31eee6e5f706cd0a41ac26c45694adef1eca72a3/src/PIL/FliImagePlugin.py#L76-L81

But before it is used again, and before the end of `__init__()`, it is set back to 128.

https://github.com/python-pillow/Pillow/blob/31eee6e5f706cd0a41ac26c45694adef1eca72a3/src/PIL/FliImagePlugin.py#L108
https://github.com/python-pillow/Pillow/blob/31eee6e5f706cd0a41ac26c45694adef1eca72a3/src/PIL/FliImagePlugin.py#L128-L132
https://github.com/python-pillow/Pillow/blob/31eee6e5f706cd0a41ac26c45694adef1eca72a3/src/PIL/FliImagePlugin.py#L137-L143

So it seems simpler to just keep `self.__offset` at 128.