### PR TITLE
Force the output of ImageOps.contain() to have at least 1px dimensions

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -128,6 +128,16 @@ def test_contain_round() -> None:
     assert new_im.height == 5
 
 
+def test_contain_0px() -> None:
+    im = Image.new("1", (1, 256), 1)
+    new_im = ImageOps.contain(im, (8, 8))
+    assert new_im.width == 1
+
+    im = Image.new("1", (256, 1), 1)
+    new_im = ImageOps.contain(im, (8, 8))
+    assert new_im.height == 1
+
+
 @pytest.mark.parametrize(
     "image_name, expected_size",
     (

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -290,11 +290,11 @@ def contain(
 
     if im_ratio != dest_ratio:
         if im_ratio > dest_ratio:
-            new_height = round(image.height / image.width * size[0])
+            new_height = max(1, round(image.height / image.width * size[0]))
             if new_height != size[1]:
                 size = (size[0], new_height)
         else:
-            new_width = round(image.width / image.height * size[1])
+            new_width = max(1, round(image.width / image.height * size[1]))
             if new_width != size[0]:
                 size = (new_width, size[1])
     return image.resize(size, resample=method)


### PR DESCRIPTION
Resolves #9997. Alternative to #9673

I ran into `ValueError: height and width must be > 0` when trying to contain a very skinny image in a very small box. This fixes that.