### PR TITLE
Use reshape() instead of setting NumPy array shape directly

### DIFF
--- a/Tests/test_numpy.py
+++ b/Tests/test_numpy.py
@@ -24,14 +24,14 @@ def test_numpy_to_image() -> None:
         if bands == 1:
             if boolean:
                 data = (0, 255) * 50
-            a = numpy.array(data, dtype=dtype)
-            a.shape = TEST_IMAGE_SIZE
+            a = numpy.array(data, dtype=dtype).reshape(TEST_IMAGE_SIZE)
             i = Image.fromarray(a)
             assert i.get_flattened_data() == data
         else:
-            a = numpy.array([[x] * bands for x in data], dtype=dtype)
-            a.shape = TEST_IMAGE_SIZE[0], TEST_IMAGE_SIZE[1], bands
-            i = Image.fromarray(a)
+            a2 = numpy.array([[x] * bands for x in data], dtype=dtype).reshape(
+                TEST_IMAGE_SIZE[0], TEST_IMAGE_SIZE[1], bands
+            )
+            i = Image.fromarray(a2)
             assert i.get_flattened_data(0) == tuple(range(100))
         return i
 
@@ -133,8 +133,7 @@ def test_save_tiff_uint16() -> None:
     pixel_value = 0x1234
     a = numpy.array(
         [pixel_value] * TEST_IMAGE_SIZE[0] * TEST_IMAGE_SIZE[1], dtype=numpy.uint16
-    )
-    a.shape = TEST_IMAGE_SIZE
+    ).reshape(TEST_IMAGE_SIZE)
     img = Image.fromarray(a)
 
     assert img.getpixel((0, 0)) == pixel_value


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/actions/runs/28344043164/job/83963867727#step:12:5433

> Tests/test_numpy.py: 14 warnings
>   /Users/runner/work/Pillow/Pillow/Tests/test_numpy.py:28: DeprecationWarning: Setting the shape on a NumPy array has been deprecated in NumPy 2.5.
>   As an alternative, you can create a new view using np.reshape (with copy=False if needed).
>     a.shape = TEST_IMAGE_SIZE