### PR TITLE
Skip build 1.4.1 for lint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,8 @@ commands =
 [testenv:lint]
 skip_install = true
 deps =
+    build!=1.4.1 # pending https://github.com/pypa/build/pull/1003
     check-manifest
-    pip
     prek
 pass_env =
     PREK_COLOR


### PR DESCRIPTION
Lint has started failing in main - https://github.com/python-pillow/Pillow/actions/runs/23517939022/job/68466056810

This started when [build](https://pypi.org/project/build/) released 1.4.1. Looking at https://github.com/pypa/build/issues/1004 and https://github.com/pypa/build/pull/1003, I've found that installing `pip` fixes it.

Until another release of build is created, this fixes the problem.