### PR TITLE
Pin docutils to 0.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dynamic = [
   "version",
 ]
 optional-dependencies.docs = [
-  "docutils==0.21",  # Pending https://github.com/pradyunsg/sphinx-inline-tabs/pull/51
+  "docutils==0.21",      # Pending https://github.com/pradyunsg/sphinx-inline-tabs/pull/51
   "furo",
   "olefile",
   "sphinx>=8.2",


### PR DESCRIPTION
readthedocs has started failing - https://app.readthedocs.org/projects/pillow/builds/30766284/

https://app.readthedocs.org/api/v2/build/30766284.txt
```
      File "/home/docs/checkouts/readthedocs.org/user_builds/pillow/envs/latest/lib/python3.14/site-packages/sphinx_inline_tabs/_impl.py", line 26, in visit
        attributes.pop("backrefs")
        ~~~~~~~~~~~~~~^^^^^^^^^^^^
    KeyError: 'backrefs'
```

This is https://github.com/pradyunsg/sphinx-inline-tabs/pull/51, "Docutils 0.22 compatibility". Until that is merged and released, the solution is to downgrade docutils to 0.21.