### PR TITLE
Improve benchmark test image

### DIFF
--- a/Tests/benchmarks.py
+++ b/Tests/benchmarks.py
@@ -33,7 +33,7 @@ MODES = ["RGB", "RGBA", "L", "LA"]
 # Note that adjusting this will naturally change how long operations take.
 # The `bench` fixture takes care of saving this information in the extra info
 # for the benchmark run, so that throughput (Mpx/s) can be recomputed in the future.
-SIZES = [(1024, 1024)]
+SIZES = [(1237, 811)]  # Primes, non-power-of-two, asymmetric, approximately 1024x1024
 
 # For benchmarks that act on test fixture files, these are the paths loaded.
 IMAGES_PATH = pathlib.Path(__file__).parent / "images"

--- a/Tests/benchmarks.py
+++ b/Tests/benchmarks.py
@@ -4,6 +4,7 @@ pytest-benchmark tests for Pillow features.
 
 from __future__ import annotations
 
+import hashlib
 import pathlib
 from importlib.util import find_spec
 from io import BytesIO
@@ -78,12 +79,40 @@ def bench(
 def make_pillow_image(
     mode: str,
     size: tuple[int, int],
-    pattern_offset: int = 0,
+    seed: int = 0,
 ) -> Image.Image:
-    im = Image.new("RGB", size)
-    n = im.width * im.height * 3
-    period = bytes((i + pattern_offset) % 256 for i in range(256))
-    im.frombytes((period * (n // 256 + 1))[:n])
+    """
+    Generate a synthetic test image with the given mode and size.
+    Different seeds give different final images.
+    """
+    width, height = size
+    vertical = Image.linear_gradient("L")
+    horizontal = vertical.transpose(Transpose.ROTATE_90)
+    radial = Image.radial_gradient("L")
+    base = Image.merge("RGB", (horizontal, vertical, radial)).resize(
+        size, Resampling.BILINEAR
+    )
+    # SHAKE128 gives us a predictable noise pattern.
+    noise_bytes = hashlib.shake_128(f"pillow-benchmark-{seed}".encode()).digest(
+        width * height * 3
+    )
+    noise = Image.frombytes("RGB", size, noise_bytes)
+
+    def centered_box(area_fraction: float) -> tuple[int, int, int, int]:
+        inset = (1 - area_fraction**0.5) / 2
+        return (
+            round(width * inset),
+            round(height * inset),
+            round(width * (1 - inset)),
+            round(height * (1 - inset)),
+        )
+
+    im = base
+    noise_box = centered_box(1 / 2)
+    im.paste(noise.crop(noise_box), noise_box)  # Noise in the middle
+    im.paste(tuple(noise_bytes[:3]), centered_box(1 / 6))  # Solid center
+    if seed:
+        im = ImageChops.offset(im, seed * 383, seed * 271)
     return im.convert(mode)
 
 
@@ -96,7 +125,7 @@ def test_blend(
     size: tuple[int, int],
 ) -> None:
     im1 = make_pillow_image(mode, size)
-    im2 = make_pillow_image(mode, size, pattern_offset=1024)
+    im2 = make_pillow_image(mode, size, seed=1)
     result = bench(Image.blend, im1, im2, 0.5)
     assert result.size == im1.size
 
@@ -145,7 +174,7 @@ def test_alpha_composite(
     alpha: str,
 ) -> None:
     im1 = make_pillow_image(mode, size)
-    im2 = make_pillow_image(mode, size, pattern_offset=1024)
+    im2 = make_pillow_image(mode, size, seed=1)
     if alpha == "opaque":
         im2.putalpha(255)
     elif alpha == "transparent":
@@ -407,7 +436,7 @@ def test_chops(
     op: Callable[[Image.Image, Image.Image], Image.Image],
 ) -> None:
     im1 = make_pillow_image(mode, size)
-    im2 = make_pillow_image(mode, size, pattern_offset=1024)
+    im2 = make_pillow_image(mode, size, seed=1)
     bench.extra_info["label"] = [op.__name__]
     result = bench(op, im1, im2)
     assert result.size == im1.size


### PR DESCRIPTION
The old image was highly channel-correlated, low-color, low-structure and non-representative of anything real. My bad in #9654 :)

The new image contains both low-energy, high-energy (full noise) and zero-energy segments.
If someone has an idea for an even better synthetic image, I'm all ears!

Let's see how the Codspeed numbers change - at least locally, `test_quantize` and `test_histogram` got a lot slower, because they actually need to do work 😄 

| Old | New |
|--------|--------|
| <img width="1024" height="1024" alt="old" src="https://github.com/user-attachments/assets/af123bf4-8e00-4136-ae49-f0bf9f9935b7" /> | <img width="1237" height="811" alt="new2" src="https://github.com/user-attachments/assets/e5d42334-91b1-47e9-b4db-2dc6a3e3fe2e" /> | 
