### PR TITLE
Use borrowed data when exporting an image created by Image.fromarrow

### DIFF
--- a/Tests/test_pyarrow.py
+++ b/Tests/test_pyarrow.py
@@ -84,21 +84,21 @@ fl_uint8_4_type = pyarrow.field(
 ).type
 
 
-@pytest.mark.parametrize(
-    "mode, dtype, mask",
-    (
-        ("L", pyarrow.uint8(), None),
-        ("I", pyarrow.int32(), None),
-        ("F", pyarrow.float32(), None),
-        ("LA", fl_uint8_4_type, [0, 3]),
-        ("RGB", fl_uint8_4_type, [0, 1, 2]),
-        ("RGBA", fl_uint8_4_type, None),
-        ("RGBX", fl_uint8_4_type, None),
-        ("CMYK", fl_uint8_4_type, None),
-        ("YCbCr", fl_uint8_4_type, [0, 1, 2]),
-        ("HSV", fl_uint8_4_type, [0, 1, 2]),
-    ),
+mode_dtype_mask = (
+    ("L", pyarrow.uint8(), None),
+    ("I", pyarrow.int32(), None),
+    ("F", pyarrow.float32(), None),
+    ("LA", fl_uint8_4_type, [0, 3]),
+    ("RGB", fl_uint8_4_type, [0, 1, 2]),
+    ("RGBA", fl_uint8_4_type, None),
+    ("RGBX", fl_uint8_4_type, None),
+    ("CMYK", fl_uint8_4_type, None),
+    ("YCbCr", fl_uint8_4_type, [0, 1, 2]),
+    ("HSV", fl_uint8_4_type, [0, 1, 2]),
 )
+
+
+@pytest.mark.parametrize("mode, dtype, mask", mode_dtype_mask)
 def test_to_array(mode: str, dtype: pyarrow.DataType, mask: list[int] | None) -> None:
     img = hopper(mode)
 
@@ -218,17 +218,7 @@ def test_fromarray(mode: str, data_tp: DataShape, mask: list[int] | None) -> Non
     _test_img_equals_pyarray(img, arr, mask, elts_per_pixel)
 
 
-@pytest.mark.parametrize(
-    "mode, dtype, mask",
-    (
-        ("L", pyarrow.uint8(), None),
-        ("I", pyarrow.int32(), None),
-        ("F", pyarrow.float32(), None),
-        ("LA", fl_uint8_4_type, [0, 3]),
-        ("RGB", fl_uint8_4_type, [0, 1, 2]),
-        ("RGBA", fl_uint8_4_type, None),
-    ),
-)
+@pytest.mark.parametrize("mode, dtype, mask", mode_dtype_mask)
 def test_fromarray_to_array(
     mode: str, dtype: pyarrow.DataType, mask: list[int] | None
 ) -> None:

--- a/Tests/test_pyarrow.py
+++ b/Tests/test_pyarrow.py
@@ -219,23 +219,35 @@ def test_fromarray(mode: str, data_tp: DataShape, mask: list[int] | None) -> Non
 
 
 @pytest.mark.parametrize(
-    "mode, data_tp, mask",
+    "mode, dtype, mask",
     (
-        ("L", DataShape(pyarrow.uint8(), 3, 1), None),
-        ("RGBA", UINT_ARR, None),
+        ("L", pyarrow.uint8(), None),
+        ("I", pyarrow.int32(), None),
+        ("F", pyarrow.float32(), None),
+        ("LA", fl_uint8_4_type, [0, 3]),
+        ("RGB", fl_uint8_4_type, [0, 1, 2]),
+        ("RGBA", fl_uint8_4_type, None),
     ),
 )
 def test_fromarray_to_array(
-    mode: str, data_tp: DataShape, mask: list[int] | None
+    mode: str, dtype: pyarrow.DataType, mask: list[int] | None
 ) -> None:
-    dtype, elt, elts_per_pixel = data_tp
+    img = hopper(mode)
 
-    ct_pixels = TEST_IMAGE_SIZE[0] * TEST_IMAGE_SIZE[1]
-    arr = pyarrow.array([elt] * (ct_pixels * elts_per_pixel), type=dtype)
-    img = Image.fromarrow(arr, mode, TEST_IMAGE_SIZE)
+    borrowed = Image.fromarrow(pyarrow.array(img), mode, img.size)  # type: ignore[call-overload]
 
-    exported = pyarrow.array(img)  # type: ignore[call-overload]
-    _test_img_equals_pyarray(img, exported, mask, elts_per_pixel)
+    arr = pyarrow.array(borrowed)  # type: ignore[call-overload]
+    _test_img_equals_pyarray(img, arr, mask)
+    assert arr.type == dtype
+
+
+def test_fromarray_interleaved_to_array() -> None:
+    img = hopper("RGBA")
+
+    arr = pyarrow.array(list(img.tobytes()), type=pyarrow.uint8())
+    borrowed = Image.fromarrow(arr, "RGBA", img.size)
+
+    _test_img_equals_pyarray(img, pyarrow.array(borrowed), None)  # type: ignore[call-overload]
 
 
 @pytest.mark.parametrize(

--- a/Tests/test_pyarrow.py
+++ b/Tests/test_pyarrow.py
@@ -24,7 +24,7 @@ TEST_IMAGE_SIZE = (10, 10)
 
 
 def _test_img_equals_pyarray(
-    img: Image.Image, arr: Any, mask: list[int] | None, elts_per_pixel: int = 1
+    img: Image.Image, arr: Any, mask: list[int] | None = None, elts_per_pixel: int = 1
 ) -> None:
     assert img.height * img.width * elts_per_pixel == len(arr)
     px = img.load()
@@ -237,7 +237,7 @@ def test_fromarray_interleaved_to_array() -> None:
     arr = pyarrow.array(list(img.tobytes()), type=pyarrow.uint8())
     borrowed = Image.fromarrow(arr, "RGBA", img.size)
 
-    _test_img_equals_pyarray(img, pyarrow.array(borrowed), None)  # type: ignore[call-overload]
+    _test_img_equals_pyarray(img, pyarrow.array(borrowed))  # type: ignore[call-overload]
 
 
 @pytest.mark.parametrize(

--- a/Tests/test_pyarrow.py
+++ b/Tests/test_pyarrow.py
@@ -221,6 +221,26 @@ def test_fromarray(mode: str, data_tp: DataShape, mask: list[int] | None) -> Non
 @pytest.mark.parametrize(
     "mode, data_tp, mask",
     (
+        ("L", DataShape(pyarrow.uint8(), 3, 1), None),
+        ("RGBA", UINT_ARR, None),
+    ),
+)
+def test_fromarray_to_array(
+    mode: str, data_tp: DataShape, mask: list[int] | None
+) -> None:
+    dtype, elt, elts_per_pixel = data_tp
+
+    ct_pixels = TEST_IMAGE_SIZE[0] * TEST_IMAGE_SIZE[1]
+    arr = pyarrow.array([elt] * (ct_pixels * elts_per_pixel), type=dtype)
+    img = Image.fromarrow(arr, mode, TEST_IMAGE_SIZE)
+
+    exported = pyarrow.array(img)  # type: ignore[call-overload]
+    _test_img_equals_pyarray(img, exported, mask, elts_per_pixel)
+
+
+@pytest.mark.parametrize(
+    "mode, data_tp, mask",
+    (
         ("LA", UINT32, [0, 3]),
         ("RGB", UINT32, [0, 1, 2]),
         ("RGBA", UINT32, None),

--- a/Tests/test_pyarrow.py
+++ b/Tests/test_pyarrow.py
@@ -237,7 +237,8 @@ def test_fromarray_interleaved_to_array() -> None:
     arr = pyarrow.array(list(img.tobytes()), type=pyarrow.uint8())
     borrowed = Image.fromarrow(arr, "RGBA", img.size)
 
-    _test_img_equals_pyarray(img, pyarrow.array(borrowed))  # type: ignore[call-overload]
+    arr = pyarrow.array(borrowed)  # type: ignore[call-overload]
+    _test_img_equals_pyarray(img, arr)
 
 
 @pytest.mark.parametrize(

--- a/src/libImaging/Arrow.c
+++ b/src/libImaging/Arrow.c
@@ -324,6 +324,8 @@ export_single_channel_array(Imaging im, struct ArrowArray *array) {
 
     if (im->block) {
         array->buffers[1] = im->block;
+    } else if (im->arrow_array_capsule) {
+        array->buffers[1] = im->image[0];
     } else {
         array->buffers[1] = im->blocks[0].ptr;
     }
@@ -407,6 +409,8 @@ export_fixed_pixel_array(Imaging im, struct ArrowArray *array) {
 
     if (im->block) {
         array->children[0]->buffers[1] = im->block;
+    } else if (im->arrow_array_capsule) {
+        array->children[0]->buffers[1] = im->image[0];
     } else {
         array->children[0]->buffers[1] = im->blocks[0].ptr;
     }


### PR DESCRIPTION
Resolves #9896

An image created by `Image.fromarrow()` borrows its data, so `block` and `blocks` are both NULL and only the row pointers in `image` are set. `export_single_channel_array()` and `export_fixed_pixel_array()` fall back to `blocks[0].ptr` when `block` is NULL, which dereferenced NULL and crashed on `pa.array(im)`.

A borrowed array is only accepted when its length matches the image, so the rows are contiguous and the export can start from the first one.
