### PR TITLE
Patch libavif for svt-av1 4.0 compatibility

### DIFF
--- a/depends/install_libavif.sh
+++ b/depends/install_libavif.sh
@@ -7,6 +7,10 @@ version=1.3.0
 
 pushd libavif-$version
 
+# Apply patch for SVT-AV1 4.0 compatibility
+# Pending release of https://github.com/AOMediaCodec/libavif/pull/2971
+patch -p1 < ../libavif-svt4.patch
+
 if [ $(uname) == "Darwin" ] && [ -x "$(command -v brew)" ]; then
     PREFIX=$(brew --prefix)
 else

--- a/depends/libavif-svt4.patch
+++ b/depends/libavif-svt4.patch
@@ -1,0 +1,14 @@
+--- a/src/codec_svt.c
++++ b/src/codec_svt.c
+@@ -162,7 +162,11 @@ static avifResult svtCodecEncodeImage(avifEncoder * encoder,
+ #else
+         svt_config->logical_processors = encoder->maxThreads;
+ #endif
++#if SVT_AV1_CHECK_VERSION(4, 0, 0)
++        svt_config->aq_mode = 2;
++#else
+         svt_config->enable_adaptive_quantization = 2;
++#endif
+         // disable 2-pass
+ #if SVT_AV1_CHECK_VERSION(0, 9, 0)
+         svt_config->rc_stats_buffer = (SvtAv1FixedBuf) { NULL, 0 };


### PR DESCRIPTION
macOS builds have started failing.

Pass: https://github.com/python-pillow/Pillow/actions/runs/21415347226/job/61666976278

Fail: https://github.com/python-pillow/Pillow/actions/runs/21472202845/job/61847296515

The difference is svt-av1 (3.1.2) vs svt-av1 (4.0.0) in Homebrew.

libavif doesn't yet support 4.0.0. The fix has been made but not merged: https://github.com/AOMediaCodec/libavif/pull/2971

Our options include:

* wait for a libavif release
* temporarily comment out the svt-av1 from `macos-install.sh`
* install an old svt-av1, but Homebrew doesn't have old versions
* apply the libavif patch locally

Here's a patch to get the CI back to green.
