### PR TITLE
If ICO image is smaller than (16, 16), save original size by default

### DIFF
--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -187,6 +187,15 @@ def test_incorrect_size() -> None:
             im.size = (1, 1)
 
 
+def test_save_1x2(tmp_path: Path) -> None:
+    im = Image.new("1", (1, 2))
+    outfile = tmp_path / "temp.ico"
+    im.save(outfile)
+
+    with Image.open(outfile) as reloaded:
+        assert_image_equal(im, reloaded)
+
+
 def test_save_256x256(tmp_path: Path) -> None:
     """Issue #2264 https://github.com/python-pillow/Pillow/issues/2264"""
     # Arrange
@@ -195,9 +204,9 @@ def test_save_256x256(tmp_path: Path) -> None:
 
         # Act
         im.save(outfile)
-    with Image.open(outfile) as im_saved:
+    with Image.open(outfile) as reloaded:
         # Assert
-        assert im_saved.size == (256, 256)
+        assert reloaded.size == (256, 256)
 
 
 def test_only_save_relevant_sizes(tmp_path: Path) -> None:
@@ -211,9 +220,9 @@ def test_only_save_relevant_sizes(tmp_path: Path) -> None:
         # Act
         im.save(outfile)
 
-    with Image.open(outfile) as im_saved:
+    with Image.open(outfile) as reloaded:
         # Assert
-        assert im_saved.info["sizes"] == {(16, 16), (24, 24), (32, 32), (48, 48)}
+        assert reloaded.info["sizes"] == {(16, 16), (24, 24), (32, 32), (48, 48)}
 
 
 def test_save_append_images(tmp_path: Path) -> None:

--- a/Tests/test_file_ico.py
+++ b/Tests/test_file_ico.py
@@ -224,6 +224,11 @@ def test_only_save_relevant_sizes(tmp_path: Path) -> None:
         # Assert
         assert reloaded.info["sizes"] == {(16, 16), (24, 24), (32, 32), (48, 48)}
 
+    im2 = Image.new("1", (1, 1))
+    outfile = tmp_path / "temp.ico"
+    with pytest.raises(ValueError, match="All sizes too large for image"):
+        im2.save(outfile, sizes=[(2, 2)])
+
 
 def test_save_append_images(tmp_path: Path) -> None:
     # append_images should be used for scaled down versions of the image

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -452,8 +452,8 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
 **sizes**
     A list of sizes included in this ico file; these are a 2-tuple,
     ``(width, height)``; Default to ``[(16, 16), (24, 24), (32, 32), (48, 48),
-    (64, 64), (128, 128), (256, 256)]``. Any sizes bigger than the original
-    size or 256 will be ignored.
+    (64, 64), (128, 128), (256, 256)]``, or if it is smaller, only the image size.
+    Any sizes bigger than the original size or 256 will be ignored.
 
 The :py:meth:`~PIL.Image.Image.save` method can take the following keyword arguments:
 

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -93,6 +93,9 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
             frame = provided_im.copy()
             frame.thumbnail(size, Image.Resampling.LANCZOS, reducing_gap=None)
             frames.append(frame)
+    if not frames:
+        msg = "All sizes too large for image"
+        raise ValueError(msg)
     fp.write(o16(len(frames)))  # idCount(2)
     offset = fp.tell() + len(frames) * 16
     for frame in frames:

--- a/src/PIL/IcoImagePlugin.py
+++ b/src/PIL/IcoImagePlugin.py
@@ -57,15 +57,18 @@ _MAGIC = b"\0\0\1\0"
 def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
     fp.write(_MAGIC)  # (2+2)
     bmp = im.encoderinfo.get("bitmap_format") == "bmp"
-    sizes = im.encoderinfo.get(
-        "sizes",
-        [(16, 16), (24, 24), (32, 32), (48, 48), (64, 64), (128, 128), (256, 256)],
-    )
+    if "sizes" in im.encoderinfo:
+        sizes = sorted(set(im.encoderinfo["sizes"]))
+    else:
+        sizes = (
+            [im.size]
+            if min(im.size) < 16
+            else [(d, d) for d in (16, 24, 32, 48, 64, 128, 256)]
+        )
     frames = []
     provided_ims = [im] + im.encoderinfo.get("append_images", [])
-    width, height = im.size
-    for size in sorted(set(sizes)):
-        if size[0] > width or size[1] > height or size[0] > 256 or size[1] > 256:
+    for size in sizes:
+        if size[0] > min(256, im.width) or size[1] > min(256, im.height):
             continue
 
         for provided_im in provided_ims:


### PR DESCRIPTION
Alternative to #9745

https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#ico-saving
> **sizes**
> A list of sizes included in this ico file; these are a 2-tuple, (width, height); Default to [(16, 16), (24, 24), (32, 32), (48, 48), (64, 64), (128, 128), (256, 256)]. Any sizes bigger than the original size or 256 will be ignored.

If all sizes are ignored, then the file is still allowed to be saved at the moment, just without any visual content.

This PR updates the default behaviour to use the image size if it is smaller than (16, 16) in either dimension. If the user explicitly requested 'sizes', then raise a ValueError if all sizes were ignored.