### PR TITLE
Calculate JPEG2000 total_component_width for each tile in isolation

### DIFF
--- a/src/libImaging/Jpeg2KDecode.c
+++ b/src/libImaging/Jpeg2KDecode.c
@@ -645,7 +645,6 @@ j2k_decode_entry(Imaging im, ImagingCodecState state) {
     size_t tile_bytes = 0;
     unsigned n, tile_height, tile_width;
     int subsampling;
-    int total_component_width = 0;
 
     stream = opj_stream_create(BUFFER_SIZE, OPJ_TRUE);
 
@@ -851,6 +850,7 @@ j2k_decode_entry(Imaging im, ImagingCodecState state) {
          a, and then a malicious file could have a smaller tile_bytes
         */
 
+        int total_component_width = 0;
         for (n = 0; n < tile_info.nb_comps; n++) {
             // see csize /acsize calcs
             int csize = (image->comps[n].prec + 7) >> 3;


### PR DESCRIPTION
Within `j2k_decode_entry`, `total_component_width` is initialized before the loop through tiles, and is never reset.
https://github.com/python-pillow/Pillow/blob/2d18dacf0b4a4c1ceab2f07f65394431a4c3428e/src/libImaging/Jpeg2KDecode.c#L648
https://github.com/python-pillow/Pillow/blob/2d18dacf0b4a4c1ceab2f07f65394431a4c3428e/src/libImaging/Jpeg2KDecode.c#L787-L789
https://github.com/python-pillow/Pillow/blob/2d18dacf0b4a4c1ceab2f07f65394431a4c3428e/src/libImaging/Jpeg2KDecode.c#L858

This means that the value used in
https://github.com/python-pillow/Pillow/blob/2d18dacf0b4a4c1ceab2f07f65394431a4c3428e/src/libImaging/Jpeg2KDecode.c#L869
just keeps growing.

Instead, it should be set to zero within the tile loop, so it is only considering the current tile.