### PR TITLE
Mark compilation-unit-internal symbols `static`

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -180,10 +180,6 @@ _dealloc(ImagingObject *imagep) {
 #ifdef VERBOSE
     printf("imaging %p deleted\n", imagep);
 #endif
-
-    if (imagep->access) {
-        ImagingAccessDelete(imagep->image, imagep->access);
-    }
     ImagingDelete(imagep->image);
     PyObject_Del(imagep);
 }
@@ -2087,9 +2083,6 @@ im_setmode(ImagingObject *self, PyObject *args) {
         }
     }
 
-    if (self->access) {
-        ImagingAccessDelete(im, self->access);
-    }
     self->access = ImagingAccessNew(im);
 
     Py_RETURN_NONE;

--- a/src/libImaging/Access.c
+++ b/src/libImaging/Access.c
@@ -115,6 +115,3 @@ ImagingAccessNew(const Imaging im) {
     }
     return NULL;
 }
-
-void
-_ImagingAccessDelete(Imaging im, ImagingAccess access) {}

--- a/src/libImaging/Arrow.c
+++ b/src/libImaging/Arrow.c
@@ -60,7 +60,7 @@ ReleaseExportedSchema(struct ArrowSchema *array) {
     array->release = NULL;
 }
 
-char *
+static char *
 image_band_json(Imaging im) {
     char *format = "{\"bands\": [\"%s\", \"%s\", \"%s\", \"%s\"]}";
     char *json;
@@ -89,7 +89,7 @@ image_band_json(Imaging im) {
     return json;
 }
 
-char *
+static char *
 single_band_json(Imaging im) {
     char *format = "{\"bands\": [\"%s\"]}";
     char *json;
@@ -110,7 +110,7 @@ single_band_json(Imaging im) {
     return json;
 }
 
-char *
+static char *
 assemble_metadata(const char *band_json) {
     /* format is
        int32: number of key/value pairs (noted N below)
@@ -153,7 +153,7 @@ assemble_metadata(const char *band_json) {
     return buf;
 }
 
-int
+static int
 export_named_type(struct ArrowSchema *schema, char *format, const char *name) {
     char *formatp;
     char *namep;
@@ -283,7 +283,7 @@ release_const_array(struct ArrowArray *array) {
     array->release = NULL;
 }
 
-int
+static int
 export_single_channel_array(Imaging im, struct ArrowArray *array) {
     int length = im->xsize * im->ysize;
 
@@ -330,7 +330,7 @@ export_single_channel_array(Imaging im, struct ArrowArray *array) {
     return 0;
 }
 
-int
+static int
 export_fixed_pixel_array(Imaging im, struct ArrowArray *array) {
     int length = im->xsize * im->ysize;
 

--- a/src/libImaging/BoxBlur.c
+++ b/src/libImaging/BoxBlur.c
@@ -168,7 +168,7 @@ void static inline ImagingLineBoxBlur8(
 #undef SAVE
 }
 
-Imaging
+static Imaging
 ImagingHorizontalBoxBlur(Imaging imOut, Imaging imIn, float floatRadius) {
     ImagingSectionCookie cookie;
 

--- a/src/libImaging/Draw.c
+++ b/src/libImaging/Draw.c
@@ -667,9 +667,9 @@ typedef struct {
     void (*line)(Imaging im, int x0, int y0, int x1, int y1, int ink);
 } DRAW;
 
-DRAW draw8 = {point8, hline8, line8};
-DRAW draw32 = {point32, hline32, line32};
-DRAW draw32rgba = {point32rgba, hline32rgba, line32rgba};
+static DRAW draw8 = {point8, hline8, line8};
+static DRAW draw32 = {point32, hline32, line32};
+static DRAW draw32rgba = {point32rgba, hline32rgba, line32rgba};
 
 /* -------------------------------------------------------------------- */
 /* Interface                                                            */
@@ -933,7 +933,7 @@ typedef struct {
     int8_t finished;
 } quarter_state;
 
-void
+static void
 quarter_init(quarter_state *s, int32_t a, int32_t b) {
     if (a < 0 || b < 0) {
         s->finished = 1;
@@ -953,12 +953,12 @@ quarter_init(quarter_state *s, int32_t a, int32_t b) {
 
 // deviation of the point from ellipse curve, basically a substitution
 // of the point into the ellipse equation
-int64_t
+static int64_t
 quarter_delta(quarter_state *s, int64_t x, int64_t y) {
     return llabs(s->a2 * y * y + s->b2 * x * x - s->a2b2);
 }
 
-int8_t
+static int8_t
 quarter_next(quarter_state *s, int32_t *ret_x, int32_t *ret_y) {
     if (s->finished) {
         return -1;
@@ -1009,7 +1009,7 @@ typedef struct {
     int8_t leftmost;
 } ellipse_state;
 
-void
+static void
 ellipse_init(ellipse_state *s, int32_t a, int32_t b, int32_t w) {
     s->bufcnt = 0;
     s->leftmost = a % 2;
@@ -1023,7 +1023,7 @@ ellipse_init(ellipse_state *s, int32_t a, int32_t b, int32_t w) {
     }
 }
 
-int8_t
+static int8_t
 ellipse_next(ellipse_state *s, int32_t *ret_x0, int32_t *ret_y, int32_t *ret_x1) {
     if (s->bufcnt == 0) {
         if (s->finished) {
@@ -1106,7 +1106,7 @@ typedef struct event_list {
 } event_list;
 
 // Mirrors all the clipping nodes of the tree relative to the y = x line.
-void
+static void
 clip_tree_transpose(clip_node *root) {
     if (root != NULL) {
         if (root->type == CT_CLIP) {
@@ -1123,7 +1123,7 @@ clip_tree_transpose(clip_node *root) {
 // non-intersecting segments sorted by X coordinate.
 // Combining nodes (AND, OR) may also accept sequences for intersecting
 // segments, i.e. something like correct bracket sequences.
-int
+static int
 clip_tree_do_clip(
     clip_node *root, int32_t x0, int32_t y, int32_t x1, event_list **ret
 ) {
@@ -1267,7 +1267,7 @@ typedef void (*clip_ellipse_init)(
 );
 
 // Resulting angles will satisfy 0 <= al < 360, al <= ar <= al + 360
-void
+static void
 normalize_angles(float *al, float *ar) {
     if (*ar - *al >= 360) {
         *al = 0;
@@ -1279,7 +1279,7 @@ normalize_angles(float *al, float *ar) {
 }
 
 // An arc with caps orthogonal to the ellipse curve.
-void
+static void
 arc_init(clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float ar) {
     if (a < b) {
         // transpose the coordinate system
@@ -1349,7 +1349,7 @@ arc_init(clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float
 }
 
 // A chord line.
-void
+static void
 chord_line_init(
     clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float ar
 ) {
@@ -1377,7 +1377,7 @@ chord_line_init(
 }
 
 // Pie side.
-void
+static void
 pie_side_init(
     clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float _
 ) {
@@ -1422,7 +1422,7 @@ pie_side_init(
 }
 
 // A chord.
-void
+static void
 chord_init(clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float ar) {
     ellipse_init(&s->st, a, b, w);
 
@@ -1441,7 +1441,7 @@ chord_init(clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, flo
 }
 
 // A pie. Can also be used to draw an arc with ugly sharp caps.
-void
+static void
 pie_init(clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float ar) {
     ellipse_init(&s->st, a, b, w);
 
@@ -1485,7 +1485,7 @@ pie_init(clip_ellipse_state *s, int32_t a, int32_t b, int32_t w, float al, float
     }
 }
 
-void
+static void
 clip_ellipse_free(clip_ellipse_state *s) {
     while (s->head != NULL) {
         event_list *t = s->head;
@@ -1494,7 +1494,7 @@ clip_ellipse_free(clip_ellipse_state *s) {
     }
 }
 
-int8_t
+static int8_t
 clip_ellipse_next(
     clip_ellipse_state *s, int32_t *ret_x0, int32_t *ret_y, int32_t *ret_x1
 ) {

--- a/src/libImaging/Draw.c
+++ b/src/libImaging/Draw.c
@@ -1266,31 +1266,6 @@ typedef void (*clip_ellipse_init)(
     clip_ellipse_state *, int32_t, int32_t, int32_t, float, float
 );
 
-void
-debug_clip_tree(clip_node *root, int space) {
-    if (root == NULL) {
-        return;
-    }
-    if (root->type == CT_CLIP) {
-        int t = space;
-        while (t--) {
-            fputc(' ', stderr);
-        }
-        fprintf(stderr, "clip %+fx%+fy%+f > 0\n", root->a, root->b, root->c);
-    } else {
-        debug_clip_tree(root->l, space + 2);
-        int t = space;
-        while (t--) {
-            fputc(' ', stderr);
-        }
-        fprintf(stderr, "%s\n", root->type == CT_AND ? "and" : "or");
-        debug_clip_tree(root->r, space + 2);
-    }
-    if (space == 0) {
-        fputc('\n', stderr);
-    }
-}
-
 // Resulting angles will satisfy 0 <= al < 360, al <= ar <= al + 360
 void
 normalize_angles(float *al, float *ar) {

--- a/src/libImaging/Fill.c
+++ b/src/libImaging/Fill.c
@@ -41,7 +41,6 @@ ImagingFill(Imaging im, const void *colour) {
                     access->put_pixel(im, x, y, colour);
                 }
             }
-            ImagingAccessDelete(im, access);
         } else {
             /* wipe the image */
             for (int y = 0; y < ysize; y++) {

--- a/src/libImaging/Filter.c
+++ b/src/libImaging/Filter.c
@@ -106,6 +106,7 @@ ImagingExpand(Imaging imIn, int margin) {
     return imOut;
 }
 
+// Deliberately not static: looks like GCC inlining this may be slower.
 float
 kernel_i16(int size, UINT8 *in0, int x, const float *kernel, int bigendian) {
     int i;

--- a/src/libImaging/Geometry.c
+++ b/src/libImaging/Geometry.c
@@ -763,7 +763,7 @@ getfilter(Imaging im, int filterid) {
 
 /* transformation engines */
 
-Imaging
+static Imaging
 ImagingGenericTransform(
     Imaging imOut,
     Imaging imIn,
@@ -1006,7 +1006,7 @@ affine_fixed(
     return imOut;
 }
 
-Imaging
+static Imaging
 ImagingTransformAffine(
     Imaging imOut,
     Imaging imIn,

--- a/src/libImaging/Histo.c
+++ b/src/libImaging/Histo.c
@@ -34,7 +34,7 @@ ImagingHistogramDelete(ImagingHistogram h) {
     }
 }
 
-ImagingHistogram
+static ImagingHistogram
 ImagingHistogramNew(Imaging im) {
     ImagingHistogram h;
 

--- a/src/libImaging/Imaging.h
+++ b/src/libImaging/Imaging.h
@@ -226,9 +226,6 @@ ImagingHistogramDelete(ImagingHistogram histogram);
 
 extern ImagingAccess
 ImagingAccessNew(Imaging im);
-extern void
-_ImagingAccessDelete(Imaging im, ImagingAccess access);
-#define ImagingAccessDelete(im, access) /* nop, for now */
 
 extern ImagingPalette
 ImagingPaletteNew(ModeID mode);

--- a/src/libImaging/JpegDecode.c
+++ b/src/libImaging/JpegDecode.c
@@ -95,8 +95,7 @@ skip_input_data(j_decompress_ptr cinfo, long num_bytes) {
     }
 }
 
-GLOBAL(void)
-jpeg_buffer_src(j_decompress_ptr cinfo, JPEGSOURCE *source) {
+static GLOBAL(void) jpeg_buffer_src(j_decompress_ptr cinfo, JPEGSOURCE *source) {
     cinfo->src = (void *)source;
 
     /* Prepare for suspending reader */

--- a/src/libImaging/JpegEncode.c
+++ b/src/libImaging/JpegEncode.c
@@ -47,8 +47,9 @@ empty_output_buffer(j_compress_ptr cinfo) {
     return FALSE;
 }
 
-GLOBAL(void)
-jpeg_buffer_dest(j_compress_ptr cinfo, JPEGDESTINATION *destination) {
+static GLOBAL(void) jpeg_buffer_dest(
+    j_compress_ptr cinfo, JPEGDESTINATION *destination
+) {
     cinfo->dest = (void *)destination;
 
     destination->pub.init_destination = stub;

--- a/src/libImaging/Mode.c
+++ b/src/libImaging/Mode.c
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 #endif
 
-const ModeData MODES[] = {
+static const ModeData MODES[] = {
     [IMAGING_MODE_UNKNOWN] = {""},
 
     [IMAGING_MODE_1] = {"1"},         [IMAGING_MODE_CMYK] = {"CMYK"},
@@ -48,7 +48,7 @@ getModeData(const ModeID id) {
     return &MODES[id];
 }
 
-const RawModeData RAWMODES[] = {
+static const RawModeData RAWMODES[] = {
     [IMAGING_RAWMODE_UNKNOWN] = {""},
 
     [IMAGING_RAWMODE_1] = {"1"},

--- a/src/libImaging/Pack.c
+++ b/src/libImaging/Pack.c
@@ -254,7 +254,7 @@ packLAL(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingPackRGB(UINT8 *out, const UINT8 *in, int pixels) {
     int i = 0;
     /* RGB triplets */
@@ -270,7 +270,7 @@ ImagingPackRGB(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingPackXRGB(UINT8 *out, const UINT8 *in, int pixels) {
     int i;
     /* XRGB, triplets with left padding */
@@ -284,6 +284,7 @@ ImagingPackXRGB(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 
+// Used by Dib.c, hence not static.
 void
 ImagingPackBGR(UINT8 *out, const UINT8 *in, int pixels) {
     int i;
@@ -297,7 +298,7 @@ ImagingPackBGR(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingPackBGRX(UINT8 *out, const UINT8 *in, int pixels) {
     int i;
     /* BGRX, reversed bytes with right padding */
@@ -311,7 +312,7 @@ ImagingPackBGRX(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingPackXBGR(UINT8 *out, const UINT8 *in, int pixels) {
     int i;
     /* XBGR, reversed bytes with left padding */
@@ -325,7 +326,7 @@ ImagingPackXBGR(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingPackCMYK2RGB(UINT8 *out, const UINT8 *in, int xsize) {
     int x, nk, tmp;
     for (x = 0; x < xsize; x++) {
@@ -338,7 +339,7 @@ ImagingPackCMYK2RGB(UINT8 *out, const UINT8 *in, int xsize) {
     }
 }
 
-void
+static void
 ImagingPackBGRA(UINT8 *out, const UINT8 *in, int pixels) {
     int i;
     /* BGRA, reversed bytes with right alpha */
@@ -352,7 +353,7 @@ ImagingPackBGRA(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingPackABGR(UINT8 *out, const UINT8 *in, int pixels) {
     int i;
     /* ABGR, reversed bytes with left alpha */
@@ -366,7 +367,7 @@ ImagingPackABGR(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingPackBGRa(UINT8 *out, const UINT8 *in, int pixels) {
     int i;
     /* BGRa, reversed bytes with premultiplied alpha */
@@ -459,7 +460,7 @@ packI32S(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingPackLAB(UINT8 *out, const UINT8 *in, int pixels) {
     int i;
     /* LAB triplets */

--- a/src/libImaging/QuantHeap.c
+++ b/src/libImaging/QuantHeap.c
@@ -145,6 +145,7 @@ ImagingQuantHeapAdd(Heap *h, void *val) {
     return 1;
 }
 
+// Presently unused
 int
 ImagingQuantHeapTop(Heap *h, void **r) {
     if (!h->heapcount) {

--- a/src/libImaging/QuantOctree.c
+++ b/src/libImaging/QuantOctree.c
@@ -195,7 +195,7 @@ create_sorted_color_palette(const ColorCube cube) {
     return buckets;
 }
 
-void
+static void
 add_bucket_values(ColorBucket src, ColorBucket dst) {
     dst->count += src->count;
     dst->r += src->r;
@@ -281,7 +281,7 @@ copy_color_cube(
     return result;
 }
 
-void
+static void
 subtract_color_buckets(ColorCube cube, ColorBucket buckets, long nBuckets) {
     ColorBucket minuend, subtrahend;
     long i;
@@ -310,13 +310,13 @@ set_lookup_value(const ColorCube cube, const Pixel *p, long value) {
     bucket->count = value;
 }
 
-uint64_t
+static uint64_t
 lookup_color(const ColorCube cube, const Pixel *p) {
     ColorBucket bucket = color_bucket_from_cube(cube, p);
     return bucket->count;
 }
 
-void
+static void
 add_lookup_buckets(ColorCube cube, ColorBucket palette, long nColors, long offset) {
     long i;
     Pixel p;
@@ -326,7 +326,7 @@ add_lookup_buckets(ColorCube cube, ColorBucket palette, long nColors, long offse
     }
 }
 
-ColorBucket
+static ColorBucket
 combined_palette(
     ColorBucket bucketsA,
     unsigned long nBucketsA,
@@ -378,8 +378,8 @@ map_image_pixels(
     }
 }
 
-const unsigned int CUBE_LEVELS[8] = {4, 4, 4, 0, 2, 2, 2, 0};
-const unsigned int CUBE_LEVELS_ALPHA[8] = {3, 4, 3, 3, 2, 2, 2, 2};
+static const unsigned int CUBE_LEVELS[8] = {4, 4, 4, 0, 2, 2, 2, 0};
+static const unsigned int CUBE_LEVELS_ALPHA[8] = {3, 4, 3, 3, 2, 2, 2, 2};
 
 int
 quantize_octree(

--- a/src/libImaging/Reduce.c
+++ b/src/libImaging/Reduce.c
@@ -4,14 +4,14 @@
 
 #define ROUND_UP(f) ((int)((f) >= 0.0 ? (f) + 0.5F : (f) - 0.5F))
 
-UINT32
+static UINT32
 division_UINT32(int divider, int result_bits) {
     UINT32 max_dividend = (1 << result_bits) * divider;
     float max_int = (1 << 30) * 4.0;
     return (UINT32)(max_int / max_dividend);
 }
 
-void
+static void
 ImagingReduceNxN(Imaging imOut, Imaging imIn, int box[4], int xscale, int yscale) {
     /* The most general implementation for any xscale and yscale
      */
@@ -182,7 +182,7 @@ ImagingReduceNxN(Imaging imOut, Imaging imIn, int box[4], int xscale, int yscale
     }
 }
 
-void
+static void
 ImagingReduce1xN(Imaging imOut, Imaging imIn, int box[4], int yscale) {
     /* Optimized implementation for xscale = 1.
      */
@@ -292,7 +292,7 @@ ImagingReduce1xN(Imaging imOut, Imaging imIn, int box[4], int yscale) {
     }
 }
 
-void
+static void
 ImagingReduceNx1(Imaging imOut, Imaging imIn, int box[4], int xscale) {
     /* Optimized implementation for yscale = 1.
      */
@@ -392,7 +392,7 @@ ImagingReduceNx1(Imaging imOut, Imaging imIn, int box[4], int xscale) {
     }
 }
 
-void
+static void
 ImagingReduce1x2(Imaging imOut, Imaging imIn, int box[4]) {
     /* Optimized implementation for xscale = 1 and yscale = 2.
      */
@@ -459,7 +459,7 @@ ImagingReduce1x2(Imaging imOut, Imaging imIn, int box[4]) {
     }
 }
 
-void
+static void
 ImagingReduce2x1(Imaging imOut, Imaging imIn, int box[4]) {
     /* Optimized implementation for xscale = 2 and yscale = 1.
      */
@@ -524,7 +524,7 @@ ImagingReduce2x1(Imaging imOut, Imaging imIn, int box[4]) {
     }
 }
 
-void
+static void
 ImagingReduce2x2(Imaging imOut, Imaging imIn, int box[4]) {
     /* Optimized implementation for xscale = 2 and yscale = 2.
      */
@@ -600,7 +600,7 @@ ImagingReduce2x2(Imaging imOut, Imaging imIn, int box[4]) {
     }
 }
 
-void
+static void
 ImagingReduce1x3(Imaging imOut, Imaging imIn, int box[4]) {
     /* Optimized implementation for xscale = 1 and yscale = 3.
      */
@@ -678,7 +678,7 @@ ImagingReduce1x3(Imaging imOut, Imaging imIn, int box[4]) {
     }
 }
 
-void
+static void
 ImagingReduce3x1(Imaging imOut, Imaging imIn, int box[4]) {
     /* Optimized implementation for xscale = 3 and yscale = 1.
      */
@@ -752,7 +752,7 @@ ImagingReduce3x1(Imaging imOut, Imaging imIn, int box[4]) {
     }
 }
 
-void
+static void
 ImagingReduce3x3(Imaging imOut, Imaging imIn, int box[4]) {
     /* Optimized implementation for xscale = 3 and yscale = 3.
      */
@@ -850,7 +850,7 @@ ImagingReduce3x3(Imaging imOut, Imaging imIn, int box[4]) {
     }
 }
 
-void
+static void
 ImagingReduce4x4(Imaging imOut, Imaging imIn, int box[4]) {
     /* Optimized implementation for xscale = 4 and yscale = 4.
      */
@@ -969,7 +969,7 @@ ImagingReduce4x4(Imaging imOut, Imaging imIn, int box[4]) {
     }
 }
 
-void
+static void
 ImagingReduce5x5(Imaging imOut, Imaging imIn, int box[4]) {
     /* Fast special case for xscale = 5 and yscale = 5.
      */
@@ -1129,7 +1129,7 @@ ImagingReduce5x5(Imaging imOut, Imaging imIn, int box[4]) {
     }
 }
 
-void
+static void
 ImagingReduceCorners(Imaging imOut, Imaging imIn, int box[4], int xscale, int yscale) {
     /* Fill the last row and the last column for any xscale and yscale.
      */
@@ -1270,7 +1270,7 @@ ImagingReduceCorners(Imaging imOut, Imaging imIn, int box[4], int xscale, int ys
     }
 }
 
-void
+static void
 ImagingReduceNxN_32bpc(
     Imaging imOut, Imaging imIn, int box[4], int xscale, int yscale
 ) {
@@ -1344,7 +1344,7 @@ ImagingReduceNxN_32bpc(
     }
 }
 
-void
+static void
 ImagingReduceCorners_32bpc(
     Imaging imOut, Imaging imIn, int box[4], int xscale, int yscale
 ) {

--- a/src/libImaging/Resample.c
+++ b/src/libImaging/Resample.c
@@ -93,7 +93,7 @@ static struct filter LANCZOS = {lanczos_filter, 3.0};
 #define PRECISION_BITS (32 - 8 - 2)
 
 /* Handles values form -640 to 639. */
-UINT8 _clip8_lookups[1280] = {
+static UINT8 _clip8_lookups[1280] = {
     0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
     0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
     0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,

--- a/src/libImaging/Storage.c
+++ b/src/libImaging/Storage.c
@@ -342,7 +342,7 @@ ImagingMemoryClearCache(ImagingMemoryArena arena, int new_size) {
     }
 }
 
-ImagingMemoryBlock
+static ImagingMemoryBlock
 memory_get_block(ImagingMemoryArena arena, int requested_size, int dirty) {
     ImagingMemoryBlock block = {NULL, 0};
 
@@ -379,7 +379,7 @@ memory_get_block(ImagingMemoryArena arena, int requested_size, int dirty) {
     return block;
 }
 
-void
+static void
 memory_return_block(ImagingMemoryArena arena, ImagingMemoryBlock block) {
     if (arena->blocks_cached < arena->blocks_max) {
         // Reduce block size
@@ -413,7 +413,7 @@ ImagingDestroyArray(Imaging im) {
     }
 }
 
-Imaging
+static Imaging
 ImagingAllocateArray(Imaging im, ImagingMemoryArena arena, int dirty, int block_size) {
     int y, line_in_block, current_block;
     ImagingMemoryBlock block = {NULL, 0};
@@ -490,7 +490,7 @@ ImagingDestroyBlock(Imaging im) {
     }
 }
 
-Imaging
+static Imaging
 ImagingAllocateBlock(Imaging im) {
     Py_ssize_t y, i;
 
@@ -536,7 +536,7 @@ ImagingDestroyArrow(Imaging im) {
     }
 }
 
-int
+static int
 ImagingBorrowArrow(
     Imaging im,
     struct ArrowArray *external_array,
@@ -579,7 +579,7 @@ ImagingBorrowArrow(
  * Create a new, internally allocated, image.
  */
 
-Imaging
+static Imaging
 ImagingNewInternal(const ModeID mode, int xsize, int ysize, int dirty) {
     Imaging im;
 

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -36,7 +36,7 @@
 #define fd_to_tiff_fd(fd) ((int)_get_osfhandle(fd))
 #endif
 
-void
+static void
 dump_state(const TIFFSTATE *state) {
     TRACE(
         ("State: Location %u size %d eof %d data: %p ifd: %d\n",
@@ -52,7 +52,7 @@ dump_state(const TIFFSTATE *state) {
   procs for TIFFOpenClient
 */
 
-tsize_t
+static tsize_t
 _tiffReadProc(thandle_t hdata, tdata_t buf, tsize_t size) {
     TIFFSTATE *state = (TIFFSTATE *)hdata;
     tsize_t to_read;
@@ -79,7 +79,7 @@ _tiffReadProc(thandle_t hdata, tdata_t buf, tsize_t size) {
     return to_read;
 }
 
-tsize_t
+static tsize_t
 _tiffWriteProc(thandle_t hdata, tdata_t buf, tsize_t size) {
     TIFFSTATE *state = (TIFFSTATE *)hdata;
     tsize_t to_write;
@@ -120,7 +120,7 @@ _tiffWriteProc(thandle_t hdata, tdata_t buf, tsize_t size) {
     return to_write;
 }
 
-toff_t
+static toff_t
 _tiffSeekProc(thandle_t hdata, toff_t off, int whence) {
     TIFFSTATE *state = (TIFFSTATE *)hdata;
 
@@ -141,7 +141,7 @@ _tiffSeekProc(thandle_t hdata, toff_t off, int whence) {
     return state->loc;
 }
 
-int
+static int
 _tiffCloseProc(thandle_t hdata) {
     TIFFSTATE *state = (TIFFSTATE *)hdata;
 
@@ -151,7 +151,7 @@ _tiffCloseProc(thandle_t hdata) {
     return 0;
 }
 
-toff_t
+static toff_t
 _tiffSizeProc(thandle_t hdata) {
     TIFFSTATE *state = (TIFFSTATE *)hdata;
 
@@ -161,7 +161,7 @@ _tiffSizeProc(thandle_t hdata) {
     return (toff_t)state->size;
 }
 
-int
+static int
 _tiffMapProc(thandle_t hdata, tdata_t *pbase, toff_t *psize) {
     TIFFSTATE *state = (TIFFSTATE *)hdata;
 
@@ -174,7 +174,7 @@ _tiffMapProc(thandle_t hdata, tdata_t *pbase, toff_t *psize) {
     return (1);
 }
 
-int
+static int
 _tiffNullMapProc(thandle_t hdata, tdata_t *pbase, toff_t *psize) {
     (void)hdata;
     (void)pbase;
@@ -182,7 +182,7 @@ _tiffNullMapProc(thandle_t hdata, tdata_t *pbase, toff_t *psize) {
     return (0);
 }
 
-void
+static void
 _tiffUnmapProc(thandle_t hdata, tdata_t base, toff_t size) {
     TRACE(("_tiffUnMapProc\n"));
     (void)hdata;
@@ -224,7 +224,7 @@ ImagingLibTiffInit(ImagingCodecState state, int fp, uint32_t offset) {
     return 1;
 }
 
-int
+static int
 _pickUnpackers(
     Imaging im,
     ImagingCodecState state,
@@ -275,7 +275,7 @@ _pickUnpackers(
     }
 }
 
-int
+static int
 _decodeAsRGBA(Imaging im, ImagingCodecState state, TIFF *tiff) {
     // To avoid dealing with YCbCr subsampling and other complications, let libtiff
     // handle it Use a TIFFRGBAImage wrapping the tiff image, and let libtiff handle all
@@ -387,7 +387,7 @@ decodergba_err:
     return 0;
 }
 
-int
+static int
 _decodeTile(
     Imaging im,
     ImagingCodecState state,
@@ -493,7 +493,7 @@ _decodeTile(
     return 0;
 }
 
-int
+static int
 _decodeStrip(
     Imaging im,
     ImagingCodecState state,

--- a/src/libImaging/Unpack.c
+++ b/src/libImaging/Unpack.c
@@ -581,7 +581,7 @@ unpackP4L(UINT8 *out, const UINT8 *in, int pixels) {
 
 /* Unpack to "RGB" image */
 
-void
+static void
 ImagingUnpackRGB(UINT8 *_out, const UINT8 *in, int pixels) {
     int i = 0;
     /* RGB triplets */
@@ -601,7 +601,7 @@ ImagingUnpackRGB(UINT8 *_out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 unpackRGB16L(UINT8 *_out, const UINT8 *in, int pixels) {
     int i;
     /* 16-bit RGB triplets, little-endian order */
@@ -613,7 +613,7 @@ unpackRGB16L(UINT8 *_out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 unpackRGB16B(UINT8 *_out, const UINT8 *in, int pixels) {
     int i;
     /* 16-bit RGB triplets, big-endian order */
@@ -647,7 +647,7 @@ unpackRGBR(UINT8 *_out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingUnpackBGR(UINT8 *_out, const UINT8 *in, int pixels) {
     int i;
     /* RGB, reversed bytes */
@@ -659,7 +659,7 @@ ImagingUnpackBGR(UINT8 *_out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingUnpackRGB15(UINT8 *out, const UINT8 *in, int pixels) {
     int i, pixel;
     /* RGB, 5 bits per pixel */
@@ -674,7 +674,7 @@ ImagingUnpackRGB15(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingUnpackRGBA15(UINT8 *out, const UINT8 *in, int pixels) {
     int i, pixel;
     /* RGB, 5/5/5/1 bits per pixel */
@@ -689,7 +689,7 @@ ImagingUnpackRGBA15(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingUnpackBGR15(UINT8 *out, const UINT8 *in, int pixels) {
     int i, pixel;
     /* RGB, reversed bytes, 5 bits per pixel */
@@ -704,7 +704,7 @@ ImagingUnpackBGR15(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingUnpackBGRA15(UINT8 *out, const UINT8 *in, int pixels) {
     int i, pixel;
     /* RGB, rearranged channels, 5/5/5/1 bits per pixel */
@@ -719,7 +719,7 @@ ImagingUnpackBGRA15(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingUnpackBGRA15Z(UINT8 *out, const UINT8 *in, int pixels) {
     int i, pixel;
     /* RGB, rearranged channels, 5/5/5/1 bits per pixel, inverted alpha */
@@ -734,7 +734,7 @@ ImagingUnpackBGRA15Z(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingUnpackRGB16(UINT8 *out, const UINT8 *in, int pixels) {
     int i, pixel;
     /* RGB, 5/6/5 bits per pixel */
@@ -749,7 +749,7 @@ ImagingUnpackRGB16(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingUnpackBGR16(UINT8 *out, const UINT8 *in, int pixels) {
     int i, pixel;
     /* RGB, reversed bytes, 5/6/5 bits per pixel */
@@ -764,7 +764,7 @@ ImagingUnpackBGR16(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingUnpackRGB4B(UINT8 *out, const UINT8 *in, int pixels) {
     int i, pixel;
     /* RGB, 4 bits per pixel */
@@ -779,7 +779,7 @@ ImagingUnpackRGB4B(UINT8 *out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 ImagingUnpackRGBA4B(UINT8 *out, const UINT8 *in, int pixels) {
     int i, pixel;
     /* RGBA, 4 bits per pixel */
@@ -1042,7 +1042,7 @@ unpackRGBAL(UINT8 *_out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 unpackRGBA16L(UINT8 *_out, const UINT8 *in, int pixels) {
     int i;
     /* 16-bit RGBA, little-endian order */
@@ -1053,7 +1053,7 @@ unpackRGBA16L(UINT8 *_out, const UINT8 *in, int pixels) {
     }
 }
 
-void
+static void
 unpackRGBA16B(UINT8 *_out, const UINT8 *in, int pixels) {
     int i;
     /* 16-bit RGBA, big-endian order */
@@ -1160,7 +1160,7 @@ unpackCMYKI(UINT8 *_out, const UINT8 *in, int pixels) {
    Since we don't have any signed ints, we're going with the shifted versions
    internally, and we'll unshift for saving and whatnot.
 */
-void
+static void
 ImagingUnpackLAB(UINT8 *out, const UINT8 *in, int pixels) {
     int i;
     /* LAB triplets */


### PR DESCRIPTION
This should allow compilers to better inline those functions.

Along the way, this:

* deletes `ImageAccessDelete` (no-op since [2009](https://github.com/hugovk/pil-svn.effbot.org/commit/4ebf8e71e8c5677de8ded2d88ab48088a0f8b04e))
* deletes `debug_clip_tree` (added in 9a9d3a050a3e579d579c61549618d297a1e837a8, 2020). Since it wasn't used outside of `Draw.c`, it would've been marked `static`, and at that point become entirely dead code. In addition, it would not have compiled in its current form anyway, since `fprintf()` and friends aren't around