### PR TITLE
Catch OSError for FreeType >= 2.14.0

### DIFF
--- a/Tests/test_font_crash.py
+++ b/Tests/test_font_crash.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import pytest
+
 from PIL import Image, ImageDraw, ImageFont
 
-from .helper import skip_unless_feature_version
+from .helper import has_feature_version, skip_unless_feature_version
 
 
 class TestFontCrash:
@@ -18,5 +20,10 @@ class TestFontCrash:
 
     @skip_unless_feature_version("freetype2", "2.12.0")
     def test_segfault(self) -> None:
-        font = ImageFont.truetype("Tests/fonts/fuzz_font-5203009437302784")
-        self._fuzz_font(font)
+        font_path = "Tests/fonts/fuzz_font-5203009437302784"
+        if has_feature_version("freetype2", "2.14.0"):
+            with pytest.raises(OSError, match="broken file"):
+                ImageFont.truetype(font_path)
+        else:
+            font = ImageFont.truetype(font_path)
+            self._fuzz_font(font)


### PR DESCRIPTION
Since #8324 was merged, the modified test has started failing in main - https://github.com/python-pillow/Pillow/actions/runs/23347044302/job/67915216500#step:13:2864

Testing, I find that FreeType 2.13.3 passes, but for FreeType >= 2.14.0, `FT_New_Face()` returns [`Invalid_File_Format`](https://freetype.org/freetype2/docs/reference/ft2-error_code_values.html), a.k.a "broken file". The test file is a font generated by OSS-Fuzz though, so there is no reason it has to be a valid file.

I've updated the test to specifically catch "broken file" for FreeType >= 2.14.0.

As background, the test was originally added in #6846. Coincidentally, it also had a `with pytest.raises(OSError):`, intending to catch a "Bitmap missing for glyph" error raised by Pillow, but #8324 removed the error itsell.