### PR TITLE
Remove mode and size checks from C transpose methods

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -2175,25 +2175,25 @@ _transpose(ImagingObject *self, PyObject *args) {
     if (imOut) {
         switch (op) {
             case 0:
-                (void)ImagingFlipLeftRight(imOut, imIn);
+                ImagingFlipLeftRight(imOut, imIn);
                 break;
             case 1:
-                (void)ImagingFlipTopBottom(imOut, imIn);
+                ImagingFlipTopBottom(imOut, imIn);
                 break;
             case 2:
-                (void)ImagingRotate90(imOut, imIn);
+                ImagingRotate90(imOut, imIn);
                 break;
             case 3:
-                (void)ImagingRotate180(imOut, imIn);
+                ImagingRotate180(imOut, imIn);
                 break;
             case 4:
-                (void)ImagingRotate270(imOut, imIn);
+                ImagingRotate270(imOut, imIn);
                 break;
             case 5:
-                (void)ImagingTranspose(imOut, imIn);
+                ImagingTranspose(imOut, imIn);
                 break;
             case 6:
-                (void)ImagingTransverse(imOut, imIn);
+                ImagingTransverse(imOut, imIn);
                 break;
         }
     }

--- a/src/libImaging/Geometry.c
+++ b/src/libImaging/Geometry.c
@@ -14,17 +14,10 @@
 /* -------------------------------------------------------------------- */
 /* Transpose operations                                                 */
 
-Imaging
+void
 ImagingFlipLeftRight(Imaging imOut, Imaging imIn) {
     ImagingSectionCookie cookie;
     int x, y, xr;
-
-    if (!imOut || !imIn || imIn->mode != imOut->mode) {
-        return (Imaging)ImagingError_ModeError();
-    }
-    if (imIn->xsize != imOut->xsize || imIn->ysize != imOut->ysize) {
-        return (Imaging)ImagingError_Mismatch();
-    }
 
     ImagingCopyPalette(imOut, imIn);
 
@@ -53,21 +46,12 @@ ImagingFlipLeftRight(Imaging imOut, Imaging imIn) {
     ImagingSectionLeave(&cookie);
 
 #undef FLIP_LEFT_RIGHT
-
-    return imOut;
 }
 
-Imaging
+void
 ImagingFlipTopBottom(Imaging imOut, Imaging imIn) {
     ImagingSectionCookie cookie;
     int y, yr;
-
-    if (!imOut || !imIn || imIn->mode != imOut->mode) {
-        return (Imaging)ImagingError_ModeError();
-    }
-    if (imIn->xsize != imOut->xsize || imIn->ysize != imOut->ysize) {
-        return (Imaging)ImagingError_Mismatch();
-    }
 
     ImagingCopyPalette(imOut, imIn);
 
@@ -79,22 +63,13 @@ ImagingFlipTopBottom(Imaging imOut, Imaging imIn) {
     }
 
     ImagingSectionLeave(&cookie);
-
-    return imOut;
 }
 
-Imaging
+void
 ImagingRotate90(Imaging imOut, Imaging imIn) {
     ImagingSectionCookie cookie;
     int x, y, xx, yy, xr, xxsize, yysize;
     int xxx, yyy, xxxsize, yyysize;
-
-    if (!imOut || !imIn || imIn->mode != imOut->mode) {
-        return (Imaging)ImagingError_ModeError();
-    }
-    if (imIn->xsize != imOut->ysize || imIn->ysize != imOut->xsize) {
-        return (Imaging)ImagingError_Mismatch();
-    }
 
     ImagingCopyPalette(imOut, imIn);
 
@@ -139,22 +114,13 @@ ImagingRotate90(Imaging imOut, Imaging imIn) {
     ImagingSectionLeave(&cookie);
 
 #undef ROTATE_90
-
-    return imOut;
 }
 
-Imaging
+void
 ImagingTranspose(Imaging imOut, Imaging imIn) {
     ImagingSectionCookie cookie;
     int x, y, xx, yy, xxsize, yysize;
     int xxx, yyy, xxxsize, yyysize;
-
-    if (!imOut || !imIn || imIn->mode != imOut->mode) {
-        return (Imaging)ImagingError_ModeError();
-    }
-    if (imIn->xsize != imOut->ysize || imIn->ysize != imOut->xsize) {
-        return (Imaging)ImagingError_Mismatch();
-    }
 
     ImagingCopyPalette(imOut, imIn);
 
@@ -198,22 +164,13 @@ ImagingTranspose(Imaging imOut, Imaging imIn) {
     ImagingSectionLeave(&cookie);
 
 #undef TRANSPOSE
-
-    return imOut;
 }
 
-Imaging
+void
 ImagingTransverse(Imaging imOut, Imaging imIn) {
     ImagingSectionCookie cookie;
     int x, y, xr, yr, xx, yy, xxsize, yysize;
     int xxx, yyy, xxxsize, yyysize;
-
-    if (!imOut || !imIn || imIn->mode != imOut->mode) {
-        return (Imaging)ImagingError_ModeError();
-    }
-    if (imIn->xsize != imOut->ysize || imIn->ysize != imOut->xsize) {
-        return (Imaging)ImagingError_Mismatch();
-    }
 
     ImagingCopyPalette(imOut, imIn);
 
@@ -259,21 +216,12 @@ ImagingTransverse(Imaging imOut, Imaging imIn) {
     ImagingSectionLeave(&cookie);
 
 #undef TRANSVERSE
-
-    return imOut;
 }
 
-Imaging
+void
 ImagingRotate180(Imaging imOut, Imaging imIn) {
     ImagingSectionCookie cookie;
     int x, y, xr, yr;
-
-    if (!imOut || !imIn || imIn->mode != imOut->mode) {
-        return (Imaging)ImagingError_ModeError();
-    }
-    if (imIn->xsize != imOut->xsize || imIn->ysize != imOut->ysize) {
-        return (Imaging)ImagingError_Mismatch();
-    }
 
     ImagingCopyPalette(imOut, imIn);
 
@@ -303,22 +251,13 @@ ImagingRotate180(Imaging imOut, Imaging imIn) {
     ImagingSectionLeave(&cookie);
 
 #undef ROTATE_180
-
-    return imOut;
 }
 
-Imaging
+void
 ImagingRotate270(Imaging imOut, Imaging imIn) {
     ImagingSectionCookie cookie;
     int x, y, xx, yy, yr, xxsize, yysize;
     int xxx, yyy, xxxsize, yyysize;
-
-    if (!imOut || !imIn || imIn->mode != imOut->mode) {
-        return (Imaging)ImagingError_ModeError();
-    }
-    if (imIn->xsize != imOut->ysize || imIn->ysize != imOut->xsize) {
-        return (Imaging)ImagingError_Mismatch();
-    }
 
     ImagingCopyPalette(imOut, imIn);
 
@@ -363,8 +302,6 @@ ImagingRotate270(Imaging imOut, Imaging imIn) {
     ImagingSectionLeave(&cookie);
 
 #undef ROTATE_270
-
-    return imOut;
 }
 
 /* -------------------------------------------------------------------- */

--- a/src/libImaging/Imaging.h
+++ b/src/libImaging/Imaging.h
@@ -330,9 +330,9 @@ extern Imaging
 ImagingFillRadialGradient(ModeID mode);
 extern Imaging
 ImagingFilter(Imaging im, int xsize, int ysize, const FLOAT32 *kernel, FLOAT32 offset);
-extern Imaging
+extern void
 ImagingFlipLeftRight(Imaging imOut, Imaging imIn);
-extern Imaging
+extern void
 ImagingFlipTopBottom(Imaging imOut, Imaging imIn);
 extern Imaging
 ImagingGaussianBlur(
@@ -375,15 +375,15 @@ extern Imaging
 ImagingPutBand(Imaging im, Imaging imIn, int band);
 extern Imaging
 ImagingRankFilter(Imaging im, int size, int rank);
-extern Imaging
+extern void
 ImagingRotate90(Imaging imOut, Imaging imIn);
-extern Imaging
+extern void
 ImagingRotate180(Imaging imOut, Imaging imIn);
-extern Imaging
+extern void
 ImagingRotate270(Imaging imOut, Imaging imIn);
-extern Imaging
+extern void
 ImagingTranspose(Imaging imOut, Imaging imIn);
-extern Imaging
+extern void
 ImagingTransverse(Imaging imOut, Imaging imIn);
 extern Imaging
 ImagingResample(Imaging imIn, int xsize, int ysize, int filter, float box[4]);


### PR DESCRIPTION
Given that `_transpose` sets `imOut` from `imIn` properties
https://github.com/python-pillow/Pillow/blob/11de4b9ae7d5a6553a3561b2de210647e5e78f98/src/_imaging.c#L2162
I don't think that subsequent functions need to check the mode and size.

https://github.com/python-pillow/Pillow/pull/9785 is an alternative that goes in the opposite direction, checking the return values and cleaning up on failure.