### PR TITLE
Move dependency versions to single JSON and enable Renovate

### DIFF
--- a/.github/dependencies.json
+++ b/.github/dependencies.json
@@ -1,0 +1,19 @@
+{
+  "brotli": "1.2.0",
+  "bzip2": "1.0.8",
+  "freetype": "2.14.3",
+  "fribidi": "1.0.16",
+  "harfbuzz": "13.2.1",
+  "jpegturbo": "3.1.4.1",
+  "lcms2": "2.18",
+  "libavif": "1.4.1",
+  "libimagequant": "4.4.1",
+  "libpng": "1.6.56",
+  "libwebp": "1.6.0",
+  "libxcb": "1.17.0",
+  "openjpeg": "2.5.4",
+  "tiff": "4.7.1",
+  "xz": "5.8.3",
+  "zlib-ng": "2.3.3",
+  "zstd": "1.5.7"
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -130,7 +130,8 @@
             "matchStrings": ["\"freetype\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
             "depNameTemplate": "freetype",
             "packageNameTemplate": "freetype/freetype",
-            "datasourceTemplate": "github-tags",
+            "datasourceTemplate": "gitlab-tags",
+            "registryUrlTemplate": "https://gitlab.freedesktop.org",
             "extractVersionTemplate": "^VER-(?<version>[\\d-]+)$",
             "versioningTemplate": "regex:^(?<major>\\d+)[.-](?<minor>\\d+)[.-](?<patch>\\d+)$"
         },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,16 +7,167 @@
         "Dependency"
     ],
     "minimumReleaseAge": "7 days",
+    "schedule": [
+        "* * 3 * *"
+    ],
+    "customManagers": [
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
+            "matchStrings": ["\"brotli\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
+            "depNameTemplate": "brotli",
+            "packageNameTemplate": "google/brotli",
+            "datasourceTemplate": "github-releases",
+            "extractVersionTemplate": "^v(?<version>.+)$"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
+            "matchStrings": ["\"fribidi\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
+            "depNameTemplate": "fribidi",
+            "packageNameTemplate": "fribidi/fribidi",
+            "datasourceTemplate": "github-releases",
+            "extractVersionTemplate": "^v(?<version>.+)$"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
+            "matchStrings": ["\"harfbuzz\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
+            "depNameTemplate": "harfbuzz",
+            "packageNameTemplate": "harfbuzz/harfbuzz",
+            "datasourceTemplate": "github-releases"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
+            "matchStrings": ["\"jpegturbo\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
+            "depNameTemplate": "jpegturbo",
+            "packageNameTemplate": "libjpeg-turbo/libjpeg-turbo",
+            "datasourceTemplate": "github-releases"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
+            "matchStrings": ["\"lcms2\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
+            "depNameTemplate": "lcms2",
+            "packageNameTemplate": "mm2/Little-CMS",
+            "datasourceTemplate": "github-releases",
+            "extractVersionTemplate": "^lcms(?<version>.+)$"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
+            "matchStrings": ["\"libavif\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
+            "depNameTemplate": "libavif",
+            "packageNameTemplate": "AOMediaCodec/libavif",
+            "datasourceTemplate": "github-releases",
+            "extractVersionTemplate": "^v(?<version>.+)$"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
+            "matchStrings": ["\"libimagequant\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
+            "depNameTemplate": "libimagequant",
+            "packageNameTemplate": "ImageOptim/libimagequant",
+            "datasourceTemplate": "github-tags"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
+            "matchStrings": ["\"libwebp\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
+            "depNameTemplate": "libwebp",
+            "packageNameTemplate": "webmproject/libwebp",
+            "datasourceTemplate": "github-tags",
+            "extractVersionTemplate": "^v(?<version>.+)$"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
+            "matchStrings": ["\"openjpeg\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
+            "depNameTemplate": "openjpeg",
+            "packageNameTemplate": "uclouvain/openjpeg",
+            "datasourceTemplate": "github-releases",
+            "extractVersionTemplate": "^v(?<version>.+)$"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
+            "matchStrings": ["\"tiff\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
+            "depNameTemplate": "tiff",
+            "packageNameTemplate": "libsdl-org/libtiff",
+            "datasourceTemplate": "github-tags",
+            "extractVersionTemplate": "^v(?<version>.+)$"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
+            "matchStrings": ["\"xz\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
+            "depNameTemplate": "xz",
+            "packageNameTemplate": "tukaani-project/xz",
+            "datasourceTemplate": "github-releases",
+            "extractVersionTemplate": "^v(?<version>.+)$"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
+            "matchStrings": ["\"zlib-ng\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
+            "depNameTemplate": "zlib-ng",
+            "packageNameTemplate": "zlib-ng/zlib-ng",
+            "datasourceTemplate": "github-releases"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
+            "matchStrings": ["\"zstd\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
+            "depNameTemplate": "zstd",
+            "packageNameTemplate": "facebook/zstd",
+            "datasourceTemplate": "github-releases",
+            "extractVersionTemplate": "^v(?<version>.+)$"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
+            "matchStrings": ["\"freetype\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
+            "depNameTemplate": "freetype",
+            "packageNameTemplate": "freetype/freetype",
+            "datasourceTemplate": "github-tags",
+            "extractVersionTemplate": "^VER-(?<version>[\\d-]+)$",
+            "versioningTemplate": "regex:^(?<major>\\d+)[.-](?<minor>\\d+)[.-](?<patch>\\d+)$"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
+            "matchStrings": ["\"libpng\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
+            "depNameTemplate": "libpng",
+            "packageNameTemplate": "pnggroup/libpng",
+            "datasourceTemplate": "github-tags",
+            "extractVersionTemplate": "^v(?<version>.+)$"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
+            "matchStrings": ["\"libxcb\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
+            "depNameTemplate": "libxcb",
+            "packageNameTemplate": "xorg/lib/libxcb",
+            "datasourceTemplate": "gitlab-tags",
+            "registryUrlTemplate": "https://gitlab.freedesktop.org",
+            "extractVersionTemplate": "^libxcb-(?<version>.+)$"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
+            "matchStrings": ["\"bzip2\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
+            "depNameTemplate": "bzip2",
+            "packageNameTemplate": "bzip2/bzip2",
+            "datasourceTemplate": "gitlab-tags",
+            "extractVersionTemplate": "^bzip2-(?<version>.+)$"
+        }
+    ],
     "packageRules": [
         {
             "groupName": "github-actions",
-            "matchManagers": [
-                "github-actions"
-            ],
+            "matchManagers": ["github-actions"],
             "separateMajorMinor": false
         }
-    ],
-    "schedule": [
-        "* * 3 * *"
     ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -94,8 +94,8 @@
             "managerFilePatterns": ["/^\\.github/dependencies\\.json$/"],
             "matchStrings": ["\"tiff\":\\s*\"(?<currentValue>\\d+[^\"]*?)\""],
             "depNameTemplate": "tiff",
-            "packageNameTemplate": "libsdl-org/libtiff",
-            "datasourceTemplate": "github-tags",
+            "packageNameTemplate": "libtiff/libtiff",
+            "datasourceTemplate": "gitlab-tags",
             "extractVersionTemplate": "^v(?<version>.+)$"
         },
         {

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -5,12 +5,14 @@ on:
     branches:
       - "**"
     paths:
+      - ".github/dependencies.json"
       - ".github/workflows/cifuzz.yml"
       - ".github/workflows/wheels-dependencies.sh"
       - "**.c"
       - "**.h"
   pull_request:
     paths:
+      - ".github/dependencies.json"
       - ".github/workflows/cifuzz.yml"
       - ".github/workflows/wheels-dependencies.sh"
       - "**.c"

--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -89,22 +89,23 @@ fi
 
 ARCHIVE_SDIR=pillow-depends-main
 
-# Package versions for fresh source builds.
-FREETYPE_VERSION=2.14.3
-HARFBUZZ_VERSION=13.2.1
-LIBPNG_VERSION=1.6.56
-JPEGTURBO_VERSION=3.1.4.1
-OPENJPEG_VERSION=2.5.4
-XZ_VERSION=5.8.3
-ZSTD_VERSION=1.5.7
-TIFF_VERSION=4.7.1
-LCMS2_VERSION=2.18
-ZLIB_NG_VERSION=2.3.3
-LIBWEBP_VERSION=1.6.0
-BZIP2_VERSION=1.0.8
-LIBXCB_VERSION=1.17.0
-BROTLI_VERSION=1.2.0
-LIBAVIF_VERSION=1.4.1
+VERSIONS_FILE="$PROJECTDIR/.github/dependencies.json"
+_get_ver() { python3 -c "import json; print(json.load(open('$VERSIONS_FILE'))['$1'])"; }
+FREETYPE_VERSION=$(_get_ver freetype)
+HARFBUZZ_VERSION=$(_get_ver harfbuzz)
+LIBPNG_VERSION=$(_get_ver libpng)
+JPEGTURBO_VERSION=$(_get_ver jpegturbo)
+OPENJPEG_VERSION=$(_get_ver openjpeg)
+XZ_VERSION=$(_get_ver xz)
+ZSTD_VERSION=$(_get_ver zstd)
+TIFF_VERSION=$(_get_ver tiff)
+LCMS2_VERSION=$(_get_ver lcms2)
+ZLIB_NG_VERSION=$(_get_ver zlib-ng)
+LIBWEBP_VERSION=$(_get_ver libwebp)
+BZIP2_VERSION=$(_get_ver bzip2)
+LIBXCB_VERSION=$(_get_ver libxcb)
+BROTLI_VERSION=$(_get_ver brotli)
+LIBAVIF_VERSION=$(_get_ver libavif)
 
 function build_pkg_config {
     if [ -e pkg-config-stamp ]; then return; fi

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,6 +12,7 @@ on:
   push:
     paths:
       - ".ci/requirements-cibw.txt"
+      - ".github/dependencies.json"
       - ".github/workflows/wheel*"
       - "pyproject.toml"
       - "setup.py"
@@ -23,6 +24,7 @@ on:
   pull_request:
     paths:
       - ".ci/requirements-cibw.txt"
+      - ".github/dependencies.json"
       - ".github/workflows/wheel*"
       - "pyproject.toml"
       - "setup.py"

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import platform
 import re
@@ -8,6 +9,7 @@ import shutil
 import struct
 import subprocess
 import sys
+from pathlib import Path
 from typing import Any
 
 
@@ -112,21 +114,26 @@ ARCHITECTURES = {
     "ARM64": {"vcvars_arch": "x86_arm64", "msbuild_arch": "ARM64"},
 }
 
+_versions = json.loads(
+    (Path(__file__).parents[1] / ".github" / "dependencies.json").read_text()
+)
+
+
 V = {
-    "BROTLI": "1.2.0",
-    "FREETYPE": "2.14.3",
-    "FRIBIDI": "1.0.16",
-    "HARFBUZZ": "13.2.1",
-    "JPEGTURBO": "3.1.4.1",
-    "LCMS2": "2.18",
-    "LIBAVIF": "1.4.1",
-    "LIBIMAGEQUANT": "4.4.1",
-    "LIBPNG": "1.6.56",
-    "LIBWEBP": "1.6.0",
-    "OPENJPEG": "2.5.4",
-    "TIFF": "4.7.1",
-    "XZ": "5.8.3",
-    "ZLIBNG": "2.3.3",
+    "BROTLI": _versions["brotli"],
+    "FREETYPE": _versions["freetype"],
+    "FRIBIDI": _versions["fribidi"],
+    "HARFBUZZ": _versions["harfbuzz"],
+    "JPEGTURBO": _versions["jpegturbo"],
+    "LCMS2": _versions["lcms2"],
+    "LIBAVIF": _versions["libavif"],
+    "LIBIMAGEQUANT": _versions["libimagequant"],
+    "LIBPNG": _versions["libpng"],
+    "LIBWEBP": _versions["libwebp"],
+    "OPENJPEG": _versions["openjpeg"],
+    "TIFF": _versions["tiff"],
+    "XZ": _versions["xz"],
+    "ZLIBNG": _versions["zlib-ng"],
 }
 V["LIBPNG_XY"] = "".join(V["LIBPNG"].split(".")[:2])
 


### PR DESCRIPTION
Right now, we have the versions for our dependencies split between:

* `winbuild/build_prepare.py` - called when building Windows wheels
* `.github/workflows/wheels-dependencies.sh` - called when building all other wheels

And updating them is a lot of manual work:

* https://github.com/python-pillow/Pillow/issues?q=sort%3Aupdated-desc%20state%3Aclosed%20label%3ADependency

By having them managed by Renovate we:

* automate the update PRs
* get them on a schedule rather than many times throughout the month
* have a [cooldown](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns) applied to protect from supply chain attacks
* avoid duplicating in `build_prepare.py` and `wheels-dependencies.sh`
* avoid triplicating in the SBOM (https://github.com/python-pillow/Pillow/pull/9550) -- the WIP mostly doesn't include dep versions, but it should, and could be read from this file

Here's a demo on my fork, where I downgraded all the deps to see if it would pick them up, and it has: https://github.com/hugovk/Pillow/issues/153

