### PR TITLE
Correct function references

### DIFF
--- a/docs/reference/ImageColor.rst
+++ b/docs/reference/ImageColor.rst
@@ -53,14 +53,14 @@ The ImageColor module supports the following string formats:
 Functions
 ---------
 
-.. py:method:: getrgb(color)
+.. py:function:: getrgb(color)
 
     Convert a color string to an RGB tuple. If the string cannot be parsed,
     this function raises a :py:exc:`ValueError` exception.
 
     .. versionadded:: 1.1.4
 
-.. py:method:: getcolor(color, mode)
+.. py:function:: getcolor(color, mode)
 
     Same as :py:func:`~PIL.ImageColor.getrgb`, but converts the RGB value to a
     grayscale value if the mode is not color or a palette image. If the string

--- a/docs/releasenotes/10.2.0.rst
+++ b/docs/releasenotes/10.2.0.rst
@@ -121,15 +121,15 @@ the user, rather than always being calculated by Pillow.
 Optimized ImageColor.getrgb and getcolor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The color calculations of :py:attr:`~PIL.ImageColor.getrgb` and
-:py:attr:`~PIL.ImageColor.getcolor` are now cached using
+The color calculations of :py:func:`~PIL.ImageColor.getrgb` and
+:py:func:`~PIL.ImageColor.getcolor` are now cached using
 :py:func:`functools.lru_cache`. Cached calls of ``getrgb`` are 3.1 - 91.4 times
 as fast and ``getcolor`` are 5.1 - 19.6 times as fast.
 
 Optimized ImageMode.getmode
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The lookups made by :py:attr:`~PIL.ImageMode.getmode` are now cached using
+The lookups made by :py:func:`~PIL.ImageMode.getmode` are now cached using
 :py:func:`functools.lru_cache` instead of a custom cache. Cached calls are 1.2 times as
 fast.
 

--- a/docs/releasenotes/8.3.2.rst
+++ b/docs/releasenotes/8.3.2.rst
@@ -8,7 +8,7 @@ Security
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Avoid a potential ReDoS (regular expression denial of service) in :py:class:`~PIL.ImageColor`'s
-:py:meth:`~PIL.ImageColor.getrgb` by raising :py:exc:`ValueError` if the color specifier is
+:py:func:`~PIL.ImageColor.getrgb` by raising :py:exc:`ValueError` if the color specifier is
 too long. Present since Pillow 5.2.0.
 
 Fix 6-byte out-of-bounds (OOB) read


### PR DESCRIPTION
Resolves https://github.com/python-pillow/Pillow/issues/9894

Corrects a few locations in the documentation where [`py:method::`](https://www.sphinx-doc.org/en/master/usage/domains/python.html#directive-py-method), `:py:meth:` or `:py:attr:` were used when [`py:function::`](https://www.sphinx-doc.org/en/master/usage/domains/python.html#directive-py-function) and `:py:func:` would have been more appropriate.