### PR TITLE
Use macos-latest for iOS arm64 simulator

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -100,7 +100,7 @@ jobs:
             cibw_arch: arm64_iphoneos
           - name: "iOS arm64 simulator"
             platform: ios
-            os: macos-14
+            os: macos-latest
             cibw_arch: arm64_iphonesimulator
           - name: "iOS x86_64 simulator"
             platform: ios


### PR DESCRIPTION
Testing, I find that #9161 can now be reverted.