### PR TITLE
Catch subprocess.CalledProcessError in test_grab_x11

### DIFF
--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -35,7 +35,7 @@ class TestImageGrab:
                 ImageGrab.grab()
 
             ImageGrab.grab(xdisplay="")
-        except OSError as e:
+        except (OSError, subprocess.CalledProcessError) as e:
             pytest.skip(str(e))
 
     @pytest.mark.skipif(Image.core.HAVE_XCB, reason="tests missing XCB")


### PR DESCRIPTION
Resolves #9577

#9321 added `subprocess.CalledProcessError`.