### PR TITLE
Raise ValueError if EPS BeginBinary bytecount is negative

### DIFF
--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -205,6 +205,10 @@ def test_begin_binary() -> None:
     with Image.open(io.BytesIO(data)) as img:
         assert img.size == (399, 480)
 
+    data[76867:76873] = b"    -1"
+    with pytest.raises(ValueError, match="BeginBinary bytecount cannot be negative"):
+        Image.open(io.BytesIO(data))
+
 
 @mark_if_feature_version(
     pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -357,6 +357,9 @@ class EpsImageFile(ImageFile.ImageFile):
                 trailer_reached = True
             elif bytes_mv[:14] == b"%%BeginBinary:":
                 bytecount = int(byte_arr[14:bytes_read])
+                if bytecount < 0:
+                    msg = "BeginBinary bytecount cannot be negative"
+                    raise ValueError(msg)
                 self.fp.seek(bytecount, os.SEEK_CUR)
             bytes_read = 0
 


### PR DESCRIPTION
This adds validation to a change from https://github.com/python-pillow/Pillow/pull/9211