### PR TITLE
Raise ValueError instead of asserting ImageOps colorize() arguments

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -428,7 +428,7 @@ def test_colorize_invalid_mode() -> None:
         ImageOps.colorize(hopper("RGB"), "black", "white")
 
 
-@pytest.mark.parametrize(("blackpoint", "whitepoint"), ((-1, 255), (0, 256), (200, 50)))
+@pytest.mark.parametrize("blackpoint, whitepoint", ((-1, 255), (0, 256), (200, 50)))
 def test_colorize_invalid_points(blackpoint: int, whitepoint: int) -> None:
     with pytest.raises(ValueError, match="blackpoint and whitepoint must satisfy"):
         ImageOps.colorize(

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -423,6 +423,32 @@ def test_colorize_3color_offset() -> None:
     )
 
 
+def test_colorize_invalid_mode() -> None:
+    with pytest.raises(ValueError, match="mode must be L, not RGB"):
+        ImageOps.colorize(hopper("RGB"), "black", "white")
+
+
+@pytest.mark.parametrize(("blackpoint", "whitepoint"), ((-1, 255), (0, 256), (200, 50)))
+def test_colorize_invalid_points(blackpoint: int, whitepoint: int) -> None:
+    with pytest.raises(ValueError, match="blackpoint and whitepoint must satisfy"):
+        ImageOps.colorize(
+            hopper("L"), "black", "white", blackpoint=blackpoint, whitepoint=whitepoint
+        )
+
+
+def test_colorize_invalid_midpoint() -> None:
+    with pytest.raises(ValueError, match="midpoint must satisfy"):
+        ImageOps.colorize(
+            hopper("L"),
+            "black",
+            "white",
+            mid="blue",
+            blackpoint=0,
+            midpoint=200,
+            whitepoint=100,
+        )
+
+
 def test_exif_transpose() -> None:
     exts = [".jpg"]
     if features.check("webp"):

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -438,7 +438,7 @@ def test_colorize_invalid_points(blackpoint: int, whitepoint: int) -> None:
 
 @pytest.mark.parametrize("midpoint", (100, 200))
 def test_colorize_invalid_midpoint(midpoint: int) -> None:
-    with pytest.raises(ValueError, match="midpoint must be between"):
+    with pytest.raises(ValueError, match="midpoint must be between or equal to"):
         ImageOps.colorize(
             hopper("L"),
             "black",

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -430,22 +430,23 @@ def test_colorize_invalid_mode() -> None:
 
 @pytest.mark.parametrize("blackpoint, whitepoint", ((-1, 255), (0, 256), (200, 50)))
 def test_colorize_invalid_points(blackpoint: int, whitepoint: int) -> None:
-    with pytest.raises(ValueError, match="blackpoint and whitepoint must satisfy"):
+    with pytest.raises(ValueError, match="blackpoint and whitepoint must each be"):
         ImageOps.colorize(
             hopper("L"), "black", "white", blackpoint=blackpoint, whitepoint=whitepoint
         )
 
 
-def test_colorize_invalid_midpoint() -> None:
-    with pytest.raises(ValueError, match="midpoint must satisfy"):
+@pytest.mark.parametrize("midpoint", (100, 200))
+def test_colorize_invalid_midpoint(midpoint: int) -> None:
+    with pytest.raises(ValueError, match="midpoint must be between"):
         ImageOps.colorize(
             hopper("L"),
             "black",
             "white",
             mid="blue",
-            blackpoint=0,
-            midpoint=200,
-            whitepoint=100,
+            blackpoint=125,
+            midpoint=midpoint,
+            whitepoint=175,
         )
 
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -205,12 +205,12 @@ def colorize(
         raise ValueError(msg)
     if not 0 <= blackpoint <= whitepoint <= 255:
         msg = (
-            "blackpoint and whitepoint must satisfy"
-            " 0 <= blackpoint <= whitepoint <= 255"
+            "blackpoint and whitepoint must each be between 0 and 255, "
+            "with blackpoint less than or equal to whitepoint"
         )
         raise ValueError(msg)
     if mid is not None and not blackpoint <= midpoint <= whitepoint:
-        msg = "midpoint must satisfy blackpoint <= midpoint <= whitepoint"
+        msg = "midpoint must be between blackpoint and whitepoint"
         raise ValueError(msg)
 
     # Define colors from arguments

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -205,12 +205,12 @@ def colorize(
         raise ValueError(msg)
     if not 0 <= blackpoint <= whitepoint <= 255:
         msg = (
-            "blackpoint and whitepoint must each be between 0 and 255, "
+            "blackpoint and whitepoint must each be between or equal to 0 and 255, "
             "with blackpoint less than or equal to whitepoint"
         )
         raise ValueError(msg)
     if mid is not None and not blackpoint <= midpoint <= whitepoint:
-        msg = "midpoint must be between blackpoint and whitepoint"
+        msg = "midpoint must be between or equal to blackpoint and whitepoint"
         raise ValueError(msg)
 
     # Define colors from arguments

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -200,12 +200,18 @@ def colorize(
     :return: An image.
     """
 
-    # Initial asserts
-    assert image.mode == "L"
-    if mid is None:
-        assert 0 <= blackpoint <= whitepoint <= 255
-    else:
-        assert 0 <= blackpoint <= midpoint <= whitepoint <= 255
+    if image.mode != "L":
+        msg = f"mode must be L, not {image.mode}"
+        raise ValueError(msg)
+    if not 0 <= blackpoint <= whitepoint <= 255:
+        msg = (
+            "blackpoint and whitepoint must satisfy"
+            " 0 <= blackpoint <= whitepoint <= 255"
+        )
+        raise ValueError(msg)
+    if mid is not None and not blackpoint <= midpoint <= whitepoint:
+        msg = "midpoint must satisfy blackpoint <= midpoint <= whitepoint"
+        raise ValueError(msg)
 
     # Define colors from arguments
     rgb_black = cast(Sequence[int], _color(black, "RGB"))


### PR DESCRIPTION
`ImageOps.colorize()` checks its arguments with bare `assert` statements, which causes two problems.

Invalid arguments raise an `AssertionError` with no message, so nothing tells you which argument was wrong:

```pycon
>>> ImageOps.colorize(im, "black", "white", blackpoint=200, whitepoint=50)
AssertionError
```

Under `python -O` the checks disappear entirely. Out-of-order points then reach the lookup table and fail with an internal message that says nothing about the arguments:

```pycon
>>> ImageOps.colorize(im, "black", "white", blackpoint=200, whitepoint=50)
ValueError: wrong number of lut entries
```

A non-`L` image is the worst case: under `-O` there is no error at all, and the function returns an image without applying the intended wedge.

This raises `ValueError` with a message naming the argument at fault instead, the same way #9805 handled the assert in FtexImagePlugin.

The range of accepted values is unchanged. I compared the new conditions against the old asserts over boundary and out-of-range combinations of blackpoint/midpoint/whitepoint, and they agree on all of them.

Changes proposed in this pull request:

 * Raise `ValueError` instead of asserting argument validity in `ImageOps.colorize()`
 * Add tests for an invalid mode, invalid black/white points, and an invalid midpoint
