### PR TITLE
Adjust package installation in Linux/macOS CI

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -25,12 +25,6 @@ packages=(libfreetype6-dev liblcms2-dev libtiff-dev python3-tk
           imagemagick
           # netpbm provides ppmquant and ppmtogif for GifImagePlugin._save_netpbm
           netpbm)
-
-# PyQt6 doesn't support PyPy3
-if [[ $GHA_PYTHON_VERSION == 3.* ]]; then
-    packages+=(libegl1 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1
-               libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxkbcommon-x11-0)
-fi
 sudo apt-get -qq install --no-install-recommends "${packages[@]}"
 
 python3 -m pip install --upgrade pip

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -19,15 +19,19 @@ set -e
 
 packages=(libfreetype6-dev liblcms2-dev libtiff-dev python3-tk
           ghostscript libjpeg-turbo8-dev libopenjp2-7-dev
-          cmake meson imagemagick libharfbuzz-dev libfribidi-dev
-          sway wl-clipboard libopenblas-dev nasm)
+          cmake meson libharfbuzz-dev libfribidi-dev
+          sway wl-clipboard nasm
+          # ImageMagick is used by Tests/test_file_palm.py
+          imagemagick
+          # netpbm provides ppmquant and ppmtogif for GifImagePlugin._save_netpbm
+          netpbm)
 
 # PyQt6 doesn't support PyPy3
 if [[ $GHA_PYTHON_VERSION == 3.* ]]; then
     packages+=(libegl1 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1
                libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxkbcommon-x11-0)
 fi
-sudo apt-get -qq install "${packages[@]}"
+sudo apt-get -qq install --no-install-recommends "${packages[@]}"
 
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade wheel

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -17,10 +17,17 @@ aptget_update || aptget_update retry || aptget_update retry
 
 set -e
 
-sudo apt-get -qq install libfreetype6-dev liblcms2-dev libtiff-dev python3-tk\
-                         ghostscript libjpeg-turbo8-dev libopenjp2-7-dev\
-                         cmake meson imagemagick libharfbuzz-dev libfribidi-dev\
-                         sway wl-clipboard libopenblas-dev nasm
+packages=(libfreetype6-dev liblcms2-dev libtiff-dev python3-tk
+          ghostscript libjpeg-turbo8-dev libopenjp2-7-dev
+          cmake meson imagemagick libharfbuzz-dev libfribidi-dev
+          sway wl-clipboard libopenblas-dev nasm)
+
+# PyQt6 doesn't support PyPy3
+if [[ $GHA_PYTHON_VERSION == 3.* ]]; then
+    packages+=(libegl1 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1
+               libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxkbcommon-x11-0)
+fi
+sudo apt-get -qq install "${packages[@]}"
 
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade wheel

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -34,14 +34,8 @@ fi
 sudo apt-get -qq install --no-install-recommends "${packages[@]}"
 
 python3 -m pip install --upgrade pip
-python3 -m pip install --upgrade wheel
-python3 -m pip install coverage
-python3 -m pip install defusedxml
-python3 -m pip install ipython
-python3 -m pip install olefile
-python3 -m pip install -U pytest
-python3 -m pip install -U pytest-cov
-python3 -m pip install -U pytest-timeout
+python3 -m pip install --upgrade coverage defusedxml ipython olefile pytest pytest-cov pytest-timeout
+
 # optional test dependencies, only install if there's a binary package.
 python3 -m pip install --only-binary=:all: numpy || true
 python3 -m pip install --only-binary=:all: pyarrow || true

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -17,14 +17,24 @@ aptget_update || aptget_update retry || aptget_update retry
 
 set -e
 
-packages=(libfreetype6-dev liblcms2-dev libtiff-dev python3-tk
-          ghostscript libjpeg-turbo8-dev libopenjp2-7-dev
-          cmake meson libharfbuzz-dev libfribidi-dev
-          sway wl-clipboard nasm
-          # ImageMagick is used by Tests/test_file_palm.py
-          imagemagick
-          # netpbm provides ppmquant and ppmtogif for GifImagePlugin._save_netpbm
-          netpbm)
+packages=(
+    cmake
+    ghostscript
+    imagemagick  # ImageMagick is used by Tests/test_file_palm.py
+    libfreetype6-dev
+    libfribidi-dev
+    libharfbuzz-dev
+    libjpeg-turbo8-dev
+    liblcms2-dev
+    libopenjp2-7-dev
+    libtiff-dev
+    meson
+    nasm
+    netpbm  # netpbm provides ppmquant and ppmtogif for GifImagePlugin._save_netpbm
+    python3-tk
+    sway
+    wl-clipboard
+)
 sudo apt-get -qq install --no-install-recommends "${packages[@]}"
 
 python3 -m pip install --upgrade pip

--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -4,13 +4,8 @@ set -e
 
 brew bundle --file=.github/workflows/Brewfile
 
-python3 -m pip install coverage
-python3 -m pip install defusedxml
-python3 -m pip install ipython
-python3 -m pip install olefile
-python3 -m pip install -U pytest
-python3 -m pip install -U pytest-cov
-python3 -m pip install -U pytest-timeout
+python3 -m pip install --upgrade coverage defusedxml ipython olefile pytest pytest-cov pytest-timeout
+
 # optional test dependencies, only install if there's a binary package.
 python3 -m pip install --only-binary=:all: numpy || true
 python3 -m pip install --only-binary=:all: pyarrow || true

--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -3,7 +3,6 @@
 set -e
 
 brew bundle --file=.github/workflows/Brewfile
-export PKG_CONFIG_PATH="/usr/local/opt/openblas/lib/pkgconfig"
 
 python3 -m pip install coverage
 python3 -m pip install defusedxml


### PR DESCRIPTION
Sibling to #9945.

I noticed the "Install dependencies" step in CI takes a while – this PR:

* adjusts the `apt` dependencies:
  * All packages are now installed in a single `apt-get` invocation, so it doesn't spend time reading databases and deps and so on twice 
  * `--no-install-recommends` skips installing packages that aren't evidently needed here
  * I presume `libopenblas-dev` had been a relic from a time where `numpy` could have needed building?
  * There are now notes for a couple deps that aren't quite obvious:
    * `imagemagick` is solely used for a round-trip test for Palm images
    * `netpbm` is only used to test the `_save_netpbm` functionality #9901 proposes to remove or deprecate
* adjusts `pip` installation:
  * all packages are now installed in a single invocation, similar overhead reasons as above
  * `wheel` is dropped; unless you need the `wheel` CLI command, it hasn't been required since Setuptools 70 (May 2024)
