### PR TITLE
Use _ensure_mutable()

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2070,9 +2070,7 @@ class Image:
         :param value: The pixel value.
         """
 
-        if self.readonly:
-            self._copy()
-        self.load()
+        self._ensure_mutable()
 
         if (
             self.mode in ("P", "PA")

--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -76,9 +76,7 @@ class ImageDraw:
            must be the same as the image mode.  If omitted, the mode
            defaults to the mode of the image.
         """
-        im.load()
-        if im.readonly:
-            im._copy()  # make it writeable
+        im._ensure_mutable()
         blend = 0
         if mode is None:
             mode = im.mode


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/b7e0570cb11901fbfdc9d5bc1ae2918cb32cc9c8/src/PIL/Image.py#L2073-L2075
and
https://github.com/python-pillow/Pillow/blob/b7e0570cb11901fbfdc9d5bc1ae2918cb32cc9c8/src/PIL/ImageDraw.py#L79-L81
are virtually identical to
https://github.com/python-pillow/Pillow/blob/b7e0570cb11901fbfdc9d5bc1ae2918cb32cc9c8/src/PIL/Image.py#L629-L633

So they can be replaced with calls to `_ensure_mutable()`