### PR TITLE
Simplify `RankFilter.c` check

### DIFF
--- a/src/libImaging/RankFilter.c
+++ b/src/libImaging/RankFilter.c
@@ -73,7 +73,7 @@ MakeRankFunction(UINT8) MakeRankFunction(INT32) MakeRankFunction(FLOAT32)
     }
 
     /* malloc check ok, for overflow in the define below */
-    if (size > INT_MAX / size || size > INT_MAX / (size * (int)sizeof(FLOAT32))) {
+    if (size > INT_MAX / (size * (int)sizeof(FLOAT32))) {
         return (Imaging)ImagingError_ValueError("filter size too large");
     }
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/9c1097c861420c77af53c7c9af2a1382e2bfaa8b/src/libImaging/RankFilter.c#L76

The first condition here is made redundant by the second - if `size * size > INT_MAX`, then `size * size * sizeof(FLOAT32) > INT_MAX` will be true as well.

This code was added in https://github.com/python-pillow/Pillow/commit/52d60cd09688ff54aa707ccc5c8c41865c32954f