### PR TITLE
Fix `ResourceWarning`s in `selftest.py`

### DIFF
--- a/selftest.py
+++ b/selftest.py
@@ -40,12 +40,14 @@ def testimage() -> None:
     >>> with Image.open("Tests/images/hopper.gif") as im:
     ...     _info(im)
     ('GIF', 'P', (128, 128))
-    >>> _info(Image.open("Tests/images/hopper.ppm"))
+    >>> with Image.open("Tests/images/hopper.ppm") as im:
+    ...     _info(im)
     ('PPM', 'RGB', (128, 128))
     >>> try:
-    ...  _info(Image.open("Tests/images/hopper.jpg"))
+    ...     with Image.open("Tests/images/hopper.jpg") as im:
+    ...         _info(im)
     ... except OSError as v:
-    ...  print(v)
+    ...     print(v)
     ('JPEG', 'RGB', (128, 128))
 
     PIL doesn't actually load the image data until it's needed,


### PR DESCRIPTION
Fix some resource warnings found when running in [Python Development Mode](https://docs.python.org/3/library/devmode.html): `python -Xdev selftest.py` 


```pytb
Running selftest:
<doctest __main__.testimage[10]>:1: ResourceWarning: unclosed file <_io.BufferedReader name='Tests/images/hopper.ppm'>
  _info(Image.open("Tests/images/hopper.ppm"))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
<doctest __main__.testimage[11]>:2: ResourceWarning: unclosed file <_io.BufferedReader name='Tests/images/hopper.jpg'>
  _info(Image.open("Tests/images/hopper.jpg"))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
--- 59 tests passed.
```

