### PR TITLE
Validate size and rank when initializing RankFilter

### DIFF
--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -136,10 +136,22 @@ def test_rankfilter_error(filter: ImageFilter.RankFilter) -> None:
 
 
 def test_rankfilter_properties() -> None:
-    rankfilter = ImageFilter.RankFilter(1, 2)
+    rankfilter = ImageFilter.RankFilter(3, 2)
 
-    assert rankfilter.size == 1
+    assert rankfilter.size == 3
     assert rankfilter.rank == 2
+
+    with pytest.raises(ValueError, match="bad filter size"):
+        ImageFilter.RankFilter(2, 1)
+    with pytest.raises(ValueError, match="bad filter size"):
+        ImageFilter.MaxFilter(2)
+    with pytest.raises(ValueError, match="bad filter size"):
+        ImageFilter.MedianFilter(2)
+    with pytest.raises(ValueError, match="bad filter size"):
+        ImageFilter.MinFilter(2)
+
+    with pytest.raises(ValueError, match="bad rank value"):
+        ImageFilter.RankFilter(1, 1)
 
 
 def test_builtinfilter_p() -> None:

--- a/src/PIL/ImageFilter.py
+++ b/src/PIL/ImageFilter.py
@@ -99,6 +99,12 @@ class RankFilter(Filter):
     name = "Rank"
 
     def __init__(self, size: int, rank: int) -> None:
+        if size % 2 == 0:
+            msg = "bad filter size"
+            raise ValueError(msg)
+        if rank < 0 or rank >= size * size:
+            msg = "bad rank value"
+            raise ValueError(msg)
         self.size = size
         self.rank = rank
 
@@ -121,8 +127,8 @@ class MedianFilter(RankFilter):
     name = "Median"
 
     def __init__(self, size: int = 3) -> None:
-        self.size = size
-        self.rank = size * size // 2
+        rank = size * size // 2
+        super().__init__(size, rank)
 
 
 class MinFilter(RankFilter):
@@ -136,8 +142,8 @@ class MinFilter(RankFilter):
     name = "Min"
 
     def __init__(self, size: int = 3) -> None:
-        self.size = size
-        self.rank = 0
+        rank = 0
+        super().__init__(size, rank)
 
 
 class MaxFilter(RankFilter):
@@ -151,8 +157,8 @@ class MaxFilter(RankFilter):
     name = "Max"
 
     def __init__(self, size: int = 3) -> None:
-        self.size = size
-        self.rank = size * size - 1
+        rank = size * size - 1
+        super().__init__(size, rank)
 
 
 class ModeFilter(Filter):


### PR DESCRIPTION
```python
from PIL import Image, ImageFilter
im = Image.new("L", (100, 100))
rankfilter = ImageFilter.RankFilter(2, 1)
im.filter(rankfilter)
```
gives
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/Image.py", line 1463, in filter
    return self._new(filter.filter(self.im))
                     ^^^^^^^^^^^^^^^^^^^^^^
  File "PIL/ImageFilter.py", line 110, in filter
    return image.rankfilter(self.size, self.rank)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: bad filter size
```

See
https://github.com/python-pillow/Pillow/blob/9c1097c861420c77af53c7c9af2a1382e2bfaa8b/src/PIL/ImageFilter.py#L101
https://github.com/python-pillow/Pillow/blob/9c1097c861420c77af53c7c9af2a1382e2bfaa8b/src/libImaging/RankFilter.c#L71-L73

The `size` value used when constructing `RankFilter` was incorrect. However, it's only purpose is to be used as a filter.

So let's raise the error on construction, rather than letting the user think everything is ok at first.

This also applies to 
https://github.com/python-pillow/Pillow/blob/9c1097c861420c77af53c7c9af2a1382e2bfaa8b/src/libImaging/RankFilter.c#L83-L85