### PR TITLE
Use minimum supported Python version for Lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.x"
+          python-version: "3.10"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
     rev: v0.24.1
     hooks:
       - id: validate-pyproject
-        additional_dependencies: [trove-classifiers>=2024.10.12]
+        additional_dependencies: [tomli, trove-classifiers>=2024.10.12]
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
     rev: 1.7.0


### PR DESCRIPTION
The Lint job has started failing - https://github.com/python-pillow/Pillow/actions/runs/20627828270/job/59241207690
```
.tox/mypy/lib/python3.14/site-packages/sphinx/util/docutils.py:53: error: Type
statement is only supported in Python 3.12 and greater  [syntax]
    ...e _DocutilsSettings = docutils.frontend.Values  # pyright: ignore[repo...
                                                        ^
```

This started happening with the recent release of [Sphinx 9.1.0](https://github.com/sphinx-doc/sphinx/releases/tag/v9.1.0), which dropped support for Python 3.11.

This PR changes the Python version for our Lint job to 3.10, the minimum supported Pillow version. This also then [requires tomli.](https://github.com/radarhere/Pillow/actions/runs/20629877623/job/59246178796)