### PR TITLE
Remove unnecessary code in `WmfHandler`

### DIFF
--- a/src/PIL/WmfImagePlugin.py
+++ b/src/PIL/WmfImagePlugin.py
@@ -45,7 +45,6 @@ if hasattr(Image.core, "drawwmf"):
 
     class WmfHandler(ImageFile.StubHandler):
         def open(self, im: ImageFile.StubImageFile) -> None:
-            im._mode = "RGB"
             self.bbox = im.info["wmf_bbox"]
 
         def load(self, im: ImageFile.StubImageFile) -> Image.Image:


### PR DESCRIPTION
After the mode is set in `WmfStubImageFile._open()`,
https://github.com/python-pillow/Pillow/blob/29ff5fcb5527ff38b15a724cdb03a115eea43be9/src/PIL/WmfImagePlugin.py#L148

there is no need to set it again in `WmfHandler.open()`
https://github.com/python-pillow/Pillow/blob/29ff5fcb5527ff38b15a724cdb03a115eea43be9/src/PIL/WmfImagePlugin.py#L48