### PR TITLE
Provide a clear option to depend on zlib-ng

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -725,7 +725,12 @@ class pil_build_ext(build_ext):
 
         if feature.want("zlib"):
             _dbg("Looking for zlib")
-            if _find_include_file(self, "zlib.h"):
+            if _find_include_file(self, "zlib-ng.h"):
+                if _find_library_file(self, "z-ng"):
+                    feature.set("zlib", "z-ng")
+                elif sys.platform == "win32" and _find_library_file(self, "zlib-ng"):
+                    feature.set("zlib", "zlib-ng")
+            elif _find_include_file(self, "zlib.h"):
                 if _find_library_file(self, "z"):
                     feature.set("zlib", "z")
                 elif sys.platform == "win32" and _find_library_file(self, "zlib"):
@@ -923,9 +928,11 @@ class pil_build_ext(build_ext):
             defs.append(("HAVE_OPENJPEG", None))
             if sys.platform == "win32" and not PLATFORM_MINGW:
                 defs.append(("OPJ_STATIC", None))
-        if feature.get("zlib"):
-            libs.append(feature.get("zlib"))
+        if zlib := feature.get("zlib"):
+            libs.append(zlib)
             defs.append(("HAVE_LIBZ", None))
+            if zlib in ["z-ng", "zlib-ng"]:
+                defs.append(("HAVE_ZLIBNG", None))
         if feature.get("imagequant"):
             libs.append(feature.get("imagequant"))
             defs.append(("HAVE_LIBIMAGEQUANT", None))

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -85,8 +85,10 @@
 #endif
 #endif
 
-#ifdef HAVE_LIBZ
-#include "zlib.h"
+#ifdef HAVE_ZLIBNG
+#include <zlib-ng.h>
+#else
+#include <zlib.h>
 #endif
 
 #ifdef HAVE_LIBTIFF

--- a/src/libImaging/ZipCodecs.h
+++ b/src/libImaging/ZipCodecs.h
@@ -7,7 +7,11 @@
  * Copyright (c) Fredrik Lundh 1996.
  */
 
-#include "zlib.h"
+#ifdef HAVE_ZLIBNG
+#include <zlib-ng.h>
+#else
+#include <zlib.h>
+#endif
 
 /* modes */
 #define ZIP_PNG 0            /* continuous, filtered image data */
@@ -35,7 +39,11 @@ typedef struct {
 
     /* PRIVATE CONTEXT (set by decoder/encoder) */
 
+#ifdef HAVE_ZLIBNG
+    zng_stream z_stream; /* (de)compression stream */
+#else
     z_stream z_stream; /* (de)compression stream */
+#endif
 
     UINT8 *previous; /* previous line (allocated) */
 

--- a/src/libImaging/ZipEncode.c
+++ b/src/libImaging/ZipEncode.c
@@ -90,9 +90,6 @@ ImagingZipEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
 
 #ifdef HAVE_ZLIBNG
         err = zng_deflateInit2(
-#else
-        err = deflateInit2(
-#endif
             &context->z_stream,
             /* compression level */
             compress_level,
@@ -104,6 +101,20 @@ ImagingZipEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
             /* compression strategy (image data are filtered)*/
             compress_type
         );
+#else
+        err = deflateInit2(
+            &context->z_stream,
+            /* compression level */
+            compress_level,
+            /* compression method */
+            Z_DEFLATED,
+            /* compression memory resources */
+            15,
+            9,
+            /* compression strategy (image data are filtered)*/
+            compress_type
+        );
+#endif
         if (err < 0) {
             state->errcode = IMAGING_CODEC_CONFIG;
             return -1;
@@ -112,13 +123,17 @@ ImagingZipEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
         if (context->dictionary && context->dictionary_size > 0) {
 #ifdef HAVE_ZLIBNG
             err = zng_deflateSetDictionary(
-#else
-            err = deflateSetDictionary(
-#endif
                 &context->z_stream,
                 (unsigned char *)context->dictionary,
                 context->dictionary_size
             );
+#else
+            err = deflateSetDictionary(
+                &context->z_stream,
+                (unsigned char *)context->dictionary,
+                context->dictionary_size
+            );
+#endif
             if (err < 0) {
                 state->errcode = IMAGING_CODEC_CONFIG;
                 return -1;


### PR DESCRIPTION
This is more of a nit than anything, but the problem arose in conda-forge where we still haven't gone all-in on zlib-ng.

As such, we ship BOTH zlib, and zlib-ng, which are designed to co-exist.

I thus wrote a patch for pillow to be able to directly target zlib-ng.

I figured I would upstream it and maybe this can help other distributions with this predicament.

xref: 
* https://github.com/conda-forge/pillow-feedstock/pull/173
* https://github.com/conda-forge/zlib-ng-feedstock/issues/10
* https://github.com/conda-forge/conda-forge.github.io/issues/2638

I'm happy to address any issues you all have with this but the idea is that:

if zlib-ng is found, then choose that, and just use the `zlib-ng` headers directly instead of `zlib.h`.



-------------------------------------------------------

TODO:
- [ ] Add an explicit option to link to prioritize `zlib.h` or `zlib-ng.h` -- @mgorny 