### PR TITLE
Allow ImageOps to create zero dimension images

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -128,6 +128,16 @@ def test_contain_round() -> None:
     assert new_im.height == 5
 
 
+def test_contain_zero() -> None:
+    im = Image.new("1", (1, 10))
+    new_im = ImageOps.contain(im, (5, 5))
+    assert new_im.width == 0
+
+    im = Image.new("1", (10, 1))
+    new_im = ImageOps.contain(im, (5, 5))
+    assert new_im.height == 0
+
+
 @pytest.mark.parametrize(
     "image_name, expected_size",
     (

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -111,6 +111,16 @@ def test_fit_same_ratio() -> None:
         assert new_im.size == (1000, 755)
 
 
+def test_fit_zero() -> None:
+    im = Image.new("1", (5, 0))
+    new_im = ImageOps.fit(im, (5, 5))
+    assert new_im.size == (5, 5)
+
+    im = Image.new("1", (5, 5))
+    new_im = ImageOps.fit(im, (10, 0))
+    assert new_im.size == (10, 0)
+
+
 @pytest.mark.parametrize("new_size", ((256, 256), (512, 256), (256, 512)))
 def test_contain(new_size: tuple[int, int]) -> None:
     im = hopper()
@@ -137,6 +147,14 @@ def test_contain_zero() -> None:
     new_im = ImageOps.contain(im, (5, 5))
     assert new_im.height == 0
 
+    im = Image.new("1", (10, 0))
+    new_im = ImageOps.contain(im, (5, 5))
+    assert new_im.size == (5, 0)
+
+    im = Image.new("1", (5, 5))
+    new_im = ImageOps.contain(im, (2, 0))
+    assert new_im.size == (0, 0)
+
 
 @pytest.mark.parametrize(
     "image_name, expected_size",
@@ -150,6 +168,16 @@ def test_cover(image_name: str, expected_size: tuple[int, int]) -> None:
     with Image.open("Tests/images/" + image_name) as im:
         new_im = ImageOps.cover(im, (256, 256))
         assert new_im.size == expected_size
+
+
+def test_cover_zero() -> None:
+    im = Image.new("1", (10, 0))
+    new_im = ImageOps.cover(im, (5, 5))
+    assert new_im.size == (5, 0)
+
+    im = Image.new("1", (5, 5))
+    new_im = ImageOps.cover(im, (2, 0))
+    assert new_im.size == (0, 0)
 
 
 def test_pad() -> None:

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -112,6 +112,10 @@ def test_fit_same_ratio() -> None:
 
 
 def test_fit_zero() -> None:
+    im = Image.new("1", (5, 5))
+    new_im = ImageOps.fit(im, (0, 5))
+    assert new_im.width == 0
+
     im = Image.new("1", (5, 0))
     new_im = ImageOps.fit(im, (5, 5))
     assert new_im.size == (5, 5)

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -297,6 +297,8 @@ def contain(
             new_width = round(image.width / image.height * size[1])
             if new_width != size[0]:
                 size = (new_width, size[1])
+    if min(size) == 0:
+        return Image.new(image.mode, size)
     return image.resize(size, resample=method)
 
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -576,7 +576,7 @@ def fit(
     # kevin@cazabon.com
     # https://www.cazabon.com
 
-    if size[1] == 0:
+    if min(size) == 0:
         return Image.new(image.mode, size)
     centering_x, centering_y = centering
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -305,6 +305,8 @@ def contain(
             new_width = round(image.width / image.height * size[1])
             if new_width != size[0]:
                 size = (new_width, size[1])
+    if min(size) == 0:
+        return Image.new(image.mode, size)
     return image.resize(size, resample=method)
 
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -293,7 +293,11 @@ def contain(
     :return: An image.
     """
 
+    if image.height == 0:
+        return Image.new(image.mode, (size[0], 0))
     im_ratio = image.width / image.height
+    if size[1] == 0:
+        return Image.new(image.mode, (0, 0))
     dest_ratio = size[0] / size[1]
 
     if im_ratio != dest_ratio:
@@ -326,7 +330,11 @@ def cover(
     :return: An image.
     """
 
+    if image.height == 0:
+        return Image.new(image.mode, (size[0], 0))
     im_ratio = image.width / image.height
+    if size[1] == 0:
+        return Image.new(image.mode, (0, 0))
     dest_ratio = size[0] / size[1]
 
     if im_ratio != dest_ratio:
@@ -568,6 +576,8 @@ def fit(
     # kevin@cazabon.com
     # https://www.cazabon.com
 
+    if size[1] == 0:
+        return Image.new(image.mode, size)
     centering_x, centering_y = centering
 
     if not 0.0 <= centering_x <= 1.0:
@@ -590,6 +600,8 @@ def fit(
     )
 
     # calculate the aspect ratio of the live_size
+    if live_size[1] == 0:
+        return Image.new(image.mode, size)
     live_size_ratio = live_size[0] / live_size[1]
 
     # calculate the aspect ratio of the output image


### PR DESCRIPTION
Resolves #9997

`ImageOps.contain()` attempts to fits an image within a certain size. If those calculations end up with an image where one dimension is zero, then an error is currently raised.

```pytb
>>> from PIL import Image, ImageOps
>>> im = Image.new("1", (1, 10))
>>> ImageOps.contain(im, (5, 5))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/ImageOps.py", line 300, in contain
    return image.resize(size, resample=method)
  File "PIL/Image.py", line 2430, in resize
    im = self.im.resize(size, resample, box)
ValueError: height and width must be > 0
```

This PR suggests allowing zero dimension images to be created. It is an alternative to #9672, which forces the image to be at least 1px wide or high.

#9856 pointed out various `ZeroDivisionError`s that may occur in ImageOps, so I have also pushed a commit to fix them, and to allow `ImageOps.fit()` to create zero width images.