### PR TITLE
PDF dictionary key must be a name

### DIFF
--- a/Tests/test_pdfparser.py
+++ b/Tests/test_pdfparser.py
@@ -67,6 +67,8 @@ def test_parsing() -> None:
     assert PdfParser.get_value(b" 123.4 %", 0)[1] == 6
     with pytest.raises(PdfFormatError):
         PdfParser.get_value(b"]", 0)
+    with pytest.raises(PdfFormatError, match="key must be a name"):
+        PdfParser.get_value(b"<<true[]>>", 0)
     d = PdfParser.get_value(b"<</Name (value) /N /V>>", 0)[0]
     assert isinstance(d, PdfDict)
     assert len(d) == 2

--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -886,13 +886,13 @@ class PdfParser:
             current_offset: int | None = offset
             while not m:
                 assert current_offset is not None
-                key, current_offset = cls.get_value(
-                    data, current_offset, max_nesting=max_nesting - 1
-                )
-                if current_offset is None:
-                    return result, None
+                m = cls.re_name.match(data, current_offset)
+                if not m:
+                    msg = "key must be a name"
+                    raise PdfFormatError(msg)
+                key = PdfName(cls.interpret_name(m.group(1)))
                 value, current_offset = cls.get_value(
-                    data, current_offset, max_nesting=max_nesting - 1
+                    data, m.end(), max_nesting=max_nesting - 1
                 )
                 result[key] = value
                 if current_offset is None:


### PR DESCRIPTION
Rather than allowing any type of value for a dictionary key
https://github.com/python-pillow/Pillow/blob/8bbb9ecc7386b80f5da9bf755ac0496580c5cfdf/src/PIL/PdfParser.py#L881-L891
this PR restricts the key to a name.

https://web.archive.org/web/20211126185945/https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/pdf_reference_archives/PDFReference.pdf
> A _dictionary object_ is an associative table containing pairs of objects, known as the dictionary's _entries_. The first element of each entry is the _key_ and the second element is the _value_. The key must be a name