### PR TITLE
Add Exif tag "FrameRate"

### DIFF
--- a/src/PIL/ExifTags.py
+++ b/src/PIL/ExifTags.py
@@ -289,6 +289,7 @@ class Base(IntEnum):
     OpcodeList2 = 0xC741
     OpcodeList3 = 0xC74E
     NoiseProfile = 0xC761
+    FrameRate = 0xC764
 
 
 """Maps EXIF tags to tag names."""


### PR DESCRIPTION
Changes proposed in this pull request:

 * Add a ExifTag "FrameRate" to be supported in PIL.

Reference: https://exiftool.org/TagNames/EXIF.html