### PR TITLE
Read all non-zero transparency from mode 1 PNG images as 255

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -338,6 +338,15 @@ class TestFilePng:
             assert colors is not None
             assert colors[0][0] == num_transparent
 
+    def test_save_1_transparency(self, tmp_path: Path) -> None:
+        out = tmp_path / "temp.png"
+
+        im = Image.new("1", (1, 1), 1)
+        im.save(out, transparency=1)
+
+        with Image.open(out) as reloaded:
+            assert reloaded.info["transparency"] == 255
+
     def test_save_rgb_single_transparency(self, tmp_path: Path) -> None:
         in_file = "Tests/images/caption_6_33_22.png"
         with Image.open(in_file) as im:

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -509,7 +509,9 @@ class PngStream(ChunkStream):
                 # otherwise, we have a byte string with one alpha value
                 # for each palette entry
                 self.im_info["transparency"] = s
-        elif self.im_mode in ("1", "L", "I;16"):
+        elif self.im_mode == "1":
+            self.im_info["transparency"] = 255 if i16(s) else 0
+        elif self.im_mode in ("L", "I;16"):
             self.im_info["transparency"] = i16(s)
         elif self.im_mode == "RGB":
             self.im_info["transparency"] = i16(s), i16(s, 2), i16(s, 4)


### PR DESCRIPTION
Resolves #9281

The image in the issue has the transparency index saved as 1, which makes sense for a 1-bit image. However, non-zero values in 1-bit Pillow images have a value of 255.

This changes the read transparency to 255.