### PR TITLE
Protect getlist() walk with a critical section (free-threading, #9852)

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -97,6 +97,8 @@
 
 #include "libImaging/Imaging.h"
 
+#include "thirdparty/pythoncapi_compat.h"
+
 #define _USE_MATH_DEFINES
 #include <math.h>
 #include <stddef.h>
@@ -461,7 +463,17 @@ getlist(PyObject *arg, Py_ssize_t *length, const char *wrong_length, int type) {
         return NULL;
     }
 
-    for (i = 0; i < n; i++) {
+    // On a free-threaded build PySequence_Fast returns the list itself for a list
+    // input, so the walk below aliases the caller's list. Hold a critical section on
+    // it and clamp to its current length, so a concurrent resize cannot make
+    // PySequence_Fast_GET_ITEM read out of bounds (#9852). `n` was read before this
+    // point and may be stale.
+    Py_BEGIN_CRITICAL_SECTION(seq);
+    Py_ssize_t count = PySequence_Fast_GET_SIZE(seq);
+    if (count > n) {
+        count = n;
+    }
+    for (i = 0; i < count; i++) {
         op = PySequence_Fast_GET_ITEM(seq, i);
         // DRY, branch prediction is going to work _really_ well
         // on this switch. And 3 fewer loops to copy/paste.
@@ -484,6 +496,7 @@ getlist(PyObject *arg, Py_ssize_t *length, const char *wrong_length, int type) {
                 break;
         }
     }
+    Py_END_CRITICAL_SECTION();
 
     Py_DECREF(seq);
 


### PR DESCRIPTION
Fixes #9852. Alternative to #9853

`getlist()` (used by `Image.point()`) walks the caller's list with `PySequence_Fast` and the unchecked `PySequence_Fast_GET_ITEM` macro over a size captured earlier in the function. On a free-threaded build `PySequence_Fast` returns the list itself for a list input, so the walk aliases the caller's list; another thread resizing it drives an out-of-bounds read and a segfault. This is #9852.

This holds a critical section on the fast sequence for the walk and clamps the loop to its current length, so a resize that happened between the earlier size read and the walk cannot read out of bounds. It mirrors the critical-section approach already used for `FontObject` in #9498, and uses the `Py_BEGIN_CRITICAL_SECTION` shim already vendored in `thirdparty/pythoncapi_compat.h` (a no-op block on < 3.13, where the GIL serialises the walk anyway).

### Verification

`python3.14.0rc1t`, built from source:

- The reproducer in #9852 (12 threads `img.im.point(shared, "L")` while others resize `shared`) goes from **10/10 SIGSEGV to 0/10** with this change; the no-mutator, decoy and GIL-on controls stay clean.
- `Tests/test_image_point.py` passes (4/4), and `point()` output is unchanged for normal look-up tables (identity and offset LUTs verified).

A concurrent resize now yields a truncated read rather than a crash; if you'd prefer it to raise instead, I'm happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)