### PR TITLE
Only pass one argument to C expand

### DIFF
--- a/src/PIL/ImageFilter.py
+++ b/src/PIL/ImageFilter.py
@@ -106,7 +106,7 @@ class RankFilter(Filter):
         if image.mode == "P":
             msg = "cannot filter palette images"
             raise ValueError(msg)
-        image = image.expand(self.size // 2, self.size // 2)
+        image = image.expand(self.size // 2)
         return image.rankfilter(self.size, self.rank)
 
 

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1092,12 +1092,12 @@ _crop(ImagingObject *self, PyObject *args) {
 
 static PyObject *
 _expand_image(ImagingObject *self, PyObject *args) {
-    int x, y;
-    if (!PyArg_ParseTuple(args, "ii", &x, &y)) {
+    int m;
+    if (!PyArg_ParseTuple(args, "i", &m)) {
         return NULL;
     }
 
-    return PyImagingNew(ImagingExpand(self->image, x, y));
+    return PyImagingNew(ImagingExpand(self->image, m));
 }
 
 static PyObject *

--- a/src/libImaging/Filter.c
+++ b/src/libImaging/Filter.c
@@ -51,47 +51,46 @@ clip32(float in) {
 }
 
 Imaging
-ImagingExpand(Imaging imIn, int xmargin, int ymargin) {
+ImagingExpand(Imaging imIn, int margin) {
     Imaging imOut;
     int x, y;
     ImagingSectionCookie cookie;
 
-    if (xmargin < 0 && ymargin < 0) {
+    if (margin < 0) {
         return (Imaging)ImagingError_ValueError("bad kernel size");
     }
 
-    imOut = ImagingNewDirty(
-        imIn->mode, imIn->xsize + 2 * xmargin, imIn->ysize + 2 * ymargin
-    );
+    imOut =
+        ImagingNewDirty(imIn->mode, imIn->xsize + 2 * margin, imIn->ysize + 2 * margin);
     if (!imOut) {
         return NULL;
     }
 
-#define EXPAND_LINE(type, image, yin, yout)                        \
-    {                                                              \
-        for (x = 0; x < xmargin; x++) {                            \
-            imOut->image[yout][x] = imIn->image[yin][0];           \
-        }                                                          \
-        for (x = 0; x < imIn->xsize; x++) {                        \
-            imOut->image[yout][x + xmargin] = imIn->image[yin][x]; \
-        }                                                          \
-        for (x = 0; x < xmargin; x++) {                            \
-            imOut->image[yout][xmargin + imIn->xsize + x] =        \
-                imIn->image[yin][imIn->xsize - 1];                 \
-        }                                                          \
+#define EXPAND_LINE(type, image, yin, yout)                       \
+    {                                                             \
+        for (x = 0; x < margin; x++) {                            \
+            imOut->image[yout][x] = imIn->image[yin][0];          \
+        }                                                         \
+        for (x = 0; x < imIn->xsize; x++) {                       \
+            imOut->image[yout][x + margin] = imIn->image[yin][x]; \
+        }                                                         \
+        for (x = 0; x < margin; x++) {                            \
+            imOut->image[yout][margin + imIn->xsize + x] =        \
+                imIn->image[yin][imIn->xsize - 1];                \
+        }                                                         \
     }
 
-#define EXPAND(type, image)                                                       \
-    {                                                                             \
-        for (y = 0; y < ymargin; y++) {                                           \
-            EXPAND_LINE(type, image, 0, y);                                       \
-        }                                                                         \
-        for (y = 0; y < imIn->ysize; y++) {                                       \
-            EXPAND_LINE(type, image, y, y + ymargin);                             \
-        }                                                                         \
-        for (y = 0; y < ymargin; y++) {                                           \
-            EXPAND_LINE(type, image, imIn->ysize - 1, ymargin + imIn->ysize + y); \
-        }                                                                         \
+#define EXPAND(type, image)                                                      \
+    {                                                                            \
+        for (y = 0; y < margin; y++) {                                           \
+            EXPAND_LINE(type, image, 0, y);                                      \
+        }                                                                        \
+        for (y = 0; y < imIn->ysize; y++) {                                      \
+            EXPAND_LINE(type, image, y, y + margin);                             \
+        }                                                                        \
+        for (y = 0; y < margin; y++) {                                           \
+            EXPAND_LINE(type, image, imIn->ysize - 1, margin + imIn->ysize + y); \
+        }                                                                        \
     }
 
     ImagingSectionEnter(&cookie);

--- a/src/libImaging/Imaging.h
+++ b/src/libImaging/Imaging.h
@@ -313,7 +313,7 @@ ImagingConvertTransparent(Imaging im, ModeID mode, int r, int g, int b);
 extern Imaging
 ImagingCrop(Imaging im, int x0, int y0, int x1, int y1);
 extern Imaging
-ImagingExpand(Imaging im, int x, int y);
+ImagingExpand(Imaging im, int m);
 extern Imaging
 ImagingFill(Imaging im, const void *ink);
 extern int


### PR DESCRIPTION
This is the only time that C `expand` is called.
https://github.com/python-pillow/Pillow/blob/e55c000d1b848fa6b7df2db171c6dbc00b2175a4/src/PIL/ImageFilter.py#L109

Let's simplify this by only using one argument, instead of two.