### PR TITLE
Image will never be None

### DIFF
--- a/Tests/test_pyarrow.py
+++ b/Tests/test_pyarrow.py
@@ -112,8 +112,6 @@ def test_to_array(mode: str, dtype: pyarrow.DataType, mask: list[int] | None) ->
 
     reloaded = Image.fromarrow(arr, mode, img.size)
 
-    assert reloaded
-
     assert_image_equal(img, reloaded)
 
 

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -110,7 +110,7 @@ class ImageFont:
                 except Exception:
                     pass
                 else:
-                    if image and image.mode in ("1", "L"):
+                    if image.mode in ("1", "L"):
                         break
             else:
                 if image:


### PR DESCRIPTION
Part of #9409, removing unnecessary code.

1.
https://github.com/python-pillow/Pillow/blob/b62ff96779c4052c433fd77ba0717606cc8143c9/Tests/test_pyarrow.py#L113-L117

`fromarrow()` doesn't return `None`
https://github.com/python-pillow/Pillow/blob/b62ff96779c4052c433fd77ba0717606cc8143c9/src/PIL/Image.py#L3367

so `assert reloaded` isn't necessary. If `fromarrow()` ever did return `None` in the future, `assert_image_equal()` would catch it.

2.
https://github.com/python-pillow/Pillow/blob/b62ff96779c4052c433fd77ba0717606cc8143c9/src/PIL/ImageFont.py#L109-L113

`Image.open()` doesn't return `None`
https://github.com/python-pillow/Pillow/blob/b62ff96779c4052c433fd77ba0717606cc8143c9/src/PIL/Image.py#L3574-L3578
so the check can be simplified to `if image.mode in ("1", "L"):`