### PR TITLE
Deduplicate path triggers in workflows

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -4,19 +4,14 @@ on:
   push:
     branches:
       - "**"
-    paths:
+    paths: &paths
       - ".github/dependencies.json"
       - ".github/workflows/cifuzz.yml"
       - ".github/workflows/wheels-dependencies.sh"
       - "**.c"
       - "**.h"
   pull_request:
-    paths:
-      - ".github/dependencies.json"
-      - ".github/workflows/cifuzz.yml"
-      - ".github/workflows/wheels-dependencies.sh"
-      - "**.c"
-      - "**.h"
+    paths: *paths
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,15 +4,12 @@ on:
   push:
     branches:
       - "**"
-    paths:
+    paths: &paths
       - ".github/workflows/docs.yml"
       - "docs/**"
       - "src/PIL/**"
   pull_request:
-    paths:
-      - ".github/workflows/docs.yml"
-      - "docs/**"
-      - "src/PIL/**"
+    paths: *paths
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -4,19 +4,14 @@ on:
   push:
     branches:
       - "**"
-    paths-ignore:
+    paths-ignore: &paths-ignore
       - ".github/workflows/docs.yml"
       - ".github/workflows/wheels*"
       - ".gitmodules"
       - "docs/**"
       - "wheels/**"
   pull_request:
-    paths-ignore:
-      - ".github/workflows/docs.yml"
-      - ".github/workflows/wheels*"
-      - ".gitmodules"
-      - "docs/**"
-      - "wheels/**"
+    paths-ignore: *paths-ignore
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -4,19 +4,14 @@ on:
   push:
     branches:
       - "**"
-    paths-ignore:
+    paths-ignore: &paths-ignore
       - ".github/workflows/docs.yml"
       - ".github/workflows/wheels*"
       - ".gitmodules"
       - "docs/**"
       - "wheels/**"
   pull_request:
-    paths-ignore:
-      - ".github/workflows/docs.yml"
-      - ".github/workflows/wheels*"
-      - ".gitmodules"
-      - "docs/**"
-      - "wheels/**"
+    paths-ignore: *paths-ignore
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test-valgrind-memory.yml
+++ b/.github/workflows/test-valgrind-memory.yml
@@ -8,12 +8,13 @@ on:
   #   branches:
   #     - "**"
   #   paths:
-  #     - ".github/workflows/test-valgrind.yml"
+  #     - ".github/workflows/test-valgrind-memory.yml"
   #     - "**.c"
   #     - "**.h"
+  #     - "depends/docker-test-valgrind-memory.sh"
   pull_request:
     paths:
-      - ".github/workflows/test-valgrind.yml"
+      - ".github/workflows/test-valgrind-memory.yml"
       - "**.c"
       - "**.h"
       - "depends/docker-test-valgrind-memory.sh"

--- a/.github/workflows/test-valgrind.yml
+++ b/.github/workflows/test-valgrind.yml
@@ -6,15 +6,12 @@ on:
   push:
     branches:
       - "**"
-    paths:
+    paths: &paths
       - ".github/workflows/test-valgrind.yml"
       - "**.c"
       - "**.h"
   pull_request:
-    paths:
-      - ".github/workflows/test-valgrind.yml"
-      - "**.c"
-      - "**.h"
+    paths: *paths
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -4,19 +4,14 @@ on:
   push:
     branches:
       - "**"
-    paths-ignore:
+    paths-ignore: &paths-ignore
       - ".github/workflows/docs.yml"
       - ".github/workflows/wheels*"
       - ".gitmodules"
       - "docs/**"
       - "wheels/**"
   pull_request:
-    paths-ignore:
-      - ".github/workflows/docs.yml"
-      - ".github/workflows/wheels*"
-      - ".gitmodules"
-      - "docs/**"
-      - "wheels/**"
+    paths-ignore: *paths-ignore
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,19 +4,14 @@ on:
   push:
     branches:
       - "**"
-    paths-ignore:
+    paths-ignore: &paths-ignore
       - ".github/workflows/docs.yml"
       - ".github/workflows/wheels*"
       - ".gitmodules"
       - "docs/**"
       - "wheels/**"
   pull_request:
-    paths-ignore:
-      - ".github/workflows/docs.yml"
-      - ".github/workflows/wheels*"
-      - ".gitmodules"
-      - "docs/**"
-      - "wheels/**"
+    paths-ignore: *paths-ignore
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -10,7 +10,7 @@ on:
   #        │  │ │ │ │
   - cron: "42 1 * * 0,3"
   push:
-    paths:
+    paths: &paths
       - ".ci/requirements-cibw.txt"
       - ".ci/requirements-sbom.txt"
       - ".github/dependencies.json"
@@ -24,17 +24,7 @@ on:
     tags:
       - "*"
   pull_request:
-    paths:
-      - ".ci/requirements-cibw.txt"
-      - ".ci/requirements-sbom.txt"
-      - ".github/dependencies.json"
-      - ".github/generate-sbom.py"
-      - ".github/workflows/wheels*"
-      - "pyproject.toml"
-      - "setup.py"
-      - "wheels/*"
-      - "winbuild/build_prepare.py"
-      - "winbuild/fribidi.cmake"
+    paths: *paths
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
In general, I've been avoiding of GitHub's anchors:

https://blog.yossarian.net/2025/09/22/dear-github-no-yaml-anchors

Although deduplicating paths is simple enough and one of the working uses according to:

https://frenck.dev/github-actions-yaml-anchors-aliases-merge-keys/
