### PR TITLE
Use _accept check in WebP _open

### DIFF
--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -49,6 +49,12 @@ class TestFileWebp:
         assert version is not None
         assert re.search(r"\d+\.\d+\.\d+$", version)
 
+    def test_invalid_file(self) -> None:
+        invalid_file = "Tests/images/flower.jpg"
+
+        with pytest.raises(SyntaxError):
+            WebPImagePlugin.WebPImageFile(invalid_file)
+
     def test_read_rgb(self) -> None:
         """
         Can we read a RGB mode WebP file without error?

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -43,10 +43,15 @@ class WebPImageFile(ImageFile.ImageFile):
     __logical_frame = 0
 
     def _open(self) -> None:
+        assert self.fp is not None
+        s = self.fp.read()
+        if not _accept(s):
+            msg = "not a WEBP file"
+            raise SyntaxError(msg)
+
         # Use the newer AnimDecoder API to parse the (possibly) animated file,
         # and access muxed chunks like ICC/EXIF/XMP.
-        assert self.fp is not None
-        self._decoder = _webp.WebPAnimDecoder(self.fp.read())
+        self._decoder = _webp.WebPAnimDecoder(s)
 
         # Get info from decoder
         self._size, self.info["loop"], bgcolor, self.n_frames, self.rawmode = (


### PR DESCRIPTION
Adds the `_accept` check into WebP `_open`.

This is already done by some other plugins. For example,
https://github.com/python-pillow/Pillow/blob/7e4ca8b3abf1476b0c956bbc3642d0b2d5717e7c/src/PIL/GifImagePlugin.py#L102-L108