### PR TITLE
Add primary color dithering to ImageOps

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -615,7 +615,7 @@ def test_dither_primary_returns_image() -> None:
     assert out.mode == "RGB"
 
 
-def test_dither_primary_uses_only_primary_colors():
+def test_dither_primary_uses_only_primary_colors() -> None:
     im = Image.new("RGB", (4, 4), (200, 100, 50))
     out = ImageOps.dither_primary(im)
 

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -606,7 +606,7 @@ def test_autocontrast_preserve_one_color(color: tuple[int, int, int]) -> None:
     assert_image_equal(img, out)
 
 
-def test_dither_primary_returns_image():
+def test_dither_primary_returns_image() -> None:
     im = Image.new("RGB", (4, 4), (128, 128, 128))
     out = ImageOps.dither_primary(im)
 

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -605,10 +605,6 @@ def test_autocontrast_preserve_one_color(color: tuple[int, int, int]) -> None:
     )  # single color 10 cutoff
     assert_image_equal(img, out)
 
-
-from PIL import ImageOps
-
-
 def test_dither_primary_returns_image():
     im = Image.new("RGB", (4, 4), (128, 128, 128))
     out = ImageOps.dither_primary(im)

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -605,7 +605,8 @@ def test_autocontrast_preserve_one_color(color: tuple[int, int, int]) -> None:
     )  # single color 10 cutoff
     assert_image_equal(img, out)
 
-from PIL import Image, ImageOps
+
+from PIL import ImageOps
 
 
 def test_dither_primary_returns_image():

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -628,7 +628,7 @@ def test_dither_primary_uses_only_primary_colors() -> None:
             assert b in (0, 255)
 
 
-def test_dither_primary_small_image():
+def test_dither_primary_small_image() -> None:
     im = Image.new("RGB", (2, 2), (255, 0, 0))
     out = ImageOps.dither_primary(im)
 

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -606,35 +606,18 @@ def test_autocontrast_preserve_one_color(color: tuple[int, int, int]) -> None:
     assert_image_equal(img, out)
 
 
-def test_dither_primary_returns_image() -> None:
-    im = Image.new("RGB", (4, 4), (128, 128, 128))
+@pytest.mark.parametrize("size", (2, 4))
+def test_dither_primary(size: int) -> None:
+    im = Image.new("RGB", (size, size), (200, 100, 50))
     out = ImageOps.dither_primary(im)
 
-    assert isinstance(out, Image.Image)
-    assert out.size == im.size
-    assert out.mode == "RGB"
+    expected = Image.new("RGB", (size, size), (255, 0, 0))
+    assert_image_equal(out, expected)
 
 
-def test_dither_primary_uses_only_primary_colors() -> None:
-    im = Image.new("RGB", (4, 4), (200, 100, 50))
+def test_dither_primary_non_rgb() -> None:
+    im = Image.new("L", (2, 2), 100)
     out = ImageOps.dither_primary(im)
 
-    px = out.load()
-    assert px is not None
-
-    for x in range(out.width):
-        for y in range(out.height):
-            value = px[x, y]
-            assert isinstance(value, tuple)
-
-            r, g, b = value
-            assert r in (0, 255)
-            assert g in (0, 255)
-            assert b in (0, 255)
-
-
-def test_dither_primary_small_image() -> None:
-    im = Image.new("RGB", (2, 2), (255, 0, 0))
-    out = ImageOps.dither_primary(im)
-
-    assert out.size == (2, 2)
+    expected = Image.new("RGB", (2, 2))
+    assert_image_equal(out, expected)

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -605,6 +605,7 @@ def test_autocontrast_preserve_one_color(color: tuple[int, int, int]) -> None:
     )  # single color 10 cutoff
     assert_image_equal(img, out)
 
+
 def test_dither_primary_returns_image():
     im = Image.new("RGB", (4, 4), (128, 128, 128))
     out = ImageOps.dither_primary(im)

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -604,3 +604,34 @@ def test_autocontrast_preserve_one_color(color: tuple[int, int, int]) -> None:
         img, cutoff=10, preserve_tone=True
     )  # single color 10 cutoff
     assert_image_equal(img, out)
+
+from PIL import Image, ImageOps
+
+
+def test_dither_primary_returns_image():
+    im = Image.new("RGB", (4, 4), (128, 128, 128))
+    out = ImageOps.dither_primary(im)
+
+    assert isinstance(out, Image.Image)
+    assert out.size == im.size
+    assert out.mode == "RGB"
+
+
+def test_dither_primary_uses_only_primary_colors():
+    im = Image.new("RGB", (4, 4), (200, 100, 50))
+    out = ImageOps.dither_primary(im)
+
+    pixels = out.load()
+    for x in range(out.width):
+        for y in range(out.height):
+            r, g, b = pixels[x, y]
+            assert r in (0, 255)
+            assert g in (0, 255)
+            assert b in (0, 255)
+
+
+def test_dither_primary_small_image():
+    im = Image.new("RGB", (2, 2), (255, 0, 0))
+    out = ImageOps.dither_primary(im)
+
+    assert out.size == (2, 2)

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -606,7 +606,7 @@ def test_autocontrast_preserve_one_color(color: tuple[int, int, int]) -> None:
     assert_image_equal(img, out)
 
 
-def test_dither_primary_returns_image():
+def test_dither_primary_returns_image() -> None:
     im = Image.new("RGB", (4, 4), (128, 128, 128))
     out = ImageOps.dither_primary(im)
 
@@ -615,20 +615,25 @@ def test_dither_primary_returns_image():
     assert out.mode == "RGB"
 
 
-def test_dither_primary_uses_only_primary_colors():
+def test_dither_primary_uses_only_primary_colors() -> None:
     im = Image.new("RGB", (4, 4), (200, 100, 50))
     out = ImageOps.dither_primary(im)
 
-    pixels = out.load()
+    px = out.load()
+    assert px is not None
+
     for x in range(out.width):
         for y in range(out.height):
-            r, g, b = pixels[x, y]
+            value = px[x, y]
+            assert isinstance(value, tuple)
+
+            r, g, b = value
             assert r in (0, 255)
             assert g in (0, 255)
             assert b in (0, 255)
 
 
-def test_dither_primary_small_image():
+def test_dither_primary_small_image() -> None:
     im = Image.new("RGB", (2, 2), (255, 0, 0))
     out = ImageOps.dither_primary(im)
 

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -615,9 +615,7 @@ def test_dither_primary(size: int) -> None:
     assert_image_equal(out, expected)
 
 
-def test_dither_primary_non_rgb() -> None:
-    im = Image.new("L", (2, 2), 100)
-    out = ImageOps.dither_primary(im)
-
-    expected = Image.new("RGB", (2, 2))
-    assert_image_equal(out, expected)
+def test_dither_primary_invalid_mode() -> None:
+    im = Image.new("L", (1, 1))
+    with pytest.raises(ValueError, match="mode must be RGB, not L"):
+        ImageOps.dither_primary(im)

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -607,15 +607,15 @@ def test_autocontrast_preserve_one_color(color: tuple[int, int, int]) -> None:
 
 
 @pytest.mark.parametrize("size", (2, 4))
-def test_dither_primary(size: int) -> None:
+def test_primary(size: int) -> None:
     im = Image.new("RGB", (size, size), (200, 100, 50))
-    out = ImageOps.dither_primary(im)
+    out = ImageOps.primary(im)
 
     expected = Image.new("RGB", (size, size), (255, 0, 0))
     assert_image_equal(out, expected)
 
 
-def test_dither_primary_invalid_mode() -> None:
+def test_primary_invalid_mode() -> None:
     im = Image.new("L", (1, 1))
     with pytest.raises(ValueError, match="mode must be RGB, not L"):
-        ImageOps.dither_primary(im)
+        ImageOps.primary(im)

--- a/docs/reference/ImageOps.rst
+++ b/docs/reference/ImageOps.rst
@@ -11,9 +11,9 @@ only work on L and RGB images.
 .. versionadded:: 1.1.3
 
 .. autofunction:: autocontrast
-.. autofunction:: dither_primary
 .. autofunction:: colorize
 .. autofunction:: crop
+.. autofunction:: dither_primary
 .. autofunction:: scale
 .. autoclass:: SupportsGetMesh
     :show-inheritance:

--- a/docs/reference/ImageOps.rst
+++ b/docs/reference/ImageOps.rst
@@ -11,6 +11,7 @@ only work on L and RGB images.
 .. versionadded:: 1.1.3
 
 .. autofunction:: autocontrast
+.. autofunction:: dither_primary
 .. autofunction:: colorize
 .. autofunction:: crop
 .. autofunction:: scale

--- a/docs/reference/ImageOps.rst
+++ b/docs/reference/ImageOps.rst
@@ -13,7 +13,6 @@ only work on L and RGB images.
 .. autofunction:: autocontrast
 .. autofunction:: colorize
 .. autofunction:: crop
-.. autofunction:: dither_primary
 .. autofunction:: scale
 .. autoclass:: SupportsGetMesh
     :show-inheritance:
@@ -24,6 +23,7 @@ only work on L and RGB images.
 .. autofunction:: grayscale
 .. autofunction:: invert
 .. autofunction:: mirror
+.. autofunction:: primary
 .. autofunction:: posterize
 .. autofunction:: solarize
 .. autofunction:: exif_transpose

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -643,6 +643,7 @@ def mirror(image: Image.Image) -> Image.Image:
     """
     return image.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
 
+
 def _dither_saturation(value: float, quadrant: int) -> int:
     if value > 233:
         return 255
@@ -653,6 +654,7 @@ def _dither_saturation(value: float, quadrant: int) -> int:
     if value > 32:
         return 255 if quadrant == 1 else 0
     return 0
+
 
 def dither_primary(image: Image.Image) -> Image.Image:
     """

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -667,7 +667,8 @@ def dither_primary(image: Image.Image) -> Image.Image:
     :param image: The image to process.
     :return: An image.
     """
-    image = image.convert("RGB")
+    if image.mode != "RGB":
+        image = image.convert("RGB")
     width, height = image.size
 
     src = image.load()

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -675,9 +675,12 @@ def dither_primary(image: Image.Image) -> Image.Image:
     dst = out.load()
 
     # Step 1: primary color reduction
+    assert src is not None
     for x in range(width):
         for y in range(height):
-            r, g, b = src[x, y]
+            px = src[x, y]
+            assert isinstance(px, tuple)
+            r, g, b = px
             src[x, y] = (
                 255 if r > 127 else 0,
                 255 if g > 127 else 0,
@@ -685,6 +688,7 @@ def dither_primary(image: Image.Image) -> Image.Image:
             )
 
     # Step 2: ordered dithering (2x2 blocks)
+    assert dst is not None
     for x in range(0, width - 1, 2):
         for y in range(0, height - 1, 2):
             p1 = src[x, y]
@@ -692,18 +696,22 @@ def dither_primary(image: Image.Image) -> Image.Image:
             p3 = src[x + 1, y]
             p4 = src[x + 1, y + 1]
 
+            assert isinstance(p1, tuple)
+            assert isinstance(p2, tuple)
+            assert isinstance(p3, tuple)
+            assert isinstance(p4, tuple)
             red = (p1[0] + p2[0] + p3[0] + p4[0]) / 4
             green = (p1[1] + p2[1] + p3[1] + p4[1]) / 4
             blue = (p1[2] + p2[2] + p3[2] + p4[2]) / 4
 
-            r = [_dither_saturation(red, q) for q in range(4)]
-            g = [_dither_saturation(green, q) for q in range(4)]
-            b = [_dither_saturation(blue, q) for q in range(4)]
+            r1 = [_dither_saturation(red, q) for q in range(4)]
+            g1 = [_dither_saturation(green, q) for q in range(4)]
+            b1 = [_dither_saturation(blue, q) for q in range(4)]
 
-            dst[x, y] = (r[0], g[0], b[0])
-            dst[x, y + 1] = (r[1], g[1], b[1])
-            dst[x + 1, y] = (r[2], g[2], b[2])
-            dst[x + 1, y + 1] = (r[3], g[3], b[3])
+            dst[x, y] = (r1[0], g1[0], b1[0])
+            dst[x, y + 1] = (r1[1], g1[1], b1[1])
+            dst[x + 1, y] = (r1[2], g1[2], b1[2])
+            dst[x + 1, y + 1] = (r1[3], g1[3], b1[3])
 
     return out
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -643,6 +643,68 @@ def mirror(image: Image.Image) -> Image.Image:
     """
     return image.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
 
+def _dither_saturation(value: float, quadrant: int) -> int:
+    if value > 233:
+        return 255
+    if value > 159:
+        return 255 if quadrant != 1 else 0
+    if value > 95:
+        return 255 if quadrant in (0, 3) else 0
+    if value > 32:
+        return 255 if quadrant == 1 else 0
+    return 0
+
+def dither_primary(image: Image.Image) -> Image.Image:
+    """
+    Reduce the image to primary colors and apply ordered dithering.
+
+    This operation first reduces each RGB channel to its primary values
+    (0 or 255), then applies a 2x2 ordered dithering pattern based on the
+    average color intensity.
+
+    :param image: The image to process.
+    :return: An image.
+    """
+    image = image.convert("RGB")
+    width, height = image.size
+
+    src = image.load()
+    out = Image.new("RGB", (width, height))
+    dst = out.load()
+
+    # Step 1: primary color reduction
+    for x in range(width):
+        for y in range(height):
+            r, g, b = src[x, y]
+            src[x, y] = (
+                255 if r > 127 else 0,
+                255 if g > 127 else 0,
+                255 if b > 127 else 0,
+            )
+
+    # Step 2: ordered dithering (2x2 blocks)
+    for x in range(0, width - 1, 2):
+        for y in range(0, height - 1, 2):
+            p1 = src[x, y]
+            p2 = src[x, y + 1]
+            p3 = src[x + 1, y]
+            p4 = src[x + 1, y + 1]
+
+            red = (p1[0] + p2[0] + p3[0] + p4[0]) / 4
+            green = (p1[1] + p2[1] + p3[1] + p4[1]) / 4
+            blue = (p1[2] + p2[2] + p3[2] + p4[2]) / 4
+
+            r = [_dither_saturation(red, q) for q in range(4)]
+            g = [_dither_saturation(green, q) for q in range(4)]
+            b = [_dither_saturation(blue, q) for q in range(4)]
+
+            dst[x, y] = (r[0], g[0], b[0])
+            dst[x, y + 1] = (r[1], g[1], b[1])
+            dst[x + 1, y] = (r[2], g[2], b[2])
+            dst[x + 1, y + 1] = (r[3], g[3], b[3])
+
+    return out
+
 
 def posterize(image: Image.Image, bits: int) -> Image.Image:
     """

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -666,6 +666,8 @@ def dither_primary(image: Image.Image) -> Image.Image:
 
     :param image: The image to process.
     :return: An image.
+
+    .. versionadded:: 13.0.0
     """
 
     if image.mode != "RGB":

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -658,7 +658,7 @@ def _dither_saturation(value: float, quadrant: int) -> int:
 
 def dither_primary(image: Image.Image) -> Image.Image:
     """
-    Reduce the image to primary colors and apply ordered dithering.
+    Reduce RGB image to primary colors and apply ordered dithering.
 
     This operation first reduces each RGB channel to its primary values
     (0 or 255), then applies a 2x2 ordered dithering pattern based on the
@@ -667,9 +667,10 @@ def dither_primary(image: Image.Image) -> Image.Image:
     :param image: The image to process.
     :return: An image.
     """
-    if image.mode != "RGB":
-        image = image.convert("RGB")
 
+    if image.mode != "RGB":
+        msg = f"mode must be RGB, not {image.mode}"
+        raise ValueError(msg)
     bands = []
     for band in image.split():
         # Step 1: primary color reduction

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -656,15 +656,17 @@ def _dither_saturation(value: float, quadrant: int) -> int:
     return 0
 
 
-def dither_primary(image: Image.Image) -> Image.Image:
+def primary(image: Image.Image, dither: bool = True) -> Image.Image:
     """
-    Reduce RGB image to primary colors and apply ordered dithering.
+    Reduce RGB image to primary colors, and optionally apply ordered dithering.
 
     This operation first reduces each RGB channel to its primary values
     (0 or 255), then applies a 2x2 ordered dithering pattern based on the
     average color intensity.
 
     :param image: The image to process.
+    :param dither: Optional flag, defaulting to ``True``. If ``False``, do not apply
+        dithering.
     :return: An image.
 
     .. versionadded:: 13.0.0
@@ -675,11 +677,13 @@ def dither_primary(image: Image.Image) -> Image.Image:
         raise ValueError(msg)
     bands = []
     for band in image.split():
-        # Step 1: primary color reduction
+        # Primary color reduction
         band = band.point(lambda x: 255 if x > 127 else 0)
         bands.append(band)
+        if not dither:
+            continue
 
-        # Step 2: ordered dithering (2x2 blocks)
+        # Ordered dithering (2x2 blocks)
         px = band.load()
         assert px is not None
         for x in range(0, band.width - 1, 2):


### PR DESCRIPTION
### What does this PR do?

This PR adds a new image operation to `PIL.ImageOps` that applies a primary-color dithering filter (RGB only).

The filter:
- Thresholds RGB channels to primary colors (0 or 255)
- Applies a simple dithering strategy to preserve local contrast
- Returns a new image, leaving the input unchanged

### Why is this useful?

Primary-color dithering can be useful for:
- Educational purposes (image processing fundamentals)
- Artistic and stylized image transformations
- Low-color or hardware-constrained displays

### What is included?

- New function: `ImageOps.dither_primary`
- Unit tests covering basic behavior and output properties
- Documentation added to the ImageOps module

### Notes

- The function expects an RGB image
- The implementation follows existing ImageOps conventions

## Before Filter
![mario](https://github.com/user-attachments/assets/8087bdac-4e89-47f6-8ea8-1073123ff434)

## After Filter
<img width="300" height="168" alt="composition" src="https://github.com/user-attachments/assets/dcc20c3c-b285-4088-b6f0-aef72c5f40db" />