### PR TITLE
Fix `self.decode` typo

### DIFF
--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -579,9 +579,7 @@ class Parser:
                 pass  # not enough data
             else:
                 flag = hasattr(im, "load_seek") or hasattr(im, "load_read")
-                if flag or len(im.tile) != 1:
-                    pass  # custom load code, or multiple tiles
-                else:
+                if not flag and len(im.tile) == 1:
                     # initialize decoder
                     im.load_prepare()
                     d, e, o, a = im.tile[0]


### PR DESCRIPTION
In `ImageFile.Parser`, the class uses `self.decoder` throughout (initialized on line 516, checked on line 545, set on line 590). But line 584 assigns `self.decode = None` (missing the trailing "r"), which creates a new attribute that's never referenced anywhere.

The intent is clearly to reset `self.decoder` to `None` when the image has custom load code or multiple tiles, so the parser falls through to the `elif self.image:` branch on subsequent `feed()` calls.
