### PR TITLE
Remove PyErr_Clear() of "weird" exceptions

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1693,7 +1693,6 @@ _putdata(ImagingObject *self, PyObject *args) {
                     x = 0, y++;
                 }
             }
-            PyErr_Clear(); /* Avoid weird exceptions */
         }
     } else {
         /* 32-bit images */
@@ -1712,7 +1711,6 @@ _putdata(ImagingObject *self, PyObject *args) {
                         x = 0, y++;
                     }
                 }
-                PyErr_Clear(); /* Avoid weird exceptions */
                 break;
             case IMAGING_TYPE_FLOAT32:
                 for (i = x = y = 0; i < n; i++) {
@@ -1724,7 +1722,6 @@ _putdata(ImagingObject *self, PyObject *args) {
                         x = 0, y++;
                     }
                 }
-                PyErr_Clear(); /* Avoid weird exceptions */
                 break;
             default:
                 for (i = x = y = 0; i < n; i++) {
@@ -1746,7 +1743,6 @@ _putdata(ImagingObject *self, PyObject *args) {
                         x = 0, y++;
                     }
                 }
-                PyErr_Clear(); /* Avoid weird exceptions */
                 break;
         }
     }

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1634,6 +1634,10 @@ _putdata(ImagingObject *self, PyObject *args) {
         return NULL;                                                    \
     } else {                                                            \
         value = PyFloat_AsDouble(op);                                   \
+        if (value == -1.0 && PyErr_Occurred()) {                        \
+            Py_DECREF(seq);                                             \
+            return NULL;                                                \
+        }                                                               \
     }
     if (image->image8) {
         if (PyBytes_Check(data)) {


### PR DESCRIPTION
There are few lines like this that have been present since PIL, for no clear reason.

https://github.com/python-pillow/Pillow/blob/7fdf23e400ce4eb3d1674215fbb4e9290ba66b19/src/_imaging.c#L1696