### PR TITLE
Raise EOFError when seeking too far in PSD

### DIFF
--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -85,6 +85,11 @@ def test_eoferror() -> None:
         # Test that seeking to the last frame does not raise an error
         im.seek(n_frames - 1)
 
+    # Test seeking past the last frame without calling n_frames first
+    with Image.open(test_file) as im:
+        with pytest.raises(EOFError):
+            im.seek(3)
+
 
 def test_seek_tell() -> None:
     with Image.open(test_file) as im:

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -175,6 +175,9 @@ class PsdImageFile(ImageFile.ImageFile):
             raise self._fp.ex
 
         # seek to given layer (1..max)
+        if layer > len(self.layers):
+            msg = "no more images in PSD file"
+            raise EOFError(msg)
         _, mode, _, tile = self.layers[layer - 1]
         self._mode = mode
         self.tile = tile


### PR DESCRIPTION
If you open a PSD file, use `n_frames`, and then seek too far, an `EOFError` is raised as expected.

```pycon
>>> from PIL import Image
>>> im = Image.open("Tests/images/hopper.psd")
>>> im.n_frames
2
>>> im.seek(3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/PsdImagePlugin.py", line 172, in seek
    if not self._seek_check(layer):
  File "PIL/ImageFile.py", line 460, in _seek_check
    raise EOFError(msg)
EOFError: attempt to seek outside sequence
```

As the trace says, this is raised by [`_seek_check()`](https://github.com/python-pillow/Pillow/blob/627d8743b76e0bb4bc62286b1fa034b78e76686b/src/PIL/ImageFile.py#L449-L462), because `_n_frames` has been populated.

However, if you do not use `n_frames`, an `IndexError` is raised instead.
```pycon
>>> im = Image.open("Tests/images/hopper.psd")
>>> im.seek(3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/PsdImagePlugin.py", line 178, in seek
    _, mode, _, tile = self.layers[layer - 1]
IndexError: list index out of range
```

This is because PsdImagePlugin itself does not have any explicit handling for when you seek too far. This PR adds it, changing the second scenario to also raise an `EOFError`.