### PR TITLE
Remove unused HSV and LAB matrix conversion from C

### DIFF
--- a/src/libImaging/Matrix.c
+++ b/src/libImaging/Matrix.c
@@ -46,9 +46,7 @@ ImagingConvertMatrix(Imaging im, const ModeID mode, float m[]) {
             }
         }
         ImagingSectionLeave(&cookie);
-    } else if (
-        mode == IMAGING_MODE_HSV || mode == IMAGING_MODE_LAB || mode == IMAGING_MODE_RGB
-    ) {
+    } else if (mode == IMAGING_MODE_RGB) {
         imOut = ImagingNewDirty(mode, im->xsize, im->ysize);
         if (!imOut) {
             return NULL;


### PR DESCRIPTION
The only place that Python attempts to convert a matrix is
https://github.com/python-pillow/Pillow/blob/6a8de891fb00968e5ea79bfa84368ed90b3cfc1d/src/PIL/Image.py#L1079-L1082

So HSV and LAB images will never be sent to the C layer.