### PR TITLE
Correct ImageOps.crop border type hint

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -87,6 +87,21 @@ def test_sanity() -> None:
     ImageOps.exif_transpose(hopper("RGB"))
 
 
+@pytest.mark.parametrize(
+    "border, expected_box",
+    (
+        (1, (1, 1, 127, 127)),
+        ((1, 2), (1, 2, 127, 126)),
+        ((1, 2, 3, 4), (1, 2, 125, 124)),
+    ),
+)
+def test_crop(
+    border: int | tuple[int, ...], expected_box: tuple[int, int, int, int]
+) -> None:
+    im = hopper()
+    assert_image_equal(ImageOps.crop(im, border), im.crop(expected_box))
+
+
 def test_1pxfit() -> None:
     # Division by zero in equalize if image is 1 pixel high
     newimg = ImageOps.fit(hopper("RGB").resize((1, 1)), (35, 35))

--- a/docs/releasenotes/13.0.0.rst
+++ b/docs/releasenotes/13.0.0.rst
@@ -126,14 +126,6 @@ Two new filters are available for :py:meth:`~PIL.Image.Image.resize` and
 Other changes
 =============
 
-ImageOps.crop border type annotation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The ``border`` type annotation for :py:func:`~PIL.ImageOps.crop` now includes
-tuples, matching its existing support for two or four border widths. The tuple
-ordering is also documented for :py:func:`~PIL.ImageOps.crop` and
-:py:func:`~PIL.ImageOps.expand`.
-
 Python 3.15
 ^^^^^^^^^^^
 

--- a/docs/releasenotes/13.0.0.rst
+++ b/docs/releasenotes/13.0.0.rst
@@ -126,6 +126,14 @@ Two new filters are available for :py:meth:`~PIL.Image.Image.resize` and
 Other changes
 =============
 
+ImageOps.crop border type annotation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``border`` type annotation for :py:func:`~PIL.ImageOps.crop` now includes
+tuples, matching its existing support for two or four border widths. The tuple
+ordering is also documented for :py:func:`~PIL.ImageOps.crop` and
+:py:func:`~PIL.ImageOps.expand`.
+
 Python 3.15
 ^^^^^^^^^^^
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -408,9 +408,10 @@ def crop(image: Image.Image, border: int | tuple[int, ...] = 0) -> Image.Image:
 
     :param image: The image to crop.
     :param border: The number of pixels to remove. An integer removes the same
-        number of pixels from all four sides. A 2-tuple specifies the horizontal
-        and vertical borders. A 4-tuple specifies the left, top, right and bottom
-        borders.
+                   number of pixels from all four sides. A 2-tuple specifies
+                   the number of pixels to remove horizontally and vertically.
+                   A 4-tuple specifies the number of pixels to remove from the
+                   left, top, right and bottom of the image.
     :return: An image.
     """
     left, top, right, bottom = _border(border)
@@ -519,8 +520,9 @@ def expand(
 
     :param image: The image to expand.
     :param border: Border width, in pixels. An integer adds the same width to
-        all four sides. A 2-tuple specifies the horizontal and vertical borders.
-        A 4-tuple specifies the left, top, right and bottom borders.
+                   all four sides. A 2-tuple specifies the horizontal and
+                   vertical border widths. A 4-tuple specifies the widths of
+                   the left, top, right and bottom borders.
     :param fill: Pixel fill value (a color value).  Default is 0 (black).
     :return: An image.
     """

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -400,15 +400,17 @@ def pad(
     return out
 
 
-def crop(image: Image.Image, border: int = 0) -> Image.Image:
+def crop(image: Image.Image, border: int | tuple[int, ...] = 0) -> Image.Image:
     """
-    Remove border from image.  The same amount of pixels are removed
-    from all four sides.  This function works on all image modes.
+    Remove border from image. This function works on all image modes.
 
     .. seealso:: :py:meth:`~PIL.Image.Image.crop`
 
     :param image: The image to crop.
-    :param border: The number of pixels to remove.
+    :param border: The number of pixels to remove. An integer removes the same
+        number of pixels from all four sides. A 2-tuple specifies the horizontal
+        and vertical borders. A 4-tuple specifies the left, top, right and bottom
+        borders.
     :return: An image.
     """
     left, top, right, bottom = _border(border)
@@ -516,7 +518,9 @@ def expand(
     Add border to the image
 
     :param image: The image to expand.
-    :param border: Border width, in pixels.
+    :param border: Border width, in pixels. An integer adds the same width to
+        all four sides. A 2-tuple specifies the horizontal and vertical borders.
+        A 4-tuple specifies the left, top, right and bottom borders.
     :param fill: Pixel fill value (a color value).  Default is 0 (black).
     :return: An image.
     """


### PR DESCRIPTION
`ImageOps.crop(im, (1, 2))` and `ImageOps.crop(im, (1, 2, 3, 4))` already work through `_border()`, but type checkers reject them because `crop()` only annotates `border` as `int`.

Changes proposed in this pull request:

* Match the existing tuple support in the `crop()` annotation, consistent with `expand()`.
* Document integer, horizontal/vertical and left/top/right/bottom border forms for both functions, replacing the inaccurate statement that `crop()` always removes the same border on every side.
* Add typed crop tests for all three forms.

Validation:

* With `MYPYPATH=src`, `python3 -m mypy --follow-imports=silent --ignore-missing-imports Tests/test_imageops.py`: the new test produces one `arg-type` error with the old annotation, and passes with the updated annotation.
* All 49 tests in `Tests/test_imageops.py` pass with the checkout's `ImageOps` module and Pillow 12.3.0's prebuilt native extensions on Windows/Python 3.12. The native extensions were not rebuilt.
* Black, Ruff, Sphinx-lint and `git diff --check` pass for the changed files.
* The full Sphinx HTML documentation builds successfully with warnings treated as errors, using the checkout's `ImageOps` module and Pillow 12.3.0 for the other modules.

Prepared with AI assistance.
