### PR TITLE
Deprecate ImageQt align8to32() in favour of raw encoder stride

### DIFF
--- a/Tests/test_imageqt.py
+++ b/Tests/test_imageqt.py
@@ -53,3 +53,9 @@ def test_image(mode: str) -> None:
 def test_closed_file() -> None:
     with warnings.catch_warnings(action="error"):
         ImageQt.ImageQt("Tests/images/hopper.gif")
+
+
+def test_align8to32_deprecation() -> None:
+    im = hopper("1")
+    with pytest.warns(DeprecationWarning, match="ImageQt.align8to32"):
+        ImageQt.align8to32(im.tobytes(), im.width, im.mode)

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -21,7 +21,7 @@ ExifTags.IFD.Makernote
 ``ExifTags.IFD.MakerNote``.
 
 Image getdata()
-~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^
 
 .. deprecated:: 12.1.0
 
@@ -29,6 +29,14 @@ Image getdata()
 :py:meth:`~PIL.Image.Image.get_flattened_data` can be used instead. This new method is
 identical, except that it returns a tuple of pixel values, instead of an internal
 Pillow data type.
+
+ImageQt align8to32()
+^^^^^^^^^^^^^^^^^^^^
+
+.. deprecated:: 13.0.0
+
+``ImageQt.align8to32()`` has been deprecated. This was an undocumented helper function
+intended for internal use, so there is no replacement.
 
 
 JpegImageFile.load_djpeg

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -38,9 +38,8 @@ ImageQt align8to32()
 ``ImageQt.align8to32()`` has been deprecated. This was an undocumented helper function
 intended for internal use, so there is no replacement.
 
-
 JpegImageFile.load_djpeg
-~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. deprecated:: 13.0.0
 

--- a/docs/releasenotes/13.0.0.rst
+++ b/docs/releasenotes/13.0.0.rst
@@ -78,6 +78,12 @@ JpegImageFile.load_djpeg
 Use the built-in JPEG decoder instead, or call ``djpeg`` directly and decode the
 resulting image with Pillow.
 
+ImageQt align8to32()
+^^^^^^^^^^^^^^^^^^^^
+
+``ImageQt.align8to32()`` has been deprecated. This was an undocumented helper function
+intended for internal use, so there is no replacement.
+
 API changes
 ===========
 

--- a/src/PIL/ImageQt.py
+++ b/src/PIL/ImageQt.py
@@ -21,6 +21,7 @@ import sys
 from io import BytesIO
 
 from . import Image
+from ._deprecate import deprecate
 from ._util import is_path
 
 TYPE_CHECKING = False
@@ -107,6 +108,7 @@ def align8to32(bytes: bytes, width: int, mode: str) -> bytes:
     """
     converts each scanline of data from 8 bit to 32 bit aligned
     """
+    deprecate("ImageQt.align8to32", 14)
 
     bits_per_pixel = {"1": 1, "L": 8, "P": 8, "I;16": 16}[mode]
 
@@ -174,10 +176,16 @@ def _toqclass_helper(im: Image.Image | str | QByteArray) -> dict[str, Any]:
         raise ValueError(msg)
 
     size = im.size
-    __data = data or align8to32(im.tobytes(), size[0], im.mode)
+    if data is None:
+        # Compute the stride (scanline size) in bytes when aligned
+        # to Qt's requirement that scanlines be aligned to 32 bits.
+        bpp = {"1": 1, "L": 8, "P": 8, "I;16": 16}[im.mode]
+        stride = (bpp * size[0] + 31) // 32 * (32 // 8)
+
+        data = im.tobytes("raw", im.mode, stride)
     if exclusive_fp:
         im.close()
-    return {"data": __data, "size": size, "format": format, "colortable": colortable}
+    return {"data": data, "size": size, "format": format, "colortable": colortable}
 
 
 if qt_is_installed:


### PR DESCRIPTION
Fell out of #9938 (namely 64507dc0742f7ce506ad8a7a0590d8b9e6fe95a7): the raw encoder had supported strides all along, but no one knew because it wasn't really documented in any way. For that reason, presumably, #1430 added a Python-side realigner.

This shows the old and new impls matching for a 113-pixel-wide Hopper, and what would happen if we don't align things:

<img width="1582" height="1968" alt="2026-09-01_19-16-35" src="https://github.com/user-attachments/assets/671d1cd9-3b38-4a21-ad9c-f66796c4416b" />
