### PR TITLE
Raise ValueError if P;2L or P;4L data is truncated in frombytes()

### DIFF
--- a/Tests/test_file_pcx.py
+++ b/Tests/test_file_pcx.py
@@ -202,3 +202,16 @@ def test_break_padding(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     for x in range(5):
         px[x, 3] = 0
     _test_buffer_overflow(tmp_path, im, monkeypatch)
+
+
+@pytest.mark.parametrize(
+    "data_len, rawmode",
+    (
+        (5, "P;4L"),
+        (3, "P;2L"),
+    ),
+)
+def test_truncated(data_len: int, rawmode: str) -> None:
+    data = b"\x00" * data_len
+    with pytest.raises(ValueError, match="not enough image data"):
+        Image.frombuffer("P", (9, 1), data, "raw", rawmode, 0, 1)

--- a/Tests/test_image_array.py
+++ b/Tests/test_image_array.py
@@ -60,6 +60,9 @@ def test_fromarray() -> None:
             self.img = img
             self.__array_interface__ = arr_params
 
+        def __len__(self) -> int:
+            return len(self.img.tobytes())
+
         def tobytes(self) -> bytes:
             return self.img.tobytes()
 
@@ -99,6 +102,9 @@ def test_fromarray_strides_without_tobytes() -> None:
     class Wrapper:
         def __init__(self, arr_params: dict[str, Any]) -> None:
             self.__array_interface__ = arr_params
+
+        def __len__(self) -> int:
+            return 1
 
     with pytest.raises(ValueError):
         wrapped = Wrapper({"shape": (1, 1), "strides": (1, 1), "typestr": "|u1"})

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -943,6 +943,12 @@ class Image:
             # may pass tuple instead of argument list
             decoder_args = decoder_args[0]
 
+        if decoder_args and decoder_args[0] in {"P;2L", "P;4L"}:
+            multiple = 4 if decoder_args[0] == "P;2L" else 8
+            if len(data) % multiple:
+                msg = "not enough image data"
+                raise ValueError(msg)
+
         # default format
         if decoder_name == "raw" and decoder_args == ():
             decoder_args = self.mode
@@ -3348,6 +3354,9 @@ class SupportsArrayInterface(Protocol):
 
     @property
     def __array_interface__(self) -> dict[str, Any]:
+        raise NotImplementedError()
+
+    def __len__(self) -> int:
         raise NotImplementedError()
 
 


### PR DESCRIPTION
When passing data to `frombytes()` (or `frombuffer()` or `im.frombytes()`), it is possible to pass an insufficient amount of data. These unpackers are unusual in that they require data in multiples of 4 or 8 bytes respectively.

This is described at https://web.archive.org/web/20100206055706/http://www.qzx.com/pc-gpe/pcx.txt, where [`NPlanes` is the 2 or 4](https://github.com/python-pillow/Pillow/blob/cdaa29eb520291c4f1fb50fb71ae46502d41e460/src/PIL/PcxImagePlugin.py#L91) in P;2L or P;4L
> Then calculate how many bytes are required to hold one complete uncompressed scan line:
>
> TotalBytes = NPlanes * BytesPerLine
>
> Note that since there are always an even number of bytes per scan line,

This PR raises a ValueError if the data is truncated.