### PR TITLE
Remove test support for NumPy < 1.23

### DIFF
--- a/Tests/test_image_array.py
+++ b/Tests/test_image_array.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-from packaging.version import parse as parse_version
 
 from PIL import Image
 
@@ -44,12 +43,8 @@ def test_toarray() -> None:
     test_with_dtype(numpy.uint8)
 
     with Image.open("Tests/images/truncated_jpeg.jpg") as im_truncated:
-        if parse_version(numpy.__version__) >= parse_version("1.23"):
-            with pytest.raises(OSError):
-                numpy.array(im_truncated)
-        else:
-            with pytest.warns(DeprecationWarning, match="__array_interface__"):
-                numpy.array(im_truncated)
+        with pytest.raises(OSError):
+            numpy.array(im_truncated)
 
 
 def test_fromarray() -> None:


### PR DESCRIPTION
#8326 caught a deprecation warning from NumPy < 1.23, reporting when an exception occurred within `__array_interface__` but was not raised.
>   /Pillow/Tests/test_image_array.py:51: DeprecationWarning: An exception was ignored while fetching the attribute `__array_interface__` from an object of type 'JpegImageFile'.  With the exception of `AttributeError` NumPy will always raise this exception in the future.  Raise this deprecation warning to see the original exception. (Warning added NumPy 1.21)

Those versions of NumPy are no longer [active](https://endoflife.date/numpy) though, so the warning no longer needs to be caught, leaving just the test for the actual exception.