### PR TITLE
Match PSDraw text() encoding to the latin-1 specification in setfont()

### DIFF
--- a/src/PIL/PSDraw.py
+++ b/src/PIL/PSDraw.py
@@ -100,7 +100,8 @@ class PSDraw:
         Draws text at the given position. You must use
         :py:meth:`~PIL.PSDraw.PSDraw.setfont` before calling this method.
         """
-        text_bytes = bytes(text, "UTF-8")
+        # The font is loaded as ISOLatin1Encoding, so use latin-1 here.
+        text_bytes = bytes(text, "latin-1")
         text_bytes = b"\\(".join(text_bytes.split(b"("))
         text_bytes = b"\\)".join(text_bytes.split(b")"))
         self.fp.write(b"%d %d M (%s) S\n" % (xy + (text_bytes,)))


### PR DESCRIPTION
Without this, characters that are in latin-1 but reflected differently in UTF-8 will not be properly rendered. For example,"ó" becomes "Ã³".