### PR TITLE
Make pybind11 an optional build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,6 @@ backend-path = [
   "_custom_build",
 ]
 
-[dependency-groups]
-# Optional; enables parallel C extension compilation (see setup.py).
-build = [
-  "pybind11",
-]
-
 [project]
 name = "pillow"
 description = "Python Imaging Library (fork)"
@@ -90,6 +84,12 @@ urls.Funding = "https://tidelift.com/subscription/pkg/pypi-pillow?utm_source=pyp
 urls.Homepage = "https://python-pillow.org"
 urls.Mastodon = "https://fosstodon.org/@pillow"
 urls.Source = "https://github.com/python-pillow/Pillow"
+
+[dependency-groups]
+# Optional; enables parallel C extension compilation (see setup.py).
+build = [
+  "pybind11",
+]
 
 [tool.setuptools]
 packages = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,16 @@
 [build-system]
 build-backend = "backend"
 requires = [
-  "pybind11",
   "setuptools>=77",
 ]
 backend-path = [
   "_custom_build",
+]
+
+[dependency-groups]
+# Optional; enables parallel C extension compilation (see setup.py).
+build = [
+  "pybind11",
 ]
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ import sys
 import warnings
 from collections.abc import Iterator
 
-from pybind11.setup_helpers import ParallelCompile
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
@@ -33,7 +32,12 @@ while sys.argv[-1].startswith("--pillow-configuration="):
     configuration.setdefault(key, []).append(value)
 
 default = int(configuration.get("parallel", ["0"])[-1])
-ParallelCompile("MAX_CONCURRENCY", default).install()
+try:
+    from pybind11.setup_helpers import ParallelCompile
+
+    ParallelCompile("MAX_CONCURRENCY", default).install()
+except ImportError:
+    pass
 
 
 def get_version() -> str:


### PR DESCRIPTION
pybind11 is only used for pybind11.setup_helpers.ParallelCompile, which parallelises the compilation of the C extensions; it provides no runtime bindings. Wrap its import and use in try/except ImportError and drop it from build-system.requires, so the wheel builds without pybind11 (compiling serially) while still using it for parallel builds when it is installed.

Keep it discoverable via a PEP 735 "build" dependency group, so anyone who wants parallel source builds can install it with e.g. "pip install --group build". This lets distributions that do not want the extra build dependency (e.g. OpenWrt) build Pillow without pulling in pybind11.
