### PR TITLE
Correct `IFDRational.__float__()` return value

### DIFF
--- a/Tests/test_tiff_ifdrational.py
+++ b/Tests/test_tiff_ifdrational.py
@@ -41,14 +41,12 @@ def test_sanity() -> None:
 
 def test_float() -> None:
     # float() must agree with ==, int() and repr(), which all use the
-    # normalized fraction. For a non-integral numerator (1.5 / 3 == 0.5) the
-    # inherited Rational.__float__ used int(numerator) / int(denominator) and
-    # returned 1/3 instead.
+    # normalized fraction
     r = IFDRational(1.5, 3)
     assert r == 0.5
     assert float(r) == 0.5
 
-    # Integral and 0/0 (nan) cases stay correct.
+    # Integer numerator and 0/0 (nan) cases
     assert float(IFDRational(4, 2)) == 2.0
     assert math.isnan(float(IFDRational(0, 0)))
 

--- a/Tests/test_tiff_ifdrational.py
+++ b/Tests/test_tiff_ifdrational.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from fractions import Fraction
 from pathlib import Path
 
@@ -36,6 +37,20 @@ def test_sanity() -> None:
     _test_equal(1, 2, IFDRational(1, 2))
 
     _test_equal(7, 5, 1.4)
+
+
+def test_float() -> None:
+    # float() must agree with ==, int() and repr(), which all use the
+    # normalized fraction. For a non-integral numerator (1.5 / 3 == 0.5) the
+    # inherited Rational.__float__ used int(numerator) / int(denominator) and
+    # returned 1/3 instead.
+    r = IFDRational(1.5, 3)
+    assert r == 0.5
+    assert float(r) == 0.5
+
+    # Integral and 0/0 (nan) cases stay correct.
+    assert float(IFDRational(4, 2)) == 2.0
+    assert math.isnan(float(IFDRational(0, 0)))
 
 
 def test_ranges() -> None:

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -464,6 +464,7 @@ class IFDRational(Rational):
     __ceil__ = _delegate("__ceil__")
     __floor__ = _delegate("__floor__")
     __round__ = _delegate("__round__")
+    __float__ = _delegate("__float__")
     # Python >= 3.11
     if hasattr(Fraction, "__int__"):
         __int__ = _delegate("__int__")


### PR DESCRIPTION
## Changes proposed

`IFDRational.__float__` returns the wrong value for a non-integral numerator.

`IFDRational` delegates `__eq__`, `__int__`, `__round__`, `__repr__` and all arithmetic to `self._val` (the normalized `Fraction`), but never defined `__float__`. So `float()` falls back to `numbers.Rational.__float__`, which does `int(self.numerator) / int(self.denominator)`. For a non-integral numerator the stored `_numerator`/`_denominator` are un-normalized, so the result disagrees with every other accessor:

```python
>>> from PIL.TiffImagePlugin import IFDRational
>>> r = IFDRational(1.5, 3)   # value 1.5 / 3 == 0.5
>>> r == 0.5
True
>>> int(r), repr(r)
(0, '0.5')
>>> float(r)
0.3333333333333333          # int(1.5) / int(3) == 1/3, should be 0.5
```

This is reachable via the public `IFDRational(value, denominator)` constructor.

## Fix

Delegate `__float__` to `self._val`, the same way `__int__`, `__round__`, `__repr__` and `__eq__` are delegated, so `float()` is consistent with the normalized fraction.

## Tests

Added `test_float` to `Tests/test_tiff_ifdrational.py`: it asserts `float(IFDRational(1.5, 3)) == 0.5`, and that the integral and `0/0` (nan) cases stay correct. It fails on `main` (`0.333… != 0.5`) and passes with the change; `Tests/test_tiff_ifdrational.py` is green (6 passed). `ruff` and `black` clean.
