### PR TITLE
Fix attach SBOM to GitHub release

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -366,7 +366,7 @@ jobs:
       - name: Attach SBOM to GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "$GITHUB_REF_NAME" pillow-*.cdx.json
+        run: gh release upload "$GITHUB_REF_NAME" pillow-*.cdx.json --repo "$GITHUB_REPOSITORY"
 
   pypi-publish:
     if: github.event.repository.fork == false && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
During the 12.3.0 release (https://github.com/python-pillow/Pillow/issues/9570):

https://github.com/python-pillow/Pillow/actions/runs/28508597348/job/84525739657

The "Publish SBOM to GitHub release" job failed:

```
Run gh release upload "$GITHUB_REF_NAME" pillow-*.cdx.json
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

This PR should fix it.

The release still uploaded to PyPI okay, and we don't need to redo the release just for this, especially as this was the first release with any SBOM (https://github.com/python-pillow/Pillow/pull/9550), and we're now also embedding the SBOM in wheels (https://github.com/python-pillow/Pillow/pull/9679).