### PR TITLE
Add release notes for Python 3.15 beta wheels

### DIFF
--- a/docs/releasenotes/12.3.0.rst
+++ b/docs/releasenotes/12.3.0.rst
@@ -54,6 +54,13 @@ Previously, macOS screenshots with a ``bbox`` were captured at 1x by default.
 Other changes
 =============
 
+Python 3.15 beta
+^^^^^^^^^^^^^^^^
+
+To help other projects prepare for Python 3.15, wheels are now built for the 3.15 beta
+as a preview. This is not official support for Python 3.15, but rather an opportunity
+for you to test how Pillow works with the beta and report any problems.
+
 Removed Python 3.13 free-threaded wheels
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
#9665 added Python 3.15 beta wheels.