### PR TITLE
Fix unclosed file warning

### DIFF
--- a/Tests/test_imagemorph.py
+++ b/Tests/test_imagemorph.py
@@ -231,15 +231,15 @@ def test_negate() -> None:
 
 
 def test_incorrect_mode() -> None:
-    im = hopper()
     mop = ImageMorph.MorphOp(op_name="erosion8")
 
-    with pytest.raises(ValueError, match="Image mode must be 1 or L"):
-        mop.apply(im)
-    with pytest.raises(ValueError, match="Image mode must be 1 or L"):
-        mop.match(im)
-    with pytest.raises(ValueError, match="Image mode must be 1 or L"):
-        mop.get_on_pixels(im)
+    with hopper() as im:
+        with pytest.raises(ValueError, match="Image mode must be 1 or L"):
+            mop.apply(im)
+        with pytest.raises(ValueError, match="Image mode must be 1 or L"):
+            mop.match(im)
+        with pytest.raises(ValueError, match="Image mode must be 1 or L"):
+            mop.get_on_pixels(im)
 
 
 def test_add_patterns() -> None:


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/20654775775/job/59305577478#step:6:5825
```
Tests/test_imagemorph.py::test_incorrect_mode
  /vpy3/lib/python3.11/site-packages/_pytest/python.py:166: ResourceWarning: unclosed file <_io.BufferedReader name='Tests/images/hopper.ppm'>
    result = testfunction(**testargs)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
```