### PR TITLE
Fix cross-compiling by searching the right lib and include directories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ import shutil
 import struct
 import subprocess
 import sys
+import sysconfig
 import warnings
 
 from pybind11.setup_helpers import ParallelCompile
@@ -571,8 +572,16 @@ class pil_build_ext(build_ext):
                 for d in os.environ[k].split(os.path.pathsep):
                     _add_directory(library_dirs, d)
 
-        _add_directory(library_dirs, os.path.join(sys.prefix, "lib"))
-        _add_directory(include_dirs, os.path.join(sys.prefix, "include"))
+        _add_directory(
+            library_dirs,
+            (sys.prefix == sys.base_prefix and sysconfig.get_config_var("LIBDIR"))
+            or os.path.join(sys.prefix, "lib"),
+        )
+        _add_directory(
+            include_dirs,
+            (sys.prefix == sys.base_prefix and sysconfig.get_config_var("INCLUDEDIR"))
+            or os.path.join(sys.prefix, "include"),
+        )
 
         #
         # add platform directories


### PR DESCRIPTION
Rebase of https://github.com/python-pillow/Pillow/pull/7634

It looks like we don't have permissions to update that PR, and it is failing to build the docs because it is out of date.