### PR TITLE
Added compare_images function to ImageChops

### DIFF
--- a/Tests/test_compare_images.py
+++ b/Tests/test_compare_images.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from PIL import Image, ImageChops
 
 
-def test_compare_identical_images():
+def test_compare_identical_images() -> None:
     im1 = Image.new("RGB", (10, 10), "red")
     im2 = Image.new("RGB", (10, 10), "red")
 
@@ -13,7 +13,7 @@ def test_compare_identical_images():
     assert result["percent_difference"] == 0.0
 
 
-def test_compare_different_images():
+def test_compare_different_images() -> None:
     im1 = Image.new("RGB", (10, 10), "red")
     im2 = Image.new("RGB", (10, 10), "blue")
 

--- a/src/PIL/ImageChops.py
+++ b/src/PIL/ImageChops.py
@@ -293,7 +293,7 @@ def composite(
     return Image.composite(image1, image2, mask)
 
 
-def compare_images(image1, image2):
+def compare_images(image1: Image.Image, image2: Image.Image) -> dict[str, float]:
     """
     Compare two images pixel by pixel.
 
@@ -324,7 +324,7 @@ def compare_images(image1, image2):
         }
 
     # Count non-zero (different) pixels
-    nonzero = sum(1 for px in diff.getdata() if px != 0)
+    nonzero = sum(1 for px in tuple(diff.getdata()) if px != 0)
     total = image1.size[0] * image1.size[1]
 
     return {


### PR DESCRIPTION
This pull request implements the feature requested in issue #6478 by adding a new helper function compare_images to ImageChops.

The function compares two images pixel-by-pixel using ImageChops.difference and returns a dictionary containing:

different_pixels — the number of pixels that differ

percent_difference — the percentage of differing pixels

It raises a ValueError if the images have different modes or sizes, matching existing behavior elsewhere in Pillow.

A new test file (Tests/test_compare_images.py) is included to validate that:

identical images return zero difference

different images return nonzero values

This feature builds directly on existing ImageChops functionality and follows the project's testing and docstring conventions.

Closes #6478
