### PR TITLE
Add FreeTypeFont set_variation_by_name_index()

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -753,6 +753,8 @@ def test_variation_duplicates() -> None:
         b"Black",
         b"Black Medium Contrast",
         b"Black High Contrast",
+        b"Black High Contrast",
+        b"Black High Contrast",
         b"Default",
     ]
 
@@ -789,6 +791,18 @@ def test_variation_set_by_name(font: ImageFont.FreeTypeFont) -> None:
         font.set_variation_by_name(name)
         assert font.getname()[1] == "200"
     _check_text(font, "Tests/images/variation_tiny_name.png", 40)
+
+
+def test_variation_set_by_name_index(font: ImageFont.FreeTypeFont) -> None:
+    with pytest.raises(OSError):
+        font.set_variation_by_name_index(0)
+
+    font = ImageFont.truetype("Tests/fonts/AdobeVFPrototype.ttf", 36)
+    _check_text(font, "Tests/images/variation_adobe.png", 11)
+    index = font.get_variation_names().index(b"Bold")
+    font.set_variation_by_name_index(index)
+    assert font.getname()[1] == "Bold"
+    _check_text(font, "Tests/images/variation_adobe_name.png", 16)
 
 
 def test_variation_set_by_axes(font: ImageFont.FreeTypeFont) -> None:

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -675,12 +675,8 @@ class FreeTypeFont:
         :returns: A list of the named styles in a variation font.
         :exception OSError: If the font is not a variation font.
         """
-        names = []
-        for name in self.font.getvarnames():
-            name = name.replace(b"\x00", b"")
-            if name not in names:
-                names.append(name)
-        return names
+        names = self.font.getvarnames()
+        return [name.replace(b"\x00", b"") for name in names]
 
     def set_variation_by_name(self, name: str | bytes) -> None:
         """

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -686,7 +686,14 @@ class FreeTypeFont:
         names = self.get_variation_names()
         if not isinstance(name, bytes):
             name = name.encode()
-        index = names.index(name) + 1
+        self.set_variation_by_name_index(names.index(name))
+
+    def set_variation_by_name_index(self, index: int) -> None:
+        """
+        :param name: The index within the list of named styles in a variation font.
+        :exception OSError: If the font is not a variation font.
+        """
+        index += 1
 
         if index == getattr(self, "_last_variation_index", None):
             # When the same name is set twice in a row,


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/issues/9361 found a font with duplicate variation names.

https://github.com/python-pillow/Pillow/pull/9362#issuecomment-3703830655 would like to be able to choose between the duplicates, which [`set_variation_by_name()`](https://pillow.readthedocs.io/en/stable/reference/ImageFont.html#PIL.ImageFont.FreeTypeFont.set_variation_by_name) doesn't allow for.

This PR makes the duplicate names visible in `get_variation_names()`, and adds a new method, `set_variation_by_name_index()`, to allow the user to definitively choose between them.