### PR TITLE
If PdfParser buffer is memoryview, release it when closing

### DIFF
--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -383,7 +383,7 @@ class PdfParser:
             msg = "specify buf or f or filename, but not both buf and f"
             raise RuntimeError(msg)
         self.filename = filename
-        self.buf: bytes | bytearray | mmap.mmap | None = buf
+        self.buf: bytes | bytearray | memoryview | mmap.mmap | None = buf
         self.f = f
         self.start_offset = start_offset
         self.should_close_buf = False
@@ -435,7 +435,9 @@ class PdfParser:
         self.seek_end()
 
     def close_buf(self) -> None:
-        if isinstance(self.buf, mmap.mmap):
+        if isinstance(self.buf, memoryview):
+            self.buf.release()
+        elif isinstance(self.buf, mmap.mmap):
             self.buf.close()
         self.buf = None
 


### PR DESCRIPTION
Our PyPy job has started failing on [macOS](https://github.com/python-pillow/Pillow/actions/runs/25084826318/job/73497909249) and [Windows](https://github.com/python-pillow/Pillow/actions/runs/25084826288/job/73497908806), with
> FAILED Tests/test_file_pdf.py::test_pdf_append_to_bytesio - BufferError: Existing exports of data: object cannot be re-sized

Currently, when closing the buffer in PdfParser, only `mmap.mmap` instances are handled.
https://github.com/python-pillow/Pillow/blob/0ef81c33af3d4416feb96a0b1cd8c2d3b3d06ab7/src/PIL/PdfParser.py#L437-L440

Updating this to also release `memoryview` instances fixes the error.