### PR TITLE
Apply encoder options when saving multiple PNG frames

### DIFF
--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from io import BytesIO
 from pathlib import Path
 
 import pytest
@@ -716,6 +717,25 @@ def test_apng_save_size(tmp_path: Path) -> None:
 
     with Image.open(test_file) as reloaded:
         assert reloaded.size == (200, 200)
+
+
+def test_compress_level() -> None:
+    compress_level_sizes = {}
+    for compress_level in (0, 9):
+        out = BytesIO()
+
+        im = Image.new("L", (100, 100))
+        im.save(
+            out,
+            "PNG",
+            save_all=True,
+            append_images=[Image.new("L", (200, 200))],
+            compress_level=compress_level,
+        )
+
+        compress_level_sizes[compress_level] = len(out.getvalue())
+
+    assert compress_level_sizes[0] > compress_level_sizes[9]
 
 
 def test_seek_after_close() -> None:

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -1152,6 +1152,15 @@ class _fdat:
         self.seq_num += 1
 
 
+def _apply_encoderinfo(im: Image.Image, encoderinfo: dict[str, Any]) -> None:
+    im.encoderconfig = (
+        encoderinfo.get("optimize", False),
+        encoderinfo.get("compress_level", -1),
+        encoderinfo.get("compress_type", -1),
+        encoderinfo.get("dictionary", b""),
+    )
+
+
 class _Frame(NamedTuple):
     im: Image.Image
     bbox: tuple[int, int, int, int] | None
@@ -1245,10 +1254,10 @@ def _write_multiple_frames(
 
     # default image IDAT (if it exists)
     if default_image:
-        if im.mode != mode:
-            im = im.convert(mode)
+        default_im = im if im.mode == mode else im.convert(mode)
+        _apply_encoderinfo(default_im, im.encoderinfo)
         ImageFile._save(
-            im,
+            default_im,
             cast(IO[bytes], _idat(fp, chunk)),
             [ImageFile._Tile("zip", (0, 0) + im.size, 0, rawmode)],
         )
@@ -1282,6 +1291,7 @@ def _write_multiple_frames(
         )
         seq_num += 1
         # frame data
+        _apply_encoderinfo(im_frame, im.encoderinfo)
         if frame == 0 and not default_image:
             # first frame must be in IDAT chunks for backwards compatibility
             ImageFile._save(
@@ -1356,14 +1366,6 @@ def _save(
             else:
                 bits = 4
             outmode += f";{bits}"
-
-    # encoder options
-    im.encoderconfig = (
-        im.encoderinfo.get("optimize", False),
-        im.encoderinfo.get("compress_level", -1),
-        im.encoderinfo.get("compress_type", -1),
-        im.encoderinfo.get("dictionary", b""),
-    )
 
     # get the corresponding PNG mode
     try:
@@ -1494,6 +1496,7 @@ def _save(
             im, fp, chunk, mode, rawmode, default_image, append_images
         )
     if single_im:
+        _apply_encoderinfo(single_im, im.encoderinfo)
         ImageFile._save(
             single_im,
             cast(IO[bytes], _idat(fp, chunk)),


### PR DESCRIPTION
Resolves #9299

https://github.com/python-pillow/Pillow/blob/3b8fd040deb96cb0f54c6d2db48568a4400f6c86/src/PIL/PngImagePlugin.py#L1360-L1366
only applies the `encoderinfo` options to single frames, not multiple frames, especially after [each of the multiple frames are copied.](https://github.com/python-pillow/Pillow/blob/3b8fd040deb96cb0f54c6d2db48568a4400f6c86/src/PIL/PngImagePlugin.py#L1184-L1187)

This PR applies the `encoderinfo` options to all frames when saving PNGs.