### PR TITLE
Unsafe pointer dereference from unchecked Python integer in Tk initialization

### DIFF
--- a/src/_imagingtk.c
+++ b/src/_imagingtk.c
@@ -33,8 +33,10 @@ _tkinit(PyObject *self, PyObject *args) {
     }
 
     interp = (Tcl_Interp *)PyLong_AsVoidPtr(arg);
+    if (interp == NULL && PyErr_Occurred()) {
+        return NULL;
+    }
 
-    /* This will bomb if interp is invalid... */
     TkImaging_Init(interp);
 
     Py_RETURN_NONE;


### PR DESCRIPTION
## Problem

In `_tkinit`, `PyLong_AsVoidPtr(arg)` converts an arbitrary Python object to a `void*` pointer which is then cast to `Tcl_Interp*` and passed to `TkImaging_Init`. If `PyLong_AsVoidPtr` fails (returns NULL and sets an error), or if the caller passes an arbitrary integer value, the code proceeds to dereference it without any validation, potentially leading to a crash or arbitrary memory access.

**Severity**: `medium`
**File**: `src/_imagingtk.c`

## Solution

Check the return value of `PyLong_AsVoidPtr` for errors (NULL with exception set) before passing `interp` to `TkImaging_Init`. Add: `if (interp == NULL && PyErr_Occurred()) { return NULL; }`

## Changes

- `src/_imagingtk.c` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
