### PR TITLE
Raise error if image modes do not match ImageCms transform modes

### DIFF
--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -197,6 +197,8 @@ def test_exceptions() -> None:
     pLab = ImageCms.createProfile("LAB")
     t = ImageCms.buildTransform(pLab, psRGB, "LAB", "RGB")
     with pytest.raises(ValueError, match="mode mismatch"):
+        t.apply(hopper("LAB"), hopper("RGBA"))
+    with pytest.raises(ValueError, match="mode mismatch"):
         t.apply_in_place(hopper("RGBA"))
 
     # the procedural pyCMS API uses PyCMSError for all sorts of errors

--- a/Tests/test_imagecms.py
+++ b/Tests/test_imagecms.py
@@ -197,6 +197,8 @@ def test_exceptions() -> None:
     pLab = ImageCms.createProfile("LAB")
     t = ImageCms.buildTransform(pLab, psRGB, "LAB", "RGB")
     with pytest.raises(ValueError, match="mode mismatch"):
+        t.apply(hopper("RGBA"))
+    with pytest.raises(ValueError, match="mode mismatch"):
         t.apply(hopper("LAB"), hopper("RGBA"))
     with pytest.raises(ValueError, match="mode mismatch"):
         t.apply_in_place(hopper("RGBA"))

--- a/src/PIL/ImageCms.py
+++ b/src/PIL/ImageCms.py
@@ -327,9 +327,7 @@ class ImageCmsTransform(Image.ImagePointHandler):
         if im.mode != self.output_mode:
             msg = "mode mismatch"
             raise ValueError(msg)  # wrong output mode
-        self.transform.apply(im.getim(), im.getim())
-        im.info["icc_profile"] = self.output_profile.tobytes()
-        return im
+        return self.apply(im, im)
 
 
 def get_display_profile(handle: SupportsInt | None = None) -> ImageCmsProfile | None:

--- a/src/PIL/ImageCms.py
+++ b/src/PIL/ImageCms.py
@@ -317,6 +317,9 @@ class ImageCmsTransform(Image.ImagePointHandler):
         return self.apply(im)
 
     def apply(self, im: Image.Image, imOut: Image.Image | None = None) -> Image.Image:
+        if im.mode != self.input_mode:
+            msg = "mode mismatch"
+            raise ValueError(msg)
         if imOut is not None:
             if imOut.mode != self.output_mode:
                 msg = "mode mismatch"

--- a/src/PIL/ImageCms.py
+++ b/src/PIL/ImageCms.py
@@ -317,16 +317,17 @@ class ImageCmsTransform(Image.ImagePointHandler):
         return self.apply(im)
 
     def apply(self, im: Image.Image, imOut: Image.Image | None = None) -> Image.Image:
-        if imOut is None:
+        if imOut is not None:
+            if imOut.mode != self.output_mode:
+                msg = "mode mismatch"
+                raise ValueError(msg)
+        else:
             imOut = Image.new(self.output_mode, im.size, None)
         self.transform.apply(im.getim(), imOut.getim())
         imOut.info["icc_profile"] = self.output_profile.tobytes()
         return imOut
 
     def apply_in_place(self, im: Image.Image) -> Image.Image:
-        if im.mode != self.output_mode:
-            msg = "mode mismatch"
-            raise ValueError(msg)  # wrong output mode
         return self.apply(im, im)
 
 


### PR DESCRIPTION
https://pillow.readthedocs.io/en/stable/reference/ImageCms.html#PIL.ImageCms.applyTransform

> If im.mode != transform.input_mode, a [PyCMSError](https://pillow.readthedocs.io/en/stable/reference/ImageCms.html#PIL.ImageCms.PyCMSError) is raised.
> If inPlace is True and transform.input_mode != transform.output_mode, a [PyCMSError](https://pillow.readthedocs.io/en/stable/reference/ImageCms.html#PIL.ImageCms.PyCMSError) is raised.

This PR applies the checking of image mode against transform mode more thoroughly.