### PR TITLE
Deprecate IM image format

### DIFF
--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -15,24 +15,28 @@ TEST_IM = "Tests/images/hopper.im"
 
 
 def test_sanity() -> None:
-    with Image.open(TEST_IM) as im:
-        im.load()
-        assert im.mode == "RGB"
-        assert im.size == (128, 128)
-        assert im.format == "IM"
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        im = Image.open(TEST_IM)
+    im.load()
+    assert im.mode == "RGB"
+    assert im.size == (128, 128)
+    assert im.format == "IM"
+    im.close()
 
 
 def test_name_limit(tmp_path: Path) -> None:
     out = tmp_path / ("name_limit_test" * 7 + ".im")
-    with Image.open(TEST_IM) as im:
-        im.save(out)
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        with Image.open(TEST_IM) as im:
+            im.save(out)
     assert filecmp.cmp(out, "Tests/images/hopper_long_name.im")
 
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file() -> None:
     def open_test_image() -> None:
-        im = Image.open(TEST_IM)
+        with pytest.warns(DeprecationWarning, match="IM image format"):
+            im = Image.open(TEST_IM)
         im.load()
 
     with pytest.warns(ResourceWarning):
@@ -41,54 +45,63 @@ def test_unclosed_file() -> None:
 
 def test_closed_file() -> None:
     with warnings.catch_warnings(action="error"):
-        im = Image.open(TEST_IM)
+        with pytest.warns(DeprecationWarning, match="IM image format"):
+            im = Image.open(TEST_IM)
         im.load()
         im.close()
 
 
 def test_context_manager() -> None:
     with warnings.catch_warnings(action="error"):
-        with Image.open(TEST_IM) as im:
-            im.load()
+        with pytest.warns(DeprecationWarning, match="IM image format"):
+            with Image.open(TEST_IM) as im:
+                im.load()
 
 
 def test_tell() -> None:
     # Arrange
-    with Image.open(TEST_IM) as im:
-        # Act
-        frame = im.tell()
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        with Image.open(TEST_IM) as im:
+            # Act
+            frame = im.tell()
 
     # Assert
     assert frame == 0
 
 
 def test_n_frames() -> None:
-    with Image.open(TEST_IM) as im:
-        assert isinstance(im, ImImagePlugin.ImImageFile)
-        assert im.n_frames == 1
-        assert not im.is_animated
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        im = Image.open(TEST_IM)
+    assert isinstance(im, ImImagePlugin.ImImageFile)
+    assert im.n_frames == 1
+    assert not im.is_animated
+    im.close()
 
 
 def test_eoferror() -> None:
-    with Image.open(TEST_IM) as im:
-        assert isinstance(im, ImImagePlugin.ImImageFile)
-        n_frames = im.n_frames
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        im = Image.open(TEST_IM)
+    assert isinstance(im, ImImagePlugin.ImImageFile)
+    n_frames = im.n_frames
 
-        # Test seeking past the last frame
-        with pytest.raises(EOFError):
-            im.seek(n_frames)
-        assert im.tell() < n_frames
+    # Test seeking past the last frame
+    with pytest.raises(EOFError):
+        im.seek(n_frames)
+    assert im.tell() < n_frames
 
-        # Test that seeking to the last frame does not raise an error
-        im.seek(n_frames - 1)
+    # Test that seeking to the last frame does not raise an error
+    im.seek(n_frames - 1)
+    im.close()
 
 
 @pytest.mark.parametrize("mode", ("RGB", "P", "PA"))
 def test_roundtrip(mode: str, tmp_path: Path) -> None:
     out = tmp_path / "temp.im"
     im = hopper(mode)
-    im.save(out)
-    assert_image_equal_tofile(im, out)
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        im.save(out)
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        assert_image_equal_tofile(im, out)
 
 
 def test_small_palette(tmp_path: Path) -> None:
@@ -97,17 +110,21 @@ def test_small_palette(tmp_path: Path) -> None:
     im.putpalette(colors)
 
     out = tmp_path / "temp.im"
-    im.save(out)
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        im.save(out)
 
-    with Image.open(out) as reloaded:
-        assert reloaded.getpalette() == colors + [0] * 765
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        reloaded = Image.open(out)
+    assert reloaded.getpalette() == colors + [0] * 765
+    reloaded.close()
 
 
 def test_save_unsupported_mode(tmp_path: Path) -> None:
     out = tmp_path / "temp.im"
     im = hopper("HSV")
     with pytest.raises(ValueError):
-        im.save(out)
+        with pytest.warns(DeprecationWarning, match="IM image format"):
+            im.save(out)
 
 
 def test_invalid_file() -> None:
@@ -118,4 +135,5 @@ def test_invalid_file() -> None:
 
 
 def test_number() -> None:
-    assert ImImagePlugin.number("1.2") == 1.2
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        assert ImImagePlugin.number("1.2") == 1.2

--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -18,24 +18,28 @@ TEST_IM = "Tests/images/hopper.im"
 
 
 def test_sanity() -> None:
-    with Image.open(TEST_IM) as im:
-        im.load()
-        assert im.mode == "RGB"
-        assert im.size == (128, 128)
-        assert im.format == "IM"
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        im = Image.open(TEST_IM)
+    im.load()
+    assert im.mode == "RGB"
+    assert im.size == (128, 128)
+    assert im.format == "IM"
+    im.close()
 
 
 def test_name_limit(tmp_path: Path) -> None:
     out = tmp_path / ("name_limit_test" * 7 + ".im")
-    with Image.open(TEST_IM) as im:
-        im.save(out)
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        with Image.open(TEST_IM) as im:
+            im.save(out)
     assert filecmp.cmp(out, "Tests/images/hopper_long_name.im")
 
 
 @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
 def test_unclosed_file() -> None:
     def open_test_image() -> None:
-        im = Image.open(TEST_IM)
+        with pytest.warns(DeprecationWarning, match="IM image format"):
+            im = Image.open(TEST_IM)
         im.load()
 
     with pytest.warns(ResourceWarning):
@@ -44,54 +48,63 @@ def test_unclosed_file() -> None:
 
 def test_closed_file() -> None:
     with warnings.catch_warnings(action="error"):
-        im = Image.open(TEST_IM)
+        with pytest.warns(DeprecationWarning, match="IM image format"):
+            im = Image.open(TEST_IM)
         im.load()
         im.close()
 
 
 def test_context_manager() -> None:
     with warnings.catch_warnings(action="error"):
-        with Image.open(TEST_IM) as im:
-            im.load()
+        with pytest.warns(DeprecationWarning, match="IM image format"):
+            with Image.open(TEST_IM) as im:
+                im.load()
 
 
 def test_tell() -> None:
     # Arrange
-    with Image.open(TEST_IM) as im:
-        # Act
-        frame = im.tell()
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        with Image.open(TEST_IM) as im:
+            # Act
+            frame = im.tell()
 
     # Assert
     assert frame == 0
 
 
 def test_n_frames() -> None:
-    with Image.open(TEST_IM) as im:
-        assert isinstance(im, ImImagePlugin.ImImageFile)
-        assert im.n_frames == 1
-        assert not im.is_animated
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        im = Image.open(TEST_IM)
+    assert isinstance(im, ImImagePlugin.ImImageFile)
+    assert im.n_frames == 1
+    assert not im.is_animated
+    im.close()
 
 
 def test_eoferror() -> None:
-    with Image.open(TEST_IM) as im:
-        assert isinstance(im, ImImagePlugin.ImImageFile)
-        n_frames = im.n_frames
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        im = Image.open(TEST_IM)
+    assert isinstance(im, ImImagePlugin.ImImageFile)
+    n_frames = im.n_frames
 
-        # Test seeking past the last frame
-        with pytest.raises(EOFError):
-            im.seek(n_frames)
-        assert im.tell() < n_frames
+    # Test seeking past the last frame
+    with pytest.raises(EOFError):
+        im.seek(n_frames)
+    assert im.tell() < n_frames
 
-        # Test that seeking to the last frame does not raise an error
-        im.seek(n_frames - 1)
+    # Test that seeking to the last frame does not raise an error
+    im.seek(n_frames - 1)
+    im.close()
 
 
 @pytest.mark.parametrize("mode", ("RGB", "P", "PA"))
 def test_roundtrip(mode: str, tmp_path: Path) -> None:
     out = tmp_path / "temp.im"
     im = hopper(mode)
-    im.save(out)
-    assert_image_equal_tofile(im, out)
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        im.save(out)
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        assert_image_equal_tofile(im, out)
 
 
 def test_small_palette(tmp_path: Path) -> None:
@@ -100,17 +113,21 @@ def test_small_palette(tmp_path: Path) -> None:
     im.putpalette(colors)
 
     out = tmp_path / "temp.im"
-    im.save(out)
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        im.save(out)
 
-    with Image.open(out) as reloaded:
-        assert reloaded.getpalette() == colors + [0] * 765
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        reloaded = Image.open(out)
+    assert reloaded.getpalette() == colors + [0] * 765
+    reloaded.close()
 
 
 def test_save_unsupported_mode(tmp_path: Path) -> None:
     out = tmp_path / "temp.im"
     im = hopper("HSV")
     with pytest.raises(ValueError):
-        im.save(out)
+        with pytest.warns(DeprecationWarning, match="IM image format"):
+            im.save(out)
 
 
 def test_invalid_file() -> None:
@@ -121,4 +138,5 @@ def test_invalid_file() -> None:
 
 
 def test_number() -> None:
-    assert ImImagePlugin.number("1.2") == 1.2
+    with pytest.warns(DeprecationWarning, match="IM image format"):
+        assert ImImagePlugin.number("1.2") == 1.2

--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -52,7 +52,8 @@ class TestImageFile:
         assert_image_equal(*roundtrip("BMP"))
         im1, im2 = roundtrip("GIF")
         assert_image_similar(im1.convert("P"), im2, 1)
-        assert_image_equal(*roundtrip("IM"))
+        with pytest.warns(DeprecationWarning, match="IM image format"):
+            assert_image_equal(*roundtrip("IM"))
         assert_image_equal(*roundtrip("MSP"))
         if features.check("zlib"):
             # force multiple blocks in PNG driver

--- a/Tests/test_imagesequence.py
+++ b/Tests/test_imagesequence.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 
 def test_sanity(tmp_path: Path) -> None:
-    test_file = tmp_path / "temp.im"
+    test_file = tmp_path / "temp.tiff"
 
     im = hopper("RGB")
     im.save(test_file)

--- a/Tests/test_mode_i16.py
+++ b/Tests/test_mode_i16.py
@@ -46,7 +46,7 @@ def test_basic(tmp_path: Path, mode: str) -> None:
     im_out = im_in.transform((w, h), Image.Transform.EXTENT, (0, 0, w, h))
     verify(im_out)  # transform
 
-    filename = tmp_path / "temp.im"
+    filename = tmp_path / "temp.tiff"
     im_in.save(filename)
 
     with Image.open(filename) as im_out:

--- a/Tests/test_mode_i16.py
+++ b/Tests/test_mode_i16.py
@@ -44,7 +44,7 @@ def test_basic(tmp_path: Path, mode: str) -> None:
     im_out = im_in.transform((w, h), Image.Transform.EXTENT, (0, 0, w, h))
     verify(im_out)  # transform
 
-    filename = tmp_path / "temp.im"
+    filename = tmp_path / "temp.tiff"
     im_in.save(filename)
 
     with Image.open(filename) as im_out:

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -21,7 +21,7 @@ ExifTags.IFD.Makernote
 ``ExifTags.IFD.MakerNote``.
 
 Image getdata()
-~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^
 
 .. deprecated:: 12.1.0
 
@@ -29,6 +29,13 @@ Image getdata()
 :py:meth:`~PIL.Image.Image.get_flattened_data` can be used instead. This new method is
 identical, except that it returns a tuple of pixel values, instead of an internal
 Pillow data type.
+
+IM image format
+^^^^^^^^^^^^^^^
+
+.. deprecated:: 13.0.0
+
+The IM image format has been deprecated.
 
 Removed features
 ----------------

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -21,7 +21,7 @@ ExifTags.IFD.Makernote
 ``ExifTags.IFD.MakerNote``.
 
 Image getdata()
-~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^
 
 .. deprecated:: 12.1.0
 
@@ -30,9 +30,15 @@ Image getdata()
 identical, except that it returns a tuple of pixel values, instead of an internal
 Pillow data type.
 
+IM image format
+^^^^^^^^^^^^^^^
+
+.. deprecated:: 13.0.0
+
+The IM image format has been deprecated.
 
 JpegImageFile.load_djpeg
-~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. deprecated:: 13.0.0
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -35,7 +35,9 @@ IM image format
 
 .. deprecated:: 13.0.0
 
-The IM image format has been deprecated.
+The IM image format has been deprecated and removal is planned in Pillow 15.0.0
+(2028-10-15). If you are using this format and would like to continue doing so,
+open an issue about what other software uses it.
 
 ImageQt align8to32()
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -473,6 +473,8 @@ The :py:meth:`~PIL.Image.Image.save` method can take the following keyword argum
 IM
 ^^
 
+.. deprecated:: 13.0.0
+
 IM is a format used by LabEye and other applications based on the IFUNC image
 processing library. The library reads and writes most uncompressed interchange
 versions of this format.

--- a/docs/releasenotes/13.0.0.rst
+++ b/docs/releasenotes/13.0.0.rst
@@ -69,10 +69,13 @@ ImageCms.ImageCmsProfile.product_name and .product_info
 Deprecations
 ============
 
-TODO
-^^^^
+IM image format
+^^^^^^^^^^^^^^^
 
-TODO
+.. deprecated:: 13.0.0
+
+The IM image format has been deprecated. If you are using this format and would like
+to continue doing so, please provide a report about what other software uses it.
 
 API changes
 ===========

--- a/docs/releasenotes/13.0.0.rst
+++ b/docs/releasenotes/13.0.0.rst
@@ -69,6 +69,12 @@ ImageCms.ImageCmsProfile.product_name and .product_info
 Deprecations
 ============
 
+IM image format
+^^^^^^^^^^^^^^^
+
+The IM image format has been deprecated. If you are using this format and would like
+to continue doing so, please provide a report about what other software uses it.
+
 JpegImageFile.load_djpeg
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/releasenotes/13.0.0.rst
+++ b/docs/releasenotes/13.0.0.rst
@@ -72,8 +72,9 @@ Deprecations
 IM image format
 ^^^^^^^^^^^^^^^
 
-The IM image format has been deprecated. If you are using this format and would like
-to continue doing so, please provide a report about what other software uses it.
+The IM image format has been deprecated and removal is planned in Pillow 15.0.0
+(2028-10-15). If you are using this format and would like to continue doing so,
+open an issue about what other software uses it.
 
 JpegImageFile.load_djpeg
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/PIL/ImImagePlugin.py
+++ b/src/PIL/ImImagePlugin.py
@@ -31,6 +31,7 @@ import re
 from typing import IO, Any
 
 from . import Image, ImageFile, ImagePalette
+from ._deprecate import deprecate
 from ._util import DeferredError
 
 # --------------------------------------------------------------------
@@ -106,6 +107,7 @@ split = re.compile(rb"^([A-Za-z][^:]*):[ \t]*(.*)[ \t]*$")
 
 
 def number(s: Any) -> float:
+    deprecate("IM image format", 15)
     try:
         return int(s)
     except ValueError:
@@ -205,6 +207,8 @@ class ImImageFile(ImageFile.ImageFile):
         if not n:
             msg = "Not an IM file"
             raise SyntaxError(msg)
+
+        deprecate("IM image format", 15)
 
         # Basic attributes
         self._size = self.info[SIZE]
@@ -341,6 +345,7 @@ SAVE = {
 
 
 def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
+    deprecate("IM image format", 15)
     try:
         image_type, rawmode = SAVE[im.mode]
     except KeyError as e:

--- a/src/PIL/ImImagePlugin.py
+++ b/src/PIL/ImImagePlugin.py
@@ -30,6 +30,7 @@ import os
 import re
 
 from . import Image, ImageFile, ImagePalette
+from ._deprecate import deprecate
 from ._util import DeferredError
 
 TYPE_CHECKING = False
@@ -110,6 +111,7 @@ split = re.compile(rb"^([A-Za-z][^:]*):[ \t]*(.*)[ \t]*$")
 
 
 def number(s: Any) -> float:
+    deprecate("IM image format", 15)
     try:
         return int(s)
     except ValueError:
@@ -209,6 +211,8 @@ class ImImageFile(ImageFile.ImageFile):
         if not n:
             msg = "Not an IM file"
             raise SyntaxError(msg)
+
+        deprecate("IM image format", 15)
 
         # Basic attributes
         self._size = self.info[SIZE]
@@ -345,6 +349,7 @@ SAVE = {
 
 
 def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
+    deprecate("IM image format", 15)
     try:
         image_type, rawmode = SAVE[im.mode]
     except KeyError as e:

--- a/src/PIL/_deprecate.py
+++ b/src/PIL/_deprecate.py
@@ -48,6 +48,8 @@ def deprecate(
         raise RuntimeError(msg)
     elif when == 14:
         removed = "Pillow 14 (2027-10-15)"
+    elif when == 15:
+        removed = "Pillow 15 (2028-10-15)"
     else:
         msg = f"Unknown removal version: {when}. Update {__name__}?"
         raise ValueError(msg)


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/issues/9101#issuecomment-4134756068

> we could consider deprecating some of the obscure core plugins. There are definitely a few added during the early PIL days, where it was really hard to find sample images when adding tests decades later! These should be long deprecations, which could be dropped if we get feedback of real use.

When looking for specification for the IM format for #9800 on Google, I was unable to find anything unrelated to Pillow. I suggest deprecating with a two year deprecation period.