### PR TITLE
Use plugin method directly when saving PDFs

### DIFF
--- a/src/PIL/PdfImagePlugin.py
+++ b/src/PIL/PdfImagePlugin.py
@@ -148,10 +148,14 @@ def _write_image(
             strip_size=math.ceil(width / 8) * height,
         )
     elif decode_filter == "DCTDecode":
-        Image.SAVE["JPEG"](im, op, filename)
+        from . import JpegImagePlugin
+
+        JpegImagePlugin._save(im, op, filename)
     elif decode_filter == "JPXDecode":
+        from . import Jpeg2KImagePlugin
+
         del dict_obj["BitsPerComponent"]
-        Image.SAVE["JPEG2000"](im, op, filename)
+        Jpeg2KImagePlugin._save(im, op, filename)
     else:
         msg = f"unsupported PDF filter ({decode_filter})"
         raise ValueError(msg)


### PR DESCRIPTION
Resolves #9545

```python
from PIL import Image
im = Image.new("RGB", (1, 1))
im.save("out.pdf")
```
currently raises
```
Traceback (most recent call last):
  File "demo.py", line 3, in <module>
    im.save("out.pdf")
  File "PIL/Image.py", line 2713, in save
    save_handler(self, fp, filename)
  File "PIL/PdfImagePlugin.py", line 262, in _save
    image_ref, procset = _write_image(im, filename, existing_pdf, image_refs)
  File "PIL/PdfImagePlugin.py", line 151, in _write_image
    Image.SAVE["JPEG"](im, op, filename)
KeyError: 'JPEG'
```

The problem is that at line 151 (and for mode RGBA at line 154) JpegImagePlugin (and Jpeg2KImagePlugin) haven't necessarily been imported.
https://github.com/python-pillow/Pillow/blob/c722aaec534e55c6f55505d0464bac491e410826/src/PIL/PdfImagePlugin.py#L150-L154

One solution would be to import the plugins, so that `register_save()` is called, and still use `Image.SAVE`. However, lint raises an error that the imported plugins are not used.

I think it is better to actually call the plugin method directly, [like MpoImagePlugin does.](https://github.com/python-pillow/Pillow/blob/c722aaec534e55c6f55505d0464bac491e410826/src/PIL/MpoImagePlugin.py#L38)
```python
from . import JpegImagePlugin

JpegImagePlugin._save(im, op, filename)
```