### PR TITLE
Do not test NumPy against Python 3.15 Windows AMD64 wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,8 @@ overrides = [
   # iOS simulator environment is isolated by cibuildwheel, but needs the dependencies
   { select = "*_iphonesimulator", environment.PATH = "$(pwd)/build/deps/iphonesimulator/bin:$PATH" },
   { select = "*-win32", test-requires = [] },
+  # NumPy does not yet support Python 3.15
+  { select = "cp315*-win_amd64", test-requires = [] },
 ]
 xbuild-tools = []
 


### PR DESCRIPTION
Our Windows AMD64 wheel job has started failing to use NumPy with Python 3.15 - https://github.com/python-pillow/Pillow/actions/runs/27486116482/job/81311124359#step:7:37627
```
  ImportError while importing test module 'C:\pillow\Tests\test_image_array.py'.
  Hint: make sure your test modules/packages have valid Python names.
  Traceback:
  C:\Users\runneradmin\AppData\Local\Temp\cibw-run-bfoqmbqc\cp315-win_amd64\venv-test\Lib\site-packages\numpy\_core\__init__.py:24: in <module>
      from . import multiarray
  C:\Users\runneradmin\AppData\Local\Temp\cibw-run-bfoqmbqc\cp315-win_amd64\venv-test\Lib\site-packages\numpy\_core\multiarray.py:11: in <module>
      from . import _multiarray_umath, overrides
  E   ImportError: DLL load failed while importing _multiarray_umath: The specified module could not be found.
```

Since NumPy hasn't added support for Python 3.15 yet, this PR simply stops testing our Python 3.15 wheels with NumPy.