### PR TITLE
Remove unused PNG _OUTMODES

### DIFF
--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -1106,9 +1106,6 @@ class PngImageFile(ImageFile.ImageFile):
 _OUTMODES = {
     # supported PIL modes, and corresponding rawmode, bit depth and color type
     "1": ("1", b"\x01", b"\x00"),
-    "L;1": ("L;1", b"\x01", b"\x00"),
-    "L;2": ("L;2", b"\x02", b"\x00"),
-    "L;4": ("L;4", b"\x04", b"\x00"),
     "L": ("L", b"\x08", b"\x00"),
     "LA": ("LA", b"\x08", b"\x04"),
     "I;16": ("I;16B", b"\x10", b"\x00"),


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/767a3f17560fc56f15935090c6cf2e9d478573ff/src/PIL/PngImagePlugin.py#L1106-L1122

L;1, L;2, L;4, P;1, P;2 and P;4 are not valid Pillow modes. The P mode variants are created by

https://github.com/python-pillow/Pillow/blob/767a3f17560fc56f15935090c6cf2e9d478573ff/src/PIL/PngImagePlugin.py#L1360
https://github.com/python-pillow/Pillow/blob/767a3f17560fc56f15935090c6cf2e9d478573ff/src/PIL/PngImagePlugin.py#L1380

but the L mode variants are never used, and can be removed.