### PR TITLE
Raise ValueError for truncated gAMA and cHRM PNG chunks

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -700,7 +700,7 @@ class TestFilePng:
             assert_image_equal_tofile(im, "Tests/images/bw_gradient.png")
 
     @pytest.mark.parametrize(
-        "cid", (b"IHDR", b"sRGB", b"pHYs", b"acTL", b"fcTL", b"fdAT")
+        "cid", (b"IHDR", b"gAMA", b"sRGB", b"pHYs", b"acTL", b"fcTL", b"fdAT")
     )
     def test_truncated_chunks(
         self, cid: bytes, monkeypatch: pytest.MonkeyPatch

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -700,7 +700,8 @@ class TestFilePng:
             assert_image_equal_tofile(im, "Tests/images/bw_gradient.png")
 
     @pytest.mark.parametrize(
-        "cid", (b"IHDR", b"gAMA", b"sRGB", b"pHYs", b"acTL", b"fcTL", b"fdAT")
+        "cid",
+        (b"IHDR", b"gAMA", b"cHRM", b"sRGB", b"pHYs", b"acTL", b"fcTL", b"fdAT"),
     )
     def test_truncated_chunks(
         self, cid: bytes, monkeypatch: pytest.MonkeyPatch

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -535,7 +535,12 @@ class PngStream(ChunkStream):
 
         assert self.fp is not None
         s = ImageFile._safe_read(self.fp, length)
-        raw_vals = struct.unpack(f">{len(s) // 4}I", s)
+        if length < 32:
+            if ImageFile.LOAD_TRUNCATED_IMAGES:
+                return s
+            msg = "Truncated cHRM chunk"
+            raise ValueError(msg)
+        raw_vals = struct.unpack(">8I", s[:32])
         self.im_info["chromaticity"] = tuple(elt / 100000.0 for elt in raw_vals)
         return s
 

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -521,6 +521,11 @@ class PngStream(ChunkStream):
         # gamma setting
         assert self.fp is not None
         s = ImageFile._safe_read(self.fp, length)
+        if length < 4:
+            if ImageFile.LOAD_TRUNCATED_IMAGES:
+                return s
+            msg = "Truncated gAMA chunk"
+            raise ValueError(msg)
         self.im_info["gamma"] = i32(s) / 100000.0
         return s
 


### PR DESCRIPTION
## Summary

`chunk_gAMA` reads the 4-byte gamma value with `i32(s)` without first checking the chunk length. A PNG whose `gAMA` chunk is shorter than 4 bytes raises `struct.error`, which `ImageFile.__init__` converts to `SyntaxError`, which `Image.open()` treats as "this isn't a PNG" — so the user sees `UnidentifiedImageError: cannot identify image file` for a file that is otherwise a perfectly readable PNG.

`LOAD_TRUNCATED_IMAGES` can't rescue it either, because the failure happens before any truncation handling runs.

The sibling chunk handlers already do this correctly. `IHDR`, `sRGB`, `pHYs`, `acTL`, `fcTL` and `fdAT` all check the length first and either return the short chunk when `LOAD_TRUNCATED_IMAGES` is set, or raise `ValueError("Truncated <cid> chunk")`. `gAMA` is the one fixed-size chunk missing that guard — and it's also the one missing from the existing `test_truncated_chunks` parametrisation.

## Reproduction

```python
import io, struct, zlib
from PIL import Image, ImageFile

def chunk(tag, data):
    return (struct.pack(">I", len(data)) + tag + data
            + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF))

ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 0, 0, 0, 0)
data = (b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr)
        + chunk(b"gAMA", b"\x00\x01")                     # 2 bytes instead of 4
        + chunk(b"IDAT", zlib.compress(b"\x00\x00")) + chunk(b"IEND", b""))

ImageFile.LOAD_TRUNCATED_IMAGES = True
Image.open(io.BytesIO(data)).load()
```

Before:

```
UnidentifiedImageError: cannot identify image file <_io.BytesIO object ...>
```

(underlying cause: `struct.error: unpack_from requires a buffer of at least 4 bytes`)

After, matching `sRGB` exactly:

* `LOAD_TRUNCATED_IMAGES = False` → `ValueError: Truncated gAMA chunk`
* `LOAD_TRUNCATED_IMAGES = True` → loads fine

## Changes

```diff
         s = ImageFile._safe_read(self.fp, length)
+        if length < 4:
+            if ImageFile.LOAD_TRUNCATED_IMAGES:
+                return s
+            msg = "Truncated gAMA chunk"
+            raise ValueError(msg)
         self.im_info["gamma"] = i32(s) / 100000.0
```

and `b"gAMA"` added to the existing `test_truncated_chunks` parametrisation, which already covers the other guarded chunks.

## Tests

`Tests/test_file_png.py::TestFilePng::test_truncated_chunks[gAMA]` fails on current `main` with `struct.error` and passes with the guard. Full `Tests/test_file_png.py`: 65 passed, 1 skipped (the skip is Unix-only). `ruff` and `black` clean on both changed files.

## One question

`chunk_cHRM` has the same crash — `struct.unpack(f">{len(s) // 4}I", s)` raises `struct.error` when the length isn't a multiple of 4. I left it out of this PR because the right guard there is a judgement call: strict (`length < 32`, per spec) would reject short-but-parseable chromaticity chunks that currently decode into a partial tuple. Happy to add whichever you prefer, here or separately.
