### PR TITLE
Return LUT from LutBuilder build_default_lut()

### DIFF
--- a/Tests/test_imagemorph.py
+++ b/Tests/test_imagemorph.py
@@ -281,6 +281,11 @@ def test_pattern_syntax_error(pattern: str) -> None:
         lb.build_lut()
 
 
+def test_build_default_lut() -> None:
+    lb = ImageMorph.LutBuilder(op_name="corner")
+    assert lb.build_default_lut() == lb.lut
+
+
 def test_load_invalid_mrl() -> None:
     # Arrange
     invalid_mrl = "Tests/images/hopper.png"

--- a/src/PIL/ImageMorph.py
+++ b/src/PIL/ImageMorph.py
@@ -92,10 +92,11 @@ class LutBuilder:
     def add_patterns(self, patterns: list[str]) -> None:
         self.patterns += patterns
 
-    def build_default_lut(self) -> None:
+    def build_default_lut(self) -> bytearray:
         symbols = [0, 1]
         m = 1 << 4  # pos of current pixel
         self.lut = bytearray(symbols[(i & m) > 0] for i in range(LUT_SIZE))
+        return self.lut
 
     def get_lut(self) -> bytearray | None:
         return self.lut


### PR DESCRIPTION
`LutBuilder.build_lut()` returns `self.lut`
https://github.com/python-pillow/Pillow/blob/ca21683316a96b348197a6f5ca97ea9c6c142bb0/src/PIL/ImageMorph.py#L184

I suggest that `LutBuilder.build_default_lut()` act in the same way.