### PR TITLE
Change to ValueError when encoding an empty image

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -85,7 +85,7 @@ class TestFileJpeg:
     def test_zero(self, size: tuple[int, int], tmp_path: Path) -> None:
         f = tmp_path / "temp.jpg"
         im = Image.new("RGB", size)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="cannot write empty image"):
             im.save(f)
 
     def test_app(self) -> None:

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -1244,7 +1244,7 @@ class TestFileLibTiff(LibTiffTestCase):
     def test_save_zero(self, compression: str | None, tmp_path: Path) -> None:
         im = Image.new("RGB", (0, 0))
         out = tmp_path / "temp.tif"
-        with pytest.raises(SystemError):
+        with pytest.raises(ValueError, match="cannot write empty image"):
             im.save(out, compression=compression)
 
     def test_save_many_compressed(self, tmp_path: Path) -> None:

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -661,10 +661,6 @@ def get_sampling(im: Image.Image) -> int:
 
 
 def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
-    if im.width == 0 or im.height == 0:
-        msg = "cannot write empty image as JPEG"
-        raise ValueError(msg)
-
     try:
         rawmode = RAWMODE[im.mode]
     except KeyError as e:

--- a/src/encode.c
+++ b/src/encode.c
@@ -239,6 +239,10 @@ _setimage(ImagingEncoderObject *encoder, PyObject *args) {
     if (!im) {
         return NULL;
     }
+    if (im->xsize == 0 || im->ysize == 0) {
+        PyErr_SetString(PyExc_ValueError, "cannot write empty image");
+        return NULL;
+    }
 
     encoder->im = im;
 


### PR DESCRIPTION
```pycon
>>> from PIL import Image
>>> im = Image.new("L", (0, 0))
>>> im.save("out.png")
Traceback (most recent call last):
  File "PIL/ImageFile.py", line 660, in _save
    fh = fp.fileno()
AttributeError: '_idat' object has no attribute 'fileno'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/Image.py", line 2592, in save
    save_handler(self, fp, filename)
  File "PIL/PngImagePlugin.py", line 1508, in _save
    ImageFile._save(
  File "PIL/ImageFile.py", line 664, in _save
    _encode_tile(im, fp, tile, bufsize, None, exc)
  File "PIL/ImageFile.py", line 682, in _encode_tile
    encoder.setimage(im.im, extents)
SystemError: tile cannot extend outside image
```

#9389 feels that this error is confusing. This PR takes the `ValueError` raised when saving a (0, 0) JPEG from https://github.com/python-pillow/Pillow/pull/6159, and applies it generically when encoding images.

```pycon
>>> from PIL import Image
>>> im = Image.new("L", (0, 0))
>>> im.save("out.png")
Traceback (most recent call last):
  File "PIL/ImageFile.py", line 660, in _save
    fh = fp.fileno()
AttributeError: '_idat' object has no attribute 'fileno'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/Image.py", line 2592, in save
    save_handler(self, fp, filename)
  File "PIL/PngImagePlugin.py", line 1508, in _save
    ImageFile._save(
  File "PIL/ImageFile.py", line 664, in _save
    _encode_tile(im, fp, tile, bufsize, None, exc)
  File "PIL/ImageFile.py", line 682, in _encode_tile
    encoder.setimage(im.im, extents)
ValueError: cannot write empty image
```

This changed error specifically occurs when **encoding** images, not when saving images. SGI, ICNS and ICO formats are still able to save (0, 0) images with this change.