### PR TITLE
Speed up `Image.blend()`

### DIFF
--- a/src/libImaging/Blend.c
+++ b/src/libImaging/Blend.c
@@ -35,7 +35,7 @@ ImagingBlend(Imaging imIn1, Imaging imIn2, float alpha) {
     }
 
     /* Shortcuts */
-    if (alpha == 0.0) {
+    if (imIn1 == imIn2 || alpha == 0.0) {
         return ImagingCopy(imIn1);
     } else if (alpha == 1.0) {
         return ImagingCopy(imIn2);

--- a/src/libImaging/Blend.c
+++ b/src/libImaging/Blend.c
@@ -46,23 +46,28 @@ ImagingBlend(Imaging imIn1, Imaging imIn2, float alpha) {
         return NULL;
     }
 
+    // We know these won't change in the loops below,
+    // so the compiler can optimize better if we pull them out.
+    int ysize = imIn1->ysize;
+    int linesize = imIn1->linesize;
+
     if (alpha >= 0 && alpha <= 1.0) {
         /* Interpolate between bands */
-        for (y = 0; y < imIn1->ysize; y++) {
+        for (y = 0; y < ysize; y++) {
             UINT8 *in1 = (UINT8 *)imIn1->image[y];
             UINT8 *in2 = (UINT8 *)imIn2->image[y];
             UINT8 *out = (UINT8 *)imOut->image[y];
-            for (x = 0; x < imIn1->linesize; x++) {
+            for (x = 0; x < linesize; x++) {
                 out[x] = (UINT8)((int)in1[x] + alpha * ((int)in2[x] - (int)in1[x]));
             }
         }
     } else {
         /* Extrapolation; must make sure to clip resulting values */
-        for (y = 0; y < imIn1->ysize; y++) {
+        for (y = 0; y < ysize; y++) {
             UINT8 *in1 = (UINT8 *)imIn1->image[y];
             UINT8 *in2 = (UINT8 *)imIn2->image[y];
             UINT8 *out = (UINT8 *)imOut->image[y];
-            for (x = 0; x < imIn1->linesize; x++) {
+            for (x = 0; x < linesize; x++) {
                 float temp = (float)((int)in1[x] + alpha * ((int)in2[x] - (int)in1[x]));
                 if (temp <= 0.0) {
                     out[x] = 0;

--- a/src/libImaging/Blend.c
+++ b/src/libImaging/Blend.c
@@ -54,9 +54,10 @@ ImagingBlend(Imaging imIn1, Imaging imIn2, float alpha) {
     if (alpha >= 0 && alpha <= 1.0) {
         /* Interpolate between bands */
         for (y = 0; y < ysize; y++) {
-            UINT8 *in1 = (UINT8 *)imIn1->image[y];
-            UINT8 *in2 = (UINT8 *)imIn2->image[y];
-            UINT8 *out = (UINT8 *)imOut->image[y];
+            // restrict safe: imIn1 and imIn2 are read-only; imOut is a new allocation
+            UINT8 *restrict in1 = (UINT8 *)imIn1->image[y];
+            UINT8 *restrict in2 = (UINT8 *)imIn2->image[y];
+            UINT8 *restrict out = (UINT8 *)imOut->image[y];
             for (x = 0; x < linesize; x++) {
                 out[x] = (UINT8)((int)in1[x] + alpha * ((int)in2[x] - (int)in1[x]));
             }
@@ -64,9 +65,10 @@ ImagingBlend(Imaging imIn1, Imaging imIn2, float alpha) {
     } else {
         /* Extrapolation; must make sure to clip resulting values */
         for (y = 0; y < ysize; y++) {
-            UINT8 *in1 = (UINT8 *)imIn1->image[y];
-            UINT8 *in2 = (UINT8 *)imIn2->image[y];
-            UINT8 *out = (UINT8 *)imOut->image[y];
+            // restrict safe: imIn1 and imIn2 are read-only; imOut is a new allocation
+            UINT8 *restrict in1 = (UINT8 *)imIn1->image[y];
+            UINT8 *restrict in2 = (UINT8 *)imIn2->image[y];
+            UINT8 *restrict out = (UINT8 *)imOut->image[y];
             for (x = 0; x < linesize; x++) {
                 float temp = (float)((int)in1[x] + alpha * ((int)in2[x] - (int)in1[x]));
                 if (temp <= 0.0) {


### PR DESCRIPTION
I was working on a project that uses `Image.blend()` and it showed up pretty red in a Viztracer timeline, so I decided to investigate a little.

Very small patch, but allows the C compiler to optimize the loops better:

* we know `ysize` and `linesize` can't change during iteration (but the compiler can't statically know that), so hoisting those to locals
* we know `imOut` is a fresh allocation and can't alias another pointer, so adding `restrict` to note that.
  * `restrict` should be available on MSVC in C99 mode without having to use the MS extension name `__restrict`; we'll see how it pans out in CI and adjust accordingly.

In addition, added a little fast-path if you pass in the same image object twice.

On my machine, this shows a 300% speed improvement (with `blend_bench.py` being a pytest-benchmark suite doing `benchmark(Image.blend, im1, im2, 0.5)` on two 2048x2048 RGB images).

```
(main) $ uv pip install -e . && uv run --no-sync pytest --benchmark-autosave blend_bench.py
[...]
Name (time in ms)        Min      Max    Mean  StdDev  Median     IQR  Outliers       OPS  Rounds  Iterations
-------------------------------------------------------------------------------------------------------------
test_blend_perf       9.1552  11.0795  9.7906  0.2351  9.7934  0.1972      17;5  102.1389      90           1

(faster-blend) $ uv pip install -e . && uv run --no-sync pytest --benchmark-autosave blend_bench.py
[...]
Name (time in ms)        Min     Max    Mean  StdDev  Median     IQR  Outliers       OPS  Rounds  Iterations
------------------------------------------------------------------------------------------------------------
test_blend_perf       2.1012  3.2935  2.2357  0.1044  2.2116  0.1040      43;7  447.2908     284           1
------------------------------------------------------------------------------------------------------------

(faster-blend) $ pytest-benchmark compare .benchmarks/Darwin-CPython-3.14-64bit/*.json --between=ops

----------------- benchmark: 1 tests, 2 sources ------------------
Name (time in ms)     0001_2d4bc04 OPS  0002_9da64fc OPS      ΔOPS
------------------------------------------------------------------
test_blend_perf               102.1389          447.2908   +337.9%
------------------------------------------------------------------
```

I also looked at using the integer math from `AlphaComposite.c`, but that only made things a little slower.