### PR TITLE
Add context manager

### DIFF
--- a/Tests/benchmarks.py
+++ b/Tests/benchmarks.py
@@ -868,7 +868,8 @@ def test_quantize_to_palette(
     size: tuple[int, int],
 ) -> None:
     if isinstance(source_type, pathlib.Path):
-        im = Image.open(source_type).convert("RGB").resize(size)
+        with Image.open(source_type) as source_im:
+            im = source_im.convert("RGB").resize(size)
     elif source_type == "synthetic":
         im = make_pillow_image("RGB", size)
     if palette_type == "exact":


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/c8c74c8306eb7e1429a1a629a7471ca1794b7601/Tests/benchmarks.py#L871

Adds a context manager to this code, since images should not be implicitly closed - https://pillow.readthedocs.io/en/stable/releasenotes/6.1.0.html#deprecations