### PR TITLE
Remove palette if no longer relevant after TIFF seek

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -865,6 +865,15 @@ class TestFileLibTiff(LibTiffTestCase):
             assert im.size == (10, 10)
             im.load()
 
+    def test_seek_remove_palette(self) -> None:
+        with Image.open("Tests/images/no_rows_per_strip.tif") as im:
+            assert im.mode == "P"
+            assert im.palette is not None
+
+            im.seek(1)
+            assert im.mode == "F"
+            assert im.palette is None
+
     def test_save_tiff_with_jpegtables(self, tmp_path: Path) -> None:
         # Arrange
         outfile = tmp_path / "temp.tif"

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1673,6 +1673,8 @@ class TiffImageFile(ImageFile.ImageFile):
         if self.mode in ["P", "PA"]:
             palette = [o8(b // 256) for b in self.tag_v2[COLORMAP]]
             self.palette = ImagePalette.raw("RGB;L", b"".join(palette))
+        else:
+            self.palette = None
 
 
 #


### PR DESCRIPTION
Resolves #9851

When a TIFF image seeks to a P or PA mode frame, it adds a palette. However, if the image then seeks to a frame with a different mode, the palette is not removed. This fixes that.