### PR TITLE
Check realloc return value

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -337,7 +337,6 @@ path_compact(PyPathObject *self, PyObject *args) {
     i = self->count - j;
 
     /* shrink coordinate array */
-    /* malloc check ok, self->count is smaller than it was before */
     double *new_xy = realloc(self->xy, 2 * j * sizeof(double));
     if (!new_xy) {
         return ImagingError_MemoryError();

--- a/src/path.c
+++ b/src/path.c
@@ -335,11 +335,15 @@ path_compact(PyPathObject *self, PyObject *args) {
     }
 
     i = self->count - j;
-    self->count = j;
 
     /* shrink coordinate array */
     /* malloc check ok, self->count is smaller than it was before */
-    self->xy = realloc(self->xy, 2 * self->count * sizeof(double));
+    double *new_xy = realloc(self->xy, 2 * j * sizeof(double));
+    if (!new_xy) {
+        return ImagingError_MemoryError();
+    }
+    self->xy = new_xy;
+    self->count = j;
 
     return Py_BuildValue("i", i); /* number of removed vertices */
 }


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/6a8de891fb00968e5ea79bfa84368ed90b3cfc1d/src/path.c#L340-L342

The comment comes from https://github.com/python-pillow/Pillow/commit/4b4ef5f1e2bf3c795fc60fbbf7c40f2a24043020. It is saying that since we a reallocating to a smaller size, the `realloc` operation should not fail.

However, perhaps we can satisfy code vulnerability scanners by checking it anyway.