### PR TITLE
Use `ubuntu-slim` for lightweight jobs

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,7 +23,7 @@ jobs:
       contents: write  # for release-drafter/release-drafter to create a github release
       pull-requests: write  # for release-drafter/release-drafter to add label to PR
     if: github.repository == 'python-pillow/Pillow'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       # Drafts your next release notes as pull requests are merged into "main"
       - uses: release-drafter/release-drafter@eada3c96a64734dd381cfbda23511034e328ddb0 # v7.6.0

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       issues: write
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
     - name: "Check issues"


### PR DESCRIPTION
We can use these for the very lightweight jobs.

Doesn't make much difference either way for us, but might as well save some resources, and perhaps there may be higher availability for these.

https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/

Also used for the no-op `test-skipped.yml` in https://github.com/python-pillow/Pillow/pull/9126.