### PR TITLE
Fix typos in test comments

### DIFF
--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -1041,7 +1041,7 @@ class TestFileTiffW32:
     def test_fd_leak(self, tmp_path: Path) -> None:
         tmpfile = tmp_path / "temp.tif"
 
-        # this is an mmaped file.
+        # this is an mmapped file.
         with Image.open("Tests/images/uint16_1_4660.tif") as im:
             im.save(tmpfile)
 

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -244,7 +244,7 @@ class TestImage:
     @pytest.mark.skipif(is_win32(), reason="Test requires opening tempfile twice")
     @pytest.mark.skipif(
         sys.platform == "cygwin",
-        reason="Test requires opening an mmaped file for writing",
+        reason="Test requires opening an mmapped file for writing",
     )
     def test_readonly_save(self, tmp_path: Path) -> None:
         temp_file = tmp_path / "temp.bmp"

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -365,7 +365,7 @@ def test_rotated_transposed_font(
         bbox_b[2] - bbox_b[0],
     )
 
-    # Check top left co-ordinates are correct
+    # Check top left coordinates are correct
     assert bbox_b[:2] == (20, 20)
 
     # text length is undefined for vertical text
@@ -410,7 +410,7 @@ def test_unrotated_transposed_font(
         bbox_b[3] - bbox_b[1],
     )
 
-    # Check top left co-ordinates are correct
+    # Check top left coordinates are correct
     assert bbox_b[:2] == (20, 20)
 
     assert length_a == length_b


### PR DESCRIPTION
Two small typo fixes in test file comments:

- `mmaped` → `mmapped` in `Tests/test_file_tiff.py` and `Tests/test_image.py` (the past tense of `mmap`).
- `co-ordinates` → `coordinates` in `Tests/test_imagefont.py`, matching the unhyphenated spelling already used throughout `src/PIL/` and the other test modules.

Only comments are touched; no runtime behavior changes.