### PR TITLE
Mark ImageFile._open() as abstract

### DIFF
--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -113,7 +113,7 @@ class _Tile(NamedTuple):
 # ImageFile base class
 
 
-class ImageFile(Image.Image):
+class ImageFile(Image.Image, metaclass=abc.ABCMeta):
     """Base class for image file format handlers."""
 
     def __init__(
@@ -175,6 +175,7 @@ class ImageFile(Image.Image):
                 self.fp.close()
             raise
 
+    @abc.abstractmethod
     def _open(self) -> None:
         pass
 
@@ -480,7 +481,7 @@ class StubHandler(abc.ABC):
         pass
 
 
-class StubImageFile(ImageFile, metaclass=abc.ABCMeta):
+class StubImageFile(ImageFile):
     """
     Base class for stub image loaders.
 
@@ -489,10 +490,6 @@ class StubImageFile(ImageFile, metaclass=abc.ABCMeta):
     """
 
     _handler: StubHandler | None = None
-
-    @abc.abstractmethod
-    def _open(self) -> None:
-        pass
 
     def load(self) -> Image.core.PixelAccess | None:
         if self._handler is None:


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/blob/1cdb9a469d449fc3bdf02d324f45239f3232377d/src/PIL/ImageFile.py#L175-L176
must be implemented in an ImageFile subclass.

Without this change,
```python
from PIL import ImageFile
import io

class DummyImageFile(ImageFile.ImageFile):
  pass

DummyImageFile(io.BytesIO(b""))
```
gives
```pytb
Traceback (most recent call last):
  File "demo.py", line 7, in <module>
    DummyImageFile(io.BytesIO(b""))
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "PIL/ImageFile.py", line 166, in __init__
    raise SyntaxError(msg)
SyntaxError: not identified by this driver
```

With this change, there is the much clearer
```pytb
Traceback (most recent call last):
  File "demo.py", line 7, in <module>
    DummyImageFile(io.BytesIO(b""))
TypeError: Can't instantiate abstract class DummyImageFile with abstract method _open
```