### PR TITLE
Add test for PdfParser linearize_page_tree()

### DIFF
--- a/Tests/test_pdfparser.py
+++ b/Tests/test_pdfparser.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 import zlib
+from io import BytesIO
 
 import pytest
 
@@ -130,6 +131,31 @@ def test_pdf_repr() -> None:
     assert pdf_repr(b"a)/b\\(c") == rb"(a\)/b\\\(c)"
     assert pdf_repr([123, True, {"a": PdfName(b"b")}]) == b"[ 123 true <<\n/a /b\n>> ]"
     assert pdf_repr(PdfBinary(b"\x90\x1f\xa0")) == b"<901FA0>"
+
+
+def test_linearize_page_tree() -> None:
+    b = BytesIO()
+    with PdfParser(f=b, mode="wb") as pdf:
+        pdf.start_writing()
+        pdf.write_header()
+
+        pages_id = pdf.next_object_id(0)
+        page_ids = [pdf.next_object_id(0) for _ in range(3)]
+        for page_id in page_ids:
+            pdf.write_page(page_id)
+        pdf.write_obj(
+            pages_id,
+            Type=PdfName(b"Pages"),
+            Count=2,
+            Kids=[page_ids[0], page_ids[1]],
+        )
+
+        pdf.pages = [pages_id, page_ids[2]]
+        pdf.write_catalog()
+        pdf.write_xref_and_trailer()
+
+    with PdfParser(f=b) as pdf:
+        assert pdf.linearize_page_tree() == page_ids
 
 
 def test_duplicate_xref_entry() -> None:


### PR DESCRIPTION
Adds coverage for a line in PdfParser's `linearize_page_tree()` that is missing at the end of https://app.codecov.io/gh/python-pillow/Pillow/blob/main/src%2FPIL%2FPdfParser.py