### PR TITLE
Only run push CI on pushes to main

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,7 +3,7 @@ name: Benchmark
 on:
   push:
     branches:
-      - "**"
+      - main
     paths-ignore: &paths-ignore
       - ".github/workflows/docs.yml"
       - ".github/workflows/wheels*"

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -3,7 +3,7 @@ name: CIFuzz
 on:
   push:
     branches:
-      - "**"
+      - main
     paths: &paths
       - ".github/dependencies.json"
       - ".github/workflows/cifuzz.yml"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Docs
 on:
   push:
     branches:
-      - "**"
+      - main
     paths: &paths
       - ".github/workflows/docs.yml"
       - "docs/**"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,11 @@
 name: Lint
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -3,7 +3,7 @@ name: Test Docker
 on:
   push:
     branches:
-      - "**"
+      - main
     paths-ignore: &paths-ignore
       - ".github/workflows/docs.yml"
       - ".github/workflows/wheels*"

--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -3,7 +3,7 @@ name: Test MinGW
 on:
   push:
     branches:
-      - "**"
+      - main
     paths-ignore: &paths-ignore
       - ".github/workflows/docs.yml"
       - ".github/workflows/wheels*"

--- a/.github/workflows/test-valgrind.yml
+++ b/.github/workflows/test-valgrind.yml
@@ -5,7 +5,7 @@ name: Test Valgrind
 on:
   push:
     branches:
-      - "**"
+      - main
     paths: &paths
       - ".github/workflows/test-valgrind.yml"
       - "**.c"

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -3,7 +3,7 @@ name: Test Windows
 on:
   push:
     branches:
-      - "**"
+      - main
     paths-ignore: &paths-ignore
       - ".github/workflows/docs.yml"
       - ".github/workflows/wheels*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches:
-      - "**"
+      - main
     paths-ignore: &paths-ignore
       - ".github/workflows/docs.yml"
       - ".github/workflows/wheels*"


### PR DESCRIPTION
Workflows were triggered for every branch, including those pushed into forks (such as the tons of temporary branches on my fork), meaning each fork of Pillow with Actions enabled was running a whole lot of stuff for each push for no great reason, burning resources for everyone.

This restricts the push trigger to `main` only. If you want to run CI on your own fork, you can open a pull request or use the workflow_dispatch trigger.

This fell out of #9945 since my fork's PR for it looked like
<img width="184" height="64" alt="Screenshot 2026-09-02 at 21 41 39" src="https://github.com/user-attachments/assets/326a23bd-f527-4777-80e4-1e4b5eb7cba9" /> and
<img width="242" height="145" alt="Screenshot 2026-09-02 at 21 42 03" src="https://github.com/user-attachments/assets/92d23f93-9962-4724-86e7-ef3eca1d8b38" /> 😭 😄 
