### PR TITLE
Handle zero dimensions in ImagingOffset

### DIFF
--- a/src/libImaging/Offset.c
+++ b/src/libImaging/Offset.c
@@ -33,6 +33,9 @@ ImagingOffset(Imaging im, int xoffset, int yoffset) {
     ImagingCopyPalette(imOut, im);
 
     /* make offsets positive to avoid negative coordinates */
+    if (im->xsize == 0 || im->ysize == 0) {
+        return imOut;
+    }
     xoffset %= im->xsize;
     xoffset = im->xsize - xoffset;
     if (xoffset < 0) {


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixed division-by-zero crash in ImagingOffset when image width or height is zero
- Added dimension checks before performing xoffset %= im->xsize and yoffset %= im->ysize

Reference:
This PR addresses the division-by-zero issue previously reported in security advisory GHSA-f87v-9578-p47w. The fix follows the recommended approach: checking image dimensions before modulo operations and returning an empty image copy early when either dimension is zero.
