### PR TITLE
Invoke pyroma through the command line

### DIFF
--- a/Tests/test_pyroma.py
+++ b/Tests/test_pyroma.py
@@ -1,55 +1,15 @@
 from __future__ import annotations
 
-from importlib.metadata import metadata
+import subprocess
+import sys
 
 import pytest
 
-from PIL import __version__
-
-TYPE_CHECKING = False
-
-if TYPE_CHECKING:
-    from importlib.metadata import PackageMetadata
-
-pyroma = pytest.importorskip("pyroma", reason="Pyroma not installed")
+pytest.importorskip("pyroma", reason="Pyroma not installed")
 
 
-def map_metadata_keys(md: PackageMetadata) -> dict[str, str | list[str] | None]:
-    # Convert installed wheel metadata into canonical Core Metadata 2.4 format.
-    # This was a utility method in pyroma 4.3.3; it was removed in 5.0.
-    # This implementation is constructed from the relevant logic from
-    # Pyroma 5.0's `build_metadata()` implementation. This has been submitted
-    # upstream to Pyroma as https://github.com/regebro/pyroma/pull/116,
-    # so it may be possible to simplify this test in future.
-    data = {}
-    for key in set(md):
-        value = md.get_all(key)
-        key = pyroma.projectdata.normalize(key)
-
-        if value is not None and len(value) == 1:
-            first_value = value[0]
-            if first_value.strip() != "UNKNOWN":
-                data[key] = first_value
-        else:
-            data[key] = value
-    return data
-
-
+@pytest.mark.skipif(sys.platform == "ios", reason="Processes not supported on iOS")
 def test_pyroma() -> None:
-    # Arrange
-    data = map_metadata_keys(metadata("Pillow"))
-
-    # Act
-    rating = pyroma.ratings.rate(data)
-
-    # Assert
-    if "rc" in __version__:
-        # Pyroma needs to chill about RC versions and not kill all our tests.
-        assert rating == (
-            9,
-            ["The package's version number does not comply with PEP-386."],
-        )
-
-    else:
-        # Should have a perfect score
-        assert rating == (10, [])
+    assert b"Final rating: 10/10" in subprocess.check_output(
+        [sys.executable, "-m", "pyroma", "."]
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ optional-dependencies.tests = [
   "markdown2",
   "olefile",
   "packaging",
-  "pyroma>=5",
+  "pyroma",
   "pytest",
   "pytest-cov",
   "pytest-timeout",


### PR DESCRIPTION
Resolves #9668

The maintainer of pyroma has declared that it is [a command line tool, not a library.](https://github.com/regebro/pyroma/pull/116#issuecomment-4681987941) This PR updates test_pyroma.py to use `subprocess` to call it, rather than using the import.

You will notice that I have also removed our code handling `rc` versions (I don't think we've used this since 3.1.0.rc1) and relaxed the pyroma version requirement (now that the changes from #9116 are gone).