### PR TITLE
Correct environment URL

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -266,7 +266,7 @@ jobs:
     name: Upload wheels to scientific-python-nightly-wheels
     environment:
       name: release-anaconda
-      url: https://anaconda.org/channels/anaconda/packages/pillow/overview
+      url: https://anaconda.org/channels/scientific-python-nightly-wheels/packages/pillow/overview
     steps:
       - uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
Following up #9544

After 15 minutes of looking at https://anaconda.org/channels/anaconda/packages/pillow/overview and wondering why our recent scientific-python-nightly-wheels uploads weren't appearing there, I realised - they're being uploaded to https://anaconda.org/channels/scientific-python-nightly-wheels/packages/pillow/overview