### PR TITLE
Corrected scientific-python-nightly-wheels pattern

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -277,7 +277,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v5
         with:
-          pattern: dist-*.whl
+          pattern: dist-!(sdist)*
           path: dist
           merge-multiple: true
       - name: Upload wheels to scientific-python-nightly-wheels


### PR DESCRIPTION
In https://github.com/python-pillow/Pillow/pull/9248, I added the following `pattern`
https://github.com/python-pillow/Pillow/blob/c60b36d0a738fcfe0fc16ada872564426b5b0748/.github/workflows/wheels.yml#L278-L280

However, this was incorrect, as the individual wheels are zipped together into artifacts. So you can see at https://github.com/python-pillow/Pillow/actions/runs/18478193360/job/52651536616#step:2:14 that this didn't match any artifacts.

This PR updates it to `pattern: dist-!(sdist)*`