### PR TITLE
CI: Retry failed downloads

### DIFF
--- a/depends/download-and-extract.sh
+++ b/depends/download-and-extract.sh
@@ -5,7 +5,10 @@ archive=$1
 url=$2
 
 if [ ! -f $archive.tar.gz ]; then
-    wget --no-verbose -O $archive.tar.gz $url
+    wget -O $archive.tar.gz $url \
+        --no-verbose \
+        --retry-connrefused \
+        --retry-on-http-error=429,503,504
 fi
 
 rmdir $archive


### PR DESCRIPTION
We're seeing lots of 429 errors trying to download files from GitHub:

```
https://raw.githubusercontent.com/python-pillow/pillow-depends/main/libraqm-0.10.3.tar.gz:
2026-03-26 13:05:20 ERROR 429: Too Many Requests.
```
https://github.com/python-pillow/Pillow/actions/runs/23594957010/job/68709206700?pr=9505
https://github.com/python-pillow/Pillow/actions/runs/23594854313/job/68709340106?pr=9498

By default, wget retries downloads on errors, but not fatal errors. Let's retry those too.
