### PR TITLE
Close image on ImageFont exception

### DIFF
--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -127,11 +127,15 @@ class ImageFont:
     def _load_pilfont_data(self, file: IO[bytes], image: Image.Image) -> None:
         # check image
         if image.mode not in ("1", "L"):
+            image.close()
+
             msg = "invalid font image mode"
             raise TypeError(msg)
 
         # read PILfont header
         if file.read(8) != b"PILfont\n":
+            image.close()
+
             msg = "Not a PILfont file"
             raise SyntaxError(msg)
         file.readline()


### PR DESCRIPTION
Fixes an unclosed file warning from https://github.com/python-pillow/Pillow/actions/runs/19457141721/job/55673162157#step:11:5270

> Tests/test_imagefont.py::test_load_invalid_file
>   /Users/runner/work/Pillow/Pillow/Tests/test_imagefont.py:497: ResourceWarning: unclosed file <_io.BufferedReader name='Tests/images/1_trns.png'>
>     with pytest.raises(SyntaxError, match="Not a PILfont file"):

by adding `image.close()` when exceptions are raised in `ImageFont._load_pilfont_data()`. This method is only called internally after creating the `ImageFont` instance, so there's no need for the image afterwards.