### PR TITLE
Prevent reusing ImagingDecoderObject.setimage

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1122,6 +1122,14 @@ class TestImage:
             for name in enum.__members__:
                 assert getattr(Image, name) == enum[name]
 
+    def test_decoder_setimage_once(self) -> None:
+        im = Image.new("L", (1, 1))
+        decoder = Image._getdecoder("L", "raw", "L")
+
+        decoder.setimage(im.im, None)
+        with pytest.raises(ValueError, match="decoder already has an image"):
+            decoder.setimage(im.im, None)
+
     @pytest.mark.parametrize(
         "path",
         [

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -301,6 +301,14 @@ class CodecsTest:
 
 
 class TestPyDecoder(CodecsTest):
+    def test_c_decoder_setimage_once(self) -> None:
+        im = Image.new("L", (1, 1))
+        decoder = Image._getdecoder("L", "raw", "L")
+
+        decoder.setimage(im.im, (0, 0, 1, 1))
+        with pytest.raises(ValueError, match="decoder already has an image"):
+            decoder.setimage(im.im, (0, 0, 1, 1))
+
     def test_setimage(self) -> None:
         buf = BytesIO(b"\x00" * 255)
 

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -301,14 +301,6 @@ class CodecsTest:
 
 
 class TestPyDecoder(CodecsTest):
-    def test_c_decoder_setimage_once(self) -> None:
-        im = Image.new("L", (1, 1))
-        decoder = Image._getdecoder("L", "raw", "L")
-
-        decoder.setimage(im.im, (0, 0, 1, 1))
-        with pytest.raises(ValueError, match="decoder already has an image"):
-            decoder.setimage(im.im, (0, 0, 1, 1))
-
     def test_setimage(self) -> None:
         buf = BytesIO(b"\x00" * 255)
 

--- a/src/decode.c
+++ b/src/decode.c
@@ -53,7 +53,6 @@ typedef struct {
     Imaging im;
     PyObject *lock;
     int pulls_fd;
-    int has_image;
 } ImagingDecoderObject;
 
 static PyTypeObject ImagingDecoderType;
@@ -93,7 +92,6 @@ PyImaging_DecoderNew(int contextsize) {
     /* Target image */
     decoder->lock = NULL;
     decoder->im = NULL;
-    decoder->has_image = 0;
 
     /* Initialize the cleanup function pointer */
     decoder->cleanup = NULL;
@@ -170,10 +168,6 @@ _setimage(ImagingDecoderObject *decoder, PyObject *args) {
     if (!im) {
         return NULL;
     }
-    if (decoder->has_image) {
-        PyErr_SetString(PyExc_ValueError, "decoder already has an image");
-        return NULL;
-    }
     if (extents == Py_None) {
         x0 = 0;
         y0 = 0;
@@ -210,6 +204,10 @@ _setimage(ImagingDecoderObject *decoder, PyObject *args) {
         return NULL;
     }
 
+    if (decoder->im != NULL) {
+        PyErr_SetString(PyExc_ValueError, "decoder already has an image");
+        return NULL;
+    }
     decoder->im = im;
 
     state = &decoder->state;
@@ -240,7 +238,6 @@ _setimage(ImagingDecoderObject *decoder, PyObject *args) {
     Py_INCREF(op);
     Py_XDECREF(decoder->lock);
     decoder->lock = op;
-    decoder->has_image = 1;
 
     Py_RETURN_NONE;
 }

--- a/src/decode.c
+++ b/src/decode.c
@@ -53,6 +53,7 @@ typedef struct {
     Imaging im;
     PyObject *lock;
     int pulls_fd;
+    int has_image;
 } ImagingDecoderObject;
 
 static PyTypeObject ImagingDecoderType;
@@ -92,6 +93,7 @@ PyImaging_DecoderNew(int contextsize) {
     /* Target image */
     decoder->lock = NULL;
     decoder->im = NULL;
+    decoder->has_image = 0;
 
     /* Initialize the cleanup function pointer */
     decoder->cleanup = NULL;
@@ -168,6 +170,10 @@ _setimage(ImagingDecoderObject *decoder, PyObject *args) {
     if (!im) {
         return NULL;
     }
+    if (decoder->has_image) {
+        PyErr_SetString(PyExc_ValueError, "decoder already has an image");
+        return NULL;
+    }
     if (extents == Py_None) {
         x0 = 0;
         y0 = 0;
@@ -234,6 +240,7 @@ _setimage(ImagingDecoderObject *decoder, PyObject *args) {
     Py_INCREF(op);
     Py_XDECREF(decoder->lock);
     decoder->lock = op;
+    decoder->has_image = 1;
 
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
`ImagingDecoder.setimage()` binds a native decoder to an image before decoding. Reusing the same decoder with another image can leave decoder state from the previous binding in place.

 This adds a defensive guard so native `ImagingDecoder` objects reject a second `setimage()` call, and adds a regression test for that behavior. Existing image loading behavior is unchanged.

  Tested with:
  ```sh
  env PYTHONPATH=src python3 -m pytest Tests/test_imagefile.py
  ```