### PR TITLE
Fix ICO save producing an empty file for images smaller than 16x16

### DIFF
--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -88,6 +88,43 @@ def test_save_to_bytes() -> None:
         )
 
 
+@pytest.mark.parametrize("size", ((1, 1), (8, 8), (15, 15), (8, 12)))
+def test_save_smaller_than_default_sizes(size: tuple[int, int]) -> None:
+    # An image smaller than the smallest default size (16x16) must still be
+    # saved as a valid, readable ICO rather than a header-only, empty file.
+    im = Image.new("RGBA", size, (10, 20, 30, 255))
+    im.putpixel((size[0] - 1, size[1] - 1), (200, 100, 50, 255))
+
+    output = io.BytesIO()
+    im.save(output, "ico")
+
+    output.seek(0)
+    with Image.open(output) as reloaded:
+        assert reloaded.format == "ICO"
+        assert reloaded.size == size
+        assert reloaded.info["sizes"] == {size}
+        assert reloaded.convert("RGBA").getpixel((size[0] - 1, size[1] - 1)) == (
+            200,
+            100,
+            50,
+            255,
+        )
+
+
+def test_save_all_sizes_larger_than_image() -> None:
+    # When every requested size is larger than the image, all are ignored, so
+    # fall back to the image's own size instead of writing an empty file.
+    im = Image.new("RGBA", (8, 8), (10, 20, 30, 255))
+
+    output = io.BytesIO()
+    im.save(output, "ico", sizes=[(16, 16), (32, 32)])
+
+    output.seek(0)
+    with Image.open(output) as reloaded:
+        assert reloaded.format == "ICO"
+        assert reloaded.size == (8, 8)
+
+
 def test_getpixel(tmp_path: Path) -> None:
     temp_file = tmp_path / "temp.ico"
 

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -64,10 +64,18 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
     frames = []
     provided_ims = [im] + im.encoderinfo.get("append_images", [])
     width, height = im.size
-    for size in sorted(set(sizes)):
-        if size[0] > width or size[1] > height or size[0] > 256 or size[1] > 256:
-            continue
-
+    sizes = [
+        size
+        for size in sorted(set(sizes))
+        if size[0] <= width and size[1] <= height and size[0] <= 256 and size[1] <= 256
+    ]
+    if not sizes:
+        # Every requested size is larger than the source image, so fall back to
+        # the image's own size (capped at the 256x256 ICO maximum). This avoids
+        # writing an empty, unreadable file when the image is smaller than the
+        # smallest default size.
+        sizes = [(min(width, 256), min(height, 256))]
+    for size in sizes:
         for provided_im in provided_ims:
             if provided_im.size != size:
                 continue


### PR DESCRIPTION
Saving an image smaller than the smallest default ICO size (16×16) as ICO, without an explicit `sizes` argument, silently produces an empty, unreadable file:

```python
import io
from PIL import Image

buf = io.BytesIO()
Image.new("RGBA", (8, 8), (10, 20, 30, 255)).save(buf, "ICO")
print(len(buf.getvalue()))          # 6  -> just the ICONDIR header, idCount=0
buf.seek(0)
Image.open(buf).load()              # UnidentifiedImageError: cannot identify image file
```

The 8×8 image is representable as an ICO (`save(buf, "ICO", sizes=[(8, 8)])` works fine), but the default-`sizes` path drops it entirely with no error or warning.

### Cause

The default `sizes` start at `(16, 16)`, and `_save` skips every candidate size larger than the source image. For an image smaller than 16×16 *every* default candidate is skipped, so `frames` stays empty and `o16(len(frames))` writes `idCount=0` — a 6-byte header-only file.

### Fix

Filter the requested sizes up front, and if none fit, fall back to the image's own size (capped at the 256×256 ICO maximum) so a valid, readable icon is always written. This also fixes the related case where every *explicitly* requested size is larger than the image (previously also an empty file) — consistent with the documented behaviour that oversized requested sizes are ignored.

### Tests

`test_save_smaller_than_default_sizes` parametrizes `(1, 1)`, `(8, 8)`, `(15, 15)` and the non-square `(8, 12)`, asserting each round-trips to a valid ICO of the right size with `info["sizes"]` and a corner pixel preserved. `test_save_all_sizes_larger_than_image` pins the explicit-`sizes` fallback. All fail on `main` with `UnidentifiedImageError` and pass with the fix; the full `Tests/test_file_ico.py` suite stays green (27 passed); `ruff format`, `ruff check` and `mypy` are clean.
