### PR TITLE
Remove Setuptools obsolete `zip_safe` flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1065,10 +1065,6 @@ class pil_build_ext(build_ext):
         print("")
 
 
-def debug_build() -> bool:
-    return hasattr(sys, "gettotalrefcount") or FUZZING_BUILD
-
-
 libraries: list[tuple[str, _BuildInfo]] = [
     ("pil_imaging_mode", {"sources": ["src/libImaging/Mode.c"]}),
 ]
@@ -1099,7 +1095,6 @@ try:
         cmdclass={"build_ext": pil_build_ext},
         ext_modules=ext_modules,
         libraries=libraries,
-        zip_safe=not (debug_build() or PLATFORM_MINGW),
     )
 except RequiredDependencyException as err:
     msg = f"""


### PR DESCRIPTION
https://setuptools.pypa.io/en/latest/deprecated/zip_safe.html says:

> The `zip_safe` flag is a `setuptools` configuration mainly associated with the `egg` distribution format (which got replaced in the ecosystem by the newer wheel format) and the `easy_install` command (deprecated in `setuptools` v58.3.0).
> 
> It is very unlikely that the values of `zip_safe` will affect modern deployments that use [pip](https://pypi.org/project/pip) for installing packages. Moreover, new users of `setuptools` should not attempt to create egg files using the deprecated `build_egg` command. Therefore, this flag is considered obsolete.

We require `setuptools>=77`:

https://github.com/python-pillow/Pillow/blob/bb1d8e8ab8d29048624d96e3ee53cecf7c13d13d/pyproject.toml#L5