### PR TITLE
Pin GitHub Action to digests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,8 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "config:recommended"
+        "config:recommended",
+        "helpers:pinGitHubActionDigestsToSemver"
     ],
     "labels": [
         "Dependency"


### PR DESCRIPTION
Adding "helpers:pinGitHubActionDigestsToSemver" to renovate.json should be all that is needed to update our GitHub Actions from
https://github.com/python-pillow/Pillow/blob/b8933100453ed24352db2dc753880aebea46087f/.github/workflows/cifuzz.yml#L52
to
```
uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
```

See https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver