### PR TITLE
Do not draw line or arc if width is zero

### DIFF
--- a/src/PIL/ImageDraw.py
+++ b/src/PIL/ImageDraw.py
@@ -175,7 +175,7 @@ class ImageDraw:
     ) -> None:
         """Draw an arc."""
         ink, fill = self._getink(fill)
-        if ink is not None:
+        if ink is not None and width != 0:
             self.draw.draw_arc(xy, start, end, ink, width)
 
     def bitmap(
@@ -235,12 +235,12 @@ class ImageDraw:
         self,
         xy: Coords,
         fill: _Ink | None = None,
-        width: int = 0,
+        width: int = 1,
         joint: str | None = None,
     ) -> None:
         """Draw a line, or a connected sequence of line segments."""
         ink = self._getink(fill)[0]
-        if ink is not None:
+        if ink is not None and width != 0:
             self.draw.draw_lines(xy, ink, width)
             if joint == "curve" and width > 4:
                 points: Sequence[Sequence[float]]

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -3172,8 +3172,8 @@ _draw_lines(ImagingDrawObject *self, PyObject *args) {
 
     PyObject *data;
     int ink;
-    int width = 0;
-    if (!PyArg_ParseTuple(args, "Oi|i", &data, &ink, &width)) {
+    int width;
+    if (!PyArg_ParseTuple(args, "Oii", &data, &ink, &width)) {
         return NULL;
     }
 

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -3182,7 +3182,7 @@ _draw_lines(ImagingDrawObject *self, PyObject *args) {
         return NULL;
     }
 
-    if (width <= 1) {
+    if (width == 1) {
         double *p = NULL;
         for (i = 0; i < n - 1; i++) {
             p = &xy[i + i];


### PR DESCRIPTION
ImageDraw functions that fill and outline shapes skip the outline if the width is zero.
https://github.com/python-pillow/Pillow/blob/fba17910aabccb9c8fe24db6b83a3e1b81bba10b/src/PIL/ImageDraw.py#L219

 This PR also skips the draw operation within `line()` or `arc()` if the width is zero.