### PR TITLE
Save as RGB(A) when APNG frames have different palettes

### DIFF
--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -770,7 +770,8 @@ def test_apng_save_p_frames_with_different_palettes(tmp_path: Path) -> None:
     test_file = tmp_path / "temp.png"
     red = Image.new("RGB", (1, 1), (255, 0, 0)).quantize(colors=2)
     green = Image.new("RGB", (1, 1), (0, 255, 0)).quantize(colors=2)
-    assert red.mode == "P" and green.mode == "P"
+    assert red.mode == "P"
+    assert green.mode == "P"
     assert red.getpalette() != green.getpalette()
 
     red.save(test_file, save_all=True, append_images=[green])

--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -299,6 +299,23 @@ def test_apng_mode() -> None:
     assert im_rgba.getpixel((64, 32)) == (0, 0, 255, 128)
 
 
+def test_apng_save_different_palettes(tmp_path: Path) -> None:
+    # APNG does not support multiple palettes
+    test_file = tmp_path / "temp.png"
+    red = Image.new("P", (1, 1), (255, 0, 0))
+    green = Image.new("P", (1, 1), (0, 255, 0))
+    red.save(test_file, save_all=True, append_images=[green])
+
+    with Image.open(test_file) as reloaded:
+        # So the frames must be converted to another mode
+        assert reloaded.mode == "RGB"
+        assert reloaded.getpixel((0, 0)) == (255, 0, 0)
+
+        reloaded.seek(1)
+        assert reloaded.mode == "RGB"
+        assert reloaded.getpixel((0, 0)) == (0, 255, 0)
+
+
 def test_apng_chunk_errors() -> None:
     with Image.open("Tests/images/apng/chunk_no_actl.png") as im:
         assert isinstance(im, PngImagePlugin.PngImageFile)
@@ -763,41 +780,6 @@ def test_seek_after_close() -> None:
 
     with pytest.raises(ValueError):
         im.seek(0)
-
-
-def test_apng_save_p_frames_with_different_palettes(tmp_path: Path) -> None:
-    """APNG has one PLTE; differing P palettes must not share the first frame's."""
-    test_file = tmp_path / "temp.png"
-    red = Image.new("RGB", (1, 1), (255, 0, 0)).quantize(colors=2)
-    green = Image.new("RGB", (1, 1), (0, 255, 0)).quantize(colors=2)
-    assert red.mode == "P"
-    assert green.mode == "P"
-    assert red.getpalette() != green.getpalette()
-
-    red.save(test_file, save_all=True, append_images=[green])
-
-    with Image.open(test_file) as reloaded:
-        assert reloaded.convert("RGB").getpixel((0, 0)) == (255, 0, 0)
-        reloaded.seek(1)
-        assert reloaded.convert("RGB").getpixel((0, 0)) == (0, 255, 0)
-
-
-def test_apng_save_p_frames_with_same_palette(tmp_path: Path) -> None:
-    """Identical palettes can stay indexed."""
-    test_file = tmp_path / "temp.png"
-    first = Image.new("P", (1, 1))
-    first.putpalette([255, 0, 0, 0, 255, 0] + [0] * 762)
-    first.putpixel((0, 0), 0)
-    second = first.copy()
-    second.putpixel((0, 0), 1)
-
-    first.save(test_file, save_all=True, append_images=[second])
-
-    with Image.open(test_file) as reloaded:
-        assert reloaded.mode == "P"
-        assert reloaded.convert("RGB").getpixel((0, 0)) == (255, 0, 0)
-        reloaded.seek(1)
-        assert reloaded.convert("RGB").getpixel((0, 0)) == (0, 255, 0)
 
 
 @pytest.mark.parametrize("mode", ("RGBA", "RGB", "P"))

--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -765,6 +765,40 @@ def test_seek_after_close() -> None:
         im.seek(0)
 
 
+def test_apng_save_p_frames_with_different_palettes(tmp_path: Path) -> None:
+    """APNG has one PLTE; differing P palettes must not share the first frame's."""
+    test_file = tmp_path / "temp.png"
+    red = Image.new("RGB", (1, 1), (255, 0, 0)).quantize(colors=2)
+    green = Image.new("RGB", (1, 1), (0, 255, 0)).quantize(colors=2)
+    assert red.mode == "P" and green.mode == "P"
+    assert red.getpalette() != green.getpalette()
+
+    red.save(test_file, save_all=True, append_images=[green])
+
+    with Image.open(test_file) as reloaded:
+        assert reloaded.convert("RGB").getpixel((0, 0)) == (255, 0, 0)
+        reloaded.seek(1)
+        assert reloaded.convert("RGB").getpixel((0, 0)) == (0, 255, 0)
+
+
+def test_apng_save_p_frames_with_same_palette(tmp_path: Path) -> None:
+    """Identical palettes can stay indexed."""
+    test_file = tmp_path / "temp.png"
+    first = Image.new("P", (1, 1))
+    first.putpalette([255, 0, 0, 0, 255, 0] + [0] * 762)
+    first.putpixel((0, 0), 0)
+    second = first.copy()
+    second.putpixel((0, 0), 1)
+
+    first.save(test_file, save_all=True, append_images=[second])
+
+    with Image.open(test_file) as reloaded:
+        assert reloaded.mode == "P"
+        assert reloaded.convert("RGB").getpixel((0, 0)) == (255, 0, 0)
+        reloaded.seek(1)
+        assert reloaded.convert("RGB").getpixel((0, 0)) == (0, 255, 0)
+
+
 @pytest.mark.parametrize("mode", ("RGBA", "RGB", "P"))
 @pytest.mark.parametrize("default_image", (True, False))
 @pytest.mark.parametrize("duplicate", (True, False))

--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -315,6 +315,13 @@ def test_apng_save_different_palettes(tmp_path: Path) -> None:
         assert reloaded.mode == "RGB"
         assert reloaded.getpixel((0, 0)) == (0, 255, 0)
 
+    # Test that RGBA palettes result in an RGBA image
+    green = Image.new("L", (1, 1))
+    green.putpalette([], "RGBA")
+    red.save(test_file, save_all=True, append_images=[green])
+    with Image.open(test_file) as reloaded:
+        assert reloaded.mode == "RGBA"
+
 
 def test_apng_chunk_errors() -> None:
     with Image.open("Tests/images/apng/chunk_no_actl.png") as im:

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -1332,20 +1332,26 @@ def _save(
         )
         modes = set()
         sizes = set()
-        palettes: set[tuple[int, ...]] = set()
+        last_palette = None
+        different_palette = False
         append_images = im.encoderinfo.get("append_images", [])
         for im_seq in itertools.chain([im], append_images):
             for im_frame in ImageSequence.Iterator(im_seq):
                 modes.add(im_frame.mode)
                 sizes.add(im_frame.size)
-                if im_frame.mode == "P":
-                    palettes.add(tuple(im_frame.getpalette() or []))
+                if im_frame.mode == "P" and not different_palette:
+                    frame_palette = im_frame.getpalette() or []
+                    if last_palette is not None:
+                        if frame_palette != last_palette:
+                            different_palette = True
+                    else:
+                        last_palette = frame_palette
         for mode in ("RGBA", "RGB", "P"):
             if mode in modes:
                 break
         else:
             mode = modes.pop()
-        if mode == "P" and len(palettes) > 1:
+        if mode == "P" and different_palette:
             # APNG has a single PLTE. Differing frame palettes would
             # otherwise all render with the first frame's colors (#9868).
             mode = "RGB"

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -1332,7 +1332,7 @@ def _save(
         )
         modes = set()
         sizes = set()
-        last_palette = None
+        palette = None
         different_palette = None
         append_images = im.encoderinfo.get("append_images", [])
         for im_seq in itertools.chain([im], append_images):
@@ -1342,11 +1342,11 @@ def _save(
                 if im_frame.mode == "P":
                     if different_palette is None:
                         frame_palette = im_frame.getpalette() or []
-                        if last_palette is not None:
-                            if frame_palette != last_palette:
+                        if palette is not None:
+                            if frame_palette != palette:
                                 different_palette = True
                         else:
-                            last_palette = frame_palette
+                            palette = frame_palette
                 elif im_frame.mode in ("RGBA", "RGBA"):
                     different_palette = False
         if different_palette:
@@ -1362,11 +1362,10 @@ def _save(
     else:
         size = im.size
         mode = im.mode
+        if mode == "P":
+            palette = im.getpalette() or []
 
     outmode = mode
-    palette = []
-    if im.palette:
-        palette = im.getpalette() or []
     if mode == "P":
         #
         # attempt to minimize storage requirements for palette images
@@ -1375,7 +1374,7 @@ def _save(
             colors = min(1 << im.encoderinfo["bits"], 256)
         else:
             # check palette contents
-            if im.palette:
+            if palette:
                 colors = max(min(len(palette) // 3, 256), 1)
             else:
                 colors = 256

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -1333,6 +1333,7 @@ def _save(
         modes = set()
         sizes = set()
         palette = None
+        palette_frame_with_alpha = None
         different_palette = None
         append_images = im.encoderinfo.get("append_images", [])
         for im_seq in itertools.chain([im], append_images):
@@ -1340,6 +1341,8 @@ def _save(
                 modes.add(im_frame.mode)
                 sizes.add(im_frame.size)
                 if im_frame.mode == "P":
+                    if im_frame.palette and im_frame.palette.mode == "RGBA":
+                        palette_frame_with_alpha = im_frame
                     if different_palette is None:
                         frame_palette = im_frame.getpalette() or []
                         if palette is not None:
@@ -1351,7 +1354,7 @@ def _save(
                     different_palette = False
         if different_palette:
             # APNG can only contain a single PLTE, so use another mode.
-            mode = "RGB"
+            mode = "RGBA" if palette_frame_with_alpha else "RGB"
         else:
             for mode in ("RGBA", "RGB", "P"):
                 if mode in modes:
@@ -1362,8 +1365,9 @@ def _save(
     else:
         size = im.size
         mode = im.mode
-        if mode == "P":
+        if mode == "P" and im.palette:
             palette = im.getpalette() or []
+            palette_frame_with_alpha = im if im.palette.mode == "RGBA" else None
 
     outmode = mode
     if mode == "P":
@@ -1444,7 +1448,7 @@ def _save(
                 if not after_idat:
                     chunk(fp, cid, data)
 
-    if mode == "P":
+    if mode == "P" and palette is not None:
         palette_byte_number = colors * 3
         palette_bytes = bytes(palette[:palette_byte_number])
         while len(palette_bytes) < palette_byte_number:
@@ -1488,8 +1492,8 @@ def _save(
             # and it's in the info dict. It's probably just stale.
             msg = "cannot use transparency for this mode"
             raise OSError(msg)
-    elif mode == "P" and im.mode == "P" and im.im.getpalettemode() == "RGBA":
-        alpha = im.im.getpalette("RGBA", "A")
+    elif mode == "P" and palette_frame_with_alpha:
+        alpha = palette_frame_with_alpha.im.getpalette("RGBA", "A")
         alpha_bytes = colors
         chunk(fp, b"tRNS", alpha[:alpha_bytes])
 

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -1333,28 +1333,31 @@ def _save(
         modes = set()
         sizes = set()
         last_palette = None
-        different_palette = False
+        different_palette = None
         append_images = im.encoderinfo.get("append_images", [])
         for im_seq in itertools.chain([im], append_images):
             for im_frame in ImageSequence.Iterator(im_seq):
                 modes.add(im_frame.mode)
                 sizes.add(im_frame.size)
-                if im_frame.mode == "P" and not different_palette:
-                    frame_palette = im_frame.getpalette() or []
-                    if last_palette is not None:
-                        if frame_palette != last_palette:
-                            different_palette = True
-                    else:
-                        last_palette = frame_palette
-        for mode in ("RGBA", "RGB", "P"):
-            if mode in modes:
-                break
-        else:
-            mode = modes.pop()
-        if mode == "P" and different_palette:
-            # APNG has a single PLTE. Differing frame palettes would
-            # otherwise all render with the first frame's colors (#9868).
+                if im_frame.mode == "P":
+                    if different_palette is None:
+                        frame_palette = im_frame.getpalette() or []
+                        if last_palette is not None:
+                            if frame_palette != last_palette:
+                                different_palette = True
+                        else:
+                            last_palette = frame_palette
+                elif im_frame.mode in ("RGBA", "RGBA"):
+                    different_palette = False
+        if different_palette:
+            # APNG can only contain a single PLTE, so use another mode.
             mode = "RGB"
+        else:
+            for mode in ("RGBA", "RGB", "P"):
+                if mode in modes:
+                    break
+            else:
+                mode = modes.pop()
         size = tuple(max(frame_size[i] for frame_size in sizes) for i in range(2))
     else:
         size = im.size

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -1332,16 +1332,23 @@ def _save(
         )
         modes = set()
         sizes = set()
+        palettes: set[tuple[int, ...]] = set()
         append_images = im.encoderinfo.get("append_images", [])
         for im_seq in itertools.chain([im], append_images):
             for im_frame in ImageSequence.Iterator(im_seq):
                 modes.add(im_frame.mode)
                 sizes.add(im_frame.size)
+                if im_frame.mode == "P":
+                    palettes.add(tuple(im_frame.getpalette() or []))
         for mode in ("RGBA", "RGB", "P"):
             if mode in modes:
                 break
         else:
             mode = modes.pop()
+        if mode == "P" and len(palettes) > 1:
+            # APNG has a single PLTE. Differing frame palettes would
+            # otherwise all render with the first frame's colors (#9868).
+            mode = "RGB"
         size = tuple(max(frame_size[i] for frame_size in sizes) for i in range(2))
     else:
         size = im.size
@@ -1429,7 +1436,7 @@ def _save(
                 if not after_idat:
                     chunk(fp, cid, data)
 
-    if im.mode == "P":
+    if mode == "P":
         palette_byte_number = colors * 3
         palette_bytes = bytes(palette[:palette_byte_number])
         while len(palette_bytes) < palette_byte_number:
@@ -1439,7 +1446,7 @@ def _save(
     transparency = im.encoderinfo.get("transparency", im.info.get("transparency"))
 
     if transparency is not None:
-        if im.mode == "P":
+        if mode == "P":
             # limit to actual palette size
             alpha_bytes = colors
             if isinstance(transparency, bytes):
@@ -1473,7 +1480,7 @@ def _save(
             # and it's in the info dict. It's probably just stale.
             msg = "cannot use transparency for this mode"
             raise OSError(msg)
-    elif im.mode == "P" and im.im.getpalettemode() == "RGBA":
+    elif mode == "P" and im.mode == "P" and im.im.getpalettemode() == "RGBA":
         alpha = im.im.getpalette("RGBA", "A")
         alpha_bytes = colors
         chunk(fp, b"tRNS", alpha[:alpha_bytes])


### PR DESCRIPTION
Helps #9868

APNG has a single `PLTE`. Saving several `P` frames with different palettes previously wrote only the first frame's palette, so later frames rendered with the wrong colors.

When the collected palettes differ, the animation is now saved as RGB so each frame keeps its colors. Frames that share one palette stay indexed.

## Test plan

- [x] `Tests/test_file_apng.py::test_apng_save_p_frames_with_different_palettes`
- [x] `Tests/test_file_apng.py::test_apng_save_p_frames_with_same_palette`
- [x] Full `Tests/test_file_apng.py` (49 passed)