### PR TITLE
DECREF PyDict_GetItemRef result

### DIFF
--- a/src/encode.c
+++ b/src/encode.c
@@ -799,6 +799,7 @@ PyImaging_LibTiffEncoderNew(PyObject *self, PyObject *args) {
                 if (type_int >= TIFF_BYTE && type_int <= TIFF_LONG8) {
                     type = (TIFFDataType)type_int;
                 }
+                Py_DECREF(tag_type);
             }
         }
 


### PR DESCRIPTION
Resolves #9700

In the following code, DECREF is never called on `tag_type`

https://github.com/python-pillow/Pillow/blob/2d18dacf0b4a4c1ceab2f07f65394431a4c3428e/src/encode.c#L791-L803