### PR TITLE
Fix comparison off-by-one in `getModeData`/`getRawModeData`

### DIFF
--- a/src/libImaging/Mode.c
+++ b/src/libImaging/Mode.c
@@ -42,7 +42,7 @@ findModeID(const char *const name) {
 
 const ModeData *const
 getModeData(const ModeID id) {
-    if (id < 0 || id > sizeof(MODES) / sizeof(*MODES)) {
+    if (id < 0 || id >= sizeof(MODES) / sizeof(*MODES)) {
         return &MODES[IMAGING_MODE_UNKNOWN];
     }
     return &MODES[id];
@@ -244,7 +244,7 @@ findRawModeID(const char *const name) {
 
 const RawModeData *const
 getRawModeData(const RawModeID id) {
-    if (id < 0 || id > sizeof(RAWMODES) / sizeof(*RAWMODES)) {
+    if (id < 0 || id >= sizeof(RAWMODES) / sizeof(*RAWMODES)) {
         return &RAWMODES[IMAGING_RAWMODE_UNKNOWN];
     }
     return &RAWMODES[id];


### PR DESCRIPTION
Follows up on 9527ce7f8c925e30e8b5535e8b115366743495e4 (#9256).

As far as I can tell, there is no code path in C or Python that would naturally end up passing in an out-of-bounds ModeID (or RawModeID), since they're are always acquired from `findModeID`/`findRawModeID`, which itself will never return such a value. IOW, you'll have to do something silly like in the below reproducer.

## Reproducer:

```c
#include "Mode.c"

int
main(void) {
    return getModeData(IMAGING_MODE_I_16N + 1)->name != NULL;
}
```

Run on c9e4cff871b19688789a9da4827d5e993204174c (main):

```
$ clang -fsanitize=address -Isrc/libImaging repro_modeid.c -o repro_modeid && ./repro_modeid
repro_modeid(12664,0x202fea2c0) malloc: nano zone abandoned due to inability to reserve vm space.
=================================================================
==12664==ERROR: AddressSanitizer: global-buffer-overflow on address 0x0001043200e8 at pc 0x00010431cbd8 bp 0x00016bae2d70 sp 0x00016bae2d68
READ of size 8 at 0x0001043200e8 thread T0
    #0 0x00010431cbd4 in main+0x48 (repro_modeid:arm64+0x100000bd4)
    #1 0x000194c86b94  (<unknown module>)

0x0001043200e8 is located 56 bytes before global variable 'RAWMODES' defined in 'repro_modeid.c' (0x000104320120) of size 1352
0x0001043200e8 is located 0 bytes after global variable 'MODES' defined in 'repro_modeid.c' (0x000104320040) of size 168
SUMMARY: AddressSanitizer: global-buffer-overflow (repro_modeid:arm64+0x100000bd4) in main+0x48
fish: Job 1, './repro_modeid' terminated by signal SIGABRT (Abort)
```

Run on 21774f4632ebb1234d2aa35b957ce82040b62bbc:

```
clang -fsanitize=address -Isrc/libImaging repro_modeid.c -o repro_modeid && ./repro_modeid
repro_modeid(12932,0x202fea2c0) malloc: nano zone abandoned due to inability to reserve vm space.
~/b/Pillow (mode-off-by-one) $
```