### PR TITLE
Use assert_image_equal* when similarity is zero

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -399,7 +399,7 @@ def test_save_netpbm_bmp_mode(tmp_path: Path) -> None:
     b = BytesIO()
     GifImagePlugin._save_netpbm(img_rgb, b, tempfile)
     with Image.open(tempfile) as reloaded:
-        assert_image_similar(img_rgb, reloaded.convert("RGB"), 0)
+        assert_image_equal(img_rgb, reloaded.convert("RGB"))
 
 
 @pytest.mark.skipif(not netpbm_available(), reason="Netpbm not available")
@@ -411,7 +411,7 @@ def test_save_netpbm_l_mode(tmp_path: Path) -> None:
         b = BytesIO()
         GifImagePlugin._save_netpbm(img_l, b, tempfile)
         with Image.open(tempfile) as reloaded:
-            assert_image_similar(img_l, reloaded.convert("L"), 0)
+            assert_image_equal(img_l, reloaded.convert("L"))
 
 
 def test_seek() -> None:

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -738,7 +738,7 @@ class TestFileLibTiff(LibTiffTestCase):
             buffer_io.seek(0)
 
             with Image.open(buffer_io) as saved_im:
-                assert_image_similar(pilim, saved_im, 0)
+                assert_image_equal(pilim, saved_im)
 
         save_bytesio()
         save_bytesio("raw")

--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -18,7 +18,7 @@ def test_load_raw() -> None:
             # Currently, support for WMF/EMF is Windows-only
             im.load()
             # Compare to reference rendering
-            assert_image_similar_tofile(im, "Tests/images/drawing_emf_ref.png", 0)
+            assert_image_equal_tofile(im, "Tests/images/drawing_emf_ref.png")
 
     # Test basic WMF open and rendering
     with Image.open("Tests/images/drawing.wmf") as im:

--- a/Tests/test_font_pcf.py
+++ b/Tests/test_font_pcf.py
@@ -10,7 +10,6 @@ from PIL import FontFile, Image, ImageDraw, ImageFont, PcfFontFile
 
 from .helper import (
     assert_image_equal_tofile,
-    assert_image_similar_tofile,
     skip_unless_feature,
 )
 
@@ -73,7 +72,7 @@ def test_draw(request: pytest.FixtureRequest, tmp_path: Path) -> None:
     im = Image.new("L", (130, 30), "white")
     draw = ImageDraw.Draw(im)
     draw.text((0, 0), message, "black", font=font)
-    assert_image_similar_tofile(im, "Tests/images/test_draw_pbm_target.png", 0)
+    assert_image_equal_tofile(im, "Tests/images/test_draw_pbm_target.png")
 
 
 def test_textsize(request: pytest.FixtureRequest, tmp_path: Path) -> None:
@@ -100,7 +99,7 @@ def _test_high_characters(
     im = Image.new("L", (750, 30), "white")
     draw = ImageDraw.Draw(im)
     draw.text((0, 0), message, "black", font=font)
-    assert_image_similar_tofile(im, "Tests/images/high_ascii_chars.png", 0)
+    assert_image_equal_tofile(im, "Tests/images/high_ascii_chars.png")
 
 
 def test_high_characters(request: pytest.FixtureRequest, tmp_path: Path) -> None:

--- a/Tests/test_font_pcf_charsets.py
+++ b/Tests/test_font_pcf_charsets.py
@@ -10,7 +10,6 @@ from PIL import FontFile, Image, ImageDraw, ImageFont, PcfFontFile
 
 from .helper import (
     assert_image_equal_tofile,
-    assert_image_similar_tofile,
     skip_unless_feature,
 )
 
@@ -85,7 +84,7 @@ def test_draw(request: pytest.FixtureRequest, tmp_path: Path, encoding: str) -> 
     draw = ImageDraw.Draw(im)
     message = charsets[encoding]["message"].encode(encoding)
     draw.text((0, 0), message, "black", font=font)
-    assert_image_similar_tofile(im, charsets[encoding]["image1"], 0)
+    assert_image_equal_tofile(im, charsets[encoding]["image1"])
 
 
 @pytest.mark.parametrize("encoding", ("iso8859-1", "iso8859-2", "cp1250"))

--- a/Tests/test_uploader.py
+++ b/Tests/test_uploader.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .helper import assert_image_equal, assert_image_similar, hopper
+from .helper import assert_image_equal, hopper
 
 
 def check_upload_equal() -> None:
@@ -12,4 +12,4 @@ def check_upload_equal() -> None:
 def check_upload_similar() -> None:
     result = hopper("P").convert("RGB")
     target = hopper("RGB")
-    assert_image_similar(result, target, 0)
+    assert_image_equal(result, target)


### PR DESCRIPTION
Replace `assert_image_similar(a, b, 0)` with `assert_image_equal(a, b)`,
and `assert_image_similar_tofile(a, b, 0)` with `assert_image_equal_tofile(a, b)`