### PR TITLE
Remove PIL_NO_INLINE and MSVC alias for inline

### DIFF
--- a/src/libImaging/ImPlatform.h
+++ b/src/libImaging/ImPlatform.h
@@ -18,14 +18,6 @@
 #error Sorry, this library requires ANSI header files.
 #endif
 
-#if defined(PIL_NO_INLINE)
-#define inline
-#else
-#if defined(_MSC_VER) && !defined(__GNUC__)
-#define inline __inline
-#endif
-#endif
-
 #if defined(_WIN32) || defined(__CYGWIN__) /* WIN */
 
 #define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
Changes proposed in this pull request:

* Removal of `PIL_NO_INLINE`, added in #725 (767182a56f086b0b50dbec01c311e0c9c876fced) and flipped to default inlining in #753 (b593ff06adbcfbe713f637dea220f8884a6bd83e). It wasn't documented, and Googling it doesn't yield any real results, so it's likely safe to say it's not used?
* According to [these MSVC docs](https://learn.microsoft.com/en-us/cpp/cpp/inline-functions-cpp?view=msvc-170#inline-__inline-and-__forceinline), `inline` should be just as supported as `__inline` these days, so no need to keep the define around. 

**EDIT:** Some of these same changes are in #8389.