### PR TITLE
Improve multibuild cache use in wheel builds

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -89,6 +89,20 @@ if [[ -z "$IS_MACOS" ]]; then
 fi
 
 ARCHIVE_SDIR=pillow-depends-main
+MISSING_DEPENDS_FILE=$(mktemp)
+
+# Redeclare fetch_unpack as multibuild_fetch_unpack so we can still call it
+eval "$(declare -f fetch_unpack | sed '1s/^fetch_unpack/multibuild_fetch_unpack/')"
+
+function fetch_unpack {
+    local url=$1
+    local archive_fname=${2:-$(basename $url)}
+    if [[ ! -f "${ARCHIVE_SDIR}/${archive_fname}" ]]; then
+        echo "::warning title=Dependency missing from pillow-depends::$archive_fname is not in pillow-depends; downloading it from $url" >&2
+        echo "  $archive_fname (from $url)" >> "$MISSING_DEPENDS_FILE"
+    fi
+    multibuild_fetch_unpack "$@"
+}
 
 VERSIONS_FILE="$PROJECTDIR/.github/dependencies.json"
 _get_ver() { python3 -c "import json; print(json.load(open('$VERSIONS_FILE'))['$1'])"; }
@@ -397,6 +411,15 @@ if [[ -n "$IS_MACOS" ]]; then
 fi
 
 wrap_wheel_builder build
+
+if [[ -f $MISSING_DEPENDS_FILE ]]; then
+    (
+        echo "# The following archives were not found in pillow-depends and were downloaded from upstream instead:"
+        echo '```'
+        cat "$MISSING_DEPENDS_FILE"
+        echo '```'
+    ) >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+fi
 
 # A safety catch for iOS. iOS can't use dynamic libraries, but clang will prefer
 # to link dynamic libraries to static libraries. The only way to reliably

--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -158,7 +158,11 @@ function build_zlib_ng {
     ORIGINAL_HOST_CONFIGURE_FLAGS=$HOST_CONFIGURE_FLAGS
     unset HOST_CONFIGURE_FLAGS
 
-    build_github zlib-ng/zlib-ng $ZLIB_NG_VERSION --installnamedir=$BUILD_PREFIX/lib --zlib-compat
+    local out_dir=$(fetch_unpack https://github.com/zlib-ng/zlib-ng/archive/$ZLIB_NG_VERSION.tar.gz zlib-ng-$ZLIB_NG_VERSION.tar.gz)
+    (cd $out_dir \
+        && ./configure --prefix=$BUILD_PREFIX $HOST_CONFIGURE_FLAGS --installnamedir=$BUILD_PREFIX/lib --zlib-compat \
+        && make -j4 \
+        && make install)
 
     HOST_CONFIGURE_FLAGS=$ORIGINAL_HOST_CONFIGURE_FLAGS
     touch zlib-stamp
@@ -260,6 +264,20 @@ function build_zstd {
     (cd $out_dir \
         && make -j4 install)
     touch zstd-stamp
+}
+
+function build_openjpeg {
+    if [ -e openjpeg-stamp ]; then return; fi
+    build_zlib
+    build_libpng
+    build_tiff
+    build_lcms2
+    local cmake=$(get_modern_cmake)
+    local out_dir=$(fetch_unpack https://github.com/uclouvain/openjpeg/archive/v$OPENJPEG_VERSION.tar.gz openjpeg-$OPENJPEG_VERSION.tar.gz)
+    (cd $out_dir \
+        && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_LIBDIR=$BUILD_PREFIX/lib -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib $HOST_CMAKE_FLAGS . \
+        && make -j4 install)
+    touch openjpeg-stamp
 }
 
 function build {


### PR DESCRIPTION
* Use [GitHub Actions warnings](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-a-warning-message) to note when a dependency gets downloaded as opposed to having been already found from the https://github.com/python-pillow/pillow-depends bundle
* Override builder functions for zlib-ng and openjpeg so they use files from https://github.com/python-pillow/pillow-depends (their upstream archive filenames are raw version numbers, which don't match anything in pillow-depends).

Related: https://github.com/python-pillow/pillow-depends/pull/43