### PR TITLE
Update Ghostscript test dependency via Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -163,6 +163,15 @@
             "packageNameTemplate": "facebook/zstd",
             "datasourceTemplate": "github-releases",
             "extractVersionTemplate": "^v(?<version>.+)$"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/workflows/test-windows\\.yml$/"],
+            "matchStrings": ["\\$gs = \"(?<currentValue>\\d+[^\"]*)\""],
+            "depNameTemplate": "ghostscript",
+            "packageNameTemplate": "ghostscript",
+            "datasourceTemplate": "nuget",
+            "registryUrlTemplate": "https://community.chocolatey.org/api/v2/"
         }
     ],
     "ignoreDeps": ["numpy"],

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -93,8 +93,10 @@ jobs:
         choco install nasm --no-progress
         echo "C:\Program Files\NASM" >> $env:GITHUB_PATH
 
-        choco install ghostscript --version=10.8.0 --no-progress
-        echo "C:\Program Files\gs\gs10.08.0\bin" >> $env:GITHUB_PATH
+        $gs = "10.8.0"
+        choco install ghostscript --version=$gs --no-progress
+        $v = [version]$gs
+        echo "C:\Program Files\gs\gs$($v.Major).$("{0:00}" -f $v.Minor).$($v.Build)\bin" >> $env:GITHUB_PATH
 
         # Install extra test images
         xcopy /S /Y Tests\test-images\* Tests\images


### PR DESCRIPTION
Follow on from https://github.com/python-pillow/Pillow/pull/9559. Alternative to https://github.com/python-pillow/Pillow/pull/9974

To automate PRs like https://github.com/python-pillow/Pillow/pull/9972.

Not added to `dependencies.json`, because that's used for creating the SBOM, and Ghostscript is only a test dependency.