### PR TITLE
Raise OverflowError if text width exceeds INT_MAX

### DIFF
--- a/Tests/test_imagefontpil.py
+++ b/Tests/test_imagefontpil.py
@@ -77,6 +77,16 @@ def test_negative_dx() -> None:
     assert font.getlength("A") == 0
 
 
+def test_width_overflow() -> None:
+    glyph = struct.pack(">hhhhhhhhhh", 32767, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    fp = BytesIO(b"PILfont\n\nDATA\n" + glyph * 256)
+
+    font = ImageFont.ImageFont()
+    font._load_pilfont_data(fp, Image.new("L", (1, 1)))
+    with pytest.raises(OverflowError, match="Width too large"):
+        font.getlength("A" * 100_000)
+
+
 def test_decompression_bomb() -> None:
     glyph = struct.pack(">hhhhhhhhhh", 1, 0, 0, 0, 256, 256, 0, 0, 256, 256)
     fp = BytesIO(b"PILfont\n\nDATA\n" + glyph * 256)

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -2801,7 +2801,12 @@ textwidth(ImagingFontObject *self, const unsigned char *text) {
     int xsize;
 
     for (xsize = 0; *text; text++) {
-        xsize += self->glyphs[*text].dx;
+        int dx = self->glyphs[*text].dx;
+        if (dx > 0 && xsize > INT_MAX - dx) {
+            PyErr_SetString(PyExc_OverflowError, "Width too large");
+            return -1;
+        }
+        xsize += dx;
     }
 
     if (xsize < 0) {
@@ -2866,7 +2871,12 @@ _font_getmask(ImagingFontObject *self, PyObject *args) {
         return NULL;
     }
 
-    im = ImagingNew(self->bitmap->mode, textwidth(self, text), self->ysize);
+    int xsize = textwidth(self, text);
+    if (xsize == -1) {
+        free(text);
+        return NULL;
+    }
+    im = ImagingNew(self->bitmap->mode, xsize, self->ysize);
     if (!im) {
         free(text);
         return ImagingError_MemoryError();
@@ -2928,8 +2938,12 @@ _font_getsize(ImagingFontObject *self, PyObject *args) {
         return NULL;
     }
 
-    val = Py_BuildValue("ii", textwidth(self, text), self->ysize);
+    int xsize = textwidth(self, text);
     free(text);
+    if (xsize == -1) {
+        return NULL;
+    }
+    val = Py_BuildValue("ii", xsize, self->ysize);
     return val;
 }
 


### PR DESCRIPTION
When adding together character widths, raise an `OverflowError` if the total of the integers is greater than `INT_MAX`. 