### PR TITLE
Cast before multiplying

### DIFF
--- a/src/libImaging/Copy.c
+++ b/src/libImaging/Copy.c
@@ -35,7 +35,7 @@ _copy(Imaging imOut, Imaging imIn) {
 
     ImagingSectionEnter(&cookie);
     if (imIn->block != NULL && imOut->block != NULL) {
-        memcpy(imOut->block, imIn->block, imIn->ysize * imIn->linesize);
+        memcpy(imOut->block, imIn->block, (size_t)imIn->ysize * imIn->linesize);
     } else {
         for (y = 0; y < imIn->ysize; y++) {
             memcpy(imOut->image[y], imIn->image[y], imIn->linesize);

--- a/src/libImaging/Draw.c
+++ b/src/libImaging/Draw.c
@@ -944,8 +944,8 @@ quarter_init(quarter_state *s, int32_t a, int32_t b) {
         s->cy = b % 2;
         s->ex = a % 2;
         s->ey = b;
-        s->a2 = a * a;
-        s->b2 = b * b;
+        s->a2 = (int64_t)a * a;
+        s->b2 = (int64_t)b * b;
         s->a2b2 = s->a2 * s->b2;
         s->finished = 0;
     }

--- a/src/libImaging/QuantOctree.c
+++ b/src/libImaging/QuantOctree.c
@@ -86,7 +86,8 @@ new_color_cube(int r, int g, int b, int a) {
     cube->aOffset = 0;
 
     /* the number of color buckets */
-    cube->size = cube->rWidth * cube->gWidth * cube->bWidth * cube->aWidth;
+    cube->size = (unsigned long)cube->rWidth * cube->gWidth *
+                 (unsigned long)cube->bWidth * cube->aWidth;
     /* malloc check ok, overflow checked above */
     cube->buckets = calloc(cube->size, sizeof(struct _ColorBucket));
 


### PR DESCRIPTION
When multiplying two smaller variable types and assigning to a larger type, cast to the larger type first.