### PR TITLE
Use PyErr_Format instead of sprintf

### DIFF
--- a/src/Tk/tkImaging.c
+++ b/src/Tk/tkImaging.c
@@ -247,12 +247,9 @@ _dfunc(HMODULE lib_handle, const char *func_name) {
      * Returns function pointer or NULL if not present.
      */
 
-    char message[100];
-
     FARPROC func = GetProcAddress(lib_handle, func_name);
     if (func == NULL) {
-        sprintf(message, "Cannot load function %s", func_name);
-        PyErr_SetString(PyExc_RuntimeError, message);
+        PyErr_Format(PyExc_RuntimeError, "Cannot load function %s", func_name);
     }
     return func;
 }

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -43,7 +43,7 @@ PyObject *
 HandleMuxError(WebPMuxError err, char *chunk) {
     assert(err <= WEBP_MUX_NOT_FOUND && err >= WEBP_MUX_NOT_ENOUGH_DATA);
 
-    PyObject *err_type = PyExc_RuntimeError;
+    PyObject *err_type;
     switch (err) {
         case WEBP_MUX_MEMORY_ERROR:
             return PyErr_NoMemory();
@@ -56,6 +56,10 @@ HandleMuxError(WebPMuxError err, char *chunk) {
         case WEBP_MUX_BAD_DATA:
         case WEBP_MUX_NOT_ENOUGH_DATA:
             err_type = PyExc_OSError;
+            break;
+
+        default:
+            err_type = PyExc_RuntimeError;
             break;
     }
 

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -41,44 +41,30 @@ static const char *const kErrorMessages[-WEBP_MUX_NOT_ENOUGH_DATA + 1] = {
 
 PyObject *
 HandleMuxError(WebPMuxError err, char *chunk) {
-    char message[100];
-    int message_len;
     assert(err <= WEBP_MUX_NOT_FOUND && err >= WEBP_MUX_NOT_ENOUGH_DATA);
 
-    // Check for a memory error first
-    if (err == WEBP_MUX_MEMORY_ERROR) {
-        return PyErr_NoMemory();
-    }
-
-    // Create the error message
-    if (chunk == NULL) {
-        message_len =
-            sprintf(message, "could not assemble chunks: %s", kErrorMessages[-err]);
-    } else {
-        message_len = sprintf(
-            message, "could not set %.4s chunk: %s", chunk, kErrorMessages[-err]
-        );
-    }
-    if (message_len < 0) {
-        PyErr_SetString(PyExc_RuntimeError, "failed to construct error message");
-        return NULL;
-    }
-
-    // Set the proper error type
+    PyObject *err_type = PyExc_RuntimeError;
     switch (err) {
+        case WEBP_MUX_MEMORY_ERROR:
+            return PyErr_NoMemory();
+
         case WEBP_MUX_NOT_FOUND:
         case WEBP_MUX_INVALID_ARGUMENT:
-            PyErr_SetString(PyExc_ValueError, message);
+            err_type = PyExc_ValueError;
             break;
 
         case WEBP_MUX_BAD_DATA:
         case WEBP_MUX_NOT_ENOUGH_DATA:
-            PyErr_SetString(PyExc_OSError, message);
+            err_type = PyExc_OSError;
             break;
+    }
 
-        default:
-            PyErr_SetString(PyExc_RuntimeError, message);
-            break;
+    if (chunk == NULL) {
+        PyErr_Format(err_type, "could not assemble chunks: %s", kErrorMessages[-err]);
+    } else {
+        PyErr_Format(
+            err_type, "could not set %.4s chunk: %s", chunk, kErrorMessages[-err]
+        );
     }
     return NULL;
 }

--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -1622,19 +1622,12 @@ convert(Imaging imOut, Imaging imIn, ModeID mode, ImagingPalette palette, int di
     }
 
     if (!convert) {
-#ifdef notdef
-        return (Imaging)ImagingError_ValueError("conversion not supported");
-#else
-        static char buf[100];
-        snprintf(
-            buf,
-            100,
+        return (Imaging)PyErr_Format(
+            PyExc_ValueError,
             "conversion from %.10s to %.10s not supported",
             getModeData(imIn->mode)->name,
             getModeData(mode)->name
         );
-        return (Imaging)ImagingError_ValueError(buf);
-#endif
     }
 
     imOut = ImagingNew2Dirty(mode, imOut, imIn);
@@ -1707,15 +1700,12 @@ ImagingConvertTransparent(Imaging imIn, const ModeID mode, int r, int g, int b) 
         }
         g = b = r;
     } else {
-        static char buf[100];
-        snprintf(
-            buf,
-            100,
+        return (Imaging)PyErr_Format(
+            PyExc_ValueError,
             "conversion from %.10s to %.10s not supported in convert_transparent",
             getModeData(imIn->mode)->name,
             getModeData(mode)->name
         );
-        return (Imaging)ImagingError_ValueError(buf);
     }
 
     imOut = ImagingNew2Dirty(mode, imOut, imIn);


### PR DESCRIPTION
Just noticed a couple places using sprintf() instead of `PyErr_Format`, figured those could use unifying.