### PR TITLE
Build Python 3.14 on macOS 10.15

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -60,13 +60,13 @@ jobs:
             platform: macos
             os: macos-13
             cibw_arch: x86_64
-            build: "cp3{12,13,14}*"
+            build: "cp3{12,13}*"
             macosx_deployment_target: "10.13"
           - name: "macOS 10.15 x86_64"
             platform: macos
             os: macos-13
             cibw_arch: x86_64
-            build: "pp3*"
+            build: "{cp314,pp3}*"
             macosx_deployment_target: "10.15"
           - name: "macOS arm64"
             platform: macos


### PR DESCRIPTION
macOS 10.15 should be used for Python 3.14 - https://github.com/python/cpython/pull/137753