### PR TITLE
Add decompression size limit to FITS gzip decoder

### DIFF
--- a/src/PIL/FitsImagePlugin.py
+++ b/src/PIL/FitsImagePlugin.py
@@ -128,7 +128,19 @@ class FitsGzipDecoder(ImageFile.PyDecoder):
 
     def decode(self, buffer: bytes | Image.SupportsArrayInterface) -> tuple[int, int]:
         assert self.fd is not None
+
+        # Limit decompressed size to prevent decompression bomb DoS.
+        # Each pixel uses 4 bytes in the decompressed FITS BINTABLE format.
+        max_expected = self.state.xsize * self.state.ysize * 4
+        max_decompressed = max(max_expected * 2, 1024 * 1024)  # at least 1 MB
+
         value = gzip.decompress(self.fd.read())
+        if len(value) > max_decompressed:
+            msg = (
+                f"FITS gzip decompressed data too large: "
+                f"{len(value)} bytes > {max_decompressed} bytes limit"
+            )
+            raise ValueError(msg)
 
         rows = []
         offset = 0


### PR DESCRIPTION
## Decompression Bomb in FITS Gzip Decoder (DoS)

### Summary

`FitsGzipDecoder.decode()` calls `gzip.decompress(self.fd.read())` with **no size limit**. A crafted FITS file containing a gzip bomb (~100 KB) can decompress to gigabytes, causing OOM / denial of service.

### Affected Code

`src/PIL/FitsImagePlugin.py`, line 131:
```python
value = gzip.decompress(self.fd.read())  # No size limit!
```

### Impact
- A 135 KB FITS file can force allocation of 64+ MB (485x amplification)
- Larger bombs easily achieve 1000:1+ ratios (1 MB → 1 GB)
- Unlike PNG (has `MAX_TEXT_CHUNK`) and general images (has `_decompression_bomb_check`), FITS gzip has **zero protection**

### Fix

Add a decompression size limit based on expected image dimensions:
```python
max_expected = self.state.xsize * self.state.ysize * 4
max_decompressed = max(max_expected * 2, 1024 * 1024)
value = gzip.decompress(self.fd.read())
if len(value) > max_decompressed:
    raise ValueError(...)
```

### Classification
- **CWE-409** (Improper Handling of Highly Compressed Data)
- **CVSS 3.1:** 7.5 (High) — `AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`