### PR TITLE
Revert "Removed unused code"

### DIFF
--- a/Tests/test_font_crash.py
+++ b/Tests/test_font_crash.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from PIL import ImageFont
+from PIL import Image, ImageDraw, ImageFont
 
 from .helper import skip_unless_feature
 
@@ -12,6 +12,10 @@ class TestFontCrash:
         # from fuzzers.fuzz_font
         font.getbbox("ABC")
         font.getmask("test text")
+        with Image.new(mode="RGBA", size=(200, 200)) as im:
+            draw = ImageDraw.Draw(im)
+            draw.multiline_textbbox((10, 10), "ABC\nAaaa", font, stroke_width=2)
+            draw.text((10, 10), "Test Text", font=font, fill="#000")
 
     @skip_unless_feature("freetype2")
     def test_segfault(self) -> None:

--- a/Tests/test_font_crash.py
+++ b/Tests/test_font_crash.py
@@ -9,7 +9,8 @@ from .helper import skip_unless_feature
 
 class TestFontCrash:
     def _fuzz_font(self, font: ImageFont.FreeTypeFont) -> None:
-        # from fuzzers.fuzz_font
+        # Copy of the code from fuzz_font() in Tests/oss-fuzz/fuzzers.py
+        # that triggered a problem when fuzzing
         font.getbbox("ABC")
         font.getmask("test text")
         with Image.new(mode="RGBA", size=(200, 200)) as im:


### PR DESCRIPTION
Reverts #9182 after [comments](https://github.com/python-pillow/Pillow/commit/208e9b52dc04b90a27e80a45eeedea4a419a44bd#commitcomment-165065848) that the unused code should be kept to better replicate fuzzing.