### PR TITLE
Raise error consistently from inside ImagingNewArrow

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -323,13 +323,9 @@ _new_arrow(PyObject *self, PyObject *args) {
     mode_id = findModeID(mode);
 
     // ImagingBorrowArrow is responsible for retaining the array_capsule
-    ret = PyImagingNew(
+    return PyImagingNew(
         ImagingNewArrow(mode_id, xsize, ysize, schema_capsule, array_capsule)
     );
-    if (!ret) {
-        return ImagingError_ValueError("Invalid Arrow array mode or size mismatch");
-    }
-    return ret;
 }
 
 /* -------------------------------------------------------------------- */

--- a/src/libImaging/Storage.c
+++ b/src/libImaging/Storage.c
@@ -548,7 +548,7 @@ ImagingDestroyArrow(Imaging im) {
     }
 }
 
-Imaging
+int
 ImagingBorrowArrow(
     Imaging im,
     struct ArrowArray *external_array,
@@ -571,9 +571,8 @@ ImagingBorrowArrow(
     }
 
     if (!borrowed_buffer) {
-        return (Imaging)ImagingError_ValueError(
-            "Arrow Array, exactly 2 buffers required"
-        );
+        ImagingError_ValueError("Arrow Array, exactly 2 buffers required");
+        return 0;
     }
 
     for (y = i = 0; y < im->ysize; y++) {
@@ -585,7 +584,7 @@ ImagingBorrowArrow(
     im->arrow_array_capsule = arrow_capsule;
     im->destroy = ImagingDestroyArrow;
 
-    return im;
+    return 1;
 }
 
 /* --------------------------------------------------------------------

--- a/src/libImaging/Storage.c
+++ b/src/libImaging/Storage.c
@@ -708,9 +708,11 @@ ImagingNewArrow(
           && im->bands == 1))                                 // Single band match
         && pixels == external_array->length) {
         // one arrow element per, and it matches a pixelsize*char
-        if (ImagingBorrowArrow(im, external_array, im->pixelsize, array_capsule)) {
-            return im;
+        if (!ImagingBorrowArrow(im, external_array, im->pixelsize, array_capsule)) {
+            ImagingDelete(im);
+            return NULL;
         }
+        return im;
     }
     // Stored as [[r,g,b,a],...]
     if (strcmp(schema->format, "+w:4") == 0  // 4 up array
@@ -724,9 +726,11 @@ ImagingNewArrow(
         && external_array->children                       // array is well formed
         && 4 * pixels == external_array->children[0]->length) {
         // 4 up element of char into pixelsize == 4
-        if (ImagingBorrowArrow(im, external_array, 1, array_capsule)) {
-            return im;
+        if (!ImagingBorrowArrow(im, external_array, 1, array_capsule)) {
+            ImagingDelete(im);
+            return NULL;
         }
+        return im;
     }
     // Stored as [r,g,b,a,r,g,b,a,...]
     if (strcmp(schema->format, "C") == 0            // uint8
@@ -735,13 +739,17 @@ ImagingNewArrow(
         && strcmp(im->arrow_band_format, "C") == 0  // expected format
         && 4 * pixels == external_array->length) {  // expected length
         // single flat array, interleaved storage.
-        if (ImagingBorrowArrow(im, external_array, 1, array_capsule)) {
-            return im;
+        if (!ImagingBorrowArrow(im, external_array, 1, array_capsule)) {
+            ImagingDelete(im);
+            return NULL;
         }
+        return im;
     }
     // fmt: on
     ImagingDelete(im);
-    return NULL;
+    return (Imaging)ImagingError_ValueError(
+        "Invalid Arrow array mode or size mismatch"
+    );
 }
 
 Imaging


### PR DESCRIPTION
Most of the time, when `ImagingNewArrow()` encounters an error, it [sets an exception.](https://github.com/python-pillow/Pillow/blob/087376dc18f1b956f849b29ca6275295eca00a6d/src/libImaging/Storage.c#L691)

However, when it does not [recognise the image/schema](https://github.com/python-pillow/Pillow/blob/087376dc18f1b956f849b29ca6275295eca00a6d/src/libImaging/Storage.c#L704-L742), it [returns NULL without raising an error](https://github.com/python-pillow/Pillow/blob/087376dc18f1b956f849b29ca6275295eca00a6d/src/libImaging/Storage.c#L745), leaving `_new_arrow()` to [raise an error.](https://github.com/python-pillow/Pillow/blob/087376dc18f1b956f849b29ca6275295eca00a6d/src/_imaging.c#L326-L331)

It would seem better for consistency to always raise an error on failure from within the function itself.