### PR TITLE
Improve WalImageFile test coverage

### DIFF
--- a/Tests/test_file_wal.py
+++ b/Tests/test_file_wal.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from io import BytesIO
+
 from PIL import WalImageFile
 
 from .helper import assert_image_equal_tofile
@@ -13,10 +15,20 @@ def test_open() -> None:
         assert im.format_description == "Quake2 Texture"
         assert im.mode == "P"
         assert im.size == (128, 128)
+        assert "next_name" not in im.info
 
         assert isinstance(im, WalImageFile.WalImageFile)
 
         assert_image_equal_tofile(im, "Tests/images/hopper_wal.png")
+
+
+def test_next_name() -> None:
+    with open(TEST_FILE, "rb") as fp:
+        data = bytearray(fp.read())
+    data[56:60] = b"Test"
+    f = BytesIO(data)
+    with WalImageFile.open(f) as im:
+        assert im.info["next_name"] == b"Test"
 
 
 def test_load() -> None:

--- a/src/PIL/WalImageFile.py
+++ b/src/PIL/WalImageFile.py
@@ -49,8 +49,7 @@ class WalImageFile(ImageFile.ImageFile):
 
         # strings are null-terminated
         self.info["name"] = header[:32].split(b"\0", 1)[0]
-        next_name = header[56 : 56 + 32].split(b"\0", 1)[0]
-        if next_name:
+        if next_name := header[56 : 56 + 32].split(b"\0", 1)[0]:
             self.info["next_name"] = next_name
 
     def load(self) -> Image.core.PixelAccess | None:


### PR DESCRIPTION
Adds coverage for the line missing at https://app.codecov.io/gh/python-pillow/Pillow/blob/main/src%2FPIL%2FWalImageFile.py

While I'm here, I've also added use of the walrus operator.