### PR TITLE
C interface is internal

### DIFF
--- a/docs/reference/internal_modules.rst
+++ b/docs/reference/internal_modules.rst
@@ -82,6 +82,9 @@ on some Python versions.
 An internal interface module previously known as :mod:`~PIL._imaging`,
 implemented in :file:`_imaging.c`.
 
+Pillow is a Python library, and the C interfaces within are for internal use only.
+They may change without a deprecation period or a mention in the release notes.
+
 .. py:class:: ImagingCore
 
     A representation of the image data.


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/9878#discussion_r3819063611 requested that we document that Pillow is a Python library, and we do not encourage direct use of our C code.

Based on https://github.com/python-pillow/Pillow/issues/4532#issuecomment-618255798