### PR TITLE
Run mypy with parallel workers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,11 @@ lint.isort.required-imports = [
 max_supported_python = "3.15"
 
 [tool.mypy]
+exclude = [
+  "^Tests/images/msp/",
+  "^Tests/images/picins/",
+  "^Tests/images/sunraster/",
+]
 follow_imports = "silent"
 python_version = "3.11"
 disallow_any_generics = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,7 @@ warn_unreachable = true
 enable_error_code = "ignore-without-code"
 extra_checks = true
 pretty = true
+num_workers = 4
 
 [tool.pytest]
 addopts = [ "-ra", "--color=auto" ]


### PR DESCRIPTION
mypy has added a `--num-workers` option:

> Use `NUMBER` parallel worker processes (in addition to the coordinator process) to perform type-checking. Specifying `--num-workers 0` (default) disables parallel checking. Automatic detection of the optimal number of workers is not supported yet.

https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-n

Here's running with some different values on an 8-core macOS:

* Cold cache = `.mypy_cache` deleted
* Warm cache = immediate re-run

| `--num-workers` | Cold cache | Warm cache |
| --------------- | ---------- | ---------- |
| (none / serial) | 8.08       | 0.38       |
| 2               | 3.50       | 0.31       |
| 4               | **2.75**   | 0.36       |
| 6               | 3.58       | 0.40       |
| 8               | 2.97       | 0.45       |
| 16              | 7.19       | 1.58       |

So let's go for 4.

This is mainly for local benefit, but GitHub Actions has 4 CPUs and also improves: from [20.60 seconds](https://github.com/hugovk/Pillow/actions/runs/31327975719/job/93281391367) to [11.00 seconds](https://github.com/hugovk/Pillow/actions/runs/31331807688/job/93291178117).

---

I also sometimes have the extra test images installed, let's exclude them to avoid this:

```python
Tests/images/sunraster/test.py:21: error: Function is missing a type annotation for one or
more parameters  [no-untyped-def]
    def test(f) -> None:
    ^~~~~~~~~~~~~~~~~~~~
Tests/images/picins/test.py:10: error: Function is missing a type annotation for one or more
parameters  [no-untyped-def]
    def test(f) -> None:
    ^~~~~~~~~~~~~~~~~~~~
Tests/images/msp/test.py:21: error: Function is missing a type annotation for one or more
parameters  [no-untyped-def]
```
