### PR TITLE
Allow error to be raised if PyDict_SetItemString fails

### DIFF
--- a/src/_imagingmath.c
+++ b/src/_imagingmath.c
@@ -256,19 +256,19 @@ static PyMethodDef _functions[] = {
 static void
 install_unary(PyObject *d, char *name, void *func) {
     PyObject *v = PyCapsule_New(func, MATH_FUNC_UNOP_MAGIC, NULL);
-    if (!v || PyDict_SetItemString(d, name, v)) {
-        PyErr_Clear();
+    if (v) {
+        PyDict_SetItemString(d, name, v);
+        Py_DECREF(v);
     }
-    Py_XDECREF(v);
 }
 
 static void
 install_binary(PyObject *d, char *name, void *func) {
     PyObject *v = PyCapsule_New(func, MATH_FUNC_BINOP_MAGIC, NULL);
-    if (!v || PyDict_SetItemString(d, name, v)) {
-        PyErr_Clear();
+    if (v) {
+        PyDict_SetItemString(d, name, v);
+        Py_DECREF(v);
     }
-    Py_XDECREF(v);
 }
 
 static int


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/7fdf23e400ce4eb3d1674215fbb4e9290ba66b19/src/_imagingmath.c#L257-L261

If an error occurs within `install_unary()` (or `install_binary()`, it seems like it would be good to know, rather than clearing the error and ignoring it? The calls these functions are all static, so there's no edge cases that might occur.

https://github.com/python-pillow/Pillow/blob/7fdf23e400ce4eb3d1674215fbb4e9290ba66b19/src/_imagingmath.c#L279-L280