### PR TITLE
Add error messages before returning NULL when encoding

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -148,6 +148,22 @@ def test_prog_res_rt(card: ImageFile.ImageFile) -> None:
     assert_image_equal(im, card)
 
 
+def test_unknown_progression(tmp_path: Path) -> None:
+    outfile = tmp_path / "temp.jp2"
+
+    im = Image.new("1", (1, 1))
+    with pytest.raises(ValueError, match="unknown progression"):
+        im.save(outfile, progression="invalid")
+
+
+def test_unknown_cinema_mode(tmp_path: Path) -> None:
+    outfile = tmp_path / "temp.jp2"
+
+    im = Image.new("1", (1, 1))
+    with pytest.raises(ValueError, match="unknown cinema mode"):
+        im.save(outfile, cinema_mode="invalid")
+
+
 @pytest.mark.parametrize("num_resolutions", range(2, 6))
 def test_default_num_resolutions(
     card: ImageFile.ImageFile, num_resolutions: int

--- a/src/decode.c
+++ b/src/decode.c
@@ -905,6 +905,7 @@ PyImaging_Jpeg2KDecoderNew(PyObject *self, PyObject *args) {
     } else if (strcmp(format, "jp2") == 0) {
         codec_format = OPJ_CODEC_JP2;
     } else {
+        PyErr_SetString(PyExc_ValueError, "unknown codec format");
         return NULL;
     }
 

--- a/src/encode.c
+++ b/src/encode.c
@@ -1346,6 +1346,7 @@ PyImaging_Jpeg2KEncoderNew(PyObject *self, PyObject *args) {
     } else if (strcmp(format, "jp2") == 0) {
         codec_format = OPJ_CODEC_JP2;
     } else {
+        PyErr_SetString(PyExc_ValueError, "unknown codec format");
         return NULL;
     }
 
@@ -1360,6 +1361,7 @@ PyImaging_Jpeg2KEncoderNew(PyObject *self, PyObject *args) {
     } else if (strcmp(progression, "CPRL") == 0) {
         prog_order = OPJ_CPRL;
     } else {
+        PyErr_SetString(PyExc_ValueError, "unknown progression");
         return NULL;
     }
 
@@ -1372,6 +1374,7 @@ PyImaging_Jpeg2KEncoderNew(PyObject *self, PyObject *args) {
     } else if (strcmp(cinema_mode, "cinema4k-24") == 0) {
         cine_mode = OPJ_CINEMA4K_24;
     } else {
+        PyErr_SetString(PyExc_ValueError, "unknown cinema mode");
         return NULL;
     }
 


### PR DESCRIPTION
While I'm here, I've also removed
https://github.com/python-pillow/Pillow/blob/9a89944e735283ce4bbdf2dde1ea7c44798d9683/src/encode.c#L1346-L1347
since "jpt" is never used.
https://github.com/python-pillow/Pillow/blob/9a89944e735283ce4bbdf2dde1ea7c44798d9683/src/PIL/Jpeg2KImagePlugin.py#L382-L385