### PR TITLE
Removed Image _expand()

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -284,33 +284,6 @@ class TestImage:
         assert item is not None
         assert item != num
 
-    def test_expand_x(self) -> None:
-        # Arrange
-        im = hopper()
-        orig_size = im.size
-        xmargin = 5
-
-        # Act
-        im = im._expand(xmargin)
-
-        # Assert
-        assert im.size[0] == orig_size[0] + 2 * xmargin
-        assert im.size[1] == orig_size[1] + 2 * xmargin
-
-    def test_expand_xy(self) -> None:
-        # Arrange
-        im = hopper()
-        orig_size = im.size
-        xmargin = 5
-        ymargin = 3
-
-        # Act
-        im = im._expand(xmargin, ymargin)
-
-        # Assert
-        assert im.size[0] == orig_size[0] + 2 * xmargin
-        assert im.size[1] == orig_size[1] + 2 * ymargin
-
     def test_getbands(self) -> None:
         # Assert
         assert hopper("RGB").getbands() == ("R", "G", "B")

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1336,12 +1336,6 @@ class Image:
         """
         pass
 
-    def _expand(self, xmargin: int, ymargin: int | None = None) -> Image:
-        if ymargin is None:
-            ymargin = xmargin
-        self.load()
-        return self._new(self.im.expand(xmargin, ymargin))
-
     def filter(self, filter: ImageFilter.Filter | type[ImageFilter.Filter]) -> Image:
         """
         Filters this image using the given filter.  For a list of


### PR DESCRIPTION
I suggest removing this unused function

https://github.com/python-pillow/Pillow/blob/d42e537efeb1bd11cd9df1db1c7d7a6dc529d9e2/src/PIL/Image.py#L1339-L1343

The C `expand` method is still used [elsewhere.](https://github.com/python-pillow/Pillow/blob/d42e537efeb1bd11cd9df1db1c7d7a6dc529d9e2/src/PIL/ImageFilter.py#L105-L109)