### PR TITLE
Return palette contents in suitable format for C putpalette()

### DIFF
--- a/Tests/test_imagepalette.py
+++ b/Tests/test_imagepalette.py
@@ -215,7 +215,9 @@ def test_rawmode_getdata() -> None:
 
     # Assert
     assert rawmode == "RGB"
-    assert data_in == data_out
+    assert data_out == bytes(data_in)
+    im = Image.new("P", (1, 1))
+    im.im.putpalette("RGB", rawmode, data_out)
 
 
 def test_2bit_palette(tmp_path: Path) -> None:

--- a/src/PIL/ImagePalette.py
+++ b/src/PIL/ImagePalette.py
@@ -97,7 +97,13 @@ class ImagePalette:
 
         return new
 
-    def getdata(self) -> tuple[str, Sequence[int] | bytes | bytearray]:
+    def _tobytes(self) -> bytes:
+        if isinstance(self.palette, bytes):
+            return self.palette
+        arr = array.array("B", self.palette)
+        return arr.tobytes()
+
+    def getdata(self) -> tuple[str, bytes]:
         """
         Get palette contents in format suitable for the low-level
         ``im.putpalette`` primitive.
@@ -105,7 +111,7 @@ class ImagePalette:
         .. warning:: This method is experimental.
         """
         if self.rawmode:
-            return self.rawmode, self.palette
+            return self.rawmode, self._tobytes()
         return self.mode, self.tobytes()
 
     def tobytes(self) -> bytes:
@@ -116,10 +122,7 @@ class ImagePalette:
         if self.rawmode:
             msg = "palette contains raw palette data"
             raise ValueError(msg)
-        if isinstance(self.palette, bytes):
-            return self.palette
-        arr = array.array("B", self.palette)
-        return arr.tobytes()
+        return self._tobytes()
 
     # Declare tostring as an alias for tobytes
     tostring = tobytes


### PR DESCRIPTION
`ImagePalette.getdata()` does not always fulfil its described purpose.

https://github.com/python-pillow/Pillow/blob/0253ef07e697122e9978c1abc28e091f9dab541e/src/PIL/ImagePalette.py#L100-L103

```python
from PIL import Image, ImagePalette
im = Image.new("P", (1, 1))
palette = ImagePalette.raw("RGB", list(range(256)) * 3)
rawmode, data_out = palette.getdata()
im.im.putpalette("RGB", rawmode, data_out)
```
currently raises
```pytb
Traceback (most recent call last):
  File "demo.py", line 5, in <module>
    im.im.putpalette("RGB", rawmode, data_out)
TypeError: a bytes-like object is required, not 'list'
```

This PR ensures that the palette data is always returned as bytes.