### PR TITLE
Move kernel size check into getlist()

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1146,7 +1146,7 @@ _expand_image(ImagingObject *self, PyObject *args) {
 
 static PyObject *
 _filter(ImagingObject *self, PyObject *args) {
-    static const char *wrong_number = "bad kernel size";
+    static const char *wrong_length = "bad kernel size";
 
     PyObject *imOut;
     FLOAT32 *kerneldata;
@@ -1162,7 +1162,7 @@ _filter(ImagingObject *self, PyObject *args) {
 
     /* get user-defined kernel */
     Py_ssize_t kernelsize = (Py_ssize_t)xsize * (Py_ssize_t)ysize;
-    kerneldata = getlist(kernel, kernelsize, wrong_number, TYPE_FLOAT32);
+    kerneldata = getlist(kernel, kernelsize, wrong_length, TYPE_FLOAT32);
     if (!kerneldata) {
         return NULL;
     }
@@ -1531,7 +1531,7 @@ _paste(ImagingObject *self, PyObject *args) {
 
 static PyObject *
 _point(ImagingObject *self, PyObject *args) {
-    static const char *wrong_number = "wrong number of lut entries";
+    static const char *wrong_length = "wrong number of lut entries";
 
     Py_ssize_t n;
     int i, bands;
@@ -1550,7 +1550,7 @@ _point(ImagingObject *self, PyObject *args) {
 
         /* map from 8-bit data to floating point */
         n = 256;
-        data = getlist(list, n, wrong_number, TYPE_FLOAT32);
+        data = getlist(list, n, wrong_length, TYPE_FLOAT32);
         if (!data) {
             return NULL;
         }
@@ -1562,7 +1562,7 @@ _point(ImagingObject *self, PyObject *args) {
         /* map from 16-bit subset of 32-bit data to 8-bit */
         /* FIXME: support arbitrary number of entries (requires API change) */
         n = 65536;
-        data = getlist(list, n, wrong_number, TYPE_UINT8);
+        data = getlist(list, n, wrong_length, TYPE_UINT8);
         if (!data) {
             return NULL;
         }
@@ -1583,7 +1583,7 @@ _point(ImagingObject *self, PyObject *args) {
 
         /* map to integer data */
         n = 256 * bands;
-        data = getlist(list, n, wrong_number, TYPE_INT32);
+        data = getlist(list, n, wrong_length, TYPE_INT32);
         if (!data) {
             return NULL;
         }
@@ -2093,7 +2093,7 @@ im_setalpha(ImagingObject *self, PyObject *args) {
 
 static PyObject *
 _transform(ImagingObject *self, PyObject *args) {
-    static const char *wrong_number = "wrong number of matrix entries";
+    static const char *wrong_length = "wrong number of matrix entries";
 
     Imaging imOut;
     Py_ssize_t n;
@@ -2136,7 +2136,7 @@ _transform(ImagingObject *self, PyObject *args) {
             n = -1; /* force error */
     }
 
-    a = getlist(data, n, wrong_number, TYPE_DOUBLE);
+    a = getlist(data, n, wrong_length, TYPE_DOUBLE);
     if (!a) {
         return NULL;
     }

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -419,14 +419,11 @@ getbands(const ModeID mode) {
 #define TYPE_DOUBLE (0x400 | sizeof(double))
 
 static void *
-getlist_impl(PyObject *arg, Py_ssize_t *length, const char *wrong_length, int type) {
-    /* - allocates and returns a c array of the items in the
-          python sequence arg.
+getlist_impl(PyObject *arg, Py_ssize_t length, const char *wrong_length, int type) {
+    /* - allocates and returns a c array of the items in the Python sequence arg.
        - the size of the returned array is in length
-       - all of the arg items must be numeric items of the type
-          specified in type
-       - sequence length is checked against the length parameter IF
-          an error parameter is passed in wrong_length
+       - all of the arg items must be numeric items of the type specified in type
+       - sequence length is checked against the length parameter
        - caller is responsible for freeing the memory
     */
 
@@ -444,7 +441,7 @@ getlist_impl(PyObject *arg, Py_ssize_t *length, const char *wrong_length, int ty
     }
 
     n = PySequence_Size(arg);
-    if (length && wrong_length && n != *length) {
+    if (n != length) {
         PyErr_SetString(PyExc_ValueError, wrong_length);
         return NULL;
     }
@@ -493,15 +490,11 @@ getlist_impl(PyObject *arg, Py_ssize_t *length, const char *wrong_length, int ty
         return NULL;
     }
 
-    if (length) {
-        *length = n;
-    }
-
     return list;
 }
 
 static void *
-getlist(PyObject *arg, Py_ssize_t *length, const char *wrong_length, int type) {
+getlist(PyObject *arg, Py_ssize_t length, const char *wrong_length, int type) {
     void *result;
     Py_BEGIN_CRITICAL_SECTION(arg);
     result = getlist_impl(arg, length, wrong_length, type);
@@ -875,7 +868,7 @@ _prepare_lut_table(PyObject *table, Py_ssize_t table_size) {
 
     if (!table_data) {
         free_table_data = 1;
-        table_data = getlist(table, &table_size, wrong_size, TYPE_FLOAT32);
+        table_data = getlist(table, table_size, wrong_size, TYPE_FLOAT32);
         if (!table_data) {
             return NULL;
         }
@@ -1153,8 +1146,9 @@ _expand_image(ImagingObject *self, PyObject *args) {
 
 static PyObject *
 _filter(ImagingObject *self, PyObject *args) {
+    static const char *wrong_number = "bad kernel size";
+
     PyObject *imOut;
-    Py_ssize_t kernelsize;
     FLOAT32 *kerneldata;
 
     int xsize, ysize, i;
@@ -1167,13 +1161,10 @@ _filter(ImagingObject *self, PyObject *args) {
     }
 
     /* get user-defined kernel */
-    kerneldata = getlist(kernel, &kernelsize, NULL, TYPE_FLOAT32);
+    Py_ssize_t kernelsize = (Py_ssize_t)xsize * (Py_ssize_t)ysize;
+    kerneldata = getlist(kernel, kernelsize, wrong_number, TYPE_FLOAT32);
     if (!kerneldata) {
         return NULL;
-    }
-    if (kernelsize != (Py_ssize_t)xsize * (Py_ssize_t)ysize) {
-        free(kerneldata);
-        return ImagingError_ValueError("bad kernel size");
     }
 
     for (i = 0; i < kernelsize; ++i) {
@@ -1559,7 +1550,7 @@ _point(ImagingObject *self, PyObject *args) {
 
         /* map from 8-bit data to floating point */
         n = 256;
-        data = getlist(list, &n, wrong_number, TYPE_FLOAT32);
+        data = getlist(list, n, wrong_number, TYPE_FLOAT32);
         if (!data) {
             return NULL;
         }
@@ -1571,7 +1562,7 @@ _point(ImagingObject *self, PyObject *args) {
         /* map from 16-bit subset of 32-bit data to 8-bit */
         /* FIXME: support arbitrary number of entries (requires API change) */
         n = 65536;
-        data = getlist(list, &n, wrong_number, TYPE_UINT8);
+        data = getlist(list, n, wrong_number, TYPE_UINT8);
         if (!data) {
             return NULL;
         }
@@ -1592,7 +1583,7 @@ _point(ImagingObject *self, PyObject *args) {
 
         /* map to integer data */
         n = 256 * bands;
-        data = getlist(list, &n, wrong_number, TYPE_INT32);
+        data = getlist(list, n, wrong_number, TYPE_INT32);
         if (!data) {
             return NULL;
         }
@@ -2145,7 +2136,7 @@ _transform(ImagingObject *self, PyObject *args) {
             n = -1; /* force error */
     }
 
-    a = getlist(data, &n, wrong_number, TYPE_DOUBLE);
+    a = getlist(data, n, wrong_number, TYPE_DOUBLE);
     if (!a) {
         return NULL;
     }


### PR DESCRIPTION
Within `_prepare_lut_table()`, `_point()` and `_transform()`, a size is passed to `getlist()`
https://github.com/python-pillow/Pillow/blob/0253ef07e697122e9978c1abc28e091f9dab541e/src/_imaging.c#L878
which then checks it and raises a ValueError if it is incorrect.
https://github.com/python-pillow/Pillow/blob/0253ef07e697122e9978c1abc28e091f9dab541e/src/_imaging.c#L447-L450

However, `_filter()` asks `getlist()` for the length and then checks it afterwards.
https://github.com/python-pillow/Pillow/blob/0253ef07e697122e9978c1abc28e091f9dab541e/src/_imaging.c#L1170
https://github.com/python-pillow/Pillow/blob/0253ef07e697122e9978c1abc28e091f9dab541e/src/_imaging.c#L496-L498
https://github.com/python-pillow/Pillow/blob/0253ef07e697122e9978c1abc28e091f9dab541e/src/_imaging.c#L1174-L1177

It would be simpler to use the same strategy for all scenarios.