### PR TITLE
Do not allow negative offset with memory mapping

### DIFF
--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -164,6 +164,11 @@ class TestImageFile:
         with pytest.raises(OSError):
             p.close()
 
+    def test_negative_offset(self) -> None:
+        with Image.open("Tests/images/raw_negative_stride.bin") as im:
+            with pytest.raises(ValueError, match="Tile offset cannot be negative"):
+                im.load()
+
     def test_no_format(self) -> None:
         buf = BytesIO(b"\x00" * 255)
 

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -313,6 +313,9 @@ class ImageFile(Image.Image):
                 and args[0] == self.mode
                 and args[0] in Image._MAPMODES
             ):
+                if offset < 0:
+                    msg = "Tile offset cannot be negative"
+                    raise ValueError(msg)
                 try:
                     # use mmap, if possible
                     import mmap


### PR DESCRIPTION
Before https://github.com/python-pillow/Pillow/pull/9046 allowed memory mapping to be used with [raw_negative_stride.bin](https://github.com/python-pillow/Pillow/blob/main/Tests/images/raw_negative_stride.bin), the negative offset in the tile triggered
```pytb
Traceback (most recent call last):
  File "PIL/ImageFile.py", line 341, in load
    seek(offset)
OSError: [Errno 22] Invalid argument
```

Now however, it doesn't. This PR raises a specific error when a negative offset is used with memory mapping.