### PR TITLE
Do not raise error from unknown channel ID when parsing PSD layers

### DIFF
--- a/Tests/test_file_psd.py
+++ b/Tests/test_file_psd.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import sys
 import warnings
 
@@ -155,6 +156,21 @@ def test_icc_profile() -> None:
 def test_no_icc_profile() -> None:
     with Image.open("Tests/images/hopper_merged.psd") as im:
         assert "icc_profile" not in im.info
+
+
+def test_unknown_channel_id() -> None:
+    with open("Tests/images/rgba.psd", "rb") as fp:
+        data = fp.read()
+
+    # Set channel id to 4
+    data = data[:90] + b"\x00\x04" + data[92:]
+
+    b = io.BytesIO(data)
+    with Image.open(b) as im:
+        assert isinstance(im, PsdImagePlugin.PsdImageFile)
+
+        # unknown mode
+        assert im.layers[0][1] == ""
 
 
 def test_combined_larger_than_size() -> None:

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -222,12 +222,12 @@ def _layerinfo(
             continue
 
         for _ in range(ct_types):
-            type = i16(read(2))
+            channel_id = i16(read(2))
 
-            if type == 65535:
+            if channel_id == 65535:
                 b = "A"
             else:
-                b = "RGBA"[type]
+                b = "RGBA"[channel_id]
 
             bands.append(b)
             read(4)  # size

--- a/src/PIL/PsdImagePlugin.py
+++ b/src/PIL/PsdImagePlugin.py
@@ -226,8 +226,10 @@ def _layerinfo(
 
             if channel_id == 65535:
                 b = "A"
-            else:
+            elif channel_id < 4:
                 b = "RGBA"[channel_id]
+            else:
+                b = ""
 
             bands.append(b)
             read(4)  # size


### PR DESCRIPTION
Within a PSD layer, it is possible that an unsupported channel ID will trigger an `IndexError`.
https://github.com/python-pillow/Pillow/blob/ee9e761a643aac50e8daa3feceb500c34b23ac9c/src/PIL/PsdImagePlugin.py#L224-L232

However, Pillow has already established that if the combination of channels don't lead to a recognised mode, that's not cause for an error.
https://github.com/python-pillow/Pillow/blob/ee9e761a643aac50e8daa3feceb500c34b23ac9c/src/PIL/PsdImagePlugin.py#L235-L244

This PR applies that same logic to the first step, since conceptually, not knowing what type of data is in a band is a subset of not knowing what mode the overall layer is.