### PR TITLE
Remove BytesIO from DdsImagePlugin

### DIFF
--- a/src/PIL/DdsImagePlugin.py
+++ b/src/PIL/DdsImagePlugin.py
@@ -12,7 +12,6 @@ https://creativecommons.org/publicdomain/zero/1.0/
 
 from __future__ import annotations
 
-import io
 import struct
 import sys
 from enum import IntEnum, IntFlag
@@ -340,21 +339,20 @@ class DdsImageFile(ImageFile.ImageFile):
         if header_size != 124:
             msg = f"Unsupported header size {repr(header_size)}"
             raise OSError(msg)
-        header_bytes = self.fp.read(header_size - 4)
-        if len(header_bytes) != 120:
-            msg = f"Incomplete header: {len(header_bytes)} bytes"
+        header = self.fp.read(header_size - 4)
+        if len(header) != 120:
+            msg = f"Incomplete header: {len(header)} bytes"
             raise OSError(msg)
-        header = io.BytesIO(header_bytes)
 
-        flags, height, width = struct.unpack("<3I", header.read(12))
+        flags, height, width = struct.unpack("<3I", header[:12])
         self._size = (width, height)
         extents = (0, 0) + self.size
 
-        pitch, depth, mipmaps = struct.unpack("<3I", header.read(12))
-        struct.unpack("<11I", header.read(44))  # reserved
+        pitch, depth, mipmaps = struct.unpack("<3I", header[12:24])
+        struct.unpack("<11I", header[24:68])  # reserved
 
         # pixel format
-        pfsize, pfflags, fourcc, bitcount = struct.unpack("<4I", header.read(16))
+        pfsize, pfflags, fourcc, bitcount = struct.unpack("<4I", header[68:84])
         n = 0
         rawmode = None
         if pfflags & DDPF.RGB:
@@ -366,7 +364,7 @@ class DdsImageFile(ImageFile.ImageFile):
                 self._mode = "RGB"
                 mask_count = 3
 
-            masks = struct.unpack(f"<{mask_count}I", header.read(mask_count * 4))
+            masks = struct.unpack(f"<{mask_count}I", header[84 : 84 + mask_count * 4])
             self.tile = [ImageFile._Tile("dds_rgb", extents, 0, (bitcount, masks))]
             return
         elif pfflags & DDPF.LUMINANCE:


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/76f04b46c563155a66a7fe92f500e7e8e9d6e096/src/PIL/DdsImagePlugin.py#L343-L347

Rather than reading from a new BytesIO, it seems simpler to me to just slice the bytes.