### PR TITLE
Add GPSHPositioningError to GPS IFD tag data

### DIFF
--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -517,11 +517,12 @@ def test_tag_group_data() -> None:
 # Exif 2.32 table 15: GPSDOP (11) and GPSHPositioningError (31) are both
 # RATIONAL with a count of 1.
 @pytest.mark.parametrize("tag", (11, 31))
-@pytest.mark.parametrize("value", (5.5, 5))
+@pytest.mark.parametrize("value", (4.5, 4))
 def test_gps_rational_tag_type(tag: int, value: float, tmp_path: Path) -> None:
     gps_ifd = TiffImagePlugin.ImageFileDirectory_v2(group=34853)
     gps_ifd[tag] = value
     assert gps_ifd.tagtype[tag] == TiffTags.RATIONAL
+    assert gps_ifd[tag] == value
 
     out = tmp_path / "temp.jpg"
     im = hopper()
@@ -530,7 +531,10 @@ def test_gps_rational_tag_type(tag: int, value: float, tmp_path: Path) -> None:
     im.save(out, exif=exif)
 
     with Image.open(out) as reloaded:
-        assert isinstance(reloaded.getexif().get_ifd(34853)[tag], IFDRational)
+        exif = reloaded.getexif()
+        gps = exif.get_ifd(34853)
+        assert isinstance(gps[tag], IFDRational)
+        assert gps[tag] == value
 
 
 def test_empty_subifd(tmp_path: Path) -> None:

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -514,7 +514,7 @@ def test_tag_group_data() -> None:
     assert base_ifd.tagtype[2] != interop_ifd.tagtype[256]
 
 
-# Exif 2.32 table 15: GPSDOP (11) and GPSHPositioningError (31) are both
+# Exif 2.31 table 15: GPSDOP (11) and GPSHPositioningError (31) are both
 # RATIONAL with a count of 1.
 @pytest.mark.parametrize("tag", (11, 31))
 @pytest.mark.parametrize("value", (4.5, 4))

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -514,6 +514,25 @@ def test_tag_group_data() -> None:
     assert base_ifd.tagtype[2] != interop_ifd.tagtype[256]
 
 
+# Exif 2.32 table 15: GPSDOP (11) and GPSHPositioningError (31) are both
+# RATIONAL with a count of 1.
+@pytest.mark.parametrize("tag", (11, 31))
+@pytest.mark.parametrize("value", (5.5, 5))
+def test_gps_rational_tag_type(tag: int, value: float, tmp_path: Path) -> None:
+    gps_ifd = TiffImagePlugin.ImageFileDirectory_v2(group=34853)
+    gps_ifd[tag] = value
+    assert gps_ifd.tagtype[tag] == TiffTags.RATIONAL
+
+    out = tmp_path / "temp.jpg"
+    im = hopper()
+    exif = im.getexif()
+    exif.get_ifd(34853)[tag] = value
+    im.save(out, exif=exif)
+
+    with Image.open(out) as reloaded:
+        assert isinstance(reloaded.getexif().get_ifd(34853)[tag], IFDRational)
+
+
 def test_empty_subifd(tmp_path: Path) -> None:
     out = tmp_path / "temp.jpg"
 

--- a/src/PIL/TiffTags.py
+++ b/src/PIL/TiffTags.py
@@ -290,6 +290,7 @@ _tags_v2_groups = {
         28: ("GPSAreaInformation", UNDEFINED, 0),
         29: ("GPSDateStamp", ASCII, 11),
         30: ("GPSDifferential", SHORT, 1),
+        31: ("GPSHPositioningError", RATIONAL, 1),
     },
     # InteroperabilityIFD
     40965: {1: ("InteropIndex", ASCII, 1), 2: ("InteropVersion", UNDEFINED, 1)},


### PR DESCRIPTION
Changes proposed in this pull request:

* Add `31: ("GPSHPositioningError", RATIONAL, 1)` to the GPSInfoIFD entry of `TiffTags._tags_v2_groups`
* Add a regression test asserting the emitted TIFF type for GPS tags 11 and 31

Exif 2.32 table 15 defines GPSHPositioningError (31) as RATIONAL, count 1. `ExifTags.GPS` already has it, but the GPS tag data added in #6661 stops at 30, so `TiffTags.lookup(31, 34853).type` is `None` and `ImageFileDirectory_v2._setitem` guesses the type from the Python value instead:

```
tag  value  on-wire type
 11  5.5    RATIONAL     <- GPSDOP, in the table
 11  5      RATIONAL
 31  5.5    DOUBLE       <- guessed
 31  5      SHORT
```

GPSDOP is the control here: same spec type and count, different result. piexif, checked separately, declares tag 31 as type 5 and writes type 5.

#6661 was opened for #6657, where GPS data written by Pillow was not readable in other programs, so this is the same table one entry further.

Rejected alternative: making the float branch of `_setitem` guess RATIONAL rather than DOUBLE fixes the float case but leaves the int case wrong, and it aborts `Tests/test_file_libtiff.py::test_custom_metadata` here.

Not changed, in case you want it separately: `RelatedImageFileFormat`, `RelatedImageWidth` and `RelatedImageHeight` are in `ExifTags.Interop` but not in the InteroperabilityIFD tag data. The types guessed for them are currently spec-legal, so nothing is written wrongly today.

macOS arm64, Python 3.12: `python -m pytest Tests` gives 5179 passed before and 5183 after, the +4 being the new parametrised cases, with the same single pre-existing failure both times (`test_imagegrab.py::TestImageGrab::test_grab`, screen recording permission on this machine). ruff 0.16.1 and black 26.5.1 clean on both files. Reverting only the table line fails the two tag-31 cases; the two tag-11 cases pass either way and are there as controls.

AI assistance: the diff, the test and this description were drafted by Claude Opus 5 working as a coding agent in this repository.
