### PR TITLE
Copy palette when transforming PA images

### DIFF
--- a/Tests/test_image_transform.py
+++ b/Tests/test_image_transform.py
@@ -45,14 +45,13 @@ class TestImageTransform:
             new_im = im.transform((100, 100), transform)
         assert new_im.info["comment"] == comment
 
-    def test_palette(self) -> None:
-        with Image.open("Tests/images/hopper.gif") as im:
-            transformed = im.transform(
-                im.size, Image.Transform.AFFINE, [1, 0, 0, 0, 1, 0]
-            )
-            assert im.palette is not None
-            assert transformed.palette is not None
-            assert im.palette.palette == transformed.palette.palette
+    @pytest.mark.parametrize("mode", ("P", "PA"))
+    def test_palette(self, mode: str) -> None:
+        im = hopper(mode)
+        transformed = im.transform(im.size, Image.Transform.AFFINE, [1, 0, 0, 0, 1, 0])
+        assert im.palette is not None
+        assert transformed.palette is not None
+        assert im.palette.palette == transformed.palette.palette
 
     def test_extent(self) -> None:
         im = hopper("RGB")

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3003,7 +3003,7 @@ class Image:
             raise ValueError(msg)
 
         im = new(self.mode, size, fillcolor)
-        if self.mode == "P" and self.palette:
+        if self.mode in ("P", "PA") and self.palette:
             im.palette = self.palette.copy()
         im.info = self.info.copy()
         if method == Transform.MESH:


### PR DESCRIPTION
Currently, `transform()` copies the palette from P mode images, but not PA.
```pycon
>>> from PIL import Image
>>> im = Image.open("Tests/images/hopper.gif")
>>> im.mode
'P'
>>> len(im.palette.palette)
768
>>> len(im.transform(im.size, Image.Transform.AFFINE, [1, 0, 0, 0, 1, 0]).palette.palette)
768
>>> im = im.convert("PA")
>>> im.mode
'PA'
>>> len(im.palette.palette)
768
>>> len(im.transform(im.size, Image.Transform.AFFINE, [1, 0, 0, 0, 1, 0]).palette.palette)
0
```