### PR TITLE
Revert move from python-pillow.org to python-pillow.github.io

### DIFF
--- a/.github/generate-sbom.py
+++ b/.github/generate-sbom.py
@@ -74,7 +74,7 @@ def generate(version: str) -> dict:
         "licenses": [{"license": {"id": "MIT-CMU"}}],
         "purl": purl,
         "externalReferences": [
-            {"type": "website", "url": "https://python-pillow.github.io"},
+            {"type": "website", "url": "https://python-pillow.org"},
             {"type": "vcs", "url": "https://github.com/python-pillow/Pillow"},
             {"type": "documentation", "url": "https://pillow.readthedocs.io"},
             {

--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -677,7 +677,7 @@ Reading from URL
 
     from PIL import Image
     from urllib.request import urlopen
-    url = "https://python-pillow.github.io/assets/images/pillow-logo.png"
+    url = "https://python-pillow.org/assets/images/pillow-logo.png"
     img = Image.open(urlopen(url))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ urls."Release notes" = "https://pillow.readthedocs.io/en/stable/releasenotes/ind
 urls.Changelog = "https://github.com/python-pillow/Pillow/releases"
 urls.Documentation = "https://pillow.readthedocs.io"
 urls.Funding = "https://tidelift.com/subscription/pkg/pypi-pillow?utm_source=pypi-pillow&utm_medium=pypi"
-urls.Homepage = "https://python-pillow.github.io"
+urls.Homepage = "https://python-pillow.org"
 urls.Mastodon = "https://fosstodon.org/@pillow"
 urls.Source = "https://github.com/python-pillow/Pillow"
 


### PR DESCRIPTION
Since we have to keep the python-pillow.org domain forever for security (as discussed in #8585) we may as well use it. Companion to https://github.com/python-pillow/python-pillow.github.io/pull/50

---

Reverts c5474ed43363e24602c92e5ca7b37899ce37b9a5.

`python-pillow.org` resolves correctly (GitHub Pages), and `python-pillow.github.io` redirects to it, so this restores the URLs to `python-pillow.org` in:
- `pyproject.toml`
- `docs/handbook/tutorial.rst`

Also updates `.github/generate-sbom.py`, added after the original migration and using the `.github.io` URL, for consistency.