### PR TITLE
Switch iOS back to macos-15-intel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -104,7 +104,7 @@ jobs:
             cibw_arch: arm64_iphonesimulator
           - name: "iOS x86_64 simulator"
             platform: ios
-            os: macos-26-intel
+            os: macos-15-intel
             cibw_arch: x86_64_iphonesimulator
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
The iOS x86_64 simulator wheel job has started failing - https://github.com/python-pillow/Pillow/actions/runs/23624250496/job/68846275739#step:5:8820
```
  xcodebuild: error: Unable to find a device matching the provided destination specifier:
  		{ platform:iOS Simulator, OS:latest, name:iPhone 17e }
  
  	The requested device could not be found because no available devices matched the request.
```