### PR TITLE
Correct error check when encoding AVIF images

### DIFF
--- a/src/_avif.c
+++ b/src/_avif.c
@@ -485,7 +485,7 @@ _encoder_add(AvifEncoderObject *self, PyObject *args) {
         frame = image;
     } else {
         frame = avifImageCreateEmpty();
-        if (image == NULL) {
+        if (frame == NULL) {
             PyErr_SetString(PyExc_ValueError, "Image creation failed");
             return NULL;
         }


### PR DESCRIPTION
In the following check for `NULL`, it is readily apparent that `frame` should be checked, not `image`.
https://github.com/python-pillow/Pillow/blob/3cd69cb12f10d18a58c94dc01b54c70deba19289/src/_avif.c#L487-L491

This might have been a copy-paste error from https://github.com/python-pillow/Pillow/blob/3cd69cb12f10d18a58c94dc01b54c70deba19289/src/_avif.c#L263-L268