### PR TITLE
Speed up `Image.getbbox()`; fix it for I;16 modes

### DIFF
--- a/Tests/benchmarks.py
+++ b/Tests/benchmarks.py
@@ -87,6 +87,35 @@ def make_pillow_image(
     return im.convert(mode)
 
 
+BBOX_SCENARIOS: dict[str, tuple[float, str] | None] = {
+    "half-centered": (0.5, "center"),
+    "small-centered": (0.1, "center"),
+    "half-corner": (0.5, "corner"),
+    "empty": None,
+}
+
+
+def make_bbox_image(
+    mode: str,
+    size: tuple[int, int],
+    region: tuple[float, str] | None,
+) -> Image.Image:
+    im = Image.new(mode, size, 0)
+    if region is None:
+        return im
+    fraction, placement = region
+    w, h = size
+    bw, bh = max(1, round(w * fraction)), max(1, round(h * fraction))
+    if placement == "center":
+        left, top = (w - bw) // 2, (h - bh) // 2
+    else:
+        left, top = w - bw, h - bh
+    nbands = len(im.getbands())
+    color = (255, 128, 64, 255)[:nbands] if nbands > 1 else 255
+    im.paste(color, (left, top, left + bw - 1, top + bh - 1))
+    return im
+
+
 @pytest.mark.benchmark(group="composition")
 @pytest.mark.parametrize("mode", MODES)
 @pytest.mark.parametrize("size", SIZES, ids=_format_size)
@@ -429,6 +458,21 @@ def test_offset(bench: BenchmarkFixture, mode: str, size: tuple[int, int]) -> No
     im = make_pillow_image(mode, size)
     bench.extra_info["label"] = ["offset"]
     bench(ImageChops.offset, im, 123, 45)
+
+
+@pytest.mark.benchmark(group="bbox")
+@pytest.mark.parametrize("scenario", list(BBOX_SCENARIOS))
+@pytest.mark.parametrize("mode", ["L", "LA", "I;16", "RGB", "RGBA"])
+@pytest.mark.parametrize("size", SIZES, ids=_format_size)
+def test_getbbox(
+    bench: BenchmarkFixture,
+    mode: str,
+    size: tuple[int, int],
+    scenario: str,
+) -> None:
+    im = make_bbox_image(mode, size, BBOX_SCENARIOS[scenario])
+    bench.extra_info["label"] = [scenario]
+    bench(im.getbbox)
 
 
 @pytest.mark.benchmark(group="histogram")

--- a/Tests/test_image_getbbox.py
+++ b/Tests/test_image_getbbox.py
@@ -44,6 +44,28 @@ def test_bbox() -> None:
             check(im, (255, 255))
 
 
+@pytest.mark.parametrize("mode", ("L", "RGB", "RGBA", "I", "F"))
+@pytest.mark.parametrize(
+    "box",
+    (
+        (0, 0, 1, 1),  # single pixel, top-left
+        (99, 0, 100, 1),  # single pixel, top-right
+        (0, 99, 1, 100),  # single pixel, bottom-left
+        (99, 99, 100, 100),  # single pixel, bottom-right
+        (0, 0, 100, 1),  # full top row
+        (0, 99, 100, 100),  # full bottom row
+        (0, 0, 1, 100),  # full left column
+        (99, 0, 100, 100),  # full right column
+        (40, 40, 60, 60),  # centred block
+    ),
+)
+def test_bbox_edges(mode: str, box: tuple[int, int, int, int]) -> None:
+    im = Image.new(mode, (100, 100), 0)
+    bands = Image.getmodebands(mode)
+    im.paste((255,) * bands, box)
+    assert im.getbbox() == box
+
+
 @pytest.mark.parametrize("mode", ("RGBA", "RGBa", "La", "LA", "PA"))
 def test_bbox_alpha_only_false(mode: str) -> None:
     im = Image.new(mode, (100, 100))

--- a/Tests/test_image_getbbox.py
+++ b/Tests/test_image_getbbox.py
@@ -25,9 +25,9 @@ def test_bbox() -> None:
         im.paste(fill_color, (-10, -10, 110, 110))
         assert im.getbbox() == (0, 0, 100, 100)
 
-    # 8-bit mode
-    im = Image.new("L", (100, 100), 0)
-    check(im, 255)
+    for mode in ("1", "L", "I", "P", "I;16", "I;16L", "I;16B"):
+        im = Image.new(mode, (100, 100), 0)
+        check(im, 255)
 
     # 32-bit mode
     im = Image.new("RGB", (100, 100), 0)
@@ -44,7 +44,9 @@ def test_bbox() -> None:
             check(im, (255, 255))
 
 
-@pytest.mark.parametrize("mode", ("L", "RGB", "RGBA", "I", "F"))
+@pytest.mark.parametrize(
+    "mode", ("L", "RGB", "RGBA", "I", "F", "I;16", "I;16L", "I;16B")
+)
 @pytest.mark.parametrize(
     "box",
     (

--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -22,20 +22,21 @@ int
 ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
     /* Get the bounding box for any non-zero data in the image.*/
 
-    int x, y;
+    int xsize = im->xsize, ysize = im->ysize;
     int has_data;
 
     /* Initialize bounding box to max values */
-    bbox[0] = im->xsize;
+    bbox[0] = xsize;
     bbox[1] = -1;
     bbox[2] = bbox[3] = 0;
 
-#define GETBBOX(image, mask)                                 \
+#define GETBBOX(image, mask, type)                           \
     /* first stage: looking for any pixels from top */       \
-    for (y = 0; y < im->ysize; y++) {                        \
+    for (int y = 0; y < ysize; y++) {                        \
         has_data = 0;                                        \
-        for (x = 0; x < im->xsize; x++) {                    \
-            if (im->image[y][x] & mask) {                    \
+        const type *restrict row = im->image[y];             \
+        for (int x = 0; x < xsize; x++) {                    \
+            if (row[x] & mask) {                             \
                 has_data = 1;                                \
                 bbox[0] = x;                                 \
                 bbox[1] = y;                                 \
@@ -51,14 +52,13 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
         return 0; /* no data */                              \
     }                                                        \
     /* second stage: looking for any pixels from bottom */   \
-    for (y = im->ysize - 1; y >= bbox[1]; y--) {             \
+    for (int y = ysize - 1; y >= bbox[1]; y--) {             \
         has_data = 0;                                        \
-        for (x = 0; x < im->xsize; x++) {                    \
-            if (im->image[y][x] & mask) {                    \
+        const type *restrict row = im->image[y];             \
+        for (int x = 0; x < xsize; x++) {                    \
+            if (row[x] & mask) {                             \
                 has_data = 1;                                \
-                if (x < bbox[0]) {                           \
-                    bbox[0] = x;                             \
-                }                                            \
+                bbox[0] = x < bbox[0] ? x : bbox[0];         \
                 bbox[3] = y + 1;                             \
                 break;                                       \
             }                                                \
@@ -68,15 +68,16 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
         }                                                    \
     }                                                        \
     /* third stage: looking for left and right boundaries */ \
-    for (y = bbox[1]; y < bbox[3]; y++) {                    \
-        for (x = 0; x < bbox[0]; x++) {                      \
-            if (im->image[y][x] & mask) {                    \
+    for (int y = bbox[1]; y < bbox[3]; y++) {                \
+        const type *restrict row = im->image[y];             \
+        for (int x = 0; x < bbox[0]; x++) {                  \
+            if (row[x] & mask) {                             \
                 bbox[0] = x;                                 \
                 break;                                       \
             }                                                \
         }                                                    \
-        for (x = im->xsize - 1; x >= bbox[2]; x--) {         \
-            if (im->image[y][x] & mask) {                    \
+        for (int x = xsize - 1; x >= bbox[2]; x--) {         \
+            if (row[x] & mask) {                             \
                 bbox[2] = x + 1;                             \
                 break;                                       \
             }                                                \
@@ -84,7 +85,7 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
     }
 
     if (im->image8) {
-        GETBBOX(image8, 0xff);
+        GETBBOX(image8, 0xff, UINT8);
     } else {
         INT32 mask = 0xffffffff;
         if (im->bands == 3) {
@@ -101,7 +102,7 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
             mask = 0xff000000;
 #endif
         }
-        GETBBOX(image32, mask);
+        GETBBOX(image32, mask, INT32);
     }
 
     return 1; /* ok */

--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -30,62 +30,68 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
     bbox[1] = -1;
     bbox[2] = bbox[3] = 0;
 
-#define GETBBOX(image, mask, type)                           \
-    /* first stage: looking for any pixels from top */       \
-    for (int y = 0; y < ysize; y++) {                        \
-        has_data = 0;                                        \
-        const type *restrict row = im->image[y];             \
-        for (int x = 0; x < xsize; x++) {                    \
-            if (row[x] & mask) {                             \
-                has_data = 1;                                \
-                bbox[0] = x;                                 \
-                bbox[1] = y;                                 \
-                break;                                       \
-            }                                                \
-        }                                                    \
-        if (has_data) {                                      \
-            break;                                           \
-        }                                                    \
-    }                                                        \
-    /* Check that we have a box */                           \
-    if (bbox[1] < 0) {                                       \
-        return 0; /* no data */                              \
-    }                                                        \
-    /* second stage: looking for any pixels from bottom */   \
-    for (int y = ysize - 1; y >= bbox[1]; y--) {             \
-        has_data = 0;                                        \
-        const type *restrict row = im->image[y];             \
-        for (int x = 0; x < xsize; x++) {                    \
-            if (row[x] & mask) {                             \
-                has_data = 1;                                \
-                bbox[0] = x < bbox[0] ? x : bbox[0];         \
-                bbox[3] = y + 1;                             \
-                break;                                       \
-            }                                                \
-        }                                                    \
-        if (has_data) {                                      \
-            break;                                           \
-        }                                                    \
-    }                                                        \
-    /* third stage: looking for left and right boundaries */ \
-    for (int y = bbox[1]; y < bbox[3]; y++) {                \
-        const type *restrict row = im->image[y];             \
-        for (int x = 0; x < bbox[0]; x++) {                  \
-            if (row[x] & mask) {                             \
-                bbox[0] = x;                                 \
-                break;                                       \
-            }                                                \
-        }                                                    \
-        for (int x = xsize - 1; x >= bbox[2]; x--) {         \
-            if (row[x] & mask) {                             \
-                bbox[2] = x + 1;                             \
-                break;                                       \
-            }                                                \
-        }                                                    \
+#define GETBBOX(image, mask, type)                             \
+    /* first stage: looking for any pixels from top */         \
+    for (int y = 0; y < ysize; y++) {                          \
+        has_data = 0;                                          \
+        const type *restrict row = (const type *)im->image[y]; \
+        for (int x = 0; x < xsize; x++) {                      \
+            if (row[x] & mask) {                               \
+                has_data = 1;                                  \
+                bbox[0] = x;                                   \
+                bbox[1] = y;                                   \
+                break;                                         \
+            }                                                  \
+        }                                                      \
+        if (has_data) {                                        \
+            break;                                             \
+        }                                                      \
+    }                                                          \
+    /* Check that we have a box */                             \
+    if (bbox[1] < 0) {                                         \
+        return 0; /* no data */                                \
+    }                                                          \
+    /* second stage: looking for any pixels from bottom */     \
+    for (int y = ysize - 1; y >= bbox[1]; y--) {               \
+        has_data = 0;                                          \
+        const type *restrict row = (const type *)im->image[y]; \
+        for (int x = 0; x < xsize; x++) {                      \
+            if (row[x] & mask) {                               \
+                has_data = 1;                                  \
+                bbox[0] = x < bbox[0] ? x : bbox[0];           \
+                bbox[3] = y + 1;                               \
+                break;                                         \
+            }                                                  \
+        }                                                      \
+        if (has_data) {                                        \
+            break;                                             \
+        }                                                      \
+    }                                                          \
+    /* third stage: looking for left and right boundaries */   \
+    for (int y = bbox[1]; y < bbox[3]; y++) {                  \
+        const type *restrict row = (const type *)im->image[y]; \
+        for (int x = 0; x < bbox[0]; x++) {                    \
+            if (row[x] & mask) {                               \
+                bbox[0] = x;                                   \
+                break;                                         \
+            }                                                  \
+        }                                                      \
+        for (int x = xsize - 1; x >= bbox[2]; x--) {           \
+            if (row[x] & mask) {                               \
+                bbox[2] = x + 1;                               \
+                break;                                         \
+            }                                                  \
+        }                                                      \
     }
 
     if (im->image8) {
-        GETBBOX(image8, 0xff, UINT8);
+        if (isModeI16(im->mode)) {
+            // In I16 modes, image8 is two-byte pixels, so scan as UINT16.
+            // Since we're looking for zeroes, endianness testing is independent.
+            GETBBOX(image8, 0xffff, UINT16);
+        } else {
+            GETBBOX(image8, 0xff, UINT8);
+        }
     } else {
         INT32 mask = 0xffffffff;
         if (im->bands == 3) {

--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -23,7 +23,6 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
     /* Get the bounding box for any non-zero data in the image.*/
 
     int xsize = im->xsize, ysize = im->ysize;
-    int has_data;
 
     /* Initialize bounding box to max values */
     bbox[0] = xsize;
@@ -33,19 +32,23 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
 #define GETBBOX(image, mask, type)                             \
     /* first stage: looking for any pixels from top */         \
     for (int y = 0; y < ysize; y++) {                          \
-        has_data = 0;                                          \
         const type *restrict row = (const type *)im->image[y]; \
+        /* vectorisable OR-reduce of the row */                \
+        type acc = 0;                                          \
+        for (int x = 0; x < xsize; x++) {                      \
+            acc |= row[x] & mask;                              \
+        }                                                      \
+        if (!acc) {                                            \
+            continue;                                          \
+        }                                                      \
         for (int x = 0; x < xsize; x++) {                      \
             if (row[x] & mask) {                               \
-                has_data = 1;                                  \
                 bbox[0] = x;                                   \
                 bbox[1] = y;                                   \
                 break;                                         \
             }                                                  \
         }                                                      \
-        if (has_data) {                                        \
-            break;                                             \
-        }                                                      \
+        break;                                                 \
     }                                                          \
     /* Check that we have a box */                             \
     if (bbox[1] < 0) {                                         \
@@ -53,33 +56,55 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
     }                                                          \
     /* second stage: looking for any pixels from bottom */     \
     for (int y = ysize - 1; y >= bbox[1]; y--) {               \
-        has_data = 0;                                          \
         const type *restrict row = (const type *)im->image[y]; \
+        /* vectorisable OR-reduce of the row */                \
+        type acc = 0;                                          \
+        for (int x = 0; x < xsize; x++) {                      \
+            acc |= row[x] & mask;                              \
+        }                                                      \
+        if (!acc) {                                            \
+            continue;                                          \
+        }                                                      \
         for (int x = 0; x < xsize; x++) {                      \
             if (row[x] & mask) {                               \
-                has_data = 1;                                  \
                 bbox[0] = x < bbox[0] ? x : bbox[0];           \
                 bbox[3] = y + 1;                               \
                 break;                                         \
             }                                                  \
         }                                                      \
-        if (has_data) {                                        \
-            break;                                             \
-        }                                                      \
+        break;                                                 \
     }                                                          \
     /* third stage: looking for left and right boundaries */   \
     for (int y = bbox[1]; y < bbox[3]; y++) {                  \
         const type *restrict row = (const type *)im->image[y]; \
-        for (int x = 0; x < bbox[0]; x++) {                    \
-            if (row[x] & mask) {                               \
-                bbox[0] = x;                                   \
-                break;                                         \
+        if (bbox[0] > 0) {                                     \
+            /* vectorisable OR-reduce of the left margin */    \
+            type acc = 0;                                      \
+            for (int x = 0; x < bbox[0]; x++) {                \
+                acc |= row[x] & mask;                          \
+            }                                                  \
+            if (acc) {                                         \
+                for (int x = 0; x < bbox[0]; x++) {            \
+                    if (row[x] & mask) {                       \
+                        bbox[0] = x;                           \
+                        break;                                 \
+                    }                                          \
+                }                                              \
             }                                                  \
         }                                                      \
-        for (int x = xsize - 1; x >= bbox[2]; x--) {           \
-            if (row[x] & mask) {                               \
-                bbox[2] = x + 1;                               \
-                break;                                         \
+        if (bbox[2] < xsize) {                                 \
+            /* vectorisable OR-reduce of the right margin */   \
+            type acc = 0;                                      \
+            for (int x = bbox[2]; x < xsize; x++) {            \
+                acc |= row[x] & mask;                          \
+            }                                                  \
+            if (acc) {                                         \
+                for (int x = xsize - 1; x >= bbox[2]; x--) {   \
+                    if (row[x] & mask) {                       \
+                        bbox[2] = x + 1;                       \
+                        break;                                 \
+                    }                                          \
+                }                                              \
             }                                                  \
         }                                                      \
     }
@@ -87,7 +112,7 @@ ImagingGetBBox(Imaging im, int bbox[4], int alpha_only) {
     if (im->image8) {
         if (isModeI16(im->mode)) {
             // In I16 modes, image8 is two-byte pixels, so scan as UINT16.
-            // Since we're looking for zeroes, endianness testing is independent.
+            // Since we're looking for zeroes, endianness doesn't matter.
             GETBBOX(image8, 0xffff, UINT16);
         } else {
             GETBBOX(image8, 0xff, UINT8);


### PR DESCRIPTION
Hoist/restrict and autovectorization optimizations for `getbbox()`.

A review also showed that I;16 modes weren't correctly supported by this function (they were iterating over int8), so that got fixed too. I know it's bad form to mix optimizations and bugfixes into one PR, but the bugfix would have required  the `const type* row = ...` hoist assignments anyhow.

```
-------------------------- benchmark 'bbox': 20 tests, 2 sources ---------------------------
Name (time in us)                               0001_40ea9a1 Min  0002_d07694f Min      ΔMin
--------------------------------------------------------------------------------------------
test_getbbox[1024x1024-L-half-corner]                   226.7091           10.9579    -95.2%
test_getbbox[1024x1024-RGB-half-corner]                 229.2499           38.2080    -83.3%
test_getbbox[1024x1024-RGBA-half-corner]                229.3329           40.5840    -82.3%
test_getbbox[1024x1024-LA-half-corner]                  230.6249           38.2080    -83.4%
test_getbbox[1024x1024-I;16-half-centered]              231.0410           21.3749    -90.7%
test_getbbox[1024x1024-L-half-centered]                 240.4579           11.3329    -95.3%
test_getbbox[1024x1024-RGBA-half-centered]              249.7090           44.7499    -82.1%
test_getbbox[1024x1024-LA-half-centered]                249.8330           41.2500    -83.5%
test_getbbox[1024x1024-RGB-half-centered]               251.2090           41.9160    -83.3%
test_getbbox[1024x1024-L-empty]                         295.4580           11.4590    -96.1%
test_getbbox[1024x1024-L-small-centered]                297.5831           12.5830    -95.8%
test_getbbox[1024x1024-LA-empty]                        298.1250           43.9170    -85.3%
test_getbbox[1024x1024-RGB-empty]                       298.1250           47.5419    -84.1%
test_getbbox[1024x1024-RGBA-empty]                      298.1670           47.0839    -84.2%
test_getbbox[1024x1024-I;16-small-centered]             299.1251           24.1250    -91.9%
test_getbbox[1024x1024-I;16-empty]                      300.4170           21.9160    -92.7%
test_getbbox[1024x1024-I;16-half-corner]                301.2920           19.0841    -93.7%
test_getbbox[1024x1024-LA-small-centered]               304.9170           51.2920    -83.2%
test_getbbox[1024x1024-RGB-small-centered]              305.0419           54.7920    -82.0%
test_getbbox[1024x1024-RGBA-small-centered]             305.0419           50.4589    -83.5%
--------------------------------------------------------------------------------------------
```