### PR TITLE
Copy qtables list when saving JPEG image

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -27,6 +27,7 @@ from .helper import (
     assert_image_similar_tofile,
     djpeg_available,
     hopper,
+    is_pypy,
     is_win32,
     mark_if_feature_version,
     skip_unless_feature,
@@ -687,6 +688,7 @@ class TestFileJpeg:
             with pytest.raises(ValueError):
                 self.roundtrip(im, qtables=[[1, 2, 3, 4]])
 
+    @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
     def test_qtables_iteration_error(self) -> None:
         class FailOnSecondIteration(list[list[int]]):
             iterated = False

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -689,19 +689,37 @@ class TestFileJpeg:
 
     def test_qtables_iteration_error(self) -> None:
         class FailOnSecondIteration(list[list[int]]):
-            def __init__(self, values: list[list[int]]) -> None:
-                super().__init__(values)
-                self.iterations = 0
+            iterated = False
 
             def __iter__(self) -> Iterator[list[int]]:
-                self.iterations += 1
-                if self.iterations > 1:
+                if self.iterated:
                     raise RuntimeError
+                self.iterated = True
                 return super().__iter__()
 
         with Image.open(TEST_FILE) as im:
             with pytest.raises(RuntimeError):
                 self.roundtrip(im, qtables=FailOnSecondIteration([[1] * 64]))
+
+    def test_qtables_inconsistent_length(self) -> None:
+        class LongerLen(list[list[int]]):
+            def __len__(self) -> int:
+                return 4
+
+        class ShorterTable(list[int]):
+            def __len__(self) -> int:
+                return 64
+
+        class SwappedTable(list[list[int]]):
+            def __iter__(self) -> Iterator[list[int]]:
+                return iter([ShorterTable([1])])
+
+        with Image.open(TEST_FILE) as im:
+            im2 = self.roundtrip(im, qtables=LongerLen([[1] * 64]))
+            assert len(im2.quantization) == 1
+
+            with pytest.raises(ValueError):
+                self.roundtrip(im, qtables=SwappedTable([[1] * 64]))
 
     def test_load_16bit_qtables(self) -> None:
         with Image.open("Tests/images/hopper_16bit_qtables.jpg") as im:

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -35,6 +35,7 @@ from .helper import (
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
     from types import ModuleType
 
@@ -685,6 +686,22 @@ class TestFileJpeg:
             # qtable entry has wrong number of items
             with pytest.raises(ValueError):
                 self.roundtrip(im, qtables=[[1, 2, 3, 4]])
+
+    def test_qtables_iteration_error(self) -> None:
+        class FailOnSecondIteration(list[list[int]]):
+            def __init__(self, values: list[list[int]]) -> None:
+                super().__init__(values)
+                self.iterations = 0
+
+            def __iter__(self) -> Iterator[list[int]]:
+                self.iterations += 1
+                if self.iterations > 1:
+                    raise RuntimeError
+                return super().__iter__()
+
+        with Image.open(TEST_FILE) as im:
+            with pytest.raises(RuntimeError):
+                self.roundtrip(im, qtables=FailOnSecondIteration([[1] * 64]))
 
     def test_load_16bit_qtables(self) -> None:
         with Image.open("Tests/images/hopper_16bit_qtables.jpg") as im:

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -35,7 +35,6 @@ from .helper import (
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from collections.abc import Iterator
     from pathlib import Path
     from types import ModuleType
 
@@ -687,25 +686,14 @@ class TestFileJpeg:
             with pytest.raises(ValueError):
                 self.roundtrip(im, qtables=[[1, 2, 3, 4]])
 
-    def test_qtables_inconsistent_length(self) -> None:
-        class LongerLen(list[list[int]]):
+    def test_qtables_incorrect_length(self) -> None:
+        class IncorrectLength(list[list[int]]):
             def __len__(self) -> int:
                 return 4
 
-        class ShorterTable(list[int]):
-            def __len__(self) -> int:
-                return 64
-
-        class SwappedTable(list[list[int]]):
-            def __iter__(self) -> Iterator[list[int]]:
-                return iter([ShorterTable([1])])
-
-        with Image.open(TEST_FILE) as im:
-            im2 = self.roundtrip(im, qtables=LongerLen([[1] * 64]))
-            assert len(im2.quantization) == 1
-
-            with pytest.raises(ValueError):
-                self.roundtrip(im, qtables=SwappedTable([[1] * 64]))
+        im = Image.new("1", (1, 1))
+        im2 = self.roundtrip(im, qtables=IncorrectLength([[1] * 64]))
+        assert len(im2.quantization) == 1
 
     def test_load_16bit_qtables(self) -> None:
         with Image.open("Tests/images/hopper_16bit_qtables.jpg") as im:

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -687,20 +687,6 @@ class TestFileJpeg:
             with pytest.raises(ValueError):
                 self.roundtrip(im, qtables=[[1, 2, 3, 4]])
 
-    def test_qtables_read_once(self) -> None:
-        class FailOnSecondIteration(list[list[int]]):
-            iterated = False
-
-            def __iter__(self) -> Iterator[list[int]]:
-                if self.iterated:
-                    raise RuntimeError
-                self.iterated = True
-                return super().__iter__()
-
-        with Image.open(TEST_FILE) as im:
-            im2 = self.roundtrip(im, qtables=FailOnSecondIteration([[1] * 64]))
-            assert len(im2.quantization) == 1
-
     def test_qtables_inconsistent_length(self) -> None:
         class LongerLen(list[list[int]]):
             def __len__(self) -> int:
@@ -720,29 +706,6 @@ class TestFileJpeg:
 
             with pytest.raises(ValueError):
                 self.roundtrip(im, qtables=SwappedTable([[1] * 64]))
-
-    def test_qtables_cleared_while_reading(self) -> None:
-        class ClearsTable:
-            table: list[Any] = []
-
-            def __index__(self) -> int:
-                self.table.clear()
-                return 1
-
-        class SwappedTable(list[list[int]]):
-            iterated = False
-
-            def __iter__(self) -> Iterator[Any]:
-                if self.iterated:
-                    value = ClearsTable()
-                    value.table = [value] + [1] * 63
-                    return iter([value.table])
-                self.iterated = True
-                return super().__iter__()
-
-        with Image.open(TEST_FILE) as im:
-            im2 = self.roundtrip(im, qtables=SwappedTable([[1] * 64]))
-            assert len(im2.quantization) == 1
 
     def test_load_16bit_qtables(self) -> None:
         with Image.open("Tests/images/hopper_16bit_qtables.jpg") as im:

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -723,6 +723,29 @@ class TestFileJpeg:
             with pytest.raises(ValueError):
                 self.roundtrip(im, qtables=SwappedTable([[1] * 64]))
 
+    def test_qtables_cleared_while_reading(self) -> None:
+        class ClearsTable:
+            table: list[Any] = []
+
+            def __index__(self) -> int:
+                self.table.clear()
+                return 1
+
+        class SwappedTable(list[list[int]]):
+            iterated = False
+
+            def __iter__(self) -> Iterator[Any]:
+                if self.iterated:
+                    value = ClearsTable()
+                    value.table = [value] + [1] * 63
+                    return iter([value.table])
+                self.iterated = True
+                return super().__iter__()
+
+        with Image.open(TEST_FILE) as im:
+            im2 = self.roundtrip(im, qtables=SwappedTable([[1] * 64]))
+            assert len(im2.quantization) == 1
+
     def test_load_16bit_qtables(self) -> None:
         with Image.open("Tests/images/hopper_16bit_qtables.jpg") as im:
             assert isinstance(im, JpegImagePlugin.JpegImageFile)

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -27,7 +27,6 @@ from .helper import (
     assert_image_similar_tofile,
     djpeg_available,
     hopper,
-    is_pypy,
     is_win32,
     mark_if_feature_version,
     skip_unless_feature,
@@ -688,8 +687,7 @@ class TestFileJpeg:
             with pytest.raises(ValueError):
                 self.roundtrip(im, qtables=[[1, 2, 3, 4]])
 
-    @pytest.mark.skipif(is_pypy(), reason="Requires CPython")
-    def test_qtables_iteration_error(self) -> None:
+    def test_qtables_read_once(self) -> None:
         class FailOnSecondIteration(list[list[int]]):
             iterated = False
 
@@ -700,8 +698,8 @@ class TestFileJpeg:
                 return super().__iter__()
 
         with Image.open(TEST_FILE) as im:
-            with pytest.raises(RuntimeError):
-                self.roundtrip(im, qtables=FailOnSecondIteration([[1] * 64]))
+            im2 = self.roundtrip(im, qtables=FailOnSecondIteration([[1] * 64]))
+            assert len(im2.quantization) == 1
 
     def test_qtables_inconsistent_length(self) -> None:
         class LongerLen(list[list[int]]):

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -731,7 +731,8 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
                 qtables = [
                     qtables[key] for key in range(len(qtables)) if key in qtables
                 ]
-            elif isinstance(qtables, tuple):
+            else:
+                # Copy the sequence, so that it cannot be changed while it is read
                 qtables = list(qtables)
             if not (0 < len(qtables) < 5):
                 msg = "None or too many quantization tables"

--- a/src/encode.c
+++ b/src/encode.c
@@ -1112,12 +1112,11 @@ get_qtables_arrays(PyObject *qtables, int *qtablesLen) {
         return NULL;
     }
 
-    /* Copy the sequence, so that it cannot be changed while it is read */
-    tables = PySequence_List(qtables);
+    tables = PySequence_Fast(qtables, "expected a sequence");
     if (tables == NULL) {
         return NULL;
     }
-    num_tables = PyList_GET_SIZE(tables);
+    num_tables = PySequence_Fast_GET_SIZE(tables);
     if (num_tables < 1 || num_tables > NUM_QUANT_TBLS) {
         PyErr_SetString(
             PyExc_ValueError,
@@ -1133,22 +1132,23 @@ get_qtables_arrays(PyObject *qtables, int *qtablesLen) {
         return ImagingError_MemoryError();
     }
     for (i = 0; i < num_tables; i++) {
-        table = PyList_GET_ITEM(tables, i);
+        table = PySequence_Fast_GET_ITEM(tables, i);
         if (!PySequence_Check(table)) {
             PyErr_SetString(PyExc_ValueError, "Invalid quantization tables");
             goto JPEG_QTABLES_ERR;
         }
-        table_data = PySequence_List(table);
+        table_data = PySequence_Fast(table, "expected a sequence");
         if (table_data == NULL) {
             goto JPEG_QTABLES_ERR;
         }
-        if (PyList_GET_SIZE(table_data) != DCTSIZE2) {
+        if (PySequence_Fast_GET_SIZE(table_data) != DCTSIZE2) {
             Py_DECREF(table_data);
             PyErr_SetString(PyExc_ValueError, "Invalid quantization table size");
             goto JPEG_QTABLES_ERR;
         }
         for (j = 0; j < DCTSIZE2; j++) {
-            qarrays[i * DCTSIZE2 + j] = PyLong_AS_LONG(PyList_GET_ITEM(table_data, j));
+            qarrays[i * DCTSIZE2 + j] =
+                PyLong_AS_LONG(PySequence_Fast_GET_ITEM(table_data, j));
         }
         Py_DECREF(table_data);
     }

--- a/src/encode.c
+++ b/src/encode.c
@@ -1111,11 +1111,12 @@ get_qtables_arrays(PyObject *qtables, int *qtablesLen) {
         return NULL;
     }
 
-    tables = PySequence_Fast(qtables, "expected a sequence");
+    /* Copy the sequence, so that it cannot be changed while it is read */
+    tables = PySequence_List(qtables);
     if (tables == NULL) {
         return NULL;
     }
-    num_tables = PySequence_Fast_GET_SIZE(tables);
+    num_tables = PyList_GET_SIZE(tables);
     if (num_tables < 1 || num_tables > NUM_QUANT_TBLS) {
         PyErr_SetString(
             PyExc_ValueError,
@@ -1131,23 +1132,22 @@ get_qtables_arrays(PyObject *qtables, int *qtablesLen) {
         return ImagingError_MemoryError();
     }
     for (i = 0; i < num_tables; i++) {
-        table = PySequence_Fast_GET_ITEM(tables, i);
+        table = PyList_GET_ITEM(tables, i);
         if (!PySequence_Check(table)) {
             PyErr_SetString(PyExc_ValueError, "Invalid quantization tables");
             goto JPEG_QTABLES_ERR;
         }
-        table_data = PySequence_Fast(table, "expected a sequence");
+        table_data = PySequence_List(table);
         if (table_data == NULL) {
             goto JPEG_QTABLES_ERR;
         }
-        if (PySequence_Fast_GET_SIZE(table_data) != DCTSIZE2) {
+        if (PyList_GET_SIZE(table_data) != DCTSIZE2) {
             Py_DECREF(table_data);
             PyErr_SetString(PyExc_ValueError, "Invalid quantization table size");
             goto JPEG_QTABLES_ERR;
         }
         for (j = 0; j < DCTSIZE2; j++) {
-            qarrays[i * DCTSIZE2 + j] =
-                PyLong_AS_LONG(PySequence_Fast_GET_ITEM(table_data, j));
+            qarrays[i * DCTSIZE2 + j] = PyLong_AS_LONG(PyList_GET_ITEM(table_data, j));
         }
         Py_DECREF(table_data);
     }

--- a/src/encode.c
+++ b/src/encode.c
@@ -1112,6 +1112,9 @@ get_qtables_arrays(PyObject *qtables, int *qtablesLen) {
     }
 
     tables = PySequence_Fast(qtables, "expected a sequence");
+    if (tables == NULL) {
+        return NULL;
+    }
     num_tables = PySequence_Size(qtables);
     if (num_tables < 1 || num_tables > NUM_QUANT_TBLS) {
         PyErr_SetString(
@@ -1138,6 +1141,9 @@ get_qtables_arrays(PyObject *qtables, int *qtablesLen) {
             goto JPEG_QTABLES_ERR;
         }
         table_data = PySequence_Fast(table, "expected a sequence");
+        if (table_data == NULL) {
+            goto JPEG_QTABLES_ERR;
+        }
         for (j = 0; j < DCTSIZE2; j++) {
             qarrays[i * DCTSIZE2 + j] =
                 PyLong_AS_LONG(PySequence_Fast_GET_ITEM(table_data, j));
@@ -1232,6 +1238,10 @@ PyImaging_JpegEncoderNew(PyObject *self, PyObject *args) {
 
     // Freed in JpegEncode, Case 6
     qarrays = get_qtables_arrays(qtables, &qtablesLen);
+    if (qarrays == NULL && PyErr_Occurred()) {
+        Py_DECREF(encoder);
+        return NULL;
+    }
 
     if (comment && comment_size > 0) {
         /* malloc check ok, length is from python parsearg */

--- a/src/encode.c
+++ b/src/encode.c
@@ -1115,7 +1115,7 @@ get_qtables_arrays(PyObject *qtables, int *qtablesLen) {
     if (tables == NULL) {
         return NULL;
     }
-    num_tables = PySequence_Size(qtables);
+    num_tables = PySequence_Fast_GET_SIZE(tables);
     if (num_tables < 1 || num_tables > NUM_QUANT_TBLS) {
         PyErr_SetString(
             PyExc_ValueError,
@@ -1136,12 +1136,13 @@ get_qtables_arrays(PyObject *qtables, int *qtablesLen) {
             PyErr_SetString(PyExc_ValueError, "Invalid quantization tables");
             goto JPEG_QTABLES_ERR;
         }
-        if (PySequence_Size(table) != DCTSIZE2) {
-            PyErr_SetString(PyExc_ValueError, "Invalid quantization table size");
-            goto JPEG_QTABLES_ERR;
-        }
         table_data = PySequence_Fast(table, "expected a sequence");
         if (table_data == NULL) {
+            goto JPEG_QTABLES_ERR;
+        }
+        if (PySequence_Fast_GET_SIZE(table_data) != DCTSIZE2) {
+            Py_DECREF(table_data);
+            PyErr_SetString(PyExc_ValueError, "Invalid quantization table size");
             goto JPEG_QTABLES_ERR;
         }
         for (j = 0; j < DCTSIZE2; j++) {


### PR DESCRIPTION
Fixes #9917.

`get_qtables_arrays()` validated `qtables` against the original object but read the items out of the list that
`PySequence_Fast()` built from it. For anything other than an exact list or tuple that means a second iteration, so a
sequence that raises the second time around returned NULL and the unchecked `PySequence_Fast_GET_ITEM()` segfaulted.
The same mismatch also let a lying `__len__` walk off the end of the converted list, both for the outer sequence and
for an individual table.

Both `PySequence_Fast()` calls are now checked, the lengths come from the converted lists, and
`PyImaging_JpegEncoderNew()` bails out when an exception is set instead of building the encoder anyway.
