### PR TITLE
Parenthesize `MIN`/`MAX` macro arguments

### DIFF
--- a/src/libImaging/ImagingUtils.h
+++ b/src/libImaging/ImagingUtils.h
@@ -14,8 +14,8 @@
 #define MASK_UINT32_CHANNEL_3 0xff000000
 #endif
 
-#define MAX(a, b) (a > b ? a : b)
-#define MIN(a, b) (a < b ? a : b)
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
 
 #define SHIFTFORDIV255(a) ((((a) >> 8) + a) >> 8)
 


### PR DESCRIPTION
#9921 replaced duplicated variants of `MIN`/`MAX` macros with the variant that has certain subtle precedence issues, see e.g. the trivial example

```c
#define MAX_BAD(a, b)  (a > b ? a : b)
#define MAX_GOOD(a, b) ((a) > (b) ? (a) : (b))

int main(void) {
    int x = 1, y = 10, z = 4;   /* y | z == 14 */
    printf("%d\n", MAX_BAD(x, y | z));   /* prints 1  */
    printf("%d\n", MAX_GOOD(x, y | z));  /* prints 14 */
}
```

or `MIN(a, flag ? x : y)` which would expand to `(a < flag ? x : y ? a : flag ? x : y)`, which parses as `(a < flag) ? x : (y ? a : (flag ? x : y))`, which is probably not what the programmer expects.

While right now it looks (quick visual grep) like there were no call sites affected, I think it's a good idea to have the predictable variant of these macros, instead of the subtly wrong one.
