### PR TITLE
Add support for Python 3.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ WEBP_ROOT = None
 ZLIB_ROOT = None
 FUZZING_BUILD = "LIB_FUZZING_ENGINE" in os.environ
 
-if sys.platform == "win32" and sys.version_info >= (3, 15):
+if sys.platform == "win32" and sys.version_info >= (3, 16):
     import atexit
 
     atexit.register(


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/3ce681240fa6ad2f19a73b2c5531baada38dee96/setup.py#L60-L71

Since Python 3.15 has now reached [beta](https://www.python.org/downloads/release/python-3150b1/), we would like users to be able to install and use it, so let's increment the version check.