### PR TITLE
Prevent saving 1 mode images as TGA with run-length encoding

### DIFF
--- a/Tests/test_file_tga.py
+++ b/Tests/test_file_tga.py
@@ -179,8 +179,18 @@ def test_save_wrong_mode(tmp_path: Path) -> None:
     im = hopper("PA")
     out = tmp_path / "temp.tga"
 
-    with pytest.raises(OSError):
+    with pytest.raises(OSError, match="cannot write mode PA as TGA"):
         im.save(out)
+
+
+def test_save_1_mode_rle(tmp_path: Path) -> None:
+    im = Image.new("1", (1, 1))
+    out = tmp_path / "temp.tga"
+
+    with pytest.raises(
+        OSError, match="cannot write mode 1 as TGA with run-length encoding"
+    ):
+        im.save(out, compression="tga_rle")
 
 
 def test_save_mapdepth() -> None:

--- a/src/PIL/TgaImagePlugin.py
+++ b/src/PIL/TgaImagePlugin.py
@@ -205,6 +205,10 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
         compression = im.encoderinfo.get("compression", im.info.get("compression"))
         rle = compression == "tga_rle"
     if rle:
+        if im.mode == "1":
+            msg = f"cannot write mode {im.mode} as TGA with run-length encoding"
+            raise OSError(msg)
+
         imagetype += 8
 
     id_section = im.encoderinfo.get("id_section", im.info.get("id_section", ""))


### PR DESCRIPTION
http://www.paulbourke.net/dataformats/tga/ lists possible data types as

> 0  -  No image data included.
> 1  -  Uncompressed, color-mapped images.
> 2  -  Uncompressed, RGB images.
> 3  -  Uncompressed, black and white images.
> 9  -  Runlength encoded color-mapped images.
> 10  -  Runlength encoded RGB images.
> 11  -  Compressed, black and white images.
> 32  -  Compressed color-mapped data, using Huffman, Delta, and runlength encoding.
> 33  -  Compressed color-mapped data, using Huffman, Delta, and runlength encoding.  4-pass quadtree-type process.

meaning that there is no black and white (1 mode) runlength encoding.

This PR raises an error when users try to save 1 mode images with "tga_rle" compression.