### PR TITLE
Derive PCX band count from the image, not the line width

### DIFF
--- a/Tests/test_file_pcx.py
+++ b/Tests/test_file_pcx.py
@@ -118,6 +118,14 @@ def test_1px_width(tmp_path: Path) -> None:
     _roundtrip(tmp_path, im)
 
 
+def test_rgb_odd_width(tmp_path: Path) -> None:
+    # An RGB (multi-plane) width whose even-padded stride differs from the
+    # width must still separate the colour planes correctly. Distinct channel
+    # values expose a misaligned split.
+    im = Image.new("RGB", (3, 3), (0x11, 0x22, 0x33))
+    _roundtrip(tmp_path, im)
+
+
 def test_large_count(tmp_path: Path) -> None:
     im = Image.new("L", (256, 1))
     px = im.load()

--- a/Tests/test_file_pcx.py
+++ b/Tests/test_file_pcx.py
@@ -80,13 +80,14 @@ def test_invalid_file() -> None:
 
 
 @pytest.mark.parametrize("mode", ("1", "L", "P", "RGB"))
-def test_odd(tmp_path: Path, mode: str) -> None:
+@pytest.mark.parametrize("size", (3, 511))
+def test_odd(tmp_path: Path, mode: str, size: int) -> None:
     # See issue #523, odd sized images should have a stride that's even.
     # Not that ImageMagick or GIMP write PCX that way.
     # We were not handling properly.
     # larger, odd sized images are better here to ensure that
     # we handle interrupted scan lines properly.
-    _roundtrip(tmp_path, hopper(mode).resize((511, 511)))
+    _roundtrip(tmp_path, hopper(mode).resize((size, size)))
 
 
 def test_odd_read() -> None:
@@ -115,14 +116,6 @@ def test_1px_width(tmp_path: Path) -> None:
     assert px is not None
     for y in range(256):
         px[0, y] = y
-    _roundtrip(tmp_path, im)
-
-
-def test_rgb_odd_width(tmp_path: Path) -> None:
-    # An RGB (multi-plane) width whose even-padded stride differs from the
-    # width must still separate the colour planes correctly. Distinct channel
-    # values expose a misaligned split.
-    im = Image.new("RGB", (3, 3), (0x11, 0x22, 0x33))
     _roundtrip(tmp_path, im)
 
 

--- a/src/libImaging/PcxDecode.c
+++ b/src/libImaging/PcxDecode.c
@@ -69,10 +69,12 @@ ImagingPcxDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t byt
                 stride = state->bytes / state->bits;
             } else {
                 xsize = state->xsize;
-                bands = state->bytes / state->xsize;
-                if (bands != 0) {
-                    stride = state->bytes / bands;
-                }
+                // state->bytes is planes * stride; derive the stride from the
+                // known band count rather than guessing it from state->xsize,
+                // which picks the wrong split when xsize != stride (e.g. an
+                // odd-width RGB line padded to an even stride).
+                bands = im->bands;
+                stride = state->bytes / bands;
             }
             if (stride > xsize) {
                 int i;

--- a/src/libImaging/PcxDecode.c
+++ b/src/libImaging/PcxDecode.c
@@ -62,20 +62,14 @@ ImagingPcxDecode(Imaging im, ImagingCodecState state, UINT8 *buf, Py_ssize_t byt
         if (state->x >= state->bytes) {
             int bands;
             int xsize = 0;
-            int stride = 0;
             if (state->bits == 2 || state->bits == 4) {
                 xsize = (state->xsize + 7) / 8;
                 bands = state->bits;
-                stride = state->bytes / state->bits;
             } else {
                 xsize = state->xsize;
-                // state->bytes is planes * stride; derive the stride from the
-                // known band count rather than guessing it from state->xsize,
-                // which picks the wrong split when xsize != stride (e.g. an
-                // odd-width RGB line padded to an even stride).
                 bands = im->bands;
-                stride = state->bytes / bands;
             }
+            int stride = state->bytes / bands;
             if (stride > xsize) {
                 int i;
                 for (i = 1; i < bands; i++) {  // note -- skipping first band


### PR DESCRIPTION
Changes proposed in this pull request:

- When decoding a multi-plane PCX scanline, `PcxDecode.c` recovered the per-plane stride by guessing the band count as `state->bytes / state->xsize`. Since `state->bytes` is `planes * stride`, that quotient is wrong whenever the
  even-padded stride differs from the width. For a width-3 RGB line it yields 4 bands / stride 3, the plane-compaction step is skipped, and the R/G/B planes stay interleaved — the image decodes to the wrong colours with no error raised. Derive the split from the known band count (`im->bands`) instead.
- Add an RGB round-trip regression at a width that triggers the even-stride padding. The existing `test_odd` uses a 511×511 RGB image, whose width makes the guess land on the right value by luck, so it never caught this.

Scope note: at width 1 an RGB PCX still raises `OSError` on read — that is a separate problem on the *encoder* side (it emits only two of the three colour planes), with a different root cause, so I've left it out of this change.

---
This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug (verified against the real C codec, not a simulation), ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
