### PR TITLE
Image.new(): correct docstring and comment about uninitialized memory

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3217,15 +3217,14 @@ def new(
     """
     Creates a new image with the given mode and size.
 
-    :param mode: The mode to use for the new image. See:
-       :ref:`concept-modes`.
+    :param mode: The mode to use for the new image. See: :ref:`concept-modes`.
     :param size: A 2-tuple, containing (width, height) in pixels.
-    :param color: What color to use for the image. Default is black. If given,
-       this should be a single integer or floating point value for single-band
-       modes, and a tuple for multi-band modes (one value per band). When
-       creating RGB or HSV images, you can also use color strings as supported
-       by the ImageColor module. See :ref:`colors` for more information. If the
-       color is None, the image is filled with zeroes.
+    :param color: What color to use for the image. If given, this should be a single
+       integer or floating point value for single-band modes, and a tuple for
+       multi-band modes (one value per band). When creating RGB or HSV images, you can
+       also use color strings as supported by the ImageColor module. See :ref:`colors`
+       for more information. The default color is zero, which appears as black in
+       single band or RGB-based images. ``None`` is also treated as zero.
     :returns: An :py:class:`~PIL.Image.Image` object.
     """
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3225,14 +3225,14 @@ def new(
        modes, and a tuple for multi-band modes (one value per band). When
        creating RGB or HSV images, you can also use color strings as supported
        by the ImageColor module. See :ref:`colors` for more information. If the
-       color is None, the image is not initialised.
+       color is None, the image is filled with zeroes.
     :returns: An :py:class:`~PIL.Image.Image` object.
     """
 
     _check_size(size)
 
     if color is None:
-        # don't initialize
+        # core.new() returns zeroed memory, so there is nothing to fill
         return Image()._new(core.new(mode, size))
 
     if isinstance(color, str):


### PR DESCRIPTION
The comment "# don't initialize" and the docstring's claim that passing `None` as the fill color leaves the image uninitialized have both been untrue for a long time.

dcd40ce5b (#348, Pillow 2.2.0) added a memset to the block-allocation path, to fix #254 (uninitialized memory showing through in image transformations); that memset later became a calloc in 52d60cd09. Since the block allocator was used for everything up to THRESHOLD (16 MiB), only very large images were still uninitialized after that. 768936fa3 (#1781, Pillow 3.3.0) turned the array-allocation path's per-line mallocs into callocs, which is the point where no allocation path could return dirty memory any more.

7a1e70d99 (#2655, Pillow 4.3.0) added an explicit internal ImagingNewDirty for callers that overwrite the whole image anyway, and 0a3c852e1 (#2738) added the block pool, where a caller asks for either a cleared or a dirty block.

Nothing exposed to Python returns an image whose memory is left dirty: core.new() uses ImagingNew (cleared), and core.fill() uses ImagingNewDirty but immediately fills it.

Follows up on #9957.