### PR TITLE
Update freetype to 2.14.2

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -90,11 +90,7 @@ fi
 ARCHIVE_SDIR=pillow-depends-main
 
 # Package versions for fresh source builds.
-if [[ -n "$IOS_SDK" ]]; then
-  FREETYPE_VERSION=2.13.3
-else
-  FREETYPE_VERSION=2.14.1
-fi
+FREETYPE_VERSION=2.14.2
 HARFBUZZ_VERSION=12.3.2
 LIBPNG_VERSION=1.6.55
 JPEGTURBO_VERSION=3.1.3
@@ -310,10 +306,6 @@ function build {
 
     if [[ -n "$IS_MACOS" ]]; then
         # Custom freetype build
-        if [[ -z "$IOS_SDK" ]]; then
-          build_simple sed 4.9 https://mirrors.middlendian.com/gnu/sed
-        fi
-
         build_simple freetype $FREETYPE_VERSION https://download.savannah.gnu.org/releases/freetype tar.gz --with-harfbuzz=no
     else
         build_freetype

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -114,7 +114,7 @@ ARCHITECTURES = {
 
 V = {
     "BROTLI": "1.2.0",
-    "FREETYPE": "2.14.1",
+    "FREETYPE": "2.14.2",
     "FRIBIDI": "1.0.16",
     "HARFBUZZ": "12.3.2",
     "JPEGTURBO": "3.1.3",


### PR DESCRIPTION
FreeType 2.14.2 is the latest version - https://freetype.org/

This also removes the installation of gnu-sed - https://github.com/python-pillow/Pillow/pull/9217#pullrequestreview-3252841440