### PR TITLE
Remove unnecessary check

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3789,7 +3789,7 @@ def merge(mode: str, bands: Sequence[Image]) -> Image:
     :returns: An :py:class:`~PIL.Image.Image` object.
     """
 
-    if getmodebands(mode) != len(bands) or "*" in mode:
+    if getmodebands(mode) != len(bands):
         msg = "wrong number of bands"
         raise ValueError(msg)
     for band in bands[1:]:


### PR DESCRIPTION
In `Image.merge()`,
https://github.com/python-pillow/Pillow/blob/6c06fa2fca58e4ee3595c16131c6442d57df5455/src/PIL/Image.py#L3792
`"*" in mode` is redundant.

`getmodebands(mode)` has to be run first for the other condition to matter, and
https://github.com/python-pillow/Pillow/blob/6c06fa2fca58e4ee3595c16131c6442d57df5455/src/PIL/Image.py#L310-L318
none of the modes in [`ImageMode`](https://github.com/python-pillow/Pillow/blob/main/src/PIL/ImageMode.py#L36) contain an asterisk.

So with or without this check,
```python
from PIL import Image
Image.merge("RGB;*", [])
```
gives
```
Traceback (most recent call last):
  File "demo.py", line 2, in <module>
    Image.merge("RGB;*", [])
  File "PIL/Image.py", line 3792, in merge
    if getmodebands(mode) != len(bands) or "*" in mode:
       ^^^^^^^^^^^^^^^^^^
  File "PIL/Image.py", line 318, in getmodebands
    return len(ImageMode.getmode(mode).bands)
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "PIL/ImageMode.py", line 84, in getmode
    type_str = mapping_modes[mode]
               ~~~~~~~~~~~~~^^^^^^
KeyError: 'RGB;*'
```