### PR TITLE
Raise error if declared JPEG2000 marker length is too small

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import struct
 from collections.abc import Generator
 from io import BytesIO
 from pathlib import Path
@@ -545,6 +546,18 @@ def test_plt_marker(card: ImageFile.ImageFile) -> None:
         hdr = out.read(2)
         length = _binary.i16be(hdr)
         out.seek(length - 2, os.SEEK_CUR)
+
+
+def test_marker_length() -> None:
+    magic = b"\xff\x4f\xff\x51"
+    b = BytesIO(magic + b"\x00\x00")
+    with pytest.raises(ValueError, match="SIZ marker length must be at least 38"):
+        Image.open(b)
+
+    siz_marker = _binary.o16be(38) + b"\x00" * 34 + struct.pack(">H", 2)
+    b = BytesIO(magic + siz_marker + b"\x00" * 4)
+    with pytest.raises(ValueError, match="Marker length too small"):
+        Image.open(b)
 
 
 def test_9bit() -> None:

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -108,6 +108,9 @@ def _parse_codestream(fp: IO[bytes]) -> tuple[tuple[int, int], str]:
 
     hdr = fp.read(2)
     lsiz = _binary.i16be(hdr)
+    if lsiz < 38:
+        msg = "SIZ marker length must be at least 38"
+        raise ValueError(msg)
     siz = hdr + fp.read(lsiz - 2)
     lsiz, rsiz, xsiz, ysiz, xosiz, yosiz, _, _, _, _, csiz = struct.unpack_from(
         ">HHIIIIIIIIH", siz
@@ -328,6 +331,9 @@ class Jpeg2KImageFile(ImageFile.ImageFile):
                 break
             hdr = self.fp.read(2)
             length = _binary.i16be(hdr)
+            if length < 2:
+                msg = "Marker length too small"
+                raise ValueError(msg)
             if typ == 0x64:
                 # Comment
                 self.info["comment"] = self.fp.read(length - 2)[2:]


### PR DESCRIPTION
In two places in Jpeg2KImagePlugin, it is possible for file data to be such that Pillow calls `read()` with a negative number.
https://github.com/python-pillow/Pillow/blob/fd0956fb06dabbdc44d57eac490c0a3eb953e79f/src/PIL/Jpeg2KImagePlugin.py#L110-L111
https://github.com/python-pillow/Pillow/blob/fd0956fb06dabbdc44d57eac490c0a3eb953e79f/src/PIL/Jpeg2KImagePlugin.py#L329-L333

This would unintentionally read the rest of the file. This PR changes those places to raise an error instead.