### PR TITLE
Updated FreeType to 2.14.1 on macOS wheels

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -93,7 +93,11 @@ ARCHIVE_SDIR=pillow-depends-main
 # Package versions for fresh source builds. Version numbers with "Patched"
 # annotations have a source code patch that is required for some platforms. If
 # you change those versions, ensure the patch is also updated.
-FREETYPE_VERSION=2.13.3
+if [[ -n "$IOS_SDK" ]]; then
+  FREETYPE_VERSION=2.13.1
+else
+  FREETYPE_VERSION=2.14.1
+fi
 HARFBUZZ_VERSION=11.5.0
 LIBPNG_VERSION=1.6.50
 JPEGTURBO_VERSION=3.1.2
@@ -314,6 +318,10 @@ function build {
 
     if [[ -n "$IS_MACOS" ]]; then
         # Custom freetype build
+        if [[ -z "$IOS_SDK" ]]; then
+          build_simple sed 4.9 https://mirrors.middlendian.com/gnu/sed
+        fi
+
         build_simple freetype $FREETYPE_VERSION https://download.savannah.gnu.org/releases/freetype tar.gz --with-harfbuzz=no
     else
         build_freetype


### PR DESCRIPTION
freetype 2.14.1 has been released - https://freetype.org/