### PR TITLE
Update tests to check for ValueError when encoding an empty image

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -314,7 +314,7 @@ def test_roundtrip_save_all_1(tmp_path: Path) -> None:
 def test_save_zero(size: tuple[int, int]) -> None:
     b = BytesIO()
     im = Image.new("RGB", size)
-    with pytest.raises(SystemError):
+    with pytest.raises(ValueError, match="cannot write empty image"):
         im.save(b, "GIF")
 
 

--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -72,7 +72,7 @@ def test_save(tmp_path: Path) -> None:
 def test_save_zero(size: tuple[int, int]) -> None:
     b = BytesIO()
     im = Image.new("1", size)
-    with pytest.raises(SystemError):
+    with pytest.raises(ValueError, match="cannot write empty image"):
         im.save(b, "SPIDER")
 
 


### PR DESCRIPTION
#9391 added two tests to check for a `SystemError` when saving an image where one dimension is zero.

However, #9394 changed this to a `ValueError`, and the combination means that main is currently failing - https://github.com/python-pillow/Pillow/actions/runs/23008335458

This updates the tests.