### PR TITLE
Removed unused access for I;32L and I;32B

### DIFF
--- a/src/libImaging/Access.c
+++ b/src/libImaging/Access.c
@@ -12,8 +12,8 @@
 #include "Imaging.h"
 
 /* use make_hash.py from the pillow-scripts repository to calculate these values */
-#define ACCESS_TABLE_SIZE 35
-#define ACCESS_TABLE_HASH 8940
+#define ACCESS_TABLE_SIZE 23
+#define ACCESS_TABLE_HASH 28677
 
 static struct ImagingAccessInstance access_table[ACCESS_TABLE_SIZE];
 
@@ -87,30 +87,6 @@ get_pixel_32(Imaging im, int x, int y, void *color) {
     memcpy(color, &im->image32[y][x], sizeof(INT32));
 }
 
-static void
-get_pixel_32L(Imaging im, int x, int y, void *color) {
-    UINT8 *in = (UINT8 *)&im->image[y][x * 4];
-#ifdef WORDS_BIGENDIAN
-    INT32 out =
-        in[0] + ((INT32)in[1] << 8) + ((INT32)in[2] << 16) + ((INT32)in[3] << 24);
-    memcpy(color, &out, sizeof(out));
-#else
-    memcpy(color, in, sizeof(INT32));
-#endif
-}
-
-static void
-get_pixel_32B(Imaging im, int x, int y, void *color) {
-    UINT8 *in = (UINT8 *)&im->image[y][x * 4];
-#ifdef WORDS_BIGENDIAN
-    memcpy(color, in, sizeof(INT32));
-#else
-    INT32 out =
-        in[3] + ((INT32)in[2] << 8) + ((INT32)in[1] << 16) + ((INT32)in[0] << 24);
-    memcpy(color, &out, sizeof(out));
-#endif
-}
-
 /* store individual pixel */
 
 static void
@@ -129,21 +105,6 @@ put_pixel_16B(Imaging im, int x, int y, const void *color) {
     UINT8 *out = (UINT8 *)&im->image8[y][x + x];
     out[0] = in[1];
     out[1] = in[0];
-}
-
-static void
-put_pixel_32L(Imaging im, int x, int y, const void *color) {
-    memcpy(&im->image8[y][x * 4], color, 4);
-}
-
-static void
-put_pixel_32B(Imaging im, int x, int y, const void *color) {
-    const char *in = color;
-    UINT8 *out = (UINT8 *)&im->image8[y][x * 4];
-    out[0] = in[3];
-    out[1] = in[2];
-    out[2] = in[1];
-    out[3] = in[0];
 }
 
 static void
@@ -174,8 +135,6 @@ ImagingAccessInit(void) {
 #else
     ADD("I;16N", get_pixel_16L, put_pixel_16L);
 #endif
-    ADD("I;32L", get_pixel_32L, put_pixel_32L);
-    ADD("I;32B", get_pixel_32B, put_pixel_32B);
     ADD("F", get_pixel_32, put_pixel_32);
     ADD("P", get_pixel_8, put_pixel_8);
     ADD("PA", get_pixel_32_2bands, put_pixel_32);


### PR DESCRIPTION
Access.c currently allows you to access data in I;32L and I;32B image modes.

https://github.com/python-pillow/Pillow/blob/6d6f0496d9bc9b044d2ce8542bcc1c0b31dbf845/src/libImaging/Access.c#L177-L178

However, the only other place these modes (not rawmodes) exist is in ImageMode.py, so this access serves no purpose.

In simpler terms, you can't create an image in these modes, so we never need to access pixel data in them.
```python
>>> from PIL import Image
>>> Image.new("I;32B", (1, 1))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/Image.py", line 3101, in new
    return im._new(core.fill(mode, size, color))
ValueError: unrecognized image mode
>>> Image.new("I;32L", (1, 1))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/Image.py", line 3101, in new
    return im._new(core.fill(mode, size, color))
ValueError: unrecognized image mode
```