### PR TITLE
Fix ImImagePlugin.seek() frame stride for non-8-bit modes

### DIFF
--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import filecmp
+import io
 import warnings
 from pathlib import Path
 
@@ -8,7 +9,7 @@ import pytest
 
 from PIL import Image, ImImagePlugin
 
-from .helper import assert_image_equal_tofile, hopper, is_pypy
+from .helper import assert_image_equal, assert_image_equal_tofile, hopper, is_pypy
 
 # sample im
 TEST_IM = "Tests/images/hopper.im"
@@ -81,6 +82,41 @@ def test_eoferror() -> None:
 
         # Test that seeking to the last frame does not raise an error
         im.seek(n_frames - 1)
+
+
+@pytest.mark.parametrize(
+    "image_type, rawmode, mode",
+    (
+        ("L 16", "I;16", "I;16"),
+        ("L 32S", "I;32S", "I"),
+        ("L 32F", "F;32F", "F"),
+        ("YCC", "YCbCr;L", "YCbCr"),
+    ),
+)
+def test_seek_non_8bit(image_type: str, rawmode: str, mode: str) -> None:
+    # The frame stride must be derived from the actual bytes per pixel, not
+    # from the length of the mode name (which only matches for 8-bit bands).
+    w, h = 4, 4
+    frames = []
+    for base in (0, 1000):
+        frame = Image.new(mode, (w, h))
+        for y in range(h):
+            for x in range(w):
+                frame.putpixel((x, y), base + y * w + x)
+        frames.append(frame)
+
+    header = (
+        f"Image type: {image_type} image\r\n"
+        f"Image size (x*y): {w}*{h}\r\n"
+        f"File size (no of images): {len(frames)}\r\n"
+    ).encode("ascii")
+    header += b"\x00" * (511 - len(header)) + b"\x1a"
+    data = b"".join(frame.tobytes("raw", rawmode, 0, -1) for frame in frames)
+
+    with Image.open(io.BytesIO(header + data)) as im:
+        for index, frame in enumerate(frames):
+            im.seek(index)
+            assert_image_equal(im, frame)
 
 
 @pytest.mark.parametrize("mode", ("RGB", "P", "PA"))

--- a/src/PIL/ImImagePlugin.py
+++ b/src/PIL/ImImagePlugin.py
@@ -30,7 +30,7 @@ import os
 import re
 from typing import IO, Any
 
-from . import Image, ImageFile, ImagePalette
+from . import Image, ImageFile, ImageMode, ImagePalette
 from ._util import DeferredError
 
 # --------------------------------------------------------------------
@@ -300,7 +300,8 @@ class ImImageFile(ImageFile.ImageFile):
         if self.mode == "1":
             bits = 1
         else:
-            bits = 8 * len(self.mode)
+            mode = ImageMode.getmode(self.mode)
+            bits = 8 * len(mode.bands) * int(mode.typestr[-1])
 
         size = ((self.size[0] * bits + 7) // 8) * self.size[1]
         offs = self.__offset + frame * size


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix `ImImagePlugin.seek()` computing the per-frame byte stride as `8 * len(self.mode)` — the length of the mode *name* string used as bits-per-pixel. That only equals the real value when `len(mode)` matches the band count and the bands are 8-bit (`L`, `RGB`, `RGBA`, `CMYK`, `LA`, `P`). For `I;16` (16-bit), `I` / `F` (32-bit) and `YCbCr` (3-byte), the stride was wrong, so `seek(frame >= 1)` on a multi-frame IM image raised `OSError: image file is truncated` (`I;16`, `YCbCr`) or returned pixels from the wrong offset (`I`, `F`).
- Use `8 * bands * itemsize` (via `ImageMode`), which matches `Image.new(mode).tobytes()` for every IM-supported mode and leaves the six already-correct modes byte-for-byte unchanged.
- Add a parametrized regression test seeking to frame 1 of a 2-frame IM image in the affected modes.

Reachability, stated honestly: this is a **low-frequency** bug. Pillow's own `_save` only writes one frame's data, so Pillow cannot itself produce a valid multi-frame IM file — the trigger is a multi-frame IM/IFUNC file from an external tool in one of these less-common modes. The IM reader does advertise multi-frame support (`n_frames`/`seek` are wired), so reading such a file with a wrong stride is a real correctness bug, but it is not a hot path. Happy to close if you'd rather not carry it.
