### PR TITLE
Add args argument to METH_NOARGS methods

### DIFF
--- a/src/_avif.c
+++ b/src/_avif.c
@@ -585,7 +585,7 @@ end:
 }
 
 PyObject *
-_encoder_finish(AvifEncoderObject *self) {
+_encoder_finish(AvifEncoderObject *self, PyObject *args) {
     avifEncoder *encoder = self->encoder;
 
     avifRWData raw = AVIF_DATA_EMPTY;
@@ -701,7 +701,7 @@ _decoder_dealloc(AvifDecoderObject *self) {
 }
 
 PyObject *
-_decoder_get_info(AvifDecoderObject *self) {
+_decoder_get_info(AvifDecoderObject *self, PyObject *args) {
     avifDecoder *decoder = self->decoder;
     avifImage *image = decoder->image;
 

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1204,7 +1204,7 @@ _getpalette(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_getpalettemode(ImagingObject *self) {
+_getpalettemode(ImagingObject *self, PyObject *args) {
     if (!self->image->palette) {
         PyErr_SetString(PyExc_ValueError, no_palette);
         return NULL;
@@ -2253,7 +2253,7 @@ _box_blur(ImagingObject *self, PyObject *args) {
 /* -------------------------------------------------------------------- */
 
 static PyObject *
-_isblock(ImagingObject *self) {
+_isblock(ImagingObject *self, PyObject *args) {
     return PyBool_FromLong(self->image->block != NULL);
 }
 
@@ -2318,7 +2318,7 @@ _getcolors(ImagingObject *self, PyObject *args) {
 }
 
 static PyObject *
-_getextrema(ImagingObject *self) {
+_getextrema(ImagingObject *self, PyObject *args) {
     union {
         UINT8 u[2];
         INT32 i[2];
@@ -2351,7 +2351,7 @@ _getextrema(ImagingObject *self) {
 }
 
 static PyObject *
-_getprojection(ImagingObject *self) {
+_getprojection(ImagingObject *self, PyObject *args) {
     unsigned char *xprofile;
     unsigned char *yprofile;
     PyObject *result;
@@ -2477,7 +2477,7 @@ _merge(PyObject *self, PyObject *args) {
 }
 
 static PyObject *
-_split(ImagingObject *self) {
+_split(ImagingObject *self, PyObject *args) {
     Py_ssize_t i;
     PyObject *list;
     PyObject *imaging_object;
@@ -2506,7 +2506,7 @@ _split(ImagingObject *self) {
 /* Channel operations (ImageChops) ------------------------------------ */
 
 static PyObject *
-_chop_invert(ImagingObject *self) {
+_chop_invert(ImagingObject *self, PyObject *args) {
     return PyImagingNew(ImagingNegative(self->image));
 }
 

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -1271,7 +1271,7 @@ font_render(FontObject *self, PyObject *args) {
 }
 
 static PyObject *
-font_getvarnames(FontObject *self) {
+font_getvarnames(FontObject *self, PyObject *args) {
     int error;
     FT_UInt i, j, num_namedstyles, name_count;
     FT_MM_Var *master;
@@ -1336,7 +1336,7 @@ font_getvarnames(FontObject *self) {
 }
 
 static PyObject *
-font_getvaraxes(FontObject *self) {
+font_getvaraxes(FontObject *self, PyObject *args) {
     int error;
     FT_UInt i, j, num_axis, name_count;
     FT_MM_Var *master;

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -449,7 +449,7 @@ _anim_decoder_dealloc(PyObject *self) {
 }
 
 PyObject *
-_anim_decoder_get_info(PyObject *self) {
+_anim_decoder_get_info(PyObject *self, PyObject *args) {
     WebPAnimDecoderObject *decp = (WebPAnimDecoderObject *)self;
     WebPAnimInfo *info = &(decp->info);
 
@@ -488,7 +488,7 @@ _anim_decoder_get_chunk(PyObject *self, PyObject *args) {
 }
 
 PyObject *
-_anim_decoder_get_next(PyObject *self) {
+_anim_decoder_get_next(PyObject *self, PyObject *args) {
     uint8_t *buf;
     int timestamp;
     int ok;
@@ -519,7 +519,7 @@ _anim_decoder_get_next(PyObject *self) {
 }
 
 PyObject *
-_anim_decoder_reset(PyObject *self) {
+_anim_decoder_reset(PyObject *self, PyObject *args) {
     WebPAnimDecoderObject *decp = (WebPAnimDecoderObject *)self;
     WebPAnimDecoderReset(decp->dec);
     Py_RETURN_NONE;

--- a/src/encode.c
+++ b/src/encode.c
@@ -153,7 +153,7 @@ _encode(ImagingEncoderObject *encoder, PyObject *args) {
 }
 
 static PyObject *
-_encode_to_pyfd(ImagingEncoderObject *encoder) {
+_encode_to_pyfd(ImagingEncoderObject *encoder, PyObject *args) {
     PyObject *result;
     int status;
 


### PR DESCRIPTION
There are a number of instances where `METH_NOARGS` functions only have one parameter
https://github.com/python-pillow/Pillow/blob/d12af6da55cea82db0ab665df41c187a865c8ad4/src/encode.c#L156
https://github.com/python-pillow/Pillow/blob/d12af6da55cea82db0ab665df41c187a865c8ad4/src/encode.c#L334
despite https://docs.python.org/3/c-api/structures.html#c.METH_NOARGS
> The function must have 2 parameters.