### PR TITLE
Release buffer for `memoryview` to fix PyPy

### DIFF
--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -383,7 +383,7 @@ class PdfParser:
             msg = "specify buf or f or filename, but not both buf and f"
             raise RuntimeError(msg)
         self.filename = filename
-        self.buf: bytes | bytearray | mmap.mmap | None = buf
+        self.buf: bytes | bytearray | memoryview | mmap.mmap | None = buf
         self.f = f
         self.start_offset = start_offset
         self.should_close_buf = False
@@ -437,6 +437,8 @@ class PdfParser:
     def close_buf(self) -> None:
         if isinstance(self.buf, mmap.mmap):
             self.buf.close()
+        elif isinstance(self.buf, memoryview):
+            self.buf.release()
         self.buf = None
 
     def close(self) -> None:


### PR DESCRIPTION
PyPy recently upgraded and started failing the CI:

* https://pypy.org/posts/2026/04/pypy-v7322-release.html
* Pass: PyPy 7.3.21 https://github.com/python-pillow/Pillow/actions/runs/25004471494/job/73223300975#step:5:16
* Fail: PyPy 7.3.22 https://github.com/python-pillow/Pillow/actions/runs/25078719038/job/73478211829#step:5:16

```pytb
__________________________ test_pdf_append_to_bytesio __________________________

    def test_pdf_append_to_bytesio() -> None:
        im = hopper("RGB")
        f = io.BytesIO()
>       im.save(f, format="PDF")
           ^^^^

Tests/test_file_pdf.py:338: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../hostedtoolcache/PyPy/3.11.15/arm64/lib/pypy3.11/site-packages/PIL/Image.py:2713: in save
    save_handler(self, fp, filename)
../../../hostedtoolcache/PyPy/3.11.15/arm64/lib/pypy3.11/site-packages/PIL/PdfImagePlugin.py:223: in _save
    existing_pdf.write_header()
                 ^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <PIL.PdfParser.PdfParser object at 0x000000013b89d478>

    def write_header(self) -> None:
        assert self.f is not None
>       self.f.write(b"%PDF-1.4\n")
               ^^^^^
E       BufferError: Existing exports of data: object cannot be re-sized

../../../hostedtoolcache/PyPy/3.11.15/arm64/lib/pypy3.11/site-packages/PIL/PdfParser.py:455: BufferError
=============================== warnings summary ===============================
```

If the buffer is a `memoryview`, releasing it fixes for PyPI.