### PR TITLE
Simplify test code

### DIFF
--- a/Tests/test_image_resize.py
+++ b/Tests/test_image_resize.py
@@ -230,10 +230,8 @@ class TestReducingGapResize:
             (52, 34), Image.Resampling.BICUBIC, box=box, reducing_gap=1.0
         )
 
-        with pytest.raises(pytest.fail.Exception):
-            assert_image_equal(ref, im)
-
         assert_image_similar(ref, im, epsilon)
+        assert ref.tobytes() != im.tobytes()
 
     @pytest.mark.parametrize(
         "box, epsilon",
@@ -250,9 +248,7 @@ class TestReducingGapResize:
             (52, 34), Image.Resampling.BICUBIC, box=box, reducing_gap=2.0
         )
 
-        with pytest.raises(pytest.fail.Exception):
-            assert_image_equal(ref, im)
-
+        assert ref.tobytes() != im.tobytes()
         assert_image_similar(ref, im, epsilon)
 
     @pytest.mark.parametrize(
@@ -270,9 +266,7 @@ class TestReducingGapResize:
             (52, 34), Image.Resampling.BICUBIC, box=box, reducing_gap=3.0
         )
 
-        with pytest.raises(pytest.fail.Exception):
-            assert_image_equal(ref, im)
-
+        assert ref.tobytes() != im.tobytes()
         assert_image_similar(ref, im, epsilon)
 
     @pytest.mark.parametrize("box", (None, (1.1, 2.2, 510.8, 510.9), (3, 10, 410, 256)))

--- a/Tests/test_image_thumbnail.py
+++ b/Tests/test_image_thumbnail.py
@@ -149,9 +149,8 @@ def test_reducing_gap_values() -> None:
 
     ref = hopper()
     ref.thumbnail((18, 18), Image.Resampling.BICUBIC, reducing_gap=None)
-    with pytest.raises(pytest.fail.Exception):
-        assert_image_equal(ref, im)
 
+    assert ref.tobytes() != im.tobytes()
     assert_image_similar(ref, im, 3.5)
 
 


### PR DESCRIPTION
Given
https://github.com/python-pillow/Pillow/blob/d3b755d869917181fc87658bf7f81fd12b57fdd3/Tests/helper.py#L87-L90
https://github.com/python-pillow/Pillow/blob/d3b755d869917181fc87658bf7f81fd12b57fdd3/Tests/helper.py#L112-L116
looking at
https://github.com/python-pillow/Pillow/blob/d3b755d869917181fc87658bf7f81fd12b57fdd3/Tests/test_image_resize.py#L233-L236

`assert_image_similar` asserts that the mode and size are the same, meaning that `assert_image_equal` should only fail when comparing `im.tobytes()`.

So let's just simplify things by testing `im.tobytes()` directly. I find this clearer.
```python
assert_image_similar(ref, im, epsilon)
assert ref.tobytes() != im.tobytes()
```