### PR TITLE
Replace custom test code

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -345,12 +345,3 @@ def is_win32() -> bool:
 
 def is_pypy() -> bool:
     return hasattr(sys, "pypy_translation_info")
-
-
-class CachedProperty:
-    def __init__(self, func: Callable[[Any], Any]) -> None:
-        self.func = func
-
-    def __get__(self, instance: Any, cls: type[Any] | None = None) -> Any:
-        result = instance.__dict__[self.func.__name__] = self.func(instance)
-        return result

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -335,4 +335,4 @@ def is_win32() -> bool:
 
 
 def is_pypy() -> bool:
-    return hasattr(sys, "pypy_translation_info")
+    return sys.implementation.name == "pypy"

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -154,15 +154,6 @@ def assert_not_all_same(items: Sequence[Any], msg: str | None = None) -> None:
     assert items.count(items[0]) != len(items), msg
 
 
-def assert_tuple_approx_equal(
-    actuals: Sequence[int], targets: tuple[int, ...], threshold: int, msg: str
-) -> None:
-    """Tests if actuals has values within threshold from targets"""
-    for i, target in enumerate(targets):
-        if not (target - threshold <= actuals[i] <= target + threshold):
-            pytest.fail(msg + ": " + repr(actuals) + " != " + repr(targets))
-
-
 def timeout_unless_slower_valgrind(timeout: float) -> pytest.MarkDecorator:
     if "PILLOW_VALGRIND_TEST" in os.environ:
         return pytest.mark.pil_noop_mark()

--- a/Tests/test_image_paste.py
+++ b/Tests/test_image_paste.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from functools import cached_property
+
 import pytest
 
 from PIL import Image
 
-from .helper import CachedProperty, assert_image_equal
+from .helper import assert_image_equal
 
 
 class TestImagingPaste:
@@ -45,7 +47,7 @@ class TestImagingPaste:
         im.paste(im2, mask)
         self.assert_9points_image(im, expected)
 
-    @CachedProperty
+    @cached_property
     def mask_1(self) -> Image.Image:
         mask = Image.new("1", (self.size, self.size))
         px = mask.load()
@@ -55,11 +57,11 @@ class TestImagingPaste:
                 px[y, x] = (x + y) % 2
         return mask
 
-    @CachedProperty
+    @cached_property
     def mask_L(self) -> Image.Image:
         return self.gradient_L.transpose(Image.Transpose.ROTATE_270)
 
-    @CachedProperty
+    @cached_property
     def gradient_L(self) -> Image.Image:
         gradient = Image.new("L", (self.size, self.size))
         px = gradient.load()
@@ -69,7 +71,7 @@ class TestImagingPaste:
                 px[y, x] = (x + y) % 255
         return gradient
 
-    @CachedProperty
+    @cached_property
     def gradient_RGB(self) -> Image.Image:
         return Image.merge(
             "RGB",
@@ -80,7 +82,7 @@ class TestImagingPaste:
             ],
         )
 
-    @CachedProperty
+    @cached_property
     def gradient_LA(self) -> Image.Image:
         return Image.merge(
             "LA",
@@ -90,7 +92,7 @@ class TestImagingPaste:
             ],
         )
 
-    @CachedProperty
+    @cached_property
     def gradient_RGBA(self) -> Image.Image:
         return Image.merge(
             "RGBA",
@@ -102,7 +104,7 @@ class TestImagingPaste:
             ],
         )
 
-    @CachedProperty
+    @cached_property
     def gradient_RGBa(self) -> Image.Image:
         return Image.merge(
             "RGBa",

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -290,18 +290,15 @@ def test_colorize_2color() -> None:
     im_test = ImageOps.colorize(im_l, "red", "green")
 
     # Test output image (2-color)
-    left = (0, 1)
-    middle = (127, 1)
-    right = (255, 1)
-    value = im_test.getpixel(left)
-    assert isinstance(value, tuple)
-    assert value == pytest.approx((255, 0, 0), abs=1), "black test pixel incorrect"
-    value = im_test.getpixel(middle)
-    assert isinstance(value, tuple)
-    assert value == pytest.approx((127, 63, 0), abs=1), "mid test pixel incorrect"
-    value = im_test.getpixel(right)
-    assert isinstance(value, tuple)
-    assert value == pytest.approx((0, 127, 0), abs=1), "white test pixel incorrect"
+    assert im_test.getpixel((0, 1)) == pytest.approx(
+        (255, 0, 0), abs=1
+    ), "black test pixel incorrect"
+    assert im_test.getpixel((127, 1)) == pytest.approx(
+        (127, 63, 0), abs=1
+    ), "mid test pixel incorrect"
+    assert im_test.getpixel((255, 1)) == pytest.approx(
+        (0, 127, 0), abs=1
+    ), "white test pixel incorrect"
 
 
 def test_colorize_2color_offset() -> None:
@@ -317,18 +314,15 @@ def test_colorize_2color_offset() -> None:
     )
 
     # Test output image (2-color) with offsets
-    left = (25, 1)
-    middle = (75, 1)
-    right = (125, 1)
-    value = im_test.getpixel(left)
-    assert isinstance(value, tuple)
-    assert value == pytest.approx((255, 0, 0), abs=1), "black test pixel incorrect"
-    value = im_test.getpixel(middle)
-    assert isinstance(value, tuple)
-    assert value == pytest.approx((127, 63, 0), abs=1), "mid test pixel incorrect"
-    value = im_test.getpixel(right)
-    assert isinstance(value, tuple)
-    assert value == pytest.approx((0, 127, 0), abs=1), "white test pixel incorrect"
+    assert im_test.getpixel((25, 1)) == pytest.approx(
+        (255, 0, 0), abs=1
+    ), "black test pixel incorrect"
+    assert im_test.getpixel((75, 1)) == pytest.approx(
+        (127, 63, 0), abs=1
+    ), "mid test pixel incorrect"
+    assert im_test.getpixel((125, 1)) == pytest.approx(
+        (0, 127, 0), abs=1
+    ), "white test pixel incorrect"
 
 
 def test_colorize_3color_offset() -> None:
@@ -350,26 +344,21 @@ def test_colorize_3color_offset() -> None:
     )
 
     # Test output image (3-color) with offsets
-    left = (25, 1)
-    left_middle = (75, 1)
-    middle = (100, 1)
-    right_middle = (150, 1)
-    right = (225, 1)
-    value = im_test.getpixel(left)
-    assert isinstance(value, tuple)
-    assert value == pytest.approx((255, 0, 0), abs=1), "black test pixel incorrect"
-    value = im_test.getpixel(left_middle)
-    assert isinstance(value, tuple)
-    assert value == pytest.approx((127, 0, 127), abs=1), "low-mid test pixel incorrect"
-    value = im_test.getpixel(middle)
-    assert isinstance(value, tuple)
-    assert value == pytest.approx((0, 0, 255), abs=1), "mid incorrect"
-    value = im_test.getpixel(right_middle)
-    assert isinstance(value, tuple)
-    assert value == pytest.approx((0, 63, 127), abs=1), "high-mid test pixel incorrect"
-    value = im_test.getpixel(right)
-    assert isinstance(value, tuple)
-    assert value == pytest.approx((0, 127, 0), abs=1), "white test pixel incorrect"
+    assert im_test.getpixel((25, 1)) == pytest.approx(
+        (255, 0, 0), abs=1
+    ), "black test pixel incorrect"
+    assert im_test.getpixel((75, 1)) == pytest.approx(
+        (127, 0, 127), abs=1
+    ), "low-mid test pixel incorrect"
+    assert im_test.getpixel((100, 1)) == pytest.approx(
+        (0, 0, 255), abs=1
+    ), "mid incorrect"
+    assert im_test.getpixel((150, 1)) == pytest.approx(
+        (0, 63, 127), abs=1
+    ), "high-mid test pixel incorrect"
+    assert im_test.getpixel((225, 1)) == pytest.approx(
+        (0, 127, 0), abs=1
+    ), "white test pixel incorrect"
 
 
 def test_colorize_invalid_mode() -> None:

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -8,7 +8,6 @@ from .helper import (
     assert_image_equal,
     assert_image_similar,
     assert_image_similar_tofile,
-    assert_tuple_approx_equal,
     hopper,
 )
 
@@ -296,28 +295,13 @@ def test_colorize_2color() -> None:
     right = (255, 1)
     value = im_test.getpixel(left)
     assert isinstance(value, tuple)
-    assert_tuple_approx_equal(
-        value,
-        (255, 0, 0),
-        threshold=1,
-        msg="black test pixel incorrect",
-    )
+    assert value == pytest.approx((255, 0, 0), abs=1), "black test pixel incorrect"
     value = im_test.getpixel(middle)
     assert isinstance(value, tuple)
-    assert_tuple_approx_equal(
-        value,
-        (127, 63, 0),
-        threshold=1,
-        msg="mid test pixel incorrect",
-    )
+    assert value == pytest.approx((127, 63, 0), abs=1), "mid test pixel incorrect"
     value = im_test.getpixel(right)
     assert isinstance(value, tuple)
-    assert_tuple_approx_equal(
-        value,
-        (0, 127, 0),
-        threshold=1,
-        msg="white test pixel incorrect",
-    )
+    assert value == pytest.approx((0, 127, 0), abs=1), "white test pixel incorrect"
 
 
 def test_colorize_2color_offset() -> None:
@@ -338,28 +322,13 @@ def test_colorize_2color_offset() -> None:
     right = (125, 1)
     value = im_test.getpixel(left)
     assert isinstance(value, tuple)
-    assert_tuple_approx_equal(
-        value,
-        (255, 0, 0),
-        threshold=1,
-        msg="black test pixel incorrect",
-    )
+    assert value == pytest.approx((255, 0, 0), abs=1), "black test pixel incorrect"
     value = im_test.getpixel(middle)
     assert isinstance(value, tuple)
-    assert_tuple_approx_equal(
-        value,
-        (127, 63, 0),
-        threshold=1,
-        msg="mid test pixel incorrect",
-    )
+    assert value == pytest.approx((127, 63, 0), abs=1), "mid test pixel incorrect"
     value = im_test.getpixel(right)
     assert isinstance(value, tuple)
-    assert_tuple_approx_equal(
-        value,
-        (0, 127, 0),
-        threshold=1,
-        msg="white test pixel incorrect",
-    )
+    assert value == pytest.approx((0, 127, 0), abs=1), "white test pixel incorrect"
 
 
 def test_colorize_3color_offset() -> None:
@@ -388,39 +357,19 @@ def test_colorize_3color_offset() -> None:
     right = (225, 1)
     value = im_test.getpixel(left)
     assert isinstance(value, tuple)
-    assert_tuple_approx_equal(
-        value,
-        (255, 0, 0),
-        threshold=1,
-        msg="black test pixel incorrect",
-    )
+    assert value == pytest.approx((255, 0, 0), abs=1), "black test pixel incorrect"
     value = im_test.getpixel(left_middle)
     assert isinstance(value, tuple)
-    assert_tuple_approx_equal(
-        value,
-        (127, 0, 127),
-        threshold=1,
-        msg="low-mid test pixel incorrect",
-    )
+    assert value == pytest.approx((127, 0, 127), abs=1), "low-mid test pixel incorrect"
     value = im_test.getpixel(middle)
     assert isinstance(value, tuple)
-    assert_tuple_approx_equal(value, (0, 0, 255), threshold=1, msg="mid incorrect")
+    assert value == pytest.approx((0, 0, 255), abs=1), "mid incorrect"
     value = im_test.getpixel(right_middle)
     assert isinstance(value, tuple)
-    assert_tuple_approx_equal(
-        value,
-        (0, 63, 127),
-        threshold=1,
-        msg="high-mid test pixel incorrect",
-    )
+    assert value == pytest.approx((0, 63, 127), abs=1), "high-mid test pixel incorrect"
     value = im_test.getpixel(right)
     assert isinstance(value, tuple)
-    assert_tuple_approx_equal(
-        value,
-        (0, 127, 0),
-        threshold=1,
-        msg="white test pixel incorrect",
-    )
+    assert value == pytest.approx((0, 127, 0), abs=1), "white test pixel incorrect"
 
 
 def test_colorize_invalid_mode() -> None:
@@ -594,18 +543,12 @@ def test_autocontrast_mask_real_input() -> None:
         result_nomask = ImageOps.autocontrast(img)
 
         assert result_nomask != result
-        assert_tuple_approx_equal(
-            ImageStat.Stat(result, mask=rect_mask).median,
-            (195, 202, 184),
-            threshold=2,
-            msg="autocontrast with mask pixel incorrect",
-        )
-        assert_tuple_approx_equal(
-            ImageStat.Stat(result_nomask).median,
-            (119, 106, 79),
-            threshold=2,
-            msg="autocontrast without mask pixel incorrect",
-        )
+        assert ImageStat.Stat(result, mask=rect_mask).median == pytest.approx(
+            (195, 202, 184), abs=2
+        ), "autocontrast with mask pixel incorrect"
+        assert ImageStat.Stat(result_nomask).median == pytest.approx(
+            (119, 106, 79), abs=2
+        ), "autocontrast without mask pixel incorrect"
 
 
 def test_autocontrast_preserve_tone() -> None:


### PR DESCRIPTION
* Replace `CachedProperty` with `functools.cached_property`
* Replace `assert_tuple_approx_equal` with `pytest.approx`
* Replace Python 2's `hasattr(sys, "pypy_version_info")` with more clearer `sys.implementation.name == "pypy"`