### PR TITLE
Add Amiga Workbench .info loader to 3rd party plugins list

### DIFF
--- a/docs/handbook/third-party-plugins.rst
+++ b/docs/handbook/third-party-plugins.rst
@@ -7,6 +7,7 @@ itself.
 
 Here is a list of PyPI projects that offer additional plugins:
 
+* :pypi:`amigainfo`: Adds support for Amiga Workbench .info icon files.
 * :pypi:`DjvuRleImagePlugin`: Plugin for the DjVu RLE image format as defined in the DjVuLibre docs.
 * :pypi:`heif-image-plugin`: Simple HEIF/HEIC images plugin, based on the pyheif library.
 * :pypi:`jxlpy`: Introduces reading and writing support for JPEG XL.


### PR DESCRIPTION
I wrote this [icon loader](https://pypi.org/project/amigainfo/) for old Amiga Workbench .info files, and included a Pillow plugin. Importing `amigainfo` registers the loader.

I figured the best way to share it would be to add it to the list... I would have added to the bottom of the list, but it looks like it's alphabetical order.