### PR TITLE
Raise ValueError for zero or negative sizes in ImageOps contain/cover/pad/fit

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -129,6 +129,18 @@ def test_contain_round() -> None:
 
 
 @pytest.mark.parametrize(
+    "operation", (ImageOps.contain, ImageOps.cover, ImageOps.pad, ImageOps.fit)
+)
+@pytest.mark.parametrize("size", ((0, 10), (10, 0), (-1, 10), (10, -1)))
+def test_size_must_be_positive(operation, size: tuple[int, int]) -> None:
+    # A zero or negative dimension must raise a clear ValueError, not a
+    # ZeroDivisionError (or silently return a wrong-sized image).
+    with Image.new("RGB", (100, 50)) as im:
+        with pytest.raises(ValueError, match="height and width must be > 0"):
+            operation(im, size)
+
+
+@pytest.mark.parametrize(
     "image_name, expected_size",
     (
         ("colr_bungee.png", (1024, 256)),  # landscape

--- a/docs/releasenotes/13.0.0.rst
+++ b/docs/releasenotes/13.0.0.rst
@@ -101,3 +101,12 @@ to help projects prepare for 3.15, and to ensure Pillow could be used
 immediately at the release of 3.15.0 final (2026-10-01, :pep:`790`).
 
 Pillow 13.0.0 now officially supports Python 3.15.
+
+ImageOps invalid sizes
+^^^^^^^^^^^^^^^^^^^^^^^
+
+:py:meth:`~PIL.ImageOps.contain`, :py:meth:`~PIL.ImageOps.cover`,
+:py:meth:`~PIL.ImageOps.pad` and :py:meth:`~PIL.ImageOps.fit` now raise a
+``ValueError`` when the requested size has a dimension that is zero or negative.
+Previously a zero height raised ``ZeroDivisionError``, and some invalid sizes
+returned an incorrectly sized image.

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -277,6 +277,12 @@ def colorize(
     return _lut(image, red + green + blue)
 
 
+def _check_size(size: tuple[int, int]) -> None:
+    if size[0] <= 0 or size[1] <= 0:
+        msg = "height and width must be > 0"
+        raise ValueError(msg)
+
+
 def contain(
     image: Image.Image, size: tuple[int, int], method: int = Image.Resampling.BICUBIC
 ) -> Image.Image:
@@ -292,6 +298,8 @@ def contain(
                    See :ref:`concept-filters`.
     :return: An image.
     """
+
+    _check_size(size)
 
     im_ratio = image.width / image.height
     dest_ratio = size[0] / size[1]
@@ -323,6 +331,8 @@ def cover(
                    See :ref:`concept-filters`.
     :return: An image.
     """
+
+    _check_size(size)
 
     im_ratio = image.width / image.height
     dest_ratio = size[0] / size[1]
@@ -561,6 +571,8 @@ def fit(
                       none from the top, and therefore all off the bottom).
     :return: An image.
     """
+
+    _check_size(size)
 
     # by Kevin Cazabon, Feb 17/2000
     # kevin@cazabon.com


### PR DESCRIPTION
`ImageOps.contain`, `cover`, `pad` and `fit` handle invalid output sizes inconsistently. Because they compute `size[0] / size[1]` before `Image.resize` validates the size, a zero height raises `ZeroDivisionError`; `cover` skips validation entirely for a zero or negative width (returning a wrong-sized image); and `contain` returns a wrong-sized image for a negative height.

Before, on a 100x50 image:

| size | contain | cover | pad | fit |
|------|---------|-------|-----|-----|
| `(0, 10)` | `ValueError` | **`(20, 10)`** | `ValueError` | `ValueError` |
| `(10, 0)` | **`ZeroDivisionError`** | **`ZeroDivisionError`** | **`ZeroDivisionError`** | **`ZeroDivisionError`** |
| `(-1, 10)` | `ValueError` | **`(20, 10)`** | `ValueError` | `ValueError` |
| `(10, -1)` | **`(10, 5)`** | `ValueError` | `ValueError` | `ValueError` |

This adds an up-front size check to `contain`, `cover` and `fit` (`pad` delegates to `contain`) that raises the core's own `ValueError: height and width must be > 0` for any dimension `<= 0`, so all four behave consistently.

### Testing

Added a parametrized test over the four functions and the zero/negative sizes above; it asserts a `ValueError` rather than a crash or a silently wrong result. The full `Tests/test_imageops.py` suite passes (62 tests) and `ruff` is clean. A release note is included.

---
Used AI assistance on this; I reviewed and tested the change myself.