### PR TITLE
Specify platform when pulling docker image

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Docker pull
       run: |
-        docker pull pythonpillow/${{ matrix.docker }}:${{ matrix.dockerTag }}
+        docker pull ${{ matrix.qemu-arch && format('--platform=linux/{0}', matrix.qemu-arch)}} pythonpillow/${{ matrix.docker }}:${{ matrix.dockerTag }}
 
     - name: Docker build
       run: |


### PR DESCRIPTION
The emulated Docker jobs have started failing in main - https://github.com/python-pillow/Pillow/actions/runs/22083181535/job/63820104350
> Run docker pull pythonpillow/ubuntu-24.04-noble-ppc64le:main
> Error response from daemon: no matching manifest for linux/amd64 in the manifest list entries: no match for platform in manifest: not found

I find that adding `--platform` to the `docker pull` command fixes this.