### PR TITLE
Speed up `Image.point()` and `Image.point_transform()`

### DIFF
--- a/Tests/benchmarks.py
+++ b/Tests/benchmarks.py
@@ -488,7 +488,7 @@ def test_point_lut(bench: BenchmarkFixture, mode: str, size: tuple[int, int]) ->
 
 
 @pytest.mark.benchmark(group="point")
-@pytest.mark.parametrize("mode", ["I", "F"])
+@pytest.mark.parametrize("mode", ["I", "F", "LA", "RGBA"])
 @pytest.mark.parametrize("size", SIZES, ids=_format_size)
 def test_point_transform(
     bench: BenchmarkFixture, mode: str, size: tuple[int, int]

--- a/Tests/test_image_point.py
+++ b/Tests/test_image_point.py
@@ -39,6 +39,19 @@ def test_sanity() -> None:
         im.point(lambda x: x // 2)
 
 
+@pytest.mark.parametrize("mode", ("LA", "RGBA", "CMYK"))
+def test_multiband(mode: str) -> None:
+    # Exercises im_point_2x8_2x8 (2 bands) and im_point_4x8_4x8 (4 bands)
+    im = hopper(mode)
+    lut = [(x + 1) % 256 for x in range(256)] * len(im.getbands())
+    out = im.point(lut)
+
+    assert out.mode == mode
+    assert isinstance(px := im.getpixel((0, 0)), tuple)  # Placate mypy
+    expected_px = tuple((v + 1) % 256 for v in px)
+    assert out.getpixel((0, 0)) == expected_px
+
+
 def test_16bit_lut() -> None:
     """Tests for 16 bit -> 8 bit lut for converting I->L images
     see https://github.com/python-pillow/Pillow/issues/440

--- a/src/libImaging/Point.c
+++ b/src/libImaging/Point.c
@@ -25,29 +25,39 @@ typedef struct {
     const void *table;
 } im_point_context;
 
+/**
+ * Contract: imIn is read-only and imOut must be a distinct image.
+ */
 static void
 im_point_8_8(Imaging imOut, Imaging imIn, im_point_context *context) {
-    int x, y;
     /* 8-bit source, 8-bit destination */
     UINT8 *table = (UINT8 *)context->table;
-    for (y = 0; y < imIn->ysize; y++) {
-        UINT8 *in = imIn->image8[y];
-        UINT8 *out = imOut->image8[y];
-        for (x = 0; x < imIn->xsize; x++) {
+    // Invariant over the loop.
+    int xsize = imIn->xsize, ysize = imIn->ysize;
+    for (int y = 0; y < ysize; y++) {
+        // restrict safe: imIn is read-only, imOut is a fresh allocation.
+        UINT8 *restrict in = imIn->image8[y];
+        UINT8 *restrict out = imOut->image8[y];
+        for (int x = 0; x < xsize; x++) {
             out[x] = table[in[x]];
         }
     }
 }
 
+/**
+ * Contract: imIn is read-only and imOut must be a distinct image.
+ */
 static void
 im_point_2x8_2x8(Imaging imOut, Imaging imIn, im_point_context *context) {
-    int x, y;
     /* 2x8-bit source, 2x8-bit destination */
     UINT8 *table = (UINT8 *)context->table;
-    for (y = 0; y < imIn->ysize; y++) {
-        UINT8 *in = (UINT8 *)imIn->image[y];
-        UINT8 *out = (UINT8 *)imOut->image[y];
-        for (x = 0; x < imIn->xsize; x++) {
+    // Invariant over the loop.
+    int xsize = imIn->xsize, ysize = imIn->ysize;
+    for (int y = 0; y < ysize; y++) {
+        // restrict safe: imIn is read-only, imOut is a fresh allocation.
+        UINT8 *restrict in = (UINT8 *)imIn->image[y];
+        UINT8 *restrict out = (UINT8 *)imOut->image[y];
+        for (int x = 0; x < xsize; x++) {
             out[0] = table[in[0]];
             out[3] = table[in[3] + 256];
             in += 4;
@@ -56,15 +66,20 @@ im_point_2x8_2x8(Imaging imOut, Imaging imIn, im_point_context *context) {
     }
 }
 
+/**
+ * Contract: imIn is read-only and imOut must be a distinct image.
+ */
 static void
 im_point_3x8_3x8(Imaging imOut, Imaging imIn, im_point_context *context) {
-    int x, y;
     /* 3x8-bit source, 3x8-bit destination */
     UINT8 *table = (UINT8 *)context->table;
-    for (y = 0; y < imIn->ysize; y++) {
-        UINT8 *in = (UINT8 *)imIn->image[y];
-        UINT8 *out = (UINT8 *)imOut->image[y];
-        for (x = 0; x < imIn->xsize; x++) {
+    // Invariant over the loop.
+    int xsize = imIn->xsize, ysize = imIn->ysize;
+    for (int y = 0; y < ysize; y++) {
+        // restrict safe: imIn is read-only, imOut is a fresh allocation.
+        UINT8 *restrict in = (UINT8 *)imIn->image[y];
+        UINT8 *restrict out = (UINT8 *)imOut->image[y];
+        for (int x = 0; x < xsize; x++) {
             out[0] = table[in[0]];
             out[1] = table[in[1] + 256];
             out[2] = table[in[2] + 512];
@@ -74,15 +89,20 @@ im_point_3x8_3x8(Imaging imOut, Imaging imIn, im_point_context *context) {
     }
 }
 
+/**
+ * Contract: imIn is read-only and imOut must be a distinct image.
+ */
 static void
 im_point_4x8_4x8(Imaging imOut, Imaging imIn, im_point_context *context) {
-    int x, y;
     /* 4x8-bit source, 4x8-bit destination */
     UINT8 *table = (UINT8 *)context->table;
-    for (y = 0; y < imIn->ysize; y++) {
-        UINT8 *in = (UINT8 *)imIn->image[y];
-        UINT8 *out = (UINT8 *)imOut->image[y];
-        for (x = 0; x < imIn->xsize; x++) {
+    // Invariant over the loop.
+    int xsize = imIn->xsize, ysize = imIn->ysize;
+    for (int y = 0; y < ysize; y++) {
+        // restrict safe: imIn is read-only, imOut is a fresh allocation.
+        UINT8 *restrict in = (UINT8 *)imIn->image[y];
+        UINT8 *restrict out = (UINT8 *)imOut->image[y];
+        for (int x = 0; x < xsize; x++) {
             out[0] = table[in[0]];
             out[1] = table[in[1] + 256];
             out[2] = table[in[2] + 512];
@@ -93,29 +113,39 @@ im_point_4x8_4x8(Imaging imOut, Imaging imIn, im_point_context *context) {
     }
 }
 
+/**
+ * Contract: imIn is read-only and imOut must be a distinct image.
+ */
 static void
 im_point_8_32(Imaging imOut, Imaging imIn, im_point_context *context) {
-    int x, y;
     /* 8-bit source, 32-bit destination */
     char *table = (char *)context->table;
-    for (y = 0; y < imIn->ysize; y++) {
-        UINT8 *in = imIn->image8[y];
-        INT32 *out = imOut->image32[y];
-        for (x = 0; x < imIn->xsize; x++) {
+    // Invariant over the loop.
+    int xsize = imIn->xsize, ysize = imIn->ysize;
+    for (int y = 0; y < ysize; y++) {
+        // restrict safe: imIn is read-only, imOut is a fresh allocation.
+        UINT8 *restrict in = imIn->image8[y];
+        INT32 *restrict out = imOut->image32[y];
+        for (int x = 0; x < xsize; x++) {
             memcpy(out + x, table + in[x] * sizeof(INT32), sizeof(INT32));
         }
     }
 }
 
+/**
+ * Contract: imIn is read-only and imOut must be a distinct image.
+ */
 static void
 im_point_32_8(Imaging imOut, Imaging imIn, im_point_context *context) {
-    int x, y;
     /* 32-bit source, 8-bit destination */
     UINT8 *table = (UINT8 *)context->table;
-    for (y = 0; y < imIn->ysize; y++) {
-        INT32 *in = imIn->image32[y];
-        UINT8 *out = imOut->image8[y];
-        for (x = 0; x < imIn->xsize; x++) {
+    // Invariant over the loop.
+    int xsize = imIn->xsize, ysize = imIn->ysize;
+    for (int y = 0; y < ysize; y++) {
+        // restrict safe: imIn is read-only, imOut is a fresh allocation.
+        INT32 *restrict in = imIn->image32[y];
+        UINT8 *restrict out = imOut->image8[y];
+        for (int x = 0; x < xsize; x++) {
             int v = in[x];
             if (v < 0) {
                 v = 0;
@@ -202,20 +232,28 @@ mode_mismatch:
     );
 }
 
+/**
+ * Apply an affine (scale/offset) transform to every pixel of imIn,
+ * returning a newly allocated result.
+ *
+ * Contract: imIn is read-only.
+ */
 Imaging
 ImagingPointTransform(Imaging imIn, double scale, double offset) {
     /* scale/offset transform */
 
     ImagingSectionCookie cookie;
     Imaging imOut;
-    int x, y;
 
     if (!imIn || (imIn->mode != IMAGING_MODE_I && imIn->mode != IMAGING_MODE_I_16 &&
                   imIn->mode != IMAGING_MODE_F)) {
         return (Imaging)ImagingError_ModeError();
     }
 
-    imOut = ImagingNew(imIn->mode, imIn->xsize, imIn->ysize);
+    // Invariant over the loops.
+    int xsize = imIn->xsize, ysize = imIn->ysize;
+
+    imOut = ImagingNew(imIn->mode, xsize, ysize);
     if (!imOut) {
         return NULL;
     }
@@ -223,11 +261,12 @@ ImagingPointTransform(Imaging imIn, double scale, double offset) {
     switch (imIn->type) {
         case IMAGING_TYPE_INT32:
             ImagingSectionEnter(&cookie);
-            for (y = 0; y < imIn->ysize; y++) {
-                INT32 *in = imIn->image32[y];
-                INT32 *out = imOut->image32[y];
+            for (int y = 0; y < ysize; y++) {
+                // restrict safe: imIn is read-only, imOut is a fresh allocation.
+                INT32 *restrict in = imIn->image32[y];
+                INT32 *restrict out = imOut->image32[y];
                 /* FIXME: add clipping? */
-                for (x = 0; x < imIn->xsize; x++) {
+                for (int x = 0; x < xsize; x++) {
                     out[x] = in[x] * scale + offset;
                 }
             }
@@ -235,10 +274,11 @@ ImagingPointTransform(Imaging imIn, double scale, double offset) {
             break;
         case IMAGING_TYPE_FLOAT32:
             ImagingSectionEnter(&cookie);
-            for (y = 0; y < imIn->ysize; y++) {
-                FLOAT32 *in = (FLOAT32 *)imIn->image32[y];
-                FLOAT32 *out = (FLOAT32 *)imOut->image32[y];
-                for (x = 0; x < imIn->xsize; x++) {
+            for (int y = 0; y < ysize; y++) {
+                // restrict safe: imIn is read-only, imOut is a fresh allocation.
+                FLOAT32 *restrict in = (FLOAT32 *)imIn->image32[y];
+                FLOAT32 *restrict out = (FLOAT32 *)imOut->image32[y];
+                for (int x = 0; x < xsize; x++) {
                     out[x] = in[x] * scale + offset;
                 }
             }
@@ -247,11 +287,12 @@ ImagingPointTransform(Imaging imIn, double scale, double offset) {
         case IMAGING_TYPE_SPECIAL:
             if (imIn->mode == IMAGING_MODE_I_16) {
                 ImagingSectionEnter(&cookie);
-                for (y = 0; y < imIn->ysize; y++) {
-                    char *in = (char *)imIn->image[y];
-                    char *out = (char *)imOut->image[y];
+                for (int y = 0; y < ysize; y++) {
+                    // restrict safe: imIn is read-only, imOut is a fresh allocation.
+                    char *restrict in = imIn->image[y];
+                    char *restrict out = imOut->image[y];
                     /* FIXME: add clipping? */
-                    for (x = 0; x < imIn->xsize; x++) {
+                    for (int x = 0; x < xsize; x++) {
                         UINT16 v;
                         memcpy(&v, in + x * sizeof(v), sizeof(v));
                         v = v * scale + offset;

--- a/src/libImaging/Point.c
+++ b/src/libImaging/Point.c
@@ -170,7 +170,6 @@ ImagingPoint(Imaging imIn, ModeID mode, const void *table) {
     ImagingSectionCookie cookie;
     Imaging imOut;
     im_point_context context;
-    void (*point)(Imaging imIn, Imaging imOut, im_point_context *context);
 
     if (!imIn) {
         return (Imaging)ImagingError_ModeError();
@@ -193,41 +192,37 @@ ImagingPoint(Imaging imIn, ModeID mode, const void *table) {
         return NULL;
     }
 
-    /* find appropriate handler */
+    ImagingCopyPalette(imOut, imIn);
+
+    ImagingSectionEnter(&cookie);
+    context.table = table;
+
     if (imIn->type == IMAGING_TYPE_UINT8) {
         if (imIn->bands == imOut->bands && imIn->type == imOut->type) {
             switch (imIn->bands) {
                 case 1:
-                    point = im_point_8_8;
+                    im_point_8_8(imOut, imIn, &context);
                     break;
                 case 2:
-                    point = im_point_2x8_2x8;
+                    im_point_2x8_2x8(imOut, imIn, &context);
                     break;
                 case 3:
-                    point = im_point_3x8_3x8;
+                    im_point_3x8_3x8(imOut, imIn, &context);
                     break;
                 case 4:
-                    point = im_point_4x8_4x8;
+                    im_point_4x8_4x8(imOut, imIn, &context);
                     break;
                 default:
                     /* this cannot really happen */
-                    point = im_point_8_8;
+                    im_point_8_8(imOut, imIn, &context);
                     break;
             }
         } else {
-            point = im_point_8_32;
+            im_point_8_32(imOut, imIn, &context);
         }
     } else {
-        point = im_point_32_8;
+        im_point_32_8(imOut, imIn, &context);
     }
-
-    ImagingCopyPalette(imOut, imIn);
-
-    ImagingSectionEnter(&cookie);
-
-    context.table = table;
-    point(imOut, imIn, &context);
-
     ImagingSectionLeave(&cookie);
 
     return imOut;

--- a/src/libImaging/Point.c
+++ b/src/libImaging/Point.c
@@ -25,6 +25,9 @@ typedef struct {
     const void *table;
 } im_point_context;
 
+// Note: all point handlers must fill the entirety of `imOut`,
+//       as it is allocated dirty by `ImagingPoint`.
+
 /**
  * Contract: imIn is read-only and imOut must be a distinct image.
  */
@@ -59,6 +62,8 @@ im_point_2x8_2x8(Imaging imOut, Imaging imIn, im_point_context *context) {
         UINT8 *restrict out = (UINT8 *)imOut->image[y];
         for (int x = 0; x < xsize; x++) {
             out[0] = table[in[0]];
+            out[1] = 0;
+            out[2] = 0;
             out[3] = table[in[3] + 256];
             in += 4;
             out += 4;
@@ -83,6 +88,7 @@ im_point_3x8_3x8(Imaging imOut, Imaging imIn, im_point_context *context) {
             out[0] = table[in[0]];
             out[1] = table[in[1] + 256];
             out[2] = table[in[2] + 512];
+            out[3] = 0;
             in += 4;
             out += 4;
         }
@@ -182,7 +188,7 @@ ImagingPoint(Imaging imIn, ModeID mode, const void *table) {
         goto mode_mismatch;
     }
 
-    imOut = ImagingNew(mode, imIn->xsize, imIn->ysize);
+    imOut = ImagingNewDirty(mode, imIn->xsize, imIn->ysize);
     if (!imOut) {
         return NULL;
     }
@@ -253,7 +259,7 @@ ImagingPointTransform(Imaging imIn, double scale, double offset) {
     // Invariant over the loops.
     int xsize = imIn->xsize, ysize = imIn->ysize;
 
-    imOut = ImagingNew(imIn->mode, xsize, ysize);
+    imOut = ImagingNewDirty(imIn->mode, xsize, ysize);
     if (!imOut) {
         return NULL;
     }


### PR DESCRIPTION
Refs https://github.com/python-pillow/Pillow/pull/9649, https://github.com/python-pillow/Pillow/pull/9675, https://github.com/python-pillow/Pillow/pull/9736, https://github.com/python-pillow/Pillow/pull/9737, https://github.com/python-pillow/Pillow/pull/9738, https://github.com/python-pillow/Pillow/pull/9739, #9740 (same series, same techniques).

Cf. the aforementioned PRs, this also does a couple other cleanups for performance; on my machine, using ImagingNewDirty gave another +10% on top of the first commit. The last commit would technically allow a compiler to inline the `point` functions, but given their size, a compiler probably won't.