### PR TITLE
Docs: update major bump cadence

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -14,6 +14,7 @@ expected to be backported to earlier versions.
 .. toctree::
   :maxdepth: 2
 
+  versioning
   12.1.0
   12.0.0
   11.3.0
@@ -80,4 +81,3 @@ expected to be backported to earlier versions.
   2.5.2
   2.3.2
   2.3.1
-  versioning

--- a/docs/releasenotes/versioning.rst
+++ b/docs/releasenotes/versioning.rst
@@ -17,8 +17,8 @@ prior three months.
 
 A quarterly release bumps the MAJOR version when incompatible API changes are
 made, such as removing deprecated APIs or dropping an EOL Python version. In practice,
-these occur every 12-18 months, guided by
-`Python's EOL schedule <https://devguide.python.org/#status-of-python-branches>`_, and
+these occur every October, guided by
+`Python's EOL schedule <https://devguide.python.org/versions/>`__, and
 any APIs that have been deprecated for at least a year are removed at the same time.
 
 PATCH versions ("`Point Release <https://github.com/python-pillow/Pillow/blob/main/RELEASING.md#user-content-point-release>`_"


### PR DESCRIPTION
* Python releases and EOLs are now on an annual cycle ([PEP 602](https://peps.python.org/pep-0602/))
* Move the versioning page to the top of the releases list, no-one will notice it at the end
* Update a devguide link