### PR TITLE
Move variable declaration inside define

### DIFF
--- a/src/libImaging/Paste.c
+++ b/src/libImaging/Paste.c
@@ -356,7 +356,7 @@ fill(
 ) {
     /* fill opaque region */
 
-    int x, y, i;
+    int x, y;
     UINT8 ink8 = 0;
     INT32 ink32 = 0L;
 
@@ -372,6 +372,7 @@ fill(
 
     } else {
 #if defined _WIN32 && !defined _WIN64
+        int i;
         dx *= pixelsize;
         for (y = 0; y < ysize; y++) {
             UINT8 *out = (UINT8 *)imOut->image[y + dy] + dx;


### PR DESCRIPTION
Sequel to #9492

The `i` variable added in that PR is only used within `#if defined _WIN32 && !defined _WIN64`. This can lead to `warning: unused variable 'i'` on other platforms.