### PR TITLE
Remove minimumReleaseAge for google/oss-fuzz

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -171,6 +171,11 @@
             "groupName": "github-actions",
             "matchManagers": ["github-actions"],
             "separateMajorMinor": false
+        },
+        {
+            "matchManagers": ["github-actions"],
+            "matchPackageNames": ["google/oss-fuzz"],
+            "minimumReleaseAge": "0 days"
         }
     ]
 }


### PR DESCRIPTION
It is unlikely that there will be a whole week where [google/oss-fuzz](https://github.com/google/oss-fuzz) doesn't receive a new commit, meaning that the [minimum release age](https://github.com/python-pillow/Pillow/blob/31dba2d35897b140d1a71a52c18ffbdbc54b9e58/.github/renovate.json#L9) for Renovate is unlikely to ever pass.

Rather than manually triggering the 'github-actions' item in https://github.com/python-pillow/Pillow/issues/6604 each month, this PR attempts to remove the minimum release age, just for GitHub Actions.