### PR TITLE
Correct background color when using P mode images with ImageOps.pad()

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -256,6 +256,24 @@ def test_expand_palette(border: int | tuple[int, int, int, int]) -> None:
         assert_image_equal(im_cropped, im)
 
 
+def test_pad_palette() -> None:
+    with Image.open("Tests/images/p_16.tga") as im:
+        im_padded = ImageOps.pad(im, (im.width * 2, im.height), color=(255, 0, 0))
+
+        px = im_padded.convert("RGB").load()
+        assert px is not None
+        # The source is centred, so the outer quarters are padding.
+        for y in range(im_padded.height):
+            for x in range(im.width // 2):
+                assert px[x, y] == (255, 0, 0)
+                assert px[im_padded.width - 1 - x, y] == (255, 0, 0)
+
+        im_cropped = im_padded.crop(
+            (im.width // 2, 0, im.width // 2 + im.width, im.height)
+        )
+        assert_image_equal(im_cropped, im)
+
+
 @pytest.mark.parametrize("border", ((1,), (1, 2, 3), (1, 2, 3, 4, 5)))
 def test_expand_invalid_border(border: tuple[int, ...]) -> None:
     im = Image.new("1", (1, 1))

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -171,6 +171,23 @@ def test_pad_round() -> None:
     assert new_im.getpixel((0, 2)) == 1
 
 
+def test_pad_palette() -> None:
+    with Image.open("Tests/images/p_16.tga") as im:
+        im_padded = ImageOps.pad(im, (im.width * 2, im.height), color=(255, 0, 0))
+        im_rgb = im_padded.convert("RGB")
+
+        # Verify that the left and right sides are now red
+        px = im_rgb.load()
+        assert px is not None
+        for y in range(im_rgb.height):
+            for x in range(im.width // 2):
+                assert px[x, y] == (255, 0, 0)
+                assert px[im_rgb.width - 1 - x, y] == (255, 0, 0)
+
+        im_cropped = im_rgb.crop((im.width * 0.5, 0, im.width * 1.5, im.height))
+        assert_image_equal(im_cropped, im.convert("RGB"))
+
+
 @pytest.mark.parametrize("mode", ("P", "PA"))
 def test_palette(mode: str) -> None:
     im = hopper(mode)
@@ -252,24 +269,6 @@ def test_expand_palette(border: int | tuple[int, int, int, int]) -> None:
 
         im_cropped = im_expanded.crop(
             (left, top, im_expanded.width - right, im_expanded.height - bottom)
-        )
-        assert_image_equal(im_cropped, im)
-
-
-def test_pad_palette() -> None:
-    with Image.open("Tests/images/p_16.tga") as im:
-        im_padded = ImageOps.pad(im, (im.width * 2, im.height), color=(255, 0, 0))
-
-        px = im_padded.convert("RGB").load()
-        assert px is not None
-        # The source is centred, so the outer quarters are padding.
-        for y in range(im_padded.height):
-            for x in range(im.width // 2):
-                assert px[x, y] == (255, 0, 0)
-                assert px[im_padded.width - 1 - x, y] == (255, 0, 0)
-
-        im_cropped = im_padded.crop(
-            (im.width // 2, 0, im.width // 2 + im.width, im.height)
         )
         assert_image_equal(im_cropped, im)
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -44,7 +44,9 @@ def _border(border: int | tuple[int, ...]) -> tuple[int, int, int, int]:
     return left, top, right, bottom
 
 
-def _color(color: str | int | tuple[int, ...], mode: str) -> int | tuple[int, ...]:
+def _color(
+    color: str | int | tuple[int, ...] | None, mode: str
+) -> int | tuple[int, ...] | None:
     if isinstance(color, str):
         from . import ImageColor
 
@@ -331,6 +333,23 @@ def cover(
     return image.resize(size, resample=method)
 
 
+def _new_with_fill(
+    image: Image.Image, size: tuple[int, int], fill: str | int | tuple[int, ...] | None
+) -> Image.Image:
+    color = _color(fill, image.mode)
+    if image.palette:
+        mode = image.palette.mode
+        palette = ImagePalette.ImagePalette(mode, image.getpalette(mode))
+        if isinstance(color, tuple) and len(color) in (3, 4):
+            color = palette.getcolor(color)
+    else:
+        palette = None
+    out = Image.new(image.mode, size, color)
+    if palette:
+        out.putpalette(palette.palette, mode)
+    return out
+
+
 def pad(
     image: Image.Image,
     size: tuple[int, int],
@@ -363,21 +382,7 @@ def pad(
     if resized.size == size:
         out = resized
     else:
-        if resized.palette:
-            # Resolve the fill against the source palette before allocating, as
-            # expand() does. Image.new() would put it in a fresh palette, and
-            # putpalette() below then replaces that palette under the pixels.
-            palette_mode = resized.palette.mode
-            palette = ImagePalette.ImagePalette(
-                palette_mode, resized.getpalette(palette_mode)
-            )
-            index = _color(color, image.mode)
-            if isinstance(index, tuple) and len(index) in (3, 4):
-                index = palette.getcolor(index)
-            out = Image.new(image.mode, size, index)
-            out.putpalette(palette.palette, palette_mode)
-        else:
-            out = Image.new(image.mode, size, color)
+        out = _new_with_fill(resized, size, color)
         if resized.width != size[0]:
             x = round((size[0] - resized.width) * max(0, min(centering[0], 1)))
             out.paste(resized, (x, 0))
@@ -510,17 +515,7 @@ def expand(
     left, top, right, bottom = _border(border)
     width = left + image.size[0] + right
     height = top + image.size[1] + bottom
-    color = _color(fill, image.mode)
-    if image.palette:
-        mode = image.palette.mode
-        palette = ImagePalette.ImagePalette(mode, image.getpalette(mode))
-        if isinstance(color, tuple) and (len(color) == 3 or len(color) == 4):
-            color = palette.getcolor(color)
-    else:
-        palette = None
-    out = Image.new(image.mode, (width, height), color)
-    if palette:
-        out.putpalette(palette.palette, mode)
+    out = _new_with_fill(image, (width, height), fill)
     out.paste(image, (left, top))
     return out
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -363,11 +363,21 @@ def pad(
     if resized.size == size:
         out = resized
     else:
-        out = Image.new(image.mode, size, color)
         if resized.palette:
-            palette = resized.getpalette()
-            if palette is not None:
-                out.putpalette(palette)
+            # Resolve the fill against the source palette before allocating, as
+            # expand() does. Image.new() would put it in a fresh palette, and
+            # putpalette() below then replaces that palette under the pixels.
+            palette_mode = resized.palette.mode
+            palette = ImagePalette.ImagePalette(
+                palette_mode, resized.getpalette(palette_mode)
+            )
+            index = _color(color, image.mode)
+            if isinstance(index, tuple) and len(index) in (3, 4):
+                index = palette.getcolor(index)
+            out = Image.new(image.mode, size, index)
+            out.putpalette(palette.palette, palette_mode)
+        else:
+            out = Image.new(image.mode, size, color)
         if resized.width != size[0]:
             x = round((size[0] - resized.width) * max(0, min(centering[0], 1)))
             out.paste(resized, (x, 0))


### PR DESCRIPTION
> **AI disclosure:** this contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the bug, ran the repro, wrote the test, and wrote this description; the human operator of this account did not hand-review the diff or run the tests. Everything below is real and re-runnable from the diff — it was just done by the AI, not a person. Please review it as unsupervised AI output, and tell me if that's not something you want here.

Fixes # . (no existing issue — found while reading `ImageOps`; closely related to #6595)

Changes proposed in this pull request:

 * `ImageOps.pad()` silently ignores `color` on `P` images — it paints the padding with the source palette's colour 0 instead. `Image.new(image.mode, size, color)` allocates the colour into a *fresh* palette at index 0, and the `putpalette()` immediately after swaps the palette out from under those pixels. `expand()` already resolves the fill into the source palette with `palette.getcolor()` first; `pad()` now does the same.
 * Adds `test_pad_palette`, mirroring the existing `test_expand_palette` and using the same `p_16.tga` fixture.

```python
im = Image.new("P", (4, 4), 0)
im.putpalette([0, 128, 0,  0, 0, 255])   # 0=green, 1=blue
im.paste(1, (0, 0, 4, 4))

ImageOps.pad(im, (8, 4), color="red").convert("RGB").getpixel((0, 0))
# -> (0, 128, 0)   green, i.e. palette index 0
# expected (255, 0, 0)
```

Controls, so it's clear this is the palette path and not `pad` generally: `ImageOps.expand(im, 2, fill="red")` gives `(255, 0, 0)`, and `pad` on an RGB image gives `(255, 0, 0)`. Only `pad` + `P` is wrong.

This is the other half of #6596. That PR fixed `pad()` not copying the palette (#6595 — "returns an image that is displayed as completely black"); adding the `putpalette()` call is what made the colour resolution wrong, so the fix and the regression arrived together. Fittingly, the new test fails on `main` with `assert (0, 0, 0) == (255, 0, 0)` — still black.

The existing `test_palette` does call `pad` on `P`, but with the default `color=None` and it only asserts the pasted region (`crop((0, 0, 128, 128))`), never the padding — so the test asymmetry mirrors the code asymmetry: `test_expand_palette` exists, `test_pad_palette` didn't.

Verified red→green; `Tests/test_imageops.py Tests/test_imagepalette.py Tests/test_imagecolor.py Tests/test_image.py` → 245 passed, 3 skipped (webp unavailable in my env, unrelated). `ruff check` / `ruff format --check` clean. No reformatting mixed in.
