### PR TITLE
Do not generate SBOM in scheduled run on fork

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -276,6 +276,7 @@ jobs:
           anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
 
   sbom:
+    if: github.event_name != 'schedule' || github.event.repository.fork == false
     runs-on: ubuntu-latest
     name: Generate SBOM
     steps:


### PR DESCRIPTION
Previously, a scheduled run of the Wheels CI on my fork would skip all jobs - https://github.com/radarhere/Pillow/actions/runs/24621078728

It is now running the new job from #9550, 'Generate SBOM' - https://github.com/radarhere/Pillow/actions/runs/25270428855

This PR skips it for forks during a scheduled run.