### PR TITLE
Call parent verify method

### DIFF
--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -855,9 +855,7 @@ class PngImageFile(ImageFile.ImageFile):
         self.png.verify()
         self.png.close()
 
-        if self._exclusive_fp:
-            self.fp.close()
-        self.fp = None
+        super().verify()
 
     def seek(self, frame: int) -> None:
         if not self._seek_check(frame):


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/2ebb3e9964bcfb46e2b8dcaec1917caf67730a7d/src/PIL/PngImagePlugin.py#L858-L860
is a copy of

https://github.com/python-pillow/Pillow/blob/2ebb3e9964bcfb46e2b8dcaec1917caf67730a7d/src/PIL/ImageFile.py#L265-L272

so let's just call `super().verify()`