### PR TITLE
Mark StubHandler.open() as abstract

### DIFF
--- a/Tests/test_file_bufrstub.py
+++ b/Tests/test_file_bufrstub.py
@@ -61,6 +61,7 @@ def test_handler(tmp_path: Path) -> None:
 
         def open(self, im: ImageFile.StubImageFile) -> None:
             self.opened = True
+            im._size = (1, 1)
 
         def load(self, im: ImageFile.StubImageFile) -> Image.Image:
             self.loaded = True

--- a/Tests/test_file_bufrstub.py
+++ b/Tests/test_file_bufrstub.py
@@ -23,7 +23,7 @@ def test_open() -> None:
 
         # Dummy data from the stub
         assert im.mode == "F"
-        assert im.size == (1, 1)
+        assert im.size == (0, 0)
 
 
 def test_invalid_file() -> None:

--- a/Tests/test_file_gribstub.py
+++ b/Tests/test_file_gribstub.py
@@ -23,7 +23,7 @@ def test_open() -> None:
 
         # Dummy data from the stub
         assert im.mode == "F"
-        assert im.size == (1, 1)
+        assert im.size == (0, 0)
 
 
 def test_invalid_file() -> None:

--- a/Tests/test_file_gribstub.py
+++ b/Tests/test_file_gribstub.py
@@ -61,6 +61,7 @@ def test_handler(tmp_path: Path) -> None:
 
         def open(self, im: Image.Image) -> None:
             self.opened = True
+            im._size = (1, 1)
 
         def load(self, im: ImageFile.ImageFile) -> Image.Image:
             self.loaded = True

--- a/Tests/test_file_hdf5stub.py
+++ b/Tests/test_file_hdf5stub.py
@@ -63,6 +63,7 @@ def test_handler(tmp_path: Path) -> None:
 
         def open(self, im: Image.Image) -> None:
             self.opened = True
+            im._size = (1, 1)
 
         def load(self, im: ImageFile.ImageFile) -> Image.Image:
             self.loaded = True

--- a/Tests/test_file_hdf5stub.py
+++ b/Tests/test_file_hdf5stub.py
@@ -22,7 +22,7 @@ def test_open() -> None:
 
         # Dummy data from the stub
         assert im.mode == "F"
-        assert im.size == (1, 1)
+        assert im.size == (0, 0)
 
 
 def test_invalid_file() -> None:

--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -72,6 +72,9 @@ def test_register_handler(tmp_path: Path) -> None:
     class TestHandler(ImageFile.StubHandler):
         methodCalled = False
 
+        def open(self, im: ImageFile.StubImageFile) -> None:
+            im._size = (1, 1)
+
         def load(self, im: ImageFile.StubImageFile) -> Image.Image:
             return Image.new("RGB", (1, 1))
 

--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -79,7 +79,7 @@ def test_register_handler(tmp_path: Path) -> None:
             self.methodCalled = True
 
     handler = TestHandler()
-    original_handler = WmfImagePlugin._handler
+    original_handler = WmfImagePlugin.WmfStubImageFile._handler
     WmfImagePlugin.register_handler(handler)
 
     im = hopper()

--- a/src/PIL/BufrStubImagePlugin.py
+++ b/src/PIL/BufrStubImagePlugin.py
@@ -18,8 +18,6 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import IO
 
-_handler = None
-
 
 def register_handler(handler: ImageFile.StubHandler | None) -> None:
     """
@@ -27,8 +25,7 @@ def register_handler(handler: ImageFile.StubHandler | None) -> None:
 
     :param handler: Handler object.
     """
-    global _handler
-    _handler = handler
+    BufrStubImageFile._handler = handler
 
 
 # --------------------------------------------------------------------
@@ -55,14 +52,16 @@ class BufrStubImageFile(ImageFile.StubImageFile):
         self._mode = "F"
 
     def _load(self) -> ImageFile.StubHandler | None:
-        return _handler
+        return self._handler
 
 
 def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
-    if _handler is None or not hasattr(_handler, "save"):
+    if BufrStubImageFile._handler is None or not hasattr(
+        BufrStubImageFile._handler, "save"
+    ):
         msg = "BUFR save handler not installed"
         raise OSError(msg)
-    _handler.save(im, fp, filename)
+    BufrStubImageFile._handler.save(im, fp, filename)
 
 
 # --------------------------------------------------------------------

--- a/src/PIL/BufrStubImagePlugin.py
+++ b/src/PIL/BufrStubImagePlugin.py
@@ -53,7 +53,6 @@ class BufrStubImageFile(ImageFile.StubImageFile):
 
         # make something up
         self._mode = "F"
-        self._size = 1, 1
 
     def _load(self) -> ImageFile.StubHandler | None:
         return _handler

--- a/src/PIL/BufrStubImagePlugin.py
+++ b/src/PIL/BufrStubImagePlugin.py
@@ -51,9 +51,6 @@ class BufrStubImageFile(ImageFile.StubImageFile):
         # make something up
         self._mode = "F"
 
-    def _load(self) -> ImageFile.StubHandler | None:
-        return self._handler
-
 
 def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
     if BufrStubImageFile._handler is None or not hasattr(

--- a/src/PIL/GribStubImagePlugin.py
+++ b/src/PIL/GribStubImagePlugin.py
@@ -18,8 +18,6 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import IO
 
-_handler = None
-
 
 def register_handler(handler: ImageFile.StubHandler | None) -> None:
     """
@@ -27,8 +25,7 @@ def register_handler(handler: ImageFile.StubHandler | None) -> None:
 
     :param handler: Handler object.
     """
-    global _handler
-    _handler = handler
+    GribStubImageFile._handler = handler
 
 
 # --------------------------------------------------------------------
@@ -55,14 +52,16 @@ class GribStubImageFile(ImageFile.StubImageFile):
         self._mode = "F"
 
     def _load(self) -> ImageFile.StubHandler | None:
-        return _handler
+        return self._handler
 
 
 def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
-    if _handler is None or not hasattr(_handler, "save"):
+    if GribStubImageFile._handler is None or not hasattr(
+        GribStubImageFile._handler, "save"
+    ):
         msg = "GRIB save handler not installed"
         raise OSError(msg)
-    _handler.save(im, fp, filename)
+    GribStubImageFile._handler.save(im, fp, filename)
 
 
 # --------------------------------------------------------------------

--- a/src/PIL/GribStubImagePlugin.py
+++ b/src/PIL/GribStubImagePlugin.py
@@ -53,7 +53,6 @@ class GribStubImageFile(ImageFile.StubImageFile):
 
         # make something up
         self._mode = "F"
-        self._size = 1, 1
 
     def _load(self) -> ImageFile.StubHandler | None:
         return _handler

--- a/src/PIL/GribStubImagePlugin.py
+++ b/src/PIL/GribStubImagePlugin.py
@@ -51,9 +51,6 @@ class GribStubImageFile(ImageFile.StubImageFile):
         # make something up
         self._mode = "F"
 
-    def _load(self) -> ImageFile.StubHandler | None:
-        return self._handler
-
 
 def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
     if GribStubImageFile._handler is None or not hasattr(

--- a/src/PIL/Hdf5StubImagePlugin.py
+++ b/src/PIL/Hdf5StubImagePlugin.py
@@ -18,8 +18,6 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import IO
 
-_handler = None
-
 
 def register_handler(handler: ImageFile.StubHandler | None) -> None:
     """
@@ -27,8 +25,7 @@ def register_handler(handler: ImageFile.StubHandler | None) -> None:
 
     :param handler: Handler object.
     """
-    global _handler
-    _handler = handler
+    HDF5StubImageFile._handler = handler
 
 
 # --------------------------------------------------------------------
@@ -55,14 +52,16 @@ class HDF5StubImageFile(ImageFile.StubImageFile):
         self._mode = "F"
 
     def _load(self) -> ImageFile.StubHandler | None:
-        return _handler
+        return self._handler
 
 
 def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
-    if _handler is None or not hasattr(_handler, "save"):
+    if HDF5StubImageFile._handler is None or not hasattr(
+        HDF5StubImageFile._handler, "save"
+    ):
         msg = "HDF5 save handler not installed"
         raise OSError(msg)
-    _handler.save(im, fp, filename)
+    HDF5StubImageFile._handler.save(im, fp, filename)
 
 
 # --------------------------------------------------------------------

--- a/src/PIL/Hdf5StubImagePlugin.py
+++ b/src/PIL/Hdf5StubImagePlugin.py
@@ -51,9 +51,6 @@ class HDF5StubImageFile(ImageFile.StubImageFile):
         # make something up
         self._mode = "F"
 
-    def _load(self) -> ImageFile.StubHandler | None:
-        return self._handler
-
 
 def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
     if HDF5StubImageFile._handler is None or not hasattr(

--- a/src/PIL/Hdf5StubImagePlugin.py
+++ b/src/PIL/Hdf5StubImagePlugin.py
@@ -53,7 +53,6 @@ class HDF5StubImageFile(ImageFile.StubImageFile):
 
         # make something up
         self._mode = "F"
-        self._size = 1, 1
 
     def _load(self) -> ImageFile.StubHandler | None:
         return _handler

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -488,6 +488,8 @@ class StubImageFile(ImageFile, metaclass=abc.ABCMeta):
     certain format, but relies on external code to load the file.
     """
 
+    _handler: StubHandler | None = None
+
     @abc.abstractmethod
     def _open(self) -> None:
         pass

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -165,7 +165,7 @@ class ImageFile(Image.Image):
 
             if not self.mode or (
                 min(self.size) < 0
-                if isinstance(self, StubImageFile)
+                if isinstance(self, StubImageFile) and self._handler is None
                 else min(self.size) <= 0
             ):
                 msg = "not identified by this driver"

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -151,9 +151,8 @@ class ImageFile(Image.Image):
             try:
                 self._open()
 
-                if isinstance(self, StubImageFile):
-                    if loader := self._load():
-                        loader.open(self)
+                if isinstance(self, StubImageFile) and self._handler:
+                    self._handler.open(self)
             except (
                 IndexError,  # end of data
                 TypeError,  # end of data (ord)
@@ -495,21 +494,15 @@ class StubImageFile(ImageFile, metaclass=abc.ABCMeta):
         pass
 
     def load(self) -> Image.core.PixelAccess | None:
-        loader = self._load()
-        if loader is None:
+        if self._handler is None:
             msg = f"cannot find loader for this {self.format} file"
             raise OSError(msg)
-        image = loader.load(self)
+        image = self._handler.load(self)
         assert image is not None
         # become the other object (!)
         self.__class__ = image.__class__  # type: ignore[assignment]
         self.__dict__ = image.__dict__
         return image.load()
-
-    @abc.abstractmethod
-    def _load(self) -> StubHandler | None:
-        """(Hook) Find actual image loader."""
-        pass
 
 
 class Parser:

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -163,7 +163,11 @@ class ImageFile(Image.Image):
             ) as v:
                 raise SyntaxError(v) from v
 
-            if not self.mode or self.size[0] <= 0 or self.size[1] <= 0:
+            if not self.mode or (
+                min(self.size) < 0
+                if isinstance(self, StubImageFile)
+                else min(self.size) <= 0
+            ):
                 msg = "not identified by this driver"
                 raise SyntaxError(msg)
         except BaseException:

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -471,6 +471,7 @@ class ImageFile(Image.Image):
 
 
 class StubHandler(abc.ABC):
+    @abc.abstractmethod
     def open(self, im: StubImageFile) -> None:
         pass
 

--- a/src/PIL/WmfImagePlugin.py
+++ b/src/PIL/WmfImagePlugin.py
@@ -29,41 +29,6 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import IO
 
-_handler = None
-
-
-def register_handler(handler: ImageFile.StubHandler | None) -> None:
-    """
-    Install application-specific WMF image handler.
-
-    :param handler: Handler object.
-    """
-    global _handler
-    _handler = handler
-
-
-if hasattr(Image.core, "drawwmf"):
-    # install default handler (windows only)
-
-    class WmfHandler(ImageFile.StubHandler):
-        def open(self, im: ImageFile.StubImageFile) -> None:
-            self.bbox = im.info["wmf_bbox"]
-
-        def load(self, im: ImageFile.StubImageFile) -> Image.Image:
-            assert im.fp is not None
-            im.fp.seek(0)  # rewind
-            return Image.frombytes(
-                "RGB",
-                im.size,
-                Image.core.drawwmf(im.fp.read(), im.size, self.bbox),
-                "raw",
-                "BGR",
-                (im.size[0] * 3 + 3) & -4,
-                -1,
-            )
-
-    register_handler(WmfHandler())
-
 #
 # --------------------------------------------------------------------
 # Read WMF file
@@ -150,7 +115,7 @@ class WmfStubImageFile(ImageFile.StubImageFile):
         self._size = size
 
     def _load(self) -> ImageFile.StubHandler | None:
-        return _handler
+        return self._handler
 
     def load(
         self, dpi: float | tuple[float, float] | None = None
@@ -168,10 +133,44 @@ class WmfStubImageFile(ImageFile.StubImageFile):
 
 
 def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
-    if _handler is None or not hasattr(_handler, "save"):
+    if WmfStubImageFile._handler is None or not hasattr(
+        WmfStubImageFile._handler, "save"
+    ):
         msg = "WMF save handler not installed"
         raise OSError(msg)
-    _handler.save(im, fp, filename)
+    WmfStubImageFile._handler.save(im, fp, filename)
+
+
+def register_handler(handler: ImageFile.StubHandler | None) -> None:
+    """
+    Install application-specific WMF image handler.
+
+    :param handler: Handler object.
+    """
+    WmfStubImageFile._handler = handler
+
+
+if hasattr(Image.core, "drawwmf"):
+    # install default handler (windows only)
+
+    class WmfHandler(ImageFile.StubHandler):
+        def open(self, im: ImageFile.StubImageFile) -> None:
+            self.bbox = im.info["wmf_bbox"]
+
+        def load(self, im: ImageFile.StubImageFile) -> Image.Image:
+            assert im.fp is not None
+            im.fp.seek(0)  # rewind
+            return Image.frombytes(
+                "RGB",
+                im.size,
+                Image.core.drawwmf(im.fp.read(), im.size, self.bbox),
+                "raw",
+                "BGR",
+                (im.size[0] * 3 + 3) & -4,
+                -1,
+            )
+
+    register_handler(WmfHandler())
 
 
 #

--- a/src/PIL/WmfImagePlugin.py
+++ b/src/PIL/WmfImagePlugin.py
@@ -114,9 +114,6 @@ class WmfStubImageFile(ImageFile.StubImageFile):
         self._mode = "RGB"
         self._size = size
 
-    def _load(self) -> ImageFile.StubHandler | None:
-        return self._handler
-
     def load(
         self, dpi: float | tuple[float, float] | None = None
     ) -> Image.core.PixelAccess | None:


### PR DESCRIPTION
Within our stub plugins, we use `(1, 1)` as a placeholder size.

https://github.com/python-pillow/Pillow/blob/627f3ea94864822c10c675cb6bf44a16c1f0e987/src/PIL/BufrStubImagePlugin.py#L51-L53

1. I think `(0, 0)` might more clearly indicate that there's nothing there yet.
2. What if we added a requirement that when the handler is implemented, image size must be set (to something more than `(0, 0)`)? To communicate this better, we could also mark `StubHandler.open()` as abstract.