### PR TITLE
Use different variables for Image and ImageFile instances

### DIFF
--- a/Tests/test_file_mic.py
+++ b/Tests/test_file_mic.py
@@ -22,10 +22,10 @@ def test_sanity() -> None:
 
         # Adjust for the gamma of 2.2 encoded into the file
         lut = ImagePalette.make_gamma_lut(1 / 2.2)
-        im = Image.merge("RGBA", [chan.point(lut) for chan in im.split()])
+        im1 = Image.merge("RGBA", [chan.point(lut) for chan in im.split()])
 
         im2 = hopper("RGBA")
-        assert_image_similar(im, im2, 10)
+        assert_image_similar(im1, im2, 10)
 
 
 def test_n_frames() -> None:

--- a/Tests/test_file_mpo.py
+++ b/Tests/test_file_mpo.py
@@ -300,12 +300,12 @@ def test_save_all() -> None:
             im_reloaded.seek(1)
             assert_image_similar(im, im_reloaded, 30)
 
-    im = Image.new("RGB", (1, 1))
+    im_rgb = Image.new("RGB", (1, 1))
     for colors in (("#f00",), ("#f00", "#0f0")):
         append_images = [Image.new("RGB", (1, 1), color) for color in colors]
-        im_reloaded = roundtrip(im, save_all=True, append_images=append_images)
+        im_reloaded = roundtrip(im_rgb, save_all=True, append_images=append_images)
 
-        assert_image_equal(im, im_reloaded)
+        assert_image_equal(im_rgb, im_reloaded)
         assert isinstance(im_reloaded, MpoImagePlugin.MpoImageFile)
         assert im_reloaded.mpinfo is not None
         assert im_reloaded.mpinfo[45056] == b"0100"
@@ -315,7 +315,7 @@ def test_save_all() -> None:
             assert_image_similar(im_reloaded, im_expected, 1)
 
     # Test that a single frame image will not be saved as an MPO
-    jpg = roundtrip(im, save_all=True)
+    jpg = roundtrip(im_rgb, save_all=True)
     assert "mp" not in jpg.info
 
 

--- a/Tests/test_file_sun.py
+++ b/Tests/test_file_sun.py
@@ -84,8 +84,8 @@ def test_rgbx() -> None:
 
     with Image.open(io.BytesIO(data)) as im:
         r, g, b = im.split()
-        im = Image.merge("RGB", (b, g, r))
-        assert_image_equal_tofile(im, os.path.join(EXTRA_DIR, "32bpp.png"))
+        im_rgb = Image.merge("RGB", (b, g, r))
+        assert_image_equal_tofile(im_rgb, os.path.join(EXTRA_DIR, "32bpp.png"))
 
 
 @pytest.mark.skipif(

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -764,9 +764,9 @@ class TestFileTiff:
 
         # Test appending images
         mp = BytesIO()
-        im = Image.new("RGB", (100, 100), "#f00")
+        im_rgb = Image.new("RGB", (100, 100), "#f00")
         ims = [Image.new("RGB", (100, 100), color) for color in ["#0f0", "#00f"]]
-        im.copy().save(mp, format="TIFF", save_all=True, append_images=ims)
+        im_rgb.copy().save(mp, format="TIFF", save_all=True, append_images=ims)
 
         mp.seek(0, os.SEEK_SET)
         with Image.open(mp) as reread:
@@ -778,7 +778,7 @@ class TestFileTiff:
             yield from ims
 
         mp = BytesIO()
-        im.save(mp, format="TIFF", save_all=True, append_images=im_generator(ims))
+        im_rgb.save(mp, format="TIFF", save_all=True, append_images=im_generator(ims))
 
         mp.seek(0, os.SEEK_SET)
         with Image.open(mp) as reread:

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -175,13 +175,13 @@ def test_change_stripbytecounts_tag_type(tmp_path: Path) -> None:
         del info[278]
 
         # Resize the image so that STRIPBYTECOUNTS will be larger than a SHORT
-        im = im.resize((500, 500))
-        info[TiffImagePlugin.IMAGEWIDTH] = im.width
+        im_resized = im.resize((500, 500))
+        info[TiffImagePlugin.IMAGEWIDTH] = im_resized.width
 
         # STRIPBYTECOUNTS can be a SHORT or a LONG
         info.tagtype[TiffImagePlugin.STRIPBYTECOUNTS] = TiffTags.SHORT
 
-        im.save(out, tiffinfo=info)
+        im_resized.save(out, tiffinfo=info)
 
     with Image.open(out) as reloaded:
         assert isinstance(reloaded, TiffImagePlugin.TiffImageFile)

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -613,8 +613,8 @@ class TestImage:
         assert im.getpixel((0, 0)) == 0
         assert im.getpixel((255, 255)) == 255
         with Image.open(target_file) as target:
-            target = target.convert(mode)
-        assert_image_equal(im, target)
+            im_target = target.convert(mode)
+        assert_image_equal(im, im_target)
 
     def test_radial_gradient_wrong_mode(self) -> None:
         # Arrange
@@ -638,8 +638,8 @@ class TestImage:
         assert im.getpixel((0, 0)) == 255
         assert im.getpixel((128, 128)) == 0
         with Image.open(target_file) as target:
-            target = target.convert(mode)
-        assert_image_equal(im, target)
+            im_target = target.convert(mode)
+        assert_image_equal(im, im_target)
 
     def test_register_extensions(self) -> None:
         test_format = "a"
@@ -663,20 +663,20 @@ class TestImage:
             assert_image_equal(im, im.remap_palette(list(range(256))))
 
         # Test identity transform with an RGBA palette
-        im = Image.new("P", (256, 1))
+        im_p = Image.new("P", (256, 1))
         for x in range(256):
-            im.putpixel((x, 0), x)
-        im.putpalette(list(range(256)) * 4, "RGBA")
-        im_remapped = im.remap_palette(list(range(256)))
-        assert_image_equal(im, im_remapped)
-        assert im.palette is not None
+            im_p.putpixel((x, 0), x)
+        im_p.putpalette(list(range(256)) * 4, "RGBA")
+        im_remapped = im_p.remap_palette(list(range(256)))
+        assert_image_equal(im_p, im_remapped)
+        assert im_p.palette is not None
         assert im_remapped.palette is not None
-        assert im.palette.palette == im_remapped.palette.palette
+        assert im_p.palette.palette == im_remapped.palette.palette
 
         # Test illegal image mode
-        with hopper() as im:
+        with hopper() as im_hopper:
             with pytest.raises(ValueError):
-                im.remap_palette([])
+                im_hopper.remap_palette([])
 
     def test_remap_palette_transparency(self) -> None:
         im = Image.new("P", (1, 2), (0, 0, 0))

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -80,8 +80,8 @@ def test_16bit() -> None:
         _test_float_conversion(im)
 
     for color in (65535, 65536):
-        im = Image.new("I", (1, 1), color)
-        im_i16 = im.convert("I;16")
+        im_i = Image.new("I", (1, 1), color)
+        im_i16 = im_i.convert("I;16")
         assert im_i16.getpixel((0, 0)) == 65535
 
 

--- a/Tests/test_image_crop.py
+++ b/Tests/test_image_crop.py
@@ -78,13 +78,13 @@ def test_crop_crash() -> None:
     extents = (1, 1, 10, 10)
     # works prepatch
     with Image.open(test_img) as img:
-        img2 = img.crop(extents)
-    img2.load()
+        img1 = img.crop(extents)
+    img1.load()
 
     # fail prepatch
     with Image.open(test_img) as img:
-        img = img.crop(extents)
-    img.load()
+        img2 = img.crop(extents)
+    img2.load()
 
 
 def test_crop_zero() -> None:

--- a/Tests/test_image_quantize.py
+++ b/Tests/test_image_quantize.py
@@ -58,8 +58,8 @@ def test_rgba_quantize() -> None:
 
 def test_quantize() -> None:
     with Image.open("Tests/images/caption_6_33_22.png") as image:
-        image = image.convert("RGB")
-    converted = image.quantize()
+        converted = image.convert("RGB")
+    converted = converted.quantize()
     assert converted.mode == "P"
     assert_image_similar(converted.convert("RGB"), image, 1)
 
@@ -67,13 +67,13 @@ def test_quantize() -> None:
 def test_quantize_no_dither() -> None:
     image = hopper()
     with Image.open("Tests/images/caption_6_33_22.png") as palette:
-        palette = palette.convert("P")
+        palette_p = palette.convert("P")
 
-    converted = image.quantize(dither=Image.Dither.NONE, palette=palette)
+    converted = image.quantize(dither=Image.Dither.NONE, palette=palette_p)
     assert converted.mode == "P"
     assert converted.palette is not None
-    assert palette.palette is not None
-    assert converted.palette.palette == palette.palette.palette
+    assert palette_p.palette is not None
+    assert converted.palette.palette == palette_p.palette.palette
 
 
 def test_quantize_no_dither2() -> None:
@@ -97,10 +97,10 @@ def test_quantize_no_dither2() -> None:
 def test_quantize_dither_diff() -> None:
     image = hopper()
     with Image.open("Tests/images/caption_6_33_22.png") as palette:
-        palette = palette.convert("P")
+        palette_p = palette.convert("P")
 
-    dither = image.quantize(dither=Image.Dither.FLOYDSTEINBERG, palette=palette)
-    nodither = image.quantize(dither=Image.Dither.NONE, palette=palette)
+    dither = image.quantize(dither=Image.Dither.FLOYDSTEINBERG, palette=palette_p)
+    nodither = image.quantize(dither=Image.Dither.NONE, palette=palette_p)
 
     assert dither.tobytes() != nodither.tobytes()
 

--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -314,8 +314,8 @@ class TestImageResize:
     @skip_unless_feature("libtiff")
     def test_transposed(self) -> None:
         with Image.open("Tests/images/g4_orientation_5.tif") as im:
-            im = im.resize((64, 64))
-            assert im.size == (64, 64)
+            im_resized = im.resize((64, 64))
+            assert im_resized.size == (64, 64)
 
     @pytest.mark.parametrize(
         "mode", ("L", "RGB", "I", "I;16", "I;16L", "I;16B", "I;16N", "F")

--- a/Tests/test_image_rotate.py
+++ b/Tests/test_image_rotate.py
@@ -43,8 +43,8 @@ def test_angle(angle: int) -> None:
     with Image.open("Tests/images/test-card.png") as im:
         rotate(im, im.mode, angle)
 
-    im = hopper()
-    assert_image_equal(im.rotate(angle), im.rotate(angle, expand=1))
+    im_hopper = hopper()
+    assert_image_equal(im_hopper.rotate(angle), im_hopper.rotate(angle, expand=1))
 
 
 @pytest.mark.parametrize("angle", (0, 45, 90, 180, 270))
@@ -76,9 +76,9 @@ def test_center_0() -> None:
 
     with Image.open("Tests/images/hopper_45.png") as target:
         target_origin = target.size[1] / 2
-        target = target.crop((0, target_origin, 128, target_origin + 128))
+        im_target = target.crop((0, target_origin, 128, target_origin + 128))
 
-    assert_image_similar(im, target, 15)
+    assert_image_similar(im, im_target, 15)
 
 
 def test_center_14() -> None:
@@ -87,22 +87,22 @@ def test_center_14() -> None:
 
     with Image.open("Tests/images/hopper_45.png") as target:
         target_origin = target.size[1] / 2 - 14
-        target = target.crop((6, target_origin, 128 + 6, target_origin + 128))
+        im_target = target.crop((6, target_origin, 128 + 6, target_origin + 128))
 
-        assert_image_similar(im, target, 10)
+        assert_image_similar(im, im_target, 10)
 
 
 def test_translate() -> None:
     im = hopper()
     with Image.open("Tests/images/hopper_45.png") as target:
         target_origin = (target.size[1] / 2 - 64) - 5
-        target = target.crop(
+        im_target = target.crop(
             (target_origin, target_origin, target_origin + 128, target_origin + 128)
         )
 
     im = im.rotate(45, translate=(5, 5), resample=Image.Resampling.BICUBIC)
 
-    assert_image_similar(im, target, 1)
+    assert_image_similar(im, im_target, 1)
 
 
 def test_fastpath_center() -> None:

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -159,9 +159,9 @@ def test_reducing_gap_for_DCT_scaling() -> None:
     with Image.open("Tests/images/hopper.jpg") as ref:
         # thumbnail should call draft with reducing_gap scale
         ref.draft(None, (18 * 3, 18 * 3))
-        ref = ref.resize((18, 18), Image.Resampling.BICUBIC)
+        im_ref = ref.resize((18, 18), Image.Resampling.BICUBIC)
 
         with Image.open("Tests/images/hopper.jpg") as im:
             im.thumbnail((18, 18), Image.Resampling.BICUBIC, reducing_gap=3.0)
 
-            assert_image_similar(ref, im, 1.4)
+            assert_image_similar(im_ref, im, 1.4)

--- a/Tests/test_imagedraw.py
+++ b/Tests/test_imagedraw.py
@@ -198,10 +198,10 @@ def test_bitmap() -> None:
     im = Image.new("RGB", (W, H))
     draw = ImageDraw.Draw(im)
     with Image.open("Tests/images/pil123rgba.png") as small:
-        small = small.resize((50, 50), Image.Resampling.NEAREST)
+        small_resized = small.resize((50, 50), Image.Resampling.NEAREST)
 
         # Act
-        draw.bitmap((10, 10), small)
+        draw.bitmap((10, 10), small_resized)
 
     # Assert
     assert_image_equal_tofile(im, "Tests/images/imagedraw_bitmap.png")

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -261,10 +261,10 @@ def test_colorize_2color() -> None:
 
     # Open test image (256px by 10px, black to white)
     with Image.open("Tests/images/bw_gradient.png") as im:
-        im = im.convert("L")
+        im_l = im.convert("L")
 
     # Create image with original 2-color functionality
-    im_test = ImageOps.colorize(im, "red", "green")
+    im_test = ImageOps.colorize(im_l, "red", "green")
 
     # Test output image (2-color)
     left = (0, 1)
@@ -301,11 +301,11 @@ def test_colorize_2color_offset() -> None:
 
     # Open test image (256px by 10px, black to white)
     with Image.open("Tests/images/bw_gradient.png") as im:
-        im = im.convert("L")
+        im_l = im.convert("L")
 
     # Create image with original 2-color functionality with offsets
     im_test = ImageOps.colorize(
-        im, black="red", white="green", blackpoint=50, whitepoint=100
+        im_l, black="red", white="green", blackpoint=50, whitepoint=100
     )
 
     # Test output image (2-color) with offsets
@@ -343,11 +343,11 @@ def test_colorize_3color_offset() -> None:
 
     # Open test image (256px by 10px, black to white)
     with Image.open("Tests/images/bw_gradient.png") as im:
-        im = im.convert("L")
+        im_l = im.convert("L")
 
     # Create image with new three color functionality with offsets
     im_test = ImageOps.colorize(
-        im,
+        im_l,
         black="red",
         white="green",
         mid="blue",

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -90,18 +90,18 @@ def test_pickle_la_mode_with_palette(tmp_path: Path) -> None:
     # Arrange
     filename = tmp_path / "temp.pkl"
     with Image.open("Tests/images/hopper.jpg") as im:
-        im = im.convert("PA")
+        im_pa = im.convert("PA")
 
     # Act / Assert
     for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
-        im._mode = "LA"
+        im_pa._mode = "LA"
         with open(filename, "wb") as f:
-            pickle.dump(im, f, protocol)
+            pickle.dump(im_pa, f, protocol)
         with open(filename, "rb") as f:
             loaded_im = pickle.load(f)
 
-        im._mode = "PA"
-        assert im == loaded_im
+        im_pa._mode = "PA"
+        assert im_pa == loaded_im
 
 
 @skip_unless_feature("webp")

--- a/Tests/test_shell_injection.py
+++ b/Tests/test_shell_injection.py
@@ -49,11 +49,13 @@ class TestShellInjection:
     @pytest.mark.skipif(not netpbm_available(), reason="Netpbm not available")
     def test_save_netpbm_filename_bmp_mode(self, tmp_path: Path) -> None:
         with Image.open(TEST_GIF) as im:
-            im = im.convert("RGB")
-            self.assert_save_filename_check(tmp_path, im, GifImagePlugin._save_netpbm)
+            im_rgb = im.convert("RGB")
+            self.assert_save_filename_check(
+                tmp_path, im_rgb, GifImagePlugin._save_netpbm
+            )
 
     @pytest.mark.skipif(not netpbm_available(), reason="Netpbm not available")
     def test_save_netpbm_filename_l_mode(self, tmp_path: Path) -> None:
         with Image.open(TEST_GIF) as im:
-            im = im.convert("L")
-            self.assert_save_filename_check(tmp_path, im, GifImagePlugin._save_netpbm)
+            im_l = im.convert("L")
+            self.assert_save_filename_check(tmp_path, im_l, GifImagePlugin._save_netpbm)


### PR DESCRIPTION
This is part of #8362 - I'm hoping to break down that PR into easier-to-review chunks.

This is to fix type hint errors like
> error: Incompatible types in assignment
> (expression has type "Image", variable has type "ImageFile")  [assignment]