### PR TITLE
Do not use deprecated getdata

### DIFF
--- a/checks/check_imaging_leaks.py
+++ b/checks/check_imaging_leaks.py
@@ -46,7 +46,7 @@ def _test_leak(
 
 def test_leak_putdata() -> None:
     im = Image.new("RGB", (25, 25))
-    _test_leak(min_iterations, max_iterations, im.putdata, im.getdata())
+    _test_leak(min_iterations, max_iterations, im.putdata, im.get_flattened_data())
 
 
 def test_leak_getlist() -> None:


### PR DESCRIPTION
A use in the test suite that I missed in https://github.com/python-pillow/Pillow/pull/9292. This code was originally added in https://github.com/python-pillow/Pillow/pull/1196

Before merging though, #9883 should be considered, as that PR would like to reverse this deprecation strategy.