### PR TITLE
Add ImageFile context manager

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -164,7 +164,7 @@ def test_reduce() -> None:
     with Image.open("Tests/images/test-card-lossless.jp2") as im:
         assert callable(im.reduce)
 
-        im.reduce = 2
+        im.reduce = 2  # type: ignore[assignment, method-assign]
         assert im.reduce == 2
 
         im.load()

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -823,7 +823,7 @@ class TestFilePng:
         monkeypatch.setattr(sys, "stdout", mystdout)
 
         with Image.open(TEST_PNG_FILE) as im:
-            im.save(sys.stdout, "PNG")
+            im.save(sys.stdout, "PNG")  # type: ignore[arg-type]
 
         if isinstance(mystdout, MyStdOut):
             mystdout = mystdout.buffer

--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -389,7 +389,7 @@ def test_save_stdout(buffer: bool, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "stdout", mystdout)
 
     with Image.open(TEST_FILE) as im:
-        im.save(sys.stdout, "PPM")
+        im.save(sys.stdout, "PPM")  # type: ignore[arg-type]
 
     if isinstance(mystdout, MyStdOut):
         mystdout = mystdout.buffer

--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -250,14 +250,14 @@ class TestImageTransform:
     def test_missing_method_data(self) -> None:
         with hopper() as im:
             with pytest.raises(ValueError):
-                im.transform((100, 100), None)
+                im.transform((100, 100), None)  # type: ignore[arg-type]
 
     @pytest.mark.parametrize("resample", (Image.Resampling.BOX, "unknown"))
     def test_unknown_resampling_filter(self, resample: Image.Resampling | str) -> None:
         with hopper() as im:
             (w, h) = im.size
             with pytest.raises(ValueError):
-                im.transform((100, 100), Image.Transform.EXTENT, (0, 0, w, h), resample)
+                im.transform((100, 100), Image.Transform.EXTENT, (0, 0, w, h), resample)  # type: ignore[arg-type]
 
 
 class TestImageTransformAffine:

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -590,16 +590,11 @@ class Image:
         return new
 
     # Context manager support
-    def __enter__(self):
+    def __enter__(self) -> Image:
         return self
 
-    def __exit__(self, *args):
-        from . import ImageFile
-
-        if isinstance(self, ImageFile.ImageFile):
-            if getattr(self, "_exclusive_fp", False):
-                self._close_fp()
-            self.fp = None
+    def __exit__(self, *args: object) -> None:
+        pass
 
     def close(self) -> None:
         """

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -169,6 +169,10 @@ class ImageFile(Image.Image):
     def _open(self) -> None:
         pass
 
+    # Context manager support
+    def __enter__(self) -> ImageFile:
+        return self
+
     def _close_fp(self) -> None:
         if getattr(self, "_fp", False) and not isinstance(self._fp, DeferredError):
             if self._fp != self.fp:
@@ -176,6 +180,11 @@ class ImageFile(Image.Image):
             self._fp = DeferredError(ValueError("Operation on closed image"))
         if self.fp:
             self.fp.close()
+
+    def __exit__(self, *args: object) -> None:
+        if getattr(self, "_exclusive_fp", False):
+            self._close_fp()
+        self.fp = None
 
     def close(self) -> None:
         """


### PR DESCRIPTION
`Image.__exit__()` currently handles the case where it is an `ImageFile` instance.
https://github.com/python-pillow/Pillow/blob/a868c29eb196a082536e9a0895c4972f18c443ad/src/PIL/Image.py#L596-L602

It would be a cleaner solution to move that part of the code into a new `ImageFile.__exit__()` method.