### PR TITLE
Update harfbuzz to 11.5.0

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -94,7 +94,7 @@ ARCHIVE_SDIR=pillow-depends-main
 # annotations have a source code patch that is required for some platforms. If
 # you change those versions, ensure the patch is also updated.
 FREETYPE_VERSION=2.13.3
-HARFBUZZ_VERSION=11.4.5
+HARFBUZZ_VERSION=11.5.0
 LIBPNG_VERSION=1.6.50
 JPEGTURBO_VERSION=3.1.2
 OPENJPEG_VERSION=2.5.3

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -116,7 +116,7 @@ V = {
     "BROTLI": "1.1.0",
     "FREETYPE": "2.14.1",
     "FRIBIDI": "1.0.16",
-    "HARFBUZZ": "11.4.5",
+    "HARFBUZZ": "11.5.0",
     "JPEGTURBO": "3.1.2",
     "LCMS2": "2.17",
     "LIBAVIF": "1.3.0",


### PR DESCRIPTION
harfbuzz 11.5.0 has been released - https://github.com/harfbuzz/harfbuzz/releases/tag/11.5.0