### PR TITLE
Wheels CI: Check number of expected dists

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -306,20 +306,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           attestations: true
-
-  count-dists:
-    needs: [build-native-wheels, windows, sdist]
-    runs-on: ubuntu-latest
-    name: Count dists
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: dist-*
-          path: dist
-          merge-multiple: true
-      - name: "What did we get?"
-        run: |
-          ls -alR
-          echo "Number of dists, should be $EXPECTED_DISTS:"
-          ls -1 dist | wc -l
-          files=$(ls dist 2>/dev/null | wc -l) && [ "$files" -eq $EXPECTED_DISTS ] || exit 1


### PR DESCRIPTION
Sometimes changes to cibuildwheel (such as [#9059](https://github.com/python-pillow/Pillow/pull/9059)) change the defaults and more or less wheels are built, and we don't notice until we happen to spot an unnecessary wheel, or someone reports a missing wheel for their system.

This adds a hardcoded number of dists created by the CI (`EXPECTED_DISTS`), and fails if it's different to what's actually produced.

* If it changes when expected (as would happen for [#9214](https://github.com/python-pillow/Pillow/pull/9214), [#9030](https://github.com/python-pillow/Pillow/pull/9030), [#9031](https://github.com/python-pillow/Pillow/pull/9031)), all good, we can change the constant.
* Otherwise unexpected changes (as would happen for [#9010](https://github.com/python-pillow/Pillow/pull/9010)) can be investigated first.

This is inspired by the coverage.py CI: https://github.com/nedbat/coveragepy/blob/8827634adcfe4a4baf71cf0b3e1cd967cf9b14a2/.github/workflows/publish.yml#L76-L81

To demonstrate, right now it will fail:
```
Number of dists, should be 98:
91
```

<img width="632" height="377" alt="image" src="https://github.com/user-attachments/assets/1fe84287-f06f-4233-a20c-3cc9edcb12ab" />

https://github.com/python-pillow/Pillow/actions/runs/18407980303/job/52459987053?pr=9239