### PR TITLE
Increase buffer size to speedup `Image.tobytes()`

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -793,7 +793,11 @@ class Image:
 
         from . import ImageFile
 
-        bufsize = max(ImageFile.MAXBLOCK, self.size[0] * 4)  # see RawEncode.c
+        mode_descr = ImageMode.getmode(self.mode)
+        bytes_per_value = int(mode_descr.typestr[-1])
+        channels = len(mode_descr.bands)
+        bufsize = self.height * self.width * channels * bytes_per_value
+        bufsize = max(ImageFile.MAXBLOCK, bufsize)  # see RawEncode.c
 
         output = []
         while True:


### PR DESCRIPTION
`Image.tobytes()` is used in the [`__array_interface__`](https://github.com/python-pillow/Pillow/blob/d42e537efeb1bd11cd9df1db1c7d7a6dc529d9e2/src/PIL/Image.py#L716-L726) when images are passed to numpy using `np.asarray(...)`. Converting PIL images to numpy is very common, e.g. ML libraries like [vllm](https://github.com/vllm-project/vllm/blob/273690a50ac2a5fa79fa7acc5077e49aa1af427e/vllm/multimodal/hasher.py#L37) or some pytorch dataloaders also commonly rely on this process.

For large images this can be quite slow and can become a bottleneck since `.tobytes()` encodes the data in fixed chunks which need to be joined afterwards:
https://github.com/python-pillow/Pillow/blob/d42e537efeb1bd11cd9df1db1c7d7a6dc529d9e2/src/PIL/Image.py#L798-L808

This PR increases the buffersize to match the image size when using the default raw encoder instead of using a fixed value. In most cases this allows to encode the image in a single chunk which speeds up encoding of large images by **over 2x**:

| image size  | main    | this PR | main / this PR |
| ----------- | ------- | ------- | -------------- |
| 128x128     | 4.54 μs | 4.65 μs | 0.98           |
| 256x256     | 18.2 μs | 13.2 μs | 1.38           |
| 512x512     | 60.2 μs | 46.1 μs | 1.31           |
| 1024x1024   | 382 μs  | 245 μs  | 1.56           |
| 2048x2048   | 1.97 ms | 1.16 ms | 1.70           |
| 4096x4096   | 10.6 ms | 5.49 ms | 1.93           |
| 8192x8192   | 54.3 ms | 22.8 ms | 2.38           |
| 16384x16384 | 230 ms  | 92.3 ms | 2.49           |

Benchmarked with the following ipython script:
```python
import numpy as np
from PIL import Image

for size in (128, 256, 512, 1024, 2048, 4096, 8192, 16384):
    img = np.random.randint(0, 256, size=(size, size, 3), dtype=np.uint8)
    img = Image.fromarray(img)

    print(f"{size}x{size}")
    %timeit img.tobytes()
```
