### PR TITLE
Link security policy in project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ urls.Documentation = "https://pillow.readthedocs.io"
 urls.Funding = "https://tidelift.com/subscription/pkg/pypi-pillow?utm_source=pypi-pillow&utm_medium=pypi"
 urls.Homepage = "https://python-pillow.org"
 urls.Mastodon = "https://fosstodon.org/@pillow"
+urls.Security = "https://pillow.readthedocs.io/en/latest/handbook/security.html"
 urls.Source = "https://github.com/python-pillow/Pillow"
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ urls.Documentation = "https://pillow.readthedocs.io"
 urls.Funding = "https://tidelift.com/subscription/pkg/pypi-pillow?utm_source=pypi-pillow&utm_medium=pypi"
 urls.Homepage = "https://python-pillow.org"
 urls.Mastodon = "https://fosstodon.org/@pillow"
-urls.Security = "https://pillow.readthedocs.io/en/latest/handbook/security.html"
+urls.Security = "https://pillow.readthedocs.io/en/stable/handbook/security.html"
 urls.Source = "https://github.com/python-pillow/Pillow"
 
 [tool.setuptools]


### PR DESCRIPTION
This is now a "well-known label" and will show a shield icon on PyPI:

* https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels
* https://github.com/pypa/packaging.python.org/pull/2127
* https://github.com/pypi/warehouse/pull/20501