### PR TITLE
Fix adding a new color when image palette has missing background or transparency index

### DIFF
--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -87,38 +87,17 @@ def test_getcolor_not_special(index: int, palette: ImagePalette.ImagePalette) ->
 
     # Do not use transparency index as a new color
     im.info["transparency"] = index
-    index1 = palette.getcolor((0, 0, 0), im)
+    index1 = palette.getcolor((0, 0, 1), im)
     assert index1 != index
+    roundtripped_palette = ImagePalette.ImagePalette(palette=palette.palette)
+    assert roundtripped_palette.colors[(0, 0, 1)] == index1
 
     # Do not use background index as a new color
     im.info["background"] = index1
-    index2 = palette.getcolor((0, 0, 1), im)
+    index2 = palette.getcolor((0, 0, 2), im)
     assert index2 not in (index, index1)
-
-
-@pytest.mark.parametrize(
-    "index, palette",
-    [
-        (0, ImagePalette.ImagePalette()),
-        (255, ImagePalette.ImagePalette("RGB", list(range(256)) * 3)),
-    ],
-)
-def test_getcolor_not_special_stores_color(
-    index: int, palette: ImagePalette.ImagePalette
-) -> None:
-    im = Image.new("P", (1, 1))
-    im.info["transparency"] = index
-
-    color = (1, 2, 3)
-    returned = palette.getcolor(color, im)
-    assert returned != index
-
-    # The returned index must actually address the stored color, not a slot
-    # that was skipped to avoid the transparency/background index.
-    mode_len = len(palette.mode)
-    palette_bytes = bytes(palette.palette)
-    stored = tuple(palette_bytes[returned * mode_len : returned * mode_len + mode_len])
-    assert stored == color
+    roundtripped_palette = ImagePalette.ImagePalette(palette=palette.palette)
+    assert roundtripped_palette.colors[(0, 0, 2)] == index2
 
 
 def test_file(tmp_path: Path) -> None:

--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -96,6 +96,31 @@ def test_getcolor_not_special(index: int, palette: ImagePalette.ImagePalette) ->
     assert index2 not in (index, index1)
 
 
+@pytest.mark.parametrize(
+    "index, palette",
+    [
+        (0, ImagePalette.ImagePalette()),
+        (255, ImagePalette.ImagePalette("RGB", list(range(256)) * 3)),
+    ],
+)
+def test_getcolor_not_special_stores_color(
+    index: int, palette: ImagePalette.ImagePalette
+) -> None:
+    im = Image.new("P", (1, 1))
+    im.info["transparency"] = index
+
+    color = (1, 2, 3)
+    returned = palette.getcolor(color, im)
+    assert returned != index
+
+    # The returned index must actually address the stored color, not a slot
+    # that was skipped to avoid the transparency/background index.
+    mode_len = len(palette.mode)
+    palette_bytes = bytes(palette.palette)
+    stored = tuple(palette_bytes[returned * mode_len : returned * mode_len + mode_len])
+    assert stored == color
+
+
 def test_file(tmp_path: Path) -> None:
     palette = ImagePalette.ImagePalette("RGB", list(range(256)) * 3)
 

--- a/src/PIL/ImagePalette.py
+++ b/src/PIL/ImagePalette.py
@@ -176,6 +176,10 @@ class ImagePalette:
                         + self._palette[index * mode_len + mode_len :]
                     )
                 else:
+                    # ``index`` may have been advanced past the tail to skip a
+                    # reserved background/transparency slot; pad those slots so
+                    # the color is stored at the index that is returned.
+                    self._palette += bytes(index * mode_len - len(self._palette))
                     self._palette += bytes(color)
                 self.dirty = 1
                 return index

--- a/src/PIL/ImagePalette.py
+++ b/src/PIL/ImagePalette.py
@@ -125,7 +125,11 @@ class ImagePalette:
                 image.info.get("background"),
                 image.info.get("transparency"),
             )
+            assert isinstance(self._palette, bytearray)
             while index in special_colors:
+                # Background or transparency index points past the end of the palette.
+                # Set it to black, so that the new color can be written afterwards.
+                self._palette += bytearray(len(self.mode))
                 index += 1
         if index >= 256:
             if image:
@@ -176,10 +180,6 @@ class ImagePalette:
                         + self._palette[index * mode_len + mode_len :]
                     )
                 else:
-                    # ``index`` may have been advanced past the tail to skip a
-                    # reserved background/transparency slot; pad those slots so
-                    # the color is stored at the index that is returned.
-                    self._palette += bytes(index * mode_len - len(self._palette))
                     self._palette += bytes(color)
                 self.dirty = 1
                 return index


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix `ImagePalette.getcolor()` silently losing a color when a background/transparency index is skipped: `_new_color_index()` advances the index past the palette tail to avoid a reserved slot, but the append branch stored the color at the current tail while returning the advanced index — so the returned index addressed a nonexistent or reserved slot and the requested color was lost.
- Pad the skipped reserved slots so the color lands at the returned index (a no-op when no slot is skipped).
- Add a regression test asserting the returned index actually addresses the stored color, for both an empty and a full palette.

Reachable from the public API: `putpixel((x, y), (r, g, b))` on a `P`/`PA` image whose `transparency`/`background` index equals the next free palette slot, and `ImageDraw` fill/text on `P` images, both route through `getcolor()`. Completes the intent of #5564, which added the reserved-index skip but did not store the color at the skipped-to index.

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, reproduced it end-to-end through `putpixel`, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification is real and re-runnable from the diff (the palette/getcolor call-site test files pass). If this isn't the kind of contribution you want, say so and I'll close it.
