### PR TITLE
Raise ValueError if FPX tile size is not 64px by 64px

### DIFF
--- a/Tests/test_file_fpx.py
+++ b/Tests/test_file_fpx.py
@@ -46,7 +46,6 @@ def test_invalid_file() -> None:
 
 
 def test_invalid_tile_size() -> None:
-    # Test a valid OLE file, but not an FPX file
     with open("Tests/images/input_bw_one_band.fpx", "rb") as f:
         data = f.read()
     data = data[:4204] + b"\x00" * 8 + data[4212:]

--- a/Tests/test_file_fpx.py
+++ b/Tests/test_file_fpx.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from io import BytesIO
+
 import pytest
 
 from PIL import Image
@@ -43,7 +45,16 @@ def test_invalid_file() -> None:
         FpxImagePlugin.FpxImageFile(ole_file)
 
 
-def test_fpx_invalid_number_of_bands() -> None:
+def test_invalid_size() -> None:
+    # Test a valid OLE file, but not an FPX file
+    with open("Tests/images/input_bw_one_band.fpx", "rb") as f:
+        data = f.read()
+    data = data[:4204] + b"\x00" * 8 + data[4212:]
+    with pytest.raises(ValueError, match="Tile must be 64 pixels by 64 pixels"):
+        Image.open(BytesIO(data))
+
+
+def test_invalid_number_of_bands() -> None:
     with pytest.raises(OSError, match="Invalid number of bands"):
         with Image.open("Tests/images/input_bw_five_bands.fpx"):
             pass

--- a/Tests/test_file_fpx.py
+++ b/Tests/test_file_fpx.py
@@ -45,7 +45,7 @@ def test_invalid_file() -> None:
         FpxImagePlugin.FpxImageFile(ole_file)
 
 
-def test_invalid_size() -> None:
+def test_invalid_tile_size() -> None:
     # Test a valid OLE file, but not an FPX file
     with open("Tests/images/input_bw_one_band.fpx", "rb") as f:
         data = f.read()

--- a/src/PIL/FpxImagePlugin.py
+++ b/src/PIL/FpxImagePlugin.py
@@ -142,6 +142,10 @@ class FpxImageFile(ImageFile.ImageFile):
         size = i32(s, 4), i32(s, 8)
         # tilecount = i32(s, 12)
         xtile, ytile = i32(s, 16), i32(s, 20)
+        if xtile != 64 or ytile != 64:
+            msg = "Tile must be 64 pixels by 64 pixels"
+            raise ValueError(msg)
+
         # channels = i32(s, 24)
         offset = i32(s, 28)
         length = i32(s, 32)


### PR DESCRIPTION
Page 52 (or 42 if you're looking at the printed numbers) of https://graphcomp.com/info/specs/livepicture/fpx.pdf states that
> **Tile width field**
> This field specifies the width of a tile in pixels. The tile width must be 64 pixels.
>
> **Tile height field**
> This field specifies the height of a tile in pixels. The tile height must be 64 pixels.