### PR TITLE
Do not return negative width for text length

### DIFF
--- a/Tests/test_imagefontpil.py
+++ b/Tests/test_imagefontpil.py
@@ -68,6 +68,15 @@ def test_textbbox(font: ImageFont.ImageFont) -> None:
     assert d.textbbox((0, 0), "test", font=font) == (0, 0, 24, 11)
 
 
+def test_negative_dx() -> None:
+    glyph = struct.pack(">hhhhhhhhhh", -1, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    fp = BytesIO(b"PILfont\n\nDATA\n" + glyph * 256)
+
+    font = ImageFont.ImageFont()
+    font._load_pilfont_data(fp, Image.new("L", (1, 1)))
+    assert font.getlength("A") == 0
+
+
 def test_decompression_bomb() -> None:
     glyph = struct.pack(">hhhhhhhhhh", 1, 0, 0, 0, 256, 256, 0, 0, 256, 256)
     fp = BytesIO(b"PILfont\n\nDATA\n" + glyph * 256)

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -2779,6 +2779,9 @@ textwidth(ImagingFontObject *self, const unsigned char *text) {
         xsize += self->glyphs[*text].dx;
     }
 
+    if (xsize < 0) {
+        return 0;
+    }
     return xsize;
 }
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/24696af8898f86007252c5774da9f14f2be93879/src/_imaging.c#L2774-L2783

It is possible for `dx` to be negative. While there's probably scenarios where that makes sense for an individual glyph, when it comes to the total text width, I don't think it makes sense to say that that is negative.

This function [determines](https://github.com/python-pillow/Pillow/blob/24696af8898f86007252c5774da9f14f2be93879/src/_imaging.c#L2888-L2910) the [value returned](https://github.com/python-pillow/Pillow/blob/24696af8898f86007252c5774da9f14f2be93879/src/PIL/ImageFont.py#L199-L210) by `getlength()`. I think it's more helpful to return zero. This is likely to be used for a drawing operation, and if nothing would be drawn, then what's the difference?