### PR TITLE
Use int64_t to calculate paste box dimensions

### DIFF
--- a/Tests/test_image_paste.py
+++ b/Tests/test_image_paste.py
@@ -357,6 +357,20 @@ class TestImagingPaste:
         im.copy().paste(im2)
         im.copy().paste(im2, (0, 0))
 
+    @pytest.mark.parametrize(
+        "box",
+        (
+            (2**31 - 1, 0, -(2**31), 1),
+            (0, 2**31 - 1, 1, -(2**31)),
+        ),
+    )
+    def test_overflow(self, box: tuple[int, int, int, int]) -> None:
+        im = Image.new("1", (1, 1))
+        im.paste(1, box)
+
+        with pytest.raises(ValueError, match="images do not match"):
+            im.paste(im.copy(), box)
+
     def test_incorrect_abbreviated_form(self) -> None:
         im = Image.new("L", (1, 1))
         with pytest.raises(ValueError):

--- a/src/libImaging/Paste.c
+++ b/src/libImaging/Paste.c
@@ -274,7 +274,7 @@ int
 ImagingPaste(
     Imaging imOut, Imaging imIn, Imaging imMask, int dx0, int dy0, int dx1, int dy1
 ) {
-    int xsize, ysize;
+    int64_t xsize, ysize;
     int pixelsize;
     int sx0, sy0;
     ImagingSectionCookie cookie;
@@ -286,8 +286,8 @@ ImagingPaste(
 
     pixelsize = imOut->pixelsize;
 
-    xsize = dx1 - dx0;
-    ysize = dy1 - dy0;
+    xsize = (int64_t)dx1 - dx0;
+    ysize = (int64_t)dy1 - dy0;
 
     if (xsize != imIn->xsize || ysize != imIn->ysize || pixelsize != imIn->pixelsize) {
         (void)ImagingError_Mismatch();
@@ -598,7 +598,7 @@ ImagingFill2(
     Imaging imOut, const void *ink, Imaging imMask, int dx0, int dy0, int dx1, int dy1
 ) {
     ImagingSectionCookie cookie;
-    int xsize, ysize;
+    int64_t xsize, ysize;
     int pixelsize;
     int sx0, sy0;
 
@@ -609,8 +609,8 @@ ImagingFill2(
 
     pixelsize = imOut->pixelsize;
 
-    xsize = dx1 - dx0;
-    ysize = dy1 - dy0;
+    xsize = (int64_t)dx1 - dx0;
+    ysize = (int64_t)dy1 - dy0;
 
     if (imMask && (xsize != imMask->xsize || ysize != imMask->ysize)) {
         (void)ImagingError_Mismatch();


### PR DESCRIPTION
Similar to https://github.com/python-pillow/Pillow/pull/9686, as calculating the width and height of the `Image.paste()` `box` in C is the combination of two `int`s,

https://github.com/python-pillow/Pillow/blob/2d18dacf0b4a4c1ceab2f07f65394431a4c3428e/src/libImaging/Paste.c#L289-L290

let's allow for a larger size.