### PR TITLE
Remove duration and timestamp from WebP info after seek

### DIFF
--- a/Tests/test_file_webp_animated.py
+++ b/Tests/test_file_webp_animated.py
@@ -178,6 +178,9 @@ def test_seeking(tmp_path: Path) -> None:
         ts = dur * (im.n_frames - 1)
         for frame in reversed(range(im.n_frames)):
             im.seek(frame)
+            assert "duration" not in im.info
+            assert "timestamp" not in im.info
+
             im.load()
             assert im.info["duration"] == dur
             assert im.info["timestamp"] == ts

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1376,6 +1376,36 @@ WebP
 
 Pillow reads and writes WebP files. Requires libwebp v0.5.0 or later.
 
+Opening
+~~~~~~~
+
+The :py:meth:`~PIL.Image.open` method sets the following
+:py:attr:`~PIL.Image.Image.info` properties:
+
+**background**
+    Background color of the canvas, as an RGBA tuple with values in
+    the range of (0-255).
+
+**loop**
+    The number of times the WEBP should loop. 0 means that it will loop forever.
+
+**icc_profile**
+    May not be present. The ICC color profile for the image.
+
+**exif**
+    May not be present. Raw EXIF data from the image.
+
+**xmp**
+    May not be present. Raw XMP data from the image.
+
+**duration**
+    Only present after the current frame is loaded. The time to display the current
+    frame of the WEBP, in milliseconds.
+
+**timestamp**
+    Only present after the current frame is loaded. The total duration of all previous
+    frames of the WEBP, in milliseconds.
+
 .. _webp-saving:
 
 Saving

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -86,6 +86,8 @@ class WebPImageFile(ImageFile.ImageFile):
     def seek(self, frame: int) -> None:
         if not self._seek_check(frame):
             return
+        self.info.pop("timestamp", None)
+        self.info.pop("duration", None)
 
         # Set logical frame to requested position
         self.__logical_frame = frame


### PR DESCRIPTION
Resolves #9790

As determined in #7311, Pillow doesn't read the duration of a WebP frame until after `load()`. However, it turns out that it keeps it until the next `load()`.

```python
from PIL import Image

im = Image.open("Tests/images/iss634.webp")
im.seek(1)
im.load()
print(im.info.get("duration"))  # The first frame has a duration of 70

im.seek(2)
im.load()
print(im.info.get("duration"))  # The second frame has a duration of 60

# However, imagine if a user did this
im = Image.open("Tests/images/iss634.webp")
im.seek(1)
im.load()
im.seek(2)
print(im.info.get("duration"))  # This is the second frame, but the duration is 70? That appears incorrect.
```

This PR removes duration and timestamp from `info` after `seek()`, so that the old information does not hang around and potentially confuse the user.

If the user only `seek()`s forward by one frame, I'm tempted to keep the timestamp, since it is easily determined from the timestamp and duration of the previous frame - but I think people would probably prefer the consistency of it being cleared after all `seek()`s.