### PR TITLE
CI: Disable pip upgrade warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ concurrency:
 env:
   COVERAGE_CORE: sysmon
   FORCE_COLOR: 1
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
 
 jobs:
   build:


### PR DESCRIPTION
Add `PIP_DISABLE_PIP_VERSION_CHECK=1` to prevent warnings like:

```
macos-latest Python 3.14t
[notice] A new release of pip is available: 25.3 -> 26.0.1
[notice] To update, run: /Library/Frameworks/Python.framework/Versions/3.14/bin/python3.14 -m pip install --upgrade pip
```


https://github.com/python-pillow/Pillow/actions/runs/21798050860

After:

https://github.com/hugovk/Pillow/actions/runs/21818838104
