### PR TITLE
Add type hint for LOAD_TRUNCATED_IMAGES

### DIFF
--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -61,7 +61,7 @@ User code may set this to another number.
 
 SAFEBLOCK = 1024 * 1024
 
-LOAD_TRUNCATED_IMAGES = False
+LOAD_TRUNCATED_IMAGES: bool = False
 """Whether or not to load truncated image files. User code may change this."""
 
 ERRORS = {


### PR DESCRIPTION
Changes proposed in this pull request:

 * Adds a type hint for ImageFile.LOAD_TRUNCATED_IMAGES.
 
     Sets the type to `bool`, otherwise `Literal[False]` is assumed causing a lint error when setting `ImageFile.LOAD_TRUNCATED_IMAGES = True`.