### PR TITLE
Use ImagingNewDirty() in RankFilter and remove ImagingFill() in font.getmask()

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -2876,7 +2876,7 @@ _font_getmask(ImagingFontObject *self, PyObject *args) {
         free(text);
         return NULL;
     }
-    im = ImagingNew(self->bitmap->mode, xsize, self->ysize);
+    im = ImagingNewDirty(self->bitmap->mode, xsize, self->ysize);  // Emptied below
     if (!im) {
         free(text);
         return ImagingError_MemoryError();

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -2876,14 +2876,11 @@ _font_getmask(ImagingFontObject *self, PyObject *args) {
         free(text);
         return NULL;
     }
-    im = ImagingNewDirty(self->bitmap->mode, xsize, self->ysize);  // Emptied below
+    im = ImagingNew(self->bitmap->mode, xsize, self->ysize);
     if (!im) {
         free(text);
         return ImagingError_MemoryError();
     }
-
-    b = 0;
-    (void)ImagingFill(im, &b);
 
     b = self->baseline;
     for (x = 0; text[i]; i++) {

--- a/src/libImaging/RankFilter.c
+++ b/src/libImaging/RankFilter.c
@@ -84,7 +84,8 @@ MakeRankFunction(UINT8) MakeRankFunction(INT32) MakeRankFunction(FLOAT32)
         return (Imaging)ImagingError_ValueError("bad rank value");
     }
 
-    imOut = ImagingNew(im->mode, im->xsize - 2 * margin, im->ysize - 2 * margin);
+    // Every output pixel is written by the rank loop below
+    imOut = ImagingNewDirty(im->mode, im->xsize - 2 * margin, im->ysize - 2 * margin);
     if (!imOut) {
         return NULL;
     }


### PR DESCRIPTION
Tiny performance improvement. The image is always fully filled anyway.

Related #9743's 2nd commit (same pattern).