### PR TITLE
Free image bands when an error occurs while splitting an image

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -2489,11 +2489,17 @@ _split(ImagingObject *self, PyObject *args) {
 
     list = PyTuple_New(self->image->bands);
     if (!list) {
+        for (int j = 0; j < self->image->bands; j++) {
+            ImagingDelete(bands[j]);
+        }
         return NULL;
     }
     for (i = 0; i < self->image->bands; i++) {
         imaging_object = PyImagingNew(bands[i]);
         if (!imaging_object) {
+            for (int j = 0; j < self->image->bands; j++) {
+                ImagingDelete(bands[j]);
+            }
             Py_DECREF(list);
             list = NULL;
             break;


### PR DESCRIPTION
Here is a case where this is done earlier.
https://github.com/python-pillow/Pillow/blob/87e788339e8746e7ceb8e901df9b0c7fda55e975/src/libImaging/Bands.c#L87-L89