### PR TITLE
Factor out saving metrics in FontFile

### DIFF
--- a/src/PIL/FontFile.py
+++ b/src/PIL/FontFile.py
@@ -123,12 +123,15 @@ class FontFile:
 
         # font metrics
         with open(os.path.splitext(filename)[0] + ".pil", "wb") as fp:
-            fp.write(b"PILfont\n")
-            fp.write(f";;;;;;{self.ysize};\n".encode("ascii"))  # HACK!!!
-            fp.write(b"DATA\n")
-            for id in range(256):
-                m = self.metrics[id]
-                if not m:
-                    puti16(fp, (0,) * 10)
-                else:
-                    puti16(fp, m[0] + m[1] + m[2])
+            self.save_metrics(fp)
+
+    def save_metrics(self, fp: BinaryIO) -> None:
+        fp.write(b"PILfont\n")
+        fp.write(f";;;;;;{self.ysize};\n".encode("ascii"))  # HACK!!!
+        fp.write(b"DATA\n")
+        for id in range(256):
+            m = self.metrics[id]
+            if not m:
+                puti16(fp, (0,) * 10)
+            else:
+                puti16(fp, m[0] + m[1] + m[2])


### PR DESCRIPTION
Facilitates creating an ImageFont from a PCF or BDF file on the fly, without creating any new files, with code like this:
```python
def ifont(path):
    with open(path, 'rb') as f:
        ff = PcfFontFile.PcfFontFile(f)
    ff.compile()
    buf = io.BytesIO()
    ff.save_metrics(buf)
    buf.seek(0)
    imgfont = ImageFont.ImageFont()
    imgfont._load_pilfont_data(buf, ff.bitmap)
    return imgfont
```
This isn't ideal, creating a file in memory and using an underscore function.  Maybe it's preferable to add functionality to ImageFont.py instead?