### PR TITLE
Fix retrieving ImagePalette colors from raw palettes

### DIFF
--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -15,6 +15,20 @@ def test_sanity() -> None:
     assert len(palette.colors) == 256
 
 
+def test_colors_rawmode() -> None:
+    palette = ImagePalette.raw(
+        "BGRX",
+        bytes.fromhex("00000000ffffff000000ff0000ff0000ff000000"),
+    )
+    assert palette.colors == {
+        (0, 0, 0): 0,
+        (255, 255, 255): 1,
+        (255, 0, 0): 2,
+        (0, 255, 0): 3,
+        (0, 0, 255): 4,
+    }
+
+
 def test_reload() -> None:
     with Image.open("Tests/images/hopper.gif") as im:
         original = im.copy()

--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -17,8 +17,7 @@ def test_sanity() -> None:
 
 def test_colors_rawmode() -> None:
     palette = ImagePalette.raw(
-        "BGRX",
-        (0, 0, 0, 0, 255, 255, 255, 0, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0),
+        "BGRX", (0, 0, 0, 0, 255, 255, 255, 0, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0)
     )
     assert palette.colors == {
         (0, 0, 0): 0,

--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -18,7 +18,7 @@ def test_sanity() -> None:
 def test_colors_rawmode() -> None:
     palette = ImagePalette.raw(
         "BGRX",
-        bytes.fromhex("00000000ffffff000000ff0000ff0000ff000000"),
+        (0, 0, 0, 0, 255, 255, 255, 0, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 0),
     )
     assert palette.colors == {
         (0, 0, 0): 0,

--- a/src/PIL/ImagePalette.py
+++ b/src/PIL/ImagePalette.py
@@ -66,11 +66,9 @@ class ImagePalette:
             if self.rawmode:
                 from . import Image
 
-                image = Image.new("P", (1, 1))
-                image.putpalette(palette, self.rawmode)
-                converted_palette = image.getpalette(self.mode)
-                assert converted_palette is not None
-                palette = converted_palette
+                im = Image.core.new("P", (0, 0))
+                im.putpalette(self.mode, self.rawmode, palette)
+                palette = im.getpalette(self.mode, self.mode)
 
             mode_len = len(self.mode)
             self._colors = {}

--- a/src/PIL/ImagePalette.py
+++ b/src/PIL/ImagePalette.py
@@ -62,10 +62,20 @@ class ImagePalette:
     @property
     def colors(self) -> dict[tuple[int, ...], int]:
         if self._colors is None:
+            palette = self.palette
+            if self.rawmode:
+                from . import Image
+
+                image = Image.new("P", (1, 1))
+                image.putpalette(palette, self.rawmode)
+                converted_palette = image.getpalette(self.mode)
+                assert converted_palette is not None
+                palette = converted_palette
+
             mode_len = len(self.mode)
             self._colors = {}
-            for i in range(0, len(self.palette), mode_len):
-                color = tuple(self.palette[i : i + mode_len])
+            for i in range(0, len(palette), mode_len):
+                color = tuple(palette[i : i + mode_len])
                 if color in self._colors:
                     continue
                 self._colors[color] = i // mode_len

--- a/src/PIL/ImagePalette.py
+++ b/src/PIL/ImagePalette.py
@@ -63,7 +63,7 @@ class ImagePalette:
     def colors(self) -> dict[tuple[int, ...], int]:
         if self._colors is None:
             palette = self.palette
-            if self.rawmode:
+            if self.rawmode and self.rawmode != self.mode:
                 from . import Image
 
                 im = Image.core.new("P", (0, 0))

--- a/src/PIL/ImagePalette.py
+++ b/src/PIL/ImagePalette.py
@@ -68,7 +68,7 @@ class ImagePalette:
 
                 im = Image.core.new("P", (0, 0))
                 im.putpalette(self.mode, self.rawmode, bytes(palette))
-                palette = im.getpalette(self.mode, self.mode)
+                palette = im.getpalette(self.mode)
 
             mode_len = len(self.mode)
             self._colors = {}

--- a/src/PIL/ImagePalette.py
+++ b/src/PIL/ImagePalette.py
@@ -67,7 +67,7 @@ class ImagePalette:
                 from . import Image
 
                 im = Image.core.new("P", (0, 0))
-                im.putpalette(self.mode, self.rawmode, palette)
+                im.putpalette(self.mode, self.rawmode, bytes(palette))
                 palette = im.getpalette(self.mode, self.mode)
 
             mode_len = len(self.mode)


### PR DESCRIPTION
Fixes #9820.

Changes proposed in this pull request:

 * Convert raw palette data through Pillow's existing palette conversion path before constructing `ImagePalette.colors`.
 * Preserve the correct channel order and entry width for raw modes such as `BGRX`.
 * Add a regression test covering the five-color BGRX palette from the issue.

Tests:

 * `python -m pytest Tests/test_imagepalette.py Tests/test_file_bmp.py Tests/test_image_getpalette.py Tests/test_image_putpalette.py -q` (64 passed)
 * `ruff check --no-fix src/PIL/ImagePalette.py Tests/test_imagepalette.py`
 * `ruff format --check src/PIL/ImagePalette.py Tests/test_imagepalette.py`
 * `black --check src/PIL/ImagePalette.py Tests/test_imagepalette.py`
 * `mypy --python-executable .venv/bin/python src/PIL/ImagePalette.py Tests/test_imagepalette.py`

This change was prepared by an AI coding agent. I reviewed the focused diff and verified the issue reproducer and tests locally.
