### PR TITLE
Add check-case-conflict hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
+      - id: check-case-conflict
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
       - id: check-merge-conflict


### PR DESCRIPTION
Copying a change from https://github.com/python-pillow/docker-images/pull/259

https://github.com/pre-commit/pre-commit-hooks
> **check-case-conflict**
> Check for files with names that would conflict on a case-insensitive filesystem like MacOS HFS+ or Windows FAT.