### PR TITLE
Do not DECREF tuple until tuple items are no longer used

### DIFF
--- a/src/encode.c
+++ b/src/encode.c
@@ -774,7 +774,6 @@ PyImaging_LibTiffEncoderNew(PyObject *self, PyObject *args) {
         key = PyTuple_GET_ITEM(item, 0);
         key_int = (int)PyLong_AsLong(key);
         value = PyTuple_GET_ITEM(item, 1);
-        Py_DECREF(item);
 
         status = 0;
         is_core_tag = 0;
@@ -792,6 +791,7 @@ PyImaging_LibTiffEncoderNew(PyObject *self, PyObject *args) {
             PyObject *tag_type;
             if (PyDict_GetItemRef(types, key, &tag_type) < 0) {
                 Py_DECREF(encoder);
+                Py_DECREF(item);
                 return NULL;  // Exception has been already set
             }
             if (tag_type) {
@@ -852,6 +852,7 @@ PyImaging_LibTiffEncoderNew(PyObject *self, PyObject *args) {
             key_int == TIFFTAG_INKNAMES) {
             if (!PyBytes_Check(value)) {
                 Py_DECREF(encoder);
+                Py_DECREF(item);
                 PyErr_SetString(PyExc_ValueError, "Incorrect tag value type");
                 return NULL;
             }
@@ -870,6 +871,7 @@ PyImaging_LibTiffEncoderNew(PyObject *self, PyObject *args) {
                 int stride = 256;
                 if (len != 768) {
                     Py_DECREF(encoder);
+                    Py_DECREF(item);
                     PyErr_SetString(
                         PyExc_ValueError, "Requiring 768 items for Colormap"
                     );
@@ -1030,6 +1032,7 @@ PyImaging_LibTiffEncoderNew(PyObject *self, PyObject *args) {
             } else if (type == TIFF_ASCII) {
                 if (!PyBytes_Check(value)) {
                     Py_DECREF(encoder);
+                    Py_DECREF(item);
                     PyErr_SetString(PyExc_ValueError, "Incorrect tag value type");
                     return NULL;
                 }
@@ -1054,6 +1057,7 @@ PyImaging_LibTiffEncoderNew(PyObject *self, PyObject *args) {
                 );
             }
         }
+        Py_DECREF(item);
         if (!status) {
             TRACE(("Error setting Field\n"));
             Py_DECREF(encoder);


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/2c3a97732b4fae2dc06ccde321078d4cd7dcb207/src/encode.c#L767-L777

https://docs.python.org/3/c-api/tuple.html#c.PyTuple_GetItem
> [PyObject](https://docs.python.org/3/c-api/structures.html#c.PyObject) *PyTuple_GetItem([PyObject](https://docs.python.org/3/c-api/structures.html#c.PyObject) *p, [Py_ssize_t](https://docs.python.org/3/c-api/intro.html#c.Py_ssize_t) pos)
> ...
> The returned reference is borrowed from the tuple p (that is: it is only valid as long as you hold a reference to p).
> ...
>
> [PyObject](https://docs.python.org/3/c-api/structures.html#c.PyObject) *PyTuple_GET_ITEM([PyObject](https://docs.python.org/3/c-api/structures.html#c.PyObject) *p, [Py_ssize_t](https://docs.python.org/3/c-api/intro.html#c.Py_ssize_t) pos)
> Return value: Borrowed reference.
> Like [PyTuple_GetItem()](https://docs.python.org/3/c-api/tuple.html#c.PyTuple_GetItem), but does no checking of its arguments.

However, `key` and `value` are still used afterwards.

https://github.com/python-pillow/Pillow/blob/2c3a97732b4fae2dc06ccde321078d4cd7dcb207/src/encode.c#L793
https://github.com/python-pillow/Pillow/blob/2c3a97732b4fae2dc06ccde321078d4cd7dcb207/src/encode.c#L808