### PR TITLE
Use uppercase format ID for PALM

### DIFF
--- a/src/PIL/PalmImagePlugin.py
+++ b/src/PIL/PalmImagePlugin.py
@@ -210,8 +210,8 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
 #
 # --------------------------------------------------------------------
 
-Image.register_save("Palm", _save)
+Image.register_save("PALM", _save)
 
-Image.register_extension("Palm", ".palm")
+Image.register_extension("PALM", ".palm")
 
-Image.register_mime("Palm", "image/palm")
+Image.register_mime("PALM", "image/palm")


### PR DESCRIPTION
I have updated the `format` / `id` for PalmImagePlugin to be uppercase, since `Image` immediately transforms it anyway.

https://github.com/python-pillow/Pillow/blob/913698b6675d7455a76869fb9f0fa5c17a93a25b/src/PIL/PalmImagePlugin.py#L213-L217
https://github.com/python-pillow/Pillow/blob/913698b6675d7455a76869fb9f0fa5c17a93a25b/src/PIL/Image.py#L3845-L3855
https://github.com/python-pillow/Pillow/blob/913698b6675d7455a76869fb9f0fa5c17a93a25b/src/PIL/Image.py#L3872-L3880
https://github.com/python-pillow/Pillow/blob/913698b6675d7455a76869fb9f0fa5c17a93a25b/src/PIL/Image.py#L3830-L3842