### PR TITLE
Use NumPy 2.4.6 for mypy

### DIFF
--- a/.ci/requirements-mypy.txt
+++ b/.ci/requirements-mypy.txt
@@ -4,7 +4,7 @@ arro3-core
 IceSpringPySideStubs-PyQt6
 IceSpringPySideStubs-PySide6
 ipython
-numpy
+numpy==2.4.6
 packaging
 pyarrow-stubs
 pybind11


### PR DESCRIPTION
[NumPy 2.5.0](https://github.com/numpy/numpy/releases/tag/v2.5.0) has been released. This has caused mypy to start failing - https://github.com/python-pillow/Pillow/actions/runs/27917905477/job/82606392500#step:6:22
```
.tox/mypy/lib/python3.14/site-packages/numpy/__init__.pyi:737: error: Type
statement is only supported in Python 3.12 and greater  [syntax]
    type _Falsy = L[False, 0] | bool_[L[False]]
                                               ^
Found 1 error in 1 file (errors prevented further checking)
```
This is not a bug on the part of NumPy. 2.5.0 has its minimum Python version as 3.12.

This PR pins NumPy to 2.4.6 within the mypy requirements.