### PR TITLE
Add decompression bomb check when loading WmfStubImageFile at a different DPI

### DIFF
--- a/Tests/test_file_wmf.py
+++ b/Tests/test_file_wmf.py
@@ -118,9 +118,13 @@ def test_load_set_dpi() -> None:
 
     with Image.open("Tests/images/drawing.emf") as im:
         assert im.size == (1625, 1625)
+        assert isinstance(im, WmfImagePlugin.WmfStubImageFile)
+        with pytest.raises(Image.DecompressionBombError):
+            im.load(20000)
 
-        if not hasattr(Image.core, "drawwmf"):
-            return
+    if not hasattr(Image.core, "drawwmf"):
+        return
+    with Image.open("Tests/images/drawing.emf") as im:
         assert isinstance(im, WmfImagePlugin.WmfStubImageFile)
         im.load(im.info["dpi"])
         assert im.size == (1625, 1625)

--- a/src/PIL/WmfImagePlugin.py
+++ b/src/PIL/WmfImagePlugin.py
@@ -128,6 +128,7 @@ class WmfStubImageFile(ImageFile.StubImageFile):
                 int((x1 - x0) * dpi[0] / self._inch[0]),
                 int((y1 - y0) * dpi[1] / self._inch[1]),
             )
+            Image._decompression_bomb_check(self.size)
         return super().load()
 
 


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/4311 added the ability for WmfImagePlugin to `load()` images at a different size than they were `open()`ed with, by passing an extra `dpi` argument, like `im.load(100)`.

This adds a decompression bomb check for the final size.

Credit to @Tednoob17 and @leemoon-42 for reporting this possibility.