### PR TITLE
Run sdist when scheduled, but do not upload to scientific-python-nightly-wheels index

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -232,7 +232,7 @@ jobs:
           path: winbuild\build\bin\fribidi*
 
   sdist:
-    if: github.event_name != 'schedule'
+    if: github.event_name != 'schedule' || github.repository_owner == 'python-pillow'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
@@ -277,7 +277,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v5
         with:
-          pattern: dist-*
+          pattern: dist-*.whl
           path: dist
           merge-multiple: true
       - name: Upload wheels to scientific-python-nightly-wheels


### PR DESCRIPTION
Alternative to https://github.com/python-pillow/Pillow/pull/9244

Normally, our scheduled Wheels jobs update wheels to scientific-python-nightly-wheels - https://github.com/python-pillow/Pillow/actions/runs/18331606908

Our most recent scheduled Wheels jobs did not - https://github.com/python-pillow/Pillow/actions/runs/18437781793

This is because https://github.com/python-pillow/Pillow/pull/9239 made 'scientific-python-nightly-wheels-publish' require 'count-dists', which requires 'sdist', but 'sdist' does not run when scheduled.

This PR runs 'sdist' when scheduled, fixing the problem, but does not include the file in the uploads to the scientific-python-nightly-wheels index.