### PR TITLE
Correct variable type

### DIFF
--- a/Tests/test_file_iptc.py
+++ b/Tests/test_file_iptc.py
@@ -6,7 +6,7 @@ import pytest
 
 from PIL import Image, IptcImagePlugin, TiffImagePlugin, TiffTags
 
-from .helper import assert_image_equal, hopper
+from .helper import assert_image_equal
 
 TEST_FILE = "Tests/images/iptc.jpg"
 
@@ -85,7 +85,7 @@ def test_getiptcinfo() -> None:
 
 def test_getiptcinfo_jpg_none() -> None:
     # Arrange
-    with hopper() as im:
+    with Image.open("Tests/images/hopper.jpg") as im:
         # Act
         iptc = IptcImagePlugin.getiptcinfo(im)
 


### PR DESCRIPTION
This test uses an Image instance

https://github.com/python-pillow/Pillow/blob/2c6fd36f10ddfdda87f9354f6d50a569375a4d61/Tests/test_file_iptc.py#L86-L90

but an ImageFile instance is expected.

https://github.com/python-pillow/Pillow/blob/2c6fd36f10ddfdda87f9354f6d50a569375a4d61/src/PIL/IptcImagePlugin.py#L170-L172

