### PR TITLE
Only clear error if it is BufferError

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -190,7 +190,12 @@ PyPath_Flatten(PyObject *data, double **pxy) {
             PyBuffer_Release(&buffer);
             return n;
         }
-        PyErr_Clear();
+        if (PyErr_Occurred()) {
+            if (!PyErr_ExceptionMatches(PyExc_BufferError)) {
+                return -1;
+            }
+            PyErr_Clear();
+        }
     }
 
     if (!PySequence_Check(data)) {


### PR DESCRIPTION
The `PyErr_Clear()` here is intended to clear the `BufferError`.
https://github.com/python-pillow/Pillow/blob/095bbc312a34e2dbec68721da11c8722f8cf22e8/src/path.c#L178-L193

https://github.com/python-pillow/Pillow/blob/095bbc312a34e2dbec68721da11c8722f8cf22e8/src/_imaging.c#L227-L231

https://docs.python.org/3/c-api/buffer.html#c.PyObject_GetBuffer
> If the exporter cannot provide a buffer of the exact type, it MUST raise [BufferError](https://docs.python.org/3/library/exceptions.html#BufferError), set view->obj to NULL and return -1.

This checks that it is actually a `BufferError` that we are clearing.