### PR TITLE
Avoid blocking all threads when decoding AVIF image

### DIFF
--- a/src/_avif.c
+++ b/src/_avif.c
@@ -782,7 +782,9 @@ _decoder_get_frame(AvifDecoderObject *self, PyObject *args) {
         return NULL;
     }
 
+    Py_BEGIN_ALLOW_THREADS;
     result = avifDecoderNthImage(decoder, frame_index);
+    Py_END_ALLOW_THREADS;
     if (result != AVIF_RESULT_OK) {
         PyErr_Format(
             exc_type_for_avif_result(result),


### PR DESCRIPTION
Allow threads during AVIF decode as it can be a relatively lengthy operation and, from what I understood of the code, other Python threads executing in the meantime shouldn't cause issues (there's just `decoder->buffer` which is provided by Python code, but it is owned by this class for its whole lifetime, there should be no side effects from this change).

I develop a Dear ImGui based app where I use a thread to decode images into raw pixels to give to OpenGL, and with 4K AVIF images it stutters to the point of being unusable while decoding is happening (from 60 FPS normally to 1-2 FPS during decode), which can be up to 5-10 seconds in a row in some cases. With this patch, everything is back to being smooth.

Passed `selftest` on my machine, and I did not observe any other obvious issue using the decoder with this patch.