### PR TITLE
Test ImageChops.offset() with zero-size images

### DIFF
--- a/Tests/test_imagechops.py
+++ b/Tests/test_imagechops.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from PIL import Image, ImageChops
 
 from .helper import assert_image_equal, hopper
@@ -280,6 +282,13 @@ def test_offset() -> None:
 
         # Test no yoffset
         assert ImageChops.offset(im, xoffset) == ImageChops.offset(im, xoffset, xoffset)
+
+
+@pytest.mark.parametrize("size", ((1, 0), (0, 1), (0, 0)))
+def test_offset_zero_size(size: tuple[int, int]) -> None:
+    im = Image.new("RGB", size)
+
+    assert_image_equal(ImageChops.offset(im, 1, 1), im)
 
 
 def test_screen() -> None:


### PR DESCRIPTION
#9847 fixed a remainder by zero in `ImagingOffset` for zero-width or zero-height images. In review, @hugovk noted that the tests for `(0, 1)` and `(1, 0)` were missing from the PR; it merged with only the `Offset.c` change. This adds them, following the zero-size parameterization already used in `Tests/test_image.py`.

Without the fix the test dies with SIGFPE on x86-64 (10/10 runs against `22c1ea2a`); with it, 10/10 pass. On the arm64 build the undefined remainder by zero does not trap, so the pre-fix build passes there — the `ubuntu-latest` and `macos-26-intel` jobs are the ones that would catch a regression.
