### PR TITLE
Avoid divide-by-zero crash in RankFilter

### DIFF
--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -228,3 +228,11 @@ def test_invalid_box_blur_filter(radius: int | tuple[int, int]) -> None:
     box_blur_filter.radius = radius
     with pytest.raises(ValueError):
         im.filter(box_blur_filter)
+
+def test_rankfilter_size_1() -> None:
+    im = Image.new("L", (3, 3), 128)
+    # Size 1 should not crash (margin is 0)
+    assert im.filter(ImageFilter.MinFilter(1)).getpixel((1, 1)) == 128
+    assert im.filter(ImageFilter.MaxFilter(1)).getpixel((1, 1)) == 128
+    assert im.filter(ImageFilter.MedianFilter(1)).getpixel((1, 1)) == 128
+    assert im.filter(ImageFilter.RankFilter(1, 0)).getpixel((1, 1)) == 128

--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -232,6 +232,7 @@ def test_invalid_box_blur_filter(radius: int | tuple[int, int]) -> None:
 
 def test_rankfilter_size_1() -> None:
     im = Image.new("L", (3, 3), 128)
+
     # Size 1 should not crash (margin is 0)
     assert im.filter(ImageFilter.MinFilter(1)).getpixel((1, 1)) == 128
     assert im.filter(ImageFilter.MaxFilter(1)).getpixel((1, 1)) == 128

--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -229,6 +229,7 @@ def test_invalid_box_blur_filter(radius: int | tuple[int, int]) -> None:
     with pytest.raises(ValueError):
         im.filter(box_blur_filter)
 
+
 def test_rankfilter_size_1() -> None:
     im = Image.new("L", (3, 3), 128)
     # Size 1 should not crash (margin is 0)

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1115,6 +1115,9 @@ _expand_image(ImagingObject *self, PyObject *args) {
         return NULL;
     }
 
+    if (m == 0) {
+        return PyImagingNew(ImagingCopy(self->image));
+    }
     return PyImagingNew(ImagingExpand(self->image, m));
 }
 

--- a/src/libImaging/Filter.c
+++ b/src/libImaging/Filter.c
@@ -56,7 +56,7 @@ ImagingExpand(Imaging imIn, int margin) {
     if (margin < 0) {
         return (Imaging)ImagingError_ValueError("bad kernel size");
     }
-    if (margin > INT_MAX / (margin * (int)sizeof(FLOAT32))) {
+    if (margin > 0 && margin > INT_MAX / (margin * (int)sizeof(FLOAT32))) {
         return (Imaging)ImagingError_ValueError("filter size too large");
     }
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * Avoid divide-by-zero crash in image filtering - although a kernel size of 1 is pointless/trivial, but it shouldn't cause the C extension to crash.

Fixes a crash accidentally introduced by the validation logic added in dff01a0821c1f1cc8fa35cee5cc08e86399aac7c.