### PR TITLE
Link FreeType against the bundled HarfBuzz in wheels

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -159,6 +159,12 @@ function build_brotli {
     touch brotli-stamp
 }
 
+function build_freetype {  # overrides multibuild's function so we can add "$@" args
+    build_libpng
+    build_bzip2
+    build_simple freetype $FREETYPE_VERSION https://download.savannah.gnu.org/releases/freetype tar.gz "$@"
+}
+
 function build_harfbuzz {
     if [ -e harfbuzz-stamp ]; then return; fi
     python3 -m pip install meson ninja
@@ -304,17 +310,19 @@ function build {
 
     build_brotli
 
-    if [[ -n "$IS_MACOS" ]]; then
-        # Custom freetype build
-        build_simple freetype $FREETYPE_VERSION https://download.savannah.gnu.org/releases/freetype tar.gz --with-harfbuzz=no
-    else
-        build_freetype
-    fi
+    # FreeType and HarfBuzz each want the other:
+    # HarfBuzz reads font data through FreeType, and FreeType's autofitter asks HarfBuzz which glyphs a script covers.
+    # Break the cycle by building FreeType twice, so that the FreeType we ship is linked against the HarfBuzz we ship.
+    build_freetype --with-harfbuzz=no
 
     if [[ -z "$IOS_SDK" ]]; then
         # On iOS, there's no vendor-provided raqm, and we can't ship it due to
         # licensing, so there's no point building harfbuzz.
         build_harfbuzz
+
+        # Now that HarfBuzz exists, build FreeType again against it.
+        rm -rf freetype-$FREETYPE_VERSION freetype-stamp
+        build_freetype --with-harfbuzz=yes
     fi
 }
 

--- a/docs/releasenotes/13.0.0.rst
+++ b/docs/releasenotes/13.0.0.rst
@@ -97,6 +97,25 @@ that share a local name across different namespaces.
 Other changes
 =============
 
+Wheels now use HarfBuzz for hinting
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+FreeType can use HarfBuzz to work out which glyphs a script covers,
+so that its autofitter can derive hinting "Blue Zones" for scripts such as Arabic.
+
+Only the Windows wheels were actually built with this support.
+The macOS wheels disabled HarfBuzz intreop outright,
+and the Linux wheels left it up to FreeType's ``configure``,
+which in turn fell back to loading HarfBuzz by its unversioned name at
+runtime.
+
+Since the bundled copy of HarfBuzz is renamed when the wheel is audited and repaired
+for distribution, that lookup only succeeded if a separate copy happened to be
+installed on the system with the expected name (e.g. ``libharfbuzz.so.0``).
+
+All wheels are now linked against the HarfBuzz that Pillow ships,
+which may slightly change how text is rendered in scripts that rely on the autofitter.
+
 Python 3.15
 ^^^^^^^^^^^
 


### PR DESCRIPTION
Follows up on #8497. 

This came up as a side effect of #9909, where the last commit needed to increase the allowed comparison epsilon for the Arabic-language test, since different platforms in the CI stack would render it slightly differently... and it's a doozy! 😄

FreeType's autofitter can use HarfBuzz to work out which glyphs a script covers, so it can derive [blue zones for scripts such as Arabic](https://freetype.org/autohinting/blues.html).

Only the Windows wheels were built that way. macOS passed `--with-harfbuzz=no` (so no HarfBuzz interop, no way, no how), and Linux left it unconfigured, which meant FreeType defaulted to `dlopen`ing HarfBuzz at runtime with the name "libharfbuzz.so.0".

However, `auditwheel` renames shared libraries to avoid conflicts, so the Linux wheels ended up with a FreeType that would only find HarfBuzz if the system had its own copy with the name "libharfbuzz.so.0".

---

In the current 12.3 wheel off PyPI, the interop symbols do not exist:

```
$ wget https://files.pythonhosted.org/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl
$ unzip pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl PIL/.dylibs/libfreetype.6.dylib
$ nm -u PIL/.dylibs/libfreetype.6.dylib | grep _hb_ot_
$
```

but in a wheel built by CI off this branch (see https://github.com/akx/Pillow/pull/18):

```
$ unzip 'dist-macOS arm64.zip'
Archive:  dist-macOS arm64.zip
  inflating: pillow-13.0.0.dev0-cp311-cp311-macosx_11_0_arm64.whl
  inflating: pillow-13.0.0.dev0-cp312-cp312-macosx_11_0_arm64.whl
  inflating: pillow-13.0.0.dev0-cp313-cp313-macosx_11_0_arm64.whl
  inflating: pillow-13.0.0.dev0-cp314-cp314-macosx_11_0_arm64.whl
  inflating: pillow-13.0.0.dev0-cp314-cp314t-macosx_11_0_arm64.whl
  inflating: pillow-13.0.0.dev0-cp315-cp315-macosx_11_0_arm64.whl
  inflating: pillow-13.0.0.dev0-cp315-cp315t-macosx_11_0_arm64.whl
  inflating: pillow-13.0.0.dev0-pp311-pypy311_pp73-macosx_11_0_arm64.whl
$ unzip pillow-13.0.0.dev0-cp314-cp314-macosx_11_0_arm64.whl PIL/.dylibs/libfreetype.6.dylib
$ nm -u PIL/.dylibs/libfreetype.6.dylib | grep _hb_ot_
_hb_ot_layout_collect_lookups
_hb_ot_layout_lookup_collect_glyphs
_hb_ot_layout_lookup_would_substitute
_hb_ot_tags_from_script_and_language
$
```

