### PR TITLE
Move PyDateTime_IMPORT inside Py_mod_exec slot

### DIFF
--- a/src/_imagingcms.c
+++ b/src/_imagingcms.c
@@ -1462,6 +1462,8 @@ setup_module(PyObject *m) {
         return -1;
     }
 
+    PyDateTime_IMPORT;
+
     d = PyModule_GetDict(m);
 
     /* this check is also in PIL.features.pilinfo() */
@@ -1491,8 +1493,6 @@ static PyModuleDef_Slot slots[] = {
 
 PyMODINIT_FUNC
 PyInit__imagingcms(void) {
-    PyDateTime_IMPORT;
-
     static PyModuleDef module_def = {
         PyModuleDef_HEAD_INIT,
         .m_name = "_imagingcms",


### PR DESCRIPTION
Follow up to #8983

https://docs.python.org/3/c-api/datetime.html
> the macro [PyDateTime_IMPORT](https://docs.python.org/3/c-api/datetime.html#c.PyDateTime_IMPORT) must be invoked, usually as part of the module initialisation function.

https://peps.python.org/pep-0489/
> [The Py_mod_exec slot](https://peps.python.org/pep-0489/#the-py-mod-exec-slot)
> ...
> It will be called to initialize a module.