### PR TITLE
Remove add-imaging-libs option from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -363,7 +363,6 @@ class pil_build_ext(build_ext):
             ("disable-platform-guessing", None, "Disable platform guessing"),
             ("debug", None, "Debug logging"),
         ]
-        + [("add-imaging-libs=", None, "Add libs to _imaging build")]
     )
 
     @staticmethod
@@ -374,7 +373,6 @@ class pil_build_ext(build_ext):
         self.disable_platform_guessing = self.check_configuration(
             "platform-guessing", "disable"
         )
-        self.add_imaging_libs = ""
         build_ext.initialize_options(self)
         for x in self.feature:
             setattr(self, f"disable_{x}", self.check_configuration(x, "disable"))
@@ -901,7 +899,6 @@ class pil_build_ext(build_ext):
         # core library
 
         libs: list[str | bool | None] = []
-        libs.extend(self.add_imaging_libs.split())
         defs: list[tuple[str, str | None]] = []
         if feature.get("tiff"):
             libs.append(feature.get("tiff"))


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/8389 suggests removing `add-imaging-libs` from setup.py, as it is undocumented.

It was added in #3399 to allow use when building in AppVeyor. It is no longer used there.

It was also not included when #7171 made sure that other setup options would work with pip >= 23.3 (released October 16, 2023), so it no longer works with recent versions of pip.