### PR TITLE
Correct length when accessing ImagePath.Path subscript

### DIFF
--- a/Tests/test_imagepath.py
+++ b/Tests/test_imagepath.py
@@ -18,6 +18,7 @@ def test_path() -> None:
     assert p[0] == (0.0, 1.0)
     assert p[-1] == (8.0, 9.0)
     assert list(p[:1]) == [(0.0, 1.0)]
+    assert list(p[-1:]) == [(8.0, 9.0)]
     with pytest.raises(TypeError) as cm:
         p["foo"]
     assert str(cm.value) == "Path indices must be integers, not str"

--- a/src/path.c
+++ b/src/path.c
@@ -592,7 +592,7 @@ path_subscript(PyPathObject *self, PyObject *item) {
         return path_getitem(self, i);
     }
     if (PySlice_Check(item)) {
-        int len = 4;
+        int len = self->count;
         Py_ssize_t start, stop, step, slicelength;
 
         if (PySlice_GetIndicesEx(item, len, &start, &stop, &step, &slicelength) < 0) {


### PR DESCRIPTION
Resolves #9680