### PR TITLE
Raise ValueError instead of asserting number of FTEX texture formats

### DIFF
--- a/Tests/test_file_ftex.py
+++ b/Tests/test_file_ftex.py
@@ -38,3 +38,15 @@ def test_invalid_texture() -> None:
     with pytest.raises(ValueError, match="Invalid texture compression format: 2"):
         with Image.open(io.BytesIO(data)):
             pass
+
+
+def test_invalid_format_count() -> None:
+    with open("Tests/images/ftex_dxt1.ftc", "rb") as fp:
+        data = fp.read()
+
+    # Change the format count to an unsupported value
+    data = data[:20] + struct.pack("<i", 2) + data[24:]
+
+    with pytest.raises(ValueError, match="Unsupported number of formats: 2"):
+        with Image.open(io.BytesIO(data)):
+            pass

--- a/Tests/test_file_ftex.py
+++ b/Tests/test_file_ftex.py
@@ -40,13 +40,11 @@ def test_invalid_texture() -> None:
             pass
 
 
-def test_invalid_format_count() -> None:
+def test_unsupported_texture_format_count() -> None:
     with open("Tests/images/ftex_dxt1.ftc", "rb") as fp:
-        data = fp.read()
+        # Change the format count to an unsupported value
+        data = fp.read(20) + struct.pack("<i", 2)
 
-    # Change the format count to an unsupported value
-    data = data[:20] + struct.pack("<i", 2) + data[24:]
-
-    with pytest.raises(ValueError, match="Unsupported number of formats: 2"):
+    with pytest.raises(ValueError, match="Unsupported number of texture formats: 2"):
         with Image.open(io.BytesIO(data)):
             pass

--- a/src/PIL/FtexImagePlugin.py
+++ b/src/PIL/FtexImagePlugin.py
@@ -83,7 +83,7 @@ class FtexImageFile(ImageFile.ImageFile):
         # Only support single-format files.
         # I don't know of any multi-format file.
         if format_count != 1:
-            msg = f"Unsupported number of formats: {format_count}"
+            msg = f"Unsupported number of texture formats: {format_count}"
             raise ValueError(msg)
 
         format, where = struct.unpack("<2i", self.fp.read(8))

--- a/src/PIL/FtexImagePlugin.py
+++ b/src/PIL/FtexImagePlugin.py
@@ -82,7 +82,9 @@ class FtexImageFile(ImageFile.ImageFile):
 
         # Only support single-format files.
         # I don't know of any multi-format file.
-        assert format_count == 1
+        if format_count != 1:
+            msg = f"Unsupported number of formats: {format_count}"
+            raise ValueError(msg)
 
         format, where = struct.unpack("<2i", self.fp.read(8))
         self.fp.seek(where)


### PR DESCRIPTION
Resolves #9809

`FtexImageFile._open` used `assert format_count == 1` to reject multi-format files. That raises `AssertionError`, which is not one of the exceptions Pillow documents for unparseable files, so callers catching `UnidentifiedImageError` or `ValueError` do not catch it; and under `python -O` the assert is stripped, so the file is parsed as if valid.

This raises a `ValueError` instead, matching the existing "Invalid texture compression format" check in the same plugin. Added a regression test that patches the format count in a valid file, mirroring `test_invalid_texture`.

Used an AI assistant to find this; I reviewed and tested the change myself.