### PR TITLE
Cleanup .spider extension in the same test where it is added

### DIFF
--- a/Tests/test_file_spider.py
+++ b/Tests/test_file_spider.py
@@ -14,10 +14,6 @@ from .helper import assert_image_equal, hopper, is_pypy
 TEST_FILE = "Tests/images/hopper.spider"
 
 
-def teardown_module() -> None:
-    Image.EXTENSION.pop(".spider", None)
-
-
 def test_sanity() -> None:
     with Image.open(TEST_FILE) as im:
         im.load()
@@ -66,6 +62,8 @@ def test_save(tmp_path: Path) -> None:
         assert im2.mode == "F"
         assert im2.size == (128, 128)
         assert im2.format == "SPIDER"
+
+    del Image.EXTENSION[".spider"]
 
 
 @pytest.mark.parametrize("size", ((0, 1), (1, 0), (0, 0)))


### PR DESCRIPTION
When an image is saved to a file with SpiderImagePlugin, the file extension of the path is registered for future use.
https://github.com/python-pillow/Pillow/blob/1f74a55be222ee1281a46ac3af38ece9c51f5f7d/src/PIL/SpiderImagePlugin.py#L291-L295

#9398 added `teardown_module()` to test_file_spider.py to remove that extension after the test file is complete.

However, there is actually only one test in test_file_spider.py that saves to a path.
https://github.com/python-pillow/Pillow/blob/1f74a55be222ee1281a46ac3af38ece9c51f5f7d/Tests/test_file_spider.py#L56-L62

So it would be simpler to remove `teardown_module` and just cleanup at the end of that specific test.