### PR TITLE
Ensure Image and core palettes are in sync after PA conversion

### DIFF
--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -290,6 +290,19 @@ def test_p2pa_palette() -> None:
     assert im_pa.getpalette() == im.getpalette()
 
 
+@pytest.mark.xfail(reason="zombie colors from palette shouldn't reappear")
+def test_pa2p_truly_drops_alpha() -> None:
+    im = Image.frombytes("P", (2, 1), bytes([0, 1])).convert("PA")
+    im.putpalette(bytes([255, 0, 0, 7, 0, 255, 0, 9]), "RGBA")
+    im.putalpha(Image.frombytes("L", (2, 1), bytes([240, 220])))
+    assert im.get_flattened_data() == ((0, 240), (1, 220))  # Matches the alpha band
+    im_p = im.convert("P")
+    assert im_p.palette is not None
+    assert im_p.im.getpalettemode() == im_p.palette.mode == "RGB"
+    rgba_data = im_p.convert("RGBA").get_flattened_data()
+    assert rgba_data == ((255, 0, 0, 255), (0, 255, 0, 255))
+
+
 def test_matrix_illegal_conversion() -> None:
     # Arrange
     im = hopper("CMYK")

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -290,7 +290,6 @@ def test_p2pa_palette() -> None:
     assert im_pa.getpalette() == im.getpalette()
 
 
-@pytest.mark.xfail(reason="zombie colors from palette shouldn't reappear")
 def test_pa2p_truly_drops_alpha() -> None:
     im = Image.frombytes("P", (2, 1), bytes([0, 1])).convert("PA")
     im.putpalette(bytes([255, 0, 0, 7, 0, 255, 0, 9]), "RGBA")

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -373,3 +373,16 @@ def test_matrix_identity() -> None:
     # Test list
     converted_im = im.convert("RGB", list(identity_matrix))
     assert_image_equal(converted_im, im)
+
+
+@pytest.mark.xfail(reason="zombie colors from palette shouldn't reappear")
+def test_pa2p_truly_drops_alpha() -> None:
+    im = Image.frombytes("P", (2, 1), bytes([0, 1])).convert("PA")
+    im.putpalette(bytes([255, 0, 0, 7, 0, 255, 0, 9]), "RGBA")
+    im.putalpha(Image.frombytes("L", (2, 1), bytes([240, 220])))
+    assert im.get_flattened_data() == ((0, 240), (1, 220))  # Matches the alpha band
+    im_p = im.convert("P")
+    assert im_p.palette is not None
+    assert im_p.im.getpalettemode() == im_p.palette.mode == "RGB"
+    rgba_data = im_p.convert("RGBA").get_flattened_data()
+    assert rgba_data == ((255, 0, 0, 255), (0, 255, 0, 255))

--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -375,7 +375,6 @@ def test_matrix_identity() -> None:
     assert_image_equal(converted_im, im)
 
 
-@pytest.mark.xfail(reason="zombie colors from palette shouldn't reappear")
 def test_pa2p_truly_drops_alpha() -> None:
     im = Image.frombytes("P", (2, 1), bytes([0, 1])).convert("PA")
     im.putpalette(bytes([255, 0, 0, 7, 0, 255, 0, 9]), "RGBA")

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1242,9 +1242,8 @@ class Image:
 
         new_im = self._new(im)
         if mode in ("P", "PA") and palette != Palette.ADAPTIVE:
-            from . import ImagePalette
-
-            new_im.palette = ImagePalette.ImagePalette("RGB", im.getpalette("RGB"))
+            # Install the original image's palette into the new copy
+            new_im.putpalette(im.getpalette("RGB"))
         if delete_trns:
             # crash fail if we leave a bytes transparency in an rgb/l mode.
             del new_im.info["transparency"]

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1247,9 +1247,8 @@ class Image:
 
         new_im = self._new(im)
         if mode in ("P", "PA") and palette != Palette.ADAPTIVE:
-            from . import ImagePalette
-
-            new_im.palette = ImagePalette.ImagePalette("RGB", im.getpalette("RGB"))
+            # Install the original image's palette into the new copy
+            new_im.putpalette(im.getpalette("RGB"))
         if delete_trns:
             # crash fail if we leave a bytes transparency in an rgb/l mode.
             del new_im.info["transparency"]


### PR DESCRIPTION
Alternative to https://github.com/python-pillow/Pillow/pull/10008

While working on #9833, I noticed that an RGBA palette's alphas would be "resurrected" if you converted from PA to P (which retains the RGBA palette in the core im object even if the `ImagePalette` wrapper is recreated), and then to RGBA.

With this, the "zombie" alpha from the RGBA doesn't appear anymore.
I would suspect this is more the Do What I Mean behavior, because an RGBA palette's alpha values weren't "visible" in a PA image anyway.