### PR TITLE
Remove test support for libjpeg-turbo 2.0 under Valgrind

### DIFF
--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -13,7 +13,6 @@ from .helper import (
     assert_image_similar_tofile,
     hopper,
     is_win32,
-    mark_if_feature_version,
     skip_unless_feature,
     timeout_unless_slower_valgrind,
 )
@@ -213,9 +212,6 @@ def test_begin_binary() -> None:
         Image.open(io.BytesIO(data))
 
 
-@mark_if_feature_version(
-    pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-)
 @pytest.mark.skipif(not HAS_GHOSTSCRIPT, reason="Ghostscript not available")
 def test_cmyk() -> None:
     with Image.open("Tests/images/eps/pil_sample_cmyk.eps") as cmyk_image:

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -28,7 +28,6 @@ from .helper import (
     djpeg_available,
     hopper,
     is_win32,
-    mark_if_feature_version,
     skip_unless_feature,
     timeout_unless_slower_valgrind,
 )
@@ -186,9 +185,6 @@ class TestFileJpeg:
         with Image.open("Tests/images/jfif_unit_cm.jpg") as im:
             assert im.info["dpi"] == (2.54, 5.08)
 
-    @mark_if_feature_version(
-        pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-    )
     def test_icc(self, tmp_path: Path) -> None:
         # Test ICC support
         with Image.open("Tests/images/rgb.jpg") as im1:
@@ -231,9 +227,6 @@ class TestFileJpeg:
         im1 = self.roundtrip(hopper(), icc_profile=icc_profile)
         assert im1.info.get("icc_profile") == (icc_profile or None)
 
-    @mark_if_feature_version(
-        pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-    )
     def test_large_icc_meta(self, tmp_path: Path) -> None:
         # https://github.com/python-pillow/Pillow/issues/148
         # Sometimes the meta data on the icc_profile block is bigger than
@@ -542,9 +535,6 @@ class TestFileJpeg:
         with Image.open(filename):
             pass
 
-    @mark_if_feature_version(
-        pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-    )
     def test_truncated_jpeg_should_read_all_the_data(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -564,9 +554,6 @@ class TestFileJpeg:
             with pytest.raises(OSError):
                 im.load()
 
-    @mark_if_feature_version(
-        pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-    )
     def test_qtables(self) -> None:
         def _n_qtables_helper(n: int, test_file: str) -> None:
             b = BytesIO()
@@ -897,9 +884,6 @@ class TestFileJpeg:
             # OSError for unidentified image.
             assert im.info.get("dpi") == (72, 72)
 
-    @mark_if_feature_version(
-        pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-    )
     def test_exif_x_resolution(self, tmp_path: Path) -> None:
         with Image.open("Tests/images/flower.jpg") as im:
             exif = im.getexif()
@@ -934,9 +918,6 @@ class TestFileJpeg:
         with Image.open("Tests/images/multiple_exif.jpg") as im:
             assert im.getexif()[270] == "firstsecond"
 
-    @mark_if_feature_version(
-        pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-    )
     def test_photoshop(self) -> None:
         with Image.open("Tests/images/photoshop-200dpi.jpg") as im:
             assert im.info["photoshop"][0x03ED] == {

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -27,7 +27,6 @@ from .helper import (
     assert_image_similar,
     assert_image_similar_tofile,
     hopper,
-    mark_if_feature_version,
     skip_unless_feature,
 )
 
@@ -1006,17 +1005,11 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open(infile) as im:
             assert_image_similar_tofile(im, "Tests/images/pil_sample_cmyk.jpg", 0.5)
 
-    @mark_if_feature_version(
-        pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-    )
     def test_strip_ycbcr_jpeg_2x2_sampling(self) -> None:
         infile = "Tests/images/tiff_strip_ycbcr_jpeg_2x2_sampling.tif"
         with Image.open(infile) as im:
             assert_image_similar_tofile(im, "Tests/images/flower.jpg", 1.2)
 
-    @mark_if_feature_version(
-        pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-    )
     def test_strip_ycbcr_jpeg_1x1_sampling(self) -> None:
         infile = "Tests/images/tiff_strip_ycbcr_jpeg_1x1_sampling.tif"
         with Image.open(infile) as im:
@@ -1027,17 +1020,11 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open(infile) as im:
             assert_image_similar_tofile(im, "Tests/images/pil_sample_cmyk.jpg", 0.5)
 
-    @mark_if_feature_version(
-        pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-    )
     def test_tiled_ycbcr_jpeg_1x1_sampling(self) -> None:
         infile = "Tests/images/tiff_tiled_ycbcr_jpeg_1x1_sampling.tif"
         with Image.open(infile) as im:
             assert_image_similar_tofile(im, "Tests/images/flower2.jpg", 0.01)
 
-    @mark_if_feature_version(
-        pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-    )
     def test_tiled_ycbcr_jpeg_2x2_sampling(self) -> None:
         infile = "Tests/images/tiff_tiled_ycbcr_jpeg_2x2_sampling.tif"
         with Image.open(infile) as im:

--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -13,7 +13,6 @@ from PIL import Image, PdfParser, features
 
 from .helper import (
     hopper,
-    mark_if_feature_version,
     skip_unless_feature,
     timeout_unless_slower_valgrind,
 )
@@ -144,9 +143,6 @@ def test_dpi(params: dict[str, int | tuple[int, int]], tmp_path: Path) -> None:
     assert size == (122.88, 61.44)
 
 
-@mark_if_feature_version(
-    pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-)
 def test_save_all(tmp_path: Path) -> None:
     # Single frame image
     helper_save_as_pdf(tmp_path, "RGB", save_all=True)

--- a/Tests/test_file_png.py
+++ b/Tests/test_file_png.py
@@ -18,7 +18,6 @@ from .helper import (
     assert_image_equal_tofile,
     hopper,
     is_win32,
-    mark_if_feature_version,
     skip_unless_feature,
 )
 
@@ -849,9 +848,6 @@ class TestFilePng:
         assert exif_data is not None
         assert exif_data[274] == 1
 
-    @mark_if_feature_version(
-        pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-    )
     def test_exif_from_jpg(self, tmp_path: Path) -> None:
         with Image.open("Tests/images/pil_sample_rgb.jpg") as im:
             test_file = tmp_path / "temp.png"

--- a/Tests/test_file_webp_metadata.py
+++ b/Tests/test_file_webp_metadata.py
@@ -6,7 +6,7 @@ import pytest
 
 from PIL import Image, WebPImagePlugin
 
-from .helper import mark_if_feature_version, skip_unless_feature
+from .helper import skip_unless_feature
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -51,9 +51,6 @@ def test_read_exif_metadata_without_prefix() -> None:
         assert exif[305] == "Adobe Photoshop CS6 (Macintosh)"
 
 
-@mark_if_feature_version(
-    pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-)
 def test_write_exif_metadata() -> None:
     file_path = "Tests/images/flower.jpg"
     test_buffer = BytesIO()
@@ -82,9 +79,6 @@ def test_read_icc_profile() -> None:
             assert icc == expected_icc
 
 
-@mark_if_feature_version(
-    pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-)
 def test_write_icc_metadata() -> None:
     file_path = "Tests/images/flower2.jpg"
     test_buffer = BytesIO()
@@ -102,9 +96,6 @@ def test_write_icc_metadata() -> None:
         assert webp_icc_profile == expected_icc_profile, "Webp ICC didn't match"
 
 
-@mark_if_feature_version(
-    pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-)
 def test_read_no_exif() -> None:
     file_path = "Tests/images/flower.jpg"
     test_buffer = BytesIO()

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -29,7 +29,6 @@ from .helper import (
     assert_not_all_same,
     hopper,
     is_win32,
-    mark_if_feature_version,
     skip_unless_feature,
     timeout_unless_slower_valgrind,
 )
@@ -822,9 +821,6 @@ class TestImage:
         reloaded_exif.load(exif.tobytes())
         assert reloaded_exif.get_ifd(0x8769) == {36864: b"0220"}
 
-    @mark_if_feature_version(
-        pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-    )
     def test_exif_jpeg(self, tmp_path: Path) -> None:
         with Image.open("Tests/images/exif-72dpi-int.jpg") as im:  # Little endian
             exif = im.getexif()

--- a/Tests/test_image_resample.py
+++ b/Tests/test_image_resample.py
@@ -10,7 +10,6 @@ from .helper import (
     assert_image_equal,
     assert_image_similar,
     hopper,
-    mark_if_feature_version,
 )
 
 TYPE_CHECKING = False
@@ -555,9 +554,6 @@ class TestCoreResampleBox:
                 tiled.paste(tile, (x0, y0))
         return tiled
 
-    @mark_if_feature_version(
-        pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-    )
     def test_tiles(self) -> None:
         with Image.open("Tests/images/flower.jpg") as im:
             assert im.size == (480, 360)
@@ -568,9 +564,6 @@ class TestCoreResampleBox:
                 tiled = self.resize_tiled(im, dst_size, *tiles)
                 assert_image_similar(reference, tiled, 0.01)
 
-    @mark_if_feature_version(
-        pytest.mark.valgrind_known_error, "libjpeg_turbo", "2.0", reason="Known Failing"
-    )
     def test_subsample(self) -> None:
         # This test shows advantages of the subpixel resizing
         # after supersampling (e.g. during JPEG decoding).


### PR DESCRIPTION
I think we can feel confident that no one is going to run our test suite under Valgrind with a version of libjpeg-turbo more than [5 years old](https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/2.1.0).

This was added in https://github.com/python-pillow/Pillow/pull/5397 for Ubuntu 20.04. We don't even test Ubuntu 22.04 anymore.