### PR TITLE
Raise SyntaxError instead of OverflowError for oversized JPEG 2000 box

### DIFF
--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -240,6 +240,17 @@ def test_oversized_box_length() -> None:
         Jpeg2KImagePlugin.Jpeg2KImageFile(BytesIO(data))
 
 
+def test_oversized_box_length_when_reading() -> None:
+    # Do not raise an OverflowError() when reading the contents of a box
+    data = (
+        b"\x00\x00\x00\x0cjP  \x0d\x0a\x87\x0a"  # JP2 signature box
+        + struct.pack(">I4s", 1, b"jp2h")  # box read into with a 64-bit length
+        + struct.pack(">Q", 16 + 2**63)  # length whose contents overflow fp.read()
+    )
+    with pytest.raises(SyntaxError, match="Box length too large"):
+        Jpeg2KImagePlugin.Jpeg2KImageFile(BytesIO(data))
+
+
 def test_layers_type(card: ImageFile.ImageFile, tmp_path: Path) -> None:
     outfile = tmp_path / "temp_layers.jp2"
     for quality_layers in [[100, 50, 10], (100, 50, 10), None]:

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -230,16 +230,14 @@ def test_header_errors() -> None:
 
 
 def test_oversized_box_length() -> None:
-    # A box declaring a 64-bit length that ends beyond the maximum seekable
-    # position must be rejected instead of raising OverflowError from seek()
+    # Do not raise an OverflowError() when seeking to the end of a box
     data = (
         b"\x00\x00\x00\x0cjP  \x0d\x0a\x87\x0a"  # JP2 signature box
-        + struct.pack(">I4s", 1, b"\x00\x00\x00\x00")  # box with 64-bit length
-        + struct.pack(">Q", 0xFFFFFFFFFF000004)  # length beyond the seek range
+        + struct.pack(">I4s", 1, b"")  # box with 64-bit length
+        + struct.pack(">Q", 16 + 2**63)  # length beyond the seek range
     )
-    with pytest.raises(UnidentifiedImageError):
-        with Image.open(BytesIO(data)):
-            pass
+    with pytest.raises(SyntaxError, match="Box length too large"):
+        Jpeg2KImagePlugin.Jpeg2KImageFile(BytesIO(data))
 
 
 def test_layers_type(card: ImageFile.ImageFile, tmp_path: Path) -> None:

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -229,23 +229,14 @@ def test_header_errors() -> None:
             pass
 
 
-def test_oversized_box_length() -> None:
-    # Do not raise an OverflowError() when seeking to the end of a box
+@pytest.mark.parametrize("tbox", (b"", b"jp2h"))
+def test_oversized_box_length(tbox: bytes) -> None:
+    # Do not raise an OverflowError() when seeking to the end of a box,
+    # or when reading the contents of a box
     data = (
         b"\x00\x00\x00\x0cjP  \x0d\x0a\x87\x0a"  # JP2 signature box
-        + struct.pack(">I4s", 1, b"")  # box with 64-bit length
-        + struct.pack(">Q", 2**63 - 12)  # length beyond the seek range
-    )
-    with pytest.raises(SyntaxError, match="Box length too large"):
-        Jpeg2KImagePlugin.Jpeg2KImageFile(BytesIO(data))
-
-
-def test_oversized_box_length_when_reading() -> None:
-    # Do not raise an OverflowError() when reading the contents of a box
-    data = (
-        b"\x00\x00\x00\x0cjP  \x0d\x0a\x87\x0a"  # JP2 signature box
-        + struct.pack(">I4s", 1, b"jp2h")  # box read into with a 64-bit length
-        + struct.pack(">Q", 16 + 2**63)  # length whose contents overflow fp.read()
+        + struct.pack(">I4s", 1, tbox)  # box with 64-bit length
+        + struct.pack(">Q", 2**63 - 12)  # oversized length
     )
     with pytest.raises(SyntaxError, match="Box length too large"):
         Jpeg2KImagePlugin.Jpeg2KImageFile(BytesIO(data))

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -233,7 +233,7 @@ def test_oversized_box_length() -> None:
     # A box declaring a 64-bit length that ends beyond the maximum seekable
     # position must be rejected instead of raising OverflowError from seek()
     data = (
-        b"\x00\x00\x00\x0cjP  \r\n\x87\n"  # JP2 signature box
+        b"\x00\x00\x00\x0cjP  \x0d\x0a\x87\x0a"  # JP2 signature box
         + struct.pack(">I4s", 1, b"\x00\x00\x00\x00")  # box with 64-bit length
         + struct.pack(">Q", 0xFFFFFFFFFF000004)  # length beyond the seek range
     )

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -234,7 +234,7 @@ def test_oversized_box_length() -> None:
     data = (
         b"\x00\x00\x00\x0cjP  \x0d\x0a\x87\x0a"  # JP2 signature box
         + struct.pack(">I4s", 1, b"")  # box with 64-bit length
-        + struct.pack(">Q", 16 + 2**63)  # length beyond the seek range
+        + struct.pack(">Q", 2**63 - 12)  # length beyond the seek range
     )
     with pytest.raises(SyntaxError, match="Box length too large"):
         Jpeg2KImagePlugin.Jpeg2KImageFile(BytesIO(data))

--- a/Tests/test_file_jpeg2k.py
+++ b/Tests/test_file_jpeg2k.py
@@ -229,6 +229,19 @@ def test_header_errors() -> None:
             pass
 
 
+def test_oversized_box_length() -> None:
+    # A box declaring a 64-bit length that ends beyond the maximum seekable
+    # position must be rejected instead of raising OverflowError from seek()
+    data = (
+        b"\x00\x00\x00\x0cjP  \r\n\x87\n"  # JP2 signature box
+        + struct.pack(">I4s", 1, b"\x00\x00\x00\x00")  # box with 64-bit length
+        + struct.pack(">Q", 0xFFFFFFFFFF000004)  # length beyond the seek range
+    )
+    with pytest.raises(UnidentifiedImageError):
+        with Image.open(BytesIO(data)):
+            pass
+
+
 def test_layers_type(card: ImageFile.ImageFile, tmp_path: Path) -> None:
     outfile = tmp_path / "temp_layers.jp2"
     for quality_layers in [[100, 50, 10], (100, 50, 10), None]:

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -83,6 +83,9 @@ class BoxReader:
     def next_box_type(self) -> bytes:
         # Skip the rest of the box if it has not been read
         if self.remaining_in_box > 0:
+            if self.remaining_in_box >= 2**63:
+                msg = "Box length too large"
+                raise SyntaxError(msg)
             self.fp.seek(self.remaining_in_box, os.SEEK_CUR)
         self.remaining_in_box = -1
 
@@ -96,11 +99,6 @@ class BoxReader:
 
         if lbox < hlen or not self._can_read(lbox - hlen):
             msg = "Invalid header length"
-            raise SyntaxError(msg)
-
-        # Reject a box whose contents end beyond the maximum seekable position
-        if self.fp.tell() + lbox - hlen >= 2**63:
-            msg = "Invalid box length"
             raise SyntaxError(msg)
 
         self.remaining_in_box = lbox - hlen

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -54,6 +54,9 @@ class BoxReader:
         if not self._can_read(num_bytes):
             msg = "Not enough data in header"
             raise SyntaxError(msg)
+        if self.fp.tell() + num_bytes >= 2**63:
+            msg = "Box length too large"
+            raise SyntaxError(msg)
 
         data = self.fp.read(num_bytes)
         if len(data) < num_bytes:
@@ -83,6 +86,9 @@ class BoxReader:
     def next_box_type(self) -> bytes:
         # Skip the rest of the box if it has not been read
         if self.remaining_in_box > 0:
+            if self.fp.tell() + self.remaining_in_box >= 2**63:
+                msg = "Box length too large"
+                raise SyntaxError(msg)
             self.fp.seek(self.remaining_in_box, os.SEEK_CUR)
         self.remaining_in_box = -1
 
@@ -96,12 +102,6 @@ class BoxReader:
 
         if lbox < hlen or not self._can_read(lbox - hlen):
             msg = "Invalid header length"
-            raise SyntaxError(msg)
-
-        # Reject a box whose contents would extend beyond the maximum position
-        # that can be sought or read, before it is stored and later consumed
-        if self.fp.tell() + lbox - hlen >= 2**63:
-            msg = "Box length too large"
             raise SyntaxError(msg)
 
         self.remaining_in_box = lbox - hlen

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -98,6 +98,11 @@ class BoxReader:
             msg = "Invalid header length"
             raise SyntaxError(msg)
 
+        # Reject a box whose contents end beyond the maximum seekable position
+        if self.fp.tell() + lbox - hlen >= 2**63:
+            msg = "Invalid box length"
+            raise SyntaxError(msg)
+
         self.remaining_in_box = lbox - hlen
         return tbox
 

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -83,9 +83,6 @@ class BoxReader:
     def next_box_type(self) -> bytes:
         # Skip the rest of the box if it has not been read
         if self.remaining_in_box > 0:
-            if self.fp.tell() + self.remaining_in_box >= 2**63:
-                msg = "Box length too large"
-                raise SyntaxError(msg)
             self.fp.seek(self.remaining_in_box, os.SEEK_CUR)
         self.remaining_in_box = -1
 
@@ -99,6 +96,12 @@ class BoxReader:
 
         if lbox < hlen or not self._can_read(lbox - hlen):
             msg = "Invalid header length"
+            raise SyntaxError(msg)
+
+        # Reject a box whose contents would extend beyond the maximum position
+        # that can be sought or read, before it is stored and later consumed
+        if self.fp.tell() + lbox - hlen >= 2**63:
+            msg = "Box length too large"
             raise SyntaxError(msg)
 
         self.remaining_in_box = lbox - hlen

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -83,7 +83,7 @@ class BoxReader:
     def next_box_type(self) -> bytes:
         # Skip the rest of the box if it has not been read
         if self.remaining_in_box > 0:
-            if self.remaining_in_box >= 2**63:
+            if self.fp.tell() + self.remaining_in_box >= 2**63:
                 msg = "Box length too large"
                 raise SyntaxError(msg)
             self.fp.seek(self.remaining_in_box, os.SEEK_CUR)


### PR DESCRIPTION
Fixes #9817 .

JPEG 2000's BoxReader accepts an extended 64-bit box length with no bound (the top-level reader has no known length), then passes it to fp.seek(..., SEEK_CUR), raising OverflowError from Image.open() on malformed input. 
This is the JP2 counterpart of #9811 (TIFF, fixed in #9816). The box is now rejected as a malformed header (SyntaxError → UnidentifiedImageError), consistent with the plugin's other  #checks.

Changes proposed in this pull request:
 * In function def next_box_type(self), add a check to reject a box whose contents end beyond the maximum seekable position
 * Add a test case.

