### PR TITLE
Revert "Pin docutils to 0.21 (#9344)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dynamic = [
   "version",
 ]
 optional-dependencies.docs = [
-  "docutils==0.21",      # Pending https://github.com/pradyunsg/sphinx-inline-tabs/pull/51
   "furo",
   "olefile",
   "sphinx>=8.2",


### PR DESCRIPTION
Reverts #9344 now that https://github.com/pradyunsg/sphinx-inline-tabs/pull/51 has been merged and released as https://github.com/pradyunsg/sphinx-inline-tabs/releases/tag/2025.12.21.14