### PR TITLE
Fix multiline text line height calculation

### DIFF
--- a/src/PIL/ImageText.py
+++ b/src/PIL/ImageText.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import re
+import string
 from typing import AnyStr, Generic, NamedTuple
 
 from . import ImageFont
@@ -353,7 +354,7 @@ class Text(Generic[AnyStr]):
         fontmode = self._get_fontmode()
         line_spacing = (
             self.font.getbbox(
-                "A",
+                string.ascii_letters,
                 fontmode,
                 None,
                 self.features,


### PR DESCRIPTION
The line spacing calculation was using only 'A' which doesn't account for characters that extend below the baseline (like 'p', 'g', 'y'). Using `string.ascii_letters` ensures we measure the full font height including both ascenders and descenders.

Fixes #1646