### PR TITLE
Rename IMAGING_TYPE_SPECIAL to IMAGING_TYPE_I16

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -565,7 +565,7 @@ getpixel(Imaging im, ImagingAccess access, int x, int y) {
             return PyLong_FromLong(pixel.i);
         case IMAGING_TYPE_FLOAT32:
             return PyFloat_FromDouble(pixel.f);
-        case IMAGING_TYPE_SPECIAL:
+        case IMAGING_TYPE_I16:
             return PyLong_FromLong(pixel.h);
     }
 
@@ -594,7 +594,7 @@ getink(PyObject *color, Imaging im, char *ink) {
         color = PyTuple_GetItem(color, 0);
     }
     if (im->type == IMAGING_TYPE_UINT8 || im->type == IMAGING_TYPE_INT32 ||
-        im->type == IMAGING_TYPE_SPECIAL) {
+        im->type == IMAGING_TYPE_I16) {
         if (PyLong_Check(color)) {
             r = PyLong_AsLongLong(color);
             if (r == -1 && PyErr_Occurred()) {
@@ -682,7 +682,7 @@ getink(PyObject *color, Imaging im, char *ink) {
             ftmp = f;
             memcpy(ink, &ftmp, sizeof(ftmp));
             return ink;
-        case IMAGING_TYPE_SPECIAL:
+        case IMAGING_TYPE_I16:
             ink[0] = (UINT8)r;
             ink[1] = (UINT8)(r >> 8);
             ink[2] = ink[3] = 0;
@@ -1671,7 +1671,7 @@ _putdata(ImagingObject *self, PyObject *args) {
             }
             double value;
             int bigendian = 0;
-            if (image->type == IMAGING_TYPE_SPECIAL) {
+            if (image->type == IMAGING_TYPE_I16) {
                 // I;16*
                 if (
                     image->mode == IMAGING_MODE_I_16B
@@ -1687,7 +1687,7 @@ _putdata(ImagingObject *self, PyObject *args) {
                 if (scale != 1.0 || offset != 0.0) {
                     value = value * scale + offset;
                 }
-                if (image->type == IMAGING_TYPE_SPECIAL) {
+                if (image->type == IMAGING_TYPE_I16) {
                     image->image8[y][x * 2 + (bigendian ? 1 : 0)] =
                         CLIP8((int)value % 256);
                     image->image8[y][x * 2 + (bigendian ? 0 : 1)] =
@@ -2358,7 +2358,7 @@ _getextrema(ImagingObject *self, PyObject *args) {
                 return Py_BuildValue("ii", extrema.i[0], extrema.i[1]);
             case IMAGING_TYPE_FLOAT32:
                 return Py_BuildValue("dd", extrema.f[0], extrema.f[1]);
-            case IMAGING_TYPE_SPECIAL:
+            case IMAGING_TYPE_I16:
                 if (self->image->mode == IMAGING_MODE_I_16) {
                     return Py_BuildValue("HH", extrema.s[0], extrema.s[1]);
                 }

--- a/src/libImaging/Fill.c
+++ b/src/libImaging/Fill.c
@@ -32,7 +32,7 @@ ImagingFill(Imaging im, const void *colour) {
     int xsize = im->xsize;
     int ysize = im->ysize;
 
-    if (im->type == IMAGING_TYPE_SPECIAL) {
+    if (im->type == IMAGING_TYPE_I16) {
         /* use generic API */
         ImagingAccess access = ImagingAccessNew(im);
         if (access) {

--- a/src/libImaging/Filter.c
+++ b/src/libImaging/Filter.c
@@ -470,8 +470,7 @@ ImagingFilter(Imaging im, int xsize, int ysize, const FLOAT32 *kernel, FLOAT32 o
     Imaging imOut;
     ImagingSectionCookie cookie;
 
-    if (im->type == IMAGING_TYPE_FLOAT32 ||
-        (im->type == IMAGING_TYPE_I16 && im->bands != 1)) {
+    if (im->type == IMAGING_TYPE_FLOAT32) {
         return (Imaging)ImagingError_ModeError();
     }
 

--- a/src/libImaging/Filter.c
+++ b/src/libImaging/Filter.c
@@ -156,7 +156,7 @@ ImagingFilter3x3(Imaging imOut, Imaging im, const float *kernel, float offset) {
             }
         } else {
             int bigendian = 0;
-            if (im->type == IMAGING_TYPE_SPECIAL) {
+            if (im->type == IMAGING_TYPE_I16) {
                 if (
                     im->mode == IMAGING_MODE_I_16B
 #ifdef WORDS_BIGENDIAN
@@ -173,12 +173,12 @@ ImagingFilter3x3(Imaging imOut, Imaging im, const float *kernel, float offset) {
                 UINT8 *restrict out = (UINT8 *)imOut->image[y];
 
                 out[0] = in0[0];
-                if (im->type == IMAGING_TYPE_SPECIAL) {
+                if (im->type == IMAGING_TYPE_I16) {
                     out[1] = in0[1];
                 }
                 for (x = 1; x < xsize - 1; x++) {
                     float ss = offset;
-                    if (im->type == IMAGING_TYPE_SPECIAL) {
+                    if (im->type == IMAGING_TYPE_I16) {
                         ss += kernel_i16(3, in1, x, &kernel[0], bigendian);
                         ss += kernel_i16(3, in0, x, &kernel[3], bigendian);
                         ss += kernel_i16(3, in_1, x, &kernel[6], bigendian);
@@ -192,7 +192,7 @@ ImagingFilter3x3(Imaging imOut, Imaging im, const float *kernel, float offset) {
                         out[x] = clip8(ss);
                     }
                 }
-                if (im->type == IMAGING_TYPE_SPECIAL) {
+                if (im->type == IMAGING_TYPE_I16) {
                     out[x * 2] = in0[x * 2];
                     out[x * 2 + 1] = in0[x * 2 + 1];
                 } else {
@@ -316,7 +316,7 @@ ImagingFilter5x5(Imaging imOut, Imaging im, const float *kernel, float offset) {
             }
         } else {
             int bigendian = 0;
-            if (im->type == IMAGING_TYPE_SPECIAL) {
+            if (im->type == IMAGING_TYPE_I16) {
                 if (
                     im->mode == IMAGING_MODE_I_16B
 #ifdef WORDS_BIGENDIAN
@@ -336,13 +336,13 @@ ImagingFilter5x5(Imaging imOut, Imaging im, const float *kernel, float offset) {
 
                 out[0] = in0[0];
                 out[1] = in0[1];
-                if (im->type == IMAGING_TYPE_SPECIAL) {
+                if (im->type == IMAGING_TYPE_I16) {
                     out[2] = in0[2];
                     out[3] = in0[3];
                 }
                 for (x = 2; x < xsize - 2; x++) {
                     float ss = offset;
-                    if (im->type == IMAGING_TYPE_SPECIAL) {
+                    if (im->type == IMAGING_TYPE_I16) {
                         ss += kernel_i16(5, in2, x, &kernel[0], bigendian);
                         ss += kernel_i16(5, in1, x, &kernel[5], bigendian);
                         ss += kernel_i16(5, in0, x, &kernel[10], bigendian);
@@ -360,7 +360,7 @@ ImagingFilter5x5(Imaging imOut, Imaging im, const float *kernel, float offset) {
                         out[x] = clip8(ss);
                     }
                 }
-                if (im->type == IMAGING_TYPE_SPECIAL) {
+                if (im->type == IMAGING_TYPE_I16) {
                     out[x * 2 + 0] = in0[x * 2 + 0];
                     out[x * 2 + 1] = in0[x * 2 + 1];
                     out[x * 2 + 2] = in0[x * 2 + 2];
@@ -471,7 +471,7 @@ ImagingFilter(Imaging im, int xsize, int ysize, const FLOAT32 *kernel, FLOAT32 o
     ImagingSectionCookie cookie;
 
     if (im->type == IMAGING_TYPE_FLOAT32 ||
-        (im->type == IMAGING_TYPE_SPECIAL && im->bands != 1)) {
+        (im->type == IMAGING_TYPE_I16 && im->bands != 1)) {
         return (Imaging)ImagingError_ModeError();
     }
 

--- a/src/libImaging/Geometry.c
+++ b/src/libImaging/Geometry.c
@@ -713,7 +713,7 @@ getfilter(Imaging im, int filterid) {
                 switch (im->type) {
                     case IMAGING_TYPE_UINT8:
                         return nearest_filter8;
-                    case IMAGING_TYPE_SPECIAL:
+                    case IMAGING_TYPE_I16:
                         return nearest_filter16;
                 }
             } else {
@@ -1032,7 +1032,7 @@ ImagingTransformAffine(
         return (Imaging)ImagingError_ModeError();
     }
 
-    if (filterid || imIn->type == IMAGING_TYPE_SPECIAL) {
+    if (filterid || imIn->type == IMAGING_TYPE_I16) {
         return ImagingGenericTransform(
             imOut, imIn, x0, y0, x1, y1, affine_transform, a, filterid, fill
         );

--- a/src/libImaging/GetBBox.c
+++ b/src/libImaging/GetBBox.c
@@ -209,7 +209,7 @@ ImagingGetExtrema(Imaging im, void *extrema) {
             memcpy(extrema, &fmin, sizeof(fmin));
             memcpy(((char *)extrema) + sizeof(fmin), &fmax, sizeof(fmax));
             break;
-        case IMAGING_TYPE_SPECIAL:
+        case IMAGING_TYPE_I16:
             if (im->mode == IMAGING_MODE_I_16) {
                 UINT16 v;
                 UINT8 *pixel = *im->image8;

--- a/src/libImaging/Imaging.h
+++ b/src/libImaging/Imaging.h
@@ -70,7 +70,7 @@ typedef struct ImagingPaletteInstance *ImagingPalette;
 #define IMAGING_TYPE_UINT8 0
 #define IMAGING_TYPE_INT32 1
 #define IMAGING_TYPE_FLOAT32 2
-#define IMAGING_TYPE_SPECIAL 3 /* check mode for details */
+#define IMAGING_TYPE_I16 3
 
 typedef struct {
     char *ptr;

--- a/src/libImaging/Point.c
+++ b/src/libImaging/Point.c
@@ -244,7 +244,7 @@ ImagingPointTransform(Imaging imIn, double scale, double offset) {
             }
             ImagingSectionLeave(&cookie);
             break;
-        case IMAGING_TYPE_SPECIAL:
+        case IMAGING_TYPE_I16:
             if (imIn->mode == IMAGING_MODE_I_16) {
                 ImagingSectionEnter(&cookie);
                 for (y = 0; y < imIn->ysize; y++) {

--- a/src/libImaging/RankFilter.c
+++ b/src/libImaging/RankFilter.c
@@ -64,7 +64,7 @@ MakeRankFunction(UINT8) MakeRankFunction(INT32) MakeRankFunction(FLOAT32)
     int x, y;
     int i, margin, size2;
 
-    if (!im || im->bands != 1 || im->type == IMAGING_TYPE_SPECIAL) {
+    if (!im || im->bands != 1 || im->type == IMAGING_TYPE_I16) {
         return (Imaging)ImagingError_ModeError();
     }
 

--- a/src/libImaging/Reduce.c
+++ b/src/libImaging/Reduce.c
@@ -1456,7 +1456,7 @@ ImagingReduce(Imaging imIn, int xscale, int yscale, int box[4]) {
         return (Imaging)ImagingError_ModeError();
     }
 
-    if (imIn->type == IMAGING_TYPE_SPECIAL) {
+    if (imIn->type == IMAGING_TYPE_I16) {
         return (Imaging)ImagingError_ModeError();
     }
 

--- a/src/libImaging/Reduce.c
+++ b/src/libImaging/Reduce.c
@@ -1452,11 +1452,8 @@ ImagingReduce(Imaging imIn, int xscale, int yscale, int box[4]) {
     ImagingSectionCookie cookie;
     Imaging imOut = NULL;
 
-    if (imIn->mode == IMAGING_MODE_P || imIn->mode == IMAGING_MODE_1) {
-        return (Imaging)ImagingError_ModeError();
-    }
-
-    if (imIn->type == IMAGING_TYPE_I16) {
+    if (imIn->mode == IMAGING_MODE_P || imIn->mode == IMAGING_MODE_1 ||
+        imIn->type == IMAGING_TYPE_I16) {
         return (Imaging)ImagingError_ModeError();
     }
 

--- a/src/libImaging/Resample.c
+++ b/src/libImaging/Resample.c
@@ -718,12 +718,8 @@ ImagingResample(Imaging imIn, int xsize, int ysize, int filter, float box[4]) {
     }
 
     if (imIn->type == IMAGING_TYPE_I16) {
-        if (isModeI16(imIn->mode)) {
-            ResampleHorizontal = _ImagingResampleHorizontal_16bpc;
-            ResampleVertical = _ImagingResampleVertical_16bpc;
-        } else {
-            return (Imaging)ImagingError_ModeError();
-        }
+        ResampleHorizontal = _ImagingResampleHorizontal_16bpc;
+        ResampleVertical = _ImagingResampleVertical_16bpc;
     } else if (imIn->image8) {
         ResampleHorizontal = _ImagingResampleHorizontal_8bpc;
         ResampleVertical = _ImagingResampleVertical_8bpc;

--- a/src/libImaging/Resample.c
+++ b/src/libImaging/Resample.c
@@ -717,7 +717,7 @@ ImagingResample(Imaging imIn, int xsize, int ysize, int filter, float box[4]) {
         return (Imaging)ImagingError_ModeError();
     }
 
-    if (imIn->type == IMAGING_TYPE_SPECIAL) {
+    if (imIn->type == IMAGING_TYPE_I16) {
         if (isModeI16(imIn->mode)) {
             ResampleHorizontal = _ImagingResampleHorizontal_16bpc;
             ResampleVertical = _ImagingResampleVertical_16bpc;

--- a/src/libImaging/Storage.c
+++ b/src/libImaging/Storage.c
@@ -127,7 +127,7 @@ ImagingNewPrologueSubtype(const ModeID mode, int xsize, int ysize, int size) {
         /* 16-bit raw integer images */
         im->bands = 1;
         im->pixelsize = 2;
-        im->type = IMAGING_TYPE_SPECIAL;
+        im->type = IMAGING_TYPE_I16;
         strcpy(im->arrow_band_format, "s");
         strcpy(im->band_names[0], "I");
 


### PR DESCRIPTION
Since #9053 removed BGR;15, BGR;16 and BGR;24, the only IMAGING_TYPE_SPECIAL modes left are I;16 modes.
https://github.com/python-pillow/Pillow/blob/9cd07435967e22b56f2eeab0ed35c1d324f9e488/src/libImaging/Storage.c#L125-L130

Perhaps it would be clearer to rename IMAGING_TYPE_SPECIAL to IMAGING_TYPE_I16?