### PR TITLE
Seek past BeginBinary data when parsing EPS metadata

### DIFF
--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -197,6 +197,14 @@ def test_load_long_binary_data(prefix: bytes) -> None:
         assert img.format == "EPS"
 
 
+def test_begin_binary() -> None:
+    with open("Tests/images/eps/binary_preview_map.eps", "rb") as fp:
+        data = bytearray(fp.read())
+    data[76875 : 76875 + 11] = b"%" * 11
+    with Image.open(io.BytesIO(data)) as img:
+        assert img.size == (399, 480)
+
+
 @mark_if_feature_version(
     pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
 )

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -354,6 +354,9 @@ class EpsImageFile(ImageFile.ImageFile):
                 read_comment(s)
             elif bytes_mv[:9] == b"%%Trailer":
                 trailer_reached = True
+            elif bytes_mv[:14] == b"%%BeginBinary:":
+                bytecount = int(byte_arr[14:bytes_read])
+                self.fp.seek(bytecount, os.SEEK_CUR)
             bytes_read = 0
 
         # A "BoundingBox" is always required,


### PR DESCRIPTION
Resolves #9210

Page 44 of https://web.mit.edu/PostScript/Adobe/Documents/5001.DSC_Spec.pdf
> **%%BeginBinary:** \<bytecount>
> \<bytecount> ::= <uint>
> **%%EndBinary** (no keywords)
> These comments are used in a manner similar to the %%Begin(End)Data: comments. The %%Begin(End)Binary: comments are designed to allow a document manager to effectively ignore any binary data these comments encapsulate.

When encountering '%%BeginBinary:', rather than continuing to [loop](https://github.com/python-pillow/Pillow/blob/0013f9590a5d5b3e08c7cd152843d18ff490dd40/src/PIL/EpsImagePlugin.py#L250) through data and trying to read the mode, size and bounding box, just seek past it.