### PR TITLE
Remove use of sudo from libavif and raqm install scripts

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -51,10 +51,10 @@ pushd depends && ./install_webp.sh && popd
 pushd depends && ./install_imagequant.sh && popd
 
 # raqm
-pushd depends && ./install_raqm.sh && popd
+pushd depends && sudo ./install_raqm.sh && popd
 
 # libavif
-pushd depends && ./install_libavif.sh && popd
+pushd depends && sudo ./install_libavif.sh && popd
 
 # extra test images
 pushd depends && ./install_extra_test_images.sh && popd

--- a/depends/install_libavif.sh
+++ b/depends/install_libavif.sh
@@ -59,6 +59,6 @@ cmake \
     "${LIBAVIF_CMAKE_FLAGS[@]}" \
     .
 
-sudo make install
+make install
 
 popd

--- a/depends/install_raqm.sh
+++ b/depends/install_raqm.sh
@@ -8,6 +8,6 @@ archive=libraqm-0.10.3
 
 pushd $archive
 
-meson build --prefix=/usr && sudo ninja -C build install
+meson build --prefix=/usr && ninja -C build install
 
 popd


### PR DESCRIPTION
gentoo has started raising an error in the docker-images repository - https://github.com/python-pillow/docker-images/actions/runs/18206199669/job/51837059727#step:6:2183
> 300.9 sudo: PAM account management error: Authentication service cannot retrieve authentication info
> 300.9 sudo: a password is required

This is happening when using `sudo` inside depends/install_libavif.sh or depends/install_raqm.sh. Testing, I've found that if we stop using `sudo`, the script succeeds.

This PR suggests not forcing users to use `sudo`, by removing the command from those scripts.