### PR TITLE
Improve test stability

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -207,7 +207,14 @@ def mark_if_feature_version(
     return pytest.mark.pil_noop_mark()
 
 
+def is_pypy() -> bool:
+    return sys.implementation.name == "pypy"
+
+
 @pytest.mark.skipif(sys.platform.startswith("win32"), reason="Requires Unix or macOS")
+# Per https://stackoverflow.com/a/29007723/51685, due to JIT compilation,
+# RSS utilization is known to grow so measuring it doesn't make that much sense.
+@pytest.mark.skipif(is_pypy(), reason="max RSS utilization is not stable on PyPy")
 class PillowLeakTestCase:
     # requires unix/macOS
     iterations = 100  # count
@@ -332,7 +339,3 @@ def is_ppc64le() -> bool:
 
 def is_win32() -> bool:
     return sys.platform.startswith("win32")
-
-
-def is_pypy() -> bool:
-    return sys.implementation.name == "pypy"

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -213,7 +213,7 @@ def is_pypy() -> bool:
 
 @pytest.mark.skipif(sys.platform.startswith("win32"), reason="Requires Unix or macOS")
 # Per https://stackoverflow.com/a/29007723/51685, due to JIT compilation,
-# RSS utilization is known to grow so measuring it doesn't make that much sense.
+# RSS utilization is known to grow in PyPy.
 @pytest.mark.skipif(is_pypy(), reason="max RSS utilization is not stable on PyPy")
 class PillowLeakTestCase:
     # requires unix/macOS

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -572,7 +572,9 @@ class TestImage:
         assert isinstance(i.size, tuple)
 
     @timeout_unless_slower_valgrind(0.75)
-    @pytest.mark.parametrize("size", ((0, 100000000), (100000000, 0)))
+    @pytest.mark.parametrize(
+        "size", ((0, 10_000_000), (10_000_000, 0)), ids=("tall", "wide")
+    )
     def test_empty_image(self, size: tuple[int, int]) -> None:
         Image.new("RGB", size)
 


### PR DESCRIPTION
This proposes to fix the PyPy CI flakiness by skipping or adjusting the tests that are observed to be flaky.

* Leak test cases can't have accurate RSS measurements since PyPy may decide to JIT compile things during a test, and that'll remain in RSS. I linked Armin Rigo's, one of the PyPy head honchos', [Stack Overflow comment](https://stackoverflow.com/a/29007723/51685) as rationale.
* `test_empty_image` allocated 100,000,000 64-bit ints for row pointers, in the "tall" case, which, I guess, would take a while when there's memory pressure (again, see above; PyPy is known to be memory-hungrier).

EDIT: Oh, the tall case also fails sometimes on vanilla macOS, e.g. [here](https://github.com/python-pillow/Pillow/actions/runs/33506525080/job/99851767821?pr=9936) with "FAILED Tests/test_image.py::TestImage::test_empty_image[size0] - Failed: Timeout (>0.75s) from pytest-timeout." Making it allocate 10,000,000 ints instead of 100,000,000 should hopefully help, anyway.
