### PR TITLE
`PIL._binary`: Use `int.to_bytes()` for faster conversion

### DIFF
--- a/src/PIL/_binary.py
+++ b/src/PIL/_binary.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 __lazy_modules__ = {"struct"}
 
-from struct import pack, unpack_from
+from struct import unpack_from
 
 
 def i8(c: bytes) -> int:
@@ -26,7 +26,7 @@ def i8(c: bytes) -> int:
 
 
 def o8(i: int) -> bytes:
-    return bytes((i & 255,))
+    return (i & 255).to_bytes()
 
 
 # Input, le = little endian, be = big endian
@@ -100,16 +100,16 @@ def i32be(c: bytes, o: int = 0) -> int:
 
 # Output, le = little endian, be = big endian
 def o16le(i: int) -> bytes:
-    return pack("<H", i)
+    return i.to_bytes(2, "little")
 
 
 def o32le(i: int) -> bytes:
-    return pack("<I", i)
+    return i.to_bytes(4, "little")
 
 
 def o16be(i: int) -> bytes:
-    return pack(">H", i)
+    return i.to_bytes(2, "big")
 
 
 def o32be(i: int) -> bytes:
-    return pack(">I", i)
+    return i.to_bytes(4, "big")


### PR DESCRIPTION
`int.to_bytes()` has been a thing since Python 3.2, and it's faster than `struct.pack` having to parse that spec and all that on every invocation. This micro-benchmarks to be 1.2x to 1.5x faster on my machine for essentially free.

### Fun fact

There's an [upcoming CPython 3.16 optimization](https://github.com/python/cpython/issues/155742#issuecomment-5602585410) that will further help `o8()` memory-wise (since the `int.to_bytes(..., 1)` call will end up just returning one of the singleton byteses).

### Fun related fact

We could borrow that idea, namely something like

```patch
 from struct import unpack_from
 
+_o8_bytes = tuple(bytes(range(256))[n : n + 1] for n in range(256))
+
 
 def i8(c: bytes) -> int:
     return c[0]
 
 
 def o8(i: int) -> bytes:
-    return (i & 255).to_bytes()
+    return _o8_bytes[i & 255]
```

but it felt a little too much. It _would_ save about 42 bytes of allocations for every `o8()` call before 3.16 lands, as well as some time (microbenchmarked to be 2.6x faster), but it's a bit _weird_ - I suspect better gains would be had by looking at the call sites for `o8()` to see if they really need to pack a single byte at a time. (The weird construction for the tuple ensures we do actually get references to the immortal singleton byteses, not new allocations.)