### PR TITLE
Add colour to Linux and Windows wheel build logs

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -125,6 +125,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
           CIBW_BUILD: ${{ matrix.build }}
           CIBW_ENABLE: cpython-prerelease pypy
+          CIBW_ENVIRONMENT_PASS_LINUX: FORCE_COLOR
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macosx_deployment_target }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -201,7 +202,7 @@ jobs:
             -v {project}:C:\pillow
             -v C:\cibw:C:\cibw
             -v %CD%\..\venv-test:%CD%\..\venv-test
-            -e CI -e GITHUB_ACTIONS
+            -e CI -e GITHUB_ACTIONS -e FORCE_COLOR
             mcr.microsoft.com/windows/servercore:ltsc2022
             powershell C:\pillow\.github\workflows\wheels-test.ps1 %CD%\..\venv-test'
         shell: bash


### PR DESCRIPTION
macOS already has colour, for example: https://github.com/python-pillow/Pillow/actions/runs/27662031124/job/81808183016#step:5:17607.

But not Linux: https://github.com/python-pillow/Pillow/actions/runs/27662031124/job/81808182790#step:5:15755

Nor Windows: https://github.com/python-pillow/Pillow/actions/runs/27662031124/job/81808182698#step:7:10057

Pass the `FORCE_COLOR` variable into the relevant env to enable:

Linux: https://github.com/hugovk/Pillow/actions/runs/27573507385/job/81515770835#step:5:15906

Windows: https://github.com/hugovk/Pillow/actions/runs/27573507385/job/81515770247#step:7:15573