### PR TITLE
Fix unexpected errors when decoding truncated QOI images

### DIFF
--- a/Tests/test_file_qoi.py
+++ b/Tests/test_file_qoi.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from io import BytesIO
 from pathlib import Path
 
 import pytest
@@ -30,6 +31,15 @@ def test_invalid_file() -> None:
 
     with pytest.raises(SyntaxError):
         QoiImagePlugin.QoiImageFile(invalid_file)
+
+
+@pytest.mark.parametrize("length", (14, 44, 48, 55))
+def test_truncated(length: int) -> None:
+    with open("Tests/images/pil123rgba.qoi", "rb") as fp:
+        data = fp.read()[:length]
+    with Image.open(BytesIO(data)) as im:
+        with pytest.raises(ValueError, match="not enough image data"):
+            im.load()
 
 
 def test_op_index() -> None:

--- a/src/PIL/QoiImagePlugin.py
+++ b/src/PIL/QoiImagePlugin.py
@@ -63,21 +63,18 @@ class QoiDecoder(ImageFile.PyDecoder):
         while len(data) < dest_length:
             byte_data = self.fd.read(1)
             if not byte_data:
-                msg = "image file is truncated"
-                raise OSError(msg)
+                break
             byte = byte_data[0]
             value: bytes | bytearray
             if byte == 0b11111110 and self._previous_pixel:  # QOI_OP_RGB
                 rgb_data = self.fd.read(3)
                 if len(rgb_data) < 3:
-                    msg = "image file is truncated"
-                    raise OSError(msg)
+                    break
                 value = bytearray(rgb_data) + self._previous_pixel[3:]
             elif byte == 0b11111111:  # QOI_OP_RGBA
                 value = self.fd.read(4)
                 if len(value) < 4:
-                    msg = "image file is truncated"
-                    raise OSError(msg)
+                    break
             else:
                 op = byte >> 6
                 if op == 0:  # QOI_OP_INDEX
@@ -99,8 +96,7 @@ class QoiDecoder(ImageFile.PyDecoder):
                 elif op == 2 and self._previous_pixel:  # QOI_OP_LUMA
                     second_byte_data = self.fd.read(1)
                     if not second_byte_data:
-                        msg = "image file is truncated"
-                        raise OSError(msg)
+                        break
                     second_byte = second_byte_data[0]
                     diff_green = (byte & 0b00111111) - 32
                     diff_red = ((second_byte & 0b11110000) >> 4) - 8

--- a/src/PIL/QoiImagePlugin.py
+++ b/src/PIL/QoiImagePlugin.py
@@ -61,12 +61,23 @@ class QoiDecoder(ImageFile.PyDecoder):
         bands = Image.getmodebands(self.mode)
         dest_length = self.state.xsize * self.state.ysize * bands
         while len(data) < dest_length:
-            byte = self.fd.read(1)[0]
+            byte_data = self.fd.read(1)
+            if not byte_data:
+                msg = "image file is truncated"
+                raise OSError(msg)
+            byte = byte_data[0]
             value: bytes | bytearray
             if byte == 0b11111110 and self._previous_pixel:  # QOI_OP_RGB
-                value = bytearray(self.fd.read(3)) + self._previous_pixel[3:]
+                rgb_data = self.fd.read(3)
+                if len(rgb_data) < 3:
+                    msg = "image file is truncated"
+                    raise OSError(msg)
+                value = bytearray(rgb_data) + self._previous_pixel[3:]
             elif byte == 0b11111111:  # QOI_OP_RGBA
                 value = self.fd.read(4)
+                if len(value) < 4:
+                    msg = "image file is truncated"
+                    raise OSError(msg)
             else:
                 op = byte >> 6
                 if op == 0:  # QOI_OP_INDEX
@@ -86,7 +97,11 @@ class QoiDecoder(ImageFile.PyDecoder):
                         )
                     )
                 elif op == 2 and self._previous_pixel:  # QOI_OP_LUMA
-                    second_byte = self.fd.read(1)[0]
+                    second_byte_data = self.fd.read(1)
+                    if not second_byte_data:
+                        msg = "image file is truncated"
+                        raise OSError(msg)
+                    second_byte = second_byte_data[0]
                     diff_green = (byte & 0b00111111) - 32
                     diff_red = ((second_byte & 0b11110000) >> 4) - 8
                     diff_blue = (second_byte & 0b00001111) - 8


### PR DESCRIPTION
## Summary

Fixes a crash in `QoiDecoder.decode()` when a truncated QOI file is opened. The decoder now raises `OSError` with the standard "image file is truncated" message instead of an uncaught `IndexError`.

## Problem

When a truncated QOI file is opened, `QoiDecoder.decode()` reads past EOF and indexes the empty result of `read(1)`, causing an `IndexError`:

```python
byte = self.fd.read(1)[0]  # IndexError: index out of range when read returns b''
```

This affects multiple read sites in the decoder:
- The initial opcode byte read (line 64)
- The QOI_OP_RGB 3-byte payload read (line 67)
- The QOI_OP_RGBA 4-byte payload read (line 69)
- The QOI_OP_LUMA second byte read (line 89)

## Fix

Added length checks before indexing all `read()` results. When a short read is detected (EOF), the decoder raises `OSError("image file is truncated")`, consistent with other Pillow decoders (JPEG, PNG, etc.).

## Testing

The fix can be verified by opening a truncated QOI file:
```python
from PIL import Image
im = Image.open("truncated.qoi")
im.load()  # Previously: IndexError, Now: OSError("image file is truncated")
```

Fixes #9812
