### PR TITLE
Treat an MPO with too few MP entries as a JPEG

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -773,7 +773,7 @@ class TestFileJpeg:
             data = fp.read()
 
         # Change the number of images to three, without adding a third MP entry
-        data = data[:6048] + struct.pack(">I", 3) + data[6052:]
+        data = data[:6048] + struct.pack(">L", 3) + data[6052:]
 
         with pytest.warns(UserWarning, match="malformed MPO file"):
             with Image.open(BytesIO(data)) as im:

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import struct
 import warnings
 from io import BytesIO
 from pathlib import Path
@@ -765,6 +766,18 @@ class TestFileJpeg:
         assert im.format == "JPEG"
 
         im.close()
+
+    def test_mp_entry_count_too_high(self) -> None:
+        """Treat an MPO with fewer MP entries than images as JPEG"""
+        with open("Tests/images/sugarshack.mpo", "rb") as fp:
+            data = fp.read()
+
+        # Change the number of images to three, without adding a third MP entry
+        data = data[:6048] + struct.pack(">I", 3) + data[6052:]
+
+        with pytest.warns(UserWarning, match="malformed MPO file"):
+            with Image.open(BytesIO(data)) as im:
+                assert im.format == "JPEG"
 
     @pytest.mark.parametrize("mode", ("1", "L", "RGB", "RGBX", "CMYK", "YCbCr"))
     def test_save_correct_modes(self, mode: str) -> None:

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -605,7 +605,7 @@ def _getmp(self: JpegImageFile) -> dict[int, Any] | None:
             mpentry["Attribute"] = mpentryattr
             mpentries.append(mpentry)
         mp[0xB002] = mpentries
-    except KeyError as e:
+    except (KeyError, struct.error) as e:
         msg = "malformed MP Index (bad MP Entry)"
         raise SyntaxError(msg) from e
     # Next we should try and parse the individual image unique ID list;


### PR DESCRIPTION
`jpeg_factory()` deliberately falls back to a plain JPEG when the MP index cannot be read. It catches `TypeError` and `IndexError`, and warns for `SyntaxError`, which is what `test_bad_mpo_header` covers. One case in `_getmp()` escapes that: `struct.error`.

The MP index stores the number of images (`0xB001`) and the MP entries (`0xB002`) separately, and nothing checks that they agree. If the number of images is larger than the number of entries actually present, `struct.unpack_from()` reads off the end of the entry buffer:

```pycon
>>> data = open("Tests/images/sugarshack.mpo", "rb").read()
>>> data = data[:6048] + struct.pack(">I", 3) + data[6052:]  # 2 images -> 3
>>> Image.open(BytesIO(data))
PIL.UnidentifiedImageError: cannot identify image file <_io.BytesIO object at 0x...>
```

`struct.error` is not caught in `jpeg_factory()`, so it reaches `_open_core()`, which treats it as "this plugin cannot open the file". JPEG is the only format that accepts the prefix, so the whole image becomes unopenable even though the JPEG data itself is fine.

Removing the MP entry tag instead raises `KeyError` inside `_getmp()`, which is already turned into `SyntaxError("malformed MP Index (bad MP Entry)")`, and that file opens as a JPEG with a warning. A short entry buffer means the same thing, so this raises the same error for it.

Changes proposed in this pull request:

 * Raise `SyntaxError` instead of letting `struct.error` escape `_getmp()` when the MP index declares more images than it has entries
 * Add a test next to `test_bad_mpo_header`
