### PR TITLE
ImagingHistogramInstance can use two bands

### DIFF
--- a/src/libImaging/Imaging.h
+++ b/src/libImaging/Imaging.h
@@ -148,7 +148,7 @@ struct ImagingAccessInstance {
 struct ImagingHistogramInstance {
     /* Format */
     char mode[IMAGING_MODE_LENGTH]; /* Band names (of corresponding source image) */
-    int bands;                      /* Number of bands (1, 3, or 4) */
+    int bands;                      /* Number of bands (1, 2, 3, or 4) */
 
     /* Data */
     long *histogram; /* Histogram (bands*256 longs) */


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/c60b36d0a738fcfe0fc16ada872564426b5b0748/src/libImaging/Imaging.h#L148-L151

#9054 corrected the output for two band histograms, so this comment should be updated to reflect that 2 is also a possible value for the number of bands.