### PR TITLE
Do not install PyQt6 dependencies

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -37,7 +37,6 @@ python3 -m pip install --only-binary=:all: pyarrow || true
 
 # PyQt6 doesn't support PyPy3
 if [[ $GHA_PYTHON_VERSION == 3.* ]]; then
-    sudo apt-get -qq install libegl1 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxkbcommon-x11-0
     # pyqt6 doesn't yet support free-threading; only install if a wheel is available
     python3 -m pip install --only-binary=:all: pyqt6 || true
 fi


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/9625 switched to only installing PyQt6 from wheels on Ubuntu.