### PR TITLE
Jeffrey A. Clark -> Jeffrey 'Alex' Clark

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ The Python Imaging Library (PIL) is
 
 Pillow is the friendly PIL fork. It is
 
-    Copyright © 2010 by Jeffrey A. Clark and contributors
+    Copyright © 2010 by Jeffrey 'Alex' Clark and contributors
 
 Like PIL, Pillow is licensed under the open source MIT-CMU License:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Python Imaging Library (Fork)
 
-Pillow is the friendly PIL fork by [Jeffrey A. Clark and
+Pillow is the friendly PIL fork by [Jeffrey 'Alex' Clark and
 contributors](https://github.com/python-pillow/Pillow/graphs/contributors).
 PIL is the Python Imaging Library by Fredrik Lundh and contributors.
 As of 2019, Pillow development is

--- a/docs/COPYING
+++ b/docs/COPYING
@@ -5,7 +5,7 @@ The Python Imaging Library (PIL) is
 
 Pillow is the friendly PIL fork. It is
 
-    Copyright © 2010 by Jeffrey A. Clark and contributors
+    Copyright © 2010 by Jeffrey 'Alex' Clark and contributors
 
 Like PIL, Pillow is licensed under the open source PIL
 Software License:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,9 +55,9 @@ master_doc = "index"
 project = "Pillow (PIL Fork)"
 copyright = (
     "1995-2011 Fredrik Lundh and contributors, "
-    "2010 Jeffrey A. Clark and contributors."
+    "2010 Jeffrey 'Alex' Clark and contributors."
 )
-author = "Fredrik Lundh (PIL), Jeffrey A. Clark (Pillow)"
+author = "Fredrik Lundh (PIL), Jeffrey 'Alex' Clark (Pillow)"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Pillow
 ======
 
-Pillow is the friendly PIL fork by `Jeffrey A. Clark and contributors <https://github.com/python-pillow/Pillow/graphs/contributors>`_. PIL is the Python Imaging Library by Fredrik Lundh and contributors.
+Pillow is the friendly PIL fork by `Jeffrey 'Alex' Clark and contributors <https://github.com/python-pillow/Pillow/graphs/contributors>`_. PIL is the Python Imaging Library by Fredrik Lundh and contributors.
 
 Pillow for enterprise is available via the Tidelift Subscription. `Learn more <https://tidelift.com/subscription/pkg/pypi-pillow?utm_source=pypi-pillow&utm_medium=docs&utm_campaign=enterprise>`_.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
 license = "MIT-CMU"
 license-files = [ "LICENSE" ]
 authors = [
-  { name = "Jeffrey A. Clark", email = "aclark@aclark.net" },
+  { name = "Jeffrey 'Alex' Clark", email = "aclark@aclark.net" },
 ]
 requires-python = ">=3.10"
 classifiers = [

--- a/src/PIL/__init__.py
+++ b/src/PIL/__init__.py
@@ -1,6 +1,6 @@
 """Pillow (Fork of the Python Imaging Library)
 
-Pillow is the friendly PIL fork by Jeffrey A. Clark and contributors.
+Pillow is the friendly PIL fork by Jeffrey 'Alex' Clark and contributors.
     https://github.com/python-pillow/Pillow/
 
 Pillow is forked from PIL 1.1.7.


### PR DESCRIPTION
Follow up to 4197263dff19a79f13cd86f6cdc9a0ec6c06da92. People cannot figure out my preferred name, hence this final (I hope!) update to my name in Pillow.

Changes proposed in this pull request:

 * Rename myself again to clarify preferred name.
