### PR TITLE
If realloc fails, do not reduce block size

### DIFF
--- a/src/libImaging/Storage.c
+++ b/src/libImaging/Storage.c
@@ -384,8 +384,11 @@ memory_return_block(ImagingMemoryArena arena, ImagingMemoryBlock block) {
     if (arena->blocks_cached < arena->blocks_max) {
         // Reduce block size
         if (block.size > arena->block_size) {
-            block.size = arena->block_size;
-            block.ptr = realloc(block.ptr, arena->block_size);
+            char *ptr = realloc(block.ptr, arena->block_size);
+            if (ptr) {
+                block.ptr = ptr;
+                block.size = arena->block_size;
+            }
         }
         arena->blocks_pool[arena->blocks_cached] = block;
         arena->blocks_cached += 1;


### PR DESCRIPTION
Within this code, it is possible for `realloc` to fail.

https://github.com/python-pillow/Pillow/blob/2d18dacf0b4a4c1ceab2f07f65394431a4c3428e/src/libImaging/Storage.c#L385-L389

This doesn't have to trigger an error though. We can simply avoid reducing the block size.