### PR TITLE
Apply hoist optimizations to Geometry.c's transforms

### DIFF
--- a/src/libImaging/Geometry.c
+++ b/src/libImaging/Geometry.c
@@ -22,20 +22,23 @@ ImagingFlipLeftRight(Imaging imOut, Imaging imIn) {
     if (!imOut || !imIn || imIn->mode != imOut->mode) {
         return (Imaging)ImagingError_ModeError();
     }
-    if (imIn->xsize != imOut->xsize || imIn->ysize != imOut->ysize) {
+    int in_xsize = imIn->xsize, in_ysize = imIn->ysize;
+    int out_xsize = imOut->xsize, out_ysize = imOut->ysize;
+
+    if (in_xsize != out_xsize || in_ysize != out_ysize) {
         return (Imaging)ImagingError_Mismatch();
     }
 
     ImagingCopyPalette(imOut, imIn);
 
-#define FLIP_LEFT_RIGHT(INT, image)               \
-    for (y = 0; y < imIn->ysize; y++) {           \
-        INT *in = (INT *)imIn->image[y];          \
-        INT *out = (INT *)imOut->image[y];        \
-        xr = imIn->xsize - 1;                     \
-        for (x = 0; x < imIn->xsize; x++, xr--) { \
-            out[xr] = in[x];                      \
-        }                                         \
+#define FLIP_LEFT_RIGHT(INT, image)            \
+    for (y = 0; y < in_ysize; y++) {           \
+        INT *in = (INT *)imIn->image[y];       \
+        INT *out = (INT *)imOut->image[y];     \
+        xr = in_xsize - 1;                     \
+        for (x = 0; x < in_xsize; x++, xr--) { \
+            out[xr] = in[x];                   \
+        }                                      \
     }
 
     ImagingSectionEnter(&cookie);
@@ -65,7 +68,10 @@ ImagingFlipTopBottom(Imaging imOut, Imaging imIn) {
     if (!imOut || !imIn || imIn->mode != imOut->mode) {
         return (Imaging)ImagingError_ModeError();
     }
-    if (imIn->xsize != imOut->xsize || imIn->ysize != imOut->ysize) {
+    int in_xsize = imIn->xsize, in_ysize = imIn->ysize;
+    int out_xsize = imOut->xsize, out_ysize = imOut->ysize;
+
+    if (in_xsize != out_xsize || in_ysize != out_ysize) {
         return (Imaging)ImagingError_Mismatch();
     }
 
@@ -73,8 +79,8 @@ ImagingFlipTopBottom(Imaging imOut, Imaging imIn) {
 
     ImagingSectionEnter(&cookie);
 
-    yr = imIn->ysize - 1;
-    for (y = 0; y < imIn->ysize; y++, yr--) {
+    yr = in_ysize - 1;
+    for (y = 0; y < in_ysize; y++, yr--) {
         memcpy(imOut->image[yr], imIn->image[y], imIn->linesize);
     }
 
@@ -92,36 +98,39 @@ ImagingRotate90(Imaging imOut, Imaging imIn) {
     if (!imOut || !imIn || imIn->mode != imOut->mode) {
         return (Imaging)ImagingError_ModeError();
     }
-    if (imIn->xsize != imOut->ysize || imIn->ysize != imOut->xsize) {
+    int in_xsize = imIn->xsize, in_ysize = imIn->ysize;
+    int out_xsize = imOut->xsize, out_ysize = imOut->ysize;
+
+    if (in_xsize != out_ysize || in_ysize != out_xsize) {
         return (Imaging)ImagingError_Mismatch();
     }
 
     ImagingCopyPalette(imOut, imIn);
 
-#define ROTATE_90(INT, image)                                                         \
-    for (y = 0; y < imIn->ysize; y += ROTATE_CHUNK) {                                 \
-        for (x = 0; x < imIn->xsize; x += ROTATE_CHUNK) {                             \
-            yysize = y + ROTATE_CHUNK < imIn->ysize ? y + ROTATE_CHUNK : imIn->ysize; \
-            xxsize = x + ROTATE_CHUNK < imIn->xsize ? x + ROTATE_CHUNK : imIn->xsize; \
-            for (yy = y; yy < yysize; yy += ROTATE_SMALL_CHUNK) {                     \
-                for (xx = x; xx < xxsize; xx += ROTATE_SMALL_CHUNK) {                 \
-                    yyysize = yy + ROTATE_SMALL_CHUNK < imIn->ysize                   \
-                                  ? yy + ROTATE_SMALL_CHUNK                           \
-                                  : imIn->ysize;                                      \
-                    xxxsize = xx + ROTATE_SMALL_CHUNK < imIn->xsize                   \
-                                  ? xx + ROTATE_SMALL_CHUNK                           \
-                                  : imIn->xsize;                                      \
-                    for (yyy = yy; yyy < yyysize; yyy++) {                            \
-                        INT *in = (INT *)imIn->image[yyy];                            \
-                        xr = imIn->xsize - 1 - xx;                                    \
-                        for (xxx = xx; xxx < xxxsize; xxx++, xr--) {                  \
-                            INT *out = (INT *)imOut->image[xr];                       \
-                            out[yyy] = in[xxx];                                       \
-                        }                                                             \
-                    }                                                                 \
-                }                                                                     \
-            }                                                                         \
-        }                                                                             \
+#define ROTATE_90(INT, image)                                                   \
+    for (y = 0; y < in_ysize; y += ROTATE_CHUNK) {                              \
+        for (x = 0; x < in_xsize; x += ROTATE_CHUNK) {                          \
+            yysize = y + ROTATE_CHUNK < in_ysize ? y + ROTATE_CHUNK : in_ysize; \
+            xxsize = x + ROTATE_CHUNK < in_xsize ? x + ROTATE_CHUNK : in_xsize; \
+            for (yy = y; yy < yysize; yy += ROTATE_SMALL_CHUNK) {               \
+                for (xx = x; xx < xxsize; xx += ROTATE_SMALL_CHUNK) {           \
+                    yyysize = yy + ROTATE_SMALL_CHUNK < in_ysize                \
+                                  ? yy + ROTATE_SMALL_CHUNK                     \
+                                  : in_ysize;                                   \
+                    xxxsize = xx + ROTATE_SMALL_CHUNK < in_xsize                \
+                                  ? xx + ROTATE_SMALL_CHUNK                     \
+                                  : in_xsize;                                   \
+                    for (yyy = yy; yyy < yyysize; yyy++) {                      \
+                        INT *in = (INT *)imIn->image[yyy];                      \
+                        xr = in_xsize - 1 - xx;                                 \
+                        for (xxx = xx; xxx < xxxsize; xxx++, xr--) {            \
+                            INT *out = (INT *)imOut->image[xr];                 \
+                            out[yyy] = in[xxx];                                 \
+                        }                                                       \
+                    }                                                           \
+                }                                                               \
+            }                                                                   \
+        }                                                                       \
     }
 
     ImagingSectionEnter(&cookie);
@@ -152,35 +161,38 @@ ImagingTranspose(Imaging imOut, Imaging imIn) {
     if (!imOut || !imIn || imIn->mode != imOut->mode) {
         return (Imaging)ImagingError_ModeError();
     }
-    if (imIn->xsize != imOut->ysize || imIn->ysize != imOut->xsize) {
+    int in_xsize = imIn->xsize, in_ysize = imIn->ysize;
+    int out_xsize = imOut->xsize, out_ysize = imOut->ysize;
+
+    if (in_xsize != out_ysize || in_ysize != out_xsize) {
         return (Imaging)ImagingError_Mismatch();
     }
 
     ImagingCopyPalette(imOut, imIn);
 
-#define TRANSPOSE(INT, image)                                                         \
-    for (y = 0; y < imIn->ysize; y += ROTATE_CHUNK) {                                 \
-        for (x = 0; x < imIn->xsize; x += ROTATE_CHUNK) {                             \
-            yysize = y + ROTATE_CHUNK < imIn->ysize ? y + ROTATE_CHUNK : imIn->ysize; \
-            xxsize = x + ROTATE_CHUNK < imIn->xsize ? x + ROTATE_CHUNK : imIn->xsize; \
-            for (yy = y; yy < yysize; yy += ROTATE_SMALL_CHUNK) {                     \
-                for (xx = x; xx < xxsize; xx += ROTATE_SMALL_CHUNK) {                 \
-                    yyysize = yy + ROTATE_SMALL_CHUNK < imIn->ysize                   \
-                                  ? yy + ROTATE_SMALL_CHUNK                           \
-                                  : imIn->ysize;                                      \
-                    xxxsize = xx + ROTATE_SMALL_CHUNK < imIn->xsize                   \
-                                  ? xx + ROTATE_SMALL_CHUNK                           \
-                                  : imIn->xsize;                                      \
-                    for (yyy = yy; yyy < yyysize; yyy++) {                            \
-                        INT *in = (INT *)imIn->image[yyy];                            \
-                        for (xxx = xx; xxx < xxxsize; xxx++) {                        \
-                            INT *out = (INT *)imOut->image[xxx];                      \
-                            out[yyy] = in[xxx];                                       \
-                        }                                                             \
-                    }                                                                 \
-                }                                                                     \
-            }                                                                         \
-        }                                                                             \
+#define TRANSPOSE(INT, image)                                                   \
+    for (y = 0; y < in_ysize; y += ROTATE_CHUNK) {                              \
+        for (x = 0; x < in_xsize; x += ROTATE_CHUNK) {                          \
+            yysize = y + ROTATE_CHUNK < in_ysize ? y + ROTATE_CHUNK : in_ysize; \
+            xxsize = x + ROTATE_CHUNK < in_xsize ? x + ROTATE_CHUNK : in_xsize; \
+            for (yy = y; yy < yysize; yy += ROTATE_SMALL_CHUNK) {               \
+                for (xx = x; xx < xxsize; xx += ROTATE_SMALL_CHUNK) {           \
+                    yyysize = yy + ROTATE_SMALL_CHUNK < in_ysize                \
+                                  ? yy + ROTATE_SMALL_CHUNK                     \
+                                  : in_ysize;                                   \
+                    xxxsize = xx + ROTATE_SMALL_CHUNK < in_xsize                \
+                                  ? xx + ROTATE_SMALL_CHUNK                     \
+                                  : in_xsize;                                   \
+                    for (yyy = yy; yyy < yyysize; yyy++) {                      \
+                        INT *in = (INT *)imIn->image[yyy];                      \
+                        for (xxx = xx; xxx < xxxsize; xxx++) {                  \
+                            INT *out = (INT *)imOut->image[xxx];                \
+                            out[yyy] = in[xxx];                                 \
+                        }                                                       \
+                    }                                                           \
+                }                                                               \
+            }                                                                   \
+        }                                                                       \
     }
 
     ImagingSectionEnter(&cookie);
@@ -211,37 +223,40 @@ ImagingTransverse(Imaging imOut, Imaging imIn) {
     if (!imOut || !imIn || imIn->mode != imOut->mode) {
         return (Imaging)ImagingError_ModeError();
     }
-    if (imIn->xsize != imOut->ysize || imIn->ysize != imOut->xsize) {
+    int in_xsize = imIn->xsize, in_ysize = imIn->ysize;
+    int out_xsize = imOut->xsize, out_ysize = imOut->ysize;
+
+    if (in_xsize != out_ysize || in_ysize != out_xsize) {
         return (Imaging)ImagingError_Mismatch();
     }
 
     ImagingCopyPalette(imOut, imIn);
 
-#define TRANSVERSE(INT, image)                                                        \
-    for (y = 0; y < imIn->ysize; y += ROTATE_CHUNK) {                                 \
-        for (x = 0; x < imIn->xsize; x += ROTATE_CHUNK) {                             \
-            yysize = y + ROTATE_CHUNK < imIn->ysize ? y + ROTATE_CHUNK : imIn->ysize; \
-            xxsize = x + ROTATE_CHUNK < imIn->xsize ? x + ROTATE_CHUNK : imIn->xsize; \
-            for (yy = y; yy < yysize; yy += ROTATE_SMALL_CHUNK) {                     \
-                for (xx = x; xx < xxsize; xx += ROTATE_SMALL_CHUNK) {                 \
-                    yyysize = yy + ROTATE_SMALL_CHUNK < imIn->ysize                   \
-                                  ? yy + ROTATE_SMALL_CHUNK                           \
-                                  : imIn->ysize;                                      \
-                    xxxsize = xx + ROTATE_SMALL_CHUNK < imIn->xsize                   \
-                                  ? xx + ROTATE_SMALL_CHUNK                           \
-                                  : imIn->xsize;                                      \
-                    yr = imIn->ysize - 1 - yy;                                        \
-                    for (yyy = yy; yyy < yyysize; yyy++, yr--) {                      \
-                        INT *in = (INT *)imIn->image[yyy];                            \
-                        xr = imIn->xsize - 1 - xx;                                    \
-                        for (xxx = xx; xxx < xxxsize; xxx++, xr--) {                  \
-                            INT *out = (INT *)imOut->image[xr];                       \
-                            out[yr] = in[xxx];                                        \
-                        }                                                             \
-                    }                                                                 \
-                }                                                                     \
-            }                                                                         \
-        }                                                                             \
+#define TRANSVERSE(INT, image)                                                  \
+    for (y = 0; y < in_ysize; y += ROTATE_CHUNK) {                              \
+        for (x = 0; x < in_xsize; x += ROTATE_CHUNK) {                          \
+            yysize = y + ROTATE_CHUNK < in_ysize ? y + ROTATE_CHUNK : in_ysize; \
+            xxsize = x + ROTATE_CHUNK < in_xsize ? x + ROTATE_CHUNK : in_xsize; \
+            for (yy = y; yy < yysize; yy += ROTATE_SMALL_CHUNK) {               \
+                for (xx = x; xx < xxsize; xx += ROTATE_SMALL_CHUNK) {           \
+                    yyysize = yy + ROTATE_SMALL_CHUNK < in_ysize                \
+                                  ? yy + ROTATE_SMALL_CHUNK                     \
+                                  : in_ysize;                                   \
+                    xxxsize = xx + ROTATE_SMALL_CHUNK < in_xsize                \
+                                  ? xx + ROTATE_SMALL_CHUNK                     \
+                                  : in_xsize;                                   \
+                    yr = in_ysize - 1 - yy;                                     \
+                    for (yyy = yy; yyy < yyysize; yyy++, yr--) {                \
+                        INT *in = (INT *)imIn->image[yyy];                      \
+                        xr = in_xsize - 1 - xx;                                 \
+                        for (xxx = xx; xxx < xxxsize; xxx++, xr--) {            \
+                            INT *out = (INT *)imOut->image[xr];                 \
+                            out[yr] = in[xxx];                                  \
+                        }                                                       \
+                    }                                                           \
+                }                                                               \
+            }                                                                   \
+        }                                                                       \
     }
 
     ImagingSectionEnter(&cookie);
@@ -271,25 +286,28 @@ ImagingRotate180(Imaging imOut, Imaging imIn) {
     if (!imOut || !imIn || imIn->mode != imOut->mode) {
         return (Imaging)ImagingError_ModeError();
     }
-    if (imIn->xsize != imOut->xsize || imIn->ysize != imOut->ysize) {
+    int in_xsize = imIn->xsize, in_ysize = imIn->ysize;
+    int out_xsize = imOut->xsize, out_ysize = imOut->ysize;
+
+    if (in_xsize != out_xsize || in_ysize != out_ysize) {
         return (Imaging)ImagingError_Mismatch();
     }
 
     ImagingCopyPalette(imOut, imIn);
 
-#define ROTATE_180(INT, image)                    \
-    for (y = 0; y < imIn->ysize; y++, yr--) {     \
-        INT *in = (INT *)imIn->image[y];          \
-        INT *out = (INT *)imOut->image[yr];       \
-        xr = imIn->xsize - 1;                     \
-        for (x = 0; x < imIn->xsize; x++, xr--) { \
-            out[xr] = in[x];                      \
-        }                                         \
+#define ROTATE_180(INT, image)                 \
+    for (y = 0; y < in_ysize; y++, yr--) {     \
+        INT *in = (INT *)imIn->image[y];       \
+        INT *out = (INT *)imOut->image[yr];    \
+        xr = in_xsize - 1;                     \
+        for (x = 0; x < in_xsize; x++, xr--) { \
+            out[xr] = in[x];                   \
+        }                                      \
     }
 
     ImagingSectionEnter(&cookie);
 
-    yr = imIn->ysize - 1;
+    yr = in_ysize - 1;
     if (imIn->image8) {
         if (isModeI16(imIn->mode)) {
             ROTATE_180(UINT16, image8)
@@ -316,36 +334,39 @@ ImagingRotate270(Imaging imOut, Imaging imIn) {
     if (!imOut || !imIn || imIn->mode != imOut->mode) {
         return (Imaging)ImagingError_ModeError();
     }
-    if (imIn->xsize != imOut->ysize || imIn->ysize != imOut->xsize) {
+    int in_xsize = imIn->xsize, in_ysize = imIn->ysize;
+    int out_xsize = imOut->xsize, out_ysize = imOut->ysize;
+
+    if (in_xsize != out_ysize || in_ysize != out_xsize) {
         return (Imaging)ImagingError_Mismatch();
     }
 
     ImagingCopyPalette(imOut, imIn);
 
-#define ROTATE_270(INT, image)                                                        \
-    for (y = 0; y < imIn->ysize; y += ROTATE_CHUNK) {                                 \
-        for (x = 0; x < imIn->xsize; x += ROTATE_CHUNK) {                             \
-            yysize = y + ROTATE_CHUNK < imIn->ysize ? y + ROTATE_CHUNK : imIn->ysize; \
-            xxsize = x + ROTATE_CHUNK < imIn->xsize ? x + ROTATE_CHUNK : imIn->xsize; \
-            for (yy = y; yy < yysize; yy += ROTATE_SMALL_CHUNK) {                     \
-                for (xx = x; xx < xxsize; xx += ROTATE_SMALL_CHUNK) {                 \
-                    yyysize = yy + ROTATE_SMALL_CHUNK < imIn->ysize                   \
-                                  ? yy + ROTATE_SMALL_CHUNK                           \
-                                  : imIn->ysize;                                      \
-                    xxxsize = xx + ROTATE_SMALL_CHUNK < imIn->xsize                   \
-                                  ? xx + ROTATE_SMALL_CHUNK                           \
-                                  : imIn->xsize;                                      \
-                    yr = imIn->ysize - 1 - yy;                                        \
-                    for (yyy = yy; yyy < yyysize; yyy++, yr--) {                      \
-                        INT *in = (INT *)imIn->image[yyy];                            \
-                        for (xxx = xx; xxx < xxxsize; xxx++) {                        \
-                            INT *out = (INT *)imOut->image[xxx];                      \
-                            out[yr] = in[xxx];                                        \
-                        }                                                             \
-                    }                                                                 \
-                }                                                                     \
-            }                                                                         \
-        }                                                                             \
+#define ROTATE_270(INT, image)                                                  \
+    for (y = 0; y < in_ysize; y += ROTATE_CHUNK) {                              \
+        for (x = 0; x < in_xsize; x += ROTATE_CHUNK) {                          \
+            yysize = y + ROTATE_CHUNK < in_ysize ? y + ROTATE_CHUNK : in_ysize; \
+            xxsize = x + ROTATE_CHUNK < in_xsize ? x + ROTATE_CHUNK : in_xsize; \
+            for (yy = y; yy < yysize; yy += ROTATE_SMALL_CHUNK) {               \
+                for (xx = x; xx < xxsize; xx += ROTATE_SMALL_CHUNK) {           \
+                    yyysize = yy + ROTATE_SMALL_CHUNK < in_ysize                \
+                                  ? yy + ROTATE_SMALL_CHUNK                     \
+                                  : in_ysize;                                   \
+                    xxxsize = xx + ROTATE_SMALL_CHUNK < in_xsize                \
+                                  ? xx + ROTATE_SMALL_CHUNK                     \
+                                  : in_xsize;                                   \
+                    yr = in_ysize - 1 - yy;                                     \
+                    for (yyy = yy; yyy < yyysize; yyy++, yr--) {                \
+                        INT *in = (INT *)imIn->image[yyy];                      \
+                        for (xxx = xx; xxx < xxxsize; xxx++) {                  \
+                            INT *out = (INT *)imOut->image[xxx];                \
+                            out[yr] = in[xxx];                                  \
+                        }                                                       \
+                    }                                                           \
+                }                                                               \
+            }                                                                   \
+        }                                                                       \
     }
 
     ImagingSectionEnter(&cookie);
@@ -474,25 +495,26 @@ nearest_filter32(void *out, Imaging im, double xin, double yin) {
     return 1;
 }
 
-#define XCLIP(im, x) (((x) < 0) ? 0 : ((x) < im->xsize) ? (x) : im->xsize - 1)
-#define YCLIP(im, y) (((y) < 0) ? 0 : ((y) < im->ysize) ? (y) : im->ysize - 1)
+#define XCLIP(im, x) (((x) < 0) ? 0 : ((x) < xsize) ? (x) : xsize - 1)
+#define YCLIP(im, y) (((y) < 0) ? 0 : ((y) < ysize) ? (y) : ysize - 1)
 
 #define BILINEAR(v, a, b, d) (v = (a) + ((b) - (a)) * (d))
 
-#define BILINEAR_HEAD(type)                                               \
-    int x, y;                                                             \
-    int x0, x1;                                                           \
-    double v1, v2;                                                        \
-    double dx, dy;                                                        \
-    type *in;                                                             \
-    if (xin < 0.0 || xin >= im->xsize || yin < 0.0 || yin >= im->ysize) { \
-        return 0;                                                         \
-    }                                                                     \
-    xin -= 0.5;                                                           \
-    yin -= 0.5;                                                           \
-    x = FLOOR(xin);                                                       \
-    y = FLOOR(yin);                                                       \
-    dx = xin - x;                                                         \
+#define BILINEAR_HEAD(type)                                       \
+    int x, y;                                                     \
+    int x0, x1;                                                   \
+    double v1, v2;                                                \
+    double dx, dy;                                                \
+    type *in;                                                     \
+    int xsize = im->xsize, ysize = im->ysize;                     \
+    if (xin < 0.0 || xin >= xsize || yin < 0.0 || yin >= ysize) { \
+        return 0;                                                 \
+    }                                                             \
+    xin -= 0.5;                                                   \
+    yin -= 0.5;                                                   \
+    x = FLOOR(xin);                                               \
+    y = FLOOR(yin);                                               \
+    dx = xin - x;                                                 \
     dy = yin - y;
 
 #define BILINEAR_BODY(type, image, step, offset)       \
@@ -501,7 +523,7 @@ nearest_filter32(void *out, Imaging im, double xin, double yin) {
         x0 = XCLIP(im, x + 0) * step;                  \
         x1 = XCLIP(im, x + 1) * step;                  \
         BILINEAR(v1, in[x0], in[x1], dx);              \
-        if (y + 1 >= 0 && y + 1 < im->ysize) {         \
+        if (y + 1 >= 0 && y + 1 < ysize) {             \
             in = (type *)((image)[y + 1] + offset);    \
             BILINEAR(v2, in[x0], in[x1], dx);          \
         } else {                                       \
@@ -574,23 +596,24 @@ bilinear_filter32RGB(void *out, Imaging im, double xin, double yin) {
         v = p1 + (d) * (p2 + (d) * (p3 + (d) * p4)); \
     }
 
-#define BICUBIC_HEAD(type)                                                \
-    int x = FLOOR(xin);                                                   \
-    int y = FLOOR(yin);                                                   \
-    int x0, x1, x2, x3;                                                   \
-    double v1, v2, v3, v4;                                                \
-    double dx, dy;                                                        \
-    type *in;                                                             \
-    if (xin < 0.0 || xin >= im->xsize || yin < 0.0 || yin >= im->ysize) { \
-        return 0;                                                         \
-    }                                                                     \
-    xin -= 0.5;                                                           \
-    yin -= 0.5;                                                           \
-    x = FLOOR(xin);                                                       \
-    y = FLOOR(yin);                                                       \
-    dx = xin - x;                                                         \
-    dy = yin - y;                                                         \
-    x--;                                                                  \
+#define BICUBIC_HEAD(type)                                        \
+    int x = FLOOR(xin);                                           \
+    int y = FLOOR(yin);                                           \
+    int x0, x1, x2, x3;                                           \
+    double v1, v2, v3, v4;                                        \
+    double dx, dy;                                                \
+    type *in;                                                     \
+    int xsize = im->xsize, ysize = im->ysize;                     \
+    if (xin < 0.0 || xin >= xsize || yin < 0.0 || yin >= ysize) { \
+        return 0;                                                 \
+    }                                                             \
+    xin -= 0.5;                                                   \
+    yin -= 0.5;                                                   \
+    x = FLOOR(xin);                                               \
+    y = FLOOR(yin);                                               \
+    dx = xin - x;                                                 \
+    dy = yin - y;                                                 \
+    x--;                                                          \
     y--;
 
 #define BICUBIC_BODY(type, image, step, offset)              \
@@ -601,19 +624,19 @@ bilinear_filter32RGB(void *out, Imaging im, double xin, double yin) {
         x2 = XCLIP(im, x + 2) * step;                        \
         x3 = XCLIP(im, x + 3) * step;                        \
         BICUBIC(v1, in[x0], in[x1], in[x2], in[x3], dx);     \
-        if (y + 1 >= 0 && y + 1 < im->ysize) {               \
+        if (y + 1 >= 0 && y + 1 < ysize) {                   \
             in = (type *)((image)[y + 1] + offset);          \
             BICUBIC(v2, in[x0], in[x1], in[x2], in[x3], dx); \
         } else {                                             \
             v2 = v1;                                         \
         }                                                    \
-        if (y + 2 >= 0 && y + 2 < im->ysize) {               \
+        if (y + 2 >= 0 && y + 2 < ysize) {                   \
             in = (type *)((image)[y + 2] + offset);          \
             BICUBIC(v3, in[x0], in[x1], in[x2], in[x3], dx); \
         } else {                                             \
             v3 = v2;                                         \
         }                                                    \
-        if (y + 3 >= 0 && y + 3 < im->ysize) {               \
+        if (y + 3 >= 0 && y + 3 < ysize) {                   \
             in = (type *)((image)[y + 3] + offset);          \
             BICUBIC(v4, in[x0], in[x1], in[x2], in[x3], dx); \
         } else {                                             \
@@ -844,6 +867,8 @@ ImagingScaleAffine(
     if (!imOut || !imIn || imIn->mode != imOut->mode) {
         return (Imaging)ImagingError_ModeError();
     }
+    int in_xsize = imIn->xsize, in_ysize = imIn->ysize;
+    int out_xsize = imOut->xsize, out_ysize = imOut->ysize;
 
     ImagingCopyPalette(imOut, imIn);
 
@@ -853,15 +878,15 @@ ImagingScaleAffine(
     if (y0 < 0) {
         y0 = 0;
     }
-    if (x1 > imOut->xsize) {
-        x1 = imOut->xsize;
+    if (x1 > out_xsize) {
+        x1 = out_xsize;
     }
-    if (y1 > imOut->ysize) {
-        y1 = imOut->ysize;
+    if (y1 > out_ysize) {
+        y1 = out_ysize;
     }
 
     /* malloc check ok, uses calloc for overflow */
-    xintab = (int *)calloc(imOut->xsize, sizeof(int));
+    xintab = (int *)calloc(out_xsize, sizeof(int));
     if (!xintab) {
         ImagingDelete(imOut);
         return (Imaging)ImagingError_MemoryError();
@@ -876,7 +901,7 @@ ImagingScaleAffine(
     /* Pretabulate horizontal pixel positions */
     for (x = x0; x < x1; x++) {
         xin = COORD(xo);
-        if (xin >= 0 && xin < (int)imIn->xsize) {
+        if (xin >= 0 && xin < (int)in_xsize) {
             xmax = x + 1;
             if (x < xmin) {
                 xmin = x;
@@ -894,7 +919,7 @@ ImagingScaleAffine(
         if (fill && x1 > x0) {                              \
             memset(out + x0, 0, (x1 - x0) * sizeof(pixel)); \
         }                                                   \
-        if (yi >= 0 && yi < imIn->ysize) {                  \
+        if (yi >= 0 && yi < in_ysize) {                     \
             in = imIn->image[yi];                           \
             for (x = xmin; x < xmax; x++) {                 \
                 out[x] = in[xintab[x]];                     \


### PR DESCRIPTION
Like the other recent optimization PRs: hoist `im*->xsize` and `im*->ysize` into locals so autovectorization can do its thing.