### PR TITLE
Fix RLE4 absolute mode decoding for odd pixel counts

### DIFF
--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -206,8 +206,7 @@ def test_rle4_absolute_odd() -> None:
     # An RLE4 absolute run with an odd number of pixels is packed into
     # ceil(count / 2) bytes, the final nibble being padding. Build a 3x1
     # image whose single row is one absolute run of 3 pixels (indices 1, 2, 3).
-    palette = b"".join(o32(c) for c in (0x000000, 0x0000FF, 0x00FF00, 0xFF0000))
-    palette += b"\x00" * (16 * 4 - len(palette))
+    palette = b"\x00" * 4
     rle = (
         b"\x00\x03"  # absolute mode, 3 pixels
         b"\x12\x30"  # nibbles 1, 2, 3 and a padding nibble
@@ -221,8 +220,8 @@ def test_rle4_absolute_odd() -> None:
         + o16(4)  # bits per pixel
         + o32(2)  # BI_RLE4 compression
         + o32(len(rle))  # image size
-        + o32(0) * 2  # resolution
-        + o32(16)  # palette length
+        + o32(0) * 2  # pixels per meter
+        + o32(1)  # used colors
         + o32(0)  # important colors
     )
     offset = 14 + len(header) + len(palette)

--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -236,7 +236,7 @@ def test_rle4_absolute_odd() -> None:
     )
 
     with Image.open(io.BytesIO(data)) as im:
-        assert [im.getpixel((x, 0)) for x in range(3)] == [1, 2, 3]
+        assert [im.getpixel((x, 0)) for x in range(im.width)] == [1, 2, 3]
 
 
 @pytest.mark.parametrize(

--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -202,6 +202,44 @@ def test_rle4() -> None:
         assert_image_similar_tofile(im, "Tests/images/bmp/g/pal4.bmp", 12)
 
 
+def test_rle4_absolute_odd() -> None:
+    # An RLE4 absolute run with an odd number of pixels is packed into
+    # ceil(count / 2) bytes, the final nibble being padding. Build a 3x1
+    # image whose single row is one absolute run of 3 pixels (indices 1, 2, 3).
+    palette = b"".join(o32(c) for c in (0x000000, 0x0000FF, 0x00FF00, 0xFF0000))
+    palette += b"\x00" * (16 * 4 - len(palette))
+    rle = (
+        b"\x00\x03"  # absolute mode, 3 pixels
+        b"\x12\x30"  # nibbles 1, 2, 3 and a padding nibble
+        b"\x00\x01"  # end of bitmap
+    )
+    header = (
+        o32(40)  # header size
+        + o32(3)  # width
+        + o32(1)  # height
+        + o16(1)  # planes
+        + o16(4)  # bits per pixel
+        + o32(2)  # BI_RLE4 compression
+        + o32(len(rle))  # image size
+        + o32(0) * 2  # resolution
+        + o32(16)  # palette length
+        + o32(0)  # important colors
+    )
+    offset = 14 + len(header) + len(palette)
+    data = (
+        b"BM"
+        + o32(offset + len(rle))  # file size
+        + o32(0)  # reserved
+        + o32(offset)  # data offset
+        + header
+        + palette
+        + rle
+    )
+
+    with Image.open(io.BytesIO(data)) as im:
+        assert [im.getpixel((x, 0)) for x in range(3)] == [1, 2, 3]
+
+
 @pytest.mark.parametrize(
     "file_name,length",
     (

--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -372,12 +372,13 @@ class BmpRleDecoder(ImageFile.PyDecoder):
                 else:
                     # absolute mode
                     if rle4:
-                        # 2 pixels per byte
-                        byte_count = byte[0] // 2
+                        # 2 pixels per byte, padded up to a whole byte
+                        byte_count = (byte[0] + 1) // 2
                         bytes_read = self.fd.read(byte_count)
-                        for byte_read in bytes_read:
+                        for i, byte_read in enumerate(bytes_read):
                             data += o8(byte_read >> 4)
-                            data += o8(byte_read & 0x0F)
+                            if 2 * i + 1 < byte[0]:
+                                data += o8(byte_read & 0x0F)
                     else:
                         byte_count = byte[0]
                         bytes_read = self.fd.read(byte_count)


### PR DESCRIPTION
### Changes proposed in this pull request

* Fix RLE4 absolute-mode decoding when an absolute run contains an **odd** number of pixels.
* Add a regression test (`Tests/test_file_bmp.py::test_rle4_absolute_odd`).

### Bug

In a BMP `BI_RLE4` *absolute* run, the count byte specifies a number of 4-bit pixels. Those pixels are packed two per byte and the run is padded up to a whole byte (and then to a 16-bit word boundary). When the count is odd, the run still occupies `ceil(count / 2)` bytes — the last nibble is padding.

The decoder computed the number of bytes to read with floor division:

```python
byte_count = byte[0] // 2
```

For an odd count (e.g. 3 pixels) this reads one byte too few (`3 // 2 == 1`). As a result:

1. The final pixel of the run is dropped.
2. The file pointer is left one byte short, so the subsequent word-alignment and the rest of the RLE stream are read from the wrong offset.

In practice the desync causes the decode to terminate early and raise `ValueError: not enough image data`.

### Root cause and fix

`src/PIL/BmpImagePlugin.py`, absolute-mode branch of `BmpRleDecoder.decode`:

```python
# before
byte_count = byte[0] // 2
bytes_read = self.fd.read(byte_count)
for byte_read in bytes_read:
    data += o8(byte_read >> 4)
    data += o8(byte_read & 0x0F)

# after
byte_count = (byte[0] + 1) // 2
bytes_read = self.fd.read(byte_count)
for i, byte_read in enumerate(bytes_read):
    data += o8(byte_read >> 4)
    if 2 * i + 1 < byte[0]:
        data += o8(byte_read & 0x0F)
```

`(byte[0] + 1) // 2` reads the correct (ceil) number of bytes, and the `2 * i + 1 < byte[0]` guard emits exactly `byte[0]` pixels so the padding nibble of an odd run is discarded rather than turned into an extra pixel.

### Reproduction (red → green)

The new test builds a minimal 3×1 RLE4 BMP whose single row is one absolute run of 3 pixels (palette indices 1, 2, 3).

* On `main` it fails: `ValueError: not enough image data`.
* With this change it passes: the row decodes to `[1, 2, 3]`.

The existing `test_rle4` (which uses `Tests/images/bmp/g/pal4rle.bmp`) and the rest of `Tests/test_file_bmp.py` continue to pass (33 passed). Even-count absolute runs are unaffected. `ruff` and `black` are clean on the changed files.
