### PR TITLE
Use different variables for Image and ImageFile instances

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -104,10 +104,9 @@ def assert_image_equal_tofile(
     msg: str | None = None,
     mode: str | None = None,
 ) -> None:
-    with Image.open(filename) as img:
-        if mode:
-            img = img.convert(mode)
-        assert_image_equal(a, img, msg)
+    with Image.open(filename) as im:
+        converted_im = im.convert(mode) if mode else im
+        assert_image_equal(a, converted_im, msg)
 
 
 def assert_image_similar(

--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -95,16 +95,16 @@ def test_good() -> None:
     for f in get_files("g"):
         try:
             with Image.open(f) as im:
-                im.load()
                 with Image.open(get_compare(f)) as compare:
-                    compare.load()
-                    if im.mode == "P":
-                        # assert image similar doesn't really work
-                        # with paletized image, since the palette might
-                        # be differently ordered for an equivalent image.
-                        im = im.convert("RGBA")
-                        compare = compare.convert("RGBA")
-                    assert_image_similar(im, compare, 5)
+                    # assert image similar doesn't really work
+                    # with paletized image, since the palette might
+                    # be differently ordered for an equivalent image.
+                    im_converted = im.convert("RGBA") if im.mode == "P" else im
+                    compare_converted = (
+                        compare.convert("RGBA") if im.mode == "P" else compare
+                    )
+
+                    assert_image_similar(im_converted, compare_converted, 5)
 
         except Exception as msg:
             # there are three here that are unsupported:

--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -278,25 +278,25 @@ def test_apng_mode() -> None:
         assert isinstance(im, PngImagePlugin.PngImageFile)
         assert im.mode == "P"
         im.seek(im.n_frames - 1)
-        im = im.convert("RGB")
-        assert im.getpixel((0, 0)) == (0, 255, 0)
-        assert im.getpixel((64, 32)) == (0, 255, 0)
+        im_rgb = im.convert("RGB")
+    assert im_rgb.getpixel((0, 0)) == (0, 255, 0)
+    assert im_rgb.getpixel((64, 32)) == (0, 255, 0)
 
     with Image.open("Tests/images/apng/mode_palette_alpha.png") as im:
         assert isinstance(im, PngImagePlugin.PngImageFile)
         assert im.mode == "P"
         im.seek(im.n_frames - 1)
-        im = im.convert("RGBA")
-        assert im.getpixel((0, 0)) == (0, 255, 0, 255)
-        assert im.getpixel((64, 32)) == (0, 255, 0, 255)
+        im_rgba = im.convert("RGBA")
+    assert im_rgba.getpixel((0, 0)) == (0, 255, 0, 255)
+    assert im_rgba.getpixel((64, 32)) == (0, 255, 0, 255)
 
     with Image.open("Tests/images/apng/mode_palette_1bit_alpha.png") as im:
         assert isinstance(im, PngImagePlugin.PngImageFile)
         assert im.mode == "P"
         im.seek(im.n_frames - 1)
-        im = im.convert("RGBA")
-        assert im.getpixel((0, 0)) == (0, 0, 255, 128)
-        assert im.getpixel((64, 32)) == (0, 0, 255, 128)
+        im_rgba = im.convert("RGBA")
+    assert im_rgba.getpixel((0, 0)) == (0, 0, 255, 128)
+    assert im_rgba.getpixel((64, 32)) == (0, 0, 255, 128)
 
 
 def test_apng_chunk_errors() -> None:

--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -165,9 +165,9 @@ def test_rgba_bitfields() -> None:
     with Image.open("Tests/images/rgb32bf-rgba.bmp") as im:
         # So before the comparing the image, swap the channels
         b, g, r = im.split()[1:]
-        im = Image.merge("RGB", (r, g, b))
+        im_rgb = Image.merge("RGB", (r, g, b))
 
-    assert_image_equal_tofile(im, "Tests/images/bmp/q/rgb32bf-xbgr.bmp")
+    assert_image_equal_tofile(im_rgb, "Tests/images/bmp/q/rgb32bf-xbgr.bmp")
 
     # This test image has been manually hexedited
     # to change the bitfield compression in the header from XBGR to ABGR

--- a/Tests/test_file_dds.py
+++ b/Tests/test_file_dds.py
@@ -57,7 +57,7 @@ TEST_FILE_UNCOMPRESSED_RGB_WITH_ALPHA = "Tests/images/uncompressed_rgb.dds"
 def test_sanity_dxt1_bc1(image_path: str) -> None:
     """Check DXT1 and BC1 images can be opened"""
     with Image.open(TEST_FILE_DXT1.replace(".dds", ".png")) as target:
-        target = target.convert("RGBA")
+        target_rgba = target.convert("RGBA")
     with Image.open(image_path) as im:
         im.load()
 
@@ -65,7 +65,7 @@ def test_sanity_dxt1_bc1(image_path: str) -> None:
         assert im.mode == "RGBA"
         assert im.size == (256, 256)
 
-        assert_image_equal(im, target)
+        assert_image_equal(im, target_rgba)
 
 
 def test_sanity_dxt3() -> None:
@@ -520,9 +520,9 @@ def test_save_dx10_bc5(tmp_path: Path) -> None:
         im.save(out, pixel_format="BC5")
     assert_image_similar_tofile(im, out, 9.56)
 
-    im = hopper("L")
+    im_l = hopper("L")
     with pytest.raises(OSError, match="only RGB mode can be written as BC5"):
-        im.save(out, pixel_format="BC5")
+        im_l.save(out, pixel_format="BC5")
 
 
 @pytest.mark.parametrize(

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -265,9 +265,9 @@ def test_bytesio_object() -> None:
         img.load()
 
         with Image.open(FILE1_COMPARE) as image1_scale1_compare:
-            image1_scale1_compare = image1_scale1_compare.convert("RGB")
-        image1_scale1_compare.load()
-        assert_image_similar(img, image1_scale1_compare, 5)
+            image1_scale1_compare_rgb = image1_scale1_compare.convert("RGB")
+        image1_scale1_compare_rgb.load()
+        assert_image_similar(img, image1_scale1_compare_rgb, 5)
 
 
 @pytest.mark.skipif(not HAS_GHOSTSCRIPT, reason="Ghostscript not available")
@@ -301,17 +301,17 @@ def test_render_scale1() -> None:
     with Image.open(FILE1) as image1_scale1:
         image1_scale1.load()
         with Image.open(FILE1_COMPARE) as image1_scale1_compare:
-            image1_scale1_compare = image1_scale1_compare.convert("RGB")
-        image1_scale1_compare.load()
-        assert_image_similar(image1_scale1, image1_scale1_compare, 5)
+            image1_scale1_compare_rgb = image1_scale1_compare.convert("RGB")
+        image1_scale1_compare_rgb.load()
+        assert_image_similar(image1_scale1, image1_scale1_compare_rgb, 5)
 
     # Non-zero bounding box
     with Image.open(FILE2) as image2_scale1:
         image2_scale1.load()
         with Image.open(FILE2_COMPARE) as image2_scale1_compare:
-            image2_scale1_compare = image2_scale1_compare.convert("RGB")
-        image2_scale1_compare.load()
-        assert_image_similar(image2_scale1, image2_scale1_compare, 10)
+            image2_scale1_compare_rgb = image2_scale1_compare.convert("RGB")
+        image2_scale1_compare_rgb.load()
+        assert_image_similar(image2_scale1, image2_scale1_compare_rgb, 10)
 
 
 @pytest.mark.skipif(not HAS_GHOSTSCRIPT, reason="Ghostscript not available")
@@ -324,18 +324,16 @@ def test_render_scale2() -> None:
         assert isinstance(image1_scale2, EpsImagePlugin.EpsImageFile)
         image1_scale2.load(scale=2)
         with Image.open(FILE1_COMPARE_SCALE2) as image1_scale2_compare:
-            image1_scale2_compare = image1_scale2_compare.convert("RGB")
-        image1_scale2_compare.load()
-        assert_image_similar(image1_scale2, image1_scale2_compare, 5)
+            image1_scale2_compare_rgb = image1_scale2_compare.convert("RGB")
+        assert_image_similar(image1_scale2, image1_scale2_compare_rgb, 5)
 
     # Non-zero bounding box
     with Image.open(FILE2) as image2_scale2:
         assert isinstance(image2_scale2, EpsImagePlugin.EpsImageFile)
         image2_scale2.load(scale=2)
         with Image.open(FILE2_COMPARE_SCALE2) as image2_scale2_compare:
-            image2_scale2_compare = image2_scale2_compare.convert("RGB")
-        image2_scale2_compare.load()
-        assert_image_similar(image2_scale2, image2_scale2_compare, 10)
+            image2_scale2_compare_rgb = image2_scale2_compare.convert("RGB")
+        assert_image_similar(image2_scale2, image2_scale2_compare_rgb, 10)
 
 
 @pytest.mark.skipif(not HAS_GHOSTSCRIPT, reason="Ghostscript not available")
@@ -345,8 +343,8 @@ def test_render_scale2() -> None:
 def test_resize(filename: str) -> None:
     with Image.open(filename) as im:
         new_size = (100, 100)
-        im = im.resize(new_size)
-        assert im.size == new_size
+        im_resized = im.resize(new_size)
+        assert im_resized.size == new_size
 
 
 @pytest.mark.skipif(not HAS_GHOSTSCRIPT, reason="Ghostscript not available")

--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -327,14 +327,13 @@ def test_loading_multiple_palettes(path: str, mode: str) -> None:
 
         im.seek(1)
         assert im.mode == mode
-        if mode == "RGBA":
-            im = im.convert("RGB")
+        im_rgb = im.convert("RGB") if mode == "RGBA" else im
 
         # Check a color only from the old palette
-        assert im.getpixel((0, 0)) == original_color
+        assert im_rgb.getpixel((0, 0)) == original_color
 
         # Check a color from the new palette
-        assert im.getpixel((24, 24)) not in first_frame_colors
+        assert im_rgb.getpixel((24, 24)) not in first_frame_colors
 
 
 def test_headers_saving_for_animated_gifs(tmp_path: Path) -> None:
@@ -354,16 +353,16 @@ def test_palette_handling(tmp_path: Path) -> None:
     # see https://github.com/python-pillow/Pillow/issues/513
 
     with Image.open(TEST_GIF) as im:
-        im = im.convert("RGB")
+        im_rgb = im.convert("RGB")
 
-        im = im.resize((100, 100), Image.Resampling.LANCZOS)
-        im2 = im.convert("P", palette=Image.Palette.ADAPTIVE, colors=256)
+    im_rgb = im_rgb.resize((100, 100), Image.Resampling.LANCZOS)
+    im_p = im_rgb.convert("P", palette=Image.Palette.ADAPTIVE, colors=256)
 
-        f = tmp_path / "temp.gif"
-        im2.save(f, optimize=True)
+    f = tmp_path / "temp.gif"
+    im_p.save(f, optimize=True)
 
     with Image.open(f) as reloaded:
-        assert_image_similar(im, reloaded.convert("RGB"), 10)
+        assert_image_similar(im_rgb, reloaded.convert("RGB"), 10)
 
 
 def test_palette_434(tmp_path: Path) -> None:
@@ -383,35 +382,36 @@ def test_palette_434(tmp_path: Path) -> None:
         with roundtrip(im, optimize=True) as reloaded:
             assert_image_similar(im, reloaded, 1)
 
-        im = im.convert("RGB")
-        # check automatic P conversion
-        with roundtrip(im) as reloaded:
-            reloaded = reloaded.convert("RGB")
-            assert_image_equal(im, reloaded)
+        im_rgb = im.convert("RGB")
+
+    # check automatic P conversion
+    with roundtrip(im_rgb) as reloaded:
+        reloaded = reloaded.convert("RGB")
+        assert_image_equal(im_rgb, reloaded)
 
 
 @pytest.mark.skipif(not netpbm_available(), reason="Netpbm not available")
 def test_save_netpbm_bmp_mode(tmp_path: Path) -> None:
     with Image.open(TEST_GIF) as img:
-        img = img.convert("RGB")
+        img_rgb = img.convert("RGB")
 
-        tempfile = str(tmp_path / "temp.gif")
-        b = BytesIO()
-        GifImagePlugin._save_netpbm(img, b, tempfile)
-        with Image.open(tempfile) as reloaded:
-            assert_image_similar(img, reloaded.convert("RGB"), 0)
+    tempfile = str(tmp_path / "temp.gif")
+    b = BytesIO()
+    GifImagePlugin._save_netpbm(img_rgb, b, tempfile)
+    with Image.open(tempfile) as reloaded:
+        assert_image_similar(img_rgb, reloaded.convert("RGB"), 0)
 
 
 @pytest.mark.skipif(not netpbm_available(), reason="Netpbm not available")
 def test_save_netpbm_l_mode(tmp_path: Path) -> None:
     with Image.open(TEST_GIF) as img:
-        img = img.convert("L")
+        img_l = img.convert("L")
 
         tempfile = str(tmp_path / "temp.gif")
         b = BytesIO()
-        GifImagePlugin._save_netpbm(img, b, tempfile)
+        GifImagePlugin._save_netpbm(img_l, b, tempfile)
         with Image.open(tempfile) as reloaded:
-            assert_image_similar(img, reloaded.convert("L"), 0)
+            assert_image_similar(img_l, reloaded.convert("L"), 0)
 
 
 def test_seek() -> None:
@@ -1038,9 +1038,9 @@ def test_webp_background(tmp_path: Path) -> None:
             im.save(out)
 
     # Test non-opaque WebP background
-    im = Image.new("L", (100, 100), "#000")
-    im.info["background"] = (0, 0, 0, 0)
-    im.save(out)
+    im2 = Image.new("L", (100, 100), "#000")
+    im2.info["background"] = (0, 0, 0, 0)
+    im2.save(out)
 
 
 def test_comment(tmp_path: Path) -> None:
@@ -1048,16 +1048,16 @@ def test_comment(tmp_path: Path) -> None:
         assert im.info["comment"] == b"File written by Adobe Photoshop\xa8 4.0"
 
     out = tmp_path / "temp.gif"
-    im = Image.new("L", (100, 100), "#000")
-    im.info["comment"] = b"Test comment text"
-    im.save(out)
+    im2 = Image.new("L", (100, 100), "#000")
+    im2.info["comment"] = b"Test comment text"
+    im2.save(out)
     with Image.open(out) as reread:
-        assert reread.info["comment"] == im.info["comment"]
+        assert reread.info["comment"] == im2.info["comment"]
 
-    im.info["comment"] = "Test comment text"
-    im.save(out)
+    im2.info["comment"] = "Test comment text"
+    im2.save(out)
     with Image.open(out) as reread:
-        assert reread.info["comment"] == im.info["comment"].encode()
+        assert reread.info["comment"] == im2.info["comment"].encode()
 
         # Test that GIF89a is used for comments
         assert reread.info["version"] == b"GIF89a"

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -516,12 +516,12 @@ class TestFileLibTiff(LibTiffTestCase):
         # and save to compressed tif.
         out = tmp_path / "temp.tif"
         with Image.open("Tests/images/pport_g4.tif") as im:
-            im = im.convert("L")
+            im_l = im.convert("L")
 
-        im = im.filter(ImageFilter.GaussianBlur(4))
-        im.save(out, compression="tiff_adobe_deflate")
+        im_l = im_l.filter(ImageFilter.GaussianBlur(4))
+        im_l.save(out, compression="tiff_adobe_deflate")
 
-        assert_image_equal_tofile(im, out)
+        assert_image_equal_tofile(im_l, out)
 
     def test_compressions(self, tmp_path: Path) -> None:
         # Test various tiff compressions and assert similar image content but reduced
@@ -1087,8 +1087,10 @@ class TestFileLibTiff(LibTiffTestCase):
         data = data[:102] + b"\x02" + data[103:]
 
         with Image.open(io.BytesIO(data)) as im:
-            im = im.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
-        assert_image_equal_tofile(im, "Tests/images/old-style-jpeg-compression.png")
+            im_transposed = im.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
+        assert_image_equal_tofile(
+            im_transposed, "Tests/images/old-style-jpeg-compression.png"
+        )
 
     def test_open_missing_samplesperpixel(self) -> None:
         with Image.open(

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -101,12 +101,13 @@ class TestFilePng:
             assert im.get_format_mimetype() == "image/png"
 
         for mode in ["1", "L", "P", "RGB", "I;16", "I;16B"]:
-            im = hopper(mode)
-            im.save(test_file)
+            im1 = hopper(mode)
+            im1.save(test_file)
             with Image.open(test_file) as reloaded:
-                if mode == "I;16B":
-                    reloaded = reloaded.convert(mode)
-                assert_image_equal(reloaded, im)
+                converted_reloaded = (
+                    reloaded.convert(mode) if mode == "I;16B" else reloaded
+                )
+                assert_image_equal(converted_reloaded, im1)
 
     def test_invalid_file(self) -> None:
         invalid_file = "Tests/images/flower.jpg"
@@ -225,11 +226,11 @@ class TestFilePng:
         test_file = "Tests/images/pil123p.png"
         with Image.open(test_file) as im:
             assert_image(im, "P", (162, 150))
-            im = im.convert("RGBA")
-        assert_image(im, "RGBA", (162, 150))
+            im_rgba = im.convert("RGBA")
+        assert_image(im_rgba, "RGBA", (162, 150))
 
         # image has 124 unique alpha values
-        colors = im.getchannel("A").getcolors()
+        colors = im_rgba.getchannel("A").getcolors()
         assert colors is not None
         assert len(colors) == 124
 
@@ -239,11 +240,11 @@ class TestFilePng:
             assert im.info["transparency"] == (0, 255, 52)
 
             assert_image(im, "RGB", (64, 64))
-            im = im.convert("RGBA")
-        assert_image(im, "RGBA", (64, 64))
+            im_rgba = im.convert("RGBA")
+        assert_image(im_rgba, "RGBA", (64, 64))
 
         # image has 876 transparent pixels
-        colors = im.getchannel("A").getcolors()
+        colors = im_rgba.getchannel("A").getcolors()
         assert colors is not None
         assert colors[0][0] == 876
 
@@ -262,11 +263,11 @@ class TestFilePng:
             assert len(im.info["transparency"]) == 256
 
             assert_image(im, "P", (162, 150))
-            im = im.convert("RGBA")
-        assert_image(im, "RGBA", (162, 150))
+            im_rgba = im.convert("RGBA")
+        assert_image(im_rgba, "RGBA", (162, 150))
 
         # image has 124 unique alpha values
-        colors = im.getchannel("A").getcolors()
+        colors = im_rgba.getchannel("A").getcolors()
         assert colors is not None
         assert len(colors) == 124
 
@@ -285,13 +286,13 @@ class TestFilePng:
             assert im.info["transparency"] == 164
             assert im.getpixel((31, 31)) == 164
             assert_image(im, "P", (64, 64))
-            im = im.convert("RGBA")
-        assert_image(im, "RGBA", (64, 64))
+            im_rgba = im.convert("RGBA")
+        assert_image(im_rgba, "RGBA", (64, 64))
 
-        assert im.getpixel((31, 31)) == (0, 255, 52, 0)
+        assert im_rgba.getpixel((31, 31)) == (0, 255, 52, 0)
 
         # image has 876 transparent pixels
-        colors = im.getchannel("A").getcolors()
+        colors = im_rgba.getchannel("A").getcolors()
         assert colors is not None
         assert colors[0][0] == 876
 

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -457,9 +457,9 @@ def test_exif_transpose() -> None:
         assert 0x0112 not in transposed_im.getexif()
 
     # Orientation set directly on Image.Exif
-    im = hopper()
-    im.getexif()[0x0112] = 3
-    transposed_im = ImageOps.exif_transpose(im)
+    im1 = hopper()
+    im1.getexif()[0x0112] = 3
+    transposed_im = ImageOps.exif_transpose(im1)
     assert 0x0112 not in transposed_im.getexif()
 
 

--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -19,30 +19,28 @@ def helper_pickle_file(
     # Arrange
     with Image.open(test_file) as im:
         filename = tmp_path / "temp.pkl"
-        if mode:
-            im = im.convert(mode)
+        converted_im = im.convert(mode) if mode else im
 
         # Act
         with open(filename, "wb") as f:
-            pickle.dump(im, f, protocol)
+            pickle.dump(converted_im, f, protocol)
         with open(filename, "rb") as f:
             loaded_im = pickle.load(f)
 
         # Assert
-        assert im == loaded_im
+        assert converted_im == loaded_im
 
 
 def helper_pickle_string(protocol: int, test_file: str, mode: str | None) -> None:
     with Image.open(test_file) as im:
-        if mode:
-            im = im.convert(mode)
+        converted_im = im.convert(mode) if mode else im
 
         # Act
-        dumped_string = pickle.dumps(im, protocol)
+        dumped_string = pickle.dumps(converted_im, protocol)
         loaded_im = pickle.loads(dumped_string)
 
         # Assert
-        assert im == loaded_im
+        assert converted_im == loaded_im
 
 
 @pytest.mark.parametrize(

--- a/src/PIL/IptcImagePlugin.py
+++ b/src/PIL/IptcImagePlugin.py
@@ -154,10 +154,11 @@ class IptcImageFile(ImageFile.ImageFile):
                 if band is not None:
                     bands = [Image.new("L", _im.size)] * Image.getmodebands(self.mode)
                     bands[band] = _im
-                    _im = Image.merge(self.mode, bands)
+                    im = Image.merge(self.mode, bands)
                 else:
-                    _im.load()
-                self.im = _im.im
+                    im = _im
+                    im.load()
+                self.im = im.im
             self.tile = []
         return ImageFile.ImageFile.load(self)
 

--- a/src/PIL/SpiderImagePlugin.py
+++ b/src/PIL/SpiderImagePlugin.py
@@ -323,9 +323,9 @@ if __name__ == "__main__":
             outfile = sys.argv[2]
 
             # perform some image operation
-            im = im.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
+            transposed_im = im.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
             print(
                 f"saving a flipped version of {os.path.basename(filename)} "
                 f"as {outfile} "
             )
-            im.save(outfile, SpiderImageFile.format)
+            transposed_im.save(outfile, SpiderImageFile.format)


### PR DESCRIPTION
This is part of #8362 - I'm hoping to break down that PR into easier-to-review chunks.

This is to fix type hint errors like
> error: Incompatible types in assignment
> (expression has type "Image", variable has type "ImageFile")  [assignment]