### PR TITLE
Add validation for zero-dimension images in save()

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -263,6 +263,15 @@ class TestImage:
             im.save(temp_file)
             assert im.readonly
 
+    @pytest.mark.parametrize("size", ((0, 1), (1, 0), (0, 0)))
+    def test_save_zero_dimension(self, tmp_path: Path, size: tuple[int, int]) -> None:
+        im = Image.new("RGB", size)
+        msg = "cannot save image with zero width or height"
+        with pytest.raises(ValueError, match=msg):
+            im.save(tmp_path / "test.png")
+        with pytest.raises(ValueError, match=msg):
+            im.save(tmp_path / "test.gif")
+
     def test_dump(self, tmp_path: Path) -> None:
         im = Image.new("L", (10, 10))
         im._dump(str(tmp_path / "temp_L.ppm"))

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2517,9 +2517,14 @@ class Image:
         :returns: None
         :exception ValueError: If the output format could not be determined
            from the file name.  Use the format option to solve this.
+        :exception ValueError: If the image has zero width or height.
         :exception OSError: If the file could not be written.  The file
            may have been created, and may contain partial data.
         """
+
+        if self.size[0] <= 0 or self.size[1] <= 0:
+            msg = f"cannot save image with zero width or height (size: {self.size})"
+            raise ValueError(msg)
 
         filename: str | bytes = ""
         open_fp = False


### PR DESCRIPTION
## Summary

When saving an image with zero width or height, Pillow currently crashes with confusing internal errors:

- **GIF**: `ValueError: max() iterable argument is empty` (in `_get_optimize`)
- **PNG**: `SystemError: tile cannot extend outside image`

This PR adds early validation in `Image.save()` to raise a clear error message:

```
ValueError: cannot save image with zero width or height (size: (0, 50))
```

## Changes

- **src/PIL/Image.py**: Added dimension check at start of `save()` method
- **Tests/test_image.py**: Added parametrized test covering `(0, 1)`, `(1, 0)`, and `(0, 0)` dimensions

## Test Plan

- [x] Added test cases for zero-dimension images (width=0, height=0, both=0)
- [x] Tests verify both PNG and GIF formats raise the expected error

Fixes #9389