### PR TITLE
Python 3.9 wheels are no longer needed

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -54,7 +54,7 @@ jobs:
             platform: macos
             os: macos-13
             cibw_arch: x86_64
-            build: "cp3{9,10,11}*"
+            build: "cp3{10,11}*"
             macosx_deployment_target: "10.10"
           - name: "macOS 10.13 x86_64"
             platform: macos


### PR DESCRIPTION
Python 3.9 wheels are no longer built by the macOS 10.10 wheels job - https://github.com/python-pillow/Pillow/actions/runs/17784488122/job/50549409613#step:5:22173

They are no longer needed either - https://github.com/python-pillow/Pillow/pull/9119