### PR TITLE
Reject invalid radius in BoxBlur and GaussianBlur

### DIFF
--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -236,47 +236,22 @@ def test_consistency_i16_high_byte(mode: str) -> None:
         assert im.getpixel((4, 4)) == 1000
 
 
-@pytest.mark.parametrize(
-    "radius",
-    (
-        -2,
-        (-2, -2),
-        (-2, 2),
-        (2, -2),
-    ),
-)
-def test_invalid_box_blur_filter(radius: int | tuple[int, int]) -> None:
-    with pytest.raises(ValueError):
-        ImageFilter.BoxBlur(radius)
+@pytest.mark.parametrize("size", (-1, math.nan, math.inf, 2**31))
+def test_invalid_box_blur_filter(size: int) -> None:
+    for radius in (size, (size, size), (size, 1), (1, size)):
+        with pytest.raises(ValueError, match="radius"):
+            ImageFilter.BoxBlur(radius)
 
+        im = hopper()
+        box_blur_filter = ImageFilter.BoxBlur(2)
+        box_blur_filter.radius = radius
+        with pytest.raises(ValueError, match="radius"):
+            im.filter(box_blur_filter)
+
+
+@pytest.mark.parametrize("radius", (math.nan, math.inf, 2**31))
+def test_invalid_gaussian_blur_filter(radius: int) -> None:
     im = hopper()
-    box_blur_filter = ImageFilter.BoxBlur(2)
-    box_blur_filter.radius = radius
-    with pytest.raises(ValueError):
-        im.filter(box_blur_filter)
-
-
-@pytest.mark.parametrize(
-    "radius",
-    (
-        math.nan,
-        (math.nan, 1),
-        (1, math.nan),
-        math.inf,
-        (1, math.inf),
-        (math.inf, 1),
-    ),
-)
-def test_box_blur_non_finite_radius(radius: float | tuple[float, float]) -> None:
-    with pytest.raises(ValueError, match="radius must be a finite number >= 0"):
-        ImageFilter.BoxBlur(radius)
-
-
-@pytest.mark.parametrize("radius", (float("nan"), float("inf"), 2**31))
-def test_out_of_range_blur_filter_radius(radius: float) -> None:
-    im = hopper()
-    with pytest.raises(ValueError, match="radius"):
-        im.filter(ImageFilter.BoxBlur(radius))
     with pytest.raises(ValueError, match="radius"):
         im.filter(ImageFilter.GaussianBlur(radius))
 

--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -275,9 +275,9 @@ def test_box_blur_non_finite_radius(radius: float | tuple[float, float]) -> None
 @pytest.mark.parametrize("radius", (float("nan"), float("inf"), 2**31))
 def test_out_of_range_blur_filter_radius(radius: float) -> None:
     im = hopper()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="radius"):
         im.filter(ImageFilter.BoxBlur(radius))
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="radius"):
         im.filter(ImageFilter.GaussianBlur(radius))
 
 

--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -272,6 +272,15 @@ def test_box_blur_non_finite_radius(radius: float | tuple[float, float]) -> None
         ImageFilter.BoxBlur(radius)
 
 
+@pytest.mark.parametrize("radius", (float("nan"), float("inf"), 2**31))
+def test_out_of_range_blur_filter_radius(radius: float) -> None:
+    im = hopper()
+    with pytest.raises(ValueError):
+        im.filter(ImageFilter.BoxBlur(radius))
+    with pytest.raises(ValueError):
+        im.filter(ImageFilter.GaussianBlur(radius))
+
+
 def test_rankfilter_size_1() -> None:
     im = Image.new("L", (3, 3), 128)
 

--- a/src/PIL/ImageFilter.py
+++ b/src/PIL/ImageFilter.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import abc
-import math
 from typing import cast
 
 TYPE_CHECKING = False
@@ -221,8 +220,11 @@ class BoxBlur(MultibandFilter):
 
     def __init__(self, radius: float | Sequence[float]) -> None:
         xy = radius if isinstance(radius, (tuple, list)) else (radius, radius)
-        if not all(math.isfinite(value) and value >= 0 for value in xy):
-            msg = "radius must be a finite number >= 0"
+        if not all(value >= 0 for value in xy):
+            msg = "radius must be >= 0"
+            raise ValueError(msg)
+        if any(value >= 2**31 for value in xy):
+            msg = "radius too large"
             raise ValueError(msg)
         self.radius = radius
 

--- a/src/libImaging/BoxBlur.c
+++ b/src/libImaging/BoxBlur.c
@@ -241,8 +241,11 @@ ImagingBoxBlur(Imaging imOut, Imaging imIn, float xradius, float yradius, int n)
     if (n < 1) {
         return ImagingError_ValueError("number of passes must be greater than zero");
     }
-    if (xradius < 0 || yradius < 0) {
+    if (!(xradius >= 0) || !(yradius >= 0)) {
         return ImagingError_ValueError("radius must be >= 0");
+    }
+    if (xradius >= INT_MAX || yradius >= INT_MAX) {
+        return ImagingError_ValueError("radius is too large");
     }
 
     if (imIn->mode != imOut->mode || imIn->type != imOut->type ||

--- a/src/libImaging/BoxBlur.c
+++ b/src/libImaging/BoxBlur.c
@@ -241,11 +241,13 @@ ImagingBoxBlur(Imaging imOut, Imaging imIn, float xradius, float yradius, int n)
     if (n < 1) {
         return ImagingError_ValueError("number of passes must be greater than zero");
     }
+    /* Negated comparisons, so that NaN is rejected as well. */
     if (!(xradius >= 0) || !(yradius >= 0)) {
         return ImagingError_ValueError("radius must be >= 0");
     }
-    if (xradius >= INT_MAX || yradius >= INT_MAX) {
-        return ImagingError_ValueError("radius is too large");
+    /* 2**31 and above cannot be converted to an int. */
+    if (xradius >= 2147483648.0f || yradius >= 2147483648.0f) {
+        return ImagingError_ValueError("radius too large");
     }
 
     if (imIn->mode != imOut->mode || imIn->type != imOut->type ||


### PR DESCRIPTION
Sequel to #9906. Part of #9902

- Improve radius checking when constructing BoxBlur in Python, to check for numbers larger than an int, not merely infinite
- check for invalid radius in C for BoxBlur, addressing BoxBlur when the radius is changed after initialisation, and GuassianBlur.