### PR TITLE
Speed up `Image.getextrema()`

### DIFF
--- a/Tests/benchmarks.py
+++ b/Tests/benchmarks.py
@@ -431,6 +431,15 @@ def test_offset(bench: BenchmarkFixture, mode: str, size: tuple[int, int]) -> No
     bench(ImageChops.offset, im, 123, 45)
 
 
+@pytest.mark.benchmark(group="extrema")
+@pytest.mark.parametrize("mode", MODES)
+@pytest.mark.parametrize("size", SIZES, ids=_format_size)
+def test_getextrema(bench: BenchmarkFixture, mode: str, size: tuple[int, int]) -> None:
+    im = make_pillow_image(mode, size)
+    bench.extra_info["label"] = [f"extrema {mode}"]
+    bench(im.getextrema)
+
+
 @pytest.mark.benchmark(group="histogram")
 @pytest.mark.parametrize("mode", MODES)
 @pytest.mark.parametrize("size", SIZES, ids=_format_size)

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1568,8 +1568,6 @@ class Image:
         """
 
         self.load()
-        if self.im.bands > 1:
-            return tuple(self.im.getband(i).getextrema() for i in range(self.im.bands))
         return self.im.getextrema()
 
     def getxmp(self) -> dict[str, Any]:

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1574,8 +1574,6 @@ class Image:
         """
 
         self.load()
-        if self.im.bands > 1:
-            return tuple(self.im.getband(i).getextrema() for i in range(self.im.bands))
         return self.im.getextrema()
 
     def getxmp(self, *, strip_namespaces: bool = True) -> dict[str, Any]:

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -2337,15 +2337,39 @@ _getcolors(ImagingObject *self, PyObject *args) {
 
 static PyObject *
 _getextrema(ImagingObject *self, PyObject *args) {
+    if (self->image->type == IMAGING_TYPE_UINT8 && self->image->bands > 1 &&
+        self->image->bands <= 4) {
+        // Fast per-band extrema for 8-bit multiband images (RGB, RGBA, etc.)
+        UINT8 mb[2 * 4];
+        int bands = self->image->bands;
+        int nb = ImagingGetExtremaMultiband(self->image, mb);
+        if (nb < 0) {
+            return NULL;
+        }
+        PyObject *result = PyTuple_New(bands);
+        if (!result) {
+            return NULL;
+        }
+        for (int b = 0; b < bands; b++) {
+            // nb == 0 for an empty image: report None per band.
+            PyObject *item =
+                nb ? Py_BuildValue("BB", mb[b * 2], mb[b * 2 + 1]) : Py_NewRef(Py_None);
+            if (!item) {
+                Py_DECREF(result);
+                return NULL;
+            }
+            PyTuple_SET_ITEM(result, b, item);
+        }
+        return result;
+    }
+
     union {
         UINT8 u[2];
         INT32 i[2];
         FLOAT32 f[2];
         UINT16 s[2];
     } extrema;
-    int status;
-
-    status = ImagingGetExtrema(self->image, &extrema);
+    int status = ImagingGetExtrema(self->image, &extrema);
     if (status < 0) {
         return NULL;
     }

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -2340,15 +2340,39 @@ _getcolors(ImagingObject *self, PyObject *args) {
 
 static PyObject *
 _getextrema(ImagingObject *self, PyObject *args) {
+    if (self->image->type == IMAGING_TYPE_UINT8 && self->image->bands > 1 &&
+        self->image->bands <= 4) {
+        // Fast per-band extrema for 8-bit multiband images (RGB, RGBA, etc.)
+        UINT8 mb[2 * 4];
+        int bands = self->image->bands;
+        int nb = ImagingGetExtremaMultiband(self->image, mb);
+        if (nb < 0) {
+            return NULL;
+        }
+        PyObject *result = PyTuple_New(bands);
+        if (!result) {
+            return NULL;
+        }
+        for (int b = 0; b < bands; b++) {
+            // nb == 0 for an empty image: report None per band.
+            PyObject *item =
+                nb ? Py_BuildValue("BB", mb[b * 2], mb[b * 2 + 1]) : Py_NewRef(Py_None);
+            if (!item) {
+                Py_DECREF(result);
+                return NULL;
+            }
+            PyTuple_SET_ITEM(result, b, item);
+        }
+        return result;
+    }
+
     union {
         UINT8 u[2];
         INT32 i[2];
         FLOAT32 f[2];
         UINT16 s[2];
     } extrema;
-    int status;
-
-    status = ImagingGetExtrema(self->image, &extrema);
+    int status = ImagingGetExtrema(self->image, &extrema);
     if (status < 0) {
         return NULL;
     }

--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -147,7 +147,7 @@ ImagingGetProjection(Imaging im, UINT8 *xproj, UINT8 *yproj) {
 
 int
 ImagingGetExtrema(Imaging im, void *extrema) {
-    int x, y;
+    int xsize = im->xsize, ysize = im->ysize;
     INT32 imin, imax;
     FLOAT32 fmin, fmax;
 
@@ -156,16 +156,16 @@ ImagingGetExtrema(Imaging im, void *extrema) {
         return -1; /* mismatch */
     }
 
-    if (!im->xsize || !im->ysize) {
+    if (!xsize || !ysize) {
         return 0; /* zero size */
     }
 
     switch (im->type) {
         case IMAGING_TYPE_UINT8:
             imin = imax = im->image8[0][0];
-            for (y = 0; y < im->ysize; y++) {
+            for (int y = 0; y < ysize; y++) {
                 UINT8 *in = im->image8[y];
-                for (x = 0; x < im->xsize; x++) {
+                for (int x = 0; x < xsize; x++) {
                     imin = imin < in[x] ? imin : in[x];
                     imax = imax > in[x] ? imax : in[x];
                 }
@@ -178,9 +178,9 @@ ImagingGetExtrema(Imaging im, void *extrema) {
             break;
         case IMAGING_TYPE_INT32:
             imin = imax = im->image32[0][0];
-            for (y = 0; y < im->ysize; y++) {
+            for (int y = 0; y < ysize; y++) {
                 INT32 *in = im->image32[y];
-                for (x = 0; x < im->xsize; x++) {
+                for (int x = 0; x < xsize; x++) {
                     imin = imin < in[x] ? imin : in[x];
                     imax = imax > in[x] ? imax : in[x];
                 }
@@ -190,9 +190,9 @@ ImagingGetExtrema(Imaging im, void *extrema) {
             break;
         case IMAGING_TYPE_FLOAT32:
             fmin = fmax = ((FLOAT32 *)im->image32[0])[0];
-            for (y = 0; y < im->ysize; y++) {
+            for (int y = 0; y < ysize; y++) {
                 FLOAT32 *in = (FLOAT32 *)im->image32[y];
-                for (x = 0; x < im->xsize; x++) {
+                for (int x = 0; x < xsize; x++) {
                     // Kept as if/else (unlike the integer branches above),
                     // since float min/max isn't vectorisable due to NaN semantics.
                     if (fmin > in[x]) {
@@ -215,8 +215,8 @@ ImagingGetExtrema(Imaging im, void *extrema) {
                 memcpy(&v, pixel, sizeof(v));
 #endif
                 imin = imax = v;
-                for (y = 0; y < im->ysize; y++) {
-                    for (x = 0; x < im->xsize; x++) {
+                for (int y = 0; y < ysize; y++) {
+                    for (int x = 0; x < xsize; x++) {
                         pixel = (UINT8 *)im->image[y] + x * sizeof(v);
 #ifdef WORDS_BIGENDIAN
                         v = pixel[0] + ((UINT16)pixel[1] << 8);

--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -248,6 +248,57 @@ ImagingGetExtrema(Imaging im, void *extrema) {
     return 1; /* ok */
 }
 
+int
+ImagingGetExtremaMultiband(Imaging im, UINT8 extrema[8]) {
+    // Per-band min/max for interleaved 8-bit images (up to 4 bands).
+    // Writes 2 * im->bands bytes to extrema as [min0, max0, min1, max1, ...].
+    // Returns the band count on success, 0 for an empty image, or -1 on error.
+    int bands = im->bands, xsize = im->xsize, ysize = im->ysize;
+    UINT8 vmin[4], vmax[4];
+
+    if (im->type != IMAGING_TYPE_UINT8 || im->image8 || bands < 2 || bands > 4) {
+        // `_getextrema` should have checked these, but best be sure,
+        // in case someone ends up calling this directly.
+        (void)ImagingError_ModeError();
+        return -1;
+    }
+
+    if (!xsize || !ysize) {
+        return 0; /* zero size */
+    }
+
+    UINT8 *restrict in = (UINT8 *)im->image[0];
+    for (int b = 0; b < 4; b++) {
+        vmin[b] = vmax[b] = in[b];
+    }
+
+    for (int y = 0; y < ysize; y++) {
+        UINT8 *restrict in = (UINT8 *)im->image[y];
+        for (int x = 0; x < xsize; x++, in += 4) {
+            for (int b = 0; b < 4; b++) {
+                if (in[b] < vmin[b]) {
+                    vmin[b] = in[b];
+                }
+                if (in[b] > vmax[b]) {
+                    vmax[b] = in[b];
+                }
+            }
+        }
+    }
+
+    // The second band of a two-band image is stored in the fourth byte
+    // (mirrors the special case in ImagingGetBand).
+    if (bands == 2) {
+        vmin[1] = vmin[3];
+        vmax[1] = vmax[3];
+    }
+    for (int b = 0; b < bands; b++) {
+        extrema[b * 2 + 0] = vmin[b];
+        extrema[b * 2 + 1] = vmax[b];
+    }
+    return bands;
+}
+
 /* static ImagingColorItem* getcolors8(Imaging im, int maxcolors, int* size);*/
 static ImagingColorItem *
 getcolors32(Imaging im, int maxcolors, int *size);

--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -166,11 +166,8 @@ ImagingGetExtrema(Imaging im, void *extrema) {
             for (y = 0; y < im->ysize; y++) {
                 UINT8 *in = im->image8[y];
                 for (x = 0; x < im->xsize; x++) {
-                    if (imin > in[x]) {
-                        imin = in[x];
-                    } else if (imax < in[x]) {
-                        imax = in[x];
-                    }
+                    imin = imin < in[x] ? imin : in[x];
+                    imax = imax > in[x] ? imax : in[x];
                 }
                 if (imin == 0 && imax == 255) {
                     break;
@@ -184,11 +181,8 @@ ImagingGetExtrema(Imaging im, void *extrema) {
             for (y = 0; y < im->ysize; y++) {
                 INT32 *in = im->image32[y];
                 for (x = 0; x < im->xsize; x++) {
-                    if (imin > in[x]) {
-                        imin = in[x];
-                    } else if (imax < in[x]) {
-                        imax = in[x];
-                    }
+                    imin = imin < in[x] ? imin : in[x];
+                    imax = imax > in[x] ? imax : in[x];
                 }
             }
             memcpy(extrema, &imin, sizeof(imin));
@@ -199,6 +193,8 @@ ImagingGetExtrema(Imaging im, void *extrema) {
             for (y = 0; y < im->ysize; y++) {
                 FLOAT32 *in = (FLOAT32 *)im->image32[y];
                 for (x = 0; x < im->xsize; x++) {
+                    // Kept as if/else (unlike the integer branches above),
+                    // since float min/max isn't vectorisable due to NaN semantics.
                     if (fmin > in[x]) {
                         fmin = in[x];
                     } else if (fmax < in[x]) {

--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -248,6 +248,53 @@ ImagingGetExtrema(Imaging im, void *extrema) {
     return 1; /* ok */
 }
 
+int
+ImagingGetExtremaMultiband(Imaging im, UINT8 extrema[8]) {
+    // Per-band min/max for interleaved 8-bit images (up to 4 bands).
+    // Writes 2 * im->bands bytes to extrema as [min0, max0, min1, max1, ...].
+    // Returns the band count on success, 0 for an empty image, or -1 on error.
+    int bands = im->bands, xsize = im->xsize, ysize = im->ysize;
+    UINT8 vmin[4], vmax[4];
+
+    if (im->type != IMAGING_TYPE_UINT8 || im->image8 || bands < 2 || bands > 4) {
+        // `_getextrema` should have checked these, but best be sure,
+        // in case someone ends up calling this directly.
+        (void)ImagingError_ModeError();
+        return -1;
+    }
+
+    if (!xsize || !ysize) {
+        return 0; /* zero size */
+    }
+
+    UINT8 *restrict in = (UINT8 *)im->image[0];
+    for (int b = 0; b < 4; b++) {
+        vmin[b] = vmax[b] = in[b];
+    }
+
+    for (int y = 0; y < ysize; y++) {
+        UINT8 *restrict in = (UINT8 *)im->image[y];
+        for (int x = 0; x < xsize; x++, in += 4) {
+            for (int b = 0; b < 4; b++) {
+                vmin[b] = MIN(vmin[b], in[b]);
+                vmax[b] = MAX(vmax[b], in[b]);
+            }
+        }
+    }
+
+    // The second band of a two-band image is stored in the fourth byte
+    // (mirrors the special case in ImagingGetBand).
+    if (bands == 2) {
+        vmin[1] = vmin[3];
+        vmax[1] = vmax[3];
+    }
+    for (int b = 0; b < bands; b++) {
+        extrema[b * 2 + 0] = vmin[b];
+        extrema[b * 2 + 1] = vmax[b];
+    }
+    return bands;
+}
+
 /* static ImagingColorItem* getcolors8(Imaging im, int maxcolors, int* size);*/
 static ImagingColorItem *
 getcolors32(Imaging im, int maxcolors, int *size);

--- a/src/libImaging/Imaging.h
+++ b/src/libImaging/Imaging.h
@@ -354,6 +354,8 @@ ImagingGetColors(Imaging im, int maxcolors, int *colors);
 extern int
 ImagingGetExtrema(Imaging im, void *extrema);
 extern int
+ImagingGetExtremaMultiband(Imaging im, UINT8 extrema[8]);
+extern int
 ImagingGetProjection(Imaging im, UINT8 *xproj, UINT8 *yproj);
 extern ImagingHistogram
 ImagingGetHistogram(Imaging im, Imaging mask, void *extrema);

--- a/src/libImaging/Imaging.h
+++ b/src/libImaging/Imaging.h
@@ -356,6 +356,8 @@ ImagingGetColors(Imaging im, int maxcolors, int *colors);
 extern int
 ImagingGetExtrema(Imaging im, void *extrema);
 extern int
+ImagingGetExtremaMultiband(Imaging im, UINT8 extrema[8]);
+extern int
 ImagingGetProjection(Imaging im, UINT8 *xproj, UINT8 *yproj);
 extern ImagingHistogram
 ImagingGetHistogram(Imaging im, Imaging mask, void *extrema);


### PR DESCRIPTION
Speeds up `getextrema()` -- with _more_ than just hoist and restrict this time, by adding a separate function for the common case of 2-4 band 8bpc images. The single-channel case speeds up pleasantly too by autovectorisation, though. 

```
------------------- benchmark 'extrema': 4 tests, 2 sources --------------------
Name (time in us)                   0001_3a36c3a OPS  0003_796ae94 OPS      ΔOPS
--------------------------------------------------------------------------------
test_getextrema[1024x1024-RGB]            1,790.4542       13,099.6057   +631.6%
test_getextrema[1024x1024-L]              1,410.9957       17,641.2525  +1150.3%
test_getextrema[1024x1024-RGBA]             687.5769       13,102.1316  +1805.6%
test_getextrema[1024x1024-LA]               494.9731       11,851.6516  +2294.4%
--------------------------------------------------------------------------------
```