### PR TITLE
Return 0 or -1 from ImagingSplit(), rather than number of bands

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -2504,7 +2504,7 @@ _split(ImagingObject *self, PyObject *args) {
     PyObject *imaging_object;
     Imaging bands[4] = {NULL, NULL, NULL, NULL};
 
-    if (!ImagingSplit(self->image, bands)) {
+    if (ImagingSplit(self->image, bands)) {
         return NULL;
     }
 

--- a/src/libImaging/Bands.c
+++ b/src/libImaging/Bands.c
@@ -75,13 +75,13 @@ ImagingSplit(Imaging imIn, Imaging bands[4]) {
     /* Check arguments */
     if (!imIn || imIn->type != IMAGING_TYPE_UINT8) {
         (void)ImagingError_ModeError();
-        return 0;
+        return -1;
     }
 
     /* Shortcuts */
     if (imIn->bands == 1) {
         bands[0] = ImagingCopy(imIn);
-        return imIn->bands;
+        return 0;
     }
 
     for (i = 0; i < imIn->bands; i++) {
@@ -90,7 +90,7 @@ ImagingSplit(Imaging imIn, Imaging bands[4]) {
             for (j = 0; j < i; ++j) {
                 ImagingDelete(bands[j]);
             }
-            return 0;
+            return -1;
         }
     }
 
@@ -170,7 +170,7 @@ ImagingSplit(Imaging imIn, Imaging bands[4]) {
         }
     }
 
-    return imIn->bands;
+    return 0;
 }
 
 Imaging


### PR DESCRIPTION
The only time that `ImagingSplit()` is called, the result is only checked for success or failure.
https://github.com/python-pillow/Pillow/blob/0253ef07e697122e9978c1abc28e091f9dab541e/src/_imaging.c#L2507-L2509

There's no reason it needs to return the number of bands.
https://github.com/python-pillow/Pillow/blob/0253ef07e697122e9978c1abc28e091f9dab541e/src/libImaging/Bands.c#L173

So let's return 0 for success and -1 for failure instead.