### PR TITLE
Correct error message for matrix length

### DIFF
--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -46,7 +46,7 @@ def test_sanity() -> None:
 
 def test_unsupported_conversion() -> None:
     im = hopper()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="image has wrong mode"):
         im.convert("INVALID")
 
 
@@ -305,18 +305,26 @@ def test_matrix_illegal_conversion() -> None:
     assert im.mode != "RGB"
 
     # Act / Assert
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="illegal conversion"):
         im.convert(mode="CMYK", matrix=rgb2xyz_matrix)
 
 
 def test_matrix_wrong_mode() -> None:
     # Arrange
     im = hopper("L")
-    assert im.mode == "L"
 
     # Act / Assert
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="image has wrong mode"):
         im.convert(mode="L", matrix=rgb2xyz_matrix)
+
+
+def test_matrix_truncated() -> None:
+    # Arrange
+    im = hopper()
+
+    # Act / Assert
+    with pytest.raises(TypeError, match="matrix must be tuple of length 4 or 12"):
+        im.convert(mode="L", matrix=(0,))
 
 
 @pytest.mark.parametrize("mode", ("RGB", "L"))
@@ -324,7 +332,6 @@ def test_matrix_xyz(mode: str) -> None:
     # Arrange
     im = hopper("RGB")
     im.info["transparency"] = (255, 0, 0)
-    assert im.mode == "RGB"
 
     # Act
     # Convert an RGB image to the CIE XYZ colour space
@@ -350,7 +357,6 @@ def test_matrix_identity() -> None:
         0, 1, 0, 0,
         0, 0, 1, 0,
     )  # fmt: skip
-    assert im.mode == "RGB"
 
     # Act
     # Convert with an identity matrix

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1068,6 +1068,7 @@ _convert_matrix(ImagingObject *self, PyObject *args) {
                 m + 10,
                 m + 11
             )) {
+            PyErr_SetString(PyExc_TypeError, "matrix must be tuple of length 4 or 12");
             return NULL;
         }
     }


### PR DESCRIPTION
Suggested in https://github.com/python-pillow/Pillow/pull/9726#discussion_r3914183375

Before
```pycon
>>> from PIL import Image
>>> im = Image.new("RGB", (1, 1))
>>> im.convert("L", matrix=(0,))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/Image.py", line 1088, in convert
    im = self.im.convert_matrix(mode, matrix)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument 2 must be sequence of length 12, not 1
```

However, `matrix` can actually have [length 4 or 12](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.convert)

After
```pycon
>>> from PIL import Image
>>> im = Image.new("RGB", (1, 1))
>>> im.convert("L", matrix=(0,))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PIL/Image.py", line 1088, in convert
    im = self.im.convert_matrix(mode, matrix)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: matrix must be tuple of length 4 or 12
```