### PR TITLE
Consistently use "coordinates" instead of "co-ordinates"

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -365,7 +365,7 @@ def test_rotated_transposed_font(
         bbox_b[2] - bbox_b[0],
     )
 
-    # Check top left co-ordinates are correct
+    # Check top left coordinates are correct
     assert bbox_b[:2] == (20, 20)
 
     # text length is undefined for vertical text
@@ -410,7 +410,7 @@ def test_unrotated_transposed_font(
         bbox_b[3] - bbox_b[1],
     )
 
-    # Check top left co-ordinates are correct
+    # Check top left coordinates are correct
     assert bbox_b[:2] == (20, 20)
 
     assert length_a == length_b

--- a/docs/releasenotes/8.2.0.rst
+++ b/docs/releasenotes/8.2.0.rst
@@ -81,7 +81,7 @@ Image.alpha_composite: dest
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When calling :py:meth:`~PIL.Image.Image.alpha_composite`, the ``dest`` argument now
-accepts negative co-ordinates, like the upper left corner of the ``box`` argument of
+accepts negative coordinates, like the upper left corner of the ``box`` argument of
 :py:meth:`~PIL.Image.Image.paste` can be negative. Naturally, this has effect of
 cropping the overlaid image.
 

--- a/src/libImaging/Jpeg2KDecode.c
+++ b/src/libImaging/Jpeg2KDecode.c
@@ -812,7 +812,7 @@ j2k_decode_entry(Imaging im, ImagingCodecState state) {
             break;
         }
 
-        /* Adjust the tile co-ordinates based on the reduction (OpenJPEG
+        /* Adjust the tile coordinates based on the reduction (OpenJPEG
            doesn't do this for us) */
         tile_info.x0 = (tile_info.x0 + correction) >> context->reduce;
         tile_info.y0 = (tile_info.y0 + correction) >> context->reduce;


### PR DESCRIPTION
Based on part of #9626