### PR TITLE
Warn about duplicate Raqm text preprocessing

### DIFF
--- a/docs/reference/ImageDraw.rst
+++ b/docs/reference/ImageDraw.rst
@@ -399,6 +399,15 @@ Methods
 
     Draw a shape.
 
+.. note::
+
+    When libraqm is available, Pillow performs complex text layout, including
+    shaping and bidirectional text handling, itself. Do not pre-process text
+    with ``arabic_reshaper`` and ``python-bidi`` in this case, as applying the
+    same processing twice produces incorrect results. Use
+    :py:func:`PIL.features.check` with ``"raqm"`` to determine whether
+    libraqm is available before deciding whether pre-processing is needed.
+
 .. py:method:: ImageDraw.text(xy, text, fill=None, font=None, anchor=None, spacing=4, align="left", direction=None, features=None, language=None, stroke_width=0, stroke_fill=None, embedded_color=False, font_size=None)
 
     Draws the string at the given position.


### PR DESCRIPTION
Fixes #9907. Alternative to #9925

Pillow uses libraqm to perform shaping and bidirectional text layout when it is available. This adds a note to the `ImageDraw` documentation warning that pre-processing text with `arabic_reshaper` and `python-bidi` in that case applies the same processing twice and can produce incorrect output.

The note also points readers to `PIL.features.check("raqm")` so applications can choose the appropriate behavior at runtime.

Validation:

- Built the full documentation site with Sphinx using the released Pillow wheel for autodoc imports.
- Ran `git diff --check`.

I used OpenAI Codex to assist with investigating and preparing this change, and reviewed the resulting documentation before submission.