### PR TITLE
Copy list-valued info entries independently in Image.copy()

### DIFF
--- a/Tests/test_image_copy.py
+++ b/Tests/test_image_copy.py
@@ -56,43 +56,8 @@ def test_deepcopy() -> None:
     assert out.size == (590, 88)
 
 
-def im_with_comments() -> BytesIO:
-    im = Image.new("L", (4, 4), 128)
-    buf = BytesIO()
-    im.save(buf, format="IM")
-    raw = buf.getvalue()
-
-    header = (
-        b"Image type: Greyscale image\r\n"
-        b"Image size (x*y): 4*4\r\n"
-        b"File size (no of images): 1\r\n"
-        b"Comment: first comment\r\n"
-        b"Comment: second comment\r\n"
-    )
-    header += b"\x00" * (511 - len(header)) + b"\x1a"
-
-    return BytesIO(header + raw[512:])
-
-
-def test_copy_list_info_im() -> None:
-    with Image.open(im_with_comments()) as loaded:
-        out = loaded.copy()
-        assert out.info["Comment"] is not loaded.info["Comment"]
-
-        out.info["Comment"].append("added only to the copy")
-        assert loaded.info["Comment"] == ["first comment", "second comment"]
-
-
-def test_transform_list_info_im() -> None:
-    with Image.open(im_with_comments()) as loaded:
-        out = loaded.transform(loaded.size, Image.Transform.AFFINE, [1, 0, 0, 0, 1, 0])
-        assert out.info["Comment"] is not loaded.info["Comment"]
-
-        out.info["Comment"].append("added only to the rotated copy")
-        assert loaded.info["Comment"] == ["first comment", "second comment"]
-
-
-def test_copy_list_info_iptc() -> None:
+def test_copy_info_list() -> None:
+    # Construct IPTC image
     def field(tag: tuple[int, int], value: bytes) -> bytes:
         return bytes((0x1C,) + tag + (0, len(value))) + value
 
@@ -106,8 +71,16 @@ def test_copy_list_info_iptc() -> None:
     f = BytesIO(data)
 
     with Image.open(f) as im:
-        im2 = im.copy()
-        assert im2.info[(2, 25)] is not im.info[(2, 25)]
+        # Copy
+        im_copy = im.copy()
+        assert im_copy.info[(2, 25)] is not im.info[(2, 25)]
 
-        im2.info[(2, 25)].append(b"KeywordForCopy")
+        im_copy.info[(2, 25)].append(b"KeywordForCopy")
+        assert im.info[(2, 25)] == [b"Keyword1", b"Keyword2"]
+
+        # Transform
+        im_transform = im.transform(im.size, Image.Transform.AFFINE, [1, 0, 0, 0, 1, 0])
+        assert im_transform.info[(2, 25)] is not im.info[(2, 25)]
+
+        im_transform.info[(2, 25)].append(b"KeywordForTransform")
         assert im.info[(2, 25)] == [b"Keyword1", b"Keyword2"]

--- a/Tests/test_image_copy.py
+++ b/Tests/test_image_copy.py
@@ -85,7 +85,7 @@ def test_copy_list_info_im() -> None:
 
 def test_transform_list_info_im() -> None:
     with Image.open(im_with_comments()) as loaded:
-        out = loaded.rotate(45)
+        out = loaded.transform(loaded.size, Image.Transform.AFFINE, [1, 0, 0, 0, 1, 0])
         assert out.info["Comment"] is not loaded.info["Comment"]
 
         out.info["Comment"].append("added only to the rotated copy")

--- a/Tests/test_image_copy.py
+++ b/Tests/test_image_copy.py
@@ -96,18 +96,18 @@ def test_copy_list_info_iptc() -> None:
     def field(tag: tuple[int, int], value: bytes) -> bytes:
         return bytes((0x1C,) + tag + (0, len(value))) + value
 
-    data = field((3, 60), bytes((1, 0)))
-    data += field((3, 120), bytes((1,)))
-    data += field((2, 105), b"first title")
-    data += field((2, 105), b"second title")
-    data += field((3, 20), b"\x01")
-    data += field((3, 30), b"\x01")
+    data = field((2, 25), b"Keyword1")
+    data += field((2, 25), b"Keyword2")
+    data += field((3, 60), bytes((1, 0)))  # layers, component
+    data += field((3, 120), bytes((1,)))  # compression
+    data += field((3, 20), b"\x01")  # width
+    data += field((3, 30), b"\x01")  # height
     data += field((8, 10), bytes((0,)))
     f = BytesIO(data)
 
-    with Image.open(f) as loaded:
-        out = loaded.copy()
-        assert out.info[(2, 105)] is not loaded.info[(2, 105)]
+    with Image.open(f) as im:
+        im2 = im.copy()
+        assert im2.info[(2, 25)] is not im.info[(2, 25)]
 
-        out.info[(2, 105)].append(b"added only to the copy")
-        assert loaded.info[(2, 105)] == [b"first title", b"second title"]
+        im2.info[(2, 25)].append(b"KeywordForCopy")
+        assert im.info[(2, 25)] == [b"Keyword1", b"Keyword2"]

--- a/Tests/test_image_copy.py
+++ b/Tests/test_image_copy.py
@@ -56,7 +56,7 @@ def test_deepcopy() -> None:
     assert out.size == (590, 88)
 
 
-def test_copy_list_info_im() -> None:
+def im_with_comments() -> BytesIO:
     im = Image.new("L", (4, 4), 128)
     buf = BytesIO()
     im.save(buf, format="IM")
@@ -71,11 +71,24 @@ def test_copy_list_info_im() -> None:
     )
     header += b"\x00" * (511 - len(header)) + b"\x1a"
 
-    with Image.open(BytesIO(header + raw[512:])) as loaded:
+    return BytesIO(header + raw[512:])
+
+
+def test_copy_list_info_im() -> None:
+    with Image.open(im_with_comments()) as loaded:
         out = loaded.copy()
         assert out.info["Comment"] is not loaded.info["Comment"]
 
         out.info["Comment"].append("added only to the copy")
+        assert loaded.info["Comment"] == ["first comment", "second comment"]
+
+
+def test_transform_list_info_im() -> None:
+    with Image.open(im_with_comments()) as loaded:
+        out = loaded.rotate(45)
+        assert out.info["Comment"] is not loaded.info["Comment"]
+
+        out.info["Comment"].append("added only to the rotated copy")
         assert loaded.info["Comment"] == ["first comment", "second comment"]
 
 

--- a/Tests/test_image_copy.py
+++ b/Tests/test_image_copy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+from io import BytesIO
 
 import pytest
 
@@ -53,3 +54,47 @@ def test_deepcopy() -> None:
 
         out = copy.deepcopy(im)
     assert out.size == (590, 88)
+
+
+def test_copy_list_info_im() -> None:
+    im = Image.new("L", (4, 4), 128)
+    buf = BytesIO()
+    im.save(buf, format="IM")
+    raw = buf.getvalue()
+
+    header = (
+        b"Image type: Greyscale image\r\n"
+        b"Image size (x*y): 4*4\r\n"
+        b"File size (no of images): 1\r\n"
+        b"Comment: first comment\r\n"
+        b"Comment: second comment\r\n"
+    )
+    header += b"\x00" * (511 - len(header)) + b"\x1a"
+
+    with Image.open(BytesIO(header + raw[512:])) as loaded:
+        out = loaded.copy()
+        assert out.info["Comment"] is not loaded.info["Comment"]
+
+        out.info["Comment"].append("added only to the copy")
+        assert loaded.info["Comment"] == ["first comment", "second comment"]
+
+
+def test_copy_list_info_iptc() -> None:
+    def field(tag: tuple[int, int], value: bytes) -> bytes:
+        return bytes((0x1C,) + tag + (0, len(value))) + value
+
+    data = field((3, 60), bytes((1, 0)))
+    data += field((3, 120), bytes((1,)))
+    data += field((2, 105), b"first title")
+    data += field((2, 105), b"second title")
+    data += field((3, 20), b"\x01")
+    data += field((3, 30), b"\x01")
+    data += field((8, 10), bytes((0,)))
+    f = BytesIO(data)
+
+    with Image.open(f) as loaded:
+        out = loaded.copy()
+        assert out.info[(2, 105)] is not loaded.info[(2, 105)]
+
+        out.info[(2, 105)].append(b"added only to the copy")
+        assert loaded.info[(2, 105)] == [b"first title", b"second title"]

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -691,7 +691,9 @@ class Image:
                 from . import ImagePalette
 
                 new.palette = ImagePalette.ImagePalette()
-        new.info = self.info.copy()
+        new.info = {
+            k: v.copy() if isinstance(v, list) else v for k, v in self.info.items()
+        }
         return new
 
     # Context manager support

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -679,6 +679,9 @@ class Image:
     def readonly(self, readonly: int) -> None:
         self._readonly = readonly
 
+    def _copy_info(self) -> dict[str | tuple[int, int], Any]:
+        return {k: v.copy() if isinstance(v, list) else v for k, v in self.info.items()}
+
     def _new(self, im: core.ImagingCore) -> Image:
         new = Image()
         new.im = im
@@ -691,9 +694,7 @@ class Image:
                 from . import ImagePalette
 
                 new.palette = ImagePalette.ImagePalette()
-        new.info = {
-            k: v.copy() if isinstance(v, list) else v for k, v in self.info.items()
-        }
+        new.info = self._copy_info()
         return new
 
     # Context manager support
@@ -3007,7 +3008,7 @@ class Image:
         im = new(self.mode, size, fillcolor)
         if self.mode == "P" and self.palette:
             im.palette = self.palette.copy()
-        im.info = self.info.copy()
+        im.info = self._copy_info()
         if method == Transform.MESH:
             # list of quads
             for box, quad in data:


### PR DESCRIPTION
ImImagePlugin and IptcImagePlugin both store repeated header/tag values as a list in .info, and Image._new() only shallow-copies the info dict, so a copy shares the same list object as the original. Appending to the copy's list silently mutates the original too, breaking the independence copy() is meant to give you. transform() (and anything routed through it, like a non-90-degree rotate()) had the same shallow copy and the same problem.

Both spots now copy list values individually when building the new info dict, so the resulting images have independent lists. Added regression tests in Tests/test_image_copy.py covering ImImagePlugin, IptcImagePlugin, and transform().

Fixes #9963