### PR TITLE
Remove duplicate code

### DIFF
--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -144,18 +144,6 @@ la2lA(UINT8 *out, const UINT8 *in, int xsize) {
 }
 
 static void
-l2la(UINT8 *out, const UINT8 *in, int xsize) {
-    int x;
-    for (x = 0; x < xsize; x++) {
-        UINT8 v = *in++;
-        *out++ = v;
-        *out++ = v;
-        *out++ = v;
-        *out++ = 255;
-    }
-}
-
-static void
 l2rgb(UINT8 *out, const UINT8 *in, int xsize) {
     int x;
     for (x = 0; x < xsize; x++) {
@@ -1212,7 +1200,7 @@ topalette(
         ImagingSectionEnter(&cookie);
         for (y = 0; y < imIn->ysize; y++) {
             if (alpha) {
-                l2la((UINT8 *)imOut->image[y], (UINT8 *)imIn->image[y], imIn->xsize);
+                l2rgb((UINT8 *)imOut->image[y], (UINT8 *)imIn->image[y], imIn->xsize);
             } else {
                 memcpy(imOut->image[y], imIn->image[y], imIn->linesize);
             }
@@ -1470,7 +1458,7 @@ static struct {
     {IMAGING_MODE_1, IMAGING_MODE_HSV, bit2hsv},
 
     {IMAGING_MODE_L, IMAGING_MODE_1, l2bit},
-    {IMAGING_MODE_L, IMAGING_MODE_LA, l2la},
+    {IMAGING_MODE_L, IMAGING_MODE_LA, l2rgb},
     {IMAGING_MODE_L, IMAGING_MODE_I, l2i},
     {IMAGING_MODE_L, IMAGING_MODE_F, l2f},
     {IMAGING_MODE_L, IMAGING_MODE_RGB, l2rgb},


### PR DESCRIPTION
These two functions are identical. I suggest removing one of them.
https://github.com/python-pillow/Pillow/blob/35d64296e13c9579f59eb040ee29b11e196b3d1f/src/libImaging/Convert.c#L146-L168