### PR TITLE
Fix integer overflow in quantize_pngquant()

### DIFF
--- a/src/libImaging/QuantPngQuant.c
+++ b/src/libImaging/QuantPngQuant.c
@@ -8,6 +8,7 @@
  *
  */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -38,6 +39,13 @@ quantize_pngquant(
     *palette = NULL;
     *paletteLength = 0;
     *quantizedPixels = NULL;
+
+    /* Check for integer overflow in width * height to prevent
+     * undersized allocations leading to heap buffer overflow. */
+    if (height != 0 && (size_t)width > SIZE_MAX / (size_t)height) {
+        goto err;
+    }
+    size_t total_pixels = (size_t)width * (size_t)height;
 
     /* configure pngquant */
     attr = liq_attr_create();
@@ -77,7 +85,7 @@ quantize_pngquant(
     }
 
     /* write output pixels (pngquant uses char array) */
-    charMatrix = malloc(width * height);
+    charMatrix = malloc(total_pixels);
     if (!charMatrix) {
         goto err;
     }
@@ -86,18 +94,18 @@ quantize_pngquant(
         goto err;
     }
     for (y = 0; y < height; y++) {
-        charMatrixRows[y] = &charMatrix[y * width];
+        charMatrixRows[y] = &charMatrix[(size_t)y * width];
     }
     if (LIQ_OK != liq_write_remapped_image_rows(remap, image, charMatrixRows)) {
         goto err;
     }
 
     /* transcribe output pixels (pillow uses uint32_t array) */
-    *quantizedPixels = malloc(sizeof(uint32_t) * width * height);
+    *quantizedPixels = malloc(sizeof(uint32_t) * total_pixels);
     if (!*quantizedPixels) {
         goto err;
     }
-    for (i = 0; i < width * height; i++) {
+    for (i = 0; i < total_pixels; i++) {
         (*quantizedPixels)[i] = charMatrix[i];
     }
 
@@ -126,7 +134,7 @@ const char *
 ImagingImageQuantVersion(void) {
     static char version[20];
     int number = liq_version();
-    sprintf(version, "%d.%d.%d", number / 10000, (number / 100) % 100, number % 100);
+    snprintf(version, sizeof(version), "%d.%d.%d", number / 10000, (number / 100) % 100, number % 100);
     return version;
 }
 

--- a/src/libImaging/QuantPngQuant.c
+++ b/src/libImaging/QuantPngQuant.c
@@ -134,14 +134,7 @@ const char *
 ImagingImageQuantVersion(void) {
     static char version[20];
     int number = liq_version();
-    snprintf(
-        version,
-        sizeof(version),
-        "%d.%d.%d",
-        number / 10000,
-        (number / 100) % 100,
-        number % 100
-    );
+    sprintf(version, "%d.%d.%d", number / 10000, (number / 100) % 100, number % 100);
     return version;
 }
 

--- a/src/libImaging/QuantPngQuant.c
+++ b/src/libImaging/QuantPngQuant.c
@@ -134,7 +134,14 @@ const char *
 ImagingImageQuantVersion(void) {
     static char version[20];
     int number = liq_version();
-    snprintf(version, sizeof(version), "%d.%d.%d", number / 10000, (number / 100) % 100, number % 100);
+    snprintf(
+        version,
+        sizeof(version),
+        "%d.%d.%d",
+        number / 10000,
+        (number / 100) % 100,
+        number % 100
+    );
     return version;
 }
 

--- a/src/libImaging/QuantPngQuant.c
+++ b/src/libImaging/QuantPngQuant.c
@@ -8,7 +8,6 @@
  *
  */
 
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
## Integer Overflow → Heap Buffer Overflow in QuantPngQuant.c

### Summary

`quantize_pngquant()` allocates memory using `width * height` (both `unsigned int`) without checking for integer overflow. When the product exceeds `UINT_MAX`, it wraps to a small value, causing an undersized `malloc()`. Subsequent `liq_write_remapped_image_rows()` writes the real size into the small buffer → **heap buffer overflow**.

### Affected Code

`src/libImaging/QuantPngQuant.c`, lines 80, 96:
```c
charMatrix = malloc(width * height);                          // overflows
*quantizedPixels = malloc(sizeof(uint32_t) * width * height); // overflows
```

### Example
- `width=65537, height=65537` → product wraps to 131,073 (should be 4.3 billion)
- `malloc(131073)` allocates 128 KB; decoder writes 4 GB → **heap corruption**

### Fix

- Add overflow check: `if (height != 0 && (size_t)width > SIZE_MAX / (size_t)height)`
- Use `size_t total_pixels` for all size calculations
- Also replaces `sprintf` → `snprintf` (line 129), consistent with CVE-2024-28219

### Classification
- **CWE-190** (Integer Overflow) → **CWE-122** (Heap Buffer Overflow)
- **CVSS 3.1:** 8.1 (High) — `AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H`
- **Prerequisite:** libimagequant support compiled in