### PR TITLE
Use mode as default for C getpalette raw mode

### DIFF
--- a/src/PIL/BlpImagePlugin.py
+++ b/src/PIL/BlpImagePlugin.py
@@ -435,7 +435,7 @@ class BLPEncoder(ImageFile.PyEncoder):
     def _write_palette(self) -> bytes:
         data = b""
         assert self.im is not None
-        palette = self.im.getpalette("RGBA", "RGBA")
+        palette = self.im.getpalette("RGBA")
         for i in range(len(palette) // 4):
             r, g, b, a = palette[i * 4 : (i + 1) * 4]
             data += struct.pack("<4B", b, g, r, a)

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -994,9 +994,7 @@ class Image:
             elif self.palette.mode != mode:
                 # If the palette rawmode is different to the mode,
                 # then update the Python palette data
-                self.palette.palette = self.im.getpalette(
-                    self.palette.mode, self.palette.mode
-                )
+                self.palette.palette = self.im.getpalette(self.palette.mode)
 
         if self._im is not None:
             return self.im.pixel_access(self.readonly)
@@ -1346,7 +1344,7 @@ class Image:
         from . import ImagePalette
 
         mode = im.im.getpalettemode()
-        palette_data = im.im.getpalette(mode, mode)[: colors * len(mode)]
+        palette_data = im.im.getpalette(mode)[: colors * len(mode)]
         im.palette = ImagePalette.ImagePalette(mode, palette_data)
 
         return im
@@ -2230,7 +2228,7 @@ class Image:
                 palette_mode = self.im.getpalettemode()
                 if palette_mode == "RGBA":
                     bands = 4
-                source_palette = self.im.getpalette(palette_mode, palette_mode)
+                source_palette = self.im.getpalette(palette_mode)
             else:  # L-mode
                 source_palette = bytearray(i // 3 for i in range(768))
         elif len(source_palette) > 768:

--- a/src/PIL/PcxImagePlugin.py
+++ b/src/PIL/PcxImagePlugin.py
@@ -210,7 +210,7 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
     if im.mode == "P":
         # colour palette
         fp.write(o8(12))
-        palette = im.im.getpalette("RGB", "RGB")
+        palette = im.im.getpalette("RGB")
         palette += b"\x00" * (768 - len(palette))
         fp.write(palette)  # 768 bytes
     elif im.mode == "L":

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1189,9 +1189,12 @@ _getpalette(ImagingObject *self, PyObject *args) {
     ImagingShuffler pack;
 
     char *mode_name = "RGB";
-    char *rawmode_name = "RGB";
+    char *rawmode_name = NULL;
     if (!PyArg_ParseTuple(args, "|ss", &mode_name, &rawmode_name)) {
         return NULL;
+    }
+    if (rawmode_name == NULL) {
+        rawmode_name = mode_name;
     }
 
     if (!self->image->palette) {


### PR DESCRIPTION
In C's `getpalette()`, the default for the raw mode argument is "RGB"
https://github.com/python-pillow/Pillow/blob/9e282f5d754fe49ede35fde65fd862c6c50d1f9f/src/_imaging.c#L1185-L1193

However, I don't find this default is used anywhere. Instead, I've found four calls like
https://github.com/python-pillow/Pillow/blob/9e282f5d754fe49ede35fde65fd862c6c50d1f9f/src/PIL/Image.py#L1349

I think it makes more sense to use the mode as the default for the raw mode.