### PR TITLE
Remove unneeded code for handling zero-width characters

### DIFF
--- a/Tests/test_font_bdf.py
+++ b/Tests/test_font_bdf.py
@@ -17,13 +17,6 @@ def test_sanity() -> None:
     assert len([_f for _f in font.glyph if _f]) == 190
 
 
-def test_zero_width_chars() -> None:
-    with open(filename, "rb") as fp:
-        data = fp.read()
-    data = data[:2650] + b"\x00\x00" + data[2652:]
-    BdfFontFile.BdfFontFile(io.BytesIO(data))
-
-
 def test_decompression_bomb() -> None:
     with open(filename, "rb") as fp:
         data = fp.read()

--- a/src/PIL/BdfFontFile.py
+++ b/src/PIL/BdfFontFile.py
@@ -82,11 +82,7 @@ def bdf_char(
         (0, 0, width, height),
     )
 
-    try:
-        im = Image.frombytes("1", (width, height), bitmap, "hex", "1")
-    except ValueError:
-        # deal with zero-width characters
-        im = Image.new("1", (width, height))
+    im = Image.frombytes("1", (width, height), bitmap, "hex", "1")
 
     return id, int(props["ENCODING"]), bbox, im
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/1cdb9a469d449fc3bdf02d324f45239f3232377d/src/PIL/BdfFontFile.py#L85-L89

I don't think the exception handling is needed here.

It has been present since PIL. A test was added in #8783, but it was an artificial scenario to improve coverage, not a real need.

'deal with zero-width characters' would make you think that it would be needed for
```python
Image.frombytes("1", (0, 0), b"", "hex", "1")
Image.frombytes("1", (0, 1), b"", "hex", "1")
```
but those lines don't raise an error.

