### PR TITLE
Add coverage to tox

### DIFF
--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -22,7 +22,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  COVERAGE_CORE: sysmon
   FORCE_COLOR: 1
 
 jobs:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -22,7 +22,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  COVERAGE_CORE: sysmon
   FORCE_COLOR: 1
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  COVERAGE_CORE: sysmon
   FORCE_COLOR: 1
   PIP_DISABLE_PIP_VERSION_CHECK: 1
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
 requires =
-    tox>=4.2
+    tox>=4.32
 env_list =
     lint
     mypy
-    py{py3, 315, 314, 313, 312, 311, 310}
+    py{py3}
+    py{310-315}
+    py{314-315}t
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,11 @@ extras =
 commands =
     {envpython} selftest.py
     {envpython} -m pytest \
+      --cov PIL \
+      --cov Tests \
+      --cov-report html \
+      --cov-report term \
+      --cov-report xml \
       --dist worksteal \
       --numprocesses auto \
       -W always \


### PR DESCRIPTION
Add coverage to tox, now we use the coverage sysmon core where available (3.12+, nearly all supported versions), there's much less difference in the run time: 
  * `tox -e py314`: 31s with, 21s without
  * `tox -e py314`: 40s with, 20s without


Also add `py314t` and `py315t` to tox.

And follow up to https://github.com/python-pillow/Pillow/pull/9771, we can remove the `COVERAGE_CORE: sysmon` env var from GitHub Actions because it's now set at the tool level in `pyproject.toml`.

