### PR TITLE
Avoid integer overflow when calculating reduced image size

### DIFF
--- a/Tests/test_image_reduce.py
+++ b/Tests/test_image_reduce.py
@@ -55,18 +55,18 @@ def test_args_factor(size: int | tuple[int, int], expected: tuple[int, int]) -> 
 
 @pytest.mark.parametrize("mode", ("L", "I", "F"))
 @pytest.mark.parametrize(
-    "size, expected",
+    "factor, expected",
     (
         (2**31 - 1, (1, 1)),
         ((2**31 - 1, 1), (1, 10)),
         ((1, 2**31 - 1), (10, 1)),
     ),
 )
-def test_args_factor_large(
-    size: int | tuple[int, int], expected: tuple[int, int], mode: str
+def test_large_factor(
+    factor: int | tuple[int, int], expected: tuple[int, int], mode: str
 ) -> None:
     im = Image.new(mode, (10, 10))
-    assert im.reduce(size).size == expected
+    assert im.reduce(factor).size == expected
 
 
 @pytest.mark.parametrize(

--- a/Tests/test_image_reduce.py
+++ b/Tests/test_image_reduce.py
@@ -54,6 +54,21 @@ def test_args_factor(size: int | tuple[int, int], expected: tuple[int, int]) -> 
 
 
 @pytest.mark.parametrize(
+    "size, expected",
+    (
+        (2**31 - 1, (1, 1)),
+        ((2**31 - 1, 1), (1, 10)),
+        ((1, 2**31 - 1), (10, 1)),
+    ),
+)
+def test_args_factor_large(
+    size: int | tuple[int, int], expected: tuple[int, int]
+) -> None:
+    im = Image.new("L", (10, 10))
+    assert expected == im.reduce(size).size
+
+
+@pytest.mark.parametrize(
     "size, expected_error", ((0, ValueError), (2.0, TypeError), ((0, 10), ValueError))
 )
 def test_args_factor_error(

--- a/Tests/test_image_reduce.py
+++ b/Tests/test_image_reduce.py
@@ -53,6 +53,7 @@ def test_args_factor(size: int | tuple[int, int], expected: tuple[int, int]) -> 
     assert expected == im.reduce(size).size
 
 
+@pytest.mark.parametrize("mode", ("L", "I", "F"))
 @pytest.mark.parametrize(
     "size, expected",
     (
@@ -62,10 +63,10 @@ def test_args_factor(size: int | tuple[int, int], expected: tuple[int, int]) -> 
     ),
 )
 def test_args_factor_large(
-    size: int | tuple[int, int], expected: tuple[int, int]
+    size: int | tuple[int, int], expected: tuple[int, int], mode: str
 ) -> None:
-    im = Image.new("L", (10, 10))
-    assert expected == im.reduce(size).size
+    im = Image.new(mode, (10, 10))
+    assert im.reduce(size).size == expected
 
 
 @pytest.mark.parametrize(

--- a/src/libImaging/Reduce.c
+++ b/src/libImaging/Reduce.c
@@ -1461,7 +1461,7 @@ ImagingReduce(Imaging imIn, int xscale, int yscale, int box[4]) {
     }
 
     imOut = ImagingNewDirty(
-        imIn->mode, (box[2] + xscale - 1) / xscale, (box[3] + yscale - 1) / yscale
+        imIn->mode, (box[2] - 1) / xscale + 1, (box[3] - 1) / yscale + 1
     );
     if (!imOut) {
         return NULL;

--- a/src/libImaging/Reduce.c
+++ b/src/libImaging/Reduce.c
@@ -1460,6 +1460,9 @@ ImagingReduce(Imaging imIn, int xscale, int yscale, int box[4]) {
         return (Imaging)ImagingError_ModeError();
     }
 
+    /* Round the size up. Dividing before adding avoids overflowing for a
+       large scale, and guarantees a size of at least 1x1.
+     */
     imOut = ImagingNewDirty(
         imIn->mode, (box[2] - 1) / xscale + 1, (box[3] - 1) / yscale + 1
     );


### PR DESCRIPTION
`ImagingReduce()` sizes the output image with `(box[2] + xscale - 1) / xscale`. When the box width plus the scale exceeds `INT_MAX` that addition overflows and the result is a zero-width, zero-height image. `ImagingReduceCorners()` then writes to `imOut->image8[0][0]`, which has no rows allocated, so `Image.new("L", (4, 4)).reduce(2**31 - 1)` segfaults.

Since the box is never empty, the same round-up can be written as `(box[2] - 1) / xscale + 1`, which cannot overflow and gives a 1x1 image as expected.

Fixes #9903
