### PR TITLE
Check WebPMuxNew return value

### DIFF
--- a/src/_webp.c
+++ b/src/_webp.c
@@ -691,6 +691,10 @@ WebPEncode_wrapper(PyObject *self, PyObject *args) {
                             // and value 0 indicates data will NOT be copied.
 
         WebPMux *mux = WebPMuxNew();
+        if (mux == NULL) {
+            PyErr_SetString(PyExc_RuntimeError, "could not create mux object");
+            return NULL;
+        }
         WebPMuxSetImage(mux, &image, copy_data);
 
         if (dbg) {


### PR DESCRIPTION
`WebPMuxNew()` may return `NULL` - https://github.com/webmproject/libwebp/blob/3757b8afeb54e305eaef18502812a9a88b7ed662/src/webp/mux.h#L110-L116

```c
// Creates an empty mux object.
// Returns:
//   A pointer to the newly created empty mux object.
//   Or NULL in case of memory error.
WEBP_NODISCARD static WEBP_INLINE WebPMux* WebPMuxNew(void) {
  return WebPNewInternal(WEBP_MUX_ABI_VERSION);
}
```