### PR TITLE
Use os.startfile() in WindowsViewer show_file()

### DIFF
--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -105,6 +105,12 @@ def test_viewers(viewer: ImageShow.Viewer) -> None:
         pass
 
 
+def test_windowsviewer() -> None:
+    viewer = ImageShow.WindowsViewer()
+    with pytest.raises(ValueError, match="cannot contain double quotes"):
+        viewer.get_command('"')
+
+
 def test_ipythonviewer() -> None:
     pytest.importorskip("IPython", reason="IPython not installed")
     for viewer in ImageShow._viewers:

--- a/Tests/test_imageshow.py
+++ b/Tests/test_imageshow.py
@@ -110,6 +110,9 @@ def test_windowsviewer() -> None:
     with pytest.raises(ValueError, match="cannot contain double quotes"):
         viewer.get_command('"')
 
+    # Check that percentages are escaped
+    assert "%" not in viewer.get_command("%").replace('""%""', "")
+
 
 def test_ipythonviewer() -> None:
     pytest.importorskip("IPython", reason="IPython not installed")

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -145,6 +145,9 @@ class WindowsViewer(Viewer):
     options = {"compress_level": 1, "save_all": True}
 
     def get_command(self, file: str, **options: Any) -> str:
+        if '"' in file:
+            msg = "Windows filenames cannot contain double quotes"
+            raise ValueError(msg)
         return (
             f'start "Pillow" /WAIT "{file}" '
             "&& ping -n 4 127.0.0.1 >NUL "

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -120,6 +120,20 @@ class Viewer:
         os.system(self.get_command(path, **options))  # nosec
         return 1
 
+    def _remove_path_after_delay(self, path: str) -> None:
+        pyinstaller = getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")
+        executable = (not pyinstaller and sys.executable) or shutil.which("python3")
+
+        if executable:
+            subprocess.Popen(
+                [
+                    executable,
+                    "-c",
+                    "import os, sys, time; time.sleep(20); os.remove(sys.argv[1])",
+                    path,
+                ]
+            )
+
 
 # --------------------------------------------------------------------
 
@@ -143,11 +157,9 @@ class WindowsViewer(Viewer):
         """
         if not os.path.exists(path):
             raise FileNotFoundError
-        subprocess.Popen(
-            self.get_command(path, **options),
-            shell=True,
-            creationflags=getattr(subprocess, "CREATE_NO_WINDOW"),
-        )  # nosec
+        if sys.platform == "win32":
+            os.startfile(path)
+        self._remove_path_after_delay(path)
         return 1
 
 
@@ -175,18 +187,7 @@ class MacViewer(Viewer):
         if not os.path.exists(path):
             raise FileNotFoundError
         subprocess.call(["open", "-a", "Preview.app", path])
-
-        pyinstaller = getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")
-        executable = (not pyinstaller and sys.executable) or shutil.which("python3")
-        if executable:
-            subprocess.Popen(
-                [
-                    executable,
-                    "-c",
-                    "import os, sys, time; time.sleep(20); os.remove(sys.argv[1])",
-                    path,
-                ]
-            )
+        self._remove_path_after_delay(path)
         return 1
 
 

--- a/src/PIL/ImageShow.py
+++ b/src/PIL/ImageShow.py
@@ -148,6 +148,7 @@ class WindowsViewer(Viewer):
         if '"' in file:
             msg = "Windows filenames cannot contain double quotes"
             raise ValueError(msg)
+        file = file.replace("%", '"%"')
         return (
             f'start "Pillow" /WAIT "{file}" '
             "&& ping -n 4 127.0.0.1 >NUL "


### PR DESCRIPTION
1. `WindowsViewer` currently uses `start` from [`get_command()`](https://github.com/python-pillow/Pillow/blob/87e788339e8746e7ceb8e901df9b0c7fda55e975/src/PIL/ImageShow.py#L147).

https://github.com/python-pillow/Pillow/blob/87e788339e8746e7ceb8e901df9b0c7fda55e975/src/PIL/ImageShow.py#L133-L135

However, a simpler method is to use [`os.startfile`](https://docs.python.org/3/library/os.html#os.startfile). This prevents injection. The temporary file can be removed after 20 seconds using `os.remove()`, like https://github.com/python-pillow/Pillow/pull/6010/changes/8da80130dbc747f3954b4904247d26289fe722f9

2. As for `get_command()`, direct injection can be prevented by raising an error if double quotes are used in `file`. This is valid, because [Windows filenames cannot contain them.](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file).

3. Also in `get_command()`, variable expansion can be prevented by quoting percentages.