### PR TITLE
Revert "Skip build 1.4.1 for lint"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ commands =
 [testenv:lint]
 skip_install = true
 deps =
-    build!=1.4.1 # pending https://github.com/pypa/build/pull/1003
     check-manifest
     prek
 pass_env =


### PR DESCRIPTION
Reverts python-pillow/Pillow#9491 now https://github.com/pypa/build/releases/tag/1.4.2 is out.