### PR TITLE
Remove duration and timestamp from AVIF info after seek

### DIFF
--- a/Tests/test_file_avif.py
+++ b/Tests/test_file_avif.py
@@ -773,6 +773,25 @@ class TestAvifAnimation:
                 assert im.info["timestamp"] == timestamp
                 timestamp -= duration
 
+    def test_seek_removes_frame_info(self) -> None:
+        """
+        timestamp and duration describe the loaded frame, so they must not
+        survive a seek to a frame that has not been loaded yet.
+        """
+
+        with Image.open("Tests/images/avif/star.avifs") as im:
+            im.load()
+            assert im.info["timestamp"] == 0
+            duration = im.info["duration"]
+
+            for frame in range(1, im.n_frames):
+                im.seek(frame)
+                assert "duration" not in im.info
+                assert "timestamp" not in im.info
+
+                im.load()
+                assert im.info["timestamp"] == duration * frame
+
     def test_seek_errors(self) -> None:
         with Image.open("Tests/images/avif/star.avifs") as im:
             with pytest.raises(EOFError):

--- a/Tests/test_file_avif.py
+++ b/Tests/test_file_avif.py
@@ -768,30 +768,13 @@ class TestAvifAnimation:
             timestamp = duration * (im.n_frames - 1)
             for frame in reversed(range(im.n_frames)):
                 im.seek(frame)
-                im.load()
-                assert im.info["duration"] == duration
-                assert im.info["timestamp"] == timestamp
-                timestamp -= duration
-
-    def test_seek_removes_frame_info(self) -> None:
-        """
-        timestamp and duration describe the loaded frame, so they must not
-        survive a seek to a frame that has not been loaded yet.
-        """
-
-        with Image.open("Tests/images/avif/star.avifs") as im:
-            assert isinstance(im, AvifImagePlugin.AvifImageFile)
-            im.load()
-            assert im.info["timestamp"] == 0
-            duration = im.info["duration"]
-
-            for frame in range(1, im.n_frames):
-                im.seek(frame)
                 assert "duration" not in im.info
                 assert "timestamp" not in im.info
 
                 im.load()
-                assert im.info["timestamp"] == duration * frame
+                assert im.info["duration"] == duration
+                assert im.info["timestamp"] == timestamp
+                timestamp -= duration
 
     def test_seek_errors(self) -> None:
         with Image.open("Tests/images/avif/star.avifs") as im:

--- a/Tests/test_file_avif.py
+++ b/Tests/test_file_avif.py
@@ -780,6 +780,7 @@ class TestAvifAnimation:
         """
 
         with Image.open("Tests/images/avif/star.avifs") as im:
+            assert isinstance(im, AvifImagePlugin.AvifImageFile)
             im.load()
             assert im.info["timestamp"] == 0
             duration = im.info["duration"]

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -31,6 +31,32 @@ Pillow reads and writes AVIF files, including AVIF sequence images.
 It is only possible to save 8-bit AVIF images, and all AVIF images are decoded
 as 8-bit RGB(A).
 
+Opening
+~~~~~~~
+
+The :py:meth:`~PIL.Image.open` method sets the following
+:py:attr:`~PIL.Image.Image.info` properties:
+
+**icc_profile**
+    May not be present. The ICC color profile for the image.
+
+**exif**
+    May not be present. Raw EXIF data from the image.
+
+**xmp**
+    May not be present. Raw XMP data from the image.
+
+**timestamp**
+    Only present after the current frame is loaded. The time of the current frame
+    within the AVIF sequence, in milliseconds.
+
+**duration**
+    Only present after the current frame is loaded. The time to display the current
+    frame of the AVIF sequence, in milliseconds.
+
+Saving
+~~~~~~
+
 The :py:meth:`~PIL.Image.Image.save` method supports the following options:
 
 **quality**

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -46,13 +46,13 @@ The :py:meth:`~PIL.Image.open` method sets the following
 **xmp**
     May not be present. Raw XMP data from the image.
 
-**timestamp**
-    Only present after the current frame is loaded. The time of the current frame
-    within the AVIF sequence, in milliseconds.
-
 **duration**
     Only present after the current frame is loaded. The time to display the current
     frame of the AVIF sequence, in milliseconds.
+
+**timestamp**
+    Only present after the current frame is loaded. The time of the current frame
+    within the AVIF sequence, in milliseconds.
 
 Saving
 ~~~~~~

--- a/src/PIL/AvifImagePlugin.py
+++ b/src/PIL/AvifImagePlugin.py
@@ -115,7 +115,6 @@ class AvifImageFile(ImageFile.ImageFile):
     def seek(self, frame: int) -> None:
         if not self._seek_check(frame):
             return
-
         self.info.pop("timestamp", None)
         self.info.pop("duration", None)
 

--- a/src/PIL/AvifImagePlugin.py
+++ b/src/PIL/AvifImagePlugin.py
@@ -116,6 +116,9 @@ class AvifImageFile(ImageFile.ImageFile):
         if not self._seek_check(frame):
             return
 
+        self.info.pop("timestamp", None)
+        self.info.pop("duration", None)
+
         # Set tile
         self.__frame = frame
         self.tile = [ImageFile._Tile("raw", (0, 0, *self.size), 0, self.mode)]


### PR DESCRIPTION
`AvifImageFile.load()` writes `timestamp` and `duration` into `info`, so they describe the frame that was decoded. `seek()` leaves them in place, so a seek to a frame that has not been loaded reports the previous frame's values:

```python
with Image.open("Tests/images/avif/star.avifs") as im:
    im.load()
    im.info["timestamp"], im.info["duration"]   # (0, 40)  -- frame 0
    im.seek(1)
    im.info["timestamp"], im.info["duration"]   # (0, 40)  -- still frame 0
```

This is the same defect #9791 fixed for WebP. The two plugins set the same two keys the same way, and before that PR they behaved identically — on Pillow 12.3.0 both report stale values after `seek()`. On `main` today:

| format | after `load()` on frame 0 | after `seek(1)`, not loaded |
|---|---|---|
| WebP (fixed in #9791) | `(0, 0)` | `(None, None)` |
| **AVIF** | `(0, 40)` | **`(0, 40)`** |

The fix is the same two lines in `seek()`, and the test mirrors the one #9791 added to `test_file_webp_animated.py`. Reverting `AvifImagePlugin.py` fails it with `assert 'duration' not in {'timestamp': 0, 'duration': 40}`.

I also added an `Opening` section for AVIF in `image-file-formats.rst`, as #9791 did for WebP, since `timestamp` and `duration` being present only after the frame is loaded is otherwise surprising. AVIF sets `icc_profile`, `exif` and `xmp` in `_open()`, and those two in `load()`.

`pytest Tests/test_file_avif.py`: **102 passed, 3 skipped** (the skips are `svt encode not available` locally). `pre-commit run` clean on all three files, including Sphinx Lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011M5uTyCU4WcNTsPvGrErDo
