### PR TITLE
Update putpixel type hint to allow lists in xy

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2174,7 +2174,9 @@ class Image:
         self.load()  # install new palette
 
     def putpixel(
-        self, xy: tuple[int, int], value: float | tuple[int, ...] | list[int]
+        self,
+        xy: tuple[int, int] | list[int],
+        value: float | tuple[int, ...] | list[int],
     ) -> None:
         """
         Modifies the pixel at the given position. The color is given as


### PR DESCRIPTION
`putpixel()` accepts a list of integers as `xy` coordinates.
```pycon
>>> from PIL import Image
>>> im = Image.new("RGB", (1, 1))
>>> im.putpixel([0, 0], (255, 0, 0))
>>>
```