### PR TITLE
Add max_length to PdfStream decode()

### DIFF
--- a/Tests/test_pdfparser.py
+++ b/Tests/test_pdfparser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+import zlib
 
 import pytest
 
@@ -93,6 +94,16 @@ def test_parsing() -> None:
             b = b"<</" + name.encode() + b" (" + date + b")>>"
             d = PdfParser.get_value(b, 0)[0]
             assert time.strftime("%Y%m%d%H%M%S", getattr(d, name)) == value
+
+
+def test_pdfstream_flatedecode() -> None:
+    d = PdfDict({b"Filter": b"FlateDecode"})
+    buf = zlib.compress(b"test")
+    s = PdfStream(d, buf)
+    assert s.decode() == b"test"
+
+    with pytest.raises(ValueError, match="Decompressed data too large"):
+        s.decode(3)
 
 
 def test_pdf_repr() -> None:

--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -10,6 +10,8 @@ import time
 import zlib
 from typing import Any, NamedTuple
 
+from . import ImageFile
+
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import IO
@@ -320,17 +322,18 @@ class PdfStream:
         self.dictionary = dictionary
         self.buf = buf
 
-    def decode(self) -> bytes:
+    def decode(self, max_length: int = ImageFile.SAFEBLOCK) -> bytes:
         try:
             filter = self.dictionary[b"Filter"]
         except KeyError:
             return self.buf
         if filter == b"FlateDecode":
-            try:
-                expected_length = self.dictionary[b"DL"]
-            except KeyError:
-                expected_length = self.dictionary[b"Length"]
-            return zlib.decompress(self.buf, bufsize=int(expected_length))
+            dobj = zlib.decompressobj()
+            plaintext = dobj.decompress(self.buf, max_length)
+            if dobj.unconsumed_tail:
+                msg = "Decompressed data too large"
+                raise ValueError(msg)
+            return plaintext
         else:
             msg = f"stream filter {repr(filter)} unknown/unsupported"
             raise NotImplementedError(msg)


### PR DESCRIPTION
Adds a `max_length` argument to `PdfStream.decode()`, limiting the amount of data to decompress. This is similar to
https://github.com/python-pillow/Pillow/blob/8dbaf502bda938db1d2e23807563b8f9b0a0cbd2/src/PIL/PngImagePlugin.py#L145-L151
https://github.com/python-pillow/Pillow/blob/8dbaf502bda938db1d2e23807563b8f9b0a0cbd2/src/PIL/PngImagePlugin.py#L96
I think we can do better than adding a constant to `PdfParser` though. Because `decode()` isn't called internally anywhere, I think we can let the user decide when calling, by adding a `max_length` argument to `PdfStream.decode()`, defaulting to `ImageFile.SAFEBLOCK`.

