### PR TITLE
 Do not initialize image with zero dimension or when color is zero

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3231,7 +3231,7 @@ def new(
 
     _check_size(size)
 
-    if color is None or min(size) == 0:
+    if color in {0, None} or min(size) == 0:
         # don't initialize
         return Image()._new(core.new(mode, size))
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3231,7 +3231,7 @@ def new(
 
     _check_size(size)
 
-    if color is None:
+    if color is None or min(size) == 0:
         # don't initialize
         return Image()._new(core.new(mode, size))
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/9933 mentioned that
https://github.com/python-pillow/Pillow/blob/782750745ebc9184cfc846107fb458ef0f21e87d/Tests/test_image.py#L574-L577
is intermittently failing on our CI.

I think
https://github.com/python-pillow/Pillow/blob/782750745ebc9184cfc846107fb458ef0f21e87d/src/PIL/Image.py#L3234-L3236
can be adjusted to help.