### PR TITLE
Do not set eval() globals in ImageMath.unsafe_eval()

### DIFF
--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -307,7 +307,7 @@ def unsafe_eval(expression: str, **kw: Any) -> Any:
                 raise ValueError(msg)
 
     scan(compiled_code)
-    out = builtins.eval(expression, {"__builtins": {"abs": abs}}, args)
+    out = builtins.eval(expression, None, args)
     try:
         return out.im
     except AttributeError:


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/087376dc18f1b956f849b29ca6275295eca00a6d/src/PIL/ImageMath.py#L310

The use of `{"__builtins": {"abs": abs}}` rather than `{"__builtins__": {"abs": abs}}` looks like a typo from #5923

However, if I abandon it entirely and just use `None`, nothing breaks, so I suggest that as the cleanest code.

https://docs.python.org/3/library/functions.html#eval
> Overriding `__builtins__` can be used to restrict or change the available names, but this is **not** a security mechanism: the executed code can still access all builtins.