### PR TITLE
Add strip_namespaces argument to Image.getxmp()

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1025,7 +1025,7 @@ class TestImage:
             b"<b:id>from-b</b:id>"
             b"</rdf:Description>"
             b"</rdf:RDF>"
-            b'</x:xmpmeta>\n<?xpacket end="w"?>\x00\x00 '
+            b'</x:xmpmeta>\n<?xpacket end="w"?>'
         )
         if ElementTree is None:
             pytest.skip("defusedxml is not installed")

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1033,14 +1033,12 @@ class TestImage:
         desc = stripped["xmpmeta"]["RDF"]["Description"]
         assert desc["id"] == ["from-a", "from-b"]
 
-        a_namespace = "http://example.com/ns/a/"
-        b_namespace = "http://example.com/ns/b/"
         full = im.getxmp(strip_namespaces=False)
         desc_full = full["{adobe:ns:meta/}xmpmeta"][
             "{http://www.w3.org/1999/02/22-rdf-syntax-ns#}RDF"
         ]["{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Description"]
-        assert desc_full[f"{{{a_namespace}}}id"] == "from-a"
-        assert desc_full[f"{{{b_namespace}}}id"] == "from-b"
+        assert desc_full["{http://example.com/ns/a/}id"] == "from-a"
+        assert desc_full["{http://example.com/ns/b/}id"] == "from-b"
 
     def test_getxmp_padded(self) -> None:
         im = Image.new("RGB", (1, 1))

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1012,6 +1012,7 @@ class TestImage:
                 xmp = im.getxmp()
             assert xmp == {}
 
+    @pytest.mark.skipif(ElementTree is None, reason="defusedxml is not installed")
     def test_getxmp_strip_namespaces(self) -> None:
         im = Image.new("RGB", (1, 1))
         im.info["xmp"] = (
@@ -1027,8 +1028,6 @@ class TestImage:
             b"</rdf:RDF>"
             b'</x:xmpmeta>\n<?xpacket end="w"?>'
         )
-        if ElementTree is None:
-            pytest.skip("defusedxml is not installed")
 
         stripped = im.getxmp()
         desc = stripped["xmpmeta"]["RDF"]["Description"]

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1012,6 +1012,37 @@ class TestImage:
                 xmp = im.getxmp()
             assert xmp == {}
 
+    def test_getxmp_strip_namespaces(self) -> None:
+        im = Image.new("RGB", (1, 1))
+        im.info["xmp"] = (
+            b'<?xpacket begin="\xef\xbb\xbf" id="W5M0MpCehiHzreSzNTczkc9d"?>\n'
+            b'<x:xmpmeta xmlns:x="adobe:ns:meta/">'
+            b'<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">'
+            b'<rdf:Description rdf:about=""'
+            b' xmlns:a="http://example.com/ns/a/"'
+            b' xmlns:b="http://example.com/ns/b/">'
+            b"<a:id>from-a</a:id>"
+            b"<b:id>from-b</b:id>"
+            b"</rdf:Description>"
+            b"</rdf:RDF>"
+            b'</x:xmpmeta>\n<?xpacket end="w"?>\x00\x00 '
+        )
+        if ElementTree is None:
+            pytest.skip("defusedxml is not installed")
+
+        stripped = im.getxmp()
+        desc = stripped["xmpmeta"]["RDF"]["Description"]
+        assert desc["id"] == ["from-a", "from-b"]
+
+        a_namespace = "http://example.com/ns/a/"
+        b_namespace = "http://example.com/ns/b/"
+        full = im.getxmp(strip_namespaces=False)
+        desc_full = full["{adobe:ns:meta/}xmpmeta"][
+            "{http://www.w3.org/1999/02/22-rdf-syntax-ns#}RDF"
+        ]["{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Description"]
+        assert desc_full[f"{{{a_namespace}}}id"] == "from-a"
+        assert desc_full[f"{{{b_namespace}}}id"] == "from-b"
+
     def test_getxmp_padded(self) -> None:
         im = Image.new("RGB", (1, 1))
         im.info["xmp"] = (

--- a/docs/releasenotes/13.0.0.rst
+++ b/docs/releasenotes/13.0.0.rst
@@ -85,10 +85,14 @@ TODO
 API additions
 =============
 
-TODO
-^^^^
+Added ``strip_namespaces`` argument to ``Image.getxmp()``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-TODO
+:py:meth:`~PIL.Image.Image.getxmp` now accepts an optional keyword argument of
+``strip_namespaces``. By default, this remains ``True``, stripping each tag's XML
+namespace prefix as before. If set to ``False``, each tag's full
+``{namespace-uri}local-name`` form is kept instead, avoiding collisions between tags
+that share a local name across different namespaces.
 
 Other changes
 =============

--- a/docs/releasenotes/13.0.0.rst
+++ b/docs/releasenotes/13.0.0.rst
@@ -89,8 +89,8 @@ Added ``strip_namespaces`` argument to ``Image.getxmp()``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :py:meth:`~PIL.Image.Image.getxmp` now accepts an optional keyword argument of
-``strip_namespaces``. By default, this remains ``True``, stripping each tag's XML
-namespace prefix as before. If set to ``False``, each tag's full
+``strip_namespaces``. It is set to ``True`` by default, stripping each tag's XML
+namespace URI prefix as before. If set to ``False``, each tag's full
 ``{namespace-uri}local-name`` form is kept instead, avoiding collisions between tags
 that share a local name across different namespaces.
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1581,8 +1581,15 @@ class Image:
         :returns: XMP tags in a dictionary.
         """
 
-        def get_name(tag: str) -> str:
-            return re.sub("^{[^}]+}", "", tag) if strip_namespaces else tag
+        if strip_namespaces:
+
+            def get_name(tag: str) -> str:
+                return re.sub("^{[^}]+}", "", tag)
+
+        else:
+
+            def get_name(tag: str) -> str:
+                return tag
 
         def get_value(element: Element) -> str | dict[str, Any] | None:
             value: dict[str, Any] = {get_name(k): v for k, v in element.attrib.items()}

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1578,6 +1578,9 @@ class Image:
         :param strip_namespaces: If ``False``, keep each tag's full
             ``{namespace-uri}local-name`` form instead of stripping the namespace
             prefix.
+
+            .. versionadded:: 13.0.0
+
         :returns: XMP tags in a dictionary.
         """
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1570,16 +1570,19 @@ class Image:
             return tuple(self.im.getband(i).getextrema() for i in range(self.im.bands))
         return self.im.getextrema()
 
-    def getxmp(self) -> dict[str, Any]:
+    def getxmp(self, strip_namespaces: bool = True) -> dict[str, Any]:
         """
         Returns a dictionary containing the XMP tags.
         Requires defusedxml to be installed.
 
+        :param strip_namespaces: If ``False``, keep each tag's full
+            ``{namespace-uri}local-name`` form instead of stripping the
+            namespace prefix.
         :returns: XMP tags in a dictionary.
         """
 
         def get_name(tag: str) -> str:
-            return re.sub("^{[^}]+}", "", tag)
+            return re.sub("^{[^}]+}", "", tag) if strip_namespaces else tag
 
         def get_value(element: Element) -> str | dict[str, Any] | None:
             value: dict[str, Any] = {get_name(k): v for k, v in element.attrib.items()}

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -1570,14 +1570,14 @@ class Image:
             return tuple(self.im.getband(i).getextrema() for i in range(self.im.bands))
         return self.im.getextrema()
 
-    def getxmp(self, strip_namespaces: bool = True) -> dict[str, Any]:
+    def getxmp(self, *, strip_namespaces: bool = True) -> dict[str, Any]:
         """
         Returns a dictionary containing the XMP tags.
         Requires defusedxml to be installed.
 
         :param strip_namespaces: If ``False``, keep each tag's full
-            ``{namespace-uri}local-name`` form instead of stripping the
-            namespace prefix.
+            ``{namespace-uri}local-name`` form instead of stripping the namespace
+            prefix.
         :returns: XMP tags in a dictionary.
         """
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * Added an optional `strip_namespaces` keyword argument to `Image.getxmp()`
   (defaults to `True`, preserving current behaviour).
 * When set to `False`, each tag keeps its full `{namespace-uri}local-name`
   form instead of having the namespace prefix stripped.

Currently, `getxmp()` always strips namespace prefixes, which can merge values from different namespaces that happen to share a local tag name. For example:

    >>> im.getxmp()
    {'xmpmeta': {'RDF': {'Description': {'id': ['from-a', 'from-b']}}}}

Two unrelated `id` tags from different namespaces (`a:id` and `b:id`) get merged into a list, with no way to tell which value came from which namespace. With `strip_namespaces=False`:

    >>> im.getxmp(strip_namespaces=False)
    {'{...}xmpmeta': {'{...}RDF': {'{...}Description': {
        '{http://example.com/ns/a/}id': 'from-a',
        '{http://example.com/ns/b/}id': 'from-b',
    }}}}
