### PR TITLE
Raise ValueError if Dib paste() box does not match image size

### DIFF
--- a/Tests/test_imagewin.py
+++ b/Tests/test_imagewin.py
@@ -89,7 +89,7 @@ class TestImageWinDib:
     def test_dib_paste_bbox(self) -> None:
         # Arrange
         im = hopper()
-        bbox = (0, 0, 10, 10)
+        bbox = (0, 0, 128, 128)
 
         mode = "RGBA"
         size = (128, 128)
@@ -100,6 +100,9 @@ class TestImageWinDib:
 
         # Assert
         assert dib.size == (128, 128)
+
+        with pytest.raises(ValueError, match="images do not match"):
+            dib.paste(im, (0, 0, 1, 1))
 
     def test_dib_frombytes_tobytes_roundtrip(self) -> None:
         # Arrange

--- a/src/display.c
+++ b/src/display.c
@@ -134,9 +134,13 @@ _paste(ImagingDisplayObject *display, PyObject *args) {
 
     if (xy[2] <= xy[0]) {
         xy[2] = xy[0] + im->xsize;
+    } else if (xy[2] - xy[0] != im->xsize) {
+        return ImagingError_Mismatch();
     }
     if (xy[3] <= xy[1]) {
         xy[3] = xy[1] + im->ysize;
+    } else if (xy[3] - xy[1] != im->ysize) {
+        return ImagingError_Mismatch();
     }
 
     ImagingPasteDIB(display->dib, im, xy);


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/b741b7743024c872687c98c875930967be93ed8d/src/PIL/ImageWin.py#L164-L170

This PR raises a ValueError if the `box` size does not match `im` size.