### PR TITLE
Simplify `setimage()` by always passing extents

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -885,7 +885,7 @@ class Image:
 
         # unpack data
         e = _getencoder(self.mode, encoder_name, encoder_args)
-        e.setimage(self.im)
+        e.setimage(self.im, (0, 0) + self.size)
 
         from . import ImageFile
 
@@ -956,7 +956,7 @@ class Image:
 
         # unpack data
         d = _getdecoder(self.mode, decoder_name, decoder_args)
-        d.setimage(self.im)
+        d.setimage(self.im, (0, 0) + self.size)
         s = d.decode(data)
 
         if s[0] >= 0:

--- a/src/decode.c
+++ b/src/decode.c
@@ -163,7 +163,7 @@ _setimage(ImagingDecoderObject *decoder, PyObject *args) {
     x0 = y0 = x1 = y1 = 0;
 
     /* FIXME: should publish the ImagingType descriptor */
-    if (!PyArg_ParseTuple(args, "O|(iiii)", &op, &x0, &y0, &x1, &y1)) {
+    if (!PyArg_ParseTuple(args, "O(iiii)", &op, &x0, &y0, &x1, &y1)) {
         return NULL;
     }
     im = PyImaging_AsImaging(op);
@@ -176,15 +176,10 @@ _setimage(ImagingDecoderObject *decoder, PyObject *args) {
     state = &decoder->state;
 
     /* Setup decoding tile extent */
-    if (x0 == 0 && x1 == 0) {
-        state->xsize = im->xsize;
-        state->ysize = im->ysize;
-    } else {
-        state->xoff = x0;
-        state->yoff = y0;
-        state->xsize = x1 - x0;
-        state->ysize = y1 - y0;
-    }
+    state->xoff = x0;
+    state->yoff = y0;
+    state->xsize = x1 - x0;
+    state->ysize = y1 - y0;
 
     if (state->xoff < 0 || state->xsize <= 0 ||
         state->xsize + state->xoff > (int)im->xsize || state->yoff < 0 ||

--- a/src/encode.c
+++ b/src/encode.c
@@ -232,7 +232,7 @@ _setimage(ImagingEncoderObject *encoder, PyObject *args) {
     x0 = y0 = x1 = y1 = 0;
 
     /* FIXME: should publish the ImagingType descriptor */
-    if (!PyArg_ParseTuple(args, "O|(nnnn)", &op, &x0, &y0, &x1, &y1)) {
+    if (!PyArg_ParseTuple(args, "O(nnnn)", &op, &x0, &y0, &x1, &y1)) {
         return NULL;
     }
     im = PyImaging_AsImaging(op);
@@ -244,15 +244,10 @@ _setimage(ImagingEncoderObject *encoder, PyObject *args) {
 
     state = &encoder->state;
 
-    if (x0 == 0 && x1 == 0) {
-        state->xsize = im->xsize;
-        state->ysize = im->ysize;
-    } else {
-        state->xoff = x0;
-        state->yoff = y0;
-        state->xsize = x1 - x0;
-        state->ysize = y1 - y0;
-    }
+    state->xoff = x0;
+    state->yoff = y0;
+    state->xsize = x1 - x0;
+    state->ysize = y1 - y0;
 
     if (state->xoff < 0 || state->xsize <= 0 ||
         state->xsize + state->xoff > im->xsize || state->yoff < 0 ||


### PR DESCRIPTION
Perhaps this is just me, but reading
https://github.com/python-pillow/Pillow/blob/e2b87a04209d835d1c55633e230265dcd2c4274c/src/encode.c#L235
https://github.com/python-pillow/Pillow/blob/e2b87a04209d835d1c55633e230265dcd2c4274c/src/encode.c#L247-L255
my reaction is
> Why if x0 and x1 are zero? If we're encoding an image with zero width, then use the full image size? That seems odd. Also, what if it is zero height?

The code has been like this since PIL. I suspect the intention was to handle
https://github.com/python-pillow/Pillow/blob/e2b87a04209d835d1c55633e230265dcd2c4274c/src/PIL/Image.py#L787
where no extents are passed in, and say that in that scenario, the extents should default to the entire image.

I think it would simpler if we just explicitly passed that in from Python.