### PR TITLE
Fix unexpected error when saving zero dimension images

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -310,6 +310,14 @@ def test_roundtrip_save_all_1(tmp_path: Path) -> None:
         assert reloaded.getpixel((0, 0)) == 255
 
 
+@pytest.mark.parametrize("size", ((0, 1), (1, 0), (0, 0)))
+def test_save_zero(size: tuple[int, int]) -> None:
+    b = BytesIO()
+    im = Image.new("RGB", size)
+    with pytest.raises(SystemError):
+        im.save(b, "GIF")
+
+
 @pytest.mark.parametrize(
     "path, mode",
     (

--- a/Tests/test_file_pcx.py
+++ b/Tests/test_file_pcx.py
@@ -37,6 +37,14 @@ def test_sanity(tmp_path: Path) -> None:
         im.save(f)
 
 
+@pytest.mark.parametrize("size", ((0, 1), (1, 0), (0, 0)))
+def test_save_zero(size: tuple[int, int]) -> None:
+    b = io.BytesIO()
+    im = Image.new("1", size)
+    with pytest.raises(ValueError):
+        im.save(b, "PCX")
+
+
 def test_p_4_planes() -> None:
     with Image.open("Tests/images/p_4_planes.pcx") as im:
         assert im.getpixel((0, 0)) == 3

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -64,6 +64,14 @@ def test_save(tmp_path: Path) -> None:
         assert im2.format == "SPIDER"
 
 
+@pytest.mark.parametrize("size", ((0, 1), (1, 0), (0, 0)))
+def test_save_zero(size: tuple[int, int]) -> None:
+    b = BytesIO()
+    im = Image.new("1", size)
+    with pytest.raises(SystemError):
+        im.save(b, "SPIDER")
+
+
 def test_tempfile() -> None:
     # Arrange
     im = hopper()

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -937,7 +937,13 @@ def _get_optimize(im: Image.Image, info: dict[str, Any]) -> list[int] | None:
     :param info: encoderinfo
     :returns: list of indexes of palette entries in use, or None
     """
-    if im.mode in ("P", "L") and info and info.get("optimize"):
+    if (
+        im.mode in ("P", "L")
+        and info
+        and info.get("optimize")
+        and im.width != 0
+        and im.height != 0
+    ):
         # Potentially expensive operation.
 
         # The palette saves 3 bytes per color not used, but palette

--- a/src/PIL/PcxImagePlugin.py
+++ b/src/PIL/PcxImagePlugin.py
@@ -146,6 +146,10 @@ SAVE = {
 
 
 def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
+    if im.width == 0 or im.height == 0:
+        msg = "Cannot write empty image as PCX"
+        raise ValueError(msg)
+
     try:
         version, bits, planes, rawmode = SAVE[im.mode]
     except KeyError as e:

--- a/src/PIL/SpiderImagePlugin.py
+++ b/src/PIL/SpiderImagePlugin.py
@@ -244,7 +244,7 @@ def loadImageSeries(filelist: list[str] | None = None) -> list[Image.Image] | No
 
 def makeSpiderHeader(im: Image.Image) -> list[bytes]:
     nsam, nrow = im.size
-    lenbyt = nsam * 4  # There are labrec records in the header
+    lenbyt = max(1, nsam) * 4  # There are labrec records in the header
     labrec = int(1024 / lenbyt)
     if 1024 % lenbyt != 0:
         labrec += 1


### PR DESCRIPTION
#9389 has pointed out that
```python
from PIL import Image
img = Image.new('RGB', (0, 50))
img.save('test.gif')
```
raises
```pytb
Traceback (most recent call last):
  File "demo.py", line 3, in <module>
    img.save('test.gif')
  File "PIL/Image.py", line 2592, in save
    save_handler(self, fp, filename)
  File "PIL/GifImagePlugin.py", line 808, in _save
    _write_single_frame(im, fp, palette)
  File "PIL/GifImagePlugin.py", line 625, in _write_single_frame
    im_out = _normalize_palette(im_out, palette, im.encoderinfo)
  File "PIL/GifImagePlugin.py", line 599, in _normalize_palette
    optimized_palette_colors = _get_optimize(im, info)
  File "PIL/GifImagePlugin.py", line 959, in _get_optimize
    if optimise or max(used_palette_colors) >= len(used_palette_colors):
ValueError: max() arg is an empty sequence
```

There is also an unexpected error for SPIDER images.
```python
from PIL import Image
img = Image.new('RGB', (0, 50))
img.save('test', 'SPIDER')
```
raises
```pytb
Traceback (most recent call last):
  File "demo.py", line 3, in <module>
    im.save('out', 'SPIDER')
  File "PIL/Image.py", line 2592, in save
    save_handler(self, fp, filename)
  File "PIL/SpiderImagePlugin.py", line 296, in _save_spider
    _save(im, fp, filename)
  File "PIL/SpiderImagePlugin.py", line 279, in _save
    hdr = makeSpiderHeader(im)
  File "PIL/SpiderImagePlugin.py", line 248, in makeSpiderHeader
    labrec = int(1024 / lenbyt)
ZeroDivisionError: division by zero
```

This fixes thse unexpected errors, instead raising
```pytb
Traceback (most recent call last):
  File "demo.py", line 3, in <module>
    img.save('test.gif')
  File "PIL/Image.py", line 2592, in save
    save_handler(self, fp, filename)
  File "PIL/GifImagePlugin.py", line 808, in _save
    _write_single_frame(im, fp, palette)
  File "PIL/GifImagePlugin.py", line 637, in _write_single_frame
    ImageFile._save(
  File "PIL/ImageFile.py", line 662, in _save
    _encode_tile(im, fp, tile, bufsize, fh)
  File "PIL/ImageFile.py", line 682, in _encode_tile
    encoder.setimage(im.im, extents)
SystemError: tile cannot extend outside image
```

There is also an unexpected error for PCX images.
```python
from PIL import Image
img = Image.new('RGB', (0, 50))
img.save('test.pcx')
```
raises
```pytb
Traceback (most recent call last):
  File "demo.py", line 15, in <module>
    img.save('test.pcx')
  File "PIL/Image.py", line 2592, in save
    save_handler(self, fp, filename)
  File "PIL/PcxImagePlugin.py", line 185, in _save
    + o16(im.size[0] - 1)
  File "PIL/_binary.py", line 100, in o16le
    return pack("<H", i)
struct.error: ushort format requires 0 <= number <= (32767 * 2 + 1)
```

This adds a new error, [similar to JPEG](https://github.com/python-pillow/Pillow/blob/e2b87a04209d835d1c55633e230265dcd2c4274c/src/PIL/JpegImagePlugin.py#L663-L666)
```pytb
Traceback (most recent call last):
  File "demo.py", line 15, in <module>
    img.save('test.pcx')
  File "PIL/Image.py", line 2592, in save
    save_handler(self, fp, filename)
  File "PIL/PcxImagePlugin.py", line 151, in _save
    raise ValueError(msg)
ValueError: Cannot write empty image as PCX
```