### PR TITLE
Merge PFM documentation into PPM

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1076,10 +1076,12 @@ Pillow reads and writes PBM, PGM, PPM, PNM and PFM files containing ``1``, ``L``
 
 "Raw" (P4 to P6) formats can be read, and are used when writing.
 
-Since Pillow 9.2.0, "plain" (P1 to P3) formats can be read as well.
+.. versionadded:: 9.2.0
+   "Plain" (P1 to P3) formats can be read.
 
-Since Pillow 10.3.0, grayscale (Pf format) Portable FloatMap (PFM) files containing
-``F`` data can be read and used when writing as well.
+.. versionadded:: 10.3.0
+   Grayscale (Pf format) Portable FloatMap (PFM) files containing
+   ``F`` data can be read and used when writing.
 
 Color (PF format) PFM files are not supported.
 


### PR DESCRIPTION
Most of the headings at https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html match the [`format`](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.format) attribute, as used by [`open()`](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.open) or [`save()`](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save).

This updates it so that they all do.

While here, I have also updated the `format` / `id` for PalmImagePlugin to be uppercase, since Image immediately transforms it anyway.

https://github.com/python-pillow/Pillow/blob/913698b6675d7455a76869fb9f0fa5c17a93a25b/src/PIL/PalmImagePlugin.py#L213-L217
https://github.com/python-pillow/Pillow/blob/913698b6675d7455a76869fb9f0fa5c17a93a25b/src/PIL/Image.py#L3845-L3855
https://github.com/python-pillow/Pillow/blob/913698b6675d7455a76869fb9f0fa5c17a93a25b/src/PIL/Image.py#L3872-L3880
https://github.com/python-pillow/Pillow/blob/913698b6675d7455a76869fb9f0fa5c17a93a25b/src/PIL/Image.py#L3830-L3842