### PR TITLE
Remove write method from test

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -9,7 +9,7 @@ import tempfile
 import warnings
 from pathlib import Path
 from types import ModuleType
-from typing import IO, Any
+from typing import IO
 
 import pytest
 
@@ -196,17 +196,6 @@ class TestImage:
 
         class FP(io.BytesIO):
             name: Path
-
-            if sys.version_info >= (3, 12):
-                from collections.abc import Buffer
-
-                def write(self, data: Buffer) -> int:
-                    return len(data)
-
-            else:
-
-                def write(self, data: Any) -> int:
-                    return len(data)
 
         fp = FP()
         fp.name = temp_file


### PR DESCRIPTION
Extracted from #9803

https://github.com/python-pillow/Pillow/blob/8f86212e947113e49909a1ae2012fee799adf2a8/Tests/test_image.py#L197-L209

The `write` method was originally added in #2227. I guess it became redundant after #8163 changed `FP` to inherit from `io.BytesIO`.