### PR TITLE
Move ImageCmsTransform mode check into C

### DIFF
--- a/src/PIL/ImageCms.py
+++ b/src/PIL/ImageCms.py
@@ -309,15 +309,8 @@ class ImageCmsTransform(Image.ImagePointHandler):
         return self.apply(im)
 
     def apply(self, im: Image.Image, imOut: Image.Image | None = None) -> Image.Image:
-        if im.mode != self.input_mode:
-            msg = "mode mismatch"
-            raise ValueError(msg)
-        if imOut is not None:
-            if imOut.mode != self.output_mode:
-                msg = "mode mismatch"
-                raise ValueError(msg)
-        else:
-            imOut = Image.new(self.output_mode, im.size, None)
+        if imOut is None:
+            imOut = Image.new(self.output_mode, im.size)
         self.transform.apply(im.getim(), imOut.getim())
         imOut.info["icc_profile"] = self.output_profile.tobytes()
         return imOut

--- a/src/_imagingcms.c
+++ b/src/_imagingcms.c
@@ -182,6 +182,8 @@ cms_profile_dealloc(CmsProfileObject *self) {
 
 typedef struct {
     PyObject_HEAD cmsHTRANSFORM transform;
+    ModeID in_mode;
+    ModeID out_mode;
 } CmsTransformObject;
 
 static PyTypeObject CmsTransform_Type;
@@ -189,7 +191,7 @@ static PyTypeObject CmsTransform_Type;
 #define CmsTransform_Check(op) (Py_TYPE(op) == &CmsTransform_Type)
 
 static PyObject *
-cms_transform_new(cmsHTRANSFORM transform) {
+cms_transform_new(cmsHTRANSFORM transform, ModeID in_mode, ModeID out_mode) {
     CmsTransformObject *self;
 
     self = PyObject_New(CmsTransformObject, &CmsTransform_Type);
@@ -198,6 +200,8 @@ cms_transform_new(cmsHTRANSFORM transform) {
     }
 
     self->transform = transform;
+    self->in_mode = in_mode;
+    self->out_mode = out_mode;
 
     return (PyObject *)self;
 }
@@ -475,7 +479,7 @@ buildTransform(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    return cms_transform_new(transform);
+    return cms_transform_new(transform, findModeID(sInMode), findModeID(sOutMode));
 }
 
 static PyObject *
@@ -524,7 +528,7 @@ buildProofTransform(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    return cms_transform_new(transform);
+    return cms_transform_new(transform, findModeID(sInMode), findModeID(sOutMode));
 }
 
 static PyObject *
@@ -549,6 +553,11 @@ cms_transform_apply(CmsTransformObject *self, PyObject *args) {
     }
     imOut = (Imaging)PyCapsule_GetPointer(i1, IMAGING_MAGIC);
     if (!imOut) {
+        return NULL;
+    }
+
+    if (self->in_mode != im->mode || self->out_mode != imOut->mode) {
+        PyErr_SetString(PyExc_ValueError, "mode mismatch");
         return NULL;
     }
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/security/advisories/GHSA-9hw9-ch79-4vh6
> The C extension should also defensively reject mismatched image modes before calling cmsDoTransform().

This PR moves the check from #9715 into C.