### PR TITLE
Test remap_palette()'s source_palette argument

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -674,6 +674,29 @@ class TestImage:
             with pytest.raises(ValueError):
                 im_hopper.remap_palette([])
 
+    @pytest.mark.parametrize(
+        "bands, palette_mode", ((3, "RGB"), (4, "RGBA")), ids=("RGB", "RGBA")
+    )
+    def test_remap_palette_source_palette(self, bands: int, palette_mode: str) -> None:
+        # When source_palette is passed explicitly its mode is inferred from its
+        # length, so a full 256-entry RGB palette (exactly 768 bytes) must stay
+        # RGB while a 256-entry RGBA one (1024 bytes) is detected as RGBA.
+        source_palette = bytes(
+            (entry + channel * 17) % 256
+            for entry in range(256)
+            for channel in range(bands)
+        )
+        assert len(source_palette) == 256 * bands
+
+        im = Image.new("P", (256, 1))
+        for x in range(256):
+            im.putpixel((x, 0), x)
+
+        im_remapped = im.remap_palette(list(range(256)), source_palette)
+        assert im_remapped.palette is not None
+        assert im_remapped.palette.mode == palette_mode
+        assert im_remapped.palette.palette == source_palette
+
     def test_remap_palette_transparency(self) -> None:
         im = Image.new("P", (1, 2), (0, 0, 0))
         im.putpixel((0, 1), (255, 0, 0))

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -676,19 +676,18 @@ class TestImage:
 
     @pytest.mark.parametrize("palette_mode", ("RGB", "RGBA"))
     def test_remap_palette_source_palette(self, palette_mode: str) -> None:
-        # When source_palette is passed explicitly its mode is inferred from its
-        # length, so a full 256-entry RGB palette (exactly 768 bytes) must stay
-        # RGB while a 256-entry RGBA one (1024 bytes) is detected as RGBA.
-        source_palette = bytes(
-            (entry + channel * 17) % 256
-            for entry in range(256)
-            for channel in range(len(palette_mode))
-        )
+        # When source_palette is provided, mode is inferred from length.
+        # 768 entries should be detected as a 256-entry RGB palette
+        # 1024 entries should be detected as a 256-entry RGBA palette
         im = Image.new("P", (256, 1))
+        source_palette = bytes(
+            entry for entry in range(256) for channel in range(len(palette_mode))
+        )
         im_remapped = im.remap_palette(list(range(256)), source_palette)
 
         palette = im_remapped.palette
         assert palette is not None
+        assert len(palette.colors) == 256
         assert palette.mode == palette_mode
         assert palette.palette == source_palette
 

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -674,13 +674,12 @@ class TestImage:
             with pytest.raises(ValueError):
                 im_hopper.remap_palette([])
 
-    @pytest.mark.parametrize(
-        "bands, palette_mode", ((3, "RGB"), (4, "RGBA")), ids=("RGB", "RGBA")
-    )
-    def test_remap_palette_source_palette(self, bands: int, palette_mode: str) -> None:
+    @pytest.mark.parametrize("palette_mode", ("RGB", "RGBA"))
+    def test_remap_palette_source_palette(self, palette_mode: str) -> None:
         # When source_palette is passed explicitly its mode is inferred from its
         # length, so a full 256-entry RGB palette (exactly 768 bytes) must stay
         # RGB while a 256-entry RGBA one (1024 bytes) is detected as RGBA.
+        bands = len(palette_mode)
         source_palette = bytes(
             (entry + channel * 17) % 256
             for entry in range(256)

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -679,7 +679,7 @@ class TestImage:
         # When source_palette is provided, mode is inferred from length.
         # 768 entries should be detected as a 256-entry RGB palette
         # 1024 entries should be detected as a 256-entry RGBA palette
-        im = Image.new("P", (256, 1))
+        im = Image.new("P", (1, 1))
         source_palette = bytes(
             entry for entry in range(256) for channel in range(len(palette_mode))
         )

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -679,22 +679,18 @@ class TestImage:
         # When source_palette is passed explicitly its mode is inferred from its
         # length, so a full 256-entry RGB palette (exactly 768 bytes) must stay
         # RGB while a 256-entry RGBA one (1024 bytes) is detected as RGBA.
-        bands = len(palette_mode)
         source_palette = bytes(
             (entry + channel * 17) % 256
             for entry in range(256)
-            for channel in range(bands)
+            for channel in range(len(palette_mode))
         )
-        assert len(source_palette) == 256 * bands
-
         im = Image.new("P", (256, 1))
-        for x in range(256):
-            im.putpixel((x, 0), x)
-
         im_remapped = im.remap_palette(list(range(256)), source_palette)
-        assert im_remapped.palette is not None
-        assert im_remapped.palette.mode == palette_mode
-        assert im_remapped.palette.palette == source_palette
+
+        palette = im_remapped.palette
+        assert palette is not None
+        assert palette.mode == palette_mode
+        assert palette.palette == source_palette
 
     def test_remap_palette_transparency(self) -> None:
         im = Image.new("P", (1, 2), (0, 0, 0))


### PR DESCRIPTION
#9865 suggests that `remap_palette()`'s palette-mode detection is off by one and should use `>=` instead of `>`:

https://github.com/python-pillow/Pillow/blob/c8c74c8306eb7e1429a1a629a7471ca1794b7601/src/PIL/Image.py#L2234-L2236

I looked into it, and **the current `>` is correct** — changing it to `>=` would be a regression. The issue asked for tests, so this PR adds them rather than changing the behaviour.

## Why `>` is right

A full 256-entry palette is 768 bytes in RGB and 1024 bytes in RGBA, so the boundary sits *at* 768, not above it:

| source_palette | length | `> 768` | correct? |
|---|---|---|---|
| 256-entry RGB | 768 | RGB | ✅ |
| 256-entry RGBA | 1024 | RGBA | ✅ |

With `>=`, the first row flips to RGBA and a completely ordinary 256-colour RGB palette gets re-read 4 bytes at a time, shifting every colour. Verified against 12.3.0:

```python
from PIL import Image
pal = bytearray()
for i in range(256):
    pal += bytes([i, (100 + i) % 256, (200 + i) % 256])   # 768 bytes, RGB

im = Image.new("P", (2, 2))
out = im.remap_palette(list(range(256)), bytes(pal))
print(out.palette.mode)   # '>' (current): RGB   -- correct
                          # '>=':          RGBA  -- wrong
```

There *is* a real ambiguity underneath the report — a 192-entry RGBA palette is also exactly 768 bytes, and is read as RGB. But that's inherent to inferring the mode from a bare `bytes` length, and no choice of comparison operator fixes it; distinguishing those two cases would need the caller to say which mode it means. That seems like a separate API question, so I've left it alone here.

## Changes proposed in this pull request

* Add `test_remap_palette_source_palette`, parametrized over RGB/RGBA, covering `remap_palette()`'s `source_palette` argument. The existing `test_remap_palette` only exercises the `source_palette=None` path, so this branch had no coverage at all.
* Both sides of the 768-byte boundary are asserted, so the resulting test fails if the comparison is ever changed to `>=` (confirmed: the RGB case fails with that edit, and passes on `main` as-is).

Full `Tests/test_image.py` passes (185 passed, 1 skipped — IPython not installed locally). `ruff check` / `ruff format --check` clean; `mypy` reports no new errors (the 4 it emits are pre-existing missing-IPython-stub errors, identical on a clean tree).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)