### PR TITLE
Use macos-14 for iOS arm64 simulator

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -100,7 +100,7 @@ jobs:
             cibw_arch: arm64_iphoneos
           - name: "iOS arm64 simulator"
             platform: ios
-            os: macos-latest
+            os: macos-14
             cibw_arch: arm64_iphonesimulator
           - name: "iOS x86_64 simulator"
             platform: ios


### PR DESCRIPTION
Reverts python-pillow/Pillow#9250.

See https://github.com/python-pillow/Pillow/issues/9178#issuecomment-3407202630 for more info.