### PR TITLE
Update libimagequant to 4.4.1

### DIFF
--- a/depends/install_imagequant.sh
+++ b/depends/install_imagequant.sh
@@ -2,7 +2,7 @@
 # install libimagequant
 
 archive_name=libimagequant
-archive_version=4.4.0
+archive_version=4.4.1
 
 archive=$archive_name-$archive_version
 

--- a/docs/installation/building-from-source.rst
+++ b/docs/installation/building-from-source.rst
@@ -64,7 +64,7 @@ Many of Pillow's features require external libraries:
 
 * **libimagequant** provides improved color quantization
 
-  * Pillow has been tested with libimagequant **2.6-4.4.0**
+  * Pillow has been tested with libimagequant **2.6-4.4.1**
   * Libimagequant is licensed GPLv3, which is more restrictive than
     the Pillow license, therefore we will not be distributing binaries
     with libimagequant support enabled.

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -120,7 +120,7 @@ V = {
     "JPEGTURBO": "3.1.2",
     "LCMS2": "2.17",
     "LIBAVIF": "1.3.0",
-    "LIBIMAGEQUANT": "4.4.0",
+    "LIBIMAGEQUANT": "4.4.1",
     "LIBPNG": "1.6.50",
     "LIBWEBP": "1.6.0",
     "OPENJPEG": "2.5.4",


### PR DESCRIPTION
libimagequant 4.4.1 has been released - https://github.com/ImageOptim/libimagequant/releases/tag/4.4.1