### PR TITLE
Do not use CodSpeedHQ/action on fork

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -93,4 +93,4 @@ jobs:
         mode: simulation
         run: |
           python3 -m pip install -e . pytest-codspeed
-          pytest -vv --codspeed Tests/benchmarks.py
+          python3 -m pytest -vv --codspeed Tests/benchmarks.py

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -88,9 +88,16 @@ jobs:
         GHA_LIBWEBP_CACHE_HIT: ${{ steps.cache-libwebp.outputs.cache-hit }}
 
     - name: Run CodSpeed benchmarks
+      if: github.event.repository.fork == false
       uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4.18.1
       with:
         mode: simulation
         run: |
           python3 -m pip install -e . pytest-codspeed
           python3 -m pytest -vv --codspeed Tests/benchmarks.py
+
+    - name: Run CodSpeed benchmarks on fork
+      if: github.event.repository.fork == true
+      run: |
+        python3 -m pip install -e . pytest-codspeed
+        python3 -m pytest -vv --codspeed Tests/benchmarks.py


### PR DESCRIPTION
I've noticed that codspeed is failing in my fork - https://github.com/radarhere/Pillow/actions/runs/28502089873/job/84481570060
```
Uploading results
  CodSpeed Run Hash: "ac9229155c02b8c001a1368595350a49a27a52b738385214d2cddf9c336dacb4"
  Error: Failed to retrieve upload data: 401 Unauthorized
    -> Reason: Repository not found or the user does not have access to it.
  
  Check that the workflow is correctly authenticated. View more at https://codspeed.io/docs/integrations/ci/github-actions/configuration#authentication
```

There doesn't appear to be any way to instruct CodSpeedHQ/action not to try and upload the results, so this runs pytest with codspeed normally in a separate step on forks.