### PR TITLE
Test ImageFont.ImageFont, in case freetype2 is not supported

### DIFF
--- a/Tests/test_imagetext.py
+++ b/Tests/test_imagetext.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from PIL import Image, ImageDraw, ImageFont, ImageText
+from PIL import Image, ImageDraw, ImageFont, ImageText, features
 
 from .helper import assert_image_similar_tofile, skip_unless_feature
 
@@ -20,42 +20,69 @@ def layout_engine(request: pytest.FixtureRequest) -> ImageFont.Layout:
     return request.param
 
 
-@pytest.fixture(scope="module")
-def font(layout_engine: ImageFont.Layout) -> ImageFont.FreeTypeFont:
-    return ImageFont.truetype(FONT_PATH, 20, layout_engine=layout_engine)
+@pytest.fixture(
+    scope="module",
+    params=[
+        None,
+        pytest.param(ImageFont.Layout.BASIC, marks=skip_unless_feature("freetype2")),
+        pytest.param(ImageFont.Layout.RAQM, marks=skip_unless_feature("raqm")),
+    ],
+)
+def font(
+    request: pytest.FixtureRequest,
+) -> ImageFont.ImageFont | ImageFont.FreeTypeFont:
+    layout_engine = request.param
+    if layout_engine is None:
+        return ImageFont.load_default_imagefont()
+    else:
+        return ImageFont.truetype(FONT_PATH, 20, layout_engine=layout_engine)
 
 
-def test_get_length(font: ImageFont.FreeTypeFont) -> None:
-    assert ImageText.Text("A", font).get_length() == 12
-    assert ImageText.Text("AB", font).get_length() == 24
-    assert ImageText.Text("M", font).get_length() == 12
-    assert ImageText.Text("y", font).get_length() == 12
-    assert ImageText.Text("a", font).get_length() == 12
+def test_get_length(font: ImageFont.ImageFont | ImageFont.FreeTypeFont) -> None:
+    factor = 1 if isinstance(font, ImageFont.ImageFont) else 2
+    assert ImageText.Text("A", font).get_length() == 6 * factor
+    assert ImageText.Text("AB", font).get_length() == 12 * factor
+    assert ImageText.Text("M", font).get_length() == 6 * factor
+    assert ImageText.Text("y", font).get_length() == 6 * factor
+    assert ImageText.Text("a", font).get_length() == 6 * factor
 
     text = ImageText.Text("\n", font)
     with pytest.raises(ValueError, match="can't measure length of multiline text"):
         text.get_length()
 
 
-def test_get_bbox(font: ImageFont.FreeTypeFont) -> None:
-    assert ImageText.Text("A", font).get_bbox() == (0, 4, 12, 16)
-    assert ImageText.Text("AB", font).get_bbox() == (0, 4, 24, 16)
-    assert ImageText.Text("M", font).get_bbox() == (0, 4, 12, 16)
-    assert ImageText.Text("y", font).get_bbox() == (0, 7, 12, 20)
-    assert ImageText.Text("a", font).get_bbox() == (0, 7, 12, 16)
+@pytest.mark.parametrize(
+    "text, expected",
+    (
+        ("A", (0, 4, 12, 16)),
+        ("AB", (0, 4, 24, 16)),
+        ("M", (0, 4, 12, 16)),
+        ("y", (0, 7, 12, 20)),
+        ("a", (0, 7, 12, 16)),
+    ),
+)
+def test_get_bbox(
+    font: ImageFont.ImageFont | ImageFont.FreeTypeFont,
+    text: str,
+    expected: tuple[int, int, int, int],
+) -> None:
+    if isinstance(font, ImageFont.ImageFont):
+        expected = (0, 0, expected[2] // 2, 11)
+    assert ImageText.Text(text, font).get_bbox() == expected
 
 
 def test_standard_embedded_color(layout_engine: ImageFont.Layout) -> None:
-    font = ImageFont.truetype(FONT_PATH, 40, layout_engine=layout_engine)
-    text = ImageText.Text("Hello World!", font)
-    text.embed_color()
-    assert text.get_length() == 288
+    if features.check_module("freetype2"):
+        font = ImageFont.truetype(FONT_PATH, 40, layout_engine=layout_engine)
+        text = ImageText.Text("Hello World!", font)
+        text.embed_color()
+        assert text.get_length() == 288
 
-    im = Image.new("RGB", (300, 64), "white")
-    draw = ImageDraw.Draw(im)
-    draw.text((10, 10), text, "#fa6")
+        im = Image.new("RGB", (300, 64), "white")
+        draw = ImageDraw.Draw(im)
+        draw.text((10, 10), text, "#fa6")
 
-    assert_image_similar_tofile(im, "Tests/images/standard_embedded.png", 3.1)
+        assert_image_similar_tofile(im, "Tests/images/standard_embedded.png", 3.1)
 
     text = ImageText.Text("", mode="1")
     with pytest.raises(


### PR DESCRIPTION
Running the test suite without freetype2 support leads to [three tests failing](https://github.com/radarhere/Pillow/actions/runs/19033815449/job/54353118443) in test_imagetext.py.

We could simply skip the tests, but I thought I would try running two of those tests with `ImageFont.ImageFont` instead, and avoiding only part of the third test.