### PR TITLE
Improve error message

### DIFF
--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -814,7 +814,7 @@ class PyCodec:
             self.state.ysize = y1 - y0
 
         if self.state.xsize <= 0 or self.state.ysize <= 0:
-            msg = "Size cannot be zero or negative"
+            msg = "Size must be positive"
             raise ValueError(msg)
 
         if (


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/e2b87a04209d835d1c55633e230265dcd2c4274c/src/PIL/ImageFile.py#L816-L818

Since the size might be equal to zero, this updates the error message to
> Size cannot be zero or negative