### PR TITLE
Simplify code now that I;16* modes are the only IMAGING_TYPE_SPECIAL

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -543,12 +543,7 @@ getpixel(Imaging im, ImagingAccess access, int x, int y) {
         case IMAGING_TYPE_FLOAT32:
             return PyFloat_FromDouble(pixel.f);
         case IMAGING_TYPE_SPECIAL:
-            if (im->bands == 1) {
-                return PyLong_FromLong(pixel.h);
-            } else {
-                return Py_BuildValue("BBB", pixel.b[0], pixel.b[1], pixel.b[2]);
-            }
-            break;
+            return PyLong_FromLong(pixel.h);
     }
 
     /* unknown type */
@@ -665,26 +660,10 @@ getink(PyObject *color, Imaging im, char *ink) {
             memcpy(ink, &ftmp, sizeof(ftmp));
             return ink;
         case IMAGING_TYPE_SPECIAL:
-            if (isModeI16(im->mode)) {
-                ink[0] = (UINT8)r;
-                ink[1] = (UINT8)(r >> 8);
-                ink[2] = ink[3] = 0;
-                return ink;
-            } else {
-                if (rIsInt) {
-                    b = (UINT8)(r >> 16);
-                    g = (UINT8)(r >> 8);
-                    r = (UINT8)r;
-                } else if (tupleSize != 3) {
-                    PyErr_SetString(
-                        PyExc_TypeError,
-                        "color must be int, or tuple of one or three elements"
-                    );
-                    return NULL;
-                } else if (!PyArg_ParseTuple(color, "iiL", &b, &g, &r)) {
-                    return NULL;
-                }
-            }
+            ink[0] = (UINT8)r;
+            ink[1] = (UINT8)(r >> 8);
+            ink[2] = ink[3] = 0;
+            return ink;
     }
 
     PyErr_SetString(PyExc_ValueError, wrong_mode);

--- a/src/libImaging/Geometry.c
+++ b/src/libImaging/Geometry.c
@@ -714,14 +714,7 @@ getfilter(Imaging im, int filterid) {
                     case IMAGING_TYPE_UINT8:
                         return nearest_filter8;
                     case IMAGING_TYPE_SPECIAL:
-                        switch (im->pixelsize) {
-                            case 1:
-                                return nearest_filter8;
-                            case 2:
-                                return nearest_filter16;
-                            case 4:
-                                return nearest_filter32;
-                        }
+                        return nearest_filter16;
                 }
             } else {
                 return nearest_filter32;


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/9053 removed BGR;15, BGR;16 and BGR;24, so

https://github.com/python-pillow/Pillow/blob/5122c8356d6fa8f4a0d8449e8875734bb5d4d966/src/libImaging/Storage.c#L133-L141

is the only IMAGING_TYPE_SPECIAL left.