### PR TITLE
Do not update NumPy automatically

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -165,6 +165,7 @@
             "extractVersionTemplate": "^v(?<version>.+)$"
         }
     ],
+    "ignoreDeps": ["numpy"],
     "packageRules": [
         {
             "groupName": "github-actions",


### PR DESCRIPTION
Renovate has [detected](https://github.com/python-pillow/Pillow/issues/6604) the NumPy requirement from #9705 and is scheduled to update it.

Since the intention of the PR was to deliberately downgrade it, let's [ignore](https://docs.renovatebot.com/configuration-options/#ignoredeps) it.