### PR TITLE
Catch KeyError when checking mode from PNG IHDR chunk

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -124,6 +124,14 @@ class TestFilePng:
             with Image.open(test_file):
                 pass
 
+    def test_ihdr_unknown_mode(self) -> None:
+        fp = BytesIO(chunk(b"IHDR", b"\x00" * 13))
+        with PngImagePlugin.PngStream(fp) as png:
+            cid, pos, length = png.read()
+            png.call(cid, pos, length)
+
+            assert png.im_mode == ""
+
     def test_bad_text(self) -> None:
         # Make sure PIL can read malformed tEXt chunks (@PIL152)
 

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -461,7 +461,7 @@ class PngStream(ChunkStream):
         self.im_size = i32(s, 0), i32(s, 4)
         try:
             self.im_mode, self.im_rawmode = _MODES[(s[8], s[9])]
-        except Exception:
+        except KeyError:
             pass
         if s[12]:
             self.im_info["interlace"] = 1

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -400,6 +400,9 @@ class PngStream(ChunkStream):
 
         self.text_memory = 0
 
+    def __enter__(self) -> PngStream:
+        return self
+
     def check_text_memory(self, chunklen: int) -> None:
         self.text_memory += chunklen
         if self.text_memory > MAX_TEXT_MEMORY:


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/7e4ca8b3abf1476b0c956bbc3642d0b2d5717e7c/src/PIL/PngImagePlugin.py#L462-L465

`Exception` can be made more specific. It is a `KeyError` that will be raised if the bit depth / color type combination doesn't have a match.

If you're concerned that `s` might not be long enough for `s[9]`, the length has been checked a few lines earlier.
https://github.com/python-pillow/Pillow/blob/7e4ca8b3abf1476b0c956bbc3642d0b2d5717e7c/src/PIL/PngImagePlugin.py#L455-L458