### PR TITLE
Update zlib-ng to 2.3.1, except on manylinux2014 aarch64

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -106,7 +106,11 @@ XZ_VERSION=5.8.1
 ZSTD_VERSION=1.5.7
 TIFF_VERSION=4.7.1
 LCMS2_VERSION=2.17
-ZLIB_NG_VERSION=2.2.5
+if [[ "$MB_ML_VER" == 2014 ]] && [[ "$PLAT" == "aarch64" ]]; then
+  ZLIB_NG_VERSION=2.2.5
+else
+  ZLIB_NG_VERSION=2.3.1
+fi
 LIBWEBP_VERSION=1.6.0
 BZIP2_VERSION=1.0.8
 LIBXCB_VERSION=1.17.0
@@ -149,18 +153,13 @@ function build_zlib_ng {
     ORIGINAL_HOST_CONFIGURE_FLAGS=$HOST_CONFIGURE_FLAGS
     unset HOST_CONFIGURE_FLAGS
 
-    build_github zlib-ng/zlib-ng $ZLIB_NG_VERSION --zlib-compat
+    if [[ "$ZLIB_NG_VERSION" == 2.2.5 ]]; then
+        build_github zlib-ng/zlib-ng $ZLIB_NG_VERSION --zlib-compat
+    else
+        build_github zlib-ng/zlib-ng $ZLIB_NG_VERSION --installnamedir=$BUILD_PREFIX/lib --zlib-compat
+    fi
 
     HOST_CONFIGURE_FLAGS=$ORIGINAL_HOST_CONFIGURE_FLAGS
-
-    if [[ -n "$IS_MACOS" ]] && [[ -z "$IOS_SDK" ]]; then
-        # Ensure that on macOS, the library name is an absolute path, not an
-        # @rpath, so that delocate picks up the right library (and doesn't need
-        # DYLD_LIBRARY_PATH to be set). The default Makefile doesn't have an
-        # option to control the install_name. This isn't needed on iOS, as iOS
-        # only builds the static library.
-        install_name_tool -id $BUILD_PREFIX/lib/libz.1.dylib $BUILD_PREFIX/lib/libz.1.dylib
-    fi
     touch zlib-stamp
 }
 

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -126,7 +126,7 @@ V = {
     "OPENJPEG": "2.5.4",
     "TIFF": "4.7.1",
     "XZ": "5.8.1",
-    "ZLIBNG": "2.2.5",
+    "ZLIBNG": "2.3.1",
 }
 V["LIBPNG_XY"] = "".join(V["LIBPNG"].split(".")[:2])
 
@@ -167,12 +167,12 @@ DEPS: dict[str, dict[str, Any]] = {
         "license": "LICENSE.md",
         "patch": {
             r"CMakeLists.txt": {
-                "set_target_properties(zlib PROPERTIES OUTPUT_NAME zlibstatic${{SUFFIX}})": "set_target_properties(zlib PROPERTIES OUTPUT_NAME zlib)",  # noqa: E501
+                "set_target_properties(zlib-ng PROPERTIES OUTPUT_NAME zlibstatic${{SUFFIX}})": "set_target_properties(zlib-ng PROPERTIES OUTPUT_NAME zlib)",  # noqa: E501
             },
         },
         "build": [
             *cmds_cmake(
-                "zlib", "-DBUILD_SHARED_LIBS:BOOL=OFF", "-DZLIB_COMPAT:BOOL=ON"
+                "zlib-ng", "-DBUILD_SHARED_LIBS:BOOL=OFF", "-DZLIB_COMPAT:BOOL=ON"
             ),
         ],
         "headers": [r"z*.h"],


### PR DESCRIPTION
zlib-ng 2.3.1 has been released - https://github.com/zlib-ng/zlib-ng/releases/tag/2.3.1

When I upgraded it on manylinux2014 aarch64, I found [an error](https://github.com/radarhere/Pillow/actions/runs/19763663372/job/56631262763#step:5:8864). So I have excluded that from this. It will become irrelevant in a few months when manylinux2014 support is dropped with [Amazon 2 EOL.](https://endoflife.date/amazon-linux)

I have also reverted part of https://github.com/python-pillow/Pillow/pull/8673, now that https://github.com/zlib-ng/zlib-ng/pull/1867 is included.