### PR TITLE
Speed up `getpixel()` and `get_flattened_data()`

### DIFF
--- a/Tests/benchmarks.py
+++ b/Tests/benchmarks.py
@@ -666,6 +666,18 @@ def test_radial_gradient(bench: BenchmarkFixture, mode: str) -> None:
     assert result.mode == mode
 
 
+@pytest.mark.benchmark(group="allocate")
+@pytest.mark.parametrize("mode", MODES)
+@pytest.mark.parametrize("size", SIZES, ids=_format_size)
+def test_get_flattened_data(
+    bench: BenchmarkFixture,
+    mode: str,
+    size: tuple[int, int],
+) -> None:
+    im = make_pillow_image(mode, size)
+    bench(im.get_flattened_data)
+
+
 CHOPS_OPS = [
     ImageChops.add,
     ImageChops.subtract,

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -534,6 +534,27 @@ float16tofloat32(const FLOAT16 in) {
 }
 
 static inline PyObject *
+make_pixel_tuple(const UINT8 *b, Py_ssize_t bands) {
+    PyObject *tuple = PyTuple_New(bands);
+    if (tuple == NULL) {
+        return NULL;
+    }
+    for (Py_ssize_t i = 0; i < bands; i++) {
+        PyObject *v = PyLong_FromLong(b[i]);
+        if (v == NULL) {
+            Py_DECREF(tuple);
+            return NULL;
+        }
+        PyTuple_SET_ITEM(tuple, i, v);
+    }
+    // We know these tuples will only have small integers,
+    // so we can tell the garbage collector to not look inside
+    // for cycles.
+    PyObject_GC_UnTrack(tuple);
+    return tuple;
+}
+
+static inline PyObject *
 getpixel(Imaging im, ImagingAccess access, int x, int y) {
     union {
         UINT8 b[4];
@@ -562,13 +583,11 @@ getpixel(Imaging im, ImagingAccess access, int x, int y) {
                 case 1:
                     return PyLong_FromLong(pixel.b[0]);
                 case 2:
-                    return Py_BuildValue("BB", pixel.b[0], pixel.b[1]);
+                    return make_pixel_tuple(pixel.b, 2);
                 case 3:
-                    return Py_BuildValue("BBB", pixel.b[0], pixel.b[1], pixel.b[2]);
+                    return make_pixel_tuple(pixel.b, 3);
                 case 4:
-                    return Py_BuildValue(
-                        "BBBB", pixel.b[0], pixel.b[1], pixel.b[2], pixel.b[3]
-                    );
+                    return make_pixel_tuple(pixel.b, 4);
             }
             break;
         case IMAGING_TYPE_INT32:


### PR DESCRIPTION
Came up as a side-effect of https://github.com/python-pillow/Pillow/pull/9292 + https://github.com/akx/Pillow/pull/13/changes#r3819140811. Doesn't change the memory price of `get_flattened_data()` though.

Locally (pay no heed to the benchmarks' commit IDs; this final version has less redundant mode tests and as such, different commits):

```
---------------------------- benchmark: 8 tests, 2 sources ----------------------------
Name (time in ms)                          0001_03fd7da Min  0002_e70ed66 Min      ΔMin
---------------------------------------------------------------------------------------
test_get_flattened_data[1237x811-I]                  6.8375            6.9130     +1.1%
test_get_flattened_data[1237x811-P]                  6.9563            6.9265     -0.4%
test_get_flattened_data[1237x811-L]                  7.0001            6.9799     -0.3%
test_get_flattened_data[1237x811-1]                  7.0226            6.9455     -1.1%
test_get_flattened_data[1237x811-F]                 15.2092           15.2749     +0.4%
test_get_flattened_data[1237x811-LA]                51.0383           38.8171    -23.9%
test_get_flattened_data[1237x811-RGB]               59.7311           43.9531    -26.4%
test_get_flattened_data[1237x811-RGBA]              66.1110           47.2317    -28.6%
```

Something that isn't necessarily captured by the benchmark is the `PyObject_GC_UnTrack` change; since we know that these tuples (immutable, as tuples are) will only contain 8-bit integers (and as an aside, CPython has likely returned cached small-integer references), we can tell the GC to not bother peeking inside them to see if there are cycles. This means that the next GC after `get_flattened_data` will not need to do that itself (it does need to do it for the `tuple()` cast from `get_flattened_data` _once_ though).