### PR TITLE
Don't use list as default in PdfParser read_prev_trailer

### DIFF
--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -692,7 +692,7 @@ class PdfParser:
             self.read_prev_trailer(self.trailer_dict[b"Prev"])
 
     def read_prev_trailer(
-        self, xref_section_offset: int, processed_offsets: list[int] = None
+        self, xref_section_offset: int, processed_offsets: list[int] | None = None
     ) -> None:
         assert self.buf is not None
         trailer_offset = self.read_xref_table(xref_section_offset=xref_section_offset)

--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -692,7 +692,7 @@ class PdfParser:
             self.read_prev_trailer(self.trailer_dict[b"Prev"])
 
     def read_prev_trailer(
-        self, xref_section_offset: int, processed_offsets: list[int] = []
+        self, xref_section_offset: int, processed_offsets: list[int] = None
     ) -> None:
         assert self.buf is not None
         trailer_offset = self.read_xref_table(xref_section_offset=xref_section_offset)
@@ -708,6 +708,8 @@ class PdfParser:
         )
         trailer_dict = self.interpret_trailer(trailer_data)
         if b"Prev" in trailer_dict:
+            if processed_offsets is None:
+                processed_offsets = []
             processed_offsets.append(xref_section_offset)
             check_format_condition(
                 trailer_dict[b"Prev"] not in processed_offsets, "trailer loop found"


### PR DESCRIPTION
Backporting [this patch](https://github.com/python-pillow/Pillow/pull/9519) into some openSUSE distro I've detected that it adds an empty list as a default value in a method.

It's not recommended to use the empty list as default value in functions or methods because Python interpreter evaluates during parsing, so it will be the same list for different calls.

https://pylint.pycqa.org/en/latest/user_guide/messages/warning/dangerous-default-value.html