### PR TITLE
Add dependencies.json to Windows cache key

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -112,7 +112,7 @@ jobs:
       with:
         path: winbuild\build
         key:
-          ${{ hashFiles('winbuild\build_prepare.py') }}-${{ hashFiles('.github\workflows\test-windows.yml') }}-${{ env.pythonLocation }}-${{ steps.install.outputs.vs }}
+          ${{ hashFiles('.github\dependencies.json') }}-${{ hashFiles('winbuild\build_prepare.py') }}-${{ hashFiles('.github\workflows\test-windows.yml') }}-${{ env.pythonLocation }}-${{ steps.install.outputs.vs }}
 
     - name: Prepare build
       if: steps.build-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
`.github/workflows/test-windows.yml` uses `winbuild/build_prepare.py`

https://github.com/python-pillow/Pillow/blob/b98d17883a40979adc67154b8b45f58a6c38c2ce/.github/workflows/test-windows.yml#L120

`winbuild/build_prepare.py` uses `.github/dependencies.json`

https://github.com/python-pillow/Pillow/blob/b98d17883a40979adc67154b8b45f58a6c38c2ce/winbuild/build_prepare.py#L117-L119