### PR TITLE
Open BMP image with black palette in mode 1

### DIFF
--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -76,7 +76,7 @@ def test_empty_palette(tmp_path: Path) -> None:
     im.save(out)
 
     with Image.open(out) as reloaded:
-        assert_image_equal(im.convert("L"), reloaded)
+        assert_image_equal(im.convert("1"), reloaded)
 
 
 def test_save_too_large(tmp_path: Path) -> None:
@@ -212,19 +212,10 @@ def test_rle4() -> None:
         assert_image_similar_tofile(im, "Tests/images/bmp/g/pal4.bmp", 12)
 
 
-def test_rle4_absolute_odd() -> None:
-    # An RLE4 absolute run with an odd number of pixels is packed into
-    # ceil(count / 2) bytes, the final nibble being padding. Build a 3x1
-    # image whose single row is one absolute run of 3 pixels (indices 1, 2, 3).
-    palette = b"\x00" * 4
-    rle = (
-        b"\x00\x03"  # absolute mode, 3 pixels
-        b"\x12\x30"  # nibbles 1, 2, 3 and a padding nibble
-        b"\x00\x01"  # end of bitmap
-    )
+def encode_rle4(width: int, palette: bytes, rle: bytes) -> io.BytesIO:
     header = (
         o32(40)  # header size
-        + o32(3)  # width
+        + o32(width)  # width
         + o32(1)  # height
         + o16(1)  # planes
         + o16(4)  # bits per pixel
@@ -235,7 +226,7 @@ def test_rle4_absolute_odd() -> None:
         + o32(0)  # important colors
     )
     offset = 14 + len(header) + len(palette)
-    data = (
+    return io.BytesIO(
         b"BM"
         + o32(offset + len(rle))  # file size
         + o32(0)  # reserved
@@ -245,7 +236,33 @@ def test_rle4_absolute_odd() -> None:
         + rle
     )
 
-    with Image.open(io.BytesIO(data)) as im:
+
+def test_rle4_black() -> None:
+    rle = (
+        b"\x00\x03"  # absolute mode, 3 pixels
+        b"\x00"  # nibbles 0 and 0
+        b"\x00\x01"  # end of bitmap
+    )
+    b = encode_rle4(2, b"\x00" * 4, rle)
+
+    with Image.open(b) as im:
+        assert im.mode == "1"
+        assert [im.getpixel((x, 0)) for x in range(im.width)] == [0, 0]
+
+
+def test_rle4_absolute_odd() -> None:
+    # An RLE4 absolute run with an odd number of pixels is packed into
+    # ceil(count / 2) bytes, the final nibble being padding. Build a 3x1
+    # image whose single row is one absolute run of 3 pixels (indices 1, 2, 3).
+    palette = b"\x01" * 4
+    rle = (
+        b"\x00\x03"  # absolute mode, 3 pixels
+        b"\x12\x30"  # nibbles 1, 2, 3 and a padding nibble
+        b"\x00\x01"  # end of bitmap
+    )
+    b = encode_rle4(3, palette, rle)
+
+    with Image.open(b) as im:
         assert [im.getpixel((x, 0)) for x in range(im.width)] == [1, 2, 3]
 
 

--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -280,7 +280,7 @@ class BmpImageFile(ImageFile.ImageFile):
 
                 # ------- If all colors are gray, white or black, ditch palette
                 if grayscale:
-                    self._mode = "1" if file_info["colors"] == 2 else "L"
+                    self._mode = "1" if file_info["colors"] <= 2 else "L"
                     raw_mode = self.mode
                 else:
                     self._mode = "P"
@@ -391,7 +391,7 @@ class BmpRleDecoder(ImageFile.PyDecoder):
                     # align to 16-bit word boundary
                     if self.fd.tell() % 2 != 0:
                         self.fd.seek(1, os.SEEK_CUR)
-        rawmode = "L" if self.mode == "L" else "P"
+        rawmode = "L" if self.mode in {"1", "L"} else "P"
         self.set_as_raw(bytes(data), rawmode, (0, self.args[-1]))
         return -1, 0
 

--- a/src/libImaging/Unpack.c
+++ b/src/libImaging/Unpack.c
@@ -1564,6 +1564,7 @@ static struct {
     {IMAGING_MODE_1, IMAGING_RAWMODE_1_R, 1, unpack1R},
     {IMAGING_MODE_1, IMAGING_RAWMODE_1_IR, 1, unpack1IR},
     {IMAGING_MODE_1, IMAGING_RAWMODE_1_8, 8, unpack18},
+    {IMAGING_MODE_1, IMAGING_RAWMODE_L, 8, unpack18},
 
     /* grayscale */
     {IMAGING_MODE_L, IMAGING_RAWMODE_L_2, 2, unpackL2},


### PR DESCRIPTION
Saving a P mode image with only black and white (in that order) and re-opening it
```python
from PIL import Image
im = Image.new("P", (1, 1))
im.putpalette([0, 0, 0, 255, 255, 255])
im.save("out.bmp")

with Image.open("out.bmp") as reloaded:
  print(reloaded.mode)
```
gives an 1 mode image.

This is because of
https://github.com/python-pillow/Pillow/blob/1219c2789fe5bcb66830bd720720f2016bbc8308/src/PIL/BmpImagePlugin.py#L281-L283

However, 1 mode is only applied if there are exactly two colours. This should be two colours or less. Otherwise, removing white actually changes the image to a more complex mode.

```python
from PIL import Image
im = Image.new("P", (1, 1))
im.putpalette([0, 0, 0])
im.save("out.bmp")

with Image.open("out.bmp") as reloaded:
  print(reloaded.mode)
```
currently gives mode L. This PR changes it to mode 1 as well.