### PR TITLE
Raise OverflowError if number of vertices is too large for Path

### DIFF
--- a/Tests/test_imagepath.py
+++ b/Tests/test_imagepath.py
@@ -203,10 +203,8 @@ def test_transform_with_wrap() -> None:
 
 
 def test_overflow_segfault() -> None:
-    # Some Pythons fail getting the argument as an integer, and it falls
-    # through to the sequence. Seeing this on 32-bit Windows.
-    with pytest.raises((TypeError, MemoryError)):
-        # post patch, this fails with a memory error
+    with pytest.raises((OverflowError, MemoryError)):
+        # post patch, this fails with a memory error on 64-bit
         x = Evil()
 
         # This fails due to the invalid malloc above,

--- a/src/path.c
+++ b/src/path.c
@@ -282,8 +282,16 @@ PyPath_Create(PyObject *self, PyObject *args) {
     Py_ssize_t count;
     double *xy;
 
-    if (PyArg_ParseTuple(args, "n:Path", &count)) {
+    if (!PyArg_ParseTuple(args, "O", &data)) {
+        return NULL;
+    }
+    if (PyLong_Check(data)) {
         /* number of vertices */
+        count = PyLong_AsSsize_t(data);
+        if (PyErr_Occurred()) {
+            return NULL;
+        }
+
         xy = alloc_array(count);
         if (!xy) {
             return NULL;
@@ -291,11 +299,6 @@ PyPath_Create(PyObject *self, PyObject *args) {
 
     } else {
         /* sequence or other path */
-        PyErr_Clear();
-        if (!PyArg_ParseTuple(args, "O", &data)) {
-            return NULL;
-        }
-
         count = PyPath_Flatten(data, &xy);
         if (count < 0) {
             return NULL;


### PR DESCRIPTION
```python
from PIL import ImagePath
ImagePath.Path(0x4000000000000000)
```
on 32-bit, [this](https://github.com/radarhere/Pillow/actions/runs/28364095928/job/84025593914#step:30:21) [results](https://github.com/radarhere/Pillow/commit/2060155048d2c56a255b496218d959c481fe0df6) in
```
TypeError: argument must be sequence
```

This isn't strictly true. It can be an integer, the problem is that the number is too large for the 32-bit system.

This PR changes it to an OverflowError instead.