### PR TITLE
Set Renovate prCreation to not-pending

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,7 @@
         "Dependency"
     ],
     "minimumReleaseAge": "7 days",
+    "prCreation": "not-pending",
     "schedule": [
         "* * 3 * *"
     ],


### PR DESCRIPTION
https://docs.renovatebot.com/configuration-options/#suppress-branchpr-creation-for-x-days

> If you use `minimumReleaseAge=3` days, `prCreation="not-pending"` and `internalChecksFilter="strict"` then Renovate only creates branches when 3 (or more days) have passed since the version was released. 

See also https://github.com/python-pillow/Pillow/pull/9614#issuecomment-4369201979