### PR TITLE
Raise ValueError for truncated tRNS PNG chunks

### DIFF
--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -724,7 +724,7 @@ class TestFilePng:
         fp = BytesIO()
         with PngImagePlugin.PngStream(fp) as png:
             png.im_mode = mode
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="Truncated tRNS chunk"):
                 png.call(b"tRNS", 0, 0)
 
             monkeypatch.setattr(ImageFile, "LOAD_TRUNCATED_IMAGES", True)
@@ -736,7 +736,7 @@ class TestFilePng:
         # HEAD declares a truecolour image, so tRNS must carry 6 bytes
         data = HEAD + chunk(b"tRNS", bytes(4)) + TAIL
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Truncated tRNS chunk"):
             with Image.open(BytesIO(data)):
                 pass
 

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -717,6 +717,34 @@ class TestFilePng:
             monkeypatch.setattr(ImageFile, "LOAD_TRUNCATED_IMAGES", True)
             png.call(cid, 0, 0)
 
+    @pytest.mark.parametrize("mode", ("1", "L", "I;16", "RGB"))
+    def test_truncated_trns_chunk(
+        self, mode: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fp = BytesIO()
+        with PngImagePlugin.PngStream(fp) as png:
+            png.im_mode = mode
+            with pytest.raises(ValueError):
+                png.call(b"tRNS", 0, 0)
+
+            monkeypatch.setattr(ImageFile, "LOAD_TRUNCATED_IMAGES", True)
+            png.call(b"tRNS", 0, 0)
+
+    def test_truncated_trns_chunk_in_file(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # HEAD declares a truecolour image, so tRNS must carry 6 bytes
+        data = HEAD + chunk(b"tRNS", bytes(4)) + TAIL
+
+        with pytest.raises(ValueError):
+            with Image.open(BytesIO(data)):
+                pass
+
+        monkeypatch.setattr(ImageFile, "LOAD_TRUNCATED_IMAGES", True)
+        with Image.open(BytesIO(data)) as im:
+            assert im.mode == "RGB"
+            assert "transparency" not in im.info
+
     @pytest.mark.parametrize("save_all", (True, False))
     def test_specify_bits(self, save_all: bool, tmp_path: Path) -> None:
         im = hopper("P")

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -498,6 +498,15 @@ class PngStream(ChunkStream):
         # transparency
         assert self.fp is not None
         s = ImageFile._safe_read(self.fp, length)
+        if self.im_mode in ("1", "L", "I;16", "RGB"):
+            # 2 bytes for greyscale, 6 for truecolour.
+            # For "P" the chunk holds one byte per palette entry, so it has
+            # no fixed length.
+            if length < (6 if self.im_mode == "RGB" else 2):
+                if ImageFile.LOAD_TRUNCATED_IMAGES:
+                    return s
+                msg = "Truncated tRNS chunk"
+                raise ValueError(msg)
         if self.im_mode == "P":
             if _simple_palette.match(s):
                 # tRNS contains only one full-transparent entry,

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -498,15 +498,6 @@ class PngStream(ChunkStream):
         # transparency
         assert self.fp is not None
         s = ImageFile._safe_read(self.fp, length)
-        if self.im_mode in ("1", "L", "I;16", "RGB"):
-            # 2 bytes for greyscale, 6 for truecolour.
-            # For "P" the chunk holds one byte per palette entry, so it has
-            # no fixed length.
-            if length < (6 if self.im_mode == "RGB" else 2):
-                if ImageFile.LOAD_TRUNCATED_IMAGES:
-                    return s
-                msg = "Truncated tRNS chunk"
-                raise ValueError(msg)
         if self.im_mode == "P":
             if _simple_palette.match(s):
                 # tRNS contains only one full-transparent entry,
@@ -518,12 +509,19 @@ class PngStream(ChunkStream):
                 # otherwise, we have a byte string with one alpha value
                 # for each palette entry
                 self.im_info["transparency"] = s
-        elif self.im_mode == "1":
-            self.im_info["transparency"] = 255 if i16(s) else 0
-        elif self.im_mode in ("L", "I;16"):
-            self.im_info["transparency"] = i16(s)
-        elif self.im_mode == "RGB":
-            self.im_info["transparency"] = i16(s), i16(s, 2), i16(s, 4)
+        elif self.im_mode in ("1", "L", "I;16", "RGB"):
+            # 2 bytes for greyscale, 6 for truecolour
+            if length < (6 if self.im_mode == "RGB" else 2):
+                if ImageFile.LOAD_TRUNCATED_IMAGES:
+                    return s
+                msg = "Truncated tRNS chunk"
+                raise ValueError(msg)
+            if self.im_mode == "1":
+                self.im_info["transparency"] = 255 if i16(s) else 0
+            elif self.im_mode in ("L", "I;16"):
+                self.im_info["transparency"] = i16(s)
+            elif self.im_mode == "RGB":
+                self.im_info["transparency"] = i16(s), i16(s, 2), i16(s, 4)
         return s
 
     def chunk_gAMA(self, pos: int, length: int) -> bytes:


### PR DESCRIPTION
### What this fixes

`chunk_tRNS` reads a fixed number of bytes for the non-palette modes without first checking the chunk is long enough:

```python
elif self.im_mode == "1":
    self.im_info["transparency"] = 255 if i16(s) else 0
elif self.im_mode in ("L", "I;16"):
    self.im_info["transparency"] = i16(s)
elif self.im_mode == "RGB":
    self.im_info["transparency"] = i16(s), i16(s, 2), i16(s, 4)
```

A short chunk makes `struct` raise. Because `Image.open` treats `struct.error` as "this plugin doesn't recognise the file", the result is that an otherwise valid PNG is reported as `UnidentifiedImageError`, and `LOAD_TRUNCATED_IMAGES` doesn't help.

Every neighbouring chunk already guards its length — `gAMA`, `cHRM`, `sRGB`, `pHYs`, `acTL`, `fcTL` — so `tRNS` is the odd one out.

### Evidence

Inserting a truncated chunk of each kind into a valid PNG, on current `main`:

| chunk | `LOAD_TRUNCATED_IMAGES = False` | `= True` |
|---|---|---|
| gAMA (1 of 4 bytes) | `ValueError: Truncated gAMA chunk` | loads |
| cHRM (1 of 32) | `ValueError: Truncated cHRM chunk` | loads |
| sRGB (0 of 1) | `ValueError: Truncated sRGB chunk` | loads |
| pHYs (1 of 9) | `ValueError: Truncated pHYs chunk` | loads |
| **tRNS (1 of 2, greyscale)** | **`UnidentifiedImageError`** | **`UnidentifiedImageError`** |
| **tRNS (2 of 6, truecolour)** | **`UnidentifiedImageError`** | **`UnidentifiedImageError`** |

After the change both `tRNS` rows behave like the rows above them.

This follows #9880, which did the same for `gAMA` and `cHRM`.

### Notes

The palette case is deliberately left alone: for mode `"P"` the chunk carries one byte per palette entry, so it has no required length and the existing `_simple_palette` handling stays as it is.

### Testing

- `test_truncated_trns_chunk` — parametrized over `"1"`, `"L"`, `"I;16"`, `"RGB"`, mirroring the existing `test_truncated_chunks`. It sets `im_mode` explicitly, since a bare `PngStream` starts with `im_mode = ""` and would not reach the check.
- `test_truncated_trns_chunk_in_file` — end-to-end, asserting a real PNG carrying a 4-byte truecolour `tRNS` raises `ValueError`, and opens with the transparency dropped under `LOAD_TRUNCATED_IMAGES`.

Without the fix all 5 new tests fail; with it `Tests/test_file_png.py` and `Tests/test_file_apng.py` give 119 passed, 1 skipped. ruff check and ruff format are clean.
