### PR TITLE
docs: Add cve and cwe extlinks roles (#9810)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -251,6 +251,8 @@ linkcheck_allowed_redirects = {
 # https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html
 _repo = "https://github.com/python-pillow/Pillow/"
 extlinks = {
+    "cve": ("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-%s", "CVE-%s"),
+    "cwe": ("https://cwe.mitre.org/data/definitions/%s.html", "CWE-%s"),
     "issue": (_repo + "issues/%s", "#%s"),
     "pr": (_repo + "pull/%s", "#%s"),
     "pypi": ("https://pypi.org/project/%s/", "%s"),


### PR DESCRIPTION
Fixes #9810

Add `cve` and `cwe` extlinks aliases in `docs/conf.py` so `:cve:` and `:cwe:` directives in release notes render as active hyperlinks.