### PR TITLE
Always call StubHandler open() when opening StubImageFile

### DIFF
--- a/src/PIL/BufrStubImagePlugin.py
+++ b/src/PIL/BufrStubImagePlugin.py
@@ -52,10 +52,6 @@ class BufrStubImageFile(ImageFile.StubImageFile):
         self._mode = "F"
         self._size = 1, 1
 
-        loader = self._load()
-        if loader:
-            loader.open(self)
-
     def _load(self) -> ImageFile.StubHandler | None:
         return _handler
 

--- a/src/PIL/GribStubImagePlugin.py
+++ b/src/PIL/GribStubImagePlugin.py
@@ -52,10 +52,6 @@ class GribStubImageFile(ImageFile.StubImageFile):
         self._mode = "F"
         self._size = 1, 1
 
-        loader = self._load()
-        if loader:
-            loader.open(self)
-
     def _load(self) -> ImageFile.StubHandler | None:
         return _handler
 

--- a/src/PIL/Hdf5StubImagePlugin.py
+++ b/src/PIL/Hdf5StubImagePlugin.py
@@ -52,10 +52,6 @@ class HDF5StubImageFile(ImageFile.StubImageFile):
         self._mode = "F"
         self._size = 1, 1
 
-        loader = self._load()
-        if loader:
-            loader.open(self)
-
     def _load(self) -> ImageFile.StubHandler | None:
         return _handler
 

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -148,6 +148,10 @@ class ImageFile(Image.Image):
         try:
             try:
                 self._open()
+
+                if isinstance(self, StubImageFile):
+                    if loader := self._load():
+                        loader.open(self)
             except (
                 IndexError,  # end of data
                 TypeError,  # end of data (ord)

--- a/src/PIL/WmfImagePlugin.py
+++ b/src/PIL/WmfImagePlugin.py
@@ -148,10 +148,6 @@ class WmfStubImageFile(ImageFile.StubImageFile):
         self._mode = "RGB"
         self._size = size
 
-        loader = self._load()
-        if loader:
-            loader.open(self)
-
     def _load(self) -> ImageFile.StubHandler | None:
         return _handler
 


### PR DESCRIPTION
In all of our subclasses of `StubImageFile`, `_open` ends with the following code, calling `StubHandler.open()`
https://github.com/python-pillow/Pillow/blob/29ff5fcb5527ff38b15a724cdb03a115eea43be9/src/PIL/WmfImagePlugin.py#L151-L153

This PR suggests moving that code out of the subclasses, and instead forcing it to be called when every `StubImageFile` is opened.